### PR TITLE
moveit.rosinstall: Use the unified repo from ros-planning

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -2,7 +2,7 @@
 # Used with wstool, users can download source of all packages of MoveIt!.
 - git:
     local-name: moveit
-    uri: https://github.com/davetcoleman/moveit.git
+    uri: https://github.com/ros-planning/moveit.git
     version: kinetic-devel
 - git:
     local-name: moveit_docs


### PR DESCRIPTION
Probably superseded by https://github.com/davetcoleman/moveit_merge/pull/5