### PR TITLE
Improve fillGrasp method for pick("object_name") interface

### DIFF
--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -418,7 +418,7 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
 {
   planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
 
-  if (grasp_planning_service_ && lscene->hasObjectType(goal.target_name) && !lscene->getObjectType(goal.target_name).key.empty())
+  if (grasp_planning_service_)
   {
     manipulation_msgs::GraspPlanning::Request request;
     manipulation_msgs::GraspPlanning::Response response;
@@ -430,21 +430,24 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
       request.arm_name = goal.group_name;
       request.target.reference_frame_id = lscene->getPlanningFrame();
 
-      household_objects_database_msgs::DatabaseModelPose dbp;
-      dbp.pose.header.frame_id = lscene->getPlanningFrame();
-      dbp.pose.header.stamp = ros::Time::now();
-      tf::poseEigenToMsg(object->shape_poses_[0], dbp.pose.pose);
-      dbp.type = lscene->getObjectType(goal.target_name);
-      try
+      if(lscene->hasObjectType(goal.target_name) && !lscene->getObjectType(goal.target_name).key.empty())
       {
-        dbp.model_id = boost::lexical_cast<int>(dbp.type.key);
-        ROS_DEBUG_NAMED("manipulation", "Asking database for grasps for '%s' with model id: %d", dbp.type.key.c_str(), dbp.model_id);
-        request.target.potential_models.push_back(dbp);
-      }
-      catch (boost::bad_lexical_cast &)
-      {
-        valid = false;
-        ROS_ERROR_NAMED("manipulation", "Expected an integer object id, not '%s'", dbp.type.key.c_str());
+        household_objects_database_msgs::DatabaseModelPose dbp;
+        dbp.pose.header.frame_id = lscene->getPlanningFrame();
+        dbp.pose.header.stamp = ros::Time::now();
+        tf::poseEigenToMsg(object->shape_poses_[0], dbp.pose.pose);
+        dbp.type = lscene->getObjectType(goal.target_name);
+        try
+        {
+          dbp.model_id = boost::lexical_cast<int>(dbp.type.key);
+          ROS_DEBUG_NAMED("manipulation", "Asking database for grasps for '%s' with model id: %d", dbp.type.key.c_str(), dbp.model_id);
+          request.target.potential_models.push_back(dbp);
+        }
+        catch (boost::bad_lexical_cast &)
+        {
+          valid = false;
+          ROS_ERROR_NAMED("manipulation", "Expected an integer object id, not '%s'", dbp.type.key.c_str());
+        }
       }
     }
     else

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -431,6 +431,7 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
     }
 
     request.arm_name = goal.group_name;
+    request.collision_object_name = goal.target_name;
     request.target.reference_frame_id = lscene->getPlanningFrame();
 
     if(lscene->hasObjectType(goal.target_name) && !lscene->getObjectType(goal.target_name).key.empty())


### PR DESCRIPTION
This simplifies the use of a custom external grasp planning service.

First commit:
We should be allowed to call the grasp planner in the fillGrasps method without specifying a type for the object.

Second commit:
If the object doesn't exist the method should return immediately and should not produce broken grasps.

Third commit:
The collision_object_name in the grasp planning request wasn't set.