### PR TITLE
Switch FCL dependency to correct name

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -24,7 +24,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
-  <build_depend>fcl</build_depend>
+  <build_depend>libfcl-dev</build_depend>
   <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_parser</build_depend>
@@ -49,7 +49,7 @@
   <run_depend>eigen</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
-  <run_depend>fcl</run_depend>
+  <run_depend>libfcl-dev</run_depend>
   <run_depend version_gte="0.3.4">geometric_shapes</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>kdl_parser</run_depend>


### PR DESCRIPTION
Once https://github.com/ros/rosdistro/pull/12287 is merged in we will need to switch the dependency here

@j-rivero

note: do not cherry-pick with older distros