### PR TITLE
Revert "initialize RobotModel even if URDF is empty"

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -85,9 +85,11 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.urdf_string_, opt.srdf_string_));
     else
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.robot_description_));
-
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
-  model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+  if (rdf_loader_->getURDF())
+  {
+    const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
+    model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+  }
 
   if (model_ && !rdf_loader_->getRobotDescription().empty())
   {


### PR DESCRIPTION
This reverts commit a7414a5cf572673a05c99ec95a0a531374b3aff8 from https://github.com/ros-planning/moveit_ros/pull/730

This change causes the default Rviz to segfault in Kinetic (maybe earlier) when you load the MotionPlanningPlugin.

The backtrace is [here](https://gist.github.com/davetcoleman/cbb966e5916f2c72beb0e41bd9aefbfb)

The relevant line is 

```
#5  0x00007fff85a43b49 in moveit::core::RobotModel::RobotModel (this=0x7fffb4001c00, urdf_model=..., srdf_model=...) at /home/dave/ws_moveit/src/moveit/moveit_core/robot_model/src/robot_model.cpp:56
56	  buildModel(*urdf_model, *srdf_model);
```

The boost pointer throws an assertion when ``urdf_model`` is dereferenced.

There might be a fix for this segfault that perhaps @v4hn can address but this PR fixes what introduced the bug.