### PR TITLE
create new urdf model if none is available

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -92,11 +92,9 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.urdf_string_, opt.srdf_string_));
     else
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.robot_description_));
-  if (rdf_loader_->getURDF())
-  {
-    const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
-    model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
-  }
+
+  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
+  model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
 
   if (model_ && !rdf_loader_->getRobotDescription().empty())
   {

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -94,7 +94,8 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.robot_description_));
 
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
-  model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+  const boost::shared_ptr<urdf::ModelInterface> &urdf = rdf_loader_->getURDF() ? rdf_loader_->getURDF() : boost::shared_ptr<urdf::Model>(new urdf::Model());
+  model_.reset(new robot_model::RobotModel(urdf, srdf));
 
   if (model_ && !rdf_loader_->getRobotDescription().empty())
   {


### PR DESCRIPTION
This requires
https://github.com/ros-visualization/rviz/pull/1039 and
https://github.com/ros-planning/moveit/pull/45 .

This should be "the fix" @davetcoleman mentioned in https://github.com/ros-planning/moveit/pull/43 .
However, because this depends on a bugfix in rviz and we can't influence their release cycle,
this is probably not the road to take to unblock the overdue jade release.

This can be merged once the rviz fix is merged and released.