### PR TITLE
Fix kinetic docker build

### DIFF
--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -5,7 +5,8 @@ FROM osrf/ros:kinetic-desktop
 MAINTAINER Dave Coleman dave@dav.ee
 
 # apt-commands are combined in single RUN statement with "lists" folder removal to reduce image size
-RUN apt-get update && \
+RUN echo 'deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main' | tee --append /etc/apt/sources.list.d/ros-latest.list && \
+    apt-get update && \
     apt-get install -y \
         nano \
         ros-${ROS_DISTRO}-moveit-* && \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -14,7 +14,9 @@ RUN wstool init . && \
     wstool update
 
 # Update apt-get because osrf image clears this cache. download deps
-RUN apt-get -qq update && \
+RUN echo 'deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main' | tee --append /etc/apt/sources.list.d/ros-latest.list && \
+    rosdep update && \
+    apt-get -qq update && \
     apt-get -qq install -y \
         python-catkin-tools  \
         less \


### PR DESCRIPTION
I forgot the kinetic branch still requires shadow-fixed, and the rosdep rules were just updated so an update() is called

Should have tested locally the first time, this time I verified it worked locally.