### PR TITLE
fix broken cmake dependencies

### DIFF
--- a/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(${MOVEIT_LIB_NAME}_core
 
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_lazy_free_space_updater moveit_mesh_filter moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_dependencies(${MOVEIT_LIB_NAME}_core sensor_msgs_generate_cpp)
+add_dependencies(${MOVEIT_LIB_NAME}_core ${sensor_msgs_EXPORTED_TARGETS})
 
 add_library(${MOVEIT_LIB_NAME} src/updater_plugin.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -8,7 +8,7 @@ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_F
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_dependencies(${MOVEIT_LIB_NAME} sensor_msgs_generate_cpp)
+add_dependencies(${MOVEIT_LIB_NAME} ${sensor_msgs_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)


### PR DESCRIPTION
cmake complained on each build that the targets do not exist.
It's right.
I changed them to the more generic EXPORTED_TARGETS variable.

Please pick to j/k.