### PR TITLE
remove unknown dependency sensor_msgs_generate_cpp

### DIFF
--- a/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
@@ -1,12 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_depth_image_octomap_updater)
 
-add_library(${MOVEIT_LIB_NAME}_core
-  src/depth_image_octomap_updater.cpp
-  )
-
+add_library(${MOVEIT_LIB_NAME}_core src/depth_image_octomap_updater.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_lazy_free_space_updater moveit_mesh_filter moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-
-add_dependencies(${MOVEIT_LIB_NAME}_core ${sensor_msgs_EXPORTED_TARGETS})
 
 add_library(${MOVEIT_LIB_NAME} src/updater_plugin.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -1,14 +1,9 @@
 set(MOVEIT_LIB_NAME moveit_lazy_free_space_updater)
 
-add_library(${MOVEIT_LIB_NAME}
-  src/lazy_free_space_updater.cpp
-  )
-
+add_library(${MOVEIT_LIB_NAME} src/lazy_free_space_updater.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-
-add_dependencies(${MOVEIT_LIB_NAME} ${sensor_msgs_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)


### PR DESCRIPTION
dependencies are pulled in via ${catkin_LIBRARIES}

https://github.com/ros-planning/moveit/pull/56 called to my attention this was never backported, which invalidates #56 