### PR TITLE
cherry-picked moveit_ros#717

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -39,13 +39,29 @@
 #include <moveit/move_group/capability_names.h>
 
 move_group::MoveGroupExecuteService::MoveGroupExecuteService():
-  MoveGroupCapability("ExecutePathService")
+  MoveGroupCapability("ExecutePathService"),
+  callback_queue_(),
+  spinner_(1 /* spinner threads */, &callback_queue_)
 {
+}
+
+move_group::MoveGroupExecuteService::~MoveGroupExecuteService()
+{
+  spinner_.stop();
 }
 
 void move_group::MoveGroupExecuteService::initialize()
 {
-  execute_service_ = root_node_handle_.advertiseService(EXECUTE_SERVICE_NAME, &MoveGroupExecuteService::executeTrajectoryService, this);
+  // We need to serve each service request in a thread independent of the main spinner thread.
+  // Otherwise, a synchronous execution request (i.e. waiting for the execution to finish) would block
+  // execution of the main spinner thread.
+  // Hence, we use our own asynchronous spinner listening to our own callback queue.
+  ros::AdvertiseServiceOptions ops;
+  ops.template init<moveit_msgs::ExecuteKnownTrajectory::Request, moveit_msgs::ExecuteKnownTrajectory::Response>
+      (EXECUTE_SERVICE_NAME, boost::bind(&MoveGroupExecuteService::executeTrajectoryService, this, _1, _2));
+  ops.callback_queue = &callback_queue_;
+  execute_service_ = root_node_handle_.advertiseService(ops);
+  spinner_.start();
 }
 
 bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::ExecuteKnownTrajectory::Request &req, moveit_msgs::ExecuteKnownTrajectory::Response &res)

--- a/moveit_ros/move_group/src/default_capabilities/execute_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_service_capability.h
@@ -48,6 +48,7 @@ class MoveGroupExecuteService : public MoveGroupCapability
 public:
 
   MoveGroupExecuteService();
+  ~MoveGroupExecuteService();
 
   virtual void initialize();
 
@@ -56,6 +57,8 @@ private:
   bool executeTrajectoryService(moveit_msgs::ExecuteKnownTrajectory::Request &req, moveit_msgs::ExecuteKnownTrajectory::Response &res);
 
   ros::ServiceServer execute_service_;
+  ros::CallbackQueue callback_queue_;
+  ros::AsyncSpinner spinner_;
 };
 
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -132,19 +132,16 @@ public:
 
     current_state_monitor_ = getSharedStateMonitor( robot_model_, tf_, node_handle_ );
 
-    move_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>(node_handle_,
-                                                                                              move_group::MOVE_ACTION,
-                                                                                              false));
+    move_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>
+                              (node_handle_, move_group::MOVE_ACTION, false));
     waitForAction(move_action_client_, wait_for_server, move_group::MOVE_ACTION);
 
-    pick_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PickupAction>(node_handle_,
-                                                                                           move_group::PICKUP_ACTION,
-                                                                                           false));
+    pick_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PickupAction>
+                              (node_handle_, move_group::PICKUP_ACTION, false));
     waitForAction(pick_action_client_, wait_for_server, move_group::PICKUP_ACTION);
 
-    place_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PlaceAction>(node_handle_,
-                                                                                           move_group::PLACE_ACTION,
-                                                                                           false));
+    place_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PlaceAction>
+                               (node_handle_, move_group::PLACE_ACTION, false));
     waitForAction(place_action_client_, wait_for_server, move_group::PLACE_ACTION);
 
     execute_service_ = node_handle_.serviceClient<moveit_msgs::ExecuteKnownTrajectory>(move_group::EXECUTE_SERVICE_NAME);


### PR DESCRIPTION
This was never cherry-picked to kinetic. Runs ExecuteService in a separate thread.
Use of AsyncSpinner is not problematic, because the service capability is initialized in the main thread.

indigo-devel merge: 5fbc40006bd7f937c34181ea4f3d02eb86e92dcb
