### PR TITLE
use more verbose param name fake_interpolating_controller_rate

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/README.md
+++ b/moveit_plugins/moveit_fake_controller_manager/README.md
@@ -7,7 +7,7 @@ interpolate: perform smooth interpolation between via points - the default for v
 via points:  traverse via points, w/o interpolation in between - useful for visual debugging
 last point:  warp directly to the last point of the trajectory - fastest method for offline benchmarking
 
-rate: 10 (Hz, used for interpolation controller)
+fake_interpolating_controller_rate: 10 (Hz)
 controller_list:
   - name: fake_arm_controller
     type: interpolate | via points | last point

--- a/moveit_plugins/moveit_fake_controller_manager/doc/tutorial.rst
+++ b/moveit_plugins/moveit_fake_controller_manager/doc/tutorial.rst
@@ -13,7 +13,7 @@ The following controllers are available:
 
 .. code:: yaml
 
-   rate: 10 (Hz, used for interpolation controller)
+   fake_interpolating_controller_rate: 10 (Hz)
    controller_list:
      - name: fake_arm_controller
        type: interpolate | via points | last point

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -204,7 +204,7 @@ InterpolatingController::InterpolatingController(const std::string &name, const 
   , rate_(10)
 {
   double r;
-  if (ros::param::get("~rate", r))
+  if (ros::param::get("~fake_interpolating_controller_rate", r))
     rate_ = ros::WallRate(r);
 }
 


### PR DESCRIPTION
Changed parameter name for interpolating controller to be more verbose:
move_group/rate -> move_group/fake_interpolating_controller_rate

Should be cherry-picked to Indigo/Jade.