### PR TITLE
Removed now-released messages from rosinstall file

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -12,7 +12,6 @@
     local-name: moveit_resources
     uri: https://github.com/ros-planning/moveit_resources.git
     version: master
-# Temporary until released into kinetic
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
@@ -21,11 +20,3 @@
     local-name: srdfdom
     uri: https://github.com/ros-planning/srdfdom.git
     version: indigo-devel
-- git:
-    local-name: manipulation_msgs
-    uri: https://github.com/ros-interactive-manipulation/manipulation_msgs.git
-    version: hydro-devel
-- git:
-    local-name: household_objects_database_msgs
-    uri: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
-    version: hydro-devel


### PR DESCRIPTION
manipulation_msgs and household_objects_database_msgs have been released into kinetic, this is no longer needed

Also I think we should just leave geometric_shapes and srdfdom in the rosinstall file, since they are part of ros-planning and are sometimes useful for moveit developers to use and see the source code