### PR TITLE
[indigo] Add Docker to main MoveIt! repo

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,0 +1,17 @@
+# MoveIt! Docker Images
+This repo hosts the Dockerfiles used to generate images for [MoveIt!](moveit.ros.org) :whale:
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/moveit/moveit.svg?maxAge=2592000)](https://hub.docker.com/r/moveit/moveit/)
+[![Docker Stars](https://img.shields.io/docker/stars/moveit/moveit.svg)](https://registry.hub.docker.com/moveit/moveit/)
+
+## Available Images
+
+For each ROS distribution there are 3 images, built on top of a standard [osrf/ros:indigo-desktop](https://github.com/osrf/docker_images/blob/master/ros/indigo/indigo-desktop/Dockerfile) (or other distro version) image:
+
+ - **source image**: contains all dependencies and a full MoveIt! workspace downloaded and built to ~/ws_moveit/src
+ - **release image**: the full debian-based install of MoveIt! using apt-get
+ - **ci image**: an image optimized for running continuous integration with Travis and [moveit_ci](https://github.com/ros-planning/moveit_ci)
+
+## Usage
+
+See [Docker instructions](http://moveit.ros.org/install/docker/)

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -1,0 +1,29 @@
+# moveit/moveit:indigo-ci
+# Sets up a base image to use for running Continuous Integration on Travis
+
+FROM osrf/ros:indigo-desktop
+MAINTAINER Dave Coleman dave@dav.ee
+
+# Install packages
+RUN apt-get -qq update && \
+    apt-get -qq install -y \
+        git \
+        sudo \
+        wget \
+        lsb-release \
+        freeglut3-dev \
+        libglew-dev \
+        python-pip \
+        python-catkin-tools \
+        python-rosdep \
+        python-wstool \
+        python-pyassimp \
+        libqtgui4 \
+        libqt4-opengl-dev \
+        libqt4-dev \
+        libqt4-opengl \
+        ros-$ROS_DISTRO-rosbash \
+        ros-$ROS_DISTRO-rospack && \
+    rm -rf /var/lib/apt/lists/*
+ENV IN_DOCKER 1
+ENV TERM xterm

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -1,0 +1,12 @@
+# moveit/moveit:indigo-release
+# Full debian-based install of MoveIt! using apt-get
+
+FROM osrf/ros:indigo-desktop
+MAINTAINER Dave Coleman dave@dav.ee
+
+# apt-commands are combined in single RUN statement with "lists" folder removal to reduce image size
+RUN apt-get update && \
+    apt-get install -y \
+        nano \
+        ros-${ROS_DISTRO}-moveit-full && \
+    rm -rf /var/lib/apt/lists/*

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -1,0 +1,40 @@
+# moveit/moveit:indigo-source
+# Downloads the moveit source code, install remaining debian dependencies, and builds workspace
+
+FROM osrf/ros:indigo-desktop
+MAINTAINER Dave Coleman dave@dav.ee
+
+ENV CATKIN_WS=/root/ws_moveit
+RUN mkdir -p $CATKIN_WS/src
+WORKDIR $CATKIN_WS/src
+
+# Download moveit source
+RUN wstool init . && \
+    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+    wstool update
+
+# Update apt-get because osrf image clears this cache. download deps
+RUN apt-get -qq update && \
+    apt-get -qq install -y \
+        python-catkin-tools  \
+        less \
+        ssh \
+        emacs \
+        git-core \
+        bash-completion \
+        tree \
+        wget && \
+    rosdep update && \
+    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    rm -rf /var/lib/apt/lists/*
+
+# Replacing shell with bash for later docker build commands
+RUN mv /bin/sh /bin/sh-old && \
+    ln -s /bin/bash /bin/sh
+
+# Build repo
+WORKDIR $CATKIN_WS
+ENV TERM xterm
+ENV PYTHONIOENCODING UTF-8
+RUN source /ros_entrypoint.sh && \
+    catkin build --no-status

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the new unified repository for MoveIt! code. See the [Migration Notes](h
 - [Overview of MoveIt!](http://moveit.ros.org)
 - [Installation Instructions](http://moveit.ros.org/install/)
 - [Documentation](http://moveit.ros.org/documentation/)
-- [Docker Containers](https://github.com/ros-planning/moveit_docker)
+- [Docker Containers](http://moveit.ros.org/install/docker)
 - [Get Involved](http://moveit.ros.org/documentation/contributing/)
 
 ## Travis - Continuous Integration


### PR DESCRIPTION
Almost same as https://github.com/ros-planning/moveit/pull/53 and jade version, but doesn't use shadow fixed or call rosdep update

Tested locally