### PR TITLE
[moveit_ros_planning] Fix missing dynparam setup for TrajectoryExecutionManager

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -65,6 +65,7 @@ private:
   {
     owner_->enableExecutionDurationMonitoring(config.execution_duration_monitoring);
     owner_->setAllowedExecutionDurationScaling(config.allowed_execution_duration_scaling);
+    owner_->setExecutionVelocityScaling(config.execution_velocity_scaling);
   }
 
   TrajectoryExecutionManager *owner_;


### PR DESCRIPTION
For https://github.com/ros-planning/moveit/pull/68#issuecomment-240586343

This is a bug.