### PR TITLE
Remove unavailable debians from docker CI

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -19,12 +19,9 @@ RUN apt-get -qq update && \
         python-wstool \
         python-pyassimp \
         libqtgui4 \
-        libccd-dev \
-        libqglviewer2-qt4 \
         libqt4-opengl-dev \
         libqt4-dev \
         libqt4-opengl \
-        libqglviewer-dev-qt4 \
         ros-$ROS_DISTRO-rosbash \
         ros-$ROS_DISTRO-rospack && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This didn't get properly cherry-picked from the kinetic patch (my fault)