### PR TITLE
Use MOVEIT_CLASS_FORWARD for moveit_core. (#70)

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -39,9 +39,12 @@
 
 #include <moveit/collision_detection/collision_robot.h>
 #include <moveit/collision_detection/collision_world.h>
+#include <moveit/macros/class_forward.h>
 
 namespace collision_detection
 {
+
+  MOVEIT_CLASS_FORWARD(CollisionDetectorAllocator);
 
   /** \brief An allocator for a compatible CollisionWorld/CollisionRobot pair. */
   class CollisionDetectorAllocator
@@ -63,9 +66,6 @@ namespace collision_detection
     /** create a new CollisionRobot by copying an existing CollisionRobot of the same type. */
     virtual CollisionRobotPtr allocateRobot(const CollisionRobotConstPtr& orig) const = 0;
   };
-
-  typedef boost::shared_ptr<CollisionDetectorAllocator> CollisionDetectorAllocatorPtr;
-
 
 
   /** \brief Template class to make it easy to create an allocator for a specific CollisionWorld/CollisionRobot pair. */

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -38,6 +38,7 @@
 #define MOVEIT_COLLISION_DETECTION_COLLISION_MATRIX_
 
 #include <moveit/collision_detection/collision_common.h>
+#include <moveit/macros/class_forward.h>
 #include <moveit_msgs/AllowedCollisionMatrix.h>
 #include <boost/function.hpp>
 #include <iostream>
@@ -70,6 +71,8 @@ namespace collision_detection
 
   /** \brief Signature of predicate that decides whether a contact is allowed or not (when AllowedCollision::Type is CONDITIONAL) */
   typedef boost::function<bool(collision_detection::Contact&)> DecideContactFn;
+
+  MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);
 
   /** @class AllowedCollisionMatrix
    *  @brief Definition of a structure for the allowed collision matrix. All elements in the collision world are referred to by their names.
@@ -242,9 +245,6 @@ namespace collision_detection
     std::map<std::string, DecideContactFn>                                default_allowed_contacts_;
 
   };
-
-  typedef boost::shared_ptr<AllowedCollisionMatrix> AllowedCollisionMatrixPtr;
-  typedef boost::shared_ptr<const AllowedCollisionMatrix> AllowedCollisionMatrixConstPtr;
 }
 
 #endif

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_robot.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_robot.h
@@ -38,12 +38,15 @@
 #define MOVEIT_COLLISION_DETECTION_COLLISION_ROBOT_
 
 #include <moveit/collision_detection/collision_matrix.h>
+#include <moveit/macros/class_forward.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_msgs/LinkPadding.h>
 #include <moveit_msgs/LinkScale.h>
 
 namespace collision_detection
 {
+
+  MOVEIT_CLASS_FORWARD(CollisionRobot);
 
   /** @brief This class represents a collision model of the robot and can be used for self collision checks
       (to check if the robot is in collision with itself) or in collision checks with a different robot. Collision checks with
@@ -252,9 +255,6 @@ namespace collision_detection
     /** @brief The internally maintained map (from link names to scaling)*/
     std::map<std::string, double>           link_scale_;
   };
-
-  typedef boost::shared_ptr<CollisionRobot> CollisionRobotPtr;
-  typedef boost::shared_ptr<const CollisionRobot> CollisionRobotConstPtr;
 }
 
 #endif

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_world.h
@@ -42,10 +42,13 @@
 #include <moveit/collision_detection/collision_matrix.h>
 #include <moveit/collision_detection/collision_robot.h>
 #include <moveit/collision_detection/world.h>
+#include <moveit/macros/class_forward.h>
 
 /** \brief Generic interface to collision detection */
 namespace collision_detection
 {
+
+  MOVEIT_CLASS_FORWARD(CollisionWorld);
 
   /** \brief Perform collision checking with the environment. The
    *  collision world maintains a representation of the environment
@@ -238,9 +241,6 @@ namespace collision_detection
     WorldPtr      world_;       // The world.  Always valid.  Never NULL.
     WorldConstPtr world_const_; // always same as world_
   };
-
-  typedef boost::shared_ptr<CollisionWorld> CollisionWorldPtr;
-  typedef boost::shared_ptr<const CollisionWorld> CollisionWorldConstPtr;
 }
 
 #endif

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -37,10 +37,11 @@
 #ifndef MOVEIT_COLLISION_DETECTION_WORLD_
 #define MOVEIT_COLLISION_DETECTION_WORLD_
 
+#include <moveit/macros/class_forward.h>
+
 #include <string>
 #include <vector>
 #include <map>
-#include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_vector_container.h>
@@ -48,6 +49,8 @@
 
 namespace collision_detection
 {
+
+  MOVEIT_CLASS_FORWARD(World);
 
   /** \brief Maintain a representation of the environment */
   class World
@@ -67,6 +70,8 @@ namespace collision_detection
     /**********************************************************************/
     /* Collision Bodies                                                   */
     /**********************************************************************/
+
+    MOVEIT_CLASS_FORWARD(Object);
 
     /** \brief A representation of an object */
     struct Object
@@ -97,9 +102,6 @@ namespace collision_detection
       EigenSTL::vector_Affine3d          shape_poses_;
     };
 
-    typedef boost::shared_ptr<Object> ObjectPtr;
-    typedef boost::shared_ptr<Object> ObjectConstPtr;
-
     /** \brief Get the list of Object ids */
     std::vector<std::string> getObjectIds() const;
 
@@ -107,7 +109,7 @@ namespace collision_detection
     ObjectConstPtr getObject(const std::string &id) const;
 
     /** iterator over the objects in the world. */
-    typedef std::map<std::string, ObjectConstPtr>::const_iterator const_iterator;
+    typedef std::map<std::string, ObjectPtr>::const_iterator const_iterator;
     /** iterator pointing to first change */
     const_iterator begin() const
     {
@@ -262,9 +264,6 @@ namespace collision_detection
     std::vector<Observer*> observers_;
 
   };
-
-  typedef boost::shared_ptr<World> WorldPtr;
-  typedef boost::shared_ptr<const World> WorldConstPtr;
 
 }
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -38,10 +38,13 @@
 #define MOVEIT_COLLISION_DETECTION_WORLD_DIFF_
 
 #include <moveit/collision_detection/world.h>
+#include <moveit/macros/class_forward.h>
 #include <boost/weak_ptr.hpp>
 
 namespace collision_detection
 {
+
+  MOVEIT_CLASS_FORWARD(WorldDiff);
 
   /** \brief Maintain a diff list of changes that have happened to a World. */
   class WorldDiff
@@ -123,9 +126,6 @@ namespace collision_detection
     /* used to unregister the notifier */
     boost::weak_ptr<World> world_;
   };
-
-  typedef boost::shared_ptr<WorldDiff> WorldDiffPtr;
-  typedef boost::shared_ptr<const WorldDiff> WorldDiffConstPtr;
 }
 
 #endif

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -39,6 +39,7 @@
 
 #include <moveit/collision_detection/world.h>
 #include <moveit/collision_detection/collision_world.h>
+#include <moveit/macros/class_forward.h>
 #include <fcl/broadphase/broadphase.h>
 #include <fcl/collision.h>
 #include <fcl/distance.h>
@@ -46,6 +47,8 @@
 
 namespace collision_detection
 {
+
+MOVEIT_CLASS_FORWARD(CollisionGeometryData);
 
 struct CollisionGeometryData
 {
@@ -152,6 +155,8 @@ struct CollisionData
 };
 
 
+MOVEIT_CLASS_FORWARD(FCLGeometry);
+
 struct FCLGeometry
 {
   FCLGeometry()
@@ -190,8 +195,6 @@ struct FCLGeometry
   boost::shared_ptr<CollisionGeometryData>  collision_geometry_data_;
 };
 
-typedef boost::shared_ptr<FCLGeometry> FCLGeometryPtr;
-typedef boost::shared_ptr<const FCLGeometry> FCLGeometryConstPtr;
 typedef boost::shared_ptr<fcl::CollisionObject> FCLCollisionObjectPtr;
 typedef boost::shared_ptr<const fcl::CollisionObject> FCLCollisionObjectConstPtr;
 

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -694,7 +694,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr &shape, 
     return createCollisionGeometry<BV, T>(shape, data, shape_index);
   else
   {
-    boost::shared_ptr<shapes::Shape> scaled_shape(shape->clone());
+    shapes::ShapePtr scaled_shape(shape->clone());
     scaled_shape->scaleAndPadd(scale, padding);
     return createCollisionGeometry<BV, T>(scaled_shape, data, shape_index);
   }

--- a/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -148,7 +148,7 @@ void collision_detection::CollisionWorldFCL::constructFCLObject(const World::Obj
     if (g)
     {
       fcl::CollisionObject *co = new fcl::CollisionObject(g->collision_geometry_,  transform2fcl(obj->shape_poses_[i]));
-      fcl_obj.collision_objects_.push_back(boost::shared_ptr<fcl::CollisionObject>(co));
+      fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(co));
       fcl_obj.collision_geometry_.push_back(g);
     }
   }

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -457,7 +457,7 @@ TEST_F(FclCollisionDetectionTester, ConvertObjectToAttached)
 
   EXPECT_LT(second_check, .05);
 
-  collision_detection::CollisionWorld::ObjectPtr object = cworld_->getWorld()->getObject("kinect");
+  collision_detection::CollisionWorld::ObjectConstPtr object = cworld_->getWorld()->getObject("kinect");
   cworld_->getWorld()->removeObject("kinect");
 
   robot_state::RobotState kstate1(kmodel_);

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -39,7 +39,6 @@
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 /**
@@ -52,6 +51,9 @@
  */
 namespace constraint_samplers
 {
+
+MOVEIT_CLASS_FORWARD(ConstraintSampler);
+
 /**
  * \brief ConstraintSampler is an abstract base class that allows the
  * sampling of a kinematic state for a particular group of a robot.
@@ -296,8 +298,6 @@ protected:
   robot_state::GroupStateValidityCallbackFn group_state_validity_callback_; /**< \brief Holds the callback for state validity */
   bool                                  verbose_; /**< \brief True if verbosity is on */
 };
-
-MOVEIT_CLASS_FORWARD(ConstraintSampler);
 
 }
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
@@ -38,9 +38,12 @@
 #define MOVEIT_CONSTRAINT_SAMPLERS_CONSTRAINT_SAMPLER_ALLOCATOR_
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
+#include <moveit/macros/class_forward.h>
 
 namespace constraint_samplers
 {
+
+MOVEIT_CLASS_FORWARD(ConstraintSamplerAllocator);
 
 class ConstraintSamplerAllocator
 {
@@ -61,9 +64,6 @@ public:
                           const moveit_msgs::Constraints &constr) const = 0;
 
 };
-
-typedef boost::shared_ptr<ConstraintSamplerAllocator> ConstraintSamplerAllocatorPtr;
-typedef boost::shared_ptr<const ConstraintSamplerAllocator> ConstraintSamplerAllocatorConstPtr;
 
 
 }

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -38,10 +38,12 @@
 #define MOVEIT_CONSTRAINT_SAMPLERS_CONSTRAINT_SAMPLER_MANAGER_
 
 #include <moveit/constraint_samplers/constraint_sampler_allocator.h>
-#include <boost/shared_ptr.hpp>
+#include <moveit/macros/class_forward.h>
 
 namespace constraint_samplers
 {
+
+MOVEIT_CLASS_FORWARD(ConstraintSamplerManager);
 
 /**
  * \brief This class assists in the generation of a ConstraintSampler for a
@@ -85,8 +87,8 @@ public:
    * @param group_name The group name for which to allocate the constraint sampler
    * @param constr The constraints
    *
-   * @return A boost::shared_ptr to the ConstraintSampler that is
-   * allocated, or an empty pointer if none could be allocated
+   * @return An allocated ConstraintSamplerPtr,
+   * or an empty pointer if none could be allocated
    */
   ConstraintSamplerPtr selectSampler(const planning_scene::PlanningSceneConstPtr &scene, const std::string &group_name, const moveit_msgs::Constraints &constr) const;
 
@@ -133,8 +135,6 @@ private:
 
   std::vector<ConstraintSamplerAllocatorPtr> sampler_alloc_; /**< \brief Holds the constraint sampler allocators, which will be tested in order  */
 };
-
-MOVEIT_CLASS_FORWARD(ConstraintSamplerManager);
 
 }
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -38,10 +38,13 @@
 #define MOVEIT_CONSTRAINT_SAMPLERS_DEFAULT_CONSTRAINT_SAMPLERS_
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
+#include <moveit/macros/class_forward.h>
 #include <random_numbers/random_numbers.h>
 
 namespace constraint_samplers
 {
+
+MOVEIT_CLASS_FORWARD(JointConstraintSampler);
 
 /**
  * \brief JointConstraintSampler is a class that allows the sampling
@@ -254,7 +257,7 @@ struct IKSamplingPose
    *
    * @return
    */
-  IKSamplingPose(const boost::shared_ptr<kinematic_constraints::PositionConstraint> &pc);
+  IKSamplingPose(const kinematic_constraints::PositionConstraintPtr &pc);
 
   /**
    * \brief Constructor that takes a pointer to a orientation constraint.
@@ -263,7 +266,7 @@ struct IKSamplingPose
    *
    * @return
    */
-  IKSamplingPose(const boost::shared_ptr<kinematic_constraints::OrientationConstraint> &oc);
+  IKSamplingPose(const kinematic_constraints::OrientationConstraintPtr &oc);
 
 
   /**
@@ -274,12 +277,14 @@ struct IKSamplingPose
    *
    * @return
    */
-  IKSamplingPose(const boost::shared_ptr<kinematic_constraints::PositionConstraint> &pc,
-                 const boost::shared_ptr<kinematic_constraints::OrientationConstraint> &oc);
+  IKSamplingPose(const kinematic_constraints::PositionConstraintPtr &pc,
+                 const kinematic_constraints::OrientationConstraintPtr &oc);
 
-  boost::shared_ptr<kinematic_constraints::PositionConstraint>    position_constraint_; /**< \brief Holds the position constraint for sampling */
-  boost::shared_ptr<kinematic_constraints::OrientationConstraint> orientation_constraint_; /**< \brief Holds the orientation constraint for sampling */
+  kinematic_constraints::PositionConstraintPtr    position_constraint_; /**< \brief Holds the position constraint for sampling */
+  kinematic_constraints::OrientationConstraintPtr orientation_constraint_; /**< \brief Holds the orientation constraint for sampling */
 };
+
+MOVEIT_CLASS_FORWARD(IKConstraintSampler);
 
 /**
  * \brief A class that allows the sampling of IK constraints.
@@ -289,7 +294,6 @@ struct IKSamplingPose
  * that adheres to the constraint, and then solves IK for that pose.
  *
  */
-
 class IKConstraintSampler : public ConstraintSampler
 {
 public:
@@ -387,9 +391,9 @@ public:
    * \brief Gets the position constraint associated with this sampler.
    *
    *
-   * @return The position constraint, or an empty boost::shared_ptr if none has been specified
+   * @return The position constraint, or an empty shared_ptr if none has been specified
    */
-  const boost::shared_ptr<kinematic_constraints::PositionConstraint>& getPositionConstraint() const
+  const kinematic_constraints::PositionConstraintPtr& getPositionConstraint() const
   {
     return sampling_pose_.position_constraint_;
   }
@@ -397,9 +401,9 @@ public:
    * \brief Gets the orientation constraint associated with this sampler.
    *
    *
-   * @return The orientation constraint, or an empty boost::shared_ptr if none has been specified
+   * @return The orientation constraint, or an empty shared_ptr if none has been specified
    */
-  const boost::shared_ptr<kinematic_constraints::OrientationConstraint>& getOrientationConstraint() const
+  const kinematic_constraints::OrientationConstraintPtr& getOrientationConstraint() const
   {
     return sampling_pose_.orientation_constraint_;
   }

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -202,15 +202,15 @@ constraint_samplers::IKSamplingPose::IKSamplingPose(const kinematic_constraints:
 {
 }
 
-constraint_samplers::IKSamplingPose::IKSamplingPose(const boost::shared_ptr<kinematic_constraints::PositionConstraint> &pc) : position_constraint_(pc)
+constraint_samplers::IKSamplingPose::IKSamplingPose(const kinematic_constraints::PositionConstraintPtr &pc) : position_constraint_(pc)
 {
 }
 
-constraint_samplers::IKSamplingPose::IKSamplingPose(const boost::shared_ptr<kinematic_constraints::OrientationConstraint> &oc) : orientation_constraint_(oc)
+constraint_samplers::IKSamplingPose::IKSamplingPose(const kinematic_constraints::OrientationConstraintPtr &oc) : orientation_constraint_(oc)
 {
 }
 
-constraint_samplers::IKSamplingPose::IKSamplingPose(const boost::shared_ptr<kinematic_constraints::PositionConstraint> &pc, const boost::shared_ptr<kinematic_constraints::OrientationConstraint> &oc) : position_constraint_(pc), orientation_constraint_(oc)
+constraint_samplers::IKSamplingPose::IKSamplingPose(const kinematic_constraints::PositionConstraintPtr &pc, const kinematic_constraints::OrientationConstraintPtr &oc) : position_constraint_(pc), orientation_constraint_(oc)
 {
 }
 
@@ -264,22 +264,22 @@ bool constraint_samplers::IKConstraintSampler::configure(const moveit_msgs::Cons
     for (std::size_t o = 0 ; o < constr.orientation_constraints.size() ; ++o)
       if (constr.position_constraints[p].link_name == constr.orientation_constraints[o].link_name)
       {
-        boost::shared_ptr<kinematic_constraints::PositionConstraint> pc(new kinematic_constraints::PositionConstraint(scene_->getRobotModel()));
-        boost::shared_ptr<kinematic_constraints::OrientationConstraint> oc(new kinematic_constraints::OrientationConstraint(scene_->getRobotModel()));
+        kinematic_constraints::PositionConstraintPtr pc(new kinematic_constraints::PositionConstraint(scene_->getRobotModel()));
+        kinematic_constraints::OrientationConstraintPtr oc(new kinematic_constraints::OrientationConstraint(scene_->getRobotModel()));
         if (pc->configure(constr.position_constraints[p], scene_->getTransforms()) && oc->configure(constr.orientation_constraints[o], scene_->getTransforms()))
           return configure(IKSamplingPose(pc, oc));
       }
 
   for (std::size_t p = 0 ; p < constr.position_constraints.size() ; ++p)
   {
-    boost::shared_ptr<kinematic_constraints::PositionConstraint> pc(new kinematic_constraints::PositionConstraint(scene_->getRobotModel()));
+    kinematic_constraints::PositionConstraintPtr pc(new kinematic_constraints::PositionConstraint(scene_->getRobotModel()));
     if (pc->configure(constr.position_constraints[p], scene_->getTransforms()))
       return configure(IKSamplingPose(pc));
   }
 
   for (std::size_t o = 0 ; o < constr.orientation_constraints.size() ; ++o)
   {
-    boost::shared_ptr<kinematic_constraints::OrientationConstraint> oc(new kinematic_constraints::OrientationConstraint(scene_->getRobotModel()));
+    kinematic_constraints::OrientationConstraintPtr oc(new kinematic_constraints::OrientationConstraint(scene_->getRobotModel()));
     if (oc->configure(constr.orientation_constraints[o], scene_->getTransforms()))
         return configure(IKSamplingPose(oc));
   }

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -41,6 +41,7 @@
 #include <string>
 #include <boost/shared_ptr.hpp>
 #include <moveit_msgs/RobotTrajectory.h>
+#include <moveit/macros/class_forward.h>
 
 /// Namespace for the base class of a MoveIt controller manager
 namespace moveit_controller_manager
@@ -93,6 +94,8 @@ private:
   Value status_;
 };
 
+MOVEIT_CLASS_FORWARD(MoveItControllerHandle);
+
 /** \brief MoveIt sends commands to a controller via a handle that satisfies this interface. */
 class MoveItControllerHandle
 {
@@ -131,8 +134,7 @@ protected:
 
 };
 
-typedef boost::shared_ptr<MoveItControllerHandle> MoveItControllerHandlePtr;
-typedef boost::shared_ptr<const MoveItControllerHandle> MoveItControllerHandleConstPtr;
+MOVEIT_CLASS_FORWARD(MoveItControllerManager);
 
 /** @brief MoveIt! does not enforce how controllers are
     implemented. To make your controllers usable by MoveIt, this
@@ -190,9 +192,6 @@ public:
   /** \brief Activate and deactivate controllers */
   virtual bool switchControllers(const std::vector<std::string> &activate, const std::vector<std::string> &deactivate) = 0;
 };
-
-typedef boost::shared_ptr<MoveItControllerManager> MoveItControllerManagerPtr;
-typedef boost::shared_ptr<const MoveItControllerManager> MoveItControllerManagerConstPtr;
 
 }
 

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_DISTANCE_FIELD_DISTANCE_FIELD_H
 #define MOVEIT_DISTANCE_FIELD_DISTANCE_FIELD_H
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/macros/deprecation.h>
 #include <moveit/distance_field/voxel_grid.h>
 #include <vector>
@@ -65,6 +66,8 @@ enum PlaneVisualizationType
  XZPlane,
  YZPlane
 };
+
+MOVEIT_CLASS_FORWARD(DistanceField);
 
 /**
 * \brief DistanceField is an abstract base class for computing
@@ -640,9 +643,6 @@ protected:
   double resolution_;           /**< \brief Resolution of the distance field */
   int inv_twice_resolution_;    /**< \brief Computed value 1.0/(2.0*resolution_) */
 };
-
-typedef boost::shared_ptr<DistanceField> DistanceFieldPtr;
-typedef boost::shared_ptr<const DistanceField> DistanceFieldConstPtr;
 
 }  // namespace distance_field
 

--- a/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
+++ b/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
@@ -49,6 +49,8 @@
 namespace dynamics_solver
 {
 
+MOVEIT_CLASS_FORWARD(DynamicsSolver);
+
 /**
  * This solver currently computes the required torques given a
  * joint configuration, velocities, accelerations and external wrenches
@@ -156,8 +158,6 @@ private:
   double gravity_; //Norm of the gravity vector passed in initialize()
 
 };
-
-MOVEIT_CLASS_FORWARD(DynamicsSolver);
 
 }
 #endif

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -41,13 +41,13 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/transforms/transforms.h>
 #include <moveit/collision_detection/collision_world.h>
+#include <moveit/macros/class_forward.h>
 
 #include <geometric_shapes/bodies.h>
 #include <moveit_msgs/Constraints.h>
 
 #include <iostream>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 /** \brief Representation and evaluation of kinematic constraints */
 namespace kinematic_constraints
@@ -71,6 +71,8 @@ struct ConstraintEvaluationResult
   bool   satisfied;             /**< \brief Whether or not the constraint or constraints were satisfied */
   double distance;              /**< \brief The distance evaluation from the constraint or constraints */
 };
+
+MOVEIT_CLASS_FORWARD(KinematicConstraint);
 
 /// \brief Base class for representing a kinematic constraint
 class KinematicConstraint
@@ -173,8 +175,7 @@ protected:
   double                          constraint_weight_; /**< \brief The weight of a constraint is a multiplicative factor associated to the distance computed by the decide() function  */
 };
 
-typedef boost::shared_ptr<KinematicConstraint> KinematicConstraintPtr; /**< \brief boost::shared_ptr to a Kinematic Constraint */
-typedef boost::shared_ptr<const KinematicConstraint> KinematicConstraintConstPtr; /**< \brief boost::shared_ptr to a Const Kinematic Constraint */
+MOVEIT_CLASS_FORWARD(JointConstraint);
 
 /**
  * \brief Class for handling single DOF joint constraints.
@@ -327,6 +328,8 @@ protected:
   int                                                joint_variable_index_;  /**< \brief The index of the joint variable name in the full robot state */
   double                                             joint_position_, joint_tolerance_above_, joint_tolerance_below_; /**< \brief Position and tolerance values*/
 };
+
+MOVEIT_CLASS_FORWARD(OrientationConstraint);
 
 /**
  * \brief Class for constraints on the orientation of a link
@@ -484,6 +487,8 @@ protected:
   double                        absolute_x_axis_tolerance_, absolute_y_axis_tolerance_, absolute_z_axis_tolerance_; /**< \brief Storage for the tolerances */
 };
 
+
+MOVEIT_CLASS_FORWARD(PositionConstraint);
 
 /**
  * \brief Class for constraints on the XYZ position of a link
@@ -649,6 +654,8 @@ protected:
   std::string                                       constraint_frame_id_; /**< \brief The constraint frame id */
   const robot_model::LinkModel *link_model_; /**< \brief The link model constraint subject */
 };
+
+MOVEIT_CLASS_FORWARD(VisibilityConstraint);
 
 /**
  * \brief Class for constraints on the visibility relationship between
@@ -846,6 +853,8 @@ protected:
   double                                 max_view_angle_; /**< \brief Storage for the max view angle */
   double                                 max_range_angle_; /**< \brief Storage for the max range angle */
 };
+
+MOVEIT_CLASS_FORWARD(KinematicConstraintSet);
 
 /**
  * \brief A class that contains many different constraints, and can
@@ -1063,9 +1072,6 @@ protected:
   moveit_msgs::Constraints                        all_constraints_; /**<  \brief Messages corresponding to all internal constraints */
 
 };
-
-typedef boost::shared_ptr<KinematicConstraintSet> KinematicConstraintSetPtr; /**< \brief boost::shared_ptr to a KinematicConstraintSetPtr */
-typedef boost::shared_ptr<const KinematicConstraintSet> KinematicConstraintSetConstPtr; /**< \brief boost::shared_ptr to a KinematicConstraintSet Const */
 
 }
 

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -39,6 +39,7 @@
 
 #include <geometry_msgs/PoseStamped.h>
 #include <moveit_msgs/MoveItErrorCodes.h>
+#include <moveit/macros/class_forward.h>
 #include <boost/function.hpp>
 #include <console_bridge/console.h>
 #include <string>
@@ -131,6 +132,8 @@ struct KinematicsResult
 	double solution_percentage;             /**< The percentage of solutions achieved over the total number
 	                                             of solutions explored. */
 };
+
+MOVEIT_CLASS_FORWARD(KinematicsBase);
 
 /**
  * @class KinematicsBase
@@ -632,9 +635,6 @@ private:
 
   std::string removeSlash(const std::string &str) const;
 };
-
-typedef boost::shared_ptr<KinematicsBase> KinematicsBasePtr;
-typedef boost::shared_ptr<const KinematicsBase> KinematicsBaseConstPtr;
 
 };
 

--- a/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
+++ b/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
@@ -44,6 +44,8 @@
 namespace kinematics_metrics
 {
 
+MOVEIT_CLASS_FORWARD(KinematicsMetrics);
+
 /**
  * \brief Compute different kinds of metrics for kinematics evaluation. Currently includes
  * manipulability.
@@ -167,8 +169,6 @@ private:
   double penalty_multiplier_;
 
 };
-
-MOVEIT_CLASS_FORWARD(KinematicsMetrics);
 
 }
 

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -73,6 +73,8 @@ struct PlannerConfigurationSettings
 typedef std::map<std::string, PlannerConfigurationSettings> PlannerConfigurationMap;
 
 
+MOVEIT_CLASS_FORWARD(PlanningContext);
+
 /** \brief Representation of a particular planning context -- the planning scene and the request are known,
     solution is not yet computed. */
 class PlanningContext
@@ -141,7 +143,7 @@ protected:
   MotionPlanRequest request_;
 };
 
-MOVEIT_CLASS_FORWARD(PlanningContext);
+MOVEIT_CLASS_FORWARD(PlannerManager);
 
 /** \brief Base class for a MoveIt planner */
 class PlannerManager
@@ -204,8 +206,6 @@ protected:
       form "group_name" if default settings are to be used. */
   PlannerConfigurationMap config_settings_;
 };
-
-MOVEIT_CLASS_FORWARD(PlannerManager);
 
 } // planning_interface
 

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_PLANNING_REQUEST_ADAPTER_PLANNING_REQUEST_ADAPTER_
 #define MOVEIT_PLANNING_REQUEST_ADAPTER_PLANNING_REQUEST_ADAPTER_
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/function.hpp>
@@ -44,6 +45,8 @@
 /** \brief Generic interface to adapting motion planning requests */
 namespace planning_request_adapter
 {
+
+MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);
 
 class PlanningRequestAdapter
 {
@@ -86,9 +89,6 @@ public:
                             std::vector<std::size_t> &added_path_index) const = 0;
 
 };
-
-typedef boost::shared_ptr<PlanningRequestAdapter> PlanningRequestAdapterPtr;
-typedef boost::shared_ptr<const PlanningRequestAdapter> PlanningRequestAdapterConstPtr;
 
 /// Apply a sequence of adapters to a motion plan
 class PlanningRequestAdapterChain

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -45,6 +45,7 @@
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
+#include <moveit/macros/class_forward.h>
 #include <moveit/macros/deprecation.h>
 #include <moveit_msgs/PlanningScene.h>
 #include <moveit_msgs/RobotTrajectory.h>
@@ -60,9 +61,7 @@
 namespace planning_scene
 {
 
-class PlanningScene;
-typedef boost::shared_ptr<PlanningScene> PlanningScenePtr;
-typedef boost::shared_ptr<const PlanningScene> PlanningSceneConstPtr;
+MOVEIT_CLASS_FORWARD(PlanningScene);
 
 /** \brief This is the function signature for additional feasibility checks to be imposed on states (in addition to respecting constraints and collision avoidance).
     The first argument is the state to check the feasibility for, the second one is whether the check should be verbose or not. */
@@ -892,9 +891,7 @@ private:
   void getPlanningSceneMsgOctomap(moveit_msgs::PlanningScene &scene) const;
   void getPlanningSceneMsgObjectColors(moveit_msgs::PlanningScene &scene_msg) const;
 
-  struct CollisionDetector;
-  typedef boost::shared_ptr<CollisionDetector> CollisionDetectorPtr;
-  typedef boost::shared_ptr<const CollisionDetector> CollisionDetectorConstPtr;
+  MOVEIT_CLASS_FORWARD(CollisionDetector);
 
   /* \brief A set of compatible collision detectors */
   struct CollisionDetector

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -62,6 +62,8 @@ namespace moveit
 namespace core
 {
 
+MOVEIT_CLASS_FORWARD(RobotModel);
+
 /** \brief Definition of a kinematic model. This class is not thread
     safe, however multiple instances can be created */
 class RobotModel
@@ -595,8 +597,6 @@ protected:
   /** \brief Given a geometry spec from the URDF and a filename (for a mesh), construct the corresponding shape object*/
   shapes::ShapePtr constructShape(const urdf::Geometry *geom);
 };
-
-MOVEIT_CLASS_FORWARD(RobotModel);
 
 }
 }

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -237,7 +237,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupInit)
 
 TEST_F(LoadPlanningModelsPr2, AssociatedFixedLinks)
 {
-  boost::shared_ptr<moveit::core::RobotModel> model(new moveit::core::RobotModel(urdf_model, srdf_model));
+  moveit::core::RobotModelPtr model(new moveit::core::RobotModel(urdf_model, srdf_model));
   EXPECT_TRUE(model->getLinkModel("r_gripper_palm_link")->getAssociatedFixedTransforms().size() > 1);
 }
 

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_ROBOT_TRAJECTORY_KINEMATIC_TRAJECTORY_
 #define MOVEIT_ROBOT_TRAJECTORY_KINEMATIC_TRAJECTORY_
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <moveit_msgs/RobotState.h>
@@ -44,6 +45,8 @@
 
 namespace robot_trajectory
 {
+
+MOVEIT_CLASS_FORWARD(RobotTrajectory);
 
 /** \brief Maintain a sequence of waypoints and the time durations
     between these waypoints */
@@ -238,9 +241,6 @@ private:
   std::deque<robot_state::RobotStatePtr> waypoints_;
   std::deque<double> duration_from_previous_;
 };
-
-typedef boost::shared_ptr<RobotTrajectory> RobotTrajectoryPtr;
-typedef boost::shared_ptr<const RobotTrajectory> RobotTrajectoryConstPtr;
 
 }
 

--- a/moveit_core/sensor_manager/include/moveit/sensor_manager/sensor_manager.h
+++ b/moveit_core/sensor_manager/include/moveit/sensor_manager/sensor_manager.h
@@ -39,7 +39,7 @@
 
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <moveit/macros/class_forward.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <geometry_msgs/PointStamped.h>
 
@@ -72,6 +72,8 @@ struct SensorInfo
   double y_angle;
 };
 
+MOVEIT_CLASS_FORWARD(MoveItSensorManager);
+
 class MoveItSensorManager
 {
 public:
@@ -99,9 +101,6 @@ public:
   virtual bool pointSensorTo(const std::string &name, const geometry_msgs::PointStamped &target, moveit_msgs::RobotTrajectory &sensor_trajectory) = 0;
 
 };
-
-typedef boost::shared_ptr<MoveItSensorManager> MoveItSensorManagerPtr;
-typedef boost::shared_ptr<const MoveItSensorManager> MoveItSensorManagerConstPtr;
 
 }
 

--- a/moveit_core/transforms/include/moveit/transforms/transforms.h
+++ b/moveit_core/transforms/include/moveit/transforms/transforms.h
@@ -40,7 +40,6 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/Pose.h>
 #include <Eigen/Geometry>
-#include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <moveit/macros/class_forward.h>
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -458,7 +458,7 @@ protected:
 
   typedef std::map<const robot_model::LinkModel*, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > > LinkShapeHandles;
   typedef std::map<const robot_state::AttachedBody*, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > > AttachedBodyShapeHandles;
-  typedef std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, Eigen::Affine3d*> > > CollisionBodyShapeHandles;
+  typedef std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, const Eigen::Affine3d*> > > CollisionBodyShapeHandles;
 
   LinkShapeHandles link_shape_handles_;
   AttachedBodyShapeHandles attached_body_shape_handles_;


### PR DESCRIPTION
* moveit_core: Use MOVEIT_CLASS_FORWARD for moveit classes.
* Move MOVEIT_CLASS_FORWARD before the class defintiions.
* Fix planning_scene_monitor for fixed ObjectConstPtr.

Cherry-picked from https://github.com/ros-planning/moveit/pull/70

Changes thanks to @de-vri-es 