### PR TITLE
Jade fix Docker shadow-fixed url

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -14,7 +14,7 @@ RUN wstool init . && \
     wstool update
 
 # Update apt-get because osrf image clears this cache. download deps
-RUN echo 'deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main' | tee --append /etc/apt/sources.list.d/ros-latest.list && \
+RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee --append /etc/apt/sources.list.d/ros-latest.list && \
     rosdep update && \
     apt-get -qq update && \
     apt-get -qq install -y \


### PR DESCRIPTION
The jade-source docker build is timing out: https://hub.docker.com/r/moveit/moveit/builds/bonv9hzxwkrwhgvxtapvtkh/

Not sure if this was the reason, but this is def a bug