### PR TITLE
Modified launch file templates to be able to connect to the warehouse

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse.launch
@@ -7,7 +7,7 @@
   <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse_settings.launch.xml" />
 
   <!-- Run the DB server -->
-  <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros">
+  <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">
     <param name="overwrite" value="false"/>
     <param name="database_path" value="$(arg moveit_warehouse_database_path)" />
   </node>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse_settings.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse_settings.launch.xml
@@ -11,5 +11,6 @@
   <param name="warehouse_port" value="$(arg moveit_warehouse_port)"/>
   <param name="warehouse_host" value="$(arg moveit_warehouse_host)"/>
   <param name="warehouse_exec" value="mongod" />
+  <param name="warehouse_plugin" value="warehouse_ros_mongo::MongoDatabaseConnection" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -20,6 +20,7 @@
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
+  <run_depend>warehouse_ros_mongo</run_depend>
   [OTHER_DEPENDENCIES]
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -20,7 +20,9 @@
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
-  <run_depend>warehouse_ros_mongo</run_depend>
+  
+  <!-- Commenting the warehouse_ros_mongo dependency until we have a clean release -->
+  <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
   [OTHER_DEPENDENCIES]
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -21,7 +21,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
   
-  <!-- Commenting the warehouse_ros_mongo dependency until we have a clean release -->
+  <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
   [OTHER_DEPENDENCIES]
 


### PR DESCRIPTION
as suggested in #75, this makes it possible to connect to the database as long as you have warehouse_ros and warehous_ros_mongo properly built.

tested in kinetic only but there's no reason it wouldn't work on jade.