### PR TITLE
[jade] Changelog 0.8.3

### DIFF
--- a/moveit/CHANGELOG.rst
+++ b/moveit/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package moveit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* [Jade] Unify package version numbers (see https://github.com/davetcoleman/moveit_merge/issues/9). (`#79 <https://github.com/ros-planning/moveit/issues/79>`_)
+* Add meta package moveit.
+* Contributors: Isaac I.Y. Saito

--- a/moveit_commander/CHANGELOG.rst
+++ b/moveit_commander/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_commander
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* 1st release after repository consolidation
+* [feat] Add retime_trajectory() to MoveGroupCommander `#29 <https://github.com/ros-planning/moveit_commander/pull/29>`_
+* [feat] Added set_max_velocity_scaling_factor function to move_group.py
+* Contributors: Dave Coleman, Michael Goerner, Robert Haschke
+
 0.6.1 (2016-04-28)
 ------------------
 * [feat] Add the possibility to choose description file `#43 <https://github.com/ros-planning/moveit_commander/issues/43>`_

--- a/moveit_core/CHANGELOG.rst
+++ b/moveit_core/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package moveit_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* 1st release after repository consolidation
+* [fix] Add object types when requesting attached bodies in planning scene msg. pushDiff also pushes attached bodies' types and colors
+* [improve] Cache robot FCL objects to avoid fcl::CollisionObject's being created every time a request is made `ros-planning/moveit_core#295 <https://github.com/ros-planning/moveit_core/pull/295>`_
+* [feat] Added maximum acceleration scaling factor `ros-planning/moveit_core#273 <https://github.com/ros-planning/moveit_core/pull/273>`_
+* Contributors: Levi Armstrong, Dave Coleman, Christian Dornhege, hemes, Michael Goerner, Robert Haschke, Maarten de Vries
+
 0.8.2 (2016-06-17)
 ------------------
 * [feat] planning_scene updates: expose success state to caller. This is required to get the information back for the ApplyPlanningSceneService. `#296 <https://github.com/ros-planning/moveit_core/issues/297>`_

--- a/moveit_planners/moveit_planners/CHANGELOG.rst
+++ b/moveit_planners/moveit_planners/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_planners
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* 1st release after repository consolidation
+* [feat] Enables setting optimization objectives from ompl_planning.yaml `ros-planning/moveit_planners#75 <https://github.com/ros-planning/moveit_planners/pull/75>`_
+* [doc] Short tutorial for using ompl optimization config. `ros-planning/moveit_planners#75 <https://github.com/ros-planning/moveit_planners/pull/75>`_
+* Contributors: Ruben Burger, Dave Coleman, Robert Haschke, Maarten de Vries
+
 0.7.0 (2016-01-30)
 ------------------
 

--- a/moveit_plugins/moveit_plugins/CHANGELOG.rst
+++ b/moveit_plugins/moveit_plugins/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package moveit_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* 1st release after repository consolidation
+* [fix] FakeController: publish all trajectory points in real time `ros-planning/moveit_plugins#21 <https://github.com/ros-planning/moveit_plugins/pull/21>`_
+* [fix] install plugin xml even if it's no functional controller `ros-planning/moveit_plugins#19 <https://github.com/ros-planning/moveit_plugins/pull/19>`_
+* [fix] Jade fix ROS Control API changes `ros-planning/moveit_plugins#15 <https://github.com/ros-planning/moveit_plugins/pull/15>`_
+* Contributors: Dave Coleman, Robert Haschke, Michael Goener, Maarten de Vries
+
 0.5.7 (2016-01-30)
 ------------------
 * added moveit_ros_control_interface to meta-package

--- a/moveit_ros/moveit_ros/CHANGELOG.rst
+++ b/moveit_ros/moveit_ros/CHANGELOG.rst
@@ -2,6 +2,26 @@
 Changelog for package moveit_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* 1st release after repository consolidation
+* [fix] Properly monitor trajectory execution `ros-planning/moveit#72 <https://github.com/ros-planning/moveit/pull/72>`_
+* [fix] trajectory service blocking callback queue `ros-planning/moveit_ros#717 <https://github.com/ros-planning/moveit_ros/pull/717>`_
+* [fix] Empty Robot Model `ros-planning/moveit#45 <https://github.com/ros-planning/moveit/pull/45>`_
+* [fix] Allow minimum value 0.0 for jump_factor `ros-planning/moveit_ros#727 <https://github.com/ros-planning/moveit_ros/pull/727>`_
+* [fix] joy: Clean installation `ros-planning/moveit_ros#704 <https://github.com/ros-planning/moveit_ros/pull/704>`_
+* [fix] Re-enable warehouse_ros `ros-planning/moveit_ros#699 <https://github.com/ros-planning/moveit_ros/pull/699>`_
+* [fix] MoveGroup class_loader::LibraryUnloadException on destruction `ros-planning/moveit_ros#706 <https://github.com/ros-planning/moveit_ros/pull/706>`_
+* [fix] planning_interface: Set is_diff true for empty start state `ros-planning/moveit_ros#688 <https://github.com/ros-planning/moveit_ros/pull/688>`_
+* [feat] add velocity & acceleration values to cartesian trajectory `ros-planning/moveit_ros#735 <https://github.com/ros-planning/moveit_ros/pull/735>`_
+* [feat] Added kinematics plugin that uses Levenberg-Marquardt method `ros-planning/moveit_ros#740 <https://github.com/ros-planning/moveit_ros/pull/740>`_
+* [feat] Add nodehandle for specific params `ros-planning/moveit_ros#707 <https://github.com/ros-planning/moveit_ros/pull/707>`_
+* [feat] Added support for nodes handles with specific callbacks queues `ros-planning/moveit_ros#701 <https://github.com/ros-planning/moveit_ros#701>`_
+* [feat] Extended planning_interface::PlanningSceneInterface `ros-planning/moveit_ros/issues/630 https://github.com/ros-planning/moveit_ros/issues/630>`_
+* [feat] add ApplyPlanningSceneService capability `ros-planning/moveit_ros#686 <https://github.com/ros-planning/moveit_ros/pull/686>`_
+* [improve] Improve fillGrasp method for pick("object_name") interface `ros-planning/moveit#31 <https://github.com/ros-planning/moveit/pull/31>`_
+* Contributors: anderwm, chengshy, Dave Coleman, Yannick Jonetzko, Robert Haschke, Michael Goener, Isaac I. Y. Saito, Alain Sanguinetti, Jorge Santos Simón, Maarten de Vries, Kentaro Wada
+
 0.6.6 (2016-06-08)
 ------------------
 * Removed trailing whitespace from entire repository

--- a/moveit_setup_assistant/CHANGELOG.rst
+++ b/moveit_setup_assistant/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_setup_assistant
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* 1st release after repository consolidation
+* [fix] msa: push traj exec monitor params down int proper nsroper ns `ros-planning/moveit#68 <https://github.com/ros-planning/moveit/pull/68>`_
+* [fix] write float numbers always in POSIX format `ros-planning/moveit_setup_assistant#123 <https://github.com/ros-planning/moveit_setup_assistant/pull/123>`_
+* Contributors: G.A. vd. Hoorn
+
 0.7.1 (2016-06-24)
 ------------------
 * [sys] Qt adjustment. 


### PR DESCRIPTION
Usually I don't think we need PR for changelog update, but I do so this time since this is the 1st one for consolidated repo and it's 100% hand-made. Although I'm not sure what I want to be reviewed, any comment is appreciated.

- [`catkin_generate_changelog` didn't work for this consolidated repo for its initial release](http://answers.ros.org/question/242004/catkin_generate_changelog-issue-with-a-repo-that-consolidated-multiple-repos/), so manually compiled all changelog files.
- Prefixed almost all logs for visibility. The following list is ordered below by importance IMO, and the actual entries are ordered in this way as well: 
 - `feat`: new feature
 - `fix`
 - `improve`: perfomance improvement
 - `doc`
 - `sys`: system change (e.g. Change for cmake, installation, CI etc.)
- Since the log gets larger esp. due to the repository consolidation, I've excluded system change this time.
- Hope these changelogs help to make a new release announcement ([discussed in maintainers' mtg](http://discourse.ros.org/t/maintainer-meeting-recap-july-26th/366)), although they will need to be summarized even more.

----

Less important for now, but something I noticed:

maybe a drawback of cherry-picking commits into other branches without PRs; Being able to track down from a commit to the PR is very helpful to better understand the background and etc. github automatically adds link to a PR for the included commits. However for the directly cherry-picked commits, it's not the case anymore. Actually in many commits either original commiters or maintainers nicely added links the PRs, which helped me a lot to track down.  (This may have been considered when we were discussing how to sync branches but I just reiterate for the record.)
