### PR TITLE
adaptions to testing code to match ros-planning/moveit_resources#7

### DIFF
--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -16,6 +16,9 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
   catkin_add_gtest(test_fcl_collision_detection test/test_fcl_collision_detection.cpp)
   target_link_libraries(test_fcl_collision_detection  ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
 endif()

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -68,9 +68,9 @@ protected:
       return;
     }
     boost::filesystem::path res_path(resource_dir);
-    std::string urdf_file = (res_path / "test/urdf/robot.xml").string();
-    std::string srdf_file = (res_path / "test/srdf/robot.xml").string();
-    kinect_dae_resource_ = "package://moveit_resources/test/urdf/meshes/sensors/kinect_v0/kinect.dae";
+    std::string urdf_file = (res_path / "pr2_description/urdf/robot.xml").string();
+    std::string srdf_file = (res_path / "pr2_description/srdf/robot.xml").string();
+    kinect_dae_resource_ = "package://moveit_resources/pr2_description/urdf/meshes/sensors/kinect_v0/kinect.dae";
 
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -38,10 +38,10 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/collision_detection_fcl/collision_world_fcl.h>
 #include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <moveit_resources/config.h>
 
 #include <urdf_parser/urdf_parser.h>
 #include <geometric_shapes/shape_operations.h>
-#include <ros/package.h>
 
 #include <gtest/gtest.h>
 #include <sstream>
@@ -61,13 +61,7 @@ protected:
 
   virtual void SetUp()
   {
-    std::string resource_dir = ros::package::getPath("moveit_resources");
-    if(resource_dir == "")
-    {
-      FAIL() << "Failed to find package moveit_resources.";
-      return;
-    }
-    boost::filesystem::path res_path(resource_dir);
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
     std::string urdf_file = (res_path / "pr2_description/urdf/robot.xml").string();
     std::string srdf_file = (res_path / "pr2_description/srdf/robot.xml").string();
     kinect_dae_resource_ = "package://moveit_resources/pr2_description/urdf/meshes/sensors/kinect_v0/kinect.dae";

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -26,8 +26,9 @@ if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl REQUIRED)
   find_package(angles REQUIRED)
   find_package(tf_conversions REQUIRED)
+  find_package(moveit_resources REQUIRED)
 
-  include_directories(${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf_conversions_INCLUDE_DIRS})
+  include_directories(${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf_conversions_INCLUDE_DIRS} ${moveit_resources_INCLUDE_DIRS})
 
   catkin_add_gtest(test_constraint_samplers
     test/test_constraint_samplers.cpp

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -85,7 +85,7 @@ protected:
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -97,7 +97,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (res_path / "test/srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
     kmodel.reset(new robot_model::RobotModel(urdf_model, srdf_model));
 
     pr2_kinematics_plugin_right_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -42,9 +42,9 @@
 #include <moveit/constraint_samplers/constraint_sampler_tools.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit/robot_state/conversions.h>
+#include <moveit_resources/config.h>
 
 #include <geometric_shapes/shape_operations.h>
-#include <ros/package.h>
 #include <visualization_msgs/MarkerArray.h>
 
 #include <gtest/gtest.h>
@@ -75,13 +75,7 @@ protected:
 
   virtual void SetUp()
   {
-    std::string resource_dir = ros::package::getPath("moveit_resources");
-    if(resource_dir == "")
-    {
-      FAIL() << "Failed to find package moveit_resources.";
-      return;
-    }
-    boost::filesystem::path res_path(resource_dir);
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -16,6 +16,9 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
   catkin_add_gtest(test_constraints test/test_constraints.cpp)
   target_link_libraries(test_constraints  ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -58,7 +58,7 @@ protected:
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -74,7 +74,7 @@ protected:
     {
       FAIL() << "Failed to find robot.xml";
     }
-    srdf_model->initFile(*urdf_model, (res_path / "test/srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
     kmodel.reset(new robot_model::RobotModel(urdf_model, srdf_model));
   };
 

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -40,7 +40,7 @@
 #include <fstream>
 #include <eigen_conversions/eigen_msg.h>
 #include <boost/filesystem/path.hpp>
-#include <ros/package.h>
+#include <moveit_resources/config.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -48,13 +48,7 @@ protected:
 
   virtual void SetUp()
   {
-    std::string resource_dir = ros::package::getPath("moveit_resources");
-    if(resource_dir == "")
-    {
-      FAIL() << "Failed to find package moveit_resources.";
-      return;
-    }
-    boost::filesystem::path res_path(resource_dir);
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -21,6 +21,9 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
   catkin_add_gtest(test_planning_scene test/test_planning_scene.cpp)
   target_link_libraries(test_planning_scene ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -54,7 +54,7 @@ void loadRobotModel(boost::shared_ptr<urdf::ModelInterface>& robot_model_out)
   boost::filesystem::path res_path(resource_dir);
 
   std::string xml_string;
-  std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
+  std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
   EXPECT_TRUE(xml_file.is_open());
   while ( xml_file.good() )
   {

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -39,19 +39,13 @@
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
 #include <boost/filesystem/path.hpp>
-#include <ros/package.h>
+#include <moveit_resources/config.h>
 
 // This function needs to return void so the gtest FAIL() macro inside
 // it works right.
 void loadRobotModel(boost::shared_ptr<urdf::ModelInterface>& robot_model_out)
 {
-  std::string resource_dir = ros::package::getPath("moveit_resources");
-  if(resource_dir == "")
-  {
-    FAIL() << "Failed to find package moveit_resources.";
-    return;
-  }
-  boost::filesystem::path res_path(resource_dir);
+  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
 
   std::string xml_string;
   std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(${MOVEIT_LIB_NAME} moveit_profiler moveit_exceptions movei
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
   catkin_add_gtest(test_robot_model test/test.cpp)
   target_link_libraries(test_robot_model ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -40,7 +40,7 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem/path.hpp>
 #include <moveit/profiler/profiler.h>
-#include <ros/package.h>
+#include <moveit_resources/config.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -48,15 +48,11 @@ protected:
 
   virtual void SetUp()
   {
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::string resource_dir = ros::package::getPath("moveit_resources");
-    if(resource_dir == "")
-    {
-      FAIL() << "Failed to find package moveit_resources.";
-      return;
-    }
-    std::fstream xml_file((boost::filesystem::path(resource_dir) / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -68,7 +64,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (boost::filesystem::path(resource_dir) / "pr2_description/srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
     robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   };
 

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -56,7 +56,7 @@ protected:
       FAIL() << "Failed to find package moveit_resources.";
       return;
     }
-    std::fstream xml_file((boost::filesystem::path(resource_dir) / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((boost::filesystem::path(resource_dir) / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -68,7 +68,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (boost::filesystem::path(resource_dir) / "test/srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (boost::filesystem::path(resource_dir) / "pr2_description/srdf/robot.xml").string());
     robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   };
 

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -17,6 +17,9 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 # Unit tests
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
   catkin_add_gtest(test_robot_state test/test_kinematic.cpp)
   target_link_libraries(test_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -60,7 +60,7 @@ protected:
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -72,7 +72,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (res_path / "test/srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
     robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   };
 

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -42,7 +42,7 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem/path.hpp>
 #include <moveit/profiler/profiler.h>
-#include <ros/package.h>
+#include <moveit_resources/config.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -50,13 +50,7 @@ protected:
 
   virtual void SetUp()
   {
-    std::string resource_dir = ros::package::getPath("moveit_resources");
-    if(resource_dir == "")
-    {
-      FAIL() << "Failed to find package moveit_resources.";
-      return;
-    }
-    boost::filesystem::path res_path(resource_dir);
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_core/robot_state/test/test_transforms.cpp
+++ b/moveit_core/robot_state/test/test_transforms.cpp
@@ -50,7 +50,7 @@ protected:
     srdf_model_.reset(new srdf::Model());
 
     std::string xml_string;
-    std::fstream xml_file("test/urdf/robot.xml", std::fstream::in);
+    std::fstream xml_file("pr2_description/urdf/robot.xml", std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -65,7 +65,7 @@ protected:
     }
     else
       urdf_ok_ = false;
-    srdf_ok_ = srdf_model_->initFile(*urdf_model_, "test/srdf/robot.xml");
+    srdf_ok_ = srdf_model_->initFile(*urdf_model_, "pr2_description/srdf/robot.xml");
   };
 
   virtual void TearDown()

--- a/moveit_experimental/collision_distance_field/CMakeLists.txt
+++ b/moveit_experimental/collision_distance_field/CMakeLists.txt
@@ -17,5 +17,10 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/
   DESTINATION include)
 
-catkin_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp)
-target_link_libraries(test_collision_distance_field  ${MOVEIT_LIB_NAME})
+if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
+  catkin_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp)
+  target_link_libraries(test_collision_distance_field  ${MOVEIT_LIB_NAME})
+endif()

--- a/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
@@ -40,6 +40,7 @@
 #include <moveit/collision_distance_field/collision_distance_field_types.h>
 #include <moveit/collision_distance_field/collision_robot_distance_field.h>
 #include <moveit/collision_distance_field/collision_world_distance_field.h>
+#include <moveit_resources/config.h>
 
 #include <geometric_shapes/shape_operations.h>
 #include <urdf_parser/urdf_parser.h>
@@ -62,7 +63,7 @@ protected:
   {
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file("../../../src/moveit_resources/pr2_description/urdf/robot.xml", std::fstream::in);
+    std::fstream xml_file(MOVEIT_TEST_RESOURCES_DIR "/pr2_description/urdf/robot.xml", std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -77,7 +78,7 @@ protected:
     }
     else
       urdf_ok_ = false;
-    srdf_ok_ = srdf_model_->initFile(*urdf_model_, "../../../src/moveit_resources/pr2_description/srdf/robot.xml");
+    srdf_ok_ = srdf_model_->initFile(*urdf_model_, MOVEIT_TEST_RESOURCES_DIR "/pr2_description/srdf/robot.xml");
 
     kmodel_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
 

--- a/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
@@ -62,7 +62,7 @@ protected:
   {
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file("../../../src/moveit_resources/test/urdf/robot.xml", std::fstream::in);
+    std::fstream xml_file("../../../src/moveit_resources/pr2_description/urdf/robot.xml", std::fstream::in);
     if (xml_file.is_open())
     {
       while ( xml_file.good() )
@@ -77,7 +77,7 @@ protected:
     }
     else
       urdf_ok_ = false;
-    srdf_ok_ = srdf_model_->initFile(*urdf_model_, "../../../src/moveit_resources/test/srdf/robot.xml");
+    srdf_ok_ = srdf_model_->initFile(*urdf_model_, "../../../src/moveit_resources/pr2_description/srdf/robot.xml");
 
     kmodel_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
 

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -27,10 +27,6 @@ target_link_libraries(${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} $
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
-catkin_add_gtest(test_state_space test/test_state_space.cpp)
-target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
-
 add_executable(moveit_ompl_planner src/ompl_planner.cpp)
 target_link_libraries(moveit_ompl_planner ${MOVEIT_LIB_NAME})
 set_target_properties(moveit_ompl_planner PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
@@ -46,3 +42,12 @@ install(TARGETS ${MOVEIT_LIB_NAME} moveit_ompl_planner moveit_ompl_planner_plugi
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
+  catkin_add_gtest(test_state_space test/test_state_space.cpp)
+  target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+  set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+endif()

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
 #include <moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h>
+#include <moveit_resources/config.h>
 
 #include <urdf_parser/urdf_parser.h>
 
@@ -44,7 +45,6 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include <boost/filesystem/path.hpp>
-#include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -52,13 +52,7 @@ protected:
 
   virtual void SetUp()
   {
-    std::string resource_dir = ros::package::getPath("moveit_resources");
-    if(resource_dir == "")
-    {
-      FAIL() << "Failed to find package moveit_resources.";
-      return;
-    }
-    boost::filesystem::path res_path(resource_dir);
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
 
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -62,7 +62,7 @@ protected:
 
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((res_path / "test/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -74,7 +74,7 @@ protected:
       xml_file.close();
       urdf_model_ = urdf::parseURDF(xml_string);
     }
-    srdf_model_->initFile(*urdf_model_, (res_path / "test/srdf/robot.xml").string());
+    srdf_model_->initFile(*urdf_model_, (res_path / "pr2_description/srdf/robot.xml").string());
     robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_model_));
   };
 

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -31,6 +31,8 @@
   <run_depend>tf</run_depend>
   <run_depend>pluginlib</run_depend>
 
+  <test_depend>moveit_resources</test_depend>
+
   <export>
     <moveit_core plugin="${prefix}/ompl_interface_plugin_description.xml"/>
   </export>


### PR DESCRIPTION
Depending on https://github.com/ros-planning/moveit_resources/pull/7 this is the second part of https://github.com/ros-planning/moveit/issues/17

- adapting source to match the renaming of test -> pr2_descriptionn in https://github.com/ros-planning/moveit_resources/pull/7

UPDATE: The integration tests will be filed as a separate PR. They should be disabled for now anyway, because they are blocked by:
    - [`pyassimp` failure in `kinetic`](https://travis-ci.org/ros-planning/moveit/builds/153589357): **That's a `moveit_commander` regression!**
    - cleanup.test: https://github.com/ros/ros_comm/pull/871
    - validate_traj.test: https://github.com/ros-planning/moveit/pull/63
    - robot_state_update.test: https://github.com/rhaschke/moveit/pull/1
