### PR TITLE
[changelog] Bad encoding.

### DIFF
--- a/moveit_core/CHANGELOG.rst
+++ b/moveit_core/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog for package moveit_core
 ------------------
 * [feat] planning_scene updates: expose success state to caller. This is required to get the information back for the ApplyPlanningSceneService. `#296 <https://github.com/ros-planning/moveit_core/issues/297>`_
 * [sys] replaced cmake_modules dependency with eigen
-* Contributors: Michael Ferguson, Robert Haschke, Michael G���rner, Isaac I. Y. Saito
+* Contributors: Michael Ferguson, Robert Haschke, Michael Goerner, Isaac I. Y. Saito
 
 0.8.1 (2016-05-19)
 ------------------


### PR DESCRIPTION
Sorry for the noise. Re-re-opening #88 with a different branch name.