### PR TITLE
add missing cmake dependency

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/apply_planning_scene_service_capability.cpp
   src/default_capabilities/clear_octomap_service_capability.cpp
   )
-
+add_dependencies(moveit_move_group_default_capabilities ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(moveit_move_group_capabilities_base ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(move_group moveit_move_group_capabilities_base ${catkin_LIBRARIES} ${Boost_LIBRARIES})


### PR DESCRIPTION
The capabilities include the message headers and therefore have to depend on them.

As reported in https://github.com/ros-planning/moveit/issues/92#issuecomment-241196766
we missed this dependency. Thanks to @jettan for the report!

Please cherry-pick to jade and kinetic