### PR TITLE
Reopen #85: Add capability to execute trajectory with a ROS action

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(list_move_group_capabilities src/list_capabilities.cpp)
 
 add_library(moveit_move_group_default_capabilities
   src/default_capabilities/move_action_capability.cpp
+  src/default_capabilities/execute_trajectory_action_capability.cpp
   src/default_capabilities/plan_service_capability.cpp
   src/default_capabilities/execute_service_capability.cpp
   src/default_capabilities/query_planners_service_capability.cpp

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -49,9 +49,9 @@ add_executable(list_move_group_capabilities src/list_capabilities.cpp)
 
 add_library(moveit_move_group_default_capabilities
   src/default_capabilities/move_action_capability.cpp
-  src/default_capabilities/execute_trajectory_action_capability.cpp
   src/default_capabilities/plan_service_capability.cpp
-  src/default_capabilities/execute_service_capability.cpp
+  src/default_capabilities/execute_trajectory_service_capability.cpp
+  src/default_capabilities/execute_trajectory_action_capability.cpp
   src/default_capabilities/query_planners_service_capability.cpp
   src/default_capabilities/kinematics_service_capability.cpp
   src/default_capabilities/state_validation_service_capability.cpp

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -12,6 +12,12 @@
     </description>
   </class>
 
+  <class name="move_group/MoveGroupExecuteTrajectoryAction" type="move_group::MoveGroupExecuteTrajectoryAction" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      Allow execution of previously computed trajectories via a ROS action
+    </description>
+  </class>
+
   <class name="move_group/MoveGroupKinematicsService" type="move_group::MoveGroupKinematicsService" base_class_type="move_group::MoveGroupCapability">
     <description>
       Compute forward and inverse kinematics via ROS services

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -44,6 +44,7 @@ namespace move_group
 
 static const std::string PLANNER_SERVICE_NAME = "plan_kinematic_path";    // name of the advertised service (within the ~ namespace)
 static const std::string EXECUTE_SERVICE_NAME = "execute_kinematic_path"; // name of the advertised service (within the ~ namespace)
+static const std::string EXECUTE_ACTION = "execute_trajectory"; // name of 'execute' action
 static const std::string QUERY_PLANNERS_SERVICE_NAME = "query_planner_interface"; // name of the advertised query planners service
 static const std::string GET_PLANNER_PARAMS_SERVICE_NAME = "get_planner_params"; // service name to retrieve planner parameters
 static const std::string SET_PLANNER_PARAMS_SERVICE_NAME  = "set_planner_params"; // service name to set planner parameters

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -44,7 +44,7 @@ namespace move_group
 
 static const std::string PLANNER_SERVICE_NAME = "plan_kinematic_path";    // name of the advertised service (within the ~ namespace)
 static const std::string EXECUTE_SERVICE_NAME = "execute_kinematic_path"; // name of the advertised service (within the ~ namespace)
-static const std::string EXECUTE_ACTION = "execute_trajectory"; // name of 'execute' action
+static const std::string EXECUTE_ACTION_NAME = "execute_trajectory"; // name of 'execute' action
 static const std::string QUERY_PLANNERS_SERVICE_NAME = "query_planner_interface"; // name of the advertised query planners service
 static const std::string GET_PLANNER_PARAMS_SERVICE_NAME = "get_planner_params"; // service name to retrieve planner parameters
 static const std::string SET_PLANNER_PARAMS_SERVICE_NAME  = "set_planner_params"; // service name to set planner parameters

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -52,7 +52,7 @@ void MoveGroupExecuteTrajectoryAction::initialize()
 {
   // start the move action server
   execute_action_server_.reset(new actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction>
-                               (root_node_handle_, EXECUTE_ACTION,
+                               (root_node_handle_, EXECUTE_ACTION_NAME,
                                 boost::bind(&MoveGroupExecuteTrajectoryAction::executePathCallback, this, _1), false));
   execute_action_server_->registerPreemptCallback(
     boost::bind(&MoveGroupExecuteTrajectoryAction::preemptExecuteTrajectoryCallback, this));

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -1,0 +1,143 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Kentaro Wada.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Kentaro Wada */
+
+#include "execute_trajectory_action_capability.h"
+
+#include <moveit/plan_execution/plan_execution.h>
+#include <moveit/trajectory_processing/trajectory_tools.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/move_group/capability_names.h>
+
+namespace move_group {
+
+MoveGroupExecuteTrajectoryAction::MoveGroupExecuteTrajectoryAction() :
+  MoveGroupCapability("ExecuteTrajectoryAction")
+{
+}
+
+void MoveGroupExecuteTrajectoryAction::initialize()
+{
+  // start the move action server
+  execute_action_server_.reset(new actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction>
+                               (root_node_handle_, EXECUTE_ACTION,
+                                boost::bind(&MoveGroupExecuteTrajectoryAction::executePathCallback, this, _1), false));
+  execute_action_server_->registerPreemptCallback(
+    boost::bind(&MoveGroupExecuteTrajectoryAction::preemptExecuteTrajectoryCallback, this));
+  execute_action_server_->start();
+}
+
+void MoveGroupExecuteTrajectoryAction::executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal)
+{
+  moveit_msgs::ExecuteTrajectoryResult action_res;
+  if (!context_->trajectory_execution_manager_)
+  {
+    std::string response = "Cannot execute trajectory since ~allow_trajectory_execution was set to false";
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+    execute_action_server_->setAborted(action_res, response);
+    return;
+  }
+
+  executePathCallback_Execute(goal, action_res);
+
+  std::string response = getActionResultString(action_res.error_code, false, false);
+  if (action_res.error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+  {
+    execute_action_server_->setSucceeded(action_res, response);
+  }
+  else if (action_res.error_code.val == moveit_msgs::MoveItErrorCodes::PREEMPTED)
+  {
+    execute_action_server_->setPreempted(action_res, response);
+  }
+  else
+  {
+    execute_action_server_->setAborted(action_res, response);
+  }
+
+  setExecuteTrajectoryState(IDLE);
+}
+
+void MoveGroupExecuteTrajectoryAction::executePathCallback_Execute(
+  const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
+  moveit_msgs::ExecuteTrajectoryResult &action_res)
+{
+  ROS_INFO_NAMED("move_group", "Execution request received for ExecuteTrajectory action.");
+
+  context_->trajectory_execution_manager_->clear();
+  if (context_->trajectory_execution_manager_->push(goal->trajectory))
+  {
+    setExecuteTrajectoryState(MONITOR);
+    context_->trajectory_execution_manager_->execute();
+    moveit_controller_manager::ExecutionStatus es = context_->trajectory_execution_manager_->waitForExecution();
+    if (es == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
+    {
+      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+    }
+    else if (es == moveit_controller_manager::ExecutionStatus::PREEMPTED)
+    {
+      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
+    }
+    else if (es == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
+    {
+      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
+    }
+    else
+    {
+      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+    }
+    ROS_INFO_STREAM_NAMED("move_group", "Execution completed: " << es.asString());
+  }
+  else
+  {
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+  }
+}
+
+void MoveGroupExecuteTrajectoryAction::preemptExecuteTrajectoryCallback()
+{
+  context_->trajectory_execution_manager_->stopExecution(true);
+}
+
+void MoveGroupExecuteTrajectoryAction::setExecuteTrajectoryState(MoveGroupState state)
+{
+  moveit_msgs::ExecuteTrajectoryFeedback execute_feedback;
+  execute_feedback.state = stateToStr(state);
+  execute_action_server_->publishFeedback(execute_feedback);
+}
+
+}  // namespace move_group
+
+#include <class_loader/class_loader.h>
+CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupExecuteTrajectoryAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -1,0 +1,75 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Kentaro Wada.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Capability of execute trajectory with a ROS action.
+ * In order to allow monitoring and stopping the execution,
+ * the service should be turned into an action.
+ *
+ * Author: Kentaro Wada
+ * */
+
+#ifndef MOVEIT_MOVE_GROUP_EXECUTE_TRAJECTORY_ACTION_CAPABILITY_
+#define MOVEIT_MOVE_GROUP_EXECUTE_TRAJECTORY_ACTION_CAPABILITY_
+
+#include <moveit/move_group/move_group_capability.h>
+#include <actionlib/server/simple_action_server.h>
+#include <moveit_msgs/ExecuteTrajectoryAction.h>
+
+namespace move_group
+{
+
+class MoveGroupExecuteTrajectoryAction : public MoveGroupCapability
+{
+public:
+
+  MoveGroupExecuteTrajectoryAction();
+
+  virtual void initialize();
+
+private:
+
+  void executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal);
+  void executePathCallback_Execute(
+    const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
+    moveit_msgs::ExecuteTrajectoryResult &action_res);
+  void preemptExecuteTrajectoryCallback();
+  void setExecuteTrajectoryState(MoveGroupState state);
+
+  boost::scoped_ptr<actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction> > execute_action_server_;
+};
+
+}  // namespace move_group
+
+#endif  // MOVEIT_MOVE_GROUP_EXECUTE_TRAJECTORY_ACTION_CAPABILITY_

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
@@ -34,12 +34,12 @@
 
 /* Author: Ioan Sucan */
 
-#include "execute_service_capability.h"
+#include "execute_trajectory_service_capability.h"
 #include <moveit/trajectory_execution_manager/trajectory_execution_manager.h>
 #include <moveit/move_group/capability_names.h>
 
 move_group::MoveGroupExecuteService::MoveGroupExecuteService():
-  MoveGroupCapability("ExecutePathService"),
+  MoveGroupCapability("ExecuteTrajectoryService"),
   callback_queue_(),
   spinner_(1 /* spinner threads */, &callback_queue_)
 {

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.h
@@ -34,8 +34,8 @@
 
 /* Author: Ioan Sucan */
 
-#ifndef MOVEIT_MOVE_GROUP_EXECUTE_SERVICE_CAPABILITY_
-#define MOVEIT_MOVE_GROUP_EXECUTE_SERVICE_CAPABILITY_
+#ifndef MOVEIT_MOVE_GROUP_EXECUTE_TRAJECTORY_SERVICE_CAPABILITY_
+#define MOVEIT_MOVE_GROUP_EXECUTE_TRAJECTORY_SERVICE_CAPABILITY_
 
 #include <moveit/move_group/move_group_capability.h>
 #include <moveit_msgs/ExecuteKnownTrajectory.h>

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -38,6 +38,7 @@
 #ifndef MOVEIT_MOVE_GROUP_INTERFACE_MOVE_GROUP_
 #define MOVEIT_MOVE_GROUP_INTERFACE_MOVE_GROUP_
 
+#include <moveit/macros/deprecation.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <moveit_msgs/RobotState.h>
@@ -120,7 +121,7 @@ public:
     */
   MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
             const ros::WallDuration &wait_for_servers = ros::WallDuration());
-  ROS_DEPRECATED MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
+  MOVEIT_DEPRECATED MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
                            const ros::Duration &wait_for_servers = ros::Duration());
 
   /**
@@ -131,7 +132,7 @@ public:
     */
   MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
             const ros::WallDuration &wait_for_servers = ros::WallDuration());
-  ROS_DEPRECATED MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
+  MOVEIT_DEPRECATED MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
                            const ros::Duration &wait_for_servers = ros::Duration());
 
   ~MoveGroup();

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -116,18 +116,23 @@ public:
       \param opt. A MoveGroup::Options structure, if you pass a ros::NodeHandle with a specific callback queue, it has to be of type ros::CallbackQueue
         (which is the default type of callback queues used in ROS)
       \param tf. Specify a TF instance to use. If not specified, one will be constructed internally.
-      \param wait_for_server. Optional timeout for connecting to the action server. If it is not specified, the wait time is unlimited.
+      \param wait_for_servers. Timeout for connecting to action servers. Zero time means unlimited waiting.
     */
   MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
-            const ros::Duration &wait_for_server = ros::Duration(0, 0));
+            const ros::WallDuration &wait_for_servers = ros::WallDuration());
+  ROS_DEPRECATED MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
+                           const ros::Duration &wait_for_servers = ros::Duration());
 
   /**
-      \brief Construct a client for the MoveGroup action for a particular \e group. Optionally, specify a TF instance to use.
-      If not specified, one will be constructed internally. A timeout for connecting to the action server can also be specified. If it is not specified,
-      the wait time is unlimited.
-   */
+      \brief Construct a client for the MoveGroup action for a particular \e group.
+
+      \param tf. Specify a TF instance to use. If not specified, one will be constructed internally.
+      \param wait_for_servers. Timeout for connecting to action servers. Zero time means unlimited waiting.
+    */
   MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
-            const ros::Duration &wait_for_server = ros::Duration(0, 0));
+            const ros::WallDuration &wait_for_servers = ros::WallDuration());
+  ROS_DEPRECATED MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
+                           const ros::Duration &wait_for_servers = ros::Duration());
 
   ~MoveGroup();
 

--- a/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
-  moveit::planning_interface::MoveGroup group(argc > 1 ? argv[1] : "right_arm");
+  moveit::planning_interface::MoveGroup group(argc > 1 ? argv[1] : "right_arm", boost::shared_ptr<tf::Transformer>(), ros::WallDuration());
   demoPlace(group);
 
   sleep(2);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -176,7 +176,7 @@ public:
     {
       while (node_handle_.ok() && !action->isServerConnected())
       {
-        ros::WallDuration(0.1).sleep();
+        ros::WallDuration(0.001).sleep();
         // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
         ( ( ros::CallbackQueue * ) node_handle_.getCallbackQueue())->callAvailable();
       }
@@ -185,7 +185,7 @@ public:
     {
       while (node_handle_.ok() && !action->isServerConnected() && timeout > ros::WallTime::now())
       {
-        ros::WallDuration(0.01).sleep();
+        ros::WallDuration(0.001).sleep();
         // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
         ( ( ros::CallbackQueue * ) node_handle_.getCallbackQueue())->callAvailable();
       }
@@ -212,7 +212,7 @@ public:
            !execute_service_.exists() &&
            timeout_for_servers > ros::WallTime::now())
     {
-      ros::WallDuration(0.1).sleep();
+      ros::WallDuration(0.001).sleep();
       // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
       ( ( ros::CallbackQueue * ) node_handle_.getCallbackQueue())->callAvailable();
     }

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -65,7 +65,7 @@ public:
   // ROSInitializer is constructed first, and ensures ros::init() was called, if needed
   MoveGroupWrapper(const std::string &group_name, const std::string &robot_description) :
     py_bindings_tools::ROScppInitializer(),
-    MoveGroup(Options(group_name, robot_description), boost::shared_ptr<tf::Transformer>(), ros::Duration(5, 0))
+    MoveGroup(Options(group_name, robot_description), boost::shared_ptr<tf::Transformer>(), ros::WallDuration(5, 0))
   {
   }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -288,7 +288,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     opt.node_handle_ = ros::NodeHandle(planning_display_->getMoveGroupNS());
     try
     {
-      move_group_.reset(new moveit::planning_interface::MoveGroup(opt, context_->getFrameManager()->getTFClientPtr(), ros::Duration(30, 0)));
+      move_group_.reset(new moveit::planning_interface::MoveGroup(opt, context_->getFrameManager()->getTFClientPtr(), ros::WallDuration(30, 0)));
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -51,6 +51,7 @@
 				      move_group/MoveGroupExecuteService
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupPickPlaceAction
 				      move_group/MoveGroupPlanService
 				      move_group/MoveGroupQueryPlannersService

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -48,10 +48,9 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
-				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupPickPlaceAction
 				      move_group/MoveGroupPlanService
 				      move_group/MoveGroupQueryPlannersService


### PR DESCRIPTION
This reopens #85/#60 against kinetic. As proposed in https://github.com/ros-planning/moveit_msgs/pull/27#issuecomment-241198797, I suggest to drop that new feature for Indigo, because we require user intervention to switch `moveit_config`'s launch files to the new capability.

Additional to @wkentaro great work (from #85), I cleaned up the waiting for required action servers and services to allow to issue the deprecation warning once on startup.