### PR TITLE
Revert API change due to corrected ObjectConstPtr typedef.

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -71,7 +71,9 @@ namespace collision_detection
     /* Collision Bodies                                                   */
     /**********************************************************************/
 
-    MOVEIT_CLASS_FORWARD(Object);
+    struct Object;
+    typedef boost::shared_ptr<Object> ObjectPtr;
+    typedef boost::shared_ptr<Object> ObjectConstPtr;
 
     /** \brief A representation of an object */
     struct Object
@@ -109,7 +111,7 @@ namespace collision_detection
     ObjectConstPtr getObject(const std::string &id) const;
 
     /** iterator over the objects in the world. */
-    typedef std::map<std::string, ObjectPtr>::const_iterator const_iterator;
+    typedef std::map<std::string, ObjectConstPtr>::const_iterator const_iterator;
     /** iterator pointing to first change */
     const_iterator begin() const
     {

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -453,7 +453,7 @@ protected:
 
   typedef std::map<const robot_model::LinkModel*, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > > LinkShapeHandles;
   typedef std::map<const robot_state::AttachedBody*, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > > AttachedBodyShapeHandles;
-  typedef std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, const Eigen::Affine3d*> > > CollisionBodyShapeHandles;
+  typedef std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, Eigen::Affine3d*> > > CollisionBodyShapeHandles;
 
   LinkShapeHandles link_shape_handles_;
   AttachedBodyShapeHandles attached_body_shape_handles_;


### PR DESCRIPTION
In #77 (cherry-picked from #70) a typedef for `ObjectConstPtr` was fixed to actually be a pointer-to-const, but it appears in the public API in a number of places. To avoid API breakage within indigo, this PR reverts the specific changes that touch the API. See also #98.

Note: This should not be cherry-picked to Jade or Kinetic.

