### PR TITLE
[indigo] Reduce explicit mention of boost::shared_ptr in moveit_planners and moveit_experimental

### DIFF
--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2016, Delft Robotics B.V.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
@@ -32,27 +32,24 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+#ifndef MOVEIT_MACROS_DECLARE_PTR_
+#define MOVEIT_MACROS_DECLARE_PTR_
 
-#ifndef MOVEIT_MACROS_CLASS_FORWARD_
-#define MOVEIT_MACROS_CLASS_FORWARD_
-
-#include <moveit/macros/declare_ptr.h>
+#include <boost/shared_ptr.hpp>
 
 /**
- * \def MOVEIT_CLASS_FORWARD
- * Macro that forward declares a class and defines two shared ptrs types:
- *  - ${Class}Ptr      = shared_ptr<${Class}>
- *  - ${Class}ConstPtr = shared_ptr<const ${Class}>
+ * \def MOVEIT_DELCARE_PTR
+ * Macro that given a Name and a Type declares the following types:
+ * - ${Name}Ptr      = shared_ptr<${Type}>
+ * - ${Name}ConstPtr = shared_ptr<const ${Type}>
+ *
+ * For best portability the exact type of shared_ptr declared by the macro
+ * should be considered to be an implementation detail, liable to change in
+ * future releases.
  */
 
-#define MOVEIT_CLASS_FORWARD(C) class C; MOVEIT_DECLARE_PTR(C, C);
-
-/**
- * \def MOVEIT_STRUCT_FORWARD
- * Like MOVEIT_CLASS_FORWARD, but forward declares the type as a struct
- * instead of a class.
- */
-#define MOVEIT_STRUCT_FORWARD(C) struct C; MOVEIT_DECLARE_PTR(C, C);
+#define MOVEIT_DECLARE_PTR(Name, Type)                \
+  typedef boost::shared_ptr<Type> Name##Ptr;          \
+  typedef boost::shared_ptr<const Type> Name##ConstPtr;
 
 #endif

--- a/moveit_planners/ompl/ompl_interface/cfg/cpp/ompl_interface_ros/OMPLDynamicReconfigureConfig.h
+++ b/moveit_planners/ompl/ompl_interface/cfg/cpp/ompl_interface_ros/OMPLDynamicReconfigureConfig.h
@@ -51,6 +51,7 @@
 #define __ompl_interface_ros__OMPLDYNAMICRECONFIGURECONFIG_H__
 
 #include <dynamic_reconfigure/config_tools.h>
+#include <moveit/macros/class_forward.h>
 #include <limits>
 #include <ros/node_handle.h>
 #include <dynamic_reconfigure/ConfigDescription.h>
@@ -66,6 +67,7 @@ namespace ompl_interface_ros
   class OMPLDynamicReconfigureConfig
   {
   public:
+    MOVEIT_CLASS_FORWARD(AbstractParamDescription);
     class AbstractParamDescription : public dynamic_reconfigure::ParamDescription
     {
     public:
@@ -87,9 +89,6 @@ namespace ompl_interface_ros
       virtual void toMessage(dynamic_reconfigure::Config &msg, const OMPLDynamicReconfigureConfig &config) const = 0;
       virtual void getValue(const OMPLDynamicReconfigureConfig &config, boost::any &val) const = 0;
     };
-
-    typedef boost::shared_ptr<AbstractParamDescription> AbstractParamDescriptionPtr;
-    typedef boost::shared_ptr<const AbstractParamDescription> AbstractParamDescriptionConstPtr;
 
     template <class T>
     class ParamDescription : public AbstractParamDescription
@@ -144,6 +143,7 @@ namespace ompl_interface_ros
       }
     };
 
+    MOVEIT_CLASS_FORWARD(AbstractGroupDescription);
     class AbstractGroupDescription : public dynamic_reconfigure::Group
     {
       public:
@@ -173,9 +173,6 @@ namespace ompl_interface_ros
         }
       }
     };
-
-    typedef boost::shared_ptr<AbstractGroupDescription> AbstractGroupDescriptionPtr;
-    typedef boost::shared_ptr<const AbstractGroupDescription> AbstractGroupDescriptionConstPtr;
 
     template<class T, class PT>
     class GroupDescription : public AbstractGroupDescription

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/constraints_library.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/constraints_library.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_OMPL_INTERFACE_CONSTRAINTS_LIBRARY_
 #define MOVEIT_OMPL_INTERFACE_CONSTRAINTS_LIBRARY_
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/ompl_interface/planning_context_manager.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <ompl/base/StateStorage.h>
@@ -49,9 +50,7 @@ namespace ompl_interface
 typedef std::pair<std::vector<std::size_t>, std::map<std::size_t, std::pair<std::size_t, std::size_t> > > ConstrainedStateMetadata;
 typedef ompl::base::StateStorageWithMetadata<ConstrainedStateMetadata> ConstraintApproximationStateStorage;
 
-class ConstraintApproximation;
-typedef boost::shared_ptr<ConstraintApproximation> ConstraintApproximationPtr;
-typedef boost::shared_ptr<const ConstraintApproximation> ConstraintApproximationConstPtr;
+MOVEIT_CLASS_FORWARD(ConstraintApproximation)
 
 class ConstraintApproximation
 {
@@ -160,6 +159,8 @@ struct ConstraintApproximationConstructionResults
   double                     sampling_success_rate;
 };
 
+MOVEIT_CLASS_FORWARD(ConstraintsLibrary);
+
 class ConstraintsLibrary
 {
 public:
@@ -203,9 +204,6 @@ private:
   std::map<std::string, ConstraintApproximationPtr> constraint_approximations_;
 
 };
-
-typedef boost::shared_ptr<ConstraintsLibrary> ConstraintsLibraryPtr;
-typedef boost::shared_ptr<const ConstraintsLibrary> ConstraintsLibraryConstPtr;
 
 }
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_valid_state_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_valid_state_sampler.h
@@ -40,11 +40,14 @@
 #include <ompl/base/StateSampler.h>
 #include <ompl/base/ValidStateSampler.h>
 #include <moveit/constraint_samplers/constraint_sampler.h>
+#include <moveit/macros/class_forward.h>
 
 namespace ompl_interface
 {
 
 class ModelBasedPlanningContext;
+
+MOVEIT_CLASS_FORWARD(ValidStateSampler);
 
 /** @class ValidConstrainedSampler
  *  This class defines a sampler that tries to find a valid sample that satisfies the specified constraints */
@@ -69,9 +72,6 @@ private:
   double                                            inv_dim_;
   ompl::RNG                                         rng_;
 };
-
-typedef boost::shared_ptr<ValidConstrainedSampler> ValidConstrainedSamplerPtr;
-typedef boost::shared_ptr<const ValidConstrainedSampler> ValidConstrainedSamplerConstPtr;
 
 }
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_OMPL_INTERFACE_DETAIL_CONSTRAINT_APPROXIMATION_
 #define MOVEIT_OMPL_INTERFACE_DETAIL_CONSTRAINT_APPROXIMATION_
 
+#include <moveit/macros/declare_ptr.h>
 #include <planning_scene/planning_scene.h>
 #include <kinematic_constraints/kinematic_constraint.h>
 #include <ompl/base/StateStorage.h>
@@ -71,7 +72,8 @@ struct ConstraintApproximation
   ConstraintApproximationStateStorage             *state_storage_;
 };
 
-typedef boost::shared_ptr<std::vector<ConstraintApproximation> > ConstraintApproximationsPtr;
+MOVEIT_DECLARE_PTR(ConstraintApproximations, std::vector<ConstraintApproximation>)
+
 }
 
 #endif

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
@@ -37,14 +37,14 @@
 #ifndef MOVEIT_OMPL_INTERFACE_PARAMETERIZATION_MODEL_BASED_STATE_SPACE_FACTORY_
 #define MOVEIT_OMPL_INTERFACE_PARAMETERIZATION_MODEL_BASED_STATE_SPACE_FACTORY_
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/ompl_interface/parameterization/model_based_state_space.h>
 #include <moveit_msgs/MotionPlanRequest.h>
 
 namespace ompl_interface
 {
 
-class ModelBasedStateSpaceFactory;
-typedef boost::shared_ptr<ModelBasedStateSpaceFactory> ModelBasedStateSpaceFactoryPtr;
+MOVEIT_CLASS_FORWARD(ModelBasedStateSpaceFactory);
 
 class ModelBasedStateSpaceFactory
 {

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -130,7 +130,7 @@ private:
     }
 
     const robot_model::JointModelGroup *subgroup_;
-    boost::shared_ptr<kinematics::KinematicsBase> kinematics_solver_;
+    kinematics::KinematicsBasePtr kinematics_solver_;
     std::vector<unsigned int> bijection_;
     ompl::base::StateSpacePtr state_space_;
     std::vector<std::string> fk_link_;


### PR DESCRIPTION
Cherry-pick from https://github.com/ros-planning/moveit/pull/97