### PR TITLE
make PlanningSceneInterface add/remove CollisionObjects synchronously

### DIFF
--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -37,6 +37,7 @@
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
 #include <moveit/move_group/capability_names.h>
 #include <moveit_msgs/GetPlanningScene.h>
+#include <moveit_msgs/ApplyPlanningScene.h>
 #include <ros/ros.h>
 #include <algorithm>
 
@@ -52,6 +53,7 @@ public:
   PlanningSceneInterfaceImpl()
   {
     planning_scene_service_ = node_handle_.serviceClient<moveit_msgs::GetPlanningScene>(move_group::GET_PLANNING_SCENE_SERVICE_NAME);
+    apply_planning_scene_service_ = node_handle_.serviceClient<moveit_msgs::ApplyPlanningScene>(move_group::APPLY_PLANNING_SCENE_SERVICE_NAME);
     planning_scene_diff_publisher_ = node_handle_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
   }
 
@@ -207,29 +209,45 @@ public:
     moveit_msgs::PlanningScene planning_scene;
     planning_scene.world.collision_objects = collision_objects;
     planning_scene.is_diff = true;
-    planning_scene_diff_publisher_.publish(planning_scene);
+    applyPlanningScene(planning_scene);
   }
 
   void removeCollisionObjects(const std::vector<std::string> &object_ids) const
   {
     moveit_msgs::PlanningScene planning_scene;
     moveit_msgs::CollisionObject object;
-    for(std::size_t i=0; i < object_ids.size(); ++i)
+    for (std::size_t i=0; i < object_ids.size(); ++i)
     {
       object.id = object_ids[i];
       object.operation = object.REMOVE;
       planning_scene.world.collision_objects.push_back(object);
     }
     planning_scene.is_diff = true;
-    planning_scene_diff_publisher_.publish(planning_scene);
+    applyPlanningScene(planning_scene);
   }
 
 private:
 
   ros::NodeHandle node_handle_;
   ros::ServiceClient planning_scene_service_;
+  mutable ros::ServiceClient apply_planning_scene_service_;
   ros::Publisher planning_scene_diff_publisher_;
   robot_model::RobotModelConstPtr robot_model_;
+
+  // Helper function to call ApplyPlanningScene service with fallback
+  // to asynchronous processing via "planning_scene" topic.
+  void applyPlanningScene(const moveit_msgs::PlanningScene &planning_scene) const
+  {
+    moveit_msgs::ApplyPlanningScene::Request request;
+    moveit_msgs::ApplyPlanningScene::Response response;
+    request.scene = planning_scene;
+    if (!apply_planning_scene_service_.call(request, response))
+    {
+      ROS_WARN("ApplyPlanningScene service call failed. Please add \"move_group/ApplyPlanningSceneService\" capability. Falling back to asynchronous change processing.");
+      planning_scene_diff_publisher_.publish(planning_scene);
+    }
+  }
+
 };
 
 PlanningSceneInterface::PlanningSceneInterface()


### PR DESCRIPTION
To fix #38 I added a helper function that calls ApplyPlanningScene service
with a fallback to publish().

@v4hn Points to discuss:
1. Was it ok to declare the `ros::ServiceClient` `mutable` to keep the ABI unmodified or should the methods be changed to non-const?
2. When using the `ApplyPlanningScene` service no diff messages are published to the "planning_scene" topic and therefore rviz does not reflect the changes. I think we definitely want to see collision objects in rviz. Could it make sense for [move_group::ApplyPlanningSceneService::applyScene()](https://github.com/ros-planning/moveit/blob/4ac0c7432d335f57aab6836cbcaaac3fccf4b6f9/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp#L50) to publish 'integrated changes' to topic "planning_scene", e.g. the "planning_scene" topic could become some kind of back-channel to which only MoveIt itself publishes and everybody else (e.g. rviz) only listens?
## Todo:
- [ ] Test attach/detachObject
