### PR TITLE
Remove const& from getKinematicsQueryOptions to fix warning

### DIFF
--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -363,7 +363,7 @@ public:
         const robot_state::GroupStateValidityCallbackFn &callback);
   void setIKTimeout(double timeout);
   void setIKAttempts(unsigned int attempts);
-  const kinematics::KinematicsQueryOptions& getKinematicsQueryOptions() const;
+  kinematics::KinematicsQueryOptions getKinematicsQueryOptions() const;
   void setKinematicsQueryOptions(const kinematics::KinematicsQueryOptions &opt);
   void setKinematicsQueryOptionsForGroup(const std::string& group_name,
            const kinematics::KinematicsQueryOptions &options);

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -608,12 +608,11 @@ void InteractionHandler::setGroupStateValidityCallback(
                                      KinematicOptions::STATE_VALIDITY_CALLBACK);
 }
 
-const kinematics::KinematicsQueryOptions& InteractionHandler::getKinematicsQueryOptions() const
+kinematics::KinematicsQueryOptions InteractionHandler::getKinematicsQueryOptions() const
 {
   boost::mutex::scoped_lock lock(state_lock_);
   return kinematic_options_map_->getOptions(KinematicOptionsMap::DEFAULT).options_;
 }
-
 
 void InteractionHandler::setUpdateCallback(const InteractionHandlerCallbackFn &callback)
 {


### PR DESCRIPTION
Simple fix for #5 (Warning: return returning reference to temporary). 