### PR TITLE
Check geomtric_shapes API with static_assert.

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -42,10 +42,14 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <type_traits>
+#include <memory>
 #include <boost/function.hpp>
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_vector_container.h>
 #include <geometric_shapes/shapes.h>
+
+static_assert(std::is_same<decltype(shapes::OcTree::octree), std::shared_ptr<const octomap::OcTree>>::value, "This version of moveit requires geometric_shapes 0.5.0 or later.");
 
 namespace collision_detection
 {


### PR DESCRIPTION
The changes to support FCL 0.5 require geometric_shapes 0.5.0. Older versions will trigger ugly compile warnings such as the one belowx.

This PR adds a static assert to verify that the geometric_shapes used has the correct API (uses `std::shared_ptr`). I'm not entirely happy with the message since it doesn't explain why `geometric_shapes >= 0.5.0` is needed, but I guess the message would get very long otherwise.

Additionally, I think it would be even better to verify this during the configure stage in cmake rather than compile time. Preferably by checking the `geometric_shapes` version (if possible), or with a minimal compile test.

Checking in the cmake stage does not catch the situation where moveit is compiled with the proper `geometric_shapes`, but another packages using moveit headers compiles with the wrong `geometric_shapes`. It can be argued that that is not the responsibility of moveit, so moveit shouldn't have to care. But in practise it's not that hard to achieve by sourcing the wrong files at wrong times.

So, feedback very welcome. Whatever happens, this should not be cherry-picked to Indigo or Jade.

Compiler error due to wrong `geometric_shapes` version, quoted from #97:
```
[ 47%] Building CXX object moveit/moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_octomap_filter.cpp.o
/home/fergs/kinetic/src/moveit/moveit_core/collision_detection/src/collision_octomap_filter.cpp: In function ‘int collision_detection::refineContactNormals(const ObjectConstPtr&, collision_detection::CollisionResult&, double, double, bool, double, double)’:
/home/fergs/kinetic/src/moveit/moveit_core/collision_detection/src/collision_octomap_filter.cpp:118:71: error: conversion from ‘const boost::shared_ptr<const octomap::OcTree>’ to non-scalar type ‘std::shared_ptr<const octomap::OcTree>’ requested
         std::shared_ptr<const octomap::OcTree> octree = shape_octree->octree;
                                                                       ^
moveit/moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/build.make:134: recipe for target 'moveit/moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_octomap_filter.cpp.o' failed
make[2]: *** [moveit/moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/src/collision_octomap_filter.cpp.o] Error 1
CMakeFiles/Makefile2:8831: recipe for target 'moveit/moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/all' failed
make[1]: *** [moveit/moveit_core/collision_detection/CMakeFiles/moveit_collision_detection.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
Invoking "make -j8 -l8" failed
```