### PR TITLE
Add constexpr to static test member

### DIFF
--- a/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
+++ b/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
@@ -66,7 +66,7 @@ class FilterTraits<unsigned short>
 {
   public:
     static const GLushort FILTER_GL_TYPE = GL_UNSIGNED_SHORT;
-    static const double ToMetricScale = 0.001;
+    static constexpr double ToMetricScale = 0.001;
 };
 
 template<>
@@ -74,7 +74,7 @@ class FilterTraits<float>
 {
   public:
     static const GLushort FILTER_GL_TYPE = GL_FLOAT;
-    static const double ToMetricScale = 1.0f;
+    static constexpr double ToMetricScale = 1.0f;
 };
 
 template<typename Type>


### PR DESCRIPTION
Otherwise the tests won't compile on kinetic:

```
/home/jbinney/ws/moveit_hackathon/src/moveit/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp:69:41: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double mesh_filter_test::FilterTrai
ts<short unsigned int>::ToMetricScale’ of non-integral type [-fpermissive]
     static const double ToMetricScale = 0.001;
                                         ^
/home/jbinney/ws/moveit_hackathon/src/moveit/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp:77:41: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double mesh_filter_test::FilterTrai
ts<float>::ToMetricScale’ of non-integral type [-fpermissive]
     static const double ToMetricScale = 1.0f;
```
(it seems like the tests weren't run on kinetic after c++11 was enabled?)