### PR TITLE
Temporarilly disable a test that only fails on ros.org buildfarm.

### DIFF
--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -88,4 +88,4 @@ install(FILES
 
 install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-add_rostest(test/moveit_joy.test)
+#add_rostest(test/moveit_joy.test)  # Disabled until the issue discussed at https://github.com/ros-planning/moveit/pull/46#issuecomment-240463490 gets resolved.


### PR DESCRIPTION
A test case for joy node keeps failing https://github.com/ros-planning/moveit/pull/46#issuecomment-239901030 on ros.org buildfarm only. Since neither the particular test nor the component is critical to the entire moveit suite, Dave and I [agreed to disable it for now](https://github.com/ros-planning/moveit/pull/46#issuecomment-241915890).

Portable to JK.