### PR TITLE
 Remove of collision Object when attaching it with apply planning scene service

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1062,6 +1062,11 @@ void planning_scene::PlanningScene::loadGeometryFromStream(std::istream &in, con
 
 void planning_scene::PlanningScene::setCurrentState(const moveit_msgs::RobotState &state)
 {
+  // The attached bodies will be processed separately by processAttachedCollisionObjectMsgs
+  // after kstate_ has been updated
+  moveit_msgs::RobotState state_no_attached(state);
+  state_no_attached.attached_collision_objects.clear();
+
   if (parent_)
   {
     if (!kstate_)
@@ -1069,17 +1074,19 @@ void planning_scene::PlanningScene::setCurrentState(const moveit_msgs::RobotStat
       kstate_.reset(new robot_state::RobotState(parent_->getCurrentState()));
       kstate_->setAttachedBodyUpdateCallback(current_state_attached_body_callback_);
     }
-    robot_state::robotStateMsgToRobotState(getTransforms(), state, *kstate_);
+    robot_state::robotStateMsgToRobotState(getTransforms(), state_no_attached, *kstate_);
   }
   else
-    robot_state::robotStateMsgToRobotState(*ftf_, state, *kstate_);
+    robot_state::robotStateMsgToRobotState(*ftf_, state_no_attached, *kstate_);
 
-  // we add object types to the planning scene, if any are specified
   for (std::size_t i = 0 ; i < state.attached_collision_objects.size() ; ++i)
   {
-    const moveit_msgs::CollisionObject &o = state.attached_collision_objects[i].object;
-    if (!o.id.empty() && o.operation == moveit_msgs::CollisionObject::ADD && (!o.type.db.empty() || !o.type.key.empty()))
-      setObjectType(o.id, o.type);
+    if(!state.is_diff && state.attached_collision_objects[i].object.operation != moveit_msgs::CollisionObject::ADD)
+    {
+      logError("The specified RobotState is not marked as is_diff. The request to modify the object '%s' is not supported. Object is ignored.",state.attached_collision_objects[i].object.id.c_str());
+      continue;
+    }
+    processAttachedCollisionObjectMsg(state.attached_collision_objects[i]);
   }
 }
 

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -320,7 +320,8 @@ static void _msgToAttachedBody(const Transforms *tf, const moveit_msgs::Attached
   else
     if (aco.object.operation == moveit_msgs::CollisionObject::REMOVE)
     {
-      state.clearAttachedBody(aco.object.id);
+      if(!state.clearAttachedBody(aco.object.id))
+        logError("The attached body '%s' can not be removed because it does not exist", aco.link_name.c_str());
     }
     else
       logError("Unknown collision object operation: %d", aco.object.operation);


### PR DESCRIPTION
This is part of the issue #103.

The current state is that the collision object will be removed from the planning scene when attaching
it to the robot with the asynchronous attachObject function of the move_group_interface.

So we want the same behavior with the synchronous apply planning scene service.

In this effect we added two error messages for the case that the roboState is_diff is not set.