### PR TITLE
alternative fix for joystick unittest

### DIFF
--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -107,5 +107,5 @@ install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest)
-  #add_rostest(test/moveit_joy.test)  # Disabled until the issue discussed at https://github.com/ros-planning/moveit/pull/46#issuecomment-240463490 gets resolved.
+  add_rostest(test/moveit_joy.test)
 endif()

--- a/moveit_ros/visualization/test/test_moveit_joy.py
+++ b/moveit_ros/visualization/test/test_moveit_joy.py
@@ -37,13 +37,10 @@
 
 import unittest
 
-from geometry_msgs.msg import Pose
 from moveit_ros_visualization.moveitjoy_module import MoveitJoy
 import rospy
 import rostest
-
-import math
-from tf.transformations import quaternion_from_euler
+import os
 
 _PKGNAME = 'moveit_ros_visualization'
 _NODENAME = 'test_moveit_joy'
@@ -60,15 +57,12 @@ class TestMoveitJoy(unittest.TestCase):
 
     def test_updatePlanningGroup_exception(self):
         '''Test MoveitJoy.updatePlanningGroup'''
-        exception_raised = False
-        try:
-            # Passng 0 to MoveitJoy.updatePlanningGroup should raise an exception.
-            self.moveit_joy.updatePlanningGroup(0)
-        except rospy.ROSInitException:
-            exception_raised = True
-        self.assertTrue(exception_raised)
+        # Passng 0 to MoveitJoy.updatePlanningGroup should raise an exception.
+        self.assertRaises(rospy.ROSInitException, self.moveit_joy.updatePlanningGroup(0))
 
 
 if __name__ == '__main__':
     rospy.init_node(_NODENAME)
-    rostest.rosrun(_PKGNAME, _NODENAME, TestMoveitJoy) 
+    rostest.rosrun(_PKGNAME, _NODENAME, TestMoveitJoy)
+    # Don't get trapped by https://github.com/ros/ros_comm/issues/870
+    os._exit(0)  # exit without cleanup


### PR DESCRIPTION
Instead of disabling the joystick unittest, I suggest to exit python without performing usual cleanup routines as proposed in https://github.com/ros-planning/moveit/pull/105.

This reverts commit f254737b8c1ef83ad4fce9501da12c46b7eaf88d / #143.
Should be cherry-picked to I/J again.