### PR TITLE
fix remaining issues in #94

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -121,8 +121,8 @@ public:
     */
   MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
             const ros::WallDuration &wait_for_servers = ros::WallDuration());
-  MOVEIT_DEPRECATED MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
-                           const ros::Duration &wait_for_servers = ros::Duration());
+  MOVEIT_DEPRECATED MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf,
+                              const ros::Duration &wait_for_servers);
 
   /**
       \brief Construct a client for the MoveGroup action for a particular \e group.
@@ -132,8 +132,8 @@ public:
     */
   MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
             const ros::WallDuration &wait_for_servers = ros::WallDuration());
-  MOVEIT_DEPRECATED MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
-                           const ros::Duration &wait_for_servers = ros::Duration());
+  MOVEIT_DEPRECATED MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf,
+                              const ros::Duration &wait_for_servers);
 
   ~MoveGroup();
 

--- a/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
-  moveit::planning_interface::MoveGroup group(argc > 1 ? argv[1] : "right_arm", boost::shared_ptr<tf::Transformer>(), ros::WallDuration());
+  moveit::planning_interface::MoveGroup group(argc > 1 ? argv[1] : "right_arm");
   demoPlace(group);
 
   sleep(2);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -136,7 +136,7 @@ public:
 
     ros::WallTime timeout_for_servers = ros::WallTime::now() + wait_for_servers;
     if (wait_for_servers == ros::WallDuration())
-      timeout_for_servers == ros::WallTime(); // wait for ever
+      timeout_for_servers = ros::WallTime(); // wait for ever
     double allotted_time = wait_for_servers.toSec();
 
     move_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>


### PR DESCRIPTION
We missed two issues before merging #94:

* assignment doesn't work with `==`
* Switching to the correct `WallDuration` interface for `MoveGroupInterface`, made the constructors ambigue if not the full signature is specified. Hence, I propose to remove the default values for the old constructor. This will automatically choose the new version, which is preferred anyway.

Please also cherry-pick into Jade. #94 was not yet merged into Indigo. I will integrate this patch into #144 as well, which is the corresponding PR for Indigo.