### PR TITLE
Require author information in gui

### DIFF
--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -60,6 +60,7 @@ set(HEADERS
   src/widgets/passive_joints_widget.h
   src/widgets/configuration_files_widget.h
   src/widgets/setup_screen_widget.h
+  src/widgets/author_information_widget.h
 )
 
 # Tools Library
@@ -93,6 +94,7 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/header_widget.cpp
   src/widgets/setup_assistant_widget.cpp
   src/widgets/setup_screen_widget.cpp
+  src/widgets/author_information_widget.cpp
   ${HEADERS}
 )
 target_link_libraries(${PROJECT_NAME}_widgets

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -191,6 +191,12 @@ public:
   /// Timestamp when configuration package was generated, if it was previously generated
   std::time_t config_pkg_generated_timestamp_;
 
+  /// Name of the author of this config
+  std::string author_name_;
+
+  /// Email of the author of this config
+  std::string author_email_;
+
   // ******************************************************************************************
   // Public Functions
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -265,6 +265,8 @@ bool MoveItConfigData::outputSetupAssistantFile( const std::string& file_path )
   /// Package generation time
   emitter << YAML::Key << "CONFIG";
   emitter << YAML::Value << YAML::BeginMap;
+  emitter << YAML::Key << "author_name" << YAML::Value << author_name_;
+  emitter << YAML::Key << "author_email" << YAML::Value << author_email_;
   emitter << YAML::Key << "generated_timestamp" << YAML::Value << std::time(NULL); // TODO: is this cross-platform?
   emitter << YAML::EndMap;
 
@@ -908,7 +910,7 @@ bool MoveItConfigData::inputSetupAssistantYAML( const std::string& file_path )
     loadYaml(input_stream, doc);
 
     yaml_node_t title_node, urdf_node, package_node, srdf_node,
-                relative_node, config_node, timestamp_node;
+                relative_node, config_node, timestamp_node, author_name_node, author_email_node;
 
     // Get title node
     if( title_node = findValue( doc, "moveit_setup_assistant_config" ) )
@@ -952,6 +954,15 @@ bool MoveItConfigData::inputSetupAssistantYAML( const std::string& file_path )
       // Package generation time
       if( config_node = findValue( *title_node, "CONFIG" ) )
       {
+        //Load author contact details
+        if( author_name_node = findValue( *config_node, "author_name" ) )
+        {
+          *author_name_node >> author_name_;
+        }
+        if( author_email_node = findValue( *config_node, "author_email" ) )
+        {
+          *author_email_node >> author_email_;
+        }
         // Load first property
         if( timestamp_node = findValue( *config_node, "generated_timestamp" ) )
         {

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -834,6 +834,7 @@ bool MoveItConfigData::setPackagePath( const std::string& pkg_path )
   }
 
   config_pkg_path_ = full_package_path;
+  return true;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/author_information_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.cpp
@@ -101,6 +101,8 @@ AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_
 void AuthorInformationWidget::focusGiven()
 {
   // Allow list box to populate
+  this->name_edit_->setText(QString::fromStdString(config_data_->author_name_));
+  this->email_edit_->setText(QString::fromStdString(config_data_->author_email_));
   QApplication::processEvents();
 }
 

--- a/moveit_setup_assistant/src/widgets/author_information_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.cpp
@@ -1,0 +1,117 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Michael 'v4hn' Goerner */
+
+// Qt
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QApplication>
+#include <QSplitter>
+// ROS
+#include "author_information_widget.h"
+#include <srdfdom/model.h> // use their struct datastructures
+#include <ros/ros.h>
+// Boost
+#include <boost/algorithm/string.hpp> // for trimming whitespace from user input
+#include <boost/filesystem.hpp>  // for creating folders/files
+// Read write files
+#include <iostream> // For writing yaml and launch files
+#include <fstream>
+
+namespace moveit_setup_assistant
+{
+
+// Boost file system
+namespace fs = boost::filesystem;
+
+// ******************************************************************************************
+// Outer User Interface for MoveIt Configuration Assistant
+// ******************************************************************************************
+AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_assistant::MoveItConfigDataPtr config_data ) :
+  SetupScreenWidget( parent ),
+  config_data_(config_data)
+{
+  // Basic widget container
+  QVBoxLayout *layout = new QVBoxLayout();
+
+  // Top Header Area ------------------------------------------------
+
+  HeaderWidget *header = new HeaderWidget( "Author Information",
+                                           "Specify contact information of the author and initial maintainer of the generated package. catkin requires valid details in the package's package.xml",
+                                           this);
+  layout->addWidget( header );
+
+  QLabel * name_title = new QLabel(this);
+  name_title->setText( "Name of this MoveIt! configuration:" );
+  layout->addWidget( name_title );
+
+  name_edit_ = new QLineEdit(this);
+  connect( name_edit_, SIGNAL( editingFinished() ), this, SLOT( edited_name() ) );
+  layout->addWidget( name_edit_ );
+
+  QLabel * email_title = new QLabel(this);
+  email_title->setText( "E-Mail of the maintainer of this MoveIt! configuration:" );
+  layout->addWidget( email_title );
+
+  email_edit_ = new QLineEdit(this);
+  connect( email_edit_, SIGNAL( editingFinished() ), this, SLOT( edited_email() ) );
+  layout->addWidget( email_edit_ );
+
+  // Finish Layout --------------------------------------------------
+  this->setLayout(layout);
+
+}
+
+// ******************************************************************************************
+// Called when setup assistant navigation switches to this screen
+// ******************************************************************************************
+void AuthorInformationWidget::focusGiven()
+{
+  // Allow list box to populate
+  QApplication::processEvents();
+}
+
+void AuthorInformationWidget::edited_name()
+{
+  config_data_->author_name_ = this->name_edit_->text().toStdString();
+}
+
+void AuthorInformationWidget::edited_email()
+{
+  config_data_->author_email_ = this->email_edit_->text().toStdString();
+}
+
+} // namespace

--- a/moveit_setup_assistant/src/widgets/author_information_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.cpp
@@ -66,6 +66,7 @@ AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_
 {
   // Basic widget container
   QVBoxLayout *layout = new QVBoxLayout();
+  layout->setAlignment(Qt::AlignTop);
 
   // Top Header Area ------------------------------------------------
 
@@ -75,7 +76,7 @@ AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_
   layout->addWidget( header );
 
   QLabel * name_title = new QLabel(this);
-  name_title->setText( "Name of this MoveIt! configuration:" );
+  name_title->setText( "Name of the maintainer this MoveIt! configuration:" );
   layout->addWidget( name_title );
 
   name_edit_ = new QLineEdit(this);

--- a/moveit_setup_assistant/src/widgets/author_information_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.cpp
@@ -60,9 +60,9 @@ namespace fs = boost::filesystem;
 // ******************************************************************************************
 // Outer User Interface for MoveIt Configuration Assistant
 // ******************************************************************************************
-AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_assistant::MoveItConfigDataPtr config_data ) :
-  SetupScreenWidget( parent ),
-  config_data_(config_data)
+AuthorInformationWidget::AuthorInformationWidget( QWidget *parent,
+                                                  moveit_setup_assistant::MoveItConfigDataPtr config_data )
+  : SetupScreenWidget( parent ), config_data_(config_data)
 {
   // Basic widget container
   QVBoxLayout *layout = new QVBoxLayout();
@@ -71,7 +71,9 @@ AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_
   // Top Header Area ------------------------------------------------
 
   HeaderWidget *header = new HeaderWidget( "Author Information",
-                                           "Specify contact information of the author and initial maintainer of the generated package. catkin requires valid details in the package's package.xml",
+                                           "Specify contact information of the author and initial maintainer of the "
+                                           "generated package. catkin requires valid details in the package's "
+                                           "package.xml",
                                            this);
   layout->addWidget( header );
 
@@ -84,7 +86,7 @@ AuthorInformationWidget::AuthorInformationWidget( QWidget *parent, moveit_setup_
   layout->addWidget( name_edit_ );
 
   QLabel * email_title = new QLabel(this);
-  email_title->setText( "E-Mail of the maintainer of this MoveIt! configuration:" );
+  email_title->setText( "Email of the maintainer of this MoveIt! configuration:" );
   layout->addWidget( email_title );
 
   email_edit_ = new QLineEdit(this);

--- a/moveit_setup_assistant/src/widgets/author_information_widget.h
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.h
@@ -1,0 +1,93 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Michael 'v4hn' Goerner */
+
+#ifndef MOVEIT_ROS_MOVEIT_SETUP_ASSISTANT_WIDGETS_AUTHOR_INFORMATION_WIDGET_
+#define MOVEIT_ROS_MOVEIT_SETUP_ASSISTANT_WIDGETS_AUTHOR_INFORMATION_WIDGET_
+
+#include <QWidget>
+#include <QString>
+#include <QLineEdit>
+
+#ifndef Q_MOC_RUN
+#include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
+#include "header_widget.h"
+#include "setup_screen_widget.h" // a base class for screens in the setup assistant
+
+namespace moveit_setup_assistant
+{
+
+class AuthorInformationWidget : public SetupScreenWidget
+{
+  Q_OBJECT
+
+  public:
+  // ******************************************************************************************
+  // Public Functions
+  // ******************************************************************************************
+
+  AuthorInformationWidget( QWidget *parent, moveit_setup_assistant::MoveItConfigDataPtr config_data );
+
+  /// Recieved when this widget is chosen from the navigation menu
+  virtual void focusGiven();
+
+  // ******************************************************************************************
+  // Qt Components
+  // ******************************************************************************************
+
+  QLineEdit *name_edit_;
+
+  QLineEdit *email_edit_;
+
+private Q_SLOTS:
+
+  // ******************************************************************************************
+  // Slot Event Functions
+  // ******************************************************************************************
+  void edited_name();
+  void edited_email();
+
+private:
+
+  /// Contains all the configuration data for the setup assistant
+  moveit_setup_assistant::MoveItConfigDataPtr config_data_;
+
+};
+
+} //namespace moveit_setup_assistant
+
+#endif

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -902,6 +902,9 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     deps << "  <run_depend>" << config_data_->urdf_pkg_name_ << "</run_depend>\n";
     addTemplateString("[OTHER_DEPENDENCIES]", deps.str()); // not relative to a ROS package
   }
+
+  addTemplateString("[AUTHOR_NAME]", config_data_->author_name_);
+  addTemplateString("[AUTHOR_EMAIL]", config_data_->author_email_);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -470,7 +470,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   // Check that there is a author name
   if( config_data_->author_name_.find_first_not_of(' ') == std::string::npos )
   {
-    //There is no name or it consists of whitespaces only
+    // There is no name or it consists of whitespaces only
     dependencies << "<b>No author name added</b>";
     requiredActions = true;
   }
@@ -482,7 +482,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   QString testEmail = QString::fromStdString(config_data_->author_email_);
   if( ! mailRegex.exactMatch(testEmail) )
   {
-    dependencies << "<b>No valid email adress added</b>";
+    dependencies << "<b>No valid email address added</b>";
     requiredActions = true;
   }
 
@@ -512,7 +512,8 @@ bool ConfigurationFilesWidget::checkDependencies()
       {
         return false; // abort
       }
-    } else {
+    } else
+    {
       QMessageBox::warning( this, "Incomplete MoveIt Setup Assistant Steps", dep_message );
       return false;
     }

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -117,6 +117,7 @@ SetupAssistantWidget::SetupAssistantWidget( QWidget *parent, boost::program_opti
   nav_name_list_ << "Robot Poses";
   nav_name_list_ << "End Effectors";
   nav_name_list_ << "Passive Joints";
+  nav_name_list_ << "Author Information";
   nav_name_list_ << "Configuration Files";
 
   // Navigation Left Pane --------------------------------------------------
@@ -264,6 +265,14 @@ void SetupAssistantWidget::progressPastStartScreen()
   connect( pjw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
   connect( pjw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( pjw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
+
+  // Author Information
+  aiw_ = new AuthorInformationWidget( this, config_data_ );
+  main_content_->addWidget( aiw_ );
+  connect( aiw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
+  connect( aiw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( aiw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
+  connect( aiw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
   // Configuration Files
   cfw_ = new ConfigurationFilesWidget( this, config_data_ );

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
@@ -58,6 +58,7 @@
 #include "end_effectors_widget.h"
 #include "virtual_joints_widget.h"
 #include "passive_joints_widget.h"
+#include "author_information_widget.h"
 #include "configuration_files_widget.h"
 
 #ifndef Q_MOC_RUN
@@ -223,6 +224,7 @@ private:
   EndEffectorsWidget *efw_;
   VirtualJointsWidget *vjw_;
   PassiveJointsWidget *pjw_;
+  AuthorInformationWidget *aiw_;
   ConfigurationFilesWidget *cfw_;
 
   /// Contains all the configuration data for the setup assistant

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -5,8 +5,8 @@
   <description>
      An automatically generated package with all the configuration and launch files for using the [ROBOT_NAME] with the MoveIt Motion Planning Framework
   </description>
-  <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
-  <maintainer email="assistant@moveit.ros.org">MoveIt Setup Assistant</maintainer>
+  <author email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</author>
+  <maintainer email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
This is the follow up of [this PR](https://github.com/ros-planning/moveit_setup_assistant/pull/124). I used filter-branch to restructure the old repo and cherry picked the commits afterwards.

This is a extension to the work of @v4hn who has included a widget which asks for the author's name and email adress. Following features have been implemented (as suggested by #16):
- It is now checked if a name and a valid email was entered and it is only possible to finish the assistant if the information was provided
- Name and email adress are stored in .setup_assitant and are loaded again when the configuration is edited again. In case an old configuration (with the old default email assistant@moveit.ros.org) is loaded, the author information is empty (since it was not stored in .setup_assistant) and therefore the user would need to enter and correct it.