### PR TITLE
rviz display: make move_group/monitored_planning_scene the default

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -80,7 +80,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
 
   if (listen_to_planning_scene)
     planning_scene_topic_property_ =
-      new rviz::RosTopicProperty( "Planning Scene Topic", "planning_scene",
+      new rviz::RosTopicProperty( "Planning Scene Topic", "move_group/monitored_planning_scene",
                                   ros::message_traits::datatype<moveit_msgs::PlanningScene>(),
                                   "The topic on which the moveit_msgs::PlanningScene messages are received",
                                   this,


### PR DESCRIPTION
It confused a generation of RViz users why the scene displayed in RViz
is not ok... Well, the reason is because the user should usually
look at the monitored scene instead.

Needs to be picked to j/k.

Fixes #156.