### PR TITLE
fixed moveit_joy test

### DIFF
--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -41,6 +41,7 @@
 #include <moveit/py_bindings_tools/serialize_msg.h>
 #include <moveit_msgs/RobotState.h>
 
+#include <stdexcept>
 #include <boost/python.hpp>
 #include <Python.h>
 
@@ -57,6 +58,8 @@ public:
     py_bindings_tools::ROScppInitializer()
   {
     robot_model_ = planning_interface::getSharedRobotModel(robot_description);
+    if (!robot_model_)
+      throw std::runtime_error("RobotInterfacePython: invalid robot model");
     current_state_monitor_ = planning_interface::getSharedStateMonitor(robot_model_, planning_interface::getSharedTF());
   }
 

--- a/moveit_ros/visualization/test/moveit_joy.test
+++ b/moveit_ros/visualization/test/moveit_joy.test
@@ -1,4 +1,4 @@
 <launch>
   <test pkg="moveit_ros_visualization" type="test_moveit_joy.py" test-name="moveit_joy"
-        time-limit="300" args="" />         
+        time-limit="300"/>
 </launch>

--- a/moveit_ros/visualization/test/test_moveit_joy.py
+++ b/moveit_ros/visualization/test/test_moveit_joy.py
@@ -46,20 +46,13 @@ _PKGNAME = 'moveit_ros_visualization'
 _NODENAME = 'test_moveit_joy'
 
 class TestMoveitJoy(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestMoveitJoy, self).__init__(*args, **kwargs)
 
-    @classmethod
-    def setUpClass(self):
-        self.moveit_joy = MoveitJoy()
-
-    @classmethod
-    def tearDownClass(self):
-        True  # TODO impl something meaningful
-
-    def test_updatePlanningGroup_exception(self):
-        '''Test MoveitJoy.updatePlanningGroup'''
-        # Passng 0 to MoveitJoy.updatePlanningGroup should raise an exception.
-        self.assertRaises(rospy.ROSInitException, self.moveit_joy.updatePlanningGroup(0))
-
+    def test_constructor(self):
+        # As there is no robot model loaded, the constructor will raise an exception
+        # However, at least we tested, that MoveitJoy constructor can be called...
+        self.assertRaises(RuntimeError, MoveitJoy)
 
 if __name__ == '__main__':
     rospy.init_node(_NODENAME)


### PR DESCRIPTION
Follow up for #149. Again, ROS buildfarm failed on the joystick test...

This (hopefully) fixes the issue finally. 
Actually there seems to be a bug in rostest as well: Because our python bindings segfaulted due to an empty robot model (https://github.com/ros-planning/moveit_commander/issues/32), rostest didn't finish correctly, but reported the test as [`SUCCEEDED`](https://github.com/ros-planning/moveit/pull/149#issuecomment-242361420), while the unittest log file was empty. This made only ROS buildfarm to fail, which do some extra analysis of the log files...
