### PR TITLE
mesh_filter_test: don't report errors on all 250.000 pixels

### DIFF
--- a/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
+++ b/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
@@ -223,13 +223,8 @@ void MeshFilterTest<Type>::test ()
     float sensor_depth = sensor_data_ [idx] * FilterTraits<Type>::ToMetricScale;
     if (fabs(sensor_depth - distance_ - shadow_) > epsilon_ && fabs(sensor_depth - distance_) > epsilon_)
     {
-//      if (filtered_labels [idx] != gt_labels [idx])
-//      {
-//        cout << idx << " :: " <<  filtered_labels [idx] << " vs. " << gt_labels [idx] << " :: " <<  sensor_data_ [idx] << " = " << filtered_depth [idx] << " vs. " << gt_depth [idx] << endl;
-//        exit (1);
-//      }
-      EXPECT_FLOAT_EQ (filtered_depth [idx], gt_depth [idx]);
-      EXPECT_EQ (filtered_labels [idx], gt_labels [idx]);
+      ASSERT_FLOAT_EQ (filtered_depth [idx], gt_depth [idx]);
+      ASSERT_EQ (filtered_labels [idx], gt_labels [idx]);
     }
   }
   filter_.removeMesh (handle);


### PR DESCRIPTION
Although the mesh filter is disabled on build farms (because of missing `DISPLAY`), running it locally takes ages. It turned out, that the test is actually failing and filing an error message for each and every pixel of the 250.000 pixel test images. Using `ASSERT` instead of `EXPECT` macros, this PR makes the test fail immediately on the first failing pixel.

I'm not sure why the test actually fails. Someone with more background in the perception code should have a look!

By purpose, I didn't disable the test. As it doesn't run on CI build farms (this should be fixed too), their outcome will not be affected.