### PR TITLE
scene: add comment on self-collisions to distanceToCollision functions

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -598,53 +598,53 @@ public:
    */
   /**@{*/
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions) */
   double distanceToCollision(robot_state::RobotState &kstate) const
   {
     kstate.updateCollisionBodyTransforms();
     return distanceToCollision(const_cast<const robot_state::RobotState&>(kstate));
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions) */
   double distanceToCollision(const robot_state::RobotState &kstate) const
   {
     return getCollisionWorld()->distanceRobot(*getCollisionRobot(), kstate, getAllowedCollisionMatrix());
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, if the robot has no padding */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions), if the robot has no padding */
   double distanceToCollisionUnpadded(robot_state::RobotState &kstate) const
   {
     kstate.updateCollisionBodyTransforms();
     return distanceToCollisionUnpadded(const_cast<const robot_state::RobotState&>(kstate));
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, if the robot has no padding */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions), if the robot has no padding */
   double distanceToCollisionUnpadded(const robot_state::RobotState &kstate) const
   {
     return getCollisionWorld()->distanceRobot(*getCollisionRobotUnpadded(), kstate, getAllowedCollisionMatrix());
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring distances between elements that always allowed to collide. */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions and elements that are allowed to collide. */
   double distanceToCollision(robot_state::RobotState &kstate, const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
     return distanceToCollision(const_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring distances between elements that always allowed to collide. */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions and elements that are allowed to collide. */
   double distanceToCollision(const robot_state::RobotState &kstate, const collision_detection::AllowedCollisionMatrix& acm) const
   {
     return getCollisionWorld()->distanceRobot(*getCollisionRobot(), kstate, acm);
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring distances between elements that always allowed to collide, if the robot has no padding. */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions and elements that are allowed to collide, if the robot has no padding. */
   double distanceToCollisionUnpadded(robot_state::RobotState &kstate, const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
     return distanceToCollisionUnpadded(const_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring distances between elements that always allowed to collide, if the robot has no padding. */
+  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions and elements that always allowed to collide, if the robot has no padding. */
   double distanceToCollisionUnpadded(const robot_state::RobotState &kstate, const collision_detection::AllowedCollisionMatrix& acm) const
   {
     return getCollisionWorld()->distanceRobot(*getCollisionRobotUnpadded(), kstate, acm);


### PR DESCRIPTION
The interface looks quite similar to `PlanningScene::checkCollision`
and users might expect it to behave the same way.
However, that's not the case because the distanceToCollision function family
ignores self-collisions.

The additional note should reduce confusion as seen in #166.

should be picked to j/k