### PR TITLE
Update links in union constraint sampler and fix unit test.

### DIFF
--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -135,10 +135,10 @@ bool constraint_samplers::UnionConstraintSampler::sample(robot_state::RobotState
 
   for (std::size_t i = 1 ; i < samplers_.size() ; ++i)
   {
-	//ConstraintSampler::sample returns states with dirty link transforms (because it only writes values)
-	//but requires a state with clean link transforms as input. This means that we need to clean the link 
-	//transforms between calls to ConstraintSampler::sample.
-	state.updateLinkTransforms();
+    // ConstraintSampler::sample returns states with dirty link transforms (because it only writes values)
+    // but requires a state with clean link transforms as input. This means that we need to clean the link 
+    // transforms between calls to ConstraintSampler::sample.
+    state.updateLinkTransforms();
     if (!samplers_[i]->sample(state, state, max_attempts))
       return false;
   }

--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -134,9 +134,14 @@ bool constraint_samplers::UnionConstraintSampler::sample(robot_state::RobotState
   }
 
   for (std::size_t i = 1 ; i < samplers_.size() ; ++i)
+  {
+	//ConstraintSampler::sample returns states with dirty link transforms (because it only writes values)
+	//but requires a state with clean link transforms as input. This means that we need to clean the link 
+	//transforms between calls to ConstraintSampler::sample.
+	state.updateLinkTransforms();
     if (!samplers_[i]->sample(state, state, max_attempts))
       return false;
-
+  }
   return true;
 }
 

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -582,7 +582,7 @@ TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
   {
     EXPECT_TRUE(ucs.sample(ks, ks_const, 100));
     ks.update();
-	ks.updateLinkTransforms();//Returned samples have dirty link transforms.
+	ks.updateLinkTransforms(); //Returned samples have dirty link transforms.
     ks_const.update();
     EXPECT_TRUE(jc1.decide(ks).satisfied);
     EXPECT_TRUE(jc2.decide(ks).satisfied);

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -582,6 +582,7 @@ TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
   {
     EXPECT_TRUE(ucs.sample(ks, ks_const, 100));
     ks.update();
+	ks.updateLinkTransforms();//Returned samples have dirty link transforms.
     ks_const.update();
     EXPECT_TRUE(jc1.decide(ks).satisfied);
     EXPECT_TRUE(jc2.decide(ks).satisfied);

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -582,7 +582,7 @@ TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
   {
     EXPECT_TRUE(ucs.sample(ks, ks_const, 100));
     ks.update();
-	ks.updateLinkTransforms(); //Returned samples have dirty link transforms.
+    ks.updateLinkTransforms(); //Returned samples have dirty link transforms.
     ks_const.update();
     EXPECT_TRUE(jc1.decide(ks).satisfied);
     EXPECT_TRUE(jc2.decide(ks).satisfied);


### PR DESCRIPTION
This fixes the failing assertion in the unit tests. It fixes a bug where constrained samplers were being passed robot states with dirty link transforms. This is an issue when IKConstraintSamplers are used because they read the frame transforms to get the pose of the end-effector. 