### PR TITLE
Addition to Author Information GUI

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -955,7 +955,7 @@ bool MoveItConfigData::inputSetupAssistantYAML( const std::string& file_path )
       // Package generation time
       if( config_node = findValue( *title_node, "CONFIG" ) )
       {
-        //Load author contact details
+        // Load author contact details
         if( author_name_node = findValue( *config_node, "author_name" ) )
         {
           *author_name_node >> author_name_;

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -305,6 +305,13 @@ void StartScreenWidget::loadFilesClick()
   }
   else
   {
+    if ( !create_new_package_ && config_data_->author_name_.empty() && config_data_->author_email_.empty() )
+    {
+      QMessageBox::warning( this, "Loading Project Without Author Information",
+        "The loaded configuration package does not include author information.\n"
+        "Make sure you regenerate the '.setup_assistant' and 'package.xml' files to add it.");
+    }
+
     // Hide the logo image so that other screens can resize the rviz thing properly
     right_image_label_->hide();
   }

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -307,9 +307,11 @@ void StartScreenWidget::loadFilesClick()
   {
     if ( !create_new_package_ && config_data_->author_name_.empty() && config_data_->author_email_.empty() )
     {
-      QMessageBox::warning( this, "Loading Project Without Author Information",
+      QMessageBox::warning( this, "Missing Author Information",
         "The loaded configuration package does not include author information.\n"
-        "Make sure you regenerate the '.setup_assistant' and 'package.xml' files to add it.");
+        "Make sure you regenerate the '.setup_assistant' files to add it.\n"
+        "If you didn't specify valid author information in the 'package.xml' file before,\n"
+        "you might want to update this file as well.");
     }
 
     // Hide the logo image so that other screens can resize the rviz thing properly

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -133,7 +133,7 @@ private:
   // Variables
   // ******************************************************************************************
 
-  /// Create new config files, or load previos one?
+  /// Create new config files, or load existing one?
   bool create_new_package_;
 
   // ******************************************************************************************


### PR DESCRIPTION
@jan0e's code in #154 loads the author information from .setup_assistent .
This entails that when a user loads an existing config, they have to
re-enter their contact information over and over again until they also generate the
modified .setup_assistant file. This adds a message to tell them they should
do just that.