### PR TITLE
add safety check to IKConstraintSampler

### DIFF
--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -380,6 +380,13 @@ bool constraint_samplers::IKConstraintSampler::samplePose(Eigen::Vector3d &pos, 
                                                           const robot_state::RobotState &ks,
                                                           unsigned int max_attempts)
 {
+  if ( ks.dirtyLinkTransforms() )
+  {
+    // samplePose below requires accurate transforms
+    logError("IKConstraintSampler received dirty robot state, but valid transforms are required. Failing.");
+    return false;
+  }
+
   if (sampling_pose_.position_constraint_)
   {
     const std::vector<bodies::BodyPtr> &b = sampling_pose_.position_constraint_->getConstraintRegions();


### PR DESCRIPTION
The sampler uses the transforms, but never checked if they are dirty,
so it might return invalid/unexpected robot states.

@scottpaulin noticed this in #186 and fixed the calling code.
For safety reasons, we should also check in the sampler itself.

@scottpaulin could you please check out this patch and see if it triggers in the use-case you found?