### PR TITLE
Fix issue #136

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -737,7 +737,7 @@ void cleanCollisionGeometryCache()
 void collision_detection::CollisionData::enableGroup(const robot_model::RobotModelConstPtr &kmodel)
 {
   if (kmodel->hasJointModelGroup(req_->group_name))
-    active_components_only_ = &kmodel->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsWithGeometrySet();
+    active_components_only_ = &kmodel->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsSet();
   else
     active_components_only_ = NULL;
 }

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -242,6 +242,12 @@ public:
     return updated_link_model_vector_;
   }
 
+  /** \brief Return the same data as getUpdatedLinkModels() but as a set */
+  const std::set<const LinkModel*>& getUpdatedLinkModelsSet() const
+  {
+    return updated_link_model_set_;
+  }
+
   /** \brief Get the names of the links returned by getUpdatedLinkModels() */
   const std::vector<std::string>& getUpdatedLinkModelNames() const
   {


### PR DESCRIPTION
Fix for issue #136:

When dynamically attaching a object to a given robot link without geometry, it would be ignored during collision checking because links without geometry are not included in the active_comonents_only_ set.  

This was solved by exposing an existing JointModelGroup class member providing a complete set of updated links (with and without geometry) and using this method in collision_detection::CollisionData::enableGroup.  