### PR TITLE
Use MOVEIT_CLASS_FORWARD for the last shared_ptrs to moveit types

### DIFF
--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -112,8 +112,8 @@ protected:
 
   robot_model::RobotModelPtr               kmodel_;
 
-  boost::shared_ptr<collision_detection::CollisionRobot>        crobot_;
-  boost::shared_ptr<collision_detection::CollisionWorld>        cworld_;
+  collision_detection::CollisionRobotPtr   crobot_;
+  collision_detection::CollisionWorldPtr   cworld_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -45,6 +45,7 @@
 #include <angles/angles.h>
 #include <tf_conversions/tf_kdl.h>
 
+#include <moveit/macros/class_forward.h>
 #include <moveit_msgs/GetPositionFK.h>
 #include <moveit_msgs/GetPositionIK.h>
 #include <moveit_msgs/GetKinematicSolverInfo.h>
@@ -63,6 +64,8 @@ namespace pr2_arm_kinematics
 
 static const int NO_IK_SOLUTION = -1;
 static const int TIMED_OUT = -2;
+
+MOVEIT_CLASS_FORWARD(PR2ArmIKSolver);
 
 //minimal stuff necessary
 class PR2ArmIKSolver : public KDL::ChainIkSolverPos
@@ -126,6 +129,7 @@ double computeEuclideanDistance(const std::vector<double> &array_1, const KDL::J
 void getKDLChainInfo(const KDL::Chain &chain,
                      moveit_msgs::KinematicSolverInfo &chain_info);
 
+MOVEIT_CLASS_FORWARD(PR2ArmKinematicsPlugin);
 
 class PR2ArmKinematicsPlugin : public kinematics::KinematicsBase
 {
@@ -258,7 +262,7 @@ protected:
   bool active_;
   int free_angle_;
   boost::shared_ptr<urdf::ModelInterface> robot_model_;
-  boost::shared_ptr<pr2_arm_kinematics::PR2ArmIKSolver> pr2_arm_ik_solver_;
+  pr2_arm_kinematics::PR2ArmIKSolverPtr pr2_arm_ik_solver_;
   std::string root_name_;
   int dimension_;
   boost::shared_ptr<KDL::ChainFkSolverPos_recursive> jnt_to_pose_solver_;

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -137,8 +137,8 @@ protected:
   boost::shared_ptr<srdf::Model>     srdf_model;
   robot_model::RobotModelPtr kmodel;
   planning_scene::PlanningScenePtr ps;
-  boost::shared_ptr<pr2_arm_kinematics::PR2ArmKinematicsPlugin> pr2_kinematics_plugin_right_arm_;
-  boost::shared_ptr<pr2_arm_kinematics::PR2ArmKinematicsPlugin> pr2_kinematics_plugin_left_arm_;
+  pr2_arm_kinematics::PR2ArmKinematicsPluginPtr pr2_kinematics_plugin_right_arm_;
+  pr2_arm_kinematics::PR2ArmKinematicsPluginPtr pr2_kinematics_plugin_left_arm_;
   robot_model::SolverAllocatorFn func_right_arm;
   robot_model::SolverAllocatorFn func_left_arm;
 };

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -556,7 +556,7 @@ private:
 
   bool propagate_negative_;     /**< \brief Whether or not to propagate negative distances */
 
-  boost::shared_ptr<VoxelGrid<PropDistanceFieldVoxel> > voxel_grid_; /**< \brief Actual container for distance data */
+  VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
   std::vector<std::vector<Eigen::Vector3i> > bucket_queue_; /**< \brief Data member that holds points from which to propagate, where each vector holds points that are a particular integer distance from the closest obstacle points*/

--- a/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <cmath>
 #include <Eigen/Core>
+#include <moveit/macros/declare_ptr.h>
 
 namespace distance_field
 {
@@ -61,6 +62,8 @@ template <typename T>
 class VoxelGrid
 {
 public:
+  MOVEIT_DECLARE_PTR_MEMBER(VoxelGrid);
+
   /**
    * \brief Constructor for the VoxelGrid.
    *

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -52,4 +52,19 @@
   typedef boost::shared_ptr<Type> Name##Ptr;          \
   typedef boost::shared_ptr<const Type> Name##ConstPtr;
 
+/**
+ * \def MOVEIT_DELCARE_PTR_MEMBER
+ * Macro that given a Type declares the following types:
+ * - Ptr      = shared_ptr<${Type}>
+ * - ConstPtr = shared_ptr<const ${Type}>
+ *
+ * This macro is intended for declaring the pointer typedefs as members of a
+ * class template. In other situations, MOVEIT_CLASS_FORWARD and
+ * MOVEIT_DECLARE_PTR should be preferred.
+ */
+
+#define MOVEIT_DECLARE_PTR_MEMBER(Type)         \
+  typedef boost::shared_ptr<Type> Ptr;          \
+  typedef boost::shared_ptr<const Type> ConstPtr;
+
 #endif

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -40,6 +40,7 @@
 #include <moveit/ompl_interface/model_based_planning_context.h>
 #include <moveit/ompl_interface/parameterization/model_based_state_space_factory.h>
 #include <moveit/constraint_samplers/constraint_sampler_manager.h>
+#include <moveit/macros/class_forward.h>
 
 #include <boost/shared_ptr.hpp>
 #include <vector>
@@ -222,11 +223,11 @@ protected:
 
 private:
 
-  class LastPlanningContext;
-  boost::shared_ptr<LastPlanningContext>                last_planning_context_;
+  MOVEIT_CLASS_FORWARD(LastPlanningContext);
+  LastPlanningContextPtr                                last_planning_context_;
 
-  struct CachedContexts;
-  boost::shared_ptr<CachedContexts>                     cached_contexts_;
+  MOVEIT_CLASS_FORWARD(CachedContexts);
+  CachedContextsPtr                                     cached_contexts_;
 };
 
 }

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -35,6 +35,7 @@
 
 /* Author: Ioan Sucan, Robert Haschke */
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/controller_manager/controller_manager.h>
 #include <ros/publisher.h>
 #include <ros/rate.h>
@@ -46,6 +47,8 @@
 
 namespace moveit_fake_controller_manager
 {
+
+MOVEIT_CLASS_FORWARD(BaseFakeController);
 
 // common base class to all fake controllers in this package
 class BaseFakeController : public moveit_controller_manager::MoveItControllerHandle
@@ -60,8 +63,6 @@ protected:
   std::vector<std::string> joints_;
   const ros::Publisher &pub_;
 };
-typedef boost::shared_ptr<BaseFakeController> BaseFakeControllerPtr;
-
 
 class LastPointController : public BaseFakeController
 {

--- a/moveit_plugins/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
+++ b/moveit_plugins/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
@@ -38,9 +38,13 @@
 #define MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H
 
 #include <moveit/controller_manager/controller_manager.h>
+#include <moveit/macros/class_forward.h>
 
 namespace moveit_ros_control_interface
 {
+
+MOVEIT_CLASS_FORWARD(ControllerHandleAllocator);
+
 /**
  * Base class for MoveItControllerHandle allocators
  */

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -36,6 +36,8 @@
 
 #include <ros/ros.h>
 
+#include <moveit/macros/class_forward.h>
+
 #include <moveit_ros_control_interface/ControllerHandle.h>
 
 #include <moveit/controller_manager/controller_manager.h>
@@ -70,6 +72,8 @@ bool checkTimeout(ros::Time &t, double timeout, bool force = false)
   return false;
 }
 
+MOVEIT_CLASS_FORWARD(MoveItControllerManager);
+
 /**
  * \brief moveit_controller_manager::MoveItControllerManager sub class that interfaces one ros_control
  * controller_manager
@@ -83,7 +87,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   typedef std::map<std::string, controller_manager_msgs::ControllerState> ControllersMap;
   ControllersMap managed_controllers_;
   ControllersMap active_controllers_;
-  typedef std::map<std::string, boost::shared_ptr<ControllerHandleAllocator> > AllocatorsMap;
+  typedef std::map<std::string, ControllerHandleAllocatorPtr> AllocatorsMap;
   AllocatorsMap allocators_;
 
   typedef std::map<std::string, moveit_controller_manager::MoveItControllerHandlePtr> HandleMap;
@@ -354,7 +358,6 @@ public:
     }
     return true;
   }
-  typedef boost::shared_ptr<MoveItControllerManager> Ptr;
 };
 /**
  *  \brief MoveItMultiControllerManager discovers all running ros_control node and delegates member function to the
@@ -362,7 +365,7 @@ public:
  */
 class MoveItMultiControllerManager : public moveit_controller_manager::MoveItControllerManager
 {
-  typedef std::map<std::string, moveit_ros_control_interface::MoveItControllerManager::Ptr> ControllerManagersMap;
+  typedef std::map<std::string, moveit_ros_control_interface::MoveItControllerManagerPtr> ControllerManagersMap;
   ControllerManagersMap controller_managers_;
   ros::Time controller_managers_stamp_;
   boost::mutex controller_managers_mutex_;

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
@@ -129,7 +129,7 @@ class DepthSelfFiltering : public nodelet::Nodelet
     double padding_offset_;
 
     /** mesh filter object*/
-    boost::shared_ptr<MeshFilter<StereoCameraModel> > mesh_filter_;
+    MeshFilter<StereoCameraModel>::Ptr mesh_filter_;
 };
 
 } //namespace mesh_filter

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter.h
@@ -38,6 +38,7 @@
 #define MOVEIT_MESH_FILTER_MESHFILTER_
 
 #include <map>
+#include <moveit/macros/declare_ptr.h>
 #include <moveit/mesh_filter/gl_renderer.h>
 #include <moveit/mesh_filter/mesh_filter_base.h>
 #include <boost/function.hpp>
@@ -63,6 +64,8 @@ template <typename SensorType>
 class MeshFilter : public MeshFilterBase
 {
   public:
+    MOVEIT_DECLARE_PTR_MEMBER(MeshFilter);
+
     /**
      * \brief Constructor
      * \author Suat Gedikli (gedikli@willowgarage.com)

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
@@ -52,17 +52,10 @@
 #include <xmmintrin.h>
 #endif
 
-using std::string;
-using namespace Eigen;
-using shapes::Mesh;
-using boost::shared_ptr;
-using boost::unique_lock;
-using boost::mutex;
-
 mesh_filter::MeshFilterBase::MeshFilterBase (const TransformCallback& transform_callback,
               const SensorModel::Parameters& sensor_parameters,
-              const string& render_vertex_shader, const string& render_fragment_shader,
-              const string& filter_vertex_shader, const string& filter_fragment_shader)
+              const std::string& render_vertex_shader, const std::string& render_fragment_shader,
+              const std::string& filter_vertex_shader, const std::string& filter_fragment_shader)
 : sensor_parameters_ (sensor_parameters.clone ())
 , next_handle_ (FirstLabel) // 0 and 1 are reserved!
 , min_handle_ (FirstLabel)
@@ -72,13 +65,12 @@ mesh_filter::MeshFilterBase::MeshFilterBase (const TransformCallback& transform_
 , padding_offset_ (0.01)
 , shadow_threshold_ (0.5)
 {
-  using boost::thread;
-  filter_thread_ = thread (boost::bind(&MeshFilterBase::run, this,
+  filter_thread_ = boost::thread(boost::bind(&MeshFilterBase::run, this,
                                        render_vertex_shader, render_fragment_shader, filter_vertex_shader, filter_fragment_shader));
 }
 
-void mesh_filter::MeshFilterBase::initialize (const string& render_vertex_shader, const string& render_fragment_shader,
-                                              const string& filter_vertex_shader, const string& filter_fragment_shader)
+void mesh_filter::MeshFilterBase::initialize (const std::string& render_vertex_shader, const std::string& render_fragment_shader,
+                                              const std::string& filter_vertex_shader, const std::string& filter_fragment_shader)
 {
   mesh_renderer_.reset (new GLRenderer (sensor_parameters_->getWidth(), sensor_parameters_->getHeight(),
                                         sensor_parameters_->getNearClippingPlaneDistance (),
@@ -126,7 +118,7 @@ void mesh_filter::MeshFilterBase::initialize (const string& render_vertex_shader
 mesh_filter::MeshFilterBase::~MeshFilterBase ()
 {
   {
-    unique_lock<mutex> lock (jobs_mutex_);
+    boost::unique_lock<boost::mutex> lock (jobs_mutex_);
     stop_ = true;
     while (!jobs_queue_.empty())
     {
@@ -141,7 +133,7 @@ mesh_filter::MeshFilterBase::~MeshFilterBase ()
 void mesh_filter::MeshFilterBase::addJob (const JobPtr &job) const
 {
   {
-    unique_lock<mutex> _(jobs_mutex_);
+    boost::unique_lock<boost::mutex> _(jobs_mutex_);
     jobs_queue_.push (job);
   }
   jobs_condition_.notify_one();
@@ -168,15 +160,15 @@ void mesh_filter::MeshFilterBase::setSize (unsigned int width, unsigned int heig
 
 void mesh_filter::MeshFilterBase::setTransformCallback (const TransformCallback& transform_callback)
 {
-  mutex::scoped_lock _(transform_callback_mutex_);
+  boost::mutex::scoped_lock _(transform_callback_mutex_);
   transform_callback_ = transform_callback;
 }
 
-mesh_filter::MeshHandle mesh_filter::MeshFilterBase::addMesh (const Mesh& mesh)
+mesh_filter::MeshHandle mesh_filter::MeshFilterBase::addMesh (const shapes::Mesh& mesh)
 {
-  mutex::scoped_lock _(meshes_mutex_);
+  boost::mutex::scoped_lock _(meshes_mutex_);
 
-  shared_ptr<Job> job (new FilterJob<void> (boost::bind (&MeshFilterBase::addMeshHelper, this, next_handle_, &mesh)));
+  JobPtr job (new FilterJob<void> (boost::bind (&MeshFilterBase::addMeshHelper, this, next_handle_, &mesh)));
   addJob(job);
   job->wait ();
   mesh_filter::MeshHandle ret = next_handle_;
@@ -191,16 +183,16 @@ mesh_filter::MeshHandle mesh_filter::MeshFilterBase::addMesh (const Mesh& mesh)
   return ret;
 }
 
-void mesh_filter::MeshFilterBase::addMeshHelper (MeshHandle handle, const Mesh *cmesh)
+void mesh_filter::MeshFilterBase::addMeshHelper (MeshHandle handle, const shapes::Mesh *cmesh)
 {
-  meshes_[handle] = shared_ptr<GLMesh> (new GLMesh (*cmesh, handle));
+  meshes_[handle] = GLMeshPtr (new GLMesh (*cmesh, handle));
 }
 
 void mesh_filter::MeshFilterBase::removeMesh (MeshHandle handle)
 {
-  mutex::scoped_lock _(meshes_mutex_);
+  boost::mutex::scoped_lock _(meshes_mutex_);
   FilterJob<bool>* remover = new FilterJob<bool> (boost::bind (&MeshFilterBase::removeMeshHelper, this, handle));
-  shared_ptr<Job> job (remover);
+  JobPtr job (remover);
   addJob(job);
   job->wait ();
 
@@ -222,17 +214,17 @@ void mesh_filter::MeshFilterBase::setShadowThreshold (float threshold)
 
 void mesh_filter::MeshFilterBase::getModelLabels (LabelType* labels) const
 {
-  shared_ptr<Job> job (new FilterJob<void> (boost::bind (&GLRenderer::getColorBuffer, mesh_renderer_.get(), (unsigned char*) labels)));
+  JobPtr job (new FilterJob<void> (boost::bind (&GLRenderer::getColorBuffer, mesh_renderer_.get(), (unsigned char*) labels)));
   addJob(job);
   job->wait ();
 }
 
 void mesh_filter::MeshFilterBase::getModelDepth (float* depth) const
 {
-  shared_ptr<Job> job1 (new FilterJob<void> (boost::bind (&GLRenderer::getDepthBuffer, mesh_renderer_.get(), depth)));
-  shared_ptr<Job> job2 (new FilterJob<void> (boost::bind (&SensorModel::Parameters::transformModelDepthToMetricDepth, sensor_parameters_.get(), depth)));
+  JobPtr job1 (new FilterJob<void> (boost::bind (&GLRenderer::getDepthBuffer, mesh_renderer_.get(), depth)));
+  JobPtr job2 (new FilterJob<void> (boost::bind (&SensorModel::Parameters::transformModelDepthToMetricDepth, sensor_parameters_.get(), depth)));
   {
-    unique_lock<mutex> lock (jobs_mutex_);
+    boost::unique_lock<boost::mutex> lock (jobs_mutex_);
     jobs_queue_.push (job1);
     jobs_queue_.push (job2);
   }
@@ -243,10 +235,10 @@ void mesh_filter::MeshFilterBase::getModelDepth (float* depth) const
 
 void mesh_filter::MeshFilterBase::getFilteredDepth (float* depth) const
 {
-  shared_ptr<Job> job1 (new FilterJob<void> (boost::bind (&GLRenderer::getDepthBuffer, depth_filter_.get(), depth)));
-  shared_ptr<Job> job2 (new FilterJob<void> (boost::bind (&SensorModel::Parameters::transformFilteredDepthToMetricDepth, sensor_parameters_.get(), depth)));
+  JobPtr job1 (new FilterJob<void> (boost::bind (&GLRenderer::getDepthBuffer, depth_filter_.get(), depth)));
+  JobPtr job2 (new FilterJob<void> (boost::bind (&SensorModel::Parameters::transformFilteredDepthToMetricDepth, sensor_parameters_.get(), depth)));
   {
-    unique_lock<mutex> lock (jobs_mutex_);
+    boost::unique_lock<boost::mutex> lock (jobs_mutex_);
     jobs_queue_.push (job1);
     jobs_queue_.push (job2);
   }
@@ -257,27 +249,27 @@ void mesh_filter::MeshFilterBase::getFilteredDepth (float* depth) const
 
 void mesh_filter::MeshFilterBase::getFilteredLabels (LabelType* labels) const
 {
-  shared_ptr<Job> job (new FilterJob<void> (boost::bind (&GLRenderer::getColorBuffer, depth_filter_.get(), (unsigned char*) labels)));
+  JobPtr job (new FilterJob<void> (boost::bind (&GLRenderer::getColorBuffer, depth_filter_.get(), (unsigned char*) labels)));
   addJob(job);
   job->wait ();
 }
 
-void mesh_filter::MeshFilterBase::run (const string& render_vertex_shader, const string& render_fragment_shader,
-                                       const string& filter_vertex_shader, const string& filter_fragment_shader)
+void mesh_filter::MeshFilterBase::run (const std::string& render_vertex_shader, const std::string& render_fragment_shader,
+                                       const std::string& filter_vertex_shader, const std::string& filter_fragment_shader)
 {
   initialize (render_vertex_shader, render_fragment_shader, filter_vertex_shader, filter_fragment_shader);
 
   while (!stop_)
   {
 
-    unique_lock<mutex> lock (jobs_mutex_);
+    boost::unique_lock<boost::mutex> lock (jobs_mutex_);
     // check if we have new sensor data to be processed. If not, wait until we get notified.
     if (jobs_queue_.empty ())
       jobs_condition_.wait (lock);
 
     if (!jobs_queue_.empty ())
     {
-      shared_ptr<Job> job = jobs_queue_.front ();
+      JobPtr job = jobs_queue_.front ();
       jobs_queue_.pop ();
       lock.unlock ();
       job->execute ();
@@ -296,7 +288,7 @@ void mesh_filter::MeshFilterBase::filter (const void* sensor_data, GLushort type
     throw std::runtime_error (msg.str ());
   }
 
-  shared_ptr<Job> job (new FilterJob<void> (boost::bind (&MeshFilterBase::doFilter, this, sensor_data, type)));
+  JobPtr job (new FilterJob<void> (boost::bind (&MeshFilterBase::doFilter, this, sensor_data, type)));
   addJob(job);
   if (wait)
     job->wait ();
@@ -304,7 +296,7 @@ void mesh_filter::MeshFilterBase::filter (const void* sensor_data, GLushort type
 
 void mesh_filter::MeshFilterBase::doFilter (const void* sensor_data, const int encoding) const
 {
-  mutex::scoped_lock _(transform_callback_mutex_);
+  boost::mutex::scoped_lock _(transform_callback_mutex_);
 
   mesh_renderer_->begin ();
   sensor_parameters_->setRenderParameters (*mesh_renderer_);
@@ -321,8 +313,8 @@ void mesh_filter::MeshFilterBase::doFilter (const void* sensor_data, const int e
   Eigen::Vector3f padding_coefficients = sensor_parameters_->getPaddingCoefficients () * padding_scale_ + Eigen::Vector3f (0, 0, padding_offset_);
   glUniform3f (padding_coefficients_id, padding_coefficients [0], padding_coefficients [1], padding_coefficients [2]);
 
-  Affine3d transform;
-  for (std::map<MeshHandle, shared_ptr<GLMesh> >::const_iterator meshIt = meshes_.begin (); meshIt != meshes_.end (); ++meshIt)
+  Eigen::Affine3d transform;
+  for (std::map<MeshHandle, GLMeshPtr>::const_iterator meshIt = meshes_.begin (); meshIt != meshes_.end (); ++meshIt)
     if (transform_callback_ (meshIt->first, transform))
       meshIt->second->render (transform);
 

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -41,6 +41,7 @@
 #include <srdfdom/model.h> // use their struct datastructures
 #include <srdfdom/srdf_writer.h> // for writing srdf data
 #include <urdf/model.h> // to share throughout app
+#include <moveit/macros/class_forward.h>
 #include <moveit/planning_scene/planning_scene.h> // for getting kinematic model
 #include <moveit/collision_detection/collision_matrix.h> // for figuring out if robot is in collision
 #include <moveit/setup_assistant/tools/compute_default_collisions.h> // for LinkPairMap
@@ -80,7 +81,7 @@ struct GroupMetaData
 /**
  * Planning parameters which may be set in the config files
  */
- struct OmplPlanningParameter
+struct OmplPlanningParameter
 {
   std::string name; // name of parameter
   std::string value; // value parameter will receive (but as a string)
@@ -88,19 +89,21 @@ struct GroupMetaData
  };
 
 /** \brief This class describes the OMPL planners by name, type, and parameter list, used to create the ompl_planning.yaml file */
- class OMPLPlannerDescription 
+class OMPLPlannerDescription
 {
  public:
 /** \brief Constructor
  *  @param name: name of planner
  *  @parameter type: type of planner
  */
-   OMPLPlannerDescription(const std::string  &name, const std::string  &type){
+   OMPLPlannerDescription(const std::string  &name, const std::string  &type)
+   {
      name_ = name;
      type_ = type;
    };
    /** \brief Destructor */
-   ~OMPLPlannerDescription(){
+   ~OMPLPlannerDescription()
+   {
      parameter_list_.clear();
    };
    /** \brief adds a parameter to the planner description 
@@ -108,7 +111,8 @@ struct GroupMetaData
     * @parameter: value: value of parameter as a string
     *  @parameter: value: value of parameter as a string
     */
-   void   addParameter(const std::string &name, const  std::string &value="", const  std::string  &comment=""){
+   void addParameter(const std::string &name, const  std::string &value="", const  std::string  &comment="")
+   {
      OmplPlanningParameter temp;
      temp.name =  name;
      temp.value =  value;
@@ -118,7 +122,9 @@ struct GroupMetaData
    std::vector<OmplPlanningParameter> parameter_list_;
    std::string name_; // name of planner
    std::string type_;  // type of planner (geometric)
- };
+};
+
+MOVEIT_CLASS_FORWARD(MoveItConfigData);
 
 /** \brief This class is shared with all widgets and contains the common configuration data
     needed for generating each robot's MoveIt configuration package.
@@ -316,9 +322,6 @@ private:
   // Shared planning scene
   planning_scene::PlanningScenePtr planning_scene_;
 };
-
-/// Create a shared pointer for passing this data object between widgets
-typedef boost::shared_ptr<MoveItConfigData> MoveItConfigDataPtr;
 
 
 } // namespace


### PR DESCRIPTION
This PR uses MOVEIT_CLASS_FORWARD (and friend) to remove the last explicit use of `boost::shared_ptr` to any moveit type in this repository, with the exception of `moveit_experimental/*` and the chomp and sbpl planners.

I looked for any remaining explicit `shared_ptrs` to moveit types with this pretty one-liner:
```
grep -rP 'boost::shared_ptr<(?!(?:const )?(?:tf::|srdf::|urdf::|rviz::|interactive_markers::|image_transport::|pluginlib::|ros::|KDL::|shapes::|actionlib::|QTimer|QSettings|QProgressDialog))'
```