### PR TITLE
reduce exposure of geometric_shapes headers (that requires C++11)

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -42,7 +42,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <type_traits>
 #include <memory>
 #include <boost/function.hpp>
 #include <Eigen/Geometry>

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -47,9 +47,11 @@
 #include <boost/function.hpp>
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_vector_container.h>
-#include <geometric_shapes/shapes.h>
 
-static_assert(std::is_same<decltype(shapes::OcTree::octree), std::shared_ptr<const octomap::OcTree>>::value, "This version of moveit requires geometric_shapes 0.5.1 or later.");
+namespace shapes
+{
+MOVEIT_CLASS_FORWARD(Shape);
+}
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -40,7 +40,7 @@
 #include <octomap/math/Vector3.h>
 #include <octomap/math/Utils.h>
 #include <octomap/octomap.h>
-
+#include <geometric_shapes/shapes.h>
 #include <memory>
 
 //static const double ISO_VALUE  = 0.5; // TODO magic number! (though, probably a good one).

--- a/moveit_core/collision_detection/test/test_world.cpp
+++ b/moveit_core/collision_detection/test/test_world.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 #include <moveit/collision_detection/world.h>
+#include <geometric_shapes/shapes.h>
 #include <boost/bind.hpp>
 
 

--- a/moveit_core/collision_detection/test/test_world_diff.cpp
+++ b/moveit_core/collision_detection/test/test_world_diff.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 #include <moveit/collision_detection/world_diff.h>
+#include <geometric_shapes/shapes.h>
 
 TEST(WorldDiff, TrackChanges)
 {

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -35,6 +35,7 @@
 /* Author: Ioan Sucan, Jia Pan */
 
 #include <moveit/collision_detection_fcl/collision_common.h>
+#include <geometric_shapes/shapes.h>
 #include <fcl/BVH/BVH_model.h>
 #include <fcl/shape/geometric_shapes.h>
 #include <fcl/octree.h>

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -47,7 +47,16 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_containers.h>
-#include <geometric_shapes/shapes.h>
+#include <moveit/macros/class_forward.h>
+
+namespace shapes
+{
+MOVEIT_CLASS_FORWARD(Shape);
+}
+namespace octomap
+{
+class OcTree;
+}
 
 /**
  * \brief Namespace for holding classes that generate distance fields.

--- a/moveit_core/distance_field/include/moveit/distance_field/find_internal_points.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/find_internal_points.h
@@ -38,7 +38,6 @@
 #define MOVEIT_DISTANCE_FIELD__FIND_INTERNAL_POINTS_
 
 #include <eigen_stl_containers/eigen_stl_containers.h>
-//#include <geometric_shapes/shapes.h>
 #include <geometric_shapes/bodies.h>
 
 namespace distance_field

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -25,7 +25,7 @@
   <build_depend>eigen_conversions</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>libfcl-dev</build_depend>
-  <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
+  <build_depend version_gte="0.5.1">geometric_shapes</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
@@ -50,7 +50,7 @@
   <run_depend>eigen_conversions</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
   <run_depend>libfcl-dev</run_depend>
-  <run_depend version_gte="0.3.4">geometric_shapes</run_depend>
+  <run_depend version_gte="0.5.1">geometric_shapes</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>kdl_parser</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>

--- a/moveit_core/robot_model/include/moveit/robot_model/link_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/link_model.h
@@ -42,8 +42,13 @@
 #include <utility>
 #include <map>
 #include <Eigen/Geometry>
-#include <geometric_shapes/shapes.h>
 #include <eigen_stl_containers/eigen_stl_vector_container.h>
+#include <moveit/macros/class_forward.h>
+
+namespace shapes
+{
+MOVEIT_CLASS_FORWARD(Shape);
+}
 
 namespace moveit
 {

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -35,6 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/robot_state/attached_body.h>
+#include <geometric_shapes/shapes.h>
 
 moveit::core::AttachedBody::AttachedBody(const LinkModel *parent_link_model,
                                          const std::string &id,

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -41,6 +41,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <boost/filesystem/path.hpp>
+#include <geometric_shapes/shapes.h>
 #include <moveit/profiler/profiler.h>
 #include <moveit_resources/config.h>
 

--- a/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
+++ b/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
@@ -42,9 +42,13 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <object_recognition_msgs/TableArray.h>
 #include <moveit_msgs/CollisionObject.h>
-#include <geometric_shapes/shapes.h>
-
 #include <boost/thread/mutex.hpp>
+#include <moveit/macros/class_forward.h>
+
+namespace shapes
+{
+MOVEIT_CLASS_FORWARD(Shape);
+}
 
 namespace moveit
 {


### PR DESCRIPTION
As geometric_shapes 0.5.1 now requires C++11, we should try to reduce exposure of its headers to a minimum. Otherwise we enforce downstream code to compile with C++11 too.

Using forward declarations, in many cases, exposure can be avoided.