### PR TITLE
undo reordering of dynamic reconfigure parameters in trajectory execution manager

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -5,7 +5,7 @@ gen = ParameterGenerator()
 
 gen.add("execution_duration_monitoring", bool_t, 1, "Monitor the execution duration of a trajectory. If expected duration is exceeded, the trajectory is canceled.", True)
 gen.add("allowed_execution_duration_scaling", double_t, 2, "Accept durations that take a little more time than specified", 1.1, 1, 10)
-gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling)", 0.5, 0.1, 5)
-gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
+gen.add("execution_velocity_scaling", double_t, 3, "Multiplicative factor for execution speed", 1, 0.1, 10)
+gen.add("allowed_goal_duration_margin", double_t, 4, "Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling)", 0.5, 0.1, 5)
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))


### PR DESCRIPTION
Adding the new parameter here broke ABI in two ways:

1. adding the new member

2. moving execution_velocity_scaling to a different position

We want to have the parameter here, so we will break ABI with 1.
Nevertheless, to avoid data-misinterpretation in case of ABI issues,
this commit undoes the second part.

This commit is only about ABI stability and there is no need to pick it to jade and kinetic.