### PR TITLE
refine collision widget of the setup assistant

### DIFF
--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -481,6 +481,7 @@ void DefaultCollisionsWidget::toggleCheckBox(int row, int column)
   // Copy data changes to srdf_writer object
   linkPairsToSRDF();
 
+  previewClicked(row, column, 0, 0);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -565,8 +565,9 @@ void DefaultCollisionsWidget::previewClicked( int row, int column, int _oldrow, 
   Q_EMIT unhighlightAll();
 
   // Highlight link
-  Q_EMIT highlightLink( selected[0]->text().toStdString() );
-  Q_EMIT highlightLink( selected[1]->text().toStdString() );
+  QColor color = (selected[2]->checkState() == Qt::Checked) ? QColor(0, 255, 0) : QColor(255, 0, 0);
+  Q_EMIT highlightLink( selected[0]->text().toStdString(), color );
+  Q_EMIT highlightLink( selected[1]->text().toStdString(), color );
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -439,53 +439,48 @@ void DefaultCollisionsWidget::collisionCheckboxToggle()
 void DefaultCollisionsWidget::toggleCheckBox(int row, int column)
 {
   // Only accept cell changes if table is enabled, otherwise it is this program making changes
-  if( collision_table_->isEnabled() )
+  // Also make sure the change is in the checkbox column
+  if( !collision_table_->isEnabled() || column != 2 )
+    return;
+
+  // Convert row to pair
+  std::pair<std::string, std::string> link_pair;
+  link_pair.first = collision_table_->item(row, 0)->text().toStdString();
+  link_pair.second = collision_table_->item(row, 1)->text().toStdString();
+
+  // Get the state of checkbox
+  bool check_state = collision_table_->item(row, 2)->checkState();
+
+  // Check if the checkbox state has changed from original value
+  if( link_pairs_[ link_pair ].disable_check != check_state )
   {
-    // Make sure change is the checkbox column
-    if( column == 2 )
+    // Save the change
+    link_pairs_[ link_pair ].disable_check = check_state;
+
+    // Handle USER Reasons: 1) pair is disabled by user
+    if( link_pairs_[ link_pair ].disable_check == true &&
+        link_pairs_[ link_pair ].reason == moveit_setup_assistant::NOT_DISABLED )
     {
+      link_pairs_[ link_pair ].reason = moveit_setup_assistant::USER;
 
-      // Convert row to pair
-      std::pair<std::string, std::string> link_pair;
-      link_pair.first = collision_table_->item(row, 0)->text().toStdString();
-      link_pair.second = collision_table_->item(row, 1)->text().toStdString();
-
-      // Get the state of checkbox
-      bool check_state = collision_table_->item(row, 2)->checkState();
-
-
-      // Check if the checkbox state has changed from original value
-      if( link_pairs_[ link_pair ].disable_check != check_state )
-      {
-
-        // Save the change
-        link_pairs_[ link_pair ].disable_check = check_state;
-
-        // Handle USER Reasons: 1) pair is disabled by user
-        if( link_pairs_[ link_pair ].disable_check == true &&
-            link_pairs_[ link_pair ].reason == moveit_setup_assistant::NOT_DISABLED )
-        {
-          link_pairs_[ link_pair ].reason = moveit_setup_assistant::USER;
-
-          // Change Reason in Table
-          collision_table_->item(row, 3)->setText( longReasonsToString.at( link_pairs_[ link_pair ].reason ) );
-        }
-        // Handle USER Reasons: 2) pair was disabled by user and now is enabled (not checked)
-        else if( link_pairs_[ link_pair ].disable_check == false &&
-                 link_pairs_[ link_pair ].reason == moveit_setup_assistant::USER )
-        {
-          link_pairs_[ link_pair ].reason = moveit_setup_assistant::NOT_DISABLED;
-
-          // Change Reason in Table
-          collision_table_->item(row, 3)->setText( "" );
-        }
-
-      }
-
-      // Copy data changes to srdf_writer object
-      linkPairsToSRDF();
+      // Change Reason in Table
+      collision_table_->item(row, 3)->setText( longReasonsToString.at( link_pairs_[ link_pair ].reason ) );
     }
+    // Handle USER Reasons: 2) pair was disabled by user and now is enabled (not checked)
+    else if( link_pairs_[ link_pair ].disable_check == false &&
+             link_pairs_[ link_pair ].reason == moveit_setup_assistant::USER )
+    {
+      link_pairs_[ link_pair ].reason = moveit_setup_assistant::NOT_DISABLED;
+
+      // Change Reason in Table
+      collision_table_->item(row, 3)->setText( "" );
+    }
+
   }
+
+  // Copy data changes to srdf_writer object
+  linkPairsToSRDF();
+
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -155,7 +155,7 @@ DefaultCollisionsWidget::DefaultCollisionsWidget( QWidget *parent,
   collision_table_->setSortingEnabled(true);
   collision_table_->setSelectionMode( QAbstractItemView::SingleSelection );
   collision_table_->setSelectionBehavior( QAbstractItemView::SelectRows );
-  connect(collision_table_, SIGNAL(cellClicked(int, int)), this, SLOT(previewClicked(int, int)));
+  connect(collision_table_, SIGNAL(currentCellChanged(int, int, int, int)), this, SLOT(previewClicked(int, int, int, int)));
   connect(collision_table_, SIGNAL(cellChanged(int, int)), this, SLOT(toggleCheckBox(int, int)));
   layout_->addWidget(collision_table_);
 
@@ -552,7 +552,7 @@ void DefaultCollisionsWidget::linkPairsFromSRDF()
 // ******************************************************************************************
 // Preview whatever element is selected
 // ******************************************************************************************
-void DefaultCollisionsWidget::previewClicked( int row, int column )
+void DefaultCollisionsWidget::previewClicked( int row, int column, int _oldrow, int _oldcolumn)
 {
   // Get list of all selected items
   QList<QTableWidgetItem*> selected = collision_table_->selectedItems();

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -153,6 +153,7 @@ DefaultCollisionsWidget::DefaultCollisionsWidget( QWidget *parent,
   collision_table_ = new QTableWidget( this );
   collision_table_->setColumnCount(4);
   collision_table_->setSortingEnabled(true);
+  collision_table_->setSelectionMode( QAbstractItemView::SingleSelection );
   collision_table_->setSelectionBehavior( QAbstractItemView::SelectRows );
   connect(collision_table_, SIGNAL(cellClicked(int, int)), this, SLOT(previewClicked(int, int)));
   connect(collision_table_, SIGNAL(cellChanged(int, int)), this, SLOT(toggleCheckBox(int, int)));

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -155,7 +155,9 @@ DefaultCollisionsWidget::DefaultCollisionsWidget( QWidget *parent,
   collision_table_->setSortingEnabled(true);
   collision_table_->setSelectionMode( QAbstractItemView::SingleSelection );
   collision_table_->setSelectionBehavior( QAbstractItemView::SelectRows );
-  connect(collision_table_, SIGNAL(currentCellChanged(int, int, int, int)), this, SLOT(previewClicked(int, int, int, int)));
+  connect(collision_table_, SIGNAL(cellClicked(int, int)), this, SLOT(previewClicked(int, int)));
+  connect(collision_table_, SIGNAL(currentCellChanged(int, int, int, int)),
+          this, SLOT(previewClicked(int, int, int, int)));
   connect(collision_table_, SIGNAL(cellChanged(int, int)), this, SLOT(toggleCheckBox(int, int)));
   layout_->addWidget(collision_table_);
 
@@ -481,7 +483,7 @@ void DefaultCollisionsWidget::toggleCheckBox(int row, int column)
   // Copy data changes to srdf_writer object
   linkPairsToSRDF();
 
-  previewClicked(row, column, 0, 0);
+  previewClicked(row, column);
 }
 
 // ******************************************************************************************
@@ -554,6 +556,11 @@ void DefaultCollisionsWidget::linkPairsFromSRDF()
 // Preview whatever element is selected
 // ******************************************************************************************
 void DefaultCollisionsWidget::previewClicked( int row, int column, int _oldrow, int _oldcolumn)
+{
+  this->previewClicked(row, column);
+}
+
+void DefaultCollisionsWidget::previewClicked( int row, int column )
 {
   // Get list of all selected items
   QList<QTableWidgetItem*> selected = collision_table_->selectedItems();

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -124,9 +124,14 @@ private Q_SLOTS:
   void toggleCheckBox(int j, int i);
 
   /**
-   * \breif Called when a row is clicked, to highlight links on robot
+   * \breif Called when the row is changed via keyboard, to highlight links on robot
    */
   void previewClicked( int row, int column, int _oldrow, int _oldcolumn );
+
+  /**
+  * \breif Called when a row is clicked, to highlight links on robot
+  */
+  void previewClicked( int row, int column );
 
   /**
    * \brief Called when setup assistant navigation switches to this screen

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -126,7 +126,7 @@ private Q_SLOTS:
   /**
    * \breif Called when a row is clicked, to highlight links on robot
    */
-  void previewClicked( int row, int column );
+  void previewClicked( int row, int column, int _oldrow, int _oldcolumn );
 
   /**
    * \brief Called when setup assistant navigation switches to this screen

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -278,7 +278,7 @@ void KinematicChainWidget::itemSelected()
       return;
 
     // Check that item is not empty
-    Q_EMIT highlightLink( item->text(0).toStdString() );
+    Q_EMIT highlightLink( item->text(0).toStdString(), QColor(255, 0, 0) );
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
@@ -120,7 +120,7 @@ Q_SIGNALS:
   void cancelEditing();
 
   /// Event for telling rviz to highlight a link of the robot
-  void highlightLink( const std::string& name );
+  void highlightLink( const std::string& name, const QColor& );
 
   /// Event for telling rviz to unhighlight all links of the robot
   void unhighlightAll();

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
@@ -150,7 +150,7 @@ void PassiveJointsWidget::previewSelectedJoints( std::vector<std::string> joints
     }
 
     // Highlight link
-    Q_EMIT highlightLink( link );
+    Q_EMIT highlightLink( link, QColor(255, 0, 0) );
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -127,7 +127,8 @@ PlanningGroupsWidget::PlanningGroupsWidget( QWidget *parent, moveit_setup_assist
   connect( chain_widget_, SIGNAL( cancelEditing() ), this, SLOT( cancelEditing() ) );
   connect( chain_widget_, SIGNAL( doneEditing() ), this, SLOT( saveChainScreen() ) );
   connect( chain_widget_, SIGNAL( unhighlightAll() ), this, SIGNAL( unhighlightAll() ) );
-  connect( chain_widget_, SIGNAL( highlightLink(const std::string&)), this, SIGNAL(highlightLink(const std::string&)) );
+  connect( chain_widget_, SIGNAL( highlightLink(const std::string&, const QColor&)),
+           this, SIGNAL(highlightLink(const std::string&, const QColor&)) );
 
   // Subgroups Widget
   subgroups_widget_ = new DoubleListWidget( this, config_data_, "Subgroup", "Subgroup" );
@@ -1422,7 +1423,7 @@ void PlanningGroupsWidget::previewSelectedLink( std::vector<std::string> links )
     }
 
     // Highlight link
-    Q_EMIT highlightLink( links[i] );
+    Q_EMIT highlightLink( links[i], QColor(255, 0, 0) );
   }
 }
 
@@ -1454,7 +1455,7 @@ void PlanningGroupsWidget::previewSelectedJoints( std::vector<std::string> joint
     }
 
     // Highlight link
-    Q_EMIT highlightLink( link );
+    Q_EMIT highlightLink( link, QColor(255, 0, 0) );
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -221,7 +221,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   // Self-Collisions
   dcw_ = new DefaultCollisionsWidget( this, config_data_);
   main_content_->addWidget( dcw_ );
-  connect( dcw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( dcw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( dcw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( dcw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
@@ -229,7 +229,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   vjw_ = new VirtualJointsWidget( this, config_data_ );
   main_content_->addWidget(vjw_);
   connect( vjw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
-  connect( vjw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( vjw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( vjw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( vjw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
   connect( vjw_, SIGNAL( referenceFrameChanged() ), this, SLOT( virtualJointReferenceFrameChanged() ) );
@@ -238,7 +238,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   pgw_ = new PlanningGroupsWidget( this, config_data_ );
   main_content_->addWidget(pgw_);
   connect( pgw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
-  connect( pgw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( pgw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( pgw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( pgw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
@@ -246,7 +246,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   rpw_ = new RobotPosesWidget( this, config_data_ );
   main_content_->addWidget(rpw_);
   connect( rpw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
-  connect( rpw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( rpw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( rpw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( rpw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
@@ -254,7 +254,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   efw_ = new EndEffectorsWidget( this, config_data_ );
   main_content_->addWidget(efw_);
   connect( efw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
-  connect( efw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( efw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( efw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( efw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
@@ -262,7 +262,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   pjw_ = new PassiveJointsWidget( this, config_data_ );
   main_content_->addWidget(pjw_);
   connect( pjw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
-  connect( pjw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( pjw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( pjw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( pjw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
@@ -270,7 +270,7 @@ void SetupAssistantWidget::progressPastStartScreen()
   aiw_ = new AuthorInformationWidget( this, config_data_ );
   main_content_->addWidget( aiw_ );
   connect( aiw_, SIGNAL( isModal( bool ) ), this, SLOT( setModalMode( bool ) ) );
-  connect( aiw_, SIGNAL( highlightLink( const std::string& ) ), this, SLOT( highlightLink( const std::string& ) ) );
+  connect( aiw_, SIGNAL( highlightLink( const std::string&, const QColor& ) ), this, SLOT( highlightLink( const std::string&, const QColor& ) ) );
   connect( aiw_, SIGNAL( highlightGroup( const std::string& ) ), this, SLOT( highlightGroup( const std::string& ) ) );
   connect( aiw_, SIGNAL( unhighlightAll() ), this, SLOT( unhighlightAll() ) );
 
@@ -350,11 +350,11 @@ void SetupAssistantWidget::loadRviz()
 // ******************************************************************************************
 // Highlight a robot link
 // ******************************************************************************************
-void SetupAssistantWidget::highlightLink( const std::string& link_name )
+void SetupAssistantWidget::highlightLink( const std::string& link_name, const QColor& color )
 {
   const robot_model::LinkModel *lm = config_data_->getRobotModel()->getLinkModel(link_name);
   if (!lm->getShapes().empty()) // skip links with no geometry
-    robot_state_display_->setLinkColor( link_name, QColor(255, 0, 0) );
+    robot_state_display_->setLinkColor( link_name, color );
 }
 
 // ******************************************************************************************
@@ -374,7 +374,7 @@ void SetupAssistantWidget::highlightGroup( const std::string& group_name )
     // Iterate through the links
     for( std::vector<const robot_model::LinkModel*>::const_iterator link_it = link_models.begin();
          link_it < link_models.end(); ++link_it )
-      highlightLink( (*link_it)->getName() );
+      highlightLink( (*link_it)->getName(), QColor(255, 0, 0) );
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
@@ -180,7 +180,7 @@ private Q_SLOTS:
    *
    * @param link_name name of link to highlight
    */
-  void highlightLink( const std::string& link_name );
+  void highlightLink( const std::string& link_name, const QColor& color );
 
   /**
    * Highlight a robot group

--- a/moveit_setup_assistant/src/widgets/setup_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/setup_screen_widget.h
@@ -66,7 +66,7 @@ Q_SIGNALS:
   void isModal( bool isModal );
 
   /// Event for telling rviz to highlight a link of the robot
-  void highlightLink( const std::string& name );
+  void highlightLink( const std::string& name, const QColor& );
 
   /// Event for telling rviz to highlight a group of the robot
   void highlightGroup( const std::string& name );


### PR DESCRIPTION
I just had to look through a list of way too many link pairs for a new
config, and got seriously annoyed by some issues with the widget.
So I fixed/changed them.

Does anyone know of work that improves the automatic generation of the ACM?
Generating (even a huge amount) of random samples still produced quite a number
of false-positive cases of never-in-collision over here.

@davetcoleman please review.