### PR TITLE
Add weak_ptr typedefs to MOVEIT_DECLARE_PTR

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -39,7 +39,6 @@
 
 #include <moveit/collision_detection/world.h>
 #include <moveit/macros/class_forward.h>
-#include <boost/weak_ptr.hpp>
 
 namespace collision_detection
 {
@@ -124,7 +123,7 @@ namespace collision_detection
     World::ObserverHandle observer_handle_;
 
     /* used to unregister the notifier */
-    boost::weak_ptr<World> world_;
+    WorldWeakPtr world_;
   };
 }
 

--- a/moveit_core/collision_detection/src/world_diff.cpp
+++ b/moveit_core/collision_detection/src/world_diff.cpp
@@ -61,7 +61,7 @@ collision_detection::WorldDiff::WorldDiff(WorldDiff &other)
   {
     changes_ = other.changes_;
 
-    boost::weak_ptr<World>(world).swap(world_);
+    WorldWeakPtr(world).swap(world_);
     observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, _1, _2));
   }
 }
@@ -85,7 +85,7 @@ void collision_detection::WorldDiff::reset(const WorldPtr& world)
   if (old_world)
     old_world->removeObserver(observer_handle_);
 
-  boost::weak_ptr<World>(world).swap(world_);
+  WorldWeakPtr(world).swap(world_);
   observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, _1, _2));
 }
 
@@ -98,7 +98,7 @@ void collision_detection::WorldDiff::setWorld(const WorldPtr& world)
     old_world->removeObserver(observer_handle_);
   }
 
-  boost::weak_ptr<World>(world).swap(world_);
+  WorldWeakPtr(world).swap(world_);
 
   observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, _1, _2));
   world->notifyObserverAllObjects(observer_handle_, World::CREATE|World::ADD_SHAPE);

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -36,35 +36,44 @@
 #define MOVEIT_MACROS_DECLARE_PTR_
 
 #include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
 
 /**
  * \def MOVEIT_DELCARE_PTR
  * Macro that given a Name and a Type declares the following types:
- * - ${Name}Ptr      = shared_ptr<${Type}>
- * - ${Name}ConstPtr = shared_ptr<const ${Type}>
+ * - ${Name}Ptr          = shared_ptr<${Type}>
+ * - ${Name}ConstPtr     = shared_ptr<const ${Type}>
+ * - ${Name}WeakPtr      = weak_ptr<${Type}>
+ * - ${Name}WeakConstPtr = weak_ptr<const ${Type}>
  *
  * For best portability the exact type of shared_ptr declared by the macro
  * should be considered to be an implementation detail, liable to change in
  * future releases.
  */
 
-#define MOVEIT_DECLARE_PTR(Name, Type)                \
-  typedef boost::shared_ptr<Type> Name##Ptr;          \
-  typedef boost::shared_ptr<const Type> Name##ConstPtr;
+#define MOVEIT_DECLARE_PTR(Name, Type)                  \
+  typedef boost::shared_ptr<Type> Name##Ptr;            \
+  typedef boost::shared_ptr<const Type> Name##ConstPtr; \
+  typedef boost::weak_ptr<Type> Name##WeakPtr;          \
+  typedef boost::weak_ptr<const Type> Name##WeakConstPtr;
 
 /**
  * \def MOVEIT_DELCARE_PTR_MEMBER
  * Macro that given a Type declares the following types:
- * - Ptr      = shared_ptr<${Type}>
- * - ConstPtr = shared_ptr<const ${Type}>
+ * - Ptr          = shared_ptr<${Type}>
+ * - ConstPtr     = shared_ptr<const ${Type}>
+ * - WeakPtr      = weak_ptr<${Type}>
+ * - WeakConstPtr = weak_ptr<const ${Type}>
  *
  * This macro is intended for declaring the pointer typedefs as members of a
  * class template. In other situations, MOVEIT_CLASS_FORWARD and
  * MOVEIT_DECLARE_PTR should be preferred.
  */
 
-#define MOVEIT_DECLARE_PTR_MEMBER(Type)         \
-  typedef boost::shared_ptr<Type> Ptr;          \
-  typedef boost::shared_ptr<const Type> ConstPtr;
+#define MOVEIT_DECLARE_PTR_MEMBER(Type)           \
+  typedef boost::shared_ptr<Type> Ptr;            \
+  typedef boost::shared_ptr<const Type> ConstPtr; \
+  typedef boost::weak_ptr<Type> WeakPtr;          \
+  typedef boost::weak_ptr<const Type> WeakConstPtr;
 
 #endif


### PR DESCRIPTION
**Note:** I'm not really sure if this PR is a good solution as it is. Opinions welcome.

This PR adds typedefs for `weak_ptr` to `MOVEIT_DELCARE_PTR`. Also discussed in #48, we want to tell people to use the `shared_ptr` typedefs, but that doesn't currently leave them a way to use the matching `weak_ptr`. This PR would solve that.

On the other hand, use of `weak_ptr` is much more rare. One use is to avoid `shared_ptr` cycles. Such cycles can only be made by embedding the pointers inside the pointed-to type(s), and users can't really do that. Of course, there are undoubtedly other uses for `weak_ptrs` that I'm not thinking of right now.

So, do we want to add a ton of exposed typedefs for probably a small if not zero number of niche use cases?

Slightly off-topic: All this macro hackery made me think a bit. A macro-free C++11 solution would be this in a public header somewhere:

```
template<typename T> using SharedPtr = boost::shared_ptr<T>;
template<typename T> using WeakPtr   = boost::weak_ptr<T>;
```

Or much less nice pre C++11:
```
template<typename T> struct SharedPtr { typedef boost::shared_ptr<T> type; };
template<typename T> struct WeakPtr   { typedef boost::weak_ptr<T>   type; };
```

Or even:
```
template<typename T>
struct Ptr {
  typedef boost::shared_ptr<T>       Shared;
  typedef boost::shared_ptr<const T> SharedConst;
  typedef boost::weak_ptr<T>         Weak;
  typedef boost::weak_ptr<const T>   WeakConst;
};
```

Or some variation on this theme. We could even use the not-so-pretty option just for `weak_ptrs` to avoid adding a ton of public typedefs.