### PR TITLE
Use urdf::*SharedPtr instead of boost::shared_ptr

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -23,7 +23,7 @@ set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
 find_package(octomap REQUIRED)
 
 find_package(urdfdom REQUIRED)
-find_package(urdfdom_headers REQUIRED)
+find_package(urdfdom_headers 0.4 REQUIRED)
 
 find_package(catkin REQUIRED
 COMPONENTS

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -39,6 +39,7 @@
 #include <fcl/shape/geometric_shapes.h>
 #include <fcl/octree.h>
 #include <boost/thread/mutex.hpp>
+#include <boost/weak_ptr.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -107,7 +107,7 @@ protected:
   bool urdf_ok_;
   bool srdf_ok_;
 
-  boost::shared_ptr<urdf::ModelInterface>  urdf_model_;
+  urdf::ModelInterfaceSharedPtr            urdf_model_;
   boost::shared_ptr<srdf::Model>           srdf_model_;
 
   robot_model::RobotModelPtr               kmodel_;

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -58,10 +58,10 @@ bool PR2ArmIK::init(const urdf::ModelInterface &robot_model, const std::string &
 {
   std::vector<urdf::Pose> link_offset;
   int num_joints = 0;
-  boost::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_name);
   while(link && num_joints < 7)
   {
-    boost::shared_ptr<const urdf::Joint> joint;
+    urdf::JointConstSharedPtr joint;
     if (link->parent_joint)
       joint = robot_model.getJoint(link->parent_joint->name);
     if(!joint)
@@ -149,7 +149,7 @@ bool PR2ArmIK::init(const urdf::ModelInterface &robot_model, const std::string &
   return true;
 }
 
-void PR2ArmIK::addJointToChainInfo(boost::shared_ptr<const urdf::Joint> joint, moveit_msgs::KinematicSolverInfo &info)
+void PR2ArmIK::addJointToChainInfo(urdf::JointConstSharedPtr joint, moveit_msgs::KinematicSolverInfo &info)
 {
   moveit_msgs::JointLimits limit;
   info.joint_names.push_back(joint->name);//Joints are coming in reverse order

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -167,7 +167,7 @@ public:
 
   private:
 
-  void addJointToChainInfo(boost::shared_ptr<const urdf::Joint> joint,moveit_msgs::KinematicSolverInfo &info);
+  void addJointToChainInfo(urdf::JointConstSharedPtr joint,moveit_msgs::KinematicSolverInfo &info);
 
   bool checkJointLimits(const std::vector<double> &joint_values) const;
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -261,7 +261,7 @@ bool PR2ArmKinematicsPlugin::isActive()
   return false;
 }
 
-void PR2ArmKinematicsPlugin::setRobotModel(boost::shared_ptr<urdf::ModelInterface>& robot_model)
+void PR2ArmKinematicsPlugin::setRobotModel(urdf::ModelInterfaceSharedPtr& robot_model)
 {
   robot_model_ = robot_model;
 }

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -140,7 +140,7 @@ public:
    */
   PR2ArmKinematicsPlugin();
 
-  void setRobotModel(boost::shared_ptr<urdf::ModelInterface>& robot_model);
+  void setRobotModel(urdf::ModelInterfaceSharedPtr& robot_model);
 
   /**
    *  @brief Specifies if the node is active or not
@@ -261,7 +261,7 @@ protected:
 
   bool active_;
   int free_angle_;
-  boost::shared_ptr<urdf::ModelInterface> robot_model_;
+  urdf::ModelInterfaceSharedPtr robot_model_;
   pr2_arm_kinematics::PR2ArmIKSolverPtr pr2_arm_ik_solver_;
   std::string root_name_;
   int dimension_;

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -55,6 +55,8 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <urdf_world/types.h>
+
 #include <moveit/kinematics_base/kinematics_base.h>
 
 #include "pr2_arm_ik.h"

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -133,7 +133,7 @@ protected:
 
 protected:
 
-  boost::shared_ptr<urdf::ModelInterface>     urdf_model;
+  urdf::ModelInterfaceSharedPtr      urdf_model;
   boost::shared_ptr<srdf::Model>     srdf_model;
   robot_model::RobotModelPtr kmodel;
   planning_scene::PlanningScenePtr ps;

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -102,7 +102,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr &robot_mode
   tip_name_ = joint_model_group_->getLinkModelNames().back();
   logDebug("moveit.dynamics_solver: Base name: '%s', Tip name: '%s'", base_name_.c_str(), tip_name_.c_str());
 
-  const boost::shared_ptr<const urdf::ModelInterface> urdf_model = robot_model_->getURDF();
+  const urdf::ModelInterfaceSharedPtr urdf_model = robot_model_->getURDF();
   const boost::shared_ptr<const srdf::Model> srdf_model = robot_model_->getSRDF();
   KDL::Tree tree;
 

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -78,7 +78,7 @@ protected:
 
 protected:
 
-  boost::shared_ptr<urdf::ModelInterface>     urdf_model;
+  urdf::ModelInterfaceSharedPtr      urdf_model;
   boost::shared_ptr<srdf::Model>     srdf_model;
   robot_model::RobotModelPtr kmodel;
 };

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -30,7 +30,7 @@
   <build_depend>kdl_parser</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
-  <build_depend>liburdfdom-headers-dev</build_depend>
+  <build_depend version_gte="0.4">liburdfdom-headers-dev</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>octomap_msgs</build_depend>
@@ -55,7 +55,7 @@
   <run_depend>kdl_parser</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
   <run_depend>liburdfdom-dev</run_depend>
-  <run_depend>liburdfdom-headers-dev</run_depend>
+  <run_depend version_gte="0.4">liburdfdom-headers-dev</run_depend>
   <run_depend>moveit_msgs</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>octomap_msgs</run_depend>

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -93,7 +93,7 @@ public:
 
   /** \brief construct using a urdf and srdf.
    * A RobotModel for the PlanningScene will be created using the urdf and srdf. */
-  PlanningScene(const boost::shared_ptr<const urdf::ModelInterface> &urdf_model,
+  PlanningScene(const urdf::ModelInterfaceSharedPtr &urdf_model,
                 const boost::shared_ptr<const srdf::Model> &srdf_model,
                 collision_detection::WorldPtr world = collision_detection::WorldPtr(new collision_detection::World()));
 
@@ -884,7 +884,7 @@ private:
   void initialize();
 
   /* helper function to create a RobotModel from a urdf/srdf. */
-  static robot_model::RobotModelPtr createRobotModel(const boost::shared_ptr<const urdf::ModelInterface> &urdf_model,
+  static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
                                                      const boost::shared_ptr<const srdf::Model> &srdf_model);
 
   void getPlanningSceneMsgCollisionObject(moveit_msgs::PlanningScene &scene, const std::string &ns) const;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -130,7 +130,7 @@ planning_scene::PlanningScene::PlanningScene(const robot_model::RobotModelConstP
   initialize();
 }
 
-planning_scene::PlanningScene::PlanningScene(const boost::shared_ptr<const urdf::ModelInterface> &urdf_model,
+planning_scene::PlanningScene::PlanningScene(const urdf::ModelInterfaceSharedPtr &urdf_model,
                                              const boost::shared_ptr<const srdf::Model> &srdf_model,
                                              collision_detection::WorldPtr world) :
   world_(world),
@@ -178,7 +178,7 @@ void planning_scene::PlanningScene::initialize()
 }
 
 /* return NULL on failure */
-robot_model::RobotModelPtr planning_scene::PlanningScene::createRobotModel(const boost::shared_ptr<const urdf::ModelInterface> &urdf_model,
+robot_model::RobotModelPtr planning_scene::PlanningScene::createRobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
                                                                            const boost::shared_ptr<const srdf::Model> &srdf_model)
 {
   robot_model::RobotModelPtr robot_model(new robot_model::RobotModel(urdf_model, srdf_model));

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -43,7 +43,7 @@
 
 // This function needs to return void so the gtest FAIL() macro inside
 // it works right.
-void loadRobotModel(boost::shared_ptr<urdf::ModelInterface>& robot_model_out)
+void loadRobotModel(urdf::ModelInterfaceSharedPtr& robot_model_out)
 {
   boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
 
@@ -62,7 +62,7 @@ void loadRobotModel(boost::shared_ptr<urdf::ModelInterface>& robot_model_out)
 
 TEST(PlanningScene, LoadRestore)
 {
-  boost::shared_ptr<urdf::ModelInterface> urdf_model;
+  urdf::ModelInterfaceSharedPtr urdf_model;
   loadRobotModel(urdf_model);
   boost::shared_ptr<srdf::Model> srdf_model(new srdf::Model());
   planning_scene::PlanningScene ps(urdf_model, srdf_model);
@@ -73,7 +73,7 @@ TEST(PlanningScene, LoadRestore)
 
 TEST(PlanningScene, LoadRestoreDiff)
 {
-  boost::shared_ptr<urdf::ModelInterface> urdf_model;
+  urdf::ModelInterfaceSharedPtr urdf_model;
   loadRobotModel(urdf_model);
   boost::shared_ptr<srdf::Model> srdf_model(new srdf::Model());
 
@@ -111,7 +111,7 @@ TEST(PlanningScene, LoadRestoreDiff)
 TEST(PlanningScene, MakeAttachedDiff)
 {
   boost::shared_ptr<srdf::Model> srdf_model(new srdf::Model());
-  boost::shared_ptr<urdf::ModelInterface> urdf_model;
+  urdf::ModelInterfaceSharedPtr urdf_model;
   loadRobotModel(urdf_model);
 
   planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -42,6 +42,7 @@
 #include <moveit/exceptions/exceptions.h>
 #include <console_bridge/console.h>
 #include <urdf_model/model.h>
+#include <urdf_world/types.h>
 #include <srdfdom/model.h>
 
 // joint types
@@ -71,7 +72,7 @@ class RobotModel
 public:
 
   /** \brief Construct a kinematic model from a parsed description and a list of planning groups */
-  RobotModel(const boost::shared_ptr<const urdf::ModelInterface> &urdf_model,
+  RobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
              const boost::shared_ptr<const srdf::Model> &srdf_model);
 
   /** \brief Destructor. Clear all memory. */
@@ -99,7 +100,7 @@ public:
   }
 
   /** \brief Get the parsed URDF model */
-  const boost::shared_ptr<const urdf::ModelInterface>& getURDF() const
+  const urdf::ModelInterfaceSharedPtr& getURDF() const
   {
     return urdf_;
   }
@@ -441,7 +442,7 @@ protected:
 
   boost::shared_ptr<const srdf::Model>          srdf_;
 
-  boost::shared_ptr<const urdf::ModelInterface> urdf_;
+  urdf::ModelInterfaceSharedPtr urdf_;
 
 
   // LINKS

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -47,7 +47,7 @@
 
 /* ------------------------ RobotModel ------------------------ */
 
-moveit::core::RobotModel::RobotModel(const boost::shared_ptr<const urdf::ModelInterface> &urdf_model,
+moveit::core::RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
                                      const boost::shared_ptr<const srdf::Model> &srdf_model)
 {
   root_joint_ = NULL;
@@ -935,8 +935,8 @@ moveit::core::LinkModel* moveit::core::RobotModel::constructLinkModel(const urdf
 {
   LinkModel *result = new LinkModel(urdf_link->name);
 
-  const std::vector<boost::shared_ptr<urdf::Collision> > &col_array = urdf_link->collision_array.empty() ?
-    std::vector<boost::shared_ptr<urdf::Collision> >(1, urdf_link->collision) : urdf_link->collision_array;
+  const std::vector<urdf::CollisionSharedPtr > &col_array = urdf_link->collision_array.empty() ?
+    std::vector<urdf::CollisionSharedPtr >(1, urdf_link->collision) : urdf_link->collision_array;
 
   std::vector<shapes::ShapeConstPtr> shapes;
   EigenSTL::vector_Affine3d poses;
@@ -953,8 +953,8 @@ moveit::core::LinkModel* moveit::core::RobotModel::constructLinkModel(const urdf
     }
   if (shapes.empty())
   {
-    const std::vector<boost::shared_ptr<urdf::Visual> > &vis_array = urdf_link->visual_array.empty() ?
-      std::vector<boost::shared_ptr<urdf::Visual> >(1, urdf_link->visual) : urdf_link->visual_array;
+    const std::vector<urdf::VisualSharedPtr > &vis_array = urdf_link->visual_array.empty() ?
+      std::vector<urdf::VisualSharedPtr >(1, urdf_link->visual) : urdf_link->visual_array;
     for (std::size_t i = 0 ; i < vis_array.size() ; ++i)
       if (vis_array[i] && vis_array[i]->geometry)
       {

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -74,7 +74,7 @@ protected:
 
 protected:
 
-  boost::shared_ptr<urdf::ModelInterface> urdf_model;
+  urdf::ModelInterfaceSharedPtr urdf_model;
   boost::shared_ptr<srdf::Model> srdf_model;
   moveit::core::RobotModelConstPtr robot_model;
 };

--- a/moveit_core/robot_state/test/test_kinematic.cpp
+++ b/moveit_core/robot_state/test/test_kinematic.cpp
@@ -84,7 +84,7 @@ TEST(Loading, SimpleRobot)
         "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"floating\"/>"
         "</robot>";
 
-    boost::shared_ptr<urdf::ModelInterface> urdfModel = urdf::parseURDF(MODEL0);
+    urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL0);
     boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
     srdfModel->initString(*urdfModel, SMODEL0);
 
@@ -148,7 +148,7 @@ TEST(LoadingAndFK, SimpleRobot)
         "</group>"
         "</robot>";
 
-    boost::shared_ptr<urdf::ModelInterface> urdfModel = urdf::parseURDF(MODEL1);
+    urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL1);
 
     boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
     srdfModel->initString(*urdfModel, SMODEL1);
@@ -373,7 +373,7 @@ TEST(FK, OneRobot)
         "</group>"
         "</robot>";
 
-    boost::shared_ptr<urdf::ModelInterface> urdfModel = urdf::parseURDF(MODEL2);
+    urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL2);
 
     boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
     srdfModel->initString(*urdfModel, SMODEL2);

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -76,7 +76,7 @@ protected:
 
 protected:
 
-  boost::shared_ptr<urdf::ModelInterface> urdf_model;
+  urdf::ModelInterfaceSharedPtr urdf_model;
   boost::shared_ptr<srdf::Model> srdf_model;
   moveit::core::RobotModelConstPtr robot_model;
 };

--- a/moveit_core/robot_state/test/test_transforms.cpp
+++ b/moveit_core/robot_state/test/test_transforms.cpp
@@ -74,7 +74,7 @@ protected:
 
 protected:
 
-  boost::shared_ptr<urdf::ModelInterface> urdf_model_;
+  urdf::ModelInterfaceSharedPtr urdf_model_;
   boost::shared_ptr<srdf::Model> srdf_model_;
   bool                           urdf_ok_;
   bool                           srdf_ok_;

--- a/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
@@ -100,7 +100,7 @@ protected:
   bool urdf_ok_;
   bool srdf_ok_;
 
-  boost::shared_ptr<urdf::ModelInterface>           urdf_model_;
+  urdf::ModelInterfaceSharedPtr            urdf_model_;
   boost::shared_ptr<srdf::Model>           srdf_model_;
   
   robot_model::RobotModelPtr             kmodel_;

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/src/kinematics_cache_ros.cpp
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/src/kinematics_cache_ros.cpp
@@ -76,7 +76,7 @@ bool KinematicsCacheROS::init(const kinematics_cache::KinematicsCache::Options &
   
   rdf_loader::RDFLoader rdf_loader;
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
   kinematic_model_.reset(new planning_models::RobotModel(urdf_model, srdf));
 
   if(!initialize((kinematics::KinematicsBaseConstPtr &)kinematics_solver_,

--- a/moveit_ikfast/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_ikfast/templates/ikfast61_moveit_plugin_template.cpp
@@ -357,12 +357,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkSharedPtr link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -34,6 +34,8 @@
 
 /* Author: Ioan Sucan */
 
+#include <boost/algorithm/string/trim.hpp>
+
 #include <moveit/ompl_interface/model_based_planning_context.h>
 #include <moveit/ompl_interface/detail/state_validity_checker.h>
 #include <moveit/ompl_interface/detail/constrained_sampler.h>

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -78,7 +78,7 @@ protected:
 
 protected:
   robot_model::RobotModelPtr robot_model_;
-  boost::shared_ptr<urdf::ModelInterface> urdf_model_;
+  urdf::ModelInterfaceSharedPtr      urdf_model_;
   boost::shared_ptr<srdf::Model>     srdf_model_;
   bool                               urdf_ok_;
   bool                               srdf_ok_;

--- a/moveit_ros/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_ros/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -135,7 +135,7 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)
   {

--- a/moveit_ros/planning/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_ros/planning/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -134,7 +134,7 @@ bool LMAKinematicsPlugin::initialize(const std::string &robot_description,
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)
   {

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -39,6 +39,7 @@
 
 #include <moveit/macros/class_forward.h>
 #include <urdf/model.h>
+#include <urdf_world/types.h>
 #include <srdfdom/model.h>
 #include <boost/shared_ptr.hpp>
 #include <tinyxml.h>
@@ -71,7 +72,7 @@ public:
   }
 
   /** @brief Get the parsed URDF model*/
-  const boost::shared_ptr<urdf::ModelInterface>& getURDF() const
+  const urdf::ModelInterfaceSharedPtr& getURDF() const
   {
     return urdf_;
   }
@@ -86,7 +87,7 @@ private:
 
   std::string                             robot_description_;
   boost::shared_ptr<srdf::Model>          srdf_;
-  boost::shared_ptr<urdf::ModelInterface> urdf_;
+  urdf::ModelInterfaceSharedPtr           urdf_;
 
 };
 

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -113,7 +113,7 @@ public:
   }
 
   /** @brief Get the parsed URDF model*/
-  const boost::shared_ptr<urdf::ModelInterface>& getURDF() const
+  const urdf::ModelInterfaceSharedPtr& getURDF() const
   {
     return rdf_loader_->getURDF();
   }

--- a/moveit_ros/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_ros/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -73,7 +73,7 @@ bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)
   {

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -222,7 +222,7 @@ static moveit::core::RobotModelPtr getModel()
   static moveit::core::RobotModelPtr model;
   if (!model)
   {
-    boost::shared_ptr<urdf::ModelInterface> urdf(urdf::parseURDF(URDF_STR));
+    urdf::ModelInterfaceSharedPtr urdf(urdf::parseURDF(URDF_STR));
     boost::shared_ptr<srdf::Model> srdf(new srdf::Model());
     srdf->initString(*urdf, SRDF_STR);
     model.reset(new moveit::core::RobotModel(urdf, srdf));

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -34,6 +34,9 @@
 
 /* Author: Dave Coleman */
 
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/replace.hpp>
+
 #include <moveit/rviz_plugin_render_tools/trajectory_visualization.h>
 
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -157,11 +157,7 @@ public:
   bool urdf_from_xacro_;
 
   /// URDF robot model
-#if __cplusplus <= 199711L
   boost::shared_ptr<urdf::Model> urdf_model_;
-#else
-  std::shared_ptr<urdf::Model> urdf_model_;
-#endif
 
   // ******************************************************************************************
   // SRDF Data

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -157,7 +157,11 @@ public:
   bool urdf_from_xacro_;
 
   /// URDF robot model
+#if __cplusplus <= 199711L
   boost::shared_ptr<urdf::Model> urdf_model_;
+#else
+  std::shared_ptr<urdf::Model> urdf_model_;
+#endif
 
   // ******************************************************************************************
   // SRDF Data


### PR DESCRIPTION
urdfdom_headers uses C++ std::shared_ptr. As it exports it as custom
*SharedPtr type, we can use the to stay compatible.

Not that there is no std:shared_ptr<const urdf::ModelInterface> typedef,
so I replaced it with urdf::ModelInterfaceSharedPtr (loosing a const).

Also, there is no conversion from boost::shared_ptr<urdf::Model> to
std:shared_ptr<urdf::ModelInterface>, so I used a preprocessor
directive.