### PR TITLE
Optimize size of Docker CI container and ensure newer version of packages

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -1,32 +1,39 @@
 # moveit/moveit:kinetic-ci
 # Sets up a base image to use for running Continuous Integration on Travis
 
-FROM osrf/ros:kinetic-desktop
+FROM ros:kinetic-ros-base
 MAINTAINER Dave Coleman dave@dav.ee
 
-# Install packages
-RUN apt-get -qq update && \
+ENV TERM xterm
+
+# Setup catkin workspace
+ENV CATKIN_WS=/root/ws_moveit
+RUN mkdir -p $CATKIN_WS/src
+WORKDIR $CATKIN_WS/src
+
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
+RUN wstool init . && \
+    # Download moveit source so that we can get necessary dependencies
+    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+    wstool update && \
+    # Update apt-get because previous images clear this cache
+    echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list && \
+    apt-get -qq update && \
+    # Do a dist-upgrade to ensure our CI is building on top of the latest version of packages
+    apt-get -qq dist-upgrade && \
+    # Install some base dependencies
     apt-get -qq install -y \
-        git \
-        sudo \
-        wget \
-        lsb-release \
-        freeglut3-dev \
-        libglew-dev \
-        python-pip \
-        python-catkin-tools \
         python-rosdep \
-        python-wstool \
-        python-pyassimp \
-        libqtgui4 \
-        libccd-dev \
-        libqglviewer2-qt4 \
-        libqt4-opengl-dev \
-        libqt4-dev \
-        libqt4-opengl \
-        libqglviewer-dev-qt4 \
+        python-catkin-tools \
         ros-$ROS_DISTRO-rosbash \
         ros-$ROS_DISTRO-rospack && \
+    # Download all dependencies of MoveIt!
+    rosdep update && \
+    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # Remove the source code from this container. TODO: in the future we may want to keep this here for further optimization of later containers
+    rm -rf * .* && \
+    # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*
+
+# Continous Integration Setting
 ENV IN_DOCKER 1
-ENV TERM xterm

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -1,13 +1,11 @@
 # moveit/moveit:kinetic-release
 # Full debian-based install of MoveIt! using apt-get
 
-FROM osrf/ros:kinetic-desktop
+FROM moveit/moveit:kinetic-ci
 MAINTAINER Dave Coleman dave@dav.ee
 
-# apt-commands are combined in single RUN statement with "lists" folder removal to reduce image size
-RUN echo 'deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main' | tee /etc/apt/sources.list.d/ros-latest.list && \
-    apt-get update && \
+# Commands are combined in single RUN statement with "lists" folder removal to reduce image size
+RUN apt-get update && \
     apt-get install -y \
-        nano \
         ros-${ROS_DISTRO}-moveit-* && \
     rm -rf /var/lib/apt/lists/*

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -1,7 +1,7 @@
 # moveit/moveit:kinetic-source
 # Downloads the moveit source code, install remaining debian dependencies, and builds workspace
 
-FROM osrf/ros:kinetic-desktop
+FROM moveit/moveit:kinetic-ci
 MAINTAINER Dave Coleman dave@dav.ee
 
 ENV CATKIN_WS=/root/ws_moveit
@@ -14,17 +14,11 @@ RUN wstool init . && \
     wstool update
 
 # Update apt-get because osrf image clears this cache. download deps
-RUN echo 'deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main' | tee /etc/apt/sources.list.d/ros-latest.list && \
-    rosdep update && \
-    apt-get -qq update && \
+# Note that because we're building on top of kinetic-ci, there should not be any deps installed
+# unless something has changed in the source code since the other container was made
+# (they are triggered together so should only be one-build out of sync)
+RUN apt-get -qq update && \
     apt-get -qq install -y \
-        python-catkin-tools  \
-        less \
-        ssh \
-        emacs \
-        git-core \
-        bash-completion \
-        tree \
         wget && \
     rosdep update && \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This is the new unified repository for MoveIt! code. See the [Migration Notes](h
 - [Overview of MoveIt!](http://moveit.ros.org)
 - [Installation Instructions](http://moveit.ros.org/install/)
 - [Documentation](http://moveit.ros.org/documentation/)
-- [Docker Containers](http://moveit.ros.org/install/docker)
 - [Get Involved](http://moveit.ros.org/documentation/contributing/)
 
 ## Travis - Continuous Integration
@@ -15,6 +14,10 @@ This is the new unified repository for MoveIt! code. See the [Migration Notes](h
 Indigo | Jade | Kinetic
 ------ | ---- | -------
 [![Build Status](https://travis-ci.org/ros-planning/moveit.svg?branch=indigo-devel)](https://travis-ci.org/ros-planning/moveit) | [![Build Status](https://travis-ci.org/ros-planning/moveit.svg?branch=jade-devel)](https://travis-ci.org/ros-planning/moveit) | [![Build Status](https://travis-ci.org/ros-planning/moveit.svg?branch=kinetic-devel)](https://travis-ci.org/ros-planning/moveit) |
+
+## Docker Containers
+
+[![Docker Automated build](https://img.shields.io/docker/automated/moveit/moveit.svg?maxAge=2592000)](https://hub.docker.com/r/moveit/moveit/) [![Docker Pulls](https://img.shields.io/docker/pulls/moveit/moveit_docker.svg?maxAge=2592000)](https://hub.docker.com/r/moveit/moveit_docker/) [![Docker Stars](https://img.shields.io/docker/stars/moveit/moveit_docker.svg)](https://registry.hub.docker.com/moveit/moveit_docker/)
 
 ## ROS Buildfarm
 


### PR DESCRIPTION
Currently [MoveIt!'s CI](https://github.com/ros-planning/moveit/blob/kinetic-devel/.docker/ci/Dockerfile) is using the non-shadow-fixed version of kinetic-desktop. This OSRF container is only retriggered when the base Ubuntu container is rebuilt, and it appears its been awhile. The image we're using for ROS is now [2 months old](https://hub.docker.com/r/osrf/ros/builds/).

This switches to use the main ROS container, instead of OSRF's. The ROS one was updated [10 days ago](https://github.com/docker-library/repo-info/blob/master/repos/ros/tag-details.md). The difference is that there isn't a desktop-full version, unlike what OSRF offers. This also runs a dist-upgrade to ensure we have the latest version of packages, which currently results in an increase of the container of 200 MB (not bad)

This should help address https://github.com/ros-planning/moveit/pull/209#issuecomment-246168639

Finally, this will hopefully speedup the source build (because of the fewer dependencies required to install) which is occasionally timing out. https://hub.docker.com/r/moveit/moveit/builds/bimphxfryc5fmvhqpuw7t2k/

Because we are no longer using ``kinetic-desktop`` but instead ``ros-base``, the moveit container size has changed from 3.256 GB to 2.481 GB