### PR TITLE
Convert API to use std::shared_ptr

### DIFF
--- a/moveit_core/background_processing/include/moveit/background_processing/background_processing.h
+++ b/moveit_core/background_processing/include/moveit/background_processing/background_processing.h
@@ -41,8 +41,8 @@
 #include <string>
 #include <boost/thread.hpp>
 #include <boost/function.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/noncopyable.hpp>
+#include <memory>
 
 namespace moveit
 {
@@ -100,7 +100,7 @@ public:
 
 private:
 
-  boost::scoped_ptr<boost::thread> processing_thread_;
+  std::unique_ptr<boost::thread> processing_thread_;
   bool run_processing_thread_;
 
   mutable boost::mutex action_lock_;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -39,7 +39,8 @@
 
 #include <moveit/collision_detection/world.h>
 #include <moveit/macros/class_forward.h>
-#include <boost/weak_ptr.hpp>
+
+#include <memory>
 
 namespace collision_detection
 {
@@ -124,7 +125,7 @@ namespace collision_detection
     World::ObserverHandle observer_handle_;
 
     /* used to unregister the notifier */
-    boost::weak_ptr<World> world_;
+    std::weak_ptr<World> world_;
   };
 }
 

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -112,7 +112,7 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
     if(!object->shapes_.empty())
     {
       const shapes::ShapeConstPtr& shape = object->shapes_[0];
-      boost::shared_ptr<const shapes::OcTree> shape_octree = boost::dynamic_pointer_cast<const shapes::OcTree>(shape);
+      std::shared_ptr<const shapes::OcTree> shape_octree = std::dynamic_pointer_cast<const shapes::OcTree>(shape);
       if(shape_octree)
       {
         std::shared_ptr<const octomap::OcTree> octree = shape_octree->octree;

--- a/moveit_core/collision_detection/src/world_diff.cpp
+++ b/moveit_core/collision_detection/src/world_diff.cpp
@@ -61,7 +61,7 @@ collision_detection::WorldDiff::WorldDiff(WorldDiff &other)
   {
     changes_ = other.changes_;
 
-    boost::weak_ptr<World>(world).swap(world_);
+    std::weak_ptr<World>(world).swap(world_);
     observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, _1, _2));
   }
 }
@@ -85,7 +85,7 @@ void collision_detection::WorldDiff::reset(const WorldPtr& world)
   if (old_world)
     old_world->removeObserver(observer_handle_);
 
-  boost::weak_ptr<World>(world).swap(world_);
+  std::weak_ptr<World>(world).swap(world_);
   observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, _1, _2));
 }
 
@@ -98,7 +98,7 @@ void collision_detection::WorldDiff::setWorld(const WorldPtr& world)
     old_world->removeObserver(observer_handle_);
   }
 
-  boost::weak_ptr<World>(world).swap(world_);
+  std::weak_ptr<World>(world).swap(world_);
 
   observer_handle_ = world->addObserver(boost::bind(&WorldDiff::notify, this, _1, _2));
   world->notifyObserverAllObjects(observer_handle_, World::CREATE|World::ADD_SHAPE);

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_world_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_world_fcl.h
@@ -39,7 +39,7 @@
 
 #include <moveit/collision_detection_fcl/collision_robot_fcl.h>
 #include <fcl/broadphase/broadphase.h>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace collision_detection
 {
@@ -79,7 +79,7 @@ namespace collision_detection
     void updateFCLObject(const std::string &id);
 
 
-    boost::scoped_ptr<fcl::BroadPhaseCollisionManager> manager_;
+    std::unique_ptr<fcl::BroadPhaseCollisionManager> manager_;
     std::map<std::string, FCLObject >                  fcl_objs_;
 
   private:

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -40,7 +40,7 @@
 #include <fcl/shape/geometric_shapes.h>
 #include <fcl/octree.h>
 #include <boost/thread/mutex.hpp>
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
 namespace collision_detection
 {
@@ -330,6 +330,9 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void 
 
 struct FCLShapeCache
 {
+  using ShapeKey = std::weak_ptr<const shapes::Shape>;
+  using ShapeMap = std::map<ShapeKey, FCLGeometryConstPtr, std::owner_less<ShapeKey>>;
+
   FCLShapeCache() : clean_count_(0) {}
 
   void bumpUseCount(bool force = false)
@@ -341,9 +344,9 @@ struct FCLShapeCache
     {
       clean_count_ = 0;
       unsigned int from = map_.size();
-      for (std::map<boost::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr>::iterator it = map_.begin() ; it != map_.end() ; )
+      for (ShapeMap::iterator it = map_.begin(); it != map_.end(); )
       {
-        std::map<boost::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr>::iterator nit = it; ++nit;
+        ShapeMap::iterator nit = it; ++nit;
         if (it->first.expired())
           map_.erase(it);
         it = nit;
@@ -353,7 +356,7 @@ struct FCLShapeCache
   }
 
   static const unsigned int MAX_CLEAN_COUNT = 100; // every this many uses of the cache, a cleaning operation is executed (this is only removal of expired entries)
-  std::map<boost::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr> map_;
+  ShapeMap map_;
   unsigned int clean_count_;
   boost::mutex lock_;
 };
@@ -488,12 +491,15 @@ struct IfSameType<T, T>
 template<typename BV, typename T>
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr &shape, const T *data, int shape_index)
 {
+  using ShapeKey = std::weak_ptr<const shapes::Shape>;
+  using ShapeMap = std::map<ShapeKey, FCLGeometryConstPtr, std::owner_less<ShapeKey>>;
+
   FCLShapeCache &cache = GetShapeCache<BV, T>();
 
-  boost::weak_ptr<const shapes::Shape> wptr(shape);
+  std::weak_ptr<const shapes::Shape> wptr(shape);
   {
     boost::mutex::scoped_lock slock(cache.lock_);
-    std::map<boost::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr>::const_iterator cache_it = cache.map_.find(wptr);
+    ShapeMap::const_iterator cache_it = cache.map_.find(wptr);
     if (cache_it != cache.map_.end())
     {
       if (cache_it->second->collision_geometry_data_->ptr.raw == (void*)data)
@@ -521,7 +527,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr &shape, 
 
     // attached bodies could be just moved from the environment.
     othercache.lock_.lock(); // lock manually to avoid having 2 simultaneous locks active (avoids possible deadlock)
-    std::map<boost::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr>::iterator cache_it = othercache.map_.find(wptr);
+    ShapeMap::iterator cache_it = othercache.map_.find(wptr);
     if (cache_it != othercache.map_.end())
     {
       if (cache_it->second.unique())
@@ -556,7 +562,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr &shape, 
 
       // attached bodies could be just moved from the environment.
       othercache.lock_.lock(); // lock manually to avoid having 2 simultaneous locks active (avoids possible deadlock)
-      std::map<boost::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr>::iterator cache_it = othercache.map_.find(wptr);
+      std::map<std::weak_ptr<const shapes::Shape>, FCLGeometryConstPtr>::iterator cache_it = othercache.map_.find(wptr);
       if (cache_it != othercache.map_.end())
       {
         if (cache_it->second.unique())

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -108,7 +108,7 @@ protected:
   bool srdf_ok_;
 
   urdf::ModelInterfaceSharedPtr            urdf_model_;
-  boost::shared_ptr<srdf::Model>           srdf_model_;
+  srdf::ModelSharedPtr                     srdf_model_;
 
   robot_model::RobotModelPtr               kmodel_;
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -53,11 +53,11 @@
 
 #include <kdl/chainfksolverpos_recursive.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #include <urdf_world/types.h>
 
 #include <moveit/kinematics_base/kinematics_base.h>
+
+#include <memory>
 
 #include "pr2_arm_ik.h"
 
@@ -267,7 +267,7 @@ protected:
   pr2_arm_kinematics::PR2ArmIKSolverPtr pr2_arm_ik_solver_;
   std::string root_name_;
   int dimension_;
-  boost::shared_ptr<KDL::ChainFkSolverPos_recursive> jnt_to_pose_solver_;
+  std::shared_ptr<KDL::ChainFkSolverPos_recursive> jnt_to_pose_solver_;
   KDL::Chain kdl_chain_;
   moveit_msgs::KinematicSolverInfo ik_solver_info_, fk_solver_info_;
 

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -134,7 +134,7 @@ protected:
 protected:
 
   urdf::ModelInterfaceSharedPtr      urdf_model;
-  boost::shared_ptr<srdf::Model>     srdf_model;
+  srdf::ModelSharedPtr               srdf_model;
   robot_model::RobotModelPtr kmodel;
   planning_scene::PlanningScenePtr ps;
   pr2_arm_kinematics::PR2ArmKinematicsPluginPtr pr2_kinematics_plugin_right_arm_;

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -39,7 +39,6 @@
 
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <moveit/macros/class_forward.h>
 

--- a/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
+++ b/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
@@ -45,6 +45,8 @@
 #include <geometry_msgs/Vector3.h>
 #include <geometry_msgs/Wrench.h>
 
+#include <memory>
+
 /** \brief This namespace includes the dynamics_solver library */
 namespace dynamics_solver
 {
@@ -143,7 +145,7 @@ public:
 
 private:
 
-  boost::shared_ptr<KDL::ChainIdSolver_RNE> chain_id_solver_; // KDL chain inverse dynamics
+  std::shared_ptr<KDL::ChainIdSolver_RNE> chain_id_solver_; // KDL chain inverse dynamics
   KDL::Chain kdl_chain_; // KDL chain
 
   robot_model::RobotModelConstPtr robot_model_;

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -103,7 +103,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr &robot_mode
   logDebug("moveit.dynamics_solver: Base name: '%s', Tip name: '%s'", base_name_.c_str(), tip_name_.c_str());
 
   const urdf::ModelInterfaceSharedPtr urdf_model = robot_model_->getURDF();
-  const boost::shared_ptr<const srdf::Model> srdf_model = robot_model_->getSRDF();
+  const srdf::ModelConstSharedPtr srdf_model = robot_model_->getSRDF();
   KDL::Tree tree;
 
   if (!kdl_parser::treeFromUrdfModel(*urdf_model, tree))

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -40,11 +40,11 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/collision_detection_fcl/collision_robot_fcl.h>
 #include <moveit/collision_detection_fcl/collision_world_fcl.h>
-#include <boost/scoped_ptr.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <eigen_conversions/eigen_msg.h>
 #include <boost/bind.hpp>
 #include <limits>
+#include <memory>
 
 namespace kinematic_constraints
 {
@@ -302,7 +302,7 @@ bool kinematic_constraints::PositionConstraint::configure(const moveit_msgs::Pos
   // load primitive shapes, first clearing any we already have
   for (std::size_t i = 0 ; i < pc.constraint_region.primitives.size() ; ++i)
   {
-    boost::scoped_ptr<shapes::Shape> shape(shapes::constructShapeFromMsg(pc.constraint_region.primitives[i]));
+    std::unique_ptr<shapes::Shape> shape(shapes::constructShapeFromMsg(pc.constraint_region.primitives[i]));
     if (shape)
     {
       if (pc.constraint_region.primitive_poses.size() <= i)
@@ -329,7 +329,7 @@ bool kinematic_constraints::PositionConstraint::configure(const moveit_msgs::Pos
   // load meshes
   for (std::size_t i = 0 ; i < pc.constraint_region.meshes.size() ; ++i)
   {
-    boost::scoped_ptr<shapes::Shape> shape(shapes::constructShapeFromMsg(pc.constraint_region.meshes[i]));
+    std::unique_ptr<shapes::Shape> shape(shapes::constructShapeFromMsg(pc.constraint_region.meshes[i]));
     if (shape)
     {
       if (pc.constraint_region.mesh_poses.size() <= i)
@@ -782,7 +782,7 @@ shapes::Mesh* kinematic_constraints::VisibilityConstraint::getVisibilityCone(con
 
   // transform the points on the disc to the desired target frame
   const EigenSTL::vector_Vector3d *points = &points_;
-  boost::scoped_ptr<EigenSTL::vector_Vector3d> tempPoints;
+  std::unique_ptr<EigenSTL::vector_Vector3d> tempPoints;
   if (mobile_target_frame_)
   {
     tempPoints.reset(new EigenSTL::vector_Vector3d(points_.size()));

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -79,7 +79,7 @@ protected:
 protected:
 
   urdf::ModelInterfaceSharedPtr      urdf_model;
-  boost::shared_ptr<srdf::Model>     srdf_model;
+  srdf::ModelSharedPtr               srdf_model;
   robot_model::RobotModelPtr kmodel;
 };
 

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -35,7 +35,7 @@
 #ifndef MOVEIT_MACROS_DECLARE_PTR_
 #define MOVEIT_MACROS_DECLARE_PTR_
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 /**
  * \def MOVEIT_DELCARE_PTR
@@ -49,8 +49,8 @@
  */
 
 #define MOVEIT_DECLARE_PTR(Name, Type)                \
-  typedef boost::shared_ptr<Type> Name##Ptr;          \
-  typedef boost::shared_ptr<const Type> Name##ConstPtr;
+  typedef std::shared_ptr<Type> Name##Ptr;          \
+  typedef std::shared_ptr<const Type> Name##ConstPtr;
 
 /**
  * \def MOVEIT_DELCARE_PTR_MEMBER
@@ -64,7 +64,7 @@
  */
 
 #define MOVEIT_DECLARE_PTR_MEMBER(Type)         \
-  typedef boost::shared_ptr<Type> Ptr;          \
-  typedef boost::shared_ptr<const Type> ConstPtr;
+  typedef std::shared_ptr<Type> Ptr;          \
+  typedef std::shared_ptr<const Type> ConstPtr;
 
 #endif

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -51,7 +51,6 @@
 #include <moveit_msgs/RobotTrajectory.h>
 #include <moveit_msgs/Constraints.h>
 #include <moveit_msgs/PlanningSceneComponents.h>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
@@ -83,7 +82,7 @@ typedef std::map<std::string, object_recognition_msgs::ObjectType> ObjectTypeMap
     environment as seen by a planning instance. The environment
     geometry, the robot geometry and state are maintained. */
 class PlanningScene : private boost::noncopyable,
-                      public boost::enable_shared_from_this<PlanningScene>
+                      public std::enable_shared_from_this<PlanningScene>
 {
 public:
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -953,10 +953,10 @@ private:
   StateFeasibilityFn                             state_feasibility_;
   MotionFeasibilityFn                            motion_feasibility_;
 
-  boost::scoped_ptr<ObjectColorMap>              object_colors_;
+  std::unique_ptr<ObjectColorMap>                object_colors_;
 
   // a map of object types
-  boost::scoped_ptr<ObjectTypeMap>               object_types_;
+  std::unique_ptr<ObjectTypeMap>                 object_types_;
 
 
 };

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -52,7 +52,6 @@
 #include <moveit_msgs/Constraints.h>
 #include <moveit_msgs/PlanningSceneComponents.h>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/concept_check.hpp>
 #include <memory>
@@ -93,7 +92,7 @@ public:
   /** \brief construct using a urdf and srdf.
    * A RobotModel for the PlanningScene will be created using the urdf and srdf. */
   PlanningScene(const urdf::ModelInterfaceSharedPtr &urdf_model,
-                const boost::shared_ptr<const srdf::Model> &srdf_model,
+                const srdf::ModelConstSharedPtr &srdf_model,
                 collision_detection::WorldPtr world = collision_detection::WorldPtr(new collision_detection::World()));
 
   static const std::string OCTOMAP_NS;
@@ -884,7 +883,7 @@ private:
 
   /* helper function to create a RobotModel from a urdf/srdf. */
   static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
-                                                     const boost::shared_ptr<const srdf::Model> &srdf_model);
+                                                     const srdf::ModelConstSharedPtr &srdf_model);
 
   void getPlanningSceneMsgCollisionObject(moveit_msgs::PlanningScene &scene, const std::string &ns) const;
   void getPlanningSceneMsgCollisionObjects(moveit_msgs::PlanningScene &scene) const;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -131,7 +131,7 @@ planning_scene::PlanningScene::PlanningScene(const robot_model::RobotModelConstP
 }
 
 planning_scene::PlanningScene::PlanningScene(const urdf::ModelInterfaceSharedPtr &urdf_model,
-                                             const boost::shared_ptr<const srdf::Model> &srdf_model,
+                                             const srdf::ModelConstSharedPtr &srdf_model,
                                              collision_detection::WorldPtr world) :
   world_(world),
   world_const_(world)
@@ -179,7 +179,7 @@ void planning_scene::PlanningScene::initialize()
 
 /* return NULL on failure */
 robot_model::RobotModelPtr planning_scene::PlanningScene::createRobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
-                                                                           const boost::shared_ptr<const srdf::Model> &srdf_model)
+                                                                           const srdf::ModelConstSharedPtr &srdf_model)
 {
   robot_model::RobotModelPtr robot_model(new robot_model::RobotModel(urdf_model, srdf_model));
   if (!robot_model || !robot_model->getRootJoint())

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -64,7 +64,7 @@ TEST(PlanningScene, LoadRestore)
 {
   urdf::ModelInterfaceSharedPtr urdf_model;
   loadRobotModel(urdf_model);
-  boost::shared_ptr<srdf::Model> srdf_model(new srdf::Model());
+  srdf::ModelSharedPtr srdf_model(new srdf::Model());
   planning_scene::PlanningScene ps(urdf_model, srdf_model);
   moveit_msgs::PlanningScene ps_msg;
   ps.getPlanningSceneMsg(ps_msg);
@@ -75,7 +75,7 @@ TEST(PlanningScene, LoadRestoreDiff)
 {
   urdf::ModelInterfaceSharedPtr urdf_model;
   loadRobotModel(urdf_model);
-  boost::shared_ptr<srdf::Model> srdf_model(new srdf::Model());
+  srdf::ModelSharedPtr srdf_model(new srdf::Model());
 
   planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
 
@@ -110,7 +110,7 @@ TEST(PlanningScene, LoadRestoreDiff)
 
 TEST(PlanningScene, MakeAttachedDiff)
 {
-  boost::shared_ptr<srdf::Model> srdf_model(new srdf::Model());
+  srdf::ModelSharedPtr srdf_model(new srdf::Model());
   urdf::ModelInterfaceSharedPtr urdf_model;
   loadRobotModel(urdf_model);
 

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -73,7 +73,7 @@ public:
 
   /** \brief Construct a kinematic model from a parsed description and a list of planning groups */
   RobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
-             const boost::shared_ptr<const srdf::Model> &srdf_model);
+             const srdf::ModelConstSharedPtr &srdf_model);
 
   /** \brief Destructor. Clear all memory. */
   ~RobotModel();
@@ -106,7 +106,7 @@ public:
   }
 
   /** \brief Get the parsed SRDF model */
-  const boost::shared_ptr<const srdf::Model>& getSRDF() const
+  const srdf::ModelConstSharedPtr& getSRDF() const
   {
     return srdf_;
   }
@@ -440,9 +440,9 @@ protected:
   /** \brief The reference frame for this model */
   std::string                                   model_frame_;
 
-  boost::shared_ptr<const srdf::Model>          srdf_;
+  srdf::ModelConstSharedPtr                     srdf_;
 
-  urdf::ModelInterfaceSharedPtr urdf_;
+  urdf::ModelInterfaceSharedPtr                 urdf_;
 
 
   // LINKS

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -43,12 +43,13 @@
 #include <limits>
 #include <queue>
 #include <cmath>
+#include <memory>
 #include "order_robot_model_items.inc"
 
 /* ------------------------ RobotModel ------------------------ */
 
 moveit::core::RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr &urdf_model,
-                                     const boost::shared_ptr<const srdf::Model> &srdf_model)
+                                     const srdf::ModelConstSharedPtr &srdf_model)
 {
   root_joint_ = NULL;
   urdf_ = urdf_model;

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -75,7 +75,7 @@ protected:
 protected:
 
   urdf::ModelInterfaceSharedPtr urdf_model;
-  boost::shared_ptr<srdf::Model> srdf_model;
+  srdf::ModelSharedPtr srdf_model;
   moveit::core::RobotModelConstPtr robot_model;
 };
 

--- a/moveit_core/robot_state/test/test_kinematic.cpp
+++ b/moveit_core/robot_state/test/test_kinematic.cpp
@@ -85,7 +85,7 @@ TEST(Loading, SimpleRobot)
         "</robot>";
 
     urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL0);
-    boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
+    srdf::ModelSharedPtr srdfModel(new srdf::Model());
     srdfModel->initString(*urdfModel, SMODEL0);
 
     EXPECT_TRUE(srdfModel->getVirtualJoints().size() == 1);
@@ -150,7 +150,7 @@ TEST(LoadingAndFK, SimpleRobot)
 
     urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL1);
 
-    boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
+    srdf::ModelSharedPtr srdfModel(new srdf::Model());
     srdfModel->initString(*urdfModel, SMODEL1);
 
     moveit::core::RobotModelPtr model(new moveit::core::RobotModel(urdfModel, srdfModel));
@@ -375,7 +375,7 @@ TEST(FK, OneRobot)
 
     urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL2);
 
-    boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
+    srdf::ModelSharedPtr srdfModel(new srdf::Model());
     srdfModel->initString(*urdfModel, SMODEL2);
 
     moveit::core::RobotModelPtr model(new moveit::core::RobotModel(urdfModel, srdfModel));

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -78,7 +78,7 @@ protected:
 protected:
 
   urdf::ModelInterfaceSharedPtr urdf_model;
-  boost::shared_ptr<srdf::Model> srdf_model;
+  srdf::ModelSharedPtr srdf_model;
   moveit::core::RobotModelConstPtr robot_model;
 };
 
@@ -90,7 +90,7 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
 
 TEST_F(LoadPlanningModelsPr2, ModelInit)
 {
-  boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
+  srdf::ModelSharedPtr srdfModel(new srdf::Model());
 
   // with no world multidof we should get a fixed joint
   moveit::core::RobotModel robot_model0(urdf_model, srdfModel);
@@ -134,7 +134,7 @@ TEST_F(LoadPlanningModelsPr2, GroupInit)
     "</group>"
     "</robot>";
 
-  boost::shared_ptr<srdf::Model> srdfModel(new srdf::Model());
+  srdf::ModelSharedPtr srdfModel(new srdf::Model());
   srdfModel->initString(*urdf_model, SMODEL1);
   moveit::core::RobotModel robot_model1(urdf_model, srdfModel);
 

--- a/moveit_core/robot_state/test/test_transforms.cpp
+++ b/moveit_core/robot_state/test/test_transforms.cpp
@@ -75,9 +75,9 @@ protected:
 protected:
 
   urdf::ModelInterfaceSharedPtr urdf_model_;
-  boost::shared_ptr<srdf::Model> srdf_model_;
-  bool                           urdf_ok_;
-  bool                           srdf_ok_;
+  srdf::ModelSharedPtr          srdf_model_;
+  bool                          urdf_ok_;
+  bool                          srdf_ok_;
 
 };
 

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -38,13 +38,16 @@
 #define MOVEIT_COLLISION_DETECTION_DISTANCE_FIELD_COLLISION_COMMON_
 
 #include <moveit/robot_state/robot_state.h>
+#include <moveit/macros/class_forward.h>
 #include <moveit/collision_detection/collision_common.h>
 #include <moveit/collision_detection/collision_world.h>
 #include <moveit/collision_distance_field/collision_distance_field_types.h>
 
 namespace collision_detection
 {
-struct DistanceFieldCacheEntry;
+
+MOVEIT_CLASS_FORWARD(GroupStateRepresentation);
+MOVEIT_CLASS_FORWARD(DistanceFieldCacheEntry);
 
 /** collision volume representation for a particular pose and link group
  *
@@ -79,7 +82,7 @@ struct GroupStateRepresentation
   }
 
   /** dfce used to generate this GSR */
-  boost::shared_ptr<const DistanceFieldCacheEntry> dfce_;
+  DistanceFieldCacheEntryConstPtr dfce_;
 
   /** posed spheres representing collision volume for the links in the group
    * (dfce_.group_name_) and all links below the group (i.e. links that can
@@ -113,7 +116,7 @@ struct DistanceFieldCacheEntry
   /** for checking collisions between this group and other objects */
   std::string group_name_;
   /** RobotState that this cache entry represents */
-  boost::shared_ptr<robot_state::RobotState> state_;
+  robot_state::RobotStatePtr state_;
   /** list of indices into the state_values_ vector.  One index for each joint
    * variable which is NOT in the group or a child of the group.  In other
    * words, variables which should not change if only joints in the group move.
@@ -129,10 +132,10 @@ struct DistanceFieldCacheEntry
   collision_detection::AllowedCollisionMatrix acm_;
   /** the distance field describing all links of the robot that are not in the
    * group and their attached bodies */
-  boost::shared_ptr<distance_field::DistanceField> distance_field_;
+  distance_field::DistanceFieldPtr distance_field_;
   /** this can be used as a starting point for creating a
    * GroupStateRepresentation needed for collision checking */
-  boost::shared_ptr<GroupStateRepresentation> pregenerated_group_state_representation_;
+ GroupStateRepresentationPtr pregenerated_group_state_representation_;
   /** names of all links in the group and all links below the group (links that
    * will move if any of the joints in the group move)
    */
@@ -175,7 +178,7 @@ PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const r
 PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const robot_state::AttachedBody *att,
                                                                        double resolution);
 
-void getBodySphereVisualizationMarkers(boost::shared_ptr<const collision_detection::GroupStateRepresentation> &gsr,
+void getBodySphereVisualizationMarkers(GroupStateRepresentationPtr &gsr,
                                        std::string reference_frame, visualization_msgs::MarkerArray &body_marker_array);
 }
 #endif

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -47,6 +47,7 @@
 #include <geometric_shapes/bodies.h>
 #include <octomap/OcTree.h>
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <visualization_msgs/MarkerArray.h>
@@ -103,6 +104,13 @@ struct GradientInfo
     joint_name.clear();
   }
 };
+
+MOVEIT_CLASS_FORWARD(PosedDistanceField)
+MOVEIT_CLASS_FORWARD(BodyDecomposition);
+MOVEIT_CLASS_FORWARD(PosedBodySphereDecomposition)
+MOVEIT_CLASS_FORWARD(PosedBodyPointDecomposition)
+MOVEIT_CLASS_FORWARD(PosedBodySphereDecompositionVector)
+MOVEIT_CLASS_FORWARD(PosedBodyPointDecompositionVector)
 
 class PosedDistanceField : public distance_field::PropagationDistanceField
 {
@@ -183,9 +191,6 @@ public:
 protected:
   Eigen::Affine3d pose_;
 };
-
-typedef boost::shared_ptr<PosedDistanceField> PosedDistanceFieldPtr;
-typedef boost::shared_ptr<const PosedDistanceField> PosedDistanceFieldConstPtr;
 
 // determines set of collision spheres given a posed body; this is BAD!
 // Allocation erorrs will happen; change this function so it does not return
@@ -286,9 +291,6 @@ protected:
   EigenSTL::vector_Vector3d relative_collision_points_;
 };
 
-typedef boost::shared_ptr<BodyDecomposition> BodyDecompositionPtr;
-typedef boost::shared_ptr<const BodyDecomposition> BodyDecompositionConstPtr;
-
 class PosedBodySphereDecomposition
 {
 public:
@@ -336,6 +338,7 @@ protected:
   EigenSTL::vector_Vector3d sphere_centers_;
 };
 
+
 class PosedBodyPointDecomposition
 {
 public:
@@ -358,11 +361,6 @@ protected:
   BodyDecompositionConstPtr body_decomposition_;
   EigenSTL::vector_Vector3d posed_collision_points_;
 };
-
-typedef boost::shared_ptr<PosedBodyPointDecomposition> PosedBodyPointDecompositionPtr;
-typedef boost::shared_ptr<const PosedBodyPointDecomposition> PosedBodyPointDecompositionConstPtr;
-typedef boost::shared_ptr<PosedBodySphereDecomposition> PosedBodySphereDecompositionPtr;
-typedef boost::shared_ptr<const PosedBodySphereDecomposition> PosedBodySphereDecompositionConstPtr;
 
 class PosedBodySphereDecompositionVector
 {
@@ -495,10 +493,6 @@ private:
   std::vector<PosedBodyPointDecompositionPtr> decomp_vector_;
 };
 
-typedef boost::shared_ptr<PosedBodySphereDecompositionVector> PosedBodySphereDecompositionVectorPtr;
-typedef boost::shared_ptr<const PosedBodySphereDecompositionVector> PosedBodySphereDecompositionVectorConstPtr;
-typedef boost::shared_ptr<PosedBodyPointDecompositionVector> PosedBodyPointDecompositionVectorPtr;
-typedef boost::shared_ptr<const PosedBodyPointDecompositionVector> PosedBodyPointDecompositionVectorConstPtr;
 
 struct ProximityInfo
 {

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -41,6 +41,7 @@
 #include <string>
 #include <algorithm>
 #include <sstream>
+#include <memory>
 #include <float.h>
 
 #include <geometric_shapes/shapes.h>

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_COLLISION_DISTANCE_FIELD_COLLISION_ROBOT_DISTANCE_FIELD_
 #define MOVEIT_COLLISION_DISTANCE_FIELD_COLLISION_ROBOT_DISTANCE_FIELD_
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/collision_detection/collision_robot.h>
 #include <moveit/collision_distance_field/collision_distance_field_types.h>
 #include <moveit/collision_distance_field/collision_common_distance_field.h>
@@ -52,6 +53,8 @@ static const bool DEFAULT_USE_SIGNED_DISTANCE_FIELD = false;
 static const double DEFAULT_RESOLUTION = .02;
 static const double DEFAULT_COLLISION_TOLERANCE = 0.0;
 static const double DEFAULT_MAX_PROPOGATION_DISTANCE = .25;
+
+MOVEIT_CLASS_FORWARD(CollisionRobotDistanceField);
 
 class CollisionRobotDistanceField : public CollisionRobot
 {
@@ -88,7 +91,7 @@ public:
 
   void checkSelfCollision(const collision_detection::CollisionRequest &req, collision_detection::CollisionResult &res,
                           const moveit::core::RobotState &state,
-                          boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                          GroupStateRepresentationPtr &gsr) const;
 
   virtual void checkSelfCollision(const collision_detection::CollisionRequest &req,
                                   collision_detection::CollisionResult &res, const moveit::core::RobotState &state,
@@ -96,7 +99,7 @@ public:
 
   void checkSelfCollision(const collision_detection::CollisionRequest &req, collision_detection::CollisionResult &res,
                           const moveit::core::RobotState &state, const collision_detection::AllowedCollisionMatrix &acm,
-                          boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                          GroupStateRepresentationPtr &gsr) const;
 
   virtual void checkSelfCollision(const collision_detection::CollisionRequest &req,
                                   collision_detection::CollisionResult &res, const moveit::core::RobotState &state1,
@@ -171,7 +174,7 @@ public:
     return 0.0;
   };
 
-  boost::shared_ptr<const DistanceFieldCacheEntry> getLastDistanceFieldEntry() const
+  DistanceFieldCacheEntryConstPtr getLastDistanceFieldEntry() const
   {
     return distance_field_cache_entry_;
   }
@@ -184,35 +187,35 @@ public:
   //                                 collision_detection::AllowedCollisionMatrix
   //                                 &acm) const;
 protected:
-  bool getSelfProximityGradients(boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+  bool getSelfProximityGradients(GroupStateRepresentationPtr &gsr) const;
 
-  bool getIntraGroupProximityGradients(boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+  bool getIntraGroupProximityGradients(GroupStateRepresentationPtr &gsr) const;
 
   bool getSelfCollisions(const collision_detection::CollisionRequest &req, collision_detection::CollisionResult &res,
-                         boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                         GroupStateRepresentationPtr &gsr) const;
 
   bool getIntraGroupCollisions(const collision_detection::CollisionRequest &req,
                                collision_detection::CollisionResult &res,
-                               boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                               GroupStateRepresentationPtr &gsr) const;
 
   void checkSelfCollisionHelper(const collision_detection::CollisionRequest &req,
                                 collision_detection::CollisionResult &res, const moveit::core::RobotState &state,
                                 const collision_detection::AllowedCollisionMatrix *acm,
-                                boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                GroupStateRepresentationPtr &gsr) const;
 
   void updateGroupStateRepresentationState(const moveit::core::RobotState &state,
-                                           boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                           GroupStateRepresentationPtr &gsr) const;
 
   void generateCollisionCheckingStructures(const std::string &group_name, const moveit::core::RobotState &state,
                                            const collision_detection::AllowedCollisionMatrix *acm,
-                                           boost::shared_ptr<GroupStateRepresentation> &gsr,
+                                           GroupStateRepresentationPtr &gsr,
                                            bool generate_distance_field) const;
 
-  boost::shared_ptr<const DistanceFieldCacheEntry>
+  DistanceFieldCacheEntryConstPtr
   getDistanceFieldCacheEntry(const std::string &group_name, const moveit::core::RobotState &state,
                              const collision_detection::AllowedCollisionMatrix *acm) const;
 
-  boost::shared_ptr<DistanceFieldCacheEntry> generateDistanceFieldCacheEntry(
+  DistanceFieldCacheEntryPtr generateDistanceFieldCacheEntry(
       const std::string &group_name, const moveit::core::RobotState &state,
       const collision_detection::AllowedCollisionMatrix *acm, bool generate_distance_field) const;
 
@@ -226,14 +229,14 @@ protected:
 
   PosedBodyPointDecompositionPtr getPosedLinkBodyPointDecomposition(const moveit::core::LinkModel *ls) const;
 
-  void getGroupStateRepresentation(const boost::shared_ptr<const DistanceFieldCacheEntry> &dfce,
+  void getGroupStateRepresentation(const DistanceFieldCacheEntryConstPtr &dfce,
                                    const moveit::core::RobotState &state,
-                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                   GroupStateRepresentationPtr &gsr) const;
 
-  bool compareCacheEntryToState(const boost::shared_ptr<const DistanceFieldCacheEntry> &dfce,
+  bool compareCacheEntryToState(const DistanceFieldCacheEntryConstPtr &dfce,
                                 const moveit::core::RobotState &state) const;
 
-  bool compareCacheEntryToAllowedCollisionMatrix(const boost::shared_ptr<const DistanceFieldCacheEntry> &dfce,
+  bool compareCacheEntryToAllowedCollisionMatrix(const DistanceFieldCacheEntryConstPtr &dfce,
                                                  const collision_detection::AllowedCollisionMatrix &acm) const;
 
   virtual void updatedPaddingOrScaling(const std::vector<std::string> &links){};
@@ -249,9 +252,9 @@ protected:
   std::map<std::string, unsigned int> link_body_decomposition_index_map_;
 
   mutable boost::mutex update_cache_lock_;
-  boost::shared_ptr<DistanceFieldCacheEntry> distance_field_cache_entry_;
+  DistanceFieldCacheEntryPtr distance_field_cache_entry_;
   std::map<std::string, std::map<std::string, bool>> in_group_update_map_;
-  std::map<std::string, boost::shared_ptr<GroupStateRepresentation>> pregenerated_group_state_representation_map_;
+  std::map<std::string, GroupStateRepresentationPtr> pregenerated_group_state_representation_map_;
 
   planning_scene::PlanningScenePtr planning_scene_;
 };

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_hybrid.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_hybrid.h
@@ -77,7 +77,7 @@ public:
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest &req,
                                        collision_detection::CollisionResult &res, const robot_state::RobotState &state,
-                                       boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                       GroupStateRepresentationPtr &gsr) const;
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest &req,
                                        collision_detection::CollisionResult &res, const robot_state::RobotState &state,
@@ -86,14 +86,14 @@ public:
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest &req,
                                        collision_detection::CollisionResult &res, const robot_state::RobotState &state,
                                        const collision_detection::AllowedCollisionMatrix &acm,
-                                       boost::shared_ptr<GroupStateRepresentation> &gsr) const;
-  const boost::shared_ptr<const collision_detection::CollisionRobotDistanceField> getCollisionRobotDistanceField() const
+                                       GroupStateRepresentationPtr &gsr) const;
+  const CollisionRobotDistanceFieldConstPtr getCollisionRobotDistanceField() const
   {
     return crobot_distance_;
   }
 
 protected:
-  boost::shared_ptr<collision_detection::CollisionRobotDistanceField> crobot_distance_;
+  CollisionRobotDistanceFieldPtr crobot_distance_;
 };
 }
 

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
@@ -37,20 +37,26 @@
 #ifndef MOVEIT_COLLISION_DISTANCE_FIELD_COLLISION_WORLD_DISTANCE_FIELD_
 #define MOVEIT_COLLISION_DISTANCE_FIELD_COLLISION_WORLD_DISTANCE_FIELD_
 
+#include <moveit/macros/class_forward.h>
 #include <moveit/collision_detection/collision_world.h>
 #include <moveit/collision_distance_field/collision_distance_field_types.h>
 #include <moveit/collision_distance_field/collision_robot_distance_field.h>
 
 namespace collision_detection
 {
+
+MOVEIT_CLASS_FORWARD(CollisionWorldDistanceField)
+
 class CollisionWorldDistanceField : public CollisionWorld
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  MOVEIT_CLASS_FORWARD(DistanceFieldCacheEntry)
   struct DistanceFieldCacheEntry
   {
     std::map<std::string, std::vector<PosedBodyPointDecompositionPtr>> posed_body_point_decompositions_;
-    boost::shared_ptr<distance_field::DistanceField> distance_field_;
+    distance_field::DistanceFieldPtr distance_field_;
   };
 
   CollisionWorldDistanceField(Eigen::Vector3d size = Eigen::Vector3d(DEFAULT_SIZE_X, DEFAULT_SIZE_Y, DEFAULT_SIZE_Z),
@@ -76,28 +82,28 @@ public:
 
   virtual void checkCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                               const robot_state::RobotState &state,
-                              boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                              GroupStateRepresentationPtr &gsr) const;
 
   virtual void checkCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                               const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
 
   virtual void checkCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                               const robot_state::RobotState &state, const AllowedCollisionMatrix &acm,
-                              boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                              GroupStateRepresentationPtr &gsr) const;
 
   virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state) const;
 
   virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state,
-                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                   GroupStateRepresentationPtr &gsr) const;
 
   virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
 
   virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state, const AllowedCollisionMatrix &acm,
-                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                   GroupStateRepresentationPtr &gsr) const;
 
   virtual void checkRobotCollision(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state1, const robot_state::RobotState &state2) const
@@ -139,38 +145,38 @@ public:
 
   void generateEnvironmentDistanceField(bool redo = true);
 
-  boost::shared_ptr<const distance_field::DistanceField> getDistanceField() const
+  distance_field::DistanceFieldConstPtr getDistanceField() const
   {
     return distance_field_cache_entry_->distance_field_;
   }
 
-  boost::shared_ptr<const collision_detection::GroupStateRepresentation> getLastGroupStateRepresentation() const
+  collision_detection::GroupStateRepresentationConstPtr getLastGroupStateRepresentation() const
   {
     return last_gsr_;
   }
 
   void getCollisionGradients(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                              const robot_state::RobotState &state, const AllowedCollisionMatrix *acm,
-                             boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                             GroupStateRepresentationPtr &gsr) const;
 
   void getAllCollisions(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                         const robot_state::RobotState &state, const AllowedCollisionMatrix *acm,
-                        boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                        GroupStateRepresentationPtr &gsr) const;
 
 protected:
-  boost::shared_ptr<DistanceFieldCacheEntry> generateDistanceFieldCacheEntry();
+  DistanceFieldCacheEntryPtr generateDistanceFieldCacheEntry();
 
   void updateDistanceObject(const std::string &id,
-                            boost::shared_ptr<CollisionWorldDistanceField::DistanceFieldCacheEntry> &dfce,
+                            CollisionWorldDistanceField::DistanceFieldCacheEntryPtr &dfce,
                             EigenSTL::vector_Vector3d &add_points, EigenSTL::vector_Vector3d &subtract_points);
 
   bool getEnvironmentCollisions(const CollisionRequest &req, CollisionResult &res,
-                                const boost::shared_ptr<const distance_field::DistanceField> &env_distance_field,
-                                boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                const distance_field::DistanceFieldConstPtr &env_distance_field,
+                                GroupStateRepresentationPtr &gsr) const;
 
   bool
-  getEnvironmentProximityGradients(const boost::shared_ptr<const distance_field::DistanceField> &env_distance_field,
-                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+  getEnvironmentProximityGradients(const distance_field::DistanceFieldConstPtr &env_distance_field,
+                                   GroupStateRepresentationPtr &gsr) const;
 
   static void notifyObjectChange(CollisionWorldDistanceField *self, const ObjectConstPtr &obj, World::Action action);
 
@@ -182,8 +188,8 @@ protected:
   double max_propogation_distance_;
 
   mutable boost::mutex update_cache_lock_;
-  boost::shared_ptr<DistanceFieldCacheEntry> distance_field_cache_entry_;
-  boost::shared_ptr<collision_detection::GroupStateRepresentation> last_gsr_;
+  DistanceFieldCacheEntryPtr distance_field_cache_entry_;
+  GroupStateRepresentationPtr last_gsr_;
   World::ObserverHandle observer_handle_;
 };
 }

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_hybrid.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_hybrid.h
@@ -70,46 +70,46 @@ public:
 
   void checkCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state,
-                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                   GroupStateRepresentationPtr &gsr) const;
 
   void checkCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
 
   void checkCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                    const robot_state::RobotState &state, const AllowedCollisionMatrix &acm,
-                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                   GroupStateRepresentationPtr &gsr) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                         const robot_state::RobotState &state) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                         const robot_state::RobotState &state,
-                                        boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                        GroupStateRepresentationPtr &gsr) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                         const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                                         const robot_state::RobotState &state, const AllowedCollisionMatrix &acm,
-                                        boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                                        GroupStateRepresentationPtr &gsr) const;
 
   virtual void setWorld(const WorldPtr &world);
 
   void getCollisionGradients(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                              const robot_state::RobotState &state, const AllowedCollisionMatrix *acm,
-                             boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                             GroupStateRepresentationPtr &gsr) const;
 
   void getAllCollisions(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot,
                         const robot_state::RobotState &state, const AllowedCollisionMatrix *acm,
-                        boost::shared_ptr<GroupStateRepresentation> &gsr) const;
+                        GroupStateRepresentationPtr &gsr) const;
 
-  const boost::shared_ptr<const collision_detection::CollisionWorldDistanceField> getCollisionWorldDistanceField() const
+  const CollisionWorldDistanceFieldConstPtr getCollisionWorldDistanceField() const
   {
     return cworld_distance_;
   }
 
 protected:
-  boost::shared_ptr<collision_detection::CollisionWorldDistanceField> cworld_distance_;
+  CollisionWorldDistanceFieldPtr cworld_distance_;
 };
 }
 

--- a/moveit_experimental/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_common_distance_field.cpp
@@ -125,7 +125,7 @@ PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const rob
   return ret;
 }
 
-void getBodySphereVisualizationMarkers(boost::shared_ptr<const collision_detection::GroupStateRepresentation> &gsr,
+void getBodySphereVisualizationMarkers(GroupStateRepresentationConstPtr &gsr,
                                        std::string reference_frame, visualization_msgs::MarkerArray &body_marker_array)
 {
   // creating namespaces

--- a/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
@@ -39,6 +39,7 @@
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/find_internal_points.h>
 #include <ros/console.h>
+#include <memory>
 
 const static double RESOLUTION_SCALE = 1.0;
 const static double EPSILON = 0.0001;

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -126,7 +126,7 @@ void CollisionRobotDistanceField::initialize(
     }
     in_group_update_map_[jm->getName()] = updated_group_entry;
     state.updateLinkTransforms();
-    boost::shared_ptr<DistanceFieldCacheEntry> dfce =
+    DistanceFieldCacheEntryPtr dfce =
         generateDistanceFieldCacheEntry(jm->getName(), state, &planning_scene_->getAllowedCollisionMatrix(), false);
     getGroupStateRepresentation(dfce, state, pregenerated_group_state_representation_map_[jm->getName()]);
   }
@@ -134,15 +134,15 @@ void CollisionRobotDistanceField::initialize(
 
 void CollisionRobotDistanceField::generateCollisionCheckingStructures(
     const std::string &group_name, const moveit::core::RobotState &state,
-    const collision_detection::AllowedCollisionMatrix *acm, boost::shared_ptr<GroupStateRepresentation> &gsr,
+    const collision_detection::AllowedCollisionMatrix *acm, GroupStateRepresentationPtr &gsr,
     bool generate_distance_field) const
 {
-  boost::shared_ptr<const DistanceFieldCacheEntry> dfce = getDistanceFieldCacheEntry(group_name, state, acm);
+  DistanceFieldCacheEntryConstPtr dfce = getDistanceFieldCacheEntry(group_name, state, acm);
   if (!dfce || (generate_distance_field && !dfce->distance_field_))
   {
     // ROS_DEBUG_STREAM_NAMED("distance_field","Generating new
     // DistanceFieldCacheEntry for CollisionRobot");
-    boost::shared_ptr<DistanceFieldCacheEntry> new_dfce =
+    DistanceFieldCacheEntryPtr new_dfce =
         generateDistanceFieldCacheEntry(group_name, state, acm, generate_distance_field);
     boost::mutex::scoped_lock slock(update_cache_lock_);
     (const_cast<CollisionRobotDistanceField *>(this))->distance_field_cache_entry_ = new_dfce;
@@ -155,7 +155,7 @@ void CollisionRobotDistanceField::checkSelfCollisionHelper(const collision_detec
                                                            collision_detection::CollisionResult &res,
                                                            const moveit::core::RobotState &state,
                                                            const collision_detection::AllowedCollisionMatrix *acm,
-                                                           boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                           GroupStateRepresentationPtr &gsr) const
 {
   if (!gsr)
   {
@@ -175,17 +175,17 @@ void CollisionRobotDistanceField::checkSelfCollisionHelper(const collision_detec
   }
 }
 
-boost::shared_ptr<const DistanceFieldCacheEntry> CollisionRobotDistanceField::getDistanceFieldCacheEntry(
+DistanceFieldCacheEntryConstPtr CollisionRobotDistanceField::getDistanceFieldCacheEntry(
     const std::string &group_name, const moveit::core::RobotState &state,
     const collision_detection::AllowedCollisionMatrix *acm) const
 {
-  boost::shared_ptr<const DistanceFieldCacheEntry> ret;
+  DistanceFieldCacheEntryConstPtr ret;
   if (!distance_field_cache_entry_)
   {
     ROS_DEBUG_STREAM("No current Distance field cache entry");
     return ret;
   }
-  boost::shared_ptr<const DistanceFieldCacheEntry> cur = distance_field_cache_entry_;
+  DistanceFieldCacheEntryConstPtr cur = distance_field_cache_entry_;
   if (group_name != cur->group_name_)
   {
     ROS_DEBUG("No cache entry as group name changed from %s to %s", cur->group_name_.c_str(), group_name.c_str());
@@ -210,14 +210,14 @@ void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::
                                                      collision_detection::CollisionResult &res,
                                                      const moveit::core::RobotState &state) const
 {
-  boost::shared_ptr<GroupStateRepresentation> gsr;
+  GroupStateRepresentationPtr gsr;
   checkSelfCollisionHelper(req, res, state, NULL, gsr);
 }
 
 void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::CollisionRequest &req,
                                                      collision_detection::CollisionResult &res,
                                                      const moveit::core::RobotState &state,
-                                                     boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                     GroupStateRepresentationPtr &gsr) const
 {
   checkSelfCollisionHelper(req, res, state, NULL, gsr);
 }
@@ -227,7 +227,7 @@ void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::
                                                      const moveit::core::RobotState &state,
                                                      const collision_detection::AllowedCollisionMatrix &acm) const
 {
-  boost::shared_ptr<GroupStateRepresentation> gsr;
+  GroupStateRepresentationPtr gsr;
   checkSelfCollisionHelper(req, res, state, &acm, gsr);
 }
 
@@ -235,7 +235,7 @@ void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::
                                                      collision_detection::CollisionResult &res,
                                                      const moveit::core::RobotState &state,
                                                      const collision_detection::AllowedCollisionMatrix &acm,
-                                                     boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                     GroupStateRepresentationPtr &gsr) const
 {
   if (gsr)
   {
@@ -247,7 +247,7 @@ void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::
 
 bool CollisionRobotDistanceField::getSelfCollisions(const collision_detection::CollisionRequest &req,
                                                     collision_detection::CollisionResult &res,
-                                                    boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                    GroupStateRepresentationPtr &gsr) const
 {
   for (unsigned int i = 0; i < gsr->dfce_->link_names_.size() + gsr->dfce_->attached_body_names_.size(); i++)
   {
@@ -326,7 +326,7 @@ bool CollisionRobotDistanceField::getSelfCollisions(const collision_detection::C
   return (res.contact_count >= req.max_contacts);
 }
 
-bool CollisionRobotDistanceField::getSelfProximityGradients(boost::shared_ptr<GroupStateRepresentation> &gsr) const
+bool CollisionRobotDistanceField::getSelfProximityGradients(GroupStateRepresentationPtr &gsr) const
 {
   bool in_collision = false;
 
@@ -406,7 +406,7 @@ bool CollisionRobotDistanceField::getSelfProximityGradients(boost::shared_ptr<Gr
 
 bool CollisionRobotDistanceField::getIntraGroupCollisions(const collision_detection::CollisionRequest &req,
                                                           collision_detection::CollisionResult &res,
-                                                          boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                          GroupStateRepresentationPtr &gsr) const
 {
   unsigned int num_links = gsr->dfce_->link_names_.size();
   unsigned int num_attached_bodies = gsr->dfce_->attached_body_names_.size();
@@ -634,7 +634,7 @@ bool CollisionRobotDistanceField::getIntraGroupCollisions(const collision_detect
 }
 
 bool CollisionRobotDistanceField::getIntraGroupProximityGradients(
-    boost::shared_ptr<GroupStateRepresentation> &gsr) const
+    GroupStateRepresentationPtr &gsr) const
 {
   bool in_collision = false;
   unsigned int num_links = gsr->dfce_->link_names_.size();
@@ -700,12 +700,12 @@ bool CollisionRobotDistanceField::getIntraGroupProximityGradients(
   }
   return in_collision;
 }
-boost::shared_ptr<DistanceFieldCacheEntry> CollisionRobotDistanceField::generateDistanceFieldCacheEntry(
+DistanceFieldCacheEntryPtr CollisionRobotDistanceField::generateDistanceFieldCacheEntry(
     const std::string &group_name, const moveit::core::RobotState &state,
     const collision_detection::AllowedCollisionMatrix *acm, bool generate_distance_field) const
 {
   ros::WallTime n = ros::WallTime::now();
-  boost::shared_ptr<DistanceFieldCacheEntry> dfce(new DistanceFieldCacheEntry());
+  DistanceFieldCacheEntryPtr dfce(new DistanceFieldCacheEntry());
 
   if (robot_model_->getJointModelGroup(group_name) == NULL)
   {
@@ -860,7 +860,7 @@ boost::shared_ptr<DistanceFieldCacheEntry> CollisionRobotDistanceField::generate
     }
   }
 
-  std::map<std::string, boost::shared_ptr<GroupStateRepresentation>>::const_iterator it =
+  std::map<std::string, GroupStateRepresentationPtr>::const_iterator it =
       pregenerated_group_state_representation_map_.find(dfce->group_name_);
   if (it != pregenerated_group_state_representation_map_.end())
   {
@@ -1097,7 +1097,7 @@ CollisionRobotDistanceField::getPosedLinkBodyPointDecomposition(const moveit::co
 }
 
 void CollisionRobotDistanceField::updateGroupStateRepresentationState(
-    const moveit::core::RobotState &state, boost::shared_ptr<GroupStateRepresentation> &gsr) const
+    const moveit::core::RobotState &state, GroupStateRepresentationPtr &gsr) const
 {
   for (unsigned int i = 0; i < gsr->dfce_->link_names_.size(); i++)
   {
@@ -1152,8 +1152,8 @@ void CollisionRobotDistanceField::updateGroupStateRepresentationState(
 }
 
 void CollisionRobotDistanceField::getGroupStateRepresentation(
-    const boost::shared_ptr<const DistanceFieldCacheEntry> &dfce, const moveit::core::RobotState &state,
-    boost::shared_ptr<GroupStateRepresentation> &gsr) const
+    const DistanceFieldCacheEntryConstPtr &dfce, const moveit::core::RobotState &state,
+    GroupStateRepresentationPtr &gsr) const
 {
   if (!dfce->pregenerated_group_state_representation_)
   {
@@ -1250,7 +1250,7 @@ void CollisionRobotDistanceField::getGroupStateRepresentation(
   }
 }
 
-bool CollisionRobotDistanceField::compareCacheEntryToState(const boost::shared_ptr<const DistanceFieldCacheEntry> &dfce,
+bool CollisionRobotDistanceField::compareCacheEntryToState(const DistanceFieldCacheEntryConstPtr &dfce,
                                                            const moveit::core::RobotState &state) const
 {
   std::vector<double> new_state_values(state.getVariableCount());
@@ -1311,7 +1311,7 @@ bool CollisionRobotDistanceField::compareCacheEntryToState(const boost::shared_p
 }
 
 bool CollisionRobotDistanceField::compareCacheEntryToAllowedCollisionMatrix(
-    const boost::shared_ptr<const DistanceFieldCacheEntry> &dfce,
+    const DistanceFieldCacheEntryConstPtr &dfce,
     const collision_detection::AllowedCollisionMatrix &acm) const
 {
   if (dfce->acm_.getSize() != acm.getSize())
@@ -1373,7 +1373,7 @@ bool CollisionRobotDistanceField::compareCacheEntryToAllowedCollisionMatrix(
 }
 
 // void
-// CollisionRobotDistanceField::generateAllowedCollisionInformation(boost::shared_ptr<CollisionRobotDistanceField::DistanceFieldCacheEntry>&
+// CollisionRobotDistanceField::generateAllowedCollisionInformation(CollisionRobotDistanceField::DistanceFieldCacheEntryPtr&
 // dfce)
 // {
 //   for(unsigned int i = 0; i < dfce.link_names_.size(); i++) {

--- a/moveit_experimental/collision_distance_field/src/collision_robot_hybrid.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_hybrid.cpp
@@ -71,7 +71,7 @@ void CollisionRobotHybrid::checkSelfCollisionDistanceField(const collision_detec
 void CollisionRobotHybrid::checkSelfCollisionDistanceField(const collision_detection::CollisionRequest &req,
                                                            collision_detection::CollisionResult &res,
                                                            const robot_state::RobotState &state,
-                                                           boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                           GroupStateRepresentationPtr &gsr) const
 {
   crobot_distance_->checkSelfCollision(req, res, state, gsr);
 }
@@ -88,7 +88,7 @@ void CollisionRobotHybrid::checkSelfCollisionDistanceField(const collision_detec
                                                            collision_detection::CollisionResult &res,
                                                            const robot_state::RobotState &state,
                                                            const collision_detection::AllowedCollisionMatrix &acm,
-                                                           boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                           GroupStateRepresentationPtr &gsr) const
 {
   crobot_distance_->checkSelfCollision(req, res, state, acm, gsr);
 }

--- a/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
@@ -108,13 +108,13 @@ void CollisionWorldDistanceField::checkCollision(const CollisionRequest &req, Co
                                                  const CollisionRobot &robot,
                                                  const robot_state::RobotState &state) const
 {
-  boost::shared_ptr<GroupStateRepresentation> gsr;
+  GroupStateRepresentationPtr gsr;
   checkCollision(req, res, robot, state, gsr);
 }
 
 void CollisionWorldDistanceField::checkCollision(const CollisionRequest &req, CollisionResult &res,
                                                  const CollisionRobot &robot, const robot_state::RobotState &state,
-                                                 boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                 GroupStateRepresentationPtr &gsr) const
 {
   try
   {
@@ -150,14 +150,14 @@ void CollisionWorldDistanceField::checkCollision(const CollisionRequest &req, Co
                                                  const CollisionRobot &robot, const robot_state::RobotState &state,
                                                  const AllowedCollisionMatrix &acm) const
 {
-  boost::shared_ptr<GroupStateRepresentation> gsr;
+  GroupStateRepresentationPtr gsr;
   checkCollision(req, res, robot, state, acm, gsr);
 }
 
 void CollisionWorldDistanceField::checkCollision(const CollisionRequest &req, CollisionResult &res,
                                                  const CollisionRobot &robot, const robot_state::RobotState &state,
                                                  const AllowedCollisionMatrix &acm,
-                                                 boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                 GroupStateRepresentationPtr &gsr) const
 {
   try
   {
@@ -193,20 +193,20 @@ void CollisionWorldDistanceField::checkRobotCollision(const CollisionRequest &re
                                                       const CollisionRobot &robot,
                                                       const robot_state::RobotState &state) const
 {
-  boost::shared_ptr<GroupStateRepresentation> gsr;
+  GroupStateRepresentationPtr gsr;
   checkRobotCollision(req, res, robot, state, gsr);
 }
 
 void CollisionWorldDistanceField::checkRobotCollision(const CollisionRequest &req, CollisionResult &res,
                                                       const CollisionRobot &robot, const robot_state::RobotState &state,
-                                                      boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                      GroupStateRepresentationPtr &gsr) const
 {
-  boost::shared_ptr<const distance_field::DistanceField> env_distance_field =
+  distance_field::DistanceFieldConstPtr env_distance_field =
       distance_field_cache_entry_->distance_field_;
   try
   {
     const CollisionRobotDistanceField &cdr = dynamic_cast<const CollisionRobotDistanceField &>(robot);
-    boost::shared_ptr<const DistanceFieldCacheEntry> dfce;
+    DistanceFieldCacheEntryConstPtr dfce;
     if (!gsr)
     {
       cdr.generateCollisionCheckingStructures(req.group_name, state, NULL, gsr, false);
@@ -231,21 +231,21 @@ void CollisionWorldDistanceField::checkRobotCollision(const CollisionRequest &re
                                                       const CollisionRobot &robot, const robot_state::RobotState &state,
                                                       const AllowedCollisionMatrix &acm) const
 {
-  boost::shared_ptr<GroupStateRepresentation> gsr;
+  GroupStateRepresentationPtr gsr;
   checkRobotCollision(req, res, robot, state, acm, gsr);
 }
 
 void CollisionWorldDistanceField::checkRobotCollision(const CollisionRequest &req, CollisionResult &res,
                                                       const CollisionRobot &robot, const robot_state::RobotState &state,
                                                       const AllowedCollisionMatrix &acm,
-                                                      boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                      GroupStateRepresentationPtr &gsr) const
 {
-  boost::shared_ptr<const distance_field::DistanceField> env_distance_field =
+  distance_field::DistanceFieldConstPtr env_distance_field =
       distance_field_cache_entry_->distance_field_;
   try
   {
     const CollisionRobotDistanceField &cdr = dynamic_cast<const CollisionRobotDistanceField &>(robot);
-    boost::shared_ptr<const DistanceFieldCacheEntry> dfce;
+    DistanceFieldCacheEntryPtr dfce;
     if (!gsr)
     {
       cdr.generateCollisionCheckingStructures(req.group_name, state, &acm, gsr, true);
@@ -270,9 +270,9 @@ void CollisionWorldDistanceField::getCollisionGradients(const CollisionRequest &
                                                         const CollisionRobot &robot,
                                                         const robot_state::RobotState &state,
                                                         const AllowedCollisionMatrix *acm,
-                                                        boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                        GroupStateRepresentationPtr &gsr) const
 {
-  boost::shared_ptr<const distance_field::DistanceField> env_distance_field =
+  distance_field::DistanceFieldConstPtr env_distance_field =
       distance_field_cache_entry_->distance_field_;
   try
   {
@@ -301,7 +301,7 @@ void CollisionWorldDistanceField::getCollisionGradients(const CollisionRequest &
 void CollisionWorldDistanceField::getAllCollisions(const CollisionRequest &req, CollisionResult &res,
                                                    const CollisionRobot &robot, const robot_state::RobotState &state,
                                                    const AllowedCollisionMatrix *acm,
-                                                   boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                   GroupStateRepresentationPtr &gsr) const
 {
   try
   {
@@ -316,7 +316,7 @@ void CollisionWorldDistanceField::getAllCollisions(const CollisionRequest &req, 
     }
     cdr.getSelfCollisions(req, res, gsr);
     cdr.getIntraGroupCollisions(req, res, gsr);
-    boost::shared_ptr<const distance_field::DistanceField> env_distance_field =
+    distance_field::DistanceFieldConstPtr env_distance_field =
         distance_field_cache_entry_->distance_field_;
     getEnvironmentCollisions(req, res, env_distance_field, gsr);
   }
@@ -331,8 +331,8 @@ void CollisionWorldDistanceField::getAllCollisions(const CollisionRequest &req, 
 
 bool CollisionWorldDistanceField::getEnvironmentCollisions(
     const CollisionRequest &req, CollisionResult &res,
-    const boost::shared_ptr<const distance_field::DistanceField> &env_distance_field,
-    boost::shared_ptr<GroupStateRepresentation> &gsr) const
+    const distance_field::DistanceFieldConstPtr &env_distance_field,
+    GroupStateRepresentationPtr &gsr) const
 {
   for (unsigned int i = 0; i < gsr->dfce_->link_names_.size() + gsr->dfce_->attached_body_names_.size(); i++)
   {
@@ -415,8 +415,8 @@ bool CollisionWorldDistanceField::getEnvironmentCollisions(
 }
 
 bool CollisionWorldDistanceField::getEnvironmentProximityGradients(
-    const boost::shared_ptr<const distance_field::DistanceField> &env_distance_field,
-    boost::shared_ptr<GroupStateRepresentation> &gsr) const
+    const distance_field::DistanceFieldConstPtr &env_distance_field,
+    GroupStateRepresentationPtr &gsr) const
 {
   bool in_collision = false;
   for (unsigned int i = 0; i < gsr->dfce_->link_names_.size(); i++)
@@ -501,7 +501,7 @@ void CollisionWorldDistanceField::notifyObjectChange(CollisionWorldDistanceField
 }
 
 void CollisionWorldDistanceField::updateDistanceObject(
-    const std::string &id, boost::shared_ptr<CollisionWorldDistanceField::DistanceFieldCacheEntry> &dfce,
+    const std::string &id, DistanceFieldCacheEntryPtr &dfce,
     EigenSTL::vector_Vector3d &add_points, EigenSTL::vector_Vector3d &subtract_points)
 {
   std::map<std::string, std::vector<PosedBodyPointDecompositionPtr>>::iterator cur_it =
@@ -551,10 +551,10 @@ void CollisionWorldDistanceField::updateDistanceObject(
   }
 }
 
-boost::shared_ptr<CollisionWorldDistanceField::DistanceFieldCacheEntry>
+CollisionWorldDistanceField::DistanceFieldCacheEntryPtr
 CollisionWorldDistanceField::generateDistanceFieldCacheEntry()
 {
-  boost::shared_ptr<DistanceFieldCacheEntry> dfce(new DistanceFieldCacheEntry());
+  DistanceFieldCacheEntryPtr dfce(new DistanceFieldCacheEntry());
   dfce->distance_field_.reset(new distance_field::PropagationDistanceField(
       size_.x(), size_.y(), size_.z(), resolution_, origin_.x() - 0.5 * size_.x(), origin_.y() - 0.5 * size_.y(),
       origin_.z() - 0.5 * size_.z(), max_propogation_distance_, use_signed_distance_field_));

--- a/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
@@ -38,8 +38,8 @@
 #include <moveit/collision_distance_field/collision_world_distance_field.h>
 #include <moveit/collision_distance_field/collision_common_distance_field.h>
 #include <moveit/distance_field/propagation_distance_field.h>
-#include <boost/make_shared.hpp>
 #include <boost/bind.hpp>
+#include <memory>
 
 namespace collision_detection
 {

--- a/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
@@ -529,13 +529,13 @@ void CollisionWorldDistanceField::updateDistanceObject(
         const shapes::OcTree *octree_shape = static_cast<const shapes::OcTree *>(shape.get());
         std::shared_ptr<const octomap::OcTree> octree = octree_shape->octree;
 
-        shape_points.push_back(boost::make_shared<PosedBodyPointDecomposition>(octree));
+        shape_points.push_back(std::make_shared<PosedBodyPointDecomposition>(octree));
       }
       else
       {
         BodyDecompositionConstPtr bd = getBodyDecompositionCacheEntry(shape, resolution_);
 
-        shape_points.push_back(boost::make_shared<PosedBodyPointDecomposition>(bd, object->shape_poses_[i]));
+        shape_points.push_back(std::make_shared<PosedBodyPointDecomposition>(bd, object->shape_poses_[i]));
       }
 
       add_points.insert(add_points.end(), shape_points.back()->getCollisionPoints().begin(),

--- a/moveit_experimental/collision_distance_field/src/collision_world_hybrid.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_hybrid.cpp
@@ -74,7 +74,7 @@ void CollisionWorldHybrid::checkCollisionDistanceField(const CollisionRequest &r
 void CollisionWorldHybrid::checkCollisionDistanceField(const CollisionRequest &req, CollisionResult &res,
                                                        const CollisionRobot &robot,
                                                        const robot_state::RobotState &state,
-                                                       boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                       GroupStateRepresentationPtr &gsr) const
 {
   cworld_distance_->checkCollision(req, res, robot, state, gsr);
 }
@@ -91,7 +91,7 @@ void CollisionWorldHybrid::checkCollisionDistanceField(const CollisionRequest &r
                                                        const CollisionRobot &robot,
                                                        const robot_state::RobotState &state,
                                                        const AllowedCollisionMatrix &acm,
-                                                       boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                       GroupStateRepresentationPtr &gsr) const
 {
   cworld_distance_->checkCollision(req, res, robot, state, acm, gsr);
 }
@@ -106,7 +106,7 @@ void CollisionWorldHybrid::checkRobotCollisionDistanceField(const CollisionReque
 void CollisionWorldHybrid::checkRobotCollisionDistanceField(const CollisionRequest &req, CollisionResult &res,
                                                             const CollisionRobot &robot,
                                                             const robot_state::RobotState &state,
-                                                            boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                            GroupStateRepresentationPtr &gsr) const
 {
   cworld_distance_->checkRobotCollision(req, res, robot, state, gsr);
 }
@@ -123,7 +123,7 @@ void CollisionWorldHybrid::checkRobotCollisionDistanceField(const CollisionReque
                                                             const CollisionRobot &robot,
                                                             const robot_state::RobotState &state,
                                                             const AllowedCollisionMatrix &acm,
-                                                            boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                            GroupStateRepresentationPtr &gsr) const
 {
   cworld_distance_->checkRobotCollision(req, res, robot, state, acm, gsr);
 }
@@ -140,7 +140,7 @@ void CollisionWorldHybrid::setWorld(const WorldPtr &world)
 void CollisionWorldHybrid::getCollisionGradients(const CollisionRequest &req, CollisionResult &res,
                                                  const CollisionRobot &robot, const robot_state::RobotState &state,
                                                  const AllowedCollisionMatrix *acm,
-                                                 boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                                 GroupStateRepresentationPtr &gsr) const
 {
   cworld_distance_->getCollisionGradients(req, res, robot, state, acm, gsr);
 }
@@ -148,7 +148,7 @@ void CollisionWorldHybrid::getCollisionGradients(const CollisionRequest &req, Co
 void CollisionWorldHybrid::getAllCollisions(const CollisionRequest &req, CollisionResult &res,
                                             const CollisionRobot &robot, const robot_state::RobotState &state,
                                             const AllowedCollisionMatrix *acm,
-                                            boost::shared_ptr<GroupStateRepresentation> &gsr) const
+                                            GroupStateRepresentationPtr &gsr) const
 {
   cworld_distance_->getAllCollisions(req, res, robot, state, acm, gsr);
 }

--- a/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
@@ -96,16 +96,16 @@ protected:
   bool urdf_ok_;
   bool srdf_ok_;
 
-  urdf::ModelInterfaceSharedPtr            urdf_model_;
-  boost::shared_ptr<srdf::Model>           srdf_model_;
+  urdf::ModelInterfaceSharedPtr    urdf_model_;
+  srdf::ModelSharedPtr             srdf_model_;
 
   robot_model::RobotModelPtr robot_model_;
 
   robot_state::TransformsPtr ftf_;
   robot_state::TransformsConstPtr ftf_const_;
 
-  boost::shared_ptr<collision_detection::CollisionRobot> crobot_;
-  boost::shared_ptr<collision_detection::CollisionWorld> cworld_;
+  collision_detection::CollisionRobotPtr crobot_;
+  collision_detection::CollisionWorldPtr cworld_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;
 };

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/src/kinematics_cache_ros.cpp
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/src/kinematics_cache_ros.cpp
@@ -73,7 +73,7 @@ bool KinematicsCacheROS::init(const kinematics_cache::KinematicsCache::Options& 
   }
 
   rdf_loader::RDFLoader rdf_loader;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
+  const srdf::ModelSharedPtr &srdf = rdf_loader.getSRDF();
   const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
   kinematic_model_.reset(new planning_models::RobotModel(urdf_model, srdf));
 

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -15,7 +15,7 @@ CHOMPPlanningContext::CHOMPPlanningContext(const std::string &name, const std::s
 {
   chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface());
 
-  boost::shared_ptr<collision_detection::CollisionDetectorAllocator> hybrid_cd(
+  collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
       collision_detection::CollisionDetectorAllocatorHybrid::create());
 
   if (!this->getPlanningScene())

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -131,7 +131,7 @@ private:
   const collision_detection::CollisionRobotHybrid* hy_robot_;
 
   std::vector<ChompCost> joint_costs_;
-  boost::shared_ptr<collision_detection::GroupStateRepresentation> gsr_;
+  collision_detection::GroupStateRepresentationPtr gsr_;
   bool initialized_;
 
   std::vector<std::vector<std::string> > collision_point_joint_names_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -42,7 +42,6 @@
 #include <moveit/constraint_samplers/constraint_sampler_manager.h>
 #include <moveit/macros/class_forward.h>
 
-#include <boost/shared_ptr.hpp>
 #include <vector>
 #include <string>
 #include <map>

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -47,6 +47,8 @@
 #include <moveit_msgs/DisplayRobotState.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 
+#include <memory>
+
 namespace ompl_interface
 {
 using namespace moveit_planners_ompl;
@@ -258,9 +260,9 @@ private:
   }
 
   ros::NodeHandle nh_;
-  boost::scoped_ptr<dynamic_reconfigure::Server<OMPLDynamicReconfigureConfig> > dynamic_reconfigure_server_;
-  boost::scoped_ptr<OMPLInterface> ompl_interface_;
-  boost::scoped_ptr<boost::thread> pub_valid_states_thread_;
+  std::unique_ptr<dynamic_reconfigure::Server<OMPLDynamicReconfigureConfig> > dynamic_reconfigure_server_;
+  std::unique_ptr<OMPLInterface> ompl_interface_;
+  std::unique_ptr<boost::thread> pub_valid_states_thread_;
   bool display_random_valid_states_;
   ros::Publisher pub_markers_;
   ros::Publisher pub_valid_states_;

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -77,11 +77,11 @@ protected:
   }
 
 protected:
-  robot_model::RobotModelPtr robot_model_;
-  urdf::ModelInterfaceSharedPtr      urdf_model_;
-  boost::shared_ptr<srdf::Model>     srdf_model_;
-  bool                               urdf_ok_;
-  bool                               srdf_ok_;
+  robot_model::RobotModelPtr    robot_model_;
+  urdf::ModelInterfaceSharedPtr urdf_model_;
+  srdf::ModelSharedPtr          srdf_model_;
+  bool                          urdf_ok_;
+  bool                          srdf_ok_;
 
 };
 

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -39,7 +39,6 @@
 #include <moveit/controller_manager/controller_manager.h>
 #include <ros/publisher.h>
 #include <ros/rate.h>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/thread.hpp>
 
 #ifndef MOVEIT_FAKE_CONTROLLERS

--- a/moveit_plugins/moveit_ros_control_interface/package.xml
+++ b/moveit_plugins/moveit_ros_control_interface/package.xml
@@ -14,7 +14,7 @@
   <depend>controller_manager_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_simple_controller_manager</depend>
-  <depend>pluginlib</depend>
+  <depend version_gte="1.10.4">pluginlib</depend>
   <depend>trajectory_msgs</depend>
 
   <export>

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -46,11 +46,12 @@
 #include <controller_manager_msgs/SwitchController.h>
 
 #include <pluginlib/class_list_macros.h>
-#include <map>
-
 #include <pluginlib/class_loader.h>
 
 #include <boost/bimap.hpp>
+
+#include <map>
+#include <memory>
 
 namespace moveit_ros_control_interface
 {
@@ -401,7 +402,7 @@ class MoveItMultiControllerManager : public moveit_controller_manager::MoveItCon
         {  // create MoveItControllerManager if it does not exists
           ROS_INFO_STREAM("Adding controller_manager interface for node at namespace " << ns);
           controller_managers_.insert(
-              std::make_pair(ns, boost::make_shared<moveit_ros_control_interface::MoveItControllerManager>(ns)));
+              std::make_pair(ns, std::make_shared<moveit_ros_control_interface::MoveItControllerManager>(ns)));
         }
       }
     }

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -152,7 +152,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
       AllocatorsMap::iterator alloc_it = allocators_.find(type);
       if (alloc_it == allocators_.end())
       {  // create allocator is needed
-        alloc_it = allocators_.insert(std::make_pair(type, loader_.createInstance(type))).first;
+        alloc_it = allocators_.insert(std::make_pair(type, loader_.createUniqueInstance(type))).first;
       }
 
       // Collect claimed resources across different hardware interfaces

--- a/moveit_plugins/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
@@ -37,8 +37,8 @@
 #include <ros/ros.h>
 #include <moveit_ros_control_interface/ControllerHandle.h>
 #include <pluginlib/class_list_macros.h>
-#include <boost/shared_ptr.hpp>
 #include <moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
+#include <memory>
 
 namespace moveit_ros_control_interface
 {
@@ -51,7 +51,7 @@ public:
   virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name,
                                                                      const std::vector<std::string> &resources)
   {
-    return boost::make_shared<moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle>(
+    return std::make_shared<moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle>(
         name, "follow_joint_trajectory");
   }
 };

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -41,6 +41,7 @@
 #include <moveit/controller_manager/controller_manager.h>
 #include <actionlib/client/simple_action_client.h>
 #include <moveit/macros/class_forward.h>
+#include <memory>
 
 namespace moveit_simple_controller_manager
 {
@@ -168,7 +169,7 @@ protected:
   std::vector<std::string> joints_;
 
   /* action client */
-  boost::shared_ptr<actionlib::SimpleActionClient<T> > controller_action_client_;
+  std::shared_ptr<actionlib::SimpleActionClient<T> > controller_action_client_;
 };
 
 

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -112,7 +112,7 @@ moveit_benchmarks::BenchmarkExecution::BenchmarkExecution(const planning_scene::
     ROS_INFO("Attempting to load and configure %s", classes[i].c_str());
     try
     {
-      planning_interface::PlannerManagerPtr p = planner_plugin_loader_->createInstance(classes[i]);
+      planning_interface::PlannerManagerPtr p = planner_plugin_loader_->createUniqueInstance(classes[i]);
       p->initialize(planning_scene_->getRobotModel(), "");
       planner_interfaces_[classes[i]] = p;
     }

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -56,6 +56,7 @@
 #include <Eigen/Geometry>
 
 #include <fstream>
+#include <memory>
 
 namespace moveit_benchmarks
 {
@@ -246,7 +247,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
 
   unsigned int n_call = 0;
   bool have_more_start_states = true;
-  boost::scoped_ptr<moveit_msgs::RobotState> start_state_to_use;
+  std::unique_ptr<moveit_msgs::RobotState> start_state_to_use;
   while (have_more_start_states)
   {
     start_state_to_use.reset();
@@ -660,7 +661,7 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string &filen
     std::vector<std::string> unr =
         boost::program_options::collect_unrecognized(po.options, boost::program_options::exclude_positional);
 
-    boost::scoped_ptr<PlanningPluginOptions> bpo;
+    std::unique_ptr<PlanningPluginOptions> bpo;
     for (std::size_t i = 0; i < unr.size() / 2; ++i)
     {
       std::string key = boost::to_lower_copy(unr[i * 2]);

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -54,6 +54,7 @@
 #include <vector>
 #include <string>
 #include <boost/function.hpp>
+#include <memory>
 
 namespace moveit_ros_benchmarks
 {
@@ -190,7 +191,7 @@ protected:
 
   BenchmarkOptions options_;
 
-  boost::shared_ptr<pluginlib::ClassLoader<planning_interface::PlannerManager>> planner_plugin_loader_;
+  std::shared_ptr<pluginlib::ClassLoader<planning_interface::PlannerManager>> planner_plugin_loader_;
   std::map<std::string, planning_interface::PlannerManagerPtr> planner_interfaces_;
 
   std::vector<PlannerBenchmarkData> benchmark_data_;

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -16,9 +16,11 @@
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_ros_warehouse</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend version_gte="1.10.4">pluginlib</build_depend>
 
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>moveit_ros_warehouse</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend version_gte="1.10.4">pluginlib</run_depend>
 
 </package>

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -116,7 +116,7 @@ void BenchmarkExecutor::initialize(const std::vector<std::string>& plugin_classe
 
     try
     {
-      boost::shared_ptr<planning_interface::PlannerManager> p =
+      planning_interface::PlannerManagerPtr p =
           planner_plugin_loader_->createUniqueInstance(plugin_classes[i]);
       p->initialize(planning_scene_->getRobotModel(), "");
 
@@ -136,7 +136,7 @@ void BenchmarkExecutor::initialize(const std::vector<std::string>& plugin_classe
   else
   {
     std::stringstream ss;
-    for (std::map<std::string, boost::shared_ptr<planning_interface::PlannerManager>>::const_iterator it =
+    for (std::map<std::string, planning_interface::PlannerManagerPtr>::const_iterator it =
              planner_interfaces_.begin();
          it != planner_interfaces_.end(); ++it)
       ss << it->first << " ";

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -117,7 +117,7 @@ void BenchmarkExecutor::initialize(const std::vector<std::string>& plugin_classe
     try
     {
       boost::shared_ptr<planning_interface::PlannerManager> p =
-          planner_plugin_loader_->createInstance(plugin_classes[i]);
+          planner_plugin_loader_->createUniqueInstance(plugin_classes[i]);
       p->initialize(planning_scene_->getRobotModel(), "");
 
       const planning_interface::PlannerConfigurationMap& config_map = p->getPlannerConfigurations();

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.h
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.h
@@ -43,6 +43,8 @@
 #include <moveit_msgs/PickupAction.h>
 #include <moveit_msgs/PlaceAction.h>
 
+#include <memory>
+
 namespace move_group
 {
 
@@ -83,13 +85,13 @@ private:
 
   pick_place::PickPlacePtr pick_place_;
 
-  boost::scoped_ptr<actionlib::SimpleActionServer<moveit_msgs::PickupAction> > pickup_action_server_;
+  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::PickupAction> > pickup_action_server_;
   moveit_msgs::PickupFeedback pickup_feedback_;
 
-  boost::scoped_ptr<actionlib::SimpleActionServer<moveit_msgs::PlaceAction> > place_action_server_;
+  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::PlaceAction> > place_action_server_;
   moveit_msgs::PlaceFeedback place_feedback_;
 
-  boost::scoped_ptr<moveit_msgs::AttachedCollisionObject> diff_attached_object_;
+  std::unique_ptr<moveit_msgs::AttachedCollisionObject> diff_attached_object_;
 
   MoveGroupState pickup_state_;
   MoveGroupState place_state_;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
@@ -45,7 +45,7 @@
 #include <moveit_msgs/PickupAction.h>
 #include <moveit_msgs/PlaceAction.h>
 #include <boost/noncopyable.hpp>
-#include <boost/enable_shared_from_this.hpp>
+#include <memory>
 
 namespace pick_place
 {
@@ -112,7 +112,7 @@ public:
 };
 
 class PickPlace : private boost::noncopyable,
-                  public boost::enable_shared_from_this<PickPlace>
+                  public std::enable_shared_from_this<PickPlace>
 {
 public:
 

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -121,8 +121,8 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
         if (waypoints.size() > 0)
         {
           robot_state::GroupStateValidityCallbackFn constraint_fn;
-          boost::scoped_ptr<planning_scene_monitor::LockedPlanningSceneRO> ls;
-          boost::scoped_ptr<kinematic_constraints::KinematicConstraintSet> kset;
+          std::unique_ptr<planning_scene_monitor::LockedPlanningSceneRO> ls;
+          std::unique_ptr<kinematic_constraints::KinematicConstraintSet> kset;
           if (req.avoid_collisions || !kinematic_constraints::isEmpty(req.path_constraints))
           {
             ls.reset(new planning_scene_monitor::LockedPlanningSceneRO(context_->planning_scene_monitor_));

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -46,6 +46,7 @@
 #include <moveit/move_group/move_group_capability.h>
 #include <actionlib/server/simple_action_server.h>
 #include <moveit_msgs/ExecuteTrajectoryAction.h>
+#include <memory>
 
 namespace move_group
 {
@@ -67,7 +68,7 @@ private:
   void preemptExecuteTrajectoryCallback();
   void setExecuteTrajectoryState(MoveGroupState state);
 
-  boost::scoped_ptr<actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction> > execute_action_server_;
+  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction> > execute_action_server_;
 };
 
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -40,6 +40,7 @@
 #include <moveit/move_group/move_group_capability.h>
 #include <actionlib/server/simple_action_server.h>
 #include <moveit_msgs/MoveGroupAction.h>
+#include <memory>
 
 namespace move_group
 {
@@ -63,7 +64,7 @@ private:
   void setMoveState(MoveGroupState state);
   bool planUsingPlanningPipeline(const planning_interface::MotionPlanRequest &req, plan_execution::ExecutableMotionPlan &plan);
 
-  boost::scoped_ptr<actionlib::SimpleActionServer<moveit_msgs::MoveGroupAction> > move_action_server_;
+  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::MoveGroupAction> > move_action_server_;
   moveit_msgs::MoveGroupFeedback move_feedback_;
 
   MoveGroupState move_state_;

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -41,6 +41,7 @@
 #include <boost/tokenizer.hpp>
 #include <moveit/macros/console_colors.h>
 #include <moveit/move_group/node_name.h>
+#include <memory>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";    // name of the robot description (a param name, so it can be changed externally)
 
@@ -139,7 +140,7 @@ private:
 
   ros::NodeHandle node_handle_;
   MoveGroupContextPtr context_;
-  boost::shared_ptr<pluginlib::ClassLoader<MoveGroupCapability> > capability_plugin_loader_;
+  std::shared_ptr<pluginlib::ClassLoader<MoveGroupCapability> > capability_plugin_loader_;
   std::vector<MoveGroupCapabilityPtr> capabilities_;
 };
 

--- a/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -44,7 +44,7 @@
 #include <moveit/mesh_filter/stereo_camera_model.h>
 #include <moveit/lazy_free_space_updater/lazy_free_space_updater.h>
 #include <image_transport/image_transport.h>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace occupancy_map_monitor
 {
@@ -97,8 +97,8 @@ private:
   unsigned int good_tf_;
   unsigned int failed_tf_;
 
-  boost::scoped_ptr<mesh_filter::MeshFilter<mesh_filter::StereoCameraModel> > mesh_filter_;
-  boost::scoped_ptr<LazyFreeSpaceUpdater> free_space_updater_;
+  std::unique_ptr<mesh_filter::MeshFilter<mesh_filter::StereoCameraModel> > mesh_filter_;
+  std::unique_ptr<LazyFreeSpaceUpdater> free_space_updater_;
 
   std::vector<float> x_cache_, y_cache_;
   double inv_fx_, inv_fy_, K0_, K2_, K4_, K5_;

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -41,6 +41,8 @@
 #include <XmlRpcException.h>
 #include <stdint.h>
 
+#include <memory>
+
 namespace occupancy_map_monitor
 {
 
@@ -153,7 +155,7 @@ mesh_filter::MeshHandle DepthImageOctomapUpdater::excludeShape(const shapes::Sha
       h = mesh_filter_->addMesh(static_cast<const shapes::Mesh&>(*shape));
     else
     {
-      boost::scoped_ptr<shapes::Mesh> m(shapes::createMeshFromShape(shape.get()));
+      std::unique_ptr<shapes::Mesh> m(shapes::createMeshFromShape(shape.get()));
       if (m)
         h = mesh_filter_->addMesh(*m);
     }

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
@@ -39,13 +39,13 @@
 
 #include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <moveit/mesh_filter/transform_provider.h>
 #include <moveit/mesh_filter/mesh_filter.h>
 #include <moveit/mesh_filter/stereo_camera_model.h>
 #include <cv_bridge/cv_bridge.h>
+#include <memory>
 
 namespace mesh_filter
 {
@@ -93,11 +93,11 @@ class DepthSelfFiltering : public nodelet::Nodelet
 
   private:
     // member variables to handle ros messages
-    boost::shared_ptr<image_transport::ImageTransport> input_depth_transport_;
-    boost::shared_ptr<image_transport::ImageTransport> filtered_label_transport_;
-    boost::shared_ptr<image_transport::ImageTransport> filtered_depth_transport_;
-    boost::shared_ptr<image_transport::ImageTransport> model_depth_transport_;
-    boost::shared_ptr<image_transport::ImageTransport> model_label_transport_;
+    std::shared_ptr<image_transport::ImageTransport> input_depth_transport_;
+    std::shared_ptr<image_transport::ImageTransport> filtered_label_transport_;
+    std::shared_ptr<image_transport::ImageTransport> filtered_depth_transport_;
+    std::shared_ptr<image_transport::ImageTransport> model_depth_transport_;
+    std::shared_ptr<image_transport::ImageTransport> model_label_transport_;
     image_transport::CameraSubscriber sub_depth_image_;
     image_transport::CameraPublisher pub_filtered_depth_image_;
     image_transport::CameraPublisher pub_filtered_label_image_;

--- a/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -50,6 +50,8 @@
 
 #include <boost/thread/mutex.hpp>
 
+#include <memory>
+
 namespace occupancy_map_monitor
 {
 
@@ -144,7 +146,7 @@ private:
   OccMapTreePtr tree_;
   OccMapTreeConstPtr tree_const_;
 
-  boost::scoped_ptr<pluginlib::ClassLoader<OccupancyMapUpdater> > updater_plugin_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<OccupancyMapUpdater> > updater_plugin_loader_;
   std::vector<OccupancyMapUpdaterPtr> map_updaters_;
   std::vector<std::map<ShapeHandle, ShapeHandle> > mesh_handles_;
   TransformCacheProvider transform_cache_callback_;

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -45,6 +45,8 @@
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
 #include <moveit/point_containment_filter/shape_mask.h>
 
+#include <memory>
+
 namespace occupancy_map_monitor
 {
 
@@ -93,7 +95,7 @@ private:
      we cache this here because it dynamically pre-allocates a lot of memory in its contsructor */
   octomap::KeyRay key_ray_;
 
-  boost::scoped_ptr<point_containment_filter::ShapeMask> shape_mask_;
+  std::unique_ptr<point_containment_filter::ShapeMask> shape_mask_;
   std::vector<int> mask_;
 
 };

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -41,6 +41,8 @@
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <XmlRpcException.h>
 
+#include <memory>
+
 namespace occupancy_map_monitor
 {
 
@@ -204,14 +206,14 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   updateMask(*cloud_msg, sensor_origin_eigen, mask_);
 
   octomap::KeySet free_cells, occupied_cells, model_cells, clip_cells;
-  boost::scoped_ptr<sensor_msgs::PointCloud2> filtered_cloud;
+  std::unique_ptr<sensor_msgs::PointCloud2> filtered_cloud;
 
   //We only use these iterators if we are creating a filtered_cloud for
-  //publishing. We cannot default construct these, so we use scoped_ptr's
+  //publishing. We cannot default construct these, so we use unique_ptr's
   //to defer construction
-  boost::scoped_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_x;
-  boost::scoped_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_y;
-  boost::scoped_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_z;
+  std::unique_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_x;
+  std::unique_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_y;
+  std::unique_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_z;
 
   if (!filtered_cloud_topic_.empty()) {
     filtered_cloud.reset(new sensor_msgs::PointCloud2());

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -34,6 +34,7 @@
 
 #include <moveit/collision_plugin_loader/collision_plugin_loader.h>
 #include <pluginlib/class_loader.h>
+#include <memory>
 
 namespace collision_detection
 {
@@ -92,7 +93,7 @@ public:
   }
 
 private:
-  boost::shared_ptr<pluginlib::ClassLoader<CollisionPlugin> > loader_;
+  std::shared_ptr<pluginlib::ClassLoader<CollisionPlugin> > loader_;
   std::map<std::string, CollisionPluginPtr> plugins_;
 };
 

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -38,6 +38,7 @@
 #include <pluginlib/class_loader.h>
 #include <ros/ros.h>
 #include <boost/tokenizer.hpp>
+#include <memory>
 
 namespace constraint_sampler_manager_loader
 {
@@ -82,7 +83,7 @@ public:
 private:
 
   ros::NodeHandle nh_;
-  boost::scoped_ptr<pluginlib::ClassLoader<constraint_samplers::ConstraintSamplerAllocator> > constraint_sampler_plugin_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<constraint_samplers::ConstraintSamplerAllocator> > constraint_sampler_plugin_loader_;
 };
 
 ConstraintSamplerManagerLoader::ConstraintSamplerManagerLoader(const constraint_samplers::ConstraintSamplerManagerPtr &csm) :

--- a/moveit_ros/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_ros/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -41,9 +41,6 @@
 #include <ros/ros.h>
 #include <random_numbers/random_numbers.h>
 
-// System
-#include <boost/shared_ptr.hpp>
-
 // ROS msgs
 #include <geometry_msgs/PoseStamped.h>
 #include <moveit_msgs/GetPositionFK.h>

--- a/moveit_ros/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_ros/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -134,7 +134,7 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
 
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
+  const srdf::ModelSharedPtr &srdf = rdf_loader.getSRDF();
   const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -86,7 +86,7 @@ public:
   robot_model::SolverAllocatorFn getLoaderFunction();
 
   /** \brief Get a function pointer that allocates and initializes a kinematics solver. If not previously called, this function reads ROS parameters for the groups defined in the SRDF. */
-  robot_model::SolverAllocatorFn getLoaderFunction(const boost::shared_ptr<srdf::Model> &srdf_model);
+  robot_model::SolverAllocatorFn getLoaderFunction(const srdf::ModelSharedPtr &srdf_model);
 
   /** \brief Get the groups for which the function pointer returned by getLoaderFunction() can allocate a solver */
   const std::vector<std::string>& getKnownGroups() const

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -256,7 +256,7 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
   return getLoaderFunction(rml.getSRDF());
 }
 
-robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader::getLoaderFunction(const boost::shared_ptr<srdf::Model> &srdf_model)
+robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader::getLoaderFunction(const srdf::ModelSharedPtr &srdf_model)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction(SRDF)");

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -142,7 +142,7 @@ public:
         {
           try
           {
-            result = kinematics_loader_->createInstance(it->second[i]);
+            result = kinematics_loader_->createUniqueInstance(it->second[i]);
             if (result)
             {
               const std::vector<const robot_model::LinkModel*> &links = jmg->getLinkModels();

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -41,6 +41,7 @@
 #include <sstream>
 #include <vector>
 #include <map>
+#include <memory>
 #include <ros/ros.h>
 #include <moveit/profiler/profiler.h>
 
@@ -227,7 +228,7 @@ private:
   std::map<std::string, std::vector<std::string> >                       possible_kinematics_solvers_;
   std::map<std::string, std::vector<double> >                            search_res_;
   std::map<std::string, std::vector<std::string> >                       iksolver_to_tip_links_;  // a map between each ik solver and a vector of custom-specified tip link(s)
-  boost::shared_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> > kinematics_loader_;
+  std::shared_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> >   kinematics_loader_;
   std::map<const robot_model::JointModelGroup*,
            std::vector<kinematics::KinematicsBasePtr> >                  instances_;
   boost::mutex                                                           lock_;

--- a/moveit_ros/planning/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
+++ b/moveit_ros/planning/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
@@ -41,9 +41,6 @@
 #include <ros/ros.h>
 #include <random_numbers/random_numbers.h>
 
-// System
-#include <boost/shared_ptr.hpp>
-
 // ROS msgs
 #include <geometry_msgs/PoseStamped.h>
 #include <moveit_msgs/GetPositionFK.h>

--- a/moveit_ros/planning/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_ros/planning/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -133,7 +133,7 @@ bool LMAKinematicsPlugin::initialize(const std::string &robot_description,
 
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
+  const srdf::ModelSharedPtr &srdf = rdf_loader.getSRDF();
   const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -20,7 +20,7 @@
 
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_perception</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.10.4">pluginlib</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>angles</build_depend>
@@ -28,7 +28,7 @@
 
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_perception</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.10.4">pluginlib</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>angles</run_depend>

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -44,7 +44,6 @@
 #include <moveit/planning_scene_monitor/trajectory_monitor.h>
 #include <moveit/sensor_manager/sensor_manager.h>
 #include <pluginlib/class_loader.h>
-#include <boost/scoped_ptr.hpp>
 
 /** \brief This namespace includes functionality specific to the execution and monitoring of motion plans */
 namespace plan_execution

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
@@ -44,7 +44,8 @@
 #include <moveit/planning_scene_monitor/trajectory_monitor.h>
 #include <moveit/sensor_manager/sensor_manager.h>
 #include <pluginlib/class_loader.h>
-#include <boost/scoped_ptr.hpp>
+
+#include <memory>
 
 namespace plan_execution
 {
@@ -119,7 +120,7 @@ private:
   ros::NodeHandle node_handle_;
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
 
-  boost::scoped_ptr<pluginlib::ClassLoader<moveit_sensor_manager::MoveItSensorManager> > sensor_manager_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_sensor_manager::MoveItSensorManager> > sensor_manager_loader_;
   moveit_sensor_manager::MoveItSensorManagerPtr sensor_manager_;
   unsigned int default_max_look_attempts_;
   double default_max_safe_path_cost_;

--- a/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
@@ -102,7 +102,7 @@ plan_execution::PlanWithSensing::PlanWithSensing(const trajectory_execution_mana
       if (node_handle_.getParam("moveit_sensor_manager", manager))
         try
         {
-          sensor_manager_ = sensor_manager_loader_->createInstance(manager);
+          sensor_manager_ = sensor_manager_loader_->createUniqueInstance(manager);
         }
         catch(pluginlib::PluginlibException& ex)
         {

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -40,8 +40,9 @@
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <pluginlib/class_loader.h>
-#include <boost/scoped_ptr.hpp>
 #include <ros/ros.h>
+
+#include <memory>
 
 /** \brief Planning pipeline */
 namespace planning_pipeline
@@ -175,12 +176,12 @@ private:
   bool publish_received_requests_;
   ros::Publisher received_request_publisher_;
 
-  boost::scoped_ptr<pluginlib::ClassLoader<planning_interface::PlannerManager> > planner_plugin_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<planning_interface::PlannerManager> > planner_plugin_loader_;
   planning_interface::PlannerManagerPtr planner_instance_;
   std::string planner_plugin_name_;
 
-  boost::scoped_ptr<pluginlib::ClassLoader<planning_request_adapter::PlanningRequestAdapter> > adapter_plugin_loader_;
-  boost::scoped_ptr<planning_request_adapter::PlanningRequestAdapterChain> adapter_chain_;
+  std::unique_ptr<pluginlib::ClassLoader<planning_request_adapter::PlanningRequestAdapter> > adapter_plugin_loader_;
+  std::unique_ptr<planning_request_adapter::PlanningRequestAdapterChain> adapter_chain_;
   std::vector<std::string> adapter_plugin_names_;
 
   robot_model::RobotModelConstPtr kmodel_;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
@@ -37,12 +37,13 @@
 #include <pluginlib/class_loader.h>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <ros/ros.h>
+#include <memory>
 
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "list_planning_adapter_plugins");
 
-  boost::scoped_ptr<pluginlib::ClassLoader<planning_request_adapter::PlanningRequestAdapter> > loader;
+  std::unique_ptr<pluginlib::ClassLoader<planning_request_adapter::PlanningRequestAdapter>> loader;
   try
   {
     loader.reset(new pluginlib::ClassLoader<planning_request_adapter::PlanningRequestAdapter>("moveit_core", "planning_request_adapter::PlanningRequestAdapter"));

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -50,6 +50,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
+#include <memory>
 
 namespace planning_scene_monitor
 {
@@ -437,7 +438,7 @@ protected:
 
   // variables for planning scene publishing
   ros::Publisher                        planning_scene_publisher_;
-  boost::scoped_ptr<boost::thread>      publish_planning_scene_;
+  std::unique_ptr<boost::thread>        publish_planning_scene_;
   double                                publish_planning_scene_frequency_;
   SceneUpdateType                       publish_update_types_;
   SceneUpdateType                       new_scene_update_;
@@ -449,11 +450,11 @@ protected:
 
   ros::Subscriber                       attached_collision_object_subscriber_;
 
-  boost::scoped_ptr<message_filters::Subscriber<moveit_msgs::CollisionObject> > collision_object_subscriber_;
-  boost::scoped_ptr<tf::MessageFilter<moveit_msgs::CollisionObject> > collision_object_filter_;
+  std::unique_ptr<message_filters::Subscriber<moveit_msgs::CollisionObject> > collision_object_subscriber_;
+  std::unique_ptr<tf::MessageFilter<moveit_msgs::CollisionObject> > collision_object_filter_;
 
   // include a octomap monitor
-  boost::scoped_ptr<occupancy_map_monitor::OccupancyMapMonitor> octomap_monitor_;
+  std::unique_ptr<occupancy_map_monitor::OccupancyMapMonitor> octomap_monitor_;
 
   // include a current state monitor
   CurrentStateMonitorPtr current_state_monitor_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -41,6 +41,7 @@
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <boost/thread.hpp>
+#include <memory>
 
 namespace planning_scene_monitor
 {
@@ -103,7 +104,7 @@ private:
   ros::Time trajectory_start_time_;
   ros::Time last_recorded_state_time_;
 
-  boost::scoped_ptr<boost::thread> record_states_thread_;
+  std::unique_ptr<boost::thread> record_states_thread_;
   TrajectoryStateAddedCallback state_add_callback_;
 };
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -44,6 +44,8 @@
 #include <tf_conversions/tf_eigen.h>
 #include <moveit/profiler/profiler.h>
 
+#include <memory>
+
 namespace planning_scene_monitor
 {
 
@@ -285,7 +287,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopPublishingPlanningScene()
 {
   if (publish_planning_scene_)
   {
-    boost::scoped_ptr<boost::thread> copy;
+    std::unique_ptr<boost::thread> copy;
     copy.swap(publish_planning_scene_);
     new_scene_update_condition_.notify_all();
     copy->join();

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -38,6 +38,7 @@
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <ros/rate.h>
 #include <limits>
+#include <memory>
 
 planning_scene_monitor::TrajectoryMonitor::TrajectoryMonitor(const CurrentStateMonitorConstPtr &state_monitor, double sampling_frequency) :
   current_state_monitor_(state_monitor),
@@ -78,7 +79,7 @@ void planning_scene_monitor::TrajectoryMonitor::stopTrajectoryMonitor()
 {
   if (record_states_thread_)
   {
-    boost::scoped_ptr<boost::thread> copy;
+    std::unique_ptr<boost::thread> copy;
     copy.swap(record_states_thread_);
     copy->join();
     ROS_DEBUG("Stopped trajectory monitor");

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -41,7 +41,6 @@
 #include <urdf/model.h>
 #include <urdf_world/types.h>
 #include <srdfdom/model.h>
-#include <boost/shared_ptr.hpp>
 #include <tinyxml.h>
 
 namespace rdf_loader
@@ -78,16 +77,16 @@ public:
   }
 
   /** @brief Get the parsed SRDF model*/
-  const boost::shared_ptr<srdf::Model>& getSRDF() const
+  const srdf::ModelSharedPtr& getSRDF() const
   {
     return srdf_;
   }
 
 private:
 
-  std::string                             robot_description_;
-  boost::shared_ptr<srdf::Model>          srdf_;
-  urdf::ModelInterfaceSharedPtr           urdf_;
+  std::string                   robot_description_;
+  srdf::ModelSharedPtr          srdf_;
+  urdf::ModelInterfaceSharedPtr urdf_;
 
 };
 

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -119,7 +119,7 @@ public:
   }
 
   /** @brief Get the parsed SRDF model*/
-  const boost::shared_ptr<srdf::Model>& getSRDF() const
+  const srdf::ModelSharedPtr& getSRDF() const
   {
     return rdf_loader_->getSRDF();
   }

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -87,7 +87,7 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.robot_description_));
   if (rdf_loader_->getURDF())
   {
-    const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
+    const srdf::ModelSharedPtr &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
     model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
   }
 

--- a/moveit_ros/planning/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/moveit_ros/planning/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -46,7 +46,7 @@
 #include <ros/ros.h>
 
 // System
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // ROS msgs
 #include <geometry_msgs/PoseStamped.h>
@@ -192,7 +192,7 @@ namespace srv_kinematics_plugin
 
     int num_possible_redundant_joints_;
 
-    boost::shared_ptr<ros::ServiceClient> ik_service_client_;
+    std::shared_ptr<ros::ServiceClient> ik_service_client_;
 
 
   };

--- a/moveit_ros/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_ros/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -136,7 +136,7 @@ bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
 
   // Create the ROS service client
   ros::NodeHandle nonprivate_handle("");
-  ik_service_client_ = boost::make_shared<ros::ServiceClient>(nonprivate_handle.serviceClient
+  ik_service_client_ = std::make_shared<ros::ServiceClient>(nonprivate_handle.serviceClient
                        <moveit_msgs::GetPositionIK>(ik_service_name));
   if (!ik_service_client_->waitForExistence(ros::Duration(0.1))) // wait 0.1 seconds, blocking
     ROS_WARN_STREAM_NAMED("srv","Unable to connect to ROS service client with name: " << ik_service_client_->getService());

--- a/moveit_ros/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_ros/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -72,7 +72,7 @@ bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
 
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
+  const srdf::ModelSharedPtr &srdf = rdf_loader.getSRDF();
   const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -47,7 +47,8 @@
 #include <moveit/controller_manager/controller_manager.h>
 #include <boost/thread.hpp>
 #include <pluginlib/class_loader.h>
-#include <boost/scoped_ptr.hpp>
+
+#include <memory>
 
 namespace trajectory_execution_manager
 {
@@ -266,10 +267,10 @@ private:
   bool manage_controllers_;
 
   // thread used to execute trajectories using the execute() command
-  boost::scoped_ptr<boost::thread> execution_thread_;
+  std::unique_ptr<boost::thread> execution_thread_;
 
   // thread used to execute trajectories using pushAndExecute()
-  boost::scoped_ptr<boost::thread> continuous_execution_thread_;
+  std::unique_ptr<boost::thread> continuous_execution_thread_;
 
   boost::mutex execution_state_mutex_;
   boost::mutex continuous_execution_mutex_;
@@ -291,7 +292,7 @@ private:
   std::vector<TrajectoryExecutionContext*> trajectories_;
   std::deque<TrajectoryExecutionContext*> continuous_execution_queue_;
 
-  boost::scoped_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager> > controller_manager_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager> > controller_manager_loader_;
   moveit_controller_manager::MoveItControllerManagerPtr controller_manager_;
 
   bool verbose_;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -38,6 +38,7 @@
 
 #include <stdexcept>
 #include <sstream>
+#include <memory>
 #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/move_group/capability_names.h>
@@ -1134,10 +1135,10 @@ private:
   boost::shared_ptr<tf::Transformer> tf_;
   robot_model::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
-  boost::scoped_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
-  boost::scoped_ptr<actionlib::SimpleActionClient<moveit_msgs::ExecuteTrajectoryAction> > execute_action_client_;
-  boost::scoped_ptr<actionlib::SimpleActionClient<moveit_msgs::PickupAction> > pick_action_client_;
-  boost::scoped_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction> > place_action_client_;
+  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
+  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::ExecuteTrajectoryAction> > execute_action_client_;
+  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PickupAction> > pick_action_client_;
+  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction> > place_action_client_;
 
   // general planning params
   robot_state::RobotStatePtr considered_start_state_;
@@ -1164,7 +1165,7 @@ private:
 
   // common properties for goals
   ActiveTargetType active_target_;
-  boost::scoped_ptr<moveit_msgs::Constraints> path_constraints_;
+  std::unique_ptr<moveit_msgs::Constraints> path_constraints_;
   std::string end_effector_link_;
   std::string pose_reference_frame_;
   std::string support_surface_;
@@ -1177,8 +1178,8 @@ private:
   ros::ServiceClient get_params_service_;
   ros::ServiceClient set_params_service_;
   ros::ServiceClient cartesian_path_service_;
-  boost::scoped_ptr<moveit_warehouse::ConstraintsStorage> constraints_storage_;
-  boost::scoped_ptr<boost::thread> constraints_init_thread_;
+  std::unique_ptr<moveit_warehouse::ConstraintsStorage> constraints_storage_;
+  std::unique_ptr<boost::thread> constraints_init_thread_;
   bool initializing_constraints_;
 };
 }

--- a/moveit_ros/planning_interface/py_bindings_tools/src/roscpp_initializer.cpp
+++ b/moveit_ros/planning_interface/py_bindings_tools/src/roscpp_initializer.cpp
@@ -37,8 +37,8 @@
 #include "moveit/py_bindings_tools/roscpp_initializer.h"
 #include "moveit/py_bindings_tools/py_conversions.h"
 #include <boost/thread.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <ros/ros.h>
+#include <memory>
 
 static std::vector<std::string>& ROScppArgs()
 {
@@ -94,8 +94,8 @@ static void roscpp_init_or_stop(bool init)
 
   // once per process, we start a spinner
   static bool once = true;
-  static boost::scoped_ptr<InitProxy> proxy;
-  static boost::scoped_ptr<ros::AsyncSpinner> spinner;
+  static std::unique_ptr<InitProxy> proxy;
+  static std::unique_ptr<ros::AsyncSpinner> spinner;
 
   // initialize only once
   if (once && init)

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -160,13 +160,13 @@ public:
    *         interactive markers drawn by this interaction handler.
    * @param  A menu handler. */
   void setMenuHandler(
-        const boost::shared_ptr<interactive_markers::MenuHandler>& mh);
+        const std::shared_ptr<interactive_markers::MenuHandler>& mh);
 
 
   /** \brief Get the menu handler that defines menus and callbacks for all
    *         interactive markers drawn by this interaction handler.
    * @return  The menu handler. */
-  const boost::shared_ptr<interactive_markers::MenuHandler>& getMenuHandler();
+  const std::shared_ptr<interactive_markers::MenuHandler>& getMenuHandler();
 
   /** \brief Remove the menu handler for this interaction handler. */
   void clearMenuHandler();
@@ -328,7 +328,7 @@ private:
   //
   // PROTECTED BY state_lock_ - The POINTER is protected by state_lock_.  The
   // CONTENTS is not.
-  boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_;
+  std::shared_ptr<interactive_markers::MenuHandler> menu_handler_;
 
   // Called when the RobotState maintained by the handler changes.
   // The caller may, for example, redraw the robot at the new state.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -46,6 +46,7 @@
 #include <moveit/robot_interaction/interaction.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
+#include <memory>
 
 // This is needed for legacy code that includes robot_interaction.h but not
 // interaction_handler.h
@@ -213,7 +214,7 @@ private:
   void processingThread();
   void clearInteractiveMarkersUnsafe();
 
-  boost::scoped_ptr<boost::thread> processing_thread_;
+  std::unique_ptr<boost::thread> processing_thread_;
   bool run_processing_thread_;
 
   boost::condition_variable new_feedback_condition_;

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -21,11 +21,13 @@
   <build_depend>tf</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>interactive_markers</build_depend>
+  <build_depend version_gte="1.10.4">pluginlib</build_depend>
 
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend>interactive_markers</run_depend>
+  <run_depend version_gte="1.10.4">pluginlib</run_depend>
 
 </package>

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -222,13 +222,13 @@ void InteractionHandler::clearLastMarkerPoses()
   pose_map_.clear();
 }
 
-void InteractionHandler::setMenuHandler(const boost::shared_ptr<interactive_markers::MenuHandler>& mh)
+void InteractionHandler::setMenuHandler(const std::shared_ptr<interactive_markers::MenuHandler>& mh)
 {
   boost::mutex::scoped_lock lock(state_lock_);
   menu_handler_ = mh;
 }
 
-const boost::shared_ptr<interactive_markers::MenuHandler>& InteractionHandler::getMenuHandler()
+const std::shared_ptr<interactive_markers::MenuHandler>& InteractionHandler::getMenuHandler()
 {
   boost::mutex::scoped_lock lock(state_lock_);
   return menu_handler_;

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -188,7 +188,7 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
   if (group.empty())
     return;
 
-  const boost::shared_ptr<const srdf::Model> &srdf = robot_model_->getSRDF();
+  const srdf::ModelConstSharedPtr &srdf = robot_model_->getSRDF();
   const robot_model::JointModelGroup *jmg = robot_model_->getJointModelGroup(group);
 
   if (!jmg || !srdf)
@@ -264,7 +264,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, Intera
   if (group.empty())
     return;
 
-  const boost::shared_ptr<const srdf::Model> &srdf = robot_model_->getSRDF();
+  const srdf::ModelConstSharedPtr &srdf = robot_model_->getSRDF();
   const robot_model::JointModelGroup *jmg = robot_model_->getJointModelGroup(group);
 
   if (!jmg || !srdf)

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -587,7 +587,7 @@ void RobotInteraction::addInteractiveMarkers(
                                                 _1));
 
     // Add menu handler to all markers that this interaction handler creates.
-    if (boost::shared_ptr<interactive_markers::MenuHandler> mh = handler->getMenuHandler())
+    if (std::shared_ptr<interactive_markers::MenuHandler> mh = handler->getMenuHandler())
       mh->apply(*int_marker_server_, ims[i].name);
   }
 }

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -223,7 +223,7 @@ static moveit::core::RobotModelPtr getModel()
   if (!model)
   {
     urdf::ModelInterfaceSharedPtr urdf(urdf::parseURDF(URDF_STR));
-    boost::shared_ptr<srdf::Model> srdf(new srdf::Model());
+    srdf::ModelSharedPtr srdf(new srdf::Model());
     srdf->initString(*urdf, SRDF_STR);
     model.reset(new moveit::core::RobotModel(urdf, srdf));
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -133,7 +133,7 @@ class MotionPlanningDisplay : public PlanningSceneDisplay
   // Pick Place
   void clearPlaceLocationsDisplay();
   void visualizePlaceLocations(const std::vector<geometry_msgs::PoseStamped> &place_poses);
-  std::vector<boost::shared_ptr<rviz::Shape> > place_locations_display_;
+  std::vector<std::shared_ptr<rviz::Shape> > place_locations_display_;
 
   std::string getCurrentPlanningGroup() const;
 
@@ -212,7 +212,7 @@ protected:
   void backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent event, const std::string &jobname);
 
   void setQueryStateHelper(bool use_start_state, const std::string &v);
-  void populateMenuHandler(boost::shared_ptr<interactive_markers::MenuHandler>& mh);
+  void populateMenuHandler(std::shared_ptr<interactive_markers::MenuHandler>& mh);
 
   void selectPlanningGroupCallback(const std_msgs::StringConstPtr& msg);
 
@@ -244,8 +244,8 @@ protected:
   robot_interaction::RobotInteractionPtr robot_interaction_;
   robot_interaction::RobotInteraction::InteractionHandlerPtr query_start_state_;
   robot_interaction::RobotInteraction::InteractionHandlerPtr query_goal_state_;
-  boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_start_;
-  boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_goal_;
+  std::shared_ptr<interactive_markers::MenuHandler> menu_handler_start_;
+  std::shared_ptr<interactive_markers::MenuHandler> menu_handler_goal_;
   std::map<std::string, LinkDisplayStatus> status_links_start_;
   std::map<std::string, LinkDisplayStatus> status_links_goal_;
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -57,6 +57,8 @@
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <QDockWidget>
 
+#include <memory>
+
 namespace Ogre
 {
 class SceneNode;
@@ -232,7 +234,7 @@ protected:
   ros::NodeHandle private_handle_, node_handle_;
 
   // render the workspace box
-  boost::scoped_ptr<rviz::Shape> workspace_box_;
+  std::unique_ptr<rviz::Shape> workspace_box_;
 
   // the planning frame
   MotionPlanningFrame *frame_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -125,7 +125,7 @@ protected:
   moveit_warehouse::ConstraintsStoragePtr constraints_storage_;
   moveit_warehouse::RobotStateStoragePtr robot_state_storage_;
 
-  boost::shared_ptr<rviz::InteractiveMarker> scene_marker_;
+  std::shared_ptr<rviz::InteractiveMarker> scene_marker_;
 
   typedef std::map<std::string, moveit_msgs::RobotState> RobotStateMap;
   typedef std::pair<std::string, moveit_msgs::RobotState> RobotStatePair;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -61,6 +61,7 @@
 #include <std_msgs/Empty.h>
 #include <map>
 #include <string>
+#include <memory>
 
 namespace rviz
 {
@@ -269,7 +270,7 @@ private:
   std::string selected_object_name_;
   std::string selected_support_surface_name_;
 
-  boost::scoped_ptr<actionlib::SimpleActionClient<object_recognition_msgs::ObjectRecognitionAction> > object_recognition_client_;
+  std::unique_ptr<actionlib::SimpleActionClient<object_recognition_msgs::ObjectRecognitionAction> > object_recognition_client_;
   template<typename T>
   void waitForAction(const T &action, const ros::NodeHandle &node_handle, const ros::Duration &wait_for_server, const std::string &name);
   void listenDetectedObjects(const object_recognition_msgs::RecognizedObjectArrayPtr &msg);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1053,7 +1053,7 @@ void MotionPlanningDisplay::setQueryStateHelper(bool use_start_state, const std:
   use_start_state ? setQueryStartState(state) : setQueryGoalState(state);
 }
 
-void MotionPlanningDisplay::populateMenuHandler(boost::shared_ptr<interactive_markers::MenuHandler>& mh)
+void MotionPlanningDisplay::populateMenuHandler(std::shared_ptr<interactive_markers::MenuHandler>& mh)
 {
   typedef interactive_markers::MenuHandler immh;
   std::vector<std::string> state_names;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -58,6 +58,8 @@
 
 #include <boost/math/constants/constants.hpp>
 
+#include <memory>
+
 namespace moveit_rviz_plugin
 {
 
@@ -68,7 +70,7 @@ void MotionPlanningFrame::saveSceneButtonClicked()
     const std::string &name = planning_display_->getPlanningSceneRO()->getName();
     if (name.empty() || planning_scene_storage_->hasPlanningScene(name))
     {
-      boost::scoped_ptr<QMessageBox> q;
+      std::unique_ptr<QMessageBox> q;
       if (name.empty())
         q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Scene Name",
                                 QString("The name for the planning scene should not be empty. Would you like to rename the planning scene?'"),
@@ -81,7 +83,7 @@ void MotionPlanningFrame::saveSceneButtonClicked()
                                 .append( "' already exists. Do you wish to overwrite that scene?"),
                                 QMessageBox::Yes | QMessageBox::No,
                                 this));
-      boost::scoped_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
+      std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
       if (q->exec() != QMessageBox::Yes)
       {
         if (q->clickedButton() == rename.get())
@@ -138,7 +140,7 @@ void MotionPlanningFrame::saveQueryButtonClicked()
 
         while (query_name.empty() || planning_scene_storage_->hasPlanningQuery(scene, query_name))
         {
-          boost::scoped_ptr<QMessageBox> q;
+          std::unique_ptr<QMessageBox> q;
           if (query_name.empty())
             q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Query Name",
                                     QString("The name for the planning query should not be empty. Would you like to rename the planning query?'"),
@@ -151,7 +153,7 @@ void MotionPlanningFrame::saveQueryButtonClicked()
                                     .append( "' already exists. Do you wish to overwrite that query?"),
                                     QMessageBox::Yes | QMessageBox::No,
                                     this));
-          boost::scoped_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
+          std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
           if (q->exec() == QMessageBox::Yes)
             break;
           else

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -358,7 +358,7 @@ void RobotStateDisplay::loadRobotModel()
 
   if (rdf_loader_->getURDF())
   {
-    const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
+    const srdf::ModelSharedPtr &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
     kmodel_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
     robot_->load(*kmodel_->getURDF());
     kstate_.reset(new robot_state::RobotState(kmodel_));

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
@@ -41,9 +41,9 @@
 #include <moveit/macros/class_forward.h>
 #include <geometric_shapes/shapes.h>
 #include <rviz/helpers/color.h>
-#include <boost/shared_ptr.hpp>
 #include <Eigen/Geometry>
 #include <string>
+#include <memory>
 
 namespace Ogre
 {
@@ -82,7 +82,7 @@ private:
 
   rviz::DisplayContext *context_;
 
-  std::vector< boost::shared_ptr<rviz::Shape> > scene_shapes_;
+  std::vector<std::unique_ptr<rviz::Shape> > scene_shapes_;
   std::vector<OcTreeRenderPtr> octree_voxel_grids_;
 };
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -51,7 +51,8 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/math/constants/constants.hpp>
-#include <boost/scoped_ptr.hpp>
+
+#include <memory>
 
 namespace moveit_rviz_plugin
 {
@@ -85,7 +86,7 @@ void RenderShapes::renderShape(Ogre::SceneNode *node,
   // we don't know how to render cones directly, but we can convert them to a mesh
   if (s->type == shapes::CONE)
   {
-    boost::scoped_ptr<shapes::Mesh> m(shapes::createMeshFromShape(static_cast<const shapes::Cone&>(*s)));
+    std::unique_ptr<shapes::Mesh> m(shapes::createMeshFromShape(static_cast<const shapes::Cone&>(*s)));
     if (m)
       renderShape(node, m.get(), p, octree_voxel_rendering, octree_color_mode, color, alpha);
     return;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -194,7 +194,7 @@ void RenderShapes::renderShape(Ogre::SceneNode *node,
 
     ogre_shape->setPosition(position);
     ogre_shape->setOrientation(orientation);
-    scene_shapes_.push_back(boost::shared_ptr<rviz::Shape>(ogre_shape));
+    scene_shapes_.emplace_back(ogre_shape);
   }
 }
 

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -78,7 +78,7 @@ void TrajectoryDisplay::loadRobotModel()
   }
   this->setStatus(rviz::StatusProperty::Ok, "Robot Model", "Successfully loaded");
 
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
+  const srdf::ModelSharedPtr &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
   robot_model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
 
   // Send to child class

--- a/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
@@ -36,9 +36,9 @@
 
 #include <moveit/warehouse/moveit_message_storage.h>
 #include <warehouse_ros/database_loader.h>
-#include <boost/scoped_ptr.hpp>
 //#include <warehouse_ros_mongo/database_connection.h>
 #include <boost/regex.hpp>
+#include <memory>
 
 moveit_warehouse::MoveItMessageStorage::MoveItMessageStorage(warehouse_ros::DatabaseConnection::Ptr conn) :
   conn_(conn)
@@ -61,7 +61,7 @@ void moveit_warehouse::MoveItMessageStorage::filterNames(const std::string &rege
   }
 }
 
-static boost::scoped_ptr<warehouse_ros::DatabaseLoader> dbloader;
+static std::unique_ptr<warehouse_ros::DatabaseLoader> dbloader;
 
 typename warehouse_ros::DatabaseConnection::Ptr moveit_warehouse::loadDatabase()
 {

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -261,7 +261,7 @@ void GroupEditWidget::loadKinematicPlannersComboBox()
   kinematics_solver_field_->addItem( "None" );
 
   // load all avail kin planners
-  boost::scoped_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> > loader;
+  std::unique_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase>> loader;
   try
   {
     loader.reset(new pluginlib::ClassLoader<kinematics::KinematicsBase>("moveit_core", "kinematics::KinematicsBase"));


### PR DESCRIPTION
This PR updates the API to use `std::shared_ptr` for moveit types instead of `boost::shared_ptr`.

I'm not sure what the opinions are on this topic, but this PR at the least provides a place to discuss this specific API change. But do note that other libraries are doing the same thing right about now (like `fcl` and `urdfdom`).

Technically, switching from `boost::enable_shared_from_this` to `std::enable_shared_from_this` is not 100% API compatible, since `weak_from_this` is only added in C++17. This is very unlikely to cause problems though.

One more point: `pluginlib` still returns `boost::shared_ptr` and using `createUnmanagedInstance` is discouraged. Instead I opted to convert the pointers to `std::` instead. That method is not 100% safe when `weak_ptr` are involved in the general case, but it is in this case because nobody else has a copy to the original `boost::shared_ptr`.

Because the conversion isn't safe in general I didn't want to put it in a header (the header would have to be exported or duplicated across 5 packages). Instead I opted now to duplicate the function in an anonymous namespace in 5 source files. I've also got a PR open with `class_loader` to add support for `std::` smart pointers (unique and shared), so when that lands it makes sense to adapt to that interface. In the mean time I didn't know a nicer solution than the current in this PR.

