### PR TITLE
Create new shadow-fixed CI Docker image

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,7 +1,3 @@
-# MoveIt! Docker Images
-This repo hosts the Dockerfiles used to generate images for [MoveIt!](moveit.ros.org) :whale:
-
-[![Docker Pulls](https://img.shields.io/docker/pulls/moveit/moveit.svg?maxAge=2592000)](https://hub.docker.com/r/moveit/moveit/)
-[![Docker Stars](https://img.shields.io/docker/stars/moveit/moveit.svg)](https://registry.hub.docker.com/moveit/moveit/)
+# MoveIt! Docker Containers
 
 For more information see [Continuous Integration and Docker](http://moveit.ros.org/documentation/contributing/continuous_integration.html) documentation.

--- a/.docker/ci-shadow-fixed/Dockerfile
+++ b/.docker/ci-shadow-fixed/Dockerfile
@@ -1,0 +1,25 @@
+# moveit/moveit:kinetic-ci-shadow-fixed
+# Sets up a base image to use for running Continuous Integration on Travis
+
+FROM moveit/moveit:kinetic-ci
+MAINTAINER Dave Coleman dave@dav.ee
+
+ENV TERM xterm
+
+# Setup catkin workspace
+ENV CATKIN_WS=/root/ws_moveit
+RUN mkdir -p $CATKIN_WS/src
+WORKDIR $CATKIN_WS/src
+
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
+# Switch to shadow-fixed
+RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list && \
+    # Update apt-get because previous images clear this cache
+    apt-get -qq update && \
+    # Do a dist-upgrade to ensure our CI is building on top of the latest version of packages
+    apt-get -qq dist-upgrade && \
+    # Clear apt-cache to reduce image size
+    rm -rf /var/lib/apt/lists/*
+
+# Continous Integration Setting
+ENV IN_DOCKER 1

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -17,10 +17,7 @@ RUN wstool init . && \
     wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
     wstool update && \
     # Update apt-get because previous images clear this cache
-    echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list && \
     apt-get -qq update && \
-    # Do a dist-upgrade to ensure our CI is building on top of the latest version of packages
-    apt-get -qq dist-upgrade && \
     # Install some base dependencies
     apt-get -qq install -y \
         # Required for rosdep command


### PR DESCRIPTION
Currently Travis distinguishes between regular and shadow-fixed, but my recent change https://github.com/ros-planning/moveit/pull/214 I've realized causes all Travis builds to use shadow-fixed. This creates a new Docker image that is specifically for shadow-fixed: ``moveit/moveit:kinetic-ci-shadow-fixed``

I plan on back-porting these series of Docker changes to indigo and jade soon.