### PR TITLE
fix race conditions when updating PlanningScene

### DIFF
--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -322,7 +322,7 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback(const moveit_ms
 {
   setPickupState(PLANNING);
 
-  context_->planning_scene_monitor_->syncSceneUpdates();
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::PickupGoalConstPtr goal;
@@ -365,7 +365,7 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback(const moveit_msg
 {
   setPlaceState(PLANNING);
 
-  context_->planning_scene_monitor_->syncSceneUpdates();
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::PlaceResult action_res;

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -322,6 +322,7 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback(const moveit_ms
 {
   setPickupState(PLANNING);
 
+  context_->planning_scene_monitor_->syncSceneUpdates();
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::PickupGoalConstPtr goal;
@@ -364,6 +365,7 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback(const moveit_msg
 {
   setPlaceState(PLANNING);
 
+  context_->planning_scene_monitor_->syncSceneUpdates();
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::PlaceResult action_res;

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -322,6 +322,7 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback(const moveit_ms
 {
   setPickupState(PLANNING);
 
+  // before we start planning, ensure that we have the latest robot state received...
   context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
@@ -365,6 +366,7 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback(const moveit_msg
 {
   setPlaceState(PLANNING);
 
+  // before we start planning, ensure that we have the latest robot state received...
   context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
@@ -86,14 +86,12 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
       moveit_controller_manager::ExecutionStatus es = context_->trajectory_execution_manager_->waitForExecution();
       if (es == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
         res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+      else if (es == moveit_controller_manager::ExecutionStatus::PREEMPTED)
+        res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
+      else if (es == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
+        res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
       else
-        if (es == moveit_controller_manager::ExecutionStatus::PREEMPTED)
-          res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
-        else
-          if (es == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
-            res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
-          else
-            res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+        res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
       ROS_INFO_STREAM("Execution completed: " << es.asString());
     }
     else

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -61,6 +61,7 @@ void move_group::MoveGroupMoveAction::initialize()
 void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
 {
   setMoveState(PLANNING);
+  // before we start planning, ensure that we have the latest robot state received...
   context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -61,7 +61,7 @@ void move_group::MoveGroupMoveAction::initialize()
 void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
 {
   setMoveState(PLANNING);
-  context_->planning_scene_monitor_->syncSceneUpdates();
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::MoveGroupResult action_res;

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -61,6 +61,7 @@ void move_group::MoveGroupMoveAction::initialize()
 void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
 {
   setMoveState(PLANNING);
+  context_->planning_scene_monitor_->syncSceneUpdates();
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::MoveGroupResult action_res;

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -51,6 +51,7 @@ void move_group::MoveGroupPlanService::initialize()
 bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotionPlan::Request &req, moveit_msgs::GetMotionPlan::Response &res)
 {
   ROS_INFO("Received new planning service request...");
+  // before we start planning, ensure that we have the latest robot state received...
   context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -51,6 +51,7 @@ void move_group::MoveGroupPlanService::initialize()
 bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotionPlan::Request &req, moveit_msgs::GetMotionPlan::Response &res)
 {
   ROS_INFO("Received new planning service request...");
+  context_->planning_scene_monitor_->syncSceneUpdates();
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   bool solved = false;

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -51,7 +51,7 @@ void move_group::MoveGroupPlanService::initialize()
 bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotionPlan::Request &req, moveit_msgs::GetMotionPlan::Response &res)
 {
   ROS_INFO("Received new planning service request...");
-  context_->planning_scene_monitor_->syncSceneUpdates();
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   bool solved = false;

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time program_options signals thread)
+find_package(Boost REQUIRED system filesystem date_time program_options signals thread chrono)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_perception

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -140,12 +140,15 @@ public:
   /** @brief Wait for at most \e wait_time seconds for a robot state more recent than t */
   bool waitForCurrentState(const ros::Time t=ros::Time::now(), double wait_time=1) const;
 
-  // TODO: rename functions to waitForCompleteState
   /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
-  bool waitForCurrentState(double wait_time) const;
+  bool waitForCompleteState(double wait_time) const;
+  /// replaced by waitForCompleteState, will be removed in L-turtle
+  ROS_DEPRECATED bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
-  bool waitForCurrentState(const std::string &group, double wait_time) const;
+  bool waitForCompleteState(const std::string &group, double wait_time) const;
+  /// replaced by waitForCompleteState, will be removed in L-turtle
+  ROS_DEPRECATED bool waitForCurrentState(const std::string &group, double wait_time) const;
 
   /** @brief Get the time point when the monitor was started */
   const ros::Time& getMonitorStartTime() const

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -143,12 +143,12 @@ public:
 
   /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
   bool waitForCompleteState(double wait_time) const;
-  /// replaced by waitForCompleteState, will be removed in L-turtle
+  /** replaced by waitForCompleteState, will be removed in L-turtle */
   MOVEIT_DEPRECATED bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
   bool waitForCompleteState(const std::string &group, double wait_time) const;
-  /// replaced by waitForCompleteState, will be removed in L-turtle
+  /** replaced by waitForCompleteState, will be removed in L-turtle */
   MOVEIT_DEPRECATED bool waitForCurrentState(const std::string &group, double wait_time) const;
 
   /** @brief Get the time point when the monitor was started */

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -138,17 +138,19 @@ public:
    *  @return Returns the map from joint names to joint state values*/
   std::map<std::string, double> getCurrentStateValues() const;
 
-  /** @brief Wait for at most \e wait_time seconds for a robot state more recent than t */
-  bool waitForCurrentState(const ros::Time t=ros::Time::now(), double wait_time=1) const;
+  /** @brief Wait for at most \e wait_time seconds (default 1s) for a robot state more recent than t
+   *  @return true on success, false if up-to-date robot state wasn't received within \e wait_time
+  */
+  bool waitForCurrentState(const ros::Time t = ros::Time::now(), double wait_time = 1.0) const;
 
   /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
   bool waitForCompleteState(double wait_time) const;
-  /** replaced by waitForCompleteState, will be removed in L-turtle */
+  /** replaced by waitForCompleteState, will be removed in L-turtle: function waits for complete robot state */
   MOVEIT_DEPRECATED bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
   bool waitForCompleteState(const std::string &group, double wait_time) const;
-  /** replaced by waitForCompleteState, will be removed in L-turtle */
+  /** replaced by waitForCompleteState, will be removed in L-turtle: function waits for complete robot state */
   MOVEIT_DEPRECATED bool waitForCurrentState(const std::string &group, double wait_time) const;
 
   /** @brief Get the time point when the monitor was started */

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -44,6 +44,7 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/condition_variable.hpp>
 
 namespace planning_scene_monitor
 {
@@ -136,7 +137,11 @@ public:
    *  @return Returns the map from joint names to joint state values*/
   std::map<std::string, double> getCurrentStateValues() const;
 
-  /** @brief Wait for at most \e wait_time seconds until the complete current state is known. Return true if the full state is known */
+  /** @brief Wait for at most \e wait_time seconds for a robot state more recent than t */
+  bool waitForCurrentState(const ros::Time t=ros::Time::now(), double wait_time=1) const;
+
+  // TODO: rename functions to waitForCompleteState
+  /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
   bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
@@ -199,6 +204,7 @@ private:
   ros::Time                                    last_tf_update_;
 
   mutable boost::mutex                         state_update_lock_;
+  mutable boost::condition_variable            state_update_condition_;
   std::vector< JointStateUpdateCallback >      update_callbacks_;
 };
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -45,6 +45,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
+#include <moveit/macros/deprecation.h>
 
 namespace planning_scene_monitor
 {
@@ -143,12 +144,12 @@ public:
   /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
   bool waitForCompleteState(double wait_time) const;
   /// replaced by waitForCompleteState, will be removed in L-turtle
-  ROS_DEPRECATED bool waitForCurrentState(double wait_time) const;
+  MOVEIT_DEPRECATED bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
   bool waitForCompleteState(const std::string &group, double wait_time) const;
   /// replaced by waitForCompleteState, will be removed in L-turtle
-  ROS_DEPRECATED bool waitForCurrentState(const std::string &group, double wait_time) const;
+  MOVEIT_DEPRECATED bool waitForCurrentState(const std::string &group, double wait_time) const;
 
   /** @brief Get the time point when the monitor was started */
   const ros::Time& getMonitorStartTime() const

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -523,7 +523,7 @@ private:
 
   /// Last time the state was updated from current_state_monitor_
   // Only access this from callback functions (and constructor)
-  ros::WallTime wall_last_state_update_;
+  ros::WallTime last_robot_state_update_wall_time_;
 
   robot_model_loader::RobotModelLoaderPtr rm_loader_;
   robot_model::RobotModelConstPtr robot_model_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -345,7 +345,7 @@ public:
   /** @brief This function is called every time there is a change to the planning scene */
   void triggerSceneUpdateEvent(SceneUpdateType update_type);
 
-  /** \brief Wait for robot state to become more recent than t.
+  /** \brief Wait for robot state to become more recent than time t.
    *
    * If there is no state monitor active, there will be no scene updates.
    * Hence, you can specify a timeout to wait for those updates. Default is 1s.
@@ -426,7 +426,7 @@ protected:
   boost::shared_mutex                   scene_update_mutex_; /// mutex for stored scene
   ros::Time                             last_update_time_; /// Last time the state was updated
   ros::Time                             last_robot_motion_time_; /// Last time the robot has moved
-  bool                                  enforce_next_state_update_;
+  bool                                  enforce_next_state_update_; /// flag to enforce immediate state update in onStateUpdate()
 
   ros::NodeHandle                       nh_;
   ros::NodeHandle                       root_nh_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -352,13 +352,6 @@ public:
    */
   bool waitForCurrentRobotState(const ros::Time &t, double wait_time = 1.);
 
-  /** \brief Wait current robot state and wait for all pending scene updates to be processed.
-   *
-   * Additionally to waitForCurrentRobotState() this processes also all already received scene updates
-   * as long as wait_time is not exceeded.
-   */
-  bool syncSceneUpdates(const ros::Time &t = ros::Time::now(), double wait_time = 1.);
-
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
   void lockSceneRead();
 
@@ -437,8 +430,6 @@ protected:
 
   ros::NodeHandle                       nh_;
   ros::NodeHandle                       root_nh_;
-  ros::CallbackQueue                    callback_queue_;
-  boost::scoped_ptr<ros::AsyncSpinner>  spinner_;
   boost::shared_ptr<tf::Transformer>    tf_;
   std::string                           robot_description_;
 

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -280,9 +280,8 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros:
   return true;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wait_time) const
+bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(double wait_time) const
 {
-  // TODO: rewrite to use state_update_condition_ too.
   double slept_time = 0.0;
   double sleep_step_s = std::min(0.05, wait_time / 10.0);
   ros::Duration sleep_step(sleep_step_s);
@@ -293,10 +292,14 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wai
   }
   return haveCompleteState();
 }
-
-bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std::string &group, double wait_time) const
+bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wait_time) const
 {
-  if (waitForCurrentState(wait_time))
+  waitForCompleteState(wait_time);
+}
+
+bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(const std::string &group, double wait_time) const
+{
+  if (waitForCompleteState(wait_time))
     return true;
   bool ok = true;
 
@@ -319,6 +322,10 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std:
       ok = false;
   }
   return ok;
+}
+bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std::string &group, double wait_time) const
+{
+  waitForCompleteState(group, wait_time);
 }
 
 void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const sensor_msgs::JointStateConstPtr &joint_state)

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -263,8 +263,26 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::D
   return result;
 }
 
+bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros::Time t, double wait_time) const
+{
+  ros::WallTime start = ros::WallTime::now();
+  ros::WallDuration elapsed;
+  ros::WallDuration timeout(wait_time);
+
+  boost::mutex::scoped_lock lock(state_update_lock_);
+  while (current_state_time_ < t)
+  {
+    state_update_condition_.wait_for(lock, boost::chrono::nanoseconds((timeout-elapsed).toNSec()));
+    elapsed = ros::WallTime::now() - start;
+    if (elapsed > timeout)
+      return false;
+  }
+  return true;
+}
+
 bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wait_time) const
 {
+  // TODO: rewrite to use state_update_condition_ too.
   double slept_time = 0.0;
   double sleep_step_s = std::min(0.05, wait_time / 10.0);
   ros::Duration sleep_step(sleep_step_s);
@@ -408,4 +426,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
   if (update)
     for (std::size_t i = 0 ; i < update_callbacks_.size() ; ++i)
       update_callbacks_[i](joint_state);
+
+  // notify *after* potential update callbacks
+  state_update_condition_.notify_all();
 }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -266,13 +266,13 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::D
 bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros::Time t, double wait_time) const
 {
   ros::WallTime start = ros::WallTime::now();
-  ros::WallDuration elapsed;
+  ros::WallDuration elapsed(0, 0);
   ros::WallDuration timeout(wait_time);
 
   boost::mutex::scoped_lock lock(state_update_lock_);
   while (current_state_time_ < t)
   {
-    state_update_condition_.wait_for(lock, boost::chrono::nanoseconds((timeout-elapsed).toNSec()));
+    state_update_condition_.wait_for(lock, boost::chrono::nanoseconds((timeout - elapsed).toNSec()));
     elapsed = ros::WallTime::now() - start;
     if (elapsed > timeout)
       return false;
@@ -434,6 +434,6 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
     for (std::size_t i = 0 ; i < update_callbacks_.size() ; ++i)
       update_callbacks_[i](joint_state);
 
-  // notify *after* potential update callbacks
+  // notify waitForCurrentState() *after* potential update callbacks
   state_update_condition_.notify_all();
 }

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -849,7 +849,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(cons
     if (success)
       return true;
 
-    ROS_WARN("Failed to fetch current robot state.");
+    ROS_WARN_NAMED("planning_scene_monitor", "Failed to fetch current robot state.");
     return false;
   }
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -863,7 +863,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(cons
   {
     ROS_DEBUG_STREAM_NAMED("planning_scene_monitor", "last robot motion: " << (t-last_robot_motion_time_).toSec() << " ago");
     new_scene_update_condition_.wait_for(lock, boost::chrono::nanoseconds(timeout.toNSec()));
-    timeout -= ros::WallTime::now()-start; // compute remaining wait_time
+    timeout -= ros::WallTime::now() - start; // compute remaining wait_time
   }
   bool success = last_robot_motion_time_ >= t;
   // suppress warning if we received an update at all

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -857,7 +857,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(cons
   // However, scene updates are only published if the robot actually moves. Hence we need a timeout!
   // As publishing planning scene updates is throttled (2Hz by default), a 1s timeout is a suitable default.
   boost::shared_lock<boost::shared_mutex> lock(scene_update_mutex_);
-  ros::Time prev_robot_motion_time_ = last_robot_motion_time_;
+  ros::Time prev_robot_motion_time = last_robot_motion_time_;
   while (last_robot_motion_time_ < t && // Wait until the state update actually reaches the scene.
          timeout > ros::WallDuration())
   {
@@ -867,7 +867,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(cons
   }
   bool success = last_robot_motion_time_ >= t;
   // suppress warning if we received an update at all
-  if (!success && prev_robot_motion_time_ != last_robot_motion_time_)
+  if (!success && prev_robot_motion_time != last_robot_motion_time_)
     ROS_WARN_NAMED("planning_scene_monitor", "Maybe failed to update robot state, time diff: %.3fs",
                    (t - last_robot_motion_time_).toSec());
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -841,7 +841,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(cons
     // Wait for next robot update in state monitor. Those updates are only passed to PSM when robot actually moved!
     enforce_next_state_update_ = true; // enforce potential updates to be directly applied
     bool success = current_state_monitor_->waitForCurrentState(t, wait_time);
-    enforce_next_state_update_ = false; // enforce potential updates to be directly applied
+    enforce_next_state_update_ = false; // back to normal throttling behavior, not applying incoming updates immediately
 
     /* If the robot doesn't move, we will never receive an update from CSM in planning scene.
        As we ensured that an update, if it is triggered by CSM, is directly passed to the scene,

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -829,9 +829,9 @@ void planning_scene_monitor::PlanningSceneMonitor::lockSceneRead()
 
 void planning_scene_monitor::PlanningSceneMonitor::unlockSceneRead()
 {
-  scene_update_mutex_.unlock_shared();
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->unlockRead();
+  scene_update_mutex_.unlock_shared();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::lockSceneWrite()
@@ -843,9 +843,9 @@ void planning_scene_monitor::PlanningSceneMonitor::lockSceneWrite()
 
 void planning_scene_monitor::PlanningSceneMonitor::unlockSceneWrite()
 {
-  scene_update_mutex_.unlock();
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->unlockWrite();
+  scene_update_mutex_.unlock();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::startSceneMonitor(const std::string &scene_topic)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -218,7 +218,7 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
   new_scene_update_ = UPDATE_NONE;
 
   last_update_time_ = last_robot_motion_time_ = ros::Time::now();
-  wall_last_state_update_ = ros::WallTime::now();
+  last_robot_state_update_wall_time_ = ros::WallTime::now();
   dt_state_update_ = ros::WallDuration(0.1);
 
   double temp_wait_time = 0.05;
@@ -1086,7 +1086,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopStateMonitor()
 void planning_scene_monitor::PlanningSceneMonitor::onStateUpdate(const sensor_msgs::JointStateConstPtr & /* joint_state */ )
 {
   const ros::WallTime &n = ros::WallTime::now();
-  ros::WallDuration dt = n - wall_last_state_update_;
+  ros::WallDuration dt = n - last_robot_state_update_wall_time_;
 
   bool update = enforce_next_state_update_;
   {
@@ -1099,7 +1099,7 @@ void planning_scene_monitor::PlanningSceneMonitor::onStateUpdate(const sensor_ms
     else
     {
       state_update_pending_ = false;
-      wall_last_state_update_ = n;
+      last_robot_state_update_wall_time_ = n;
       update = true;
     }
   }
@@ -1115,7 +1115,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stateUpdateTimerCallback(cons
     bool update = false;
 
     const ros::WallTime &n = ros::WallTime::now();
-    ros::WallDuration dt = n - wall_last_state_update_;
+    ros::WallDuration dt = n - last_robot_state_update_wall_time_;
 
     {
       // lock for access to dt_state_update_ and state_update_pending_
@@ -1123,9 +1123,9 @@ void planning_scene_monitor::PlanningSceneMonitor::stateUpdateTimerCallback(cons
       if (state_update_pending_ && dt >= dt_state_update_)
       {
         state_update_pending_ = false;
-        wall_last_state_update_ = ros::WallTime::now();
+        last_robot_state_update_wall_time_ = ros::WallTime::now();
         update = true;
-        ROS_DEBUG_STREAM_NAMED("planning_scene_monitor", "performPendingStateUpdate: " << fmod(wall_last_state_update_.toSec(), 10));
+        ROS_DEBUG_STREAM_NAMED("planning_scene_monitor", "performPendingStateUpdate: " << fmod(last_robot_state_update_wall_time_.toSec(), 10));
       }
     }
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -878,7 +878,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext &cont
   ROS_DEBUG_NAMED("traj_execution", "Validating trajectory with allowed_start_tolerance %g", allowed_start_tolerance_);
 
   robot_state::RobotStatePtr current_state;
-  if (!csm_->waitForCurrentState(1.0) || !(current_state = csm_->getCurrentState()))
+  if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
   {
     ROS_WARN_NAMED("traj_execution", "Failed to validate trajectory: couldn't receive full current joint state within 1s");
     return false;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -546,8 +546,11 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    if (!current_state_monitor_->waitForCurrentState(opt_.group_name_, wait_seconds))
-      ROS_WARN("Joint values for monitored state are requested but the full state is not known");
+    if (!current_state_monitor_->waitForCurrentState(ros::Time::now(), wait_seconds))
+    {
+      ROS_ERROR("Failed to fetch current robot state");
+      return false;
+    }
 
     current_state = current_state_monitor_->getCurrentState();
     return true;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -530,7 +530,7 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    current_state_monitor_->waitForCurrentState(opt_.group_name_, wait);
+    current_state_monitor_->waitForCompleteState(opt_.group_name_, wait);
     return true;
   }
 

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -191,7 +191,7 @@ public:
     if (!current_state_monitor_->isActive())
     {
       current_state_monitor_->startStateMonitor();
-      if (!current_state_monitor_->waitForCurrentState(wait))
+      if (!current_state_monitor_->waitForCompleteState(wait))
         ROS_WARN("Joint values for monitored state are requested but the full state is not known");
     }
     return true;

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -6,4 +6,5 @@ if (CATKIN_ENABLE_TESTING)
   #target_link_libraries(test_cleanup moveit_move_group_interface)
 
   add_rostest(python_move_group.test)
+  add_rostest(robot_state_update.test)
 endif()

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -58,12 +58,16 @@ class PythonMoveGroupTest(unittest.TestCase):
 
     def test_robot_state_update(self):
         current = np.asarray(self.group.get_current_joint_values())
-        for i in range(3):
+        for i in range(30):
             target = current + np.random.uniform(-0.5, 0.5, size = current.shape)
             # if plan was successfully executed, current state should be reported at target
             if self.group.execute(self.plan(target)):
                  actual = np.asarray(self.group.get_current_joint_values())
                  self.assertTrue(np.allclose(target, actual, atol=1e-4, rtol=0.0))
+            # otherwise current state should be still the same
+            else:
+               actual = np.asarray(self.group.get_current_joint_values())
+               self.assertTrue(np.allclose(current, actual, atol=1e-4, rtol=0.0))
 
 
 if __name__ == '__main__':

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -56,6 +56,15 @@ class PythonMoveGroupTest(unittest.TestCase):
         plan3 = self.plan(current)
         self.assertTrue(self.group.execute(plan3))
 
+    def test_robot_state_update(self):
+        current = np.asarray(self.group.get_current_joint_values())
+        for i in range(3):
+            target = current + np.random.uniform(-0.5, 0.5, size = current.shape)
+            # if plan was successfully executed, current state should be reported at target
+            if self.group.execute(self.plan(target)):
+                 actual = np.asarray(self.group.get_current_joint_values())
+                 self.assertTrue(np.allclose(target, actual, atol=1e-4, rtol=0.0))
+
 
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -56,19 +56,6 @@ class PythonMoveGroupTest(unittest.TestCase):
         plan3 = self.plan(current)
         self.assertTrue(self.group.execute(plan3))
 
-    def test_robot_state_update(self):
-        current = np.asarray(self.group.get_current_joint_values())
-        for i in range(30):
-            target = current + np.random.uniform(-0.5, 0.5, size = current.shape)
-            # if plan was successfully executed, current state should be reported at target
-            if self.group.execute(self.plan(target)):
-                 actual = np.asarray(self.group.get_current_joint_values())
-                 self.assertTrue(np.allclose(target, actual, atol=1e-4, rtol=0.0))
-            # otherwise current state should be still the same
-            else:
-               actual = np.asarray(self.group.get_current_joint_values())
-               self.assertTrue(np.allclose(current, actual, atol=1e-4, rtol=0.0))
-
 
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'

--- a/moveit_ros/planning_interface/test/robot_state_update.py
+++ b/moveit_ros/planning_interface/test/robot_state_update.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import unittest
+import numpy as np
+import rospy
+import rostest
+import os
+
+from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroup
+
+
+class RobotStateUpdateTest(unittest.TestCase):
+    PLANNING_GROUP = "manipulator"
+
+    @classmethod
+    def setUpClass(self):
+        self.group = MoveGroup(self.PLANNING_GROUP, "robot_description")
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def plan(self, target):
+        self.group.set_joint_value_target(target)
+        return self.group.compute_plan()
+
+    def test(self):
+        current = np.asarray(self.group.get_current_joint_values())
+        for i in range(30):
+            target = current + np.random.uniform(-0.5, 0.5, size = current.shape)
+            # if plan was successfully executed, current state should be reported at target
+            if self.group.execute(self.plan(target)):
+                 actual = np.asarray(self.group.get_current_joint_values())
+                 self.assertTrue(np.allclose(target, actual, atol=1e-4, rtol=0.0))
+            # otherwise current state should be still the same
+            else:
+               actual = np.asarray(self.group.get_current_joint_values())
+               self.assertTrue(np.allclose(current, actual, atol=1e-4, rtol=0.0))
+
+
+if __name__ == '__main__':
+    PKGNAME = 'moveit_ros_planning_interface'
+    NODENAME = 'moveit_test_robot_state_update'
+    rospy.init_node(NODENAME)
+    rostest.rosrun(PKGNAME, NODENAME, RobotStateUpdateTest)
+
+    # suppress cleanup segfault
+    os._exit(0)

--- a/moveit_ros/planning_interface/test/robot_state_update.test
+++ b/moveit_ros/planning_interface/test/robot_state_update.test
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <test pkg="moveit_ros_planning_interface" type="robot_state_update.py" test-name="robot_state_update"
+        time-limit="300" args=""/>
+</launch>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -223,6 +223,8 @@ private:
   void configureWorkspace();
   void updateQueryStateHelper(robot_state::RobotState &state, const std::string &v);
   void fillStateSelectionOptions();
+  void useStartStateButtonExec();
+  void useGoalStateButtonExec();
 
   //Scene objects tab
   void addObject(const collision_detection::WorldPtr &world, const std::string &id,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -239,6 +239,7 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState &state,
 
   if (v == "<current>")
   {
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
       state = ps->getCurrentState();
@@ -402,11 +403,11 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyCo
 {
   if (move_group_ && planning_display_)
   {
-    robot_state::RobotState state = *planning_display_->getQueryStartState();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
-      state = ps->getCurrentState();
+      robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryStartState(state);
     }
   }
@@ -416,11 +417,11 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
 {
   if (move_group_ && planning_display_)
   {
-    robot_state::RobotState state = *planning_display_->getQueryStartState();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
-      state = ps->getCurrentState();
+      robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryGoalState(state);
     }
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -181,12 +181,22 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
 
 void MotionPlanningFrame::useStartStateButtonClicked()
 {
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::useStartStateButtonExec, this), "update start state");
+}
+
+void MotionPlanningFrame::useStartStateButtonExec()
+{
   robot_state::RobotState start = *planning_display_->getQueryStartState();
   updateQueryStateHelper(start, ui_->start_state_selection->currentText().toStdString());
   planning_display_->setQueryStartState(start);
 }
 
 void MotionPlanningFrame::useGoalStateButtonClicked()
+{
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::useGoalStateButtonExec, this), "update goal state");
+}
+
+void MotionPlanningFrame::useGoalStateButtonExec()
 {
   robot_state::RobotState goal = *planning_display_->getQueryGoalState();
   updateQueryStateHelper(goal, ui_->goal_state_selection->currentText().toStdString());

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -106,7 +106,12 @@ public:
 
   const std::string getMoveGroupNS() const;
   const robot_model::RobotModelConstPtr& getRobotModel() const;
+
+  /// wait for robot state more recent than t
+  bool waitForCurrentRobotState(const ros::Time &t = ros::Time::now());
+  /// get read-only access to planning scene
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
+  /// get write access to planning scene
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -297,6 +297,13 @@ const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() con
   }
 }
 
+bool PlanningSceneDisplay::waitForCurrentRobotState(const ros::Time &t)
+{
+  if (planning_scene_monitor_)
+    return planning_scene_monitor_->waitForCurrentRobotState(t);
+  return false;
+}
+
 planning_scene_monitor::LockedPlanningSceneRO PlanningSceneDisplay::getPlanningSceneRO() const
 {
   return planning_scene_monitor::LockedPlanningSceneRO(planning_scene_monitor_);


### PR DESCRIPTION
After having merged #63 we can finally attempt to merge https://github.com/rhaschke/moveit/pull/1 against ros-planning/moveit. This PR attempts to fix https://github.com/ros-planning/moveit_ros/issues/442 and the flaky test mentioned in https://github.com/ros-planning/moveit/pull/221#issuecomment-248223570. This PR draws on reverted PRs https://github.com/ros-planning/moveit_ros/pull/716 https://github.com/ros-planning/moveit_ros/pull/724, and https://github.com/ros-planning/moveit_ros/pull/728.

* I removed `AsyncSpinner` and `CallBackQueue` in `PlanningSceneMonitor` for now. With https://github.com/ros-planning/moveit_ros/pull/717 (#59) this is not required anymore to update the robot state. However `syncSceneUpdates()` relies on them, which is why I had to remove them for now too. It's anyway in discussion, whether this function is useful. I will file a separate PR for this.
* I renamed `CurrentStateMonitor::waitForCurrentState()` and added a deprecated fallback function calling the new method `waitForCompleteState()`. Deprecation should be OK in Kinetic, but not Indigo and Jade. This should be considered when back-porting.