### PR TITLE
Fix RobotStateDisplay error message

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -122,7 +122,9 @@ protected:
   // overrides from Display
   virtual void onInitialize();
   virtual void onEnable();
+  virtual void onEnableHelper();
   virtual void onDisable();
+  virtual void load(const rviz::Config& config);
   virtual void fixedFrameChanged();
 
   // render the robot
@@ -135,6 +137,9 @@ protected:
   robot_state::RobotStatePtr kstate_;
   std::map<std::string, std_msgs::ColorRGBA> highlights_;
   bool update_state_;
+
+  // Do not load robot on first onEnable() call because the robot_description property will not be loaded yet
+  bool first_enable_ = true;
 
   rviz::StringProperty* robot_description_property_;
   rviz::StringProperty* root_link_name_property_;

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -381,6 +381,14 @@ void RobotStateDisplay::loadRobotModel()
 void RobotStateDisplay::onEnable()
 {
   Display::onEnable();
+
+  // Do not load robot on first onEnable() call because the robot_description property will not be loaded yet
+  if (!first_enable_)
+    onEnableHelper();
+}
+
+void RobotStateDisplay::onEnableHelper()
+{
   loadRobotModel();
   if (robot_)
   {
@@ -399,6 +407,15 @@ void RobotStateDisplay::onDisable()
   if (robot_)
     robot_->setVisible(false);
   Display::onDisable();
+}
+
+void RobotStateDisplay::load(const rviz::Config& config)
+{
+  Property::load(config);
+
+  if (isEnabled())
+    onEnableHelper();
+  first_enable_ = false;
 }
 
 void RobotStateDisplay::update(float wall_dt, float ros_dt)


### PR DESCRIPTION
@rhaschke introduced a helpful [error message for rdf_loader](https://github.com/ros-planning/moveit/commit/1d7abc44142aa7331b93932f0cf946a6d9590c3b#diff-2814abdc68972ad7a5e80deae1e3bc02R52), but sometimes it shows incorrectly in the RobotStateDisplay for Rviz. If you have an rviz config saved to file, and your robot description property is not the default ``robot_description`` then this message will show even though everything else still works fine.

This fix delays the loading of the robot model until after the robot description property is loaded

I did not see this problem until I upgraded to kinetic today, so I don't think it needs to be cherry picked to I/K but I'm not sure because @rhaschke's change is in all branches. I might have just missed the error message previously