### PR TITLE
Add better user feedback when virtual joint is misconfigured

### DIFF
--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -876,7 +876,17 @@ moveit::core::JointModel* moveit::core::RobotModel::constructJointModel(const ur
   {
     const std::vector<srdf::Model::VirtualJoint> &vjoints = srdf_model.getVirtualJoints();
     for (std::size_t i = 0 ; i < vjoints.size() ; ++i)
-      if (vjoints[i].child_link_ == child_link->name && !vjoints[i].parent_frame_.empty())
+    {
+      if (vjoints[i].child_link_ != child_link->name)
+      {
+        logWarn("Skipping virtual joint '%s' because its child frame '%s' does not match the URDF frame '%s'",
+                vjoints[i].name_.c_str(), vjoints[i].child_link_.c_str(), child_link->name.c_str());
+      }
+      else if (vjoints[i].parent_frame_.empty())
+      {
+        logWarn("Skipping virtual joint '%s' because its parent frame is empty", vjoints[i].name_.c_str());
+      }
+      else
       {
         if (vjoints[i].type_ == "fixed")
           result = new FixedJointModel(vjoints[i].name_);
@@ -896,9 +906,10 @@ moveit::core::JointModel* moveit::core::RobotModel::constructJointModel(const ur
           break;
         }
       }
+    }
     if (!result)
     {
-      logInform("No root joint specified. Assuming fixed joint");
+      logInform("No root/virtual joint specified in SRDF. Assuming fixed joint");
       result = new FixedJointModel("ASSUMED_FIXED_ROOT_JOINT");
     }
   }


### PR DESCRIPTION
A common tripping point for beginners is how to properly use virtual joints. Often (as I just did with the baxter_moveit_config in moveit_robots) users get the warning:

> No root joint specified. Assuming fixed joint

e.g.
http://answers.ros.org/question/165136/no-root-joint-specified-assuming-fixed-joint-moveit/
https://groups.google.com/forum/#!topic/moveit-users/a3W5sQcxRAM
https://groups.google.com/forum/#!topic/moveit-users/floIkUvtdyg

This adds very helpful feedback to diagnose the problem.

cherry-pick to I/J