### PR TITLE
Allow distance checks to be verbose, just like collision checks

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_world.h
@@ -199,24 +199,28 @@ namespace collision_detection
 
     /** \brief Compute the shortest distance between a robot and the world
      *  @param robot The robot to check distance for
-     *  @param state The state for the robot to check distances from */
+     *  @param state The state for the robot to check distances from
+     *  @param verbose Output debug information about distance checks */
     virtual double distanceRobot(const CollisionRobot &robot,
-                                 const robot_state::RobotState &state) const = 0;
+                                 const robot_state::RobotState &state, bool verbose = false) const = 0;
 
     /** \brief Compute the shortest distance between a robot and the world
      *  @param robot The robot to check distance for
      *  @param state The state for the robot to check distances from
-     *  @param acm Using an allowed collision matrix has the effect of ignoring distances from links that are always allowed to be in collision. */
+     *  @param acm Using an allowed collision matrix has the effect of ignoring distances from links that are always allowed to be in collision.
+     *  @param verbose Output debug information about distance checks */
     virtual double distanceRobot(const CollisionRobot &robot,
                                  const robot_state::RobotState &state,
-                                 const AllowedCollisionMatrix &acm) const = 0;
+                                 const AllowedCollisionMatrix &acm, bool verbose = false) const = 0;
 
-    /** \brief The shortest distance to another world instance (\e world) */
-    virtual double distanceWorld(const CollisionWorld &world) const = 0;
+    /** \brief The shortest distance to another world instance (\e world)
+     *  @param verbose Output debug information about distance checks */
+    virtual double distanceWorld(const CollisionWorld &world, bool verbose = false) const = 0;
 
-    /** \brief The shortest distance to another world instance (\e world), ignoring the distances between world elements that are allowed to collide (as specified by \e acm) */
+    /** \brief The shortest distance to another world instance (\e world), ignoring the distances between world elements that are allowed to collide (as specified by \e acm)
+     *  @param verbose Output debug information about distance checks */
     virtual double distanceWorld(const CollisionWorld &world,
-                                 const AllowedCollisionMatrix &acm) const = 0;
+                                 const AllowedCollisionMatrix &acm, bool verbose = false) const = 0;
     /** set the world to use.
      * This can be expensive unless the new and old world are empty.
      * Passing NULL will result in a new empty world being created. */

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_world_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_world_fcl.h
@@ -61,10 +61,10 @@ namespace collision_detection
     virtual void checkWorldCollision(const CollisionRequest &req, CollisionResult &res, const CollisionWorld &other_world) const;
     virtual void checkWorldCollision(const CollisionRequest &req, CollisionResult &res, const CollisionWorld &other_world, const AllowedCollisionMatrix &acm) const;
 
-    virtual double distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state) const;
-    virtual double distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
-    virtual double distanceWorld(const CollisionWorld &world) const;
-    virtual double distanceWorld(const CollisionWorld &world, const AllowedCollisionMatrix &acm) const;
+    virtual double distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state, bool verbose = false) const;
+    virtual double distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix &acm, bool verbose = false) const;
+    virtual double distanceWorld(const CollisionWorld &world, bool verbose = false) const;
+    virtual double distanceWorld(const CollisionWorld &world, const AllowedCollisionMatrix &acm, bool verbose = false) const;
 
     virtual void setWorld(const WorldPtr& world);
 
@@ -72,8 +72,8 @@ namespace collision_detection
 
     void checkWorldCollisionHelper(const CollisionRequest &req, CollisionResult &res, const CollisionWorld &other_world, const AllowedCollisionMatrix *acm) const;
     void checkRobotCollisionHelper(const CollisionRequest &req, CollisionResult &res, const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix *acm) const;
-    double distanceRobotHelper(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix *acm) const;
-    double distanceWorldHelper(const CollisionWorld &world, const AllowedCollisionMatrix *acm) const;
+    double distanceRobotHelper(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix *acm, bool verbose = false) const;
+    double distanceWorldHelper(const CollisionWorld &world, const AllowedCollisionMatrix *acm, bool verbose = false) const;
 
     void constructFCLObject(const World::Object *obj, FCLObject &fcl_obj) const;
     void updateFCLObject(const std::string &id);

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -399,7 +399,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         always_allow_collision = true;
         if (cdata->req_->verbose)
-          logDebug("Collision between '%s' and '%s' is always allowed. No contacts are computed.",
+          logDebug("Collision between '%s' and '%s' is always allowed. No distances are computed.",
                    cd1->getID().c_str(), cd2->getID().c_str());
       }
     }
@@ -413,7 +413,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     {
       always_allow_collision = true;
       if (cdata->req_->verbose)
-        logDebug("Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
+        logDebug("Robot link '%s' is allowed to touch attached object '%s'. No distances are computed.",
                  cd1->getID().c_str(), cd2->getID().c_str());
     }
   }
@@ -426,7 +426,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         always_allow_collision = true;
         if (cdata->req_->verbose)
-          logDebug("Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
+          logDebug("Robot link '%s' is allowed to touch attached object '%s'. No distances are computed.",
                    cd2->getID().c_str(), cd1->getID().c_str());
       }
     }
@@ -438,14 +438,14 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     return cdata->done_;
   }
 
-  if (cdata->req_->verbose)
-    logDebug("Actually checking collisions between %s and %s", cd1->getID().c_str(), cd2->getID().c_str());
-
   fcl::DistanceResult dist_result;
   dist_result.update(cdata->res_->distance, NULL, NULL, fcl::DistanceResult::NONE, fcl::DistanceResult::NONE); // can be faster
-  double d = fcl::distance(o1, o2, fcl::DistanceRequest(), dist_result);
+  const double d = fcl::distance(o1, o2, fcl::DistanceRequest(), dist_result);
 
-  if(d < 0)
+  if (cdata->req_->verbose)
+    logDebug("Distance between %s and %s: %f", cd1->getID().c_str(), cd2->getID().c_str(), d);
+
+  if(d < 0) // a penetration was found, no further distance calculations are necessary
   {
     cdata->done_ = true;
     cdata->res_->distance = -1;
@@ -453,7 +453,11 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
   else
   {
     if(cdata->res_->distance > d)
+    {
+      if (cdata->req_->verbose)
+        logWarn("Distance between %s and %s: %f decreased", cd1->getID().c_str(), cd2->getID().c_str(), d);
       cdata->res_->distance = d;
+    }
   }
 
   min_dist = cdata->res_->distance;

--- a/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -117,7 +117,7 @@ void collision_detection::CollisionWorldFCL::checkRobotCollisionHelper(const Col
     manager_->collide(fcl_obj.collision_objects_[i].get(), &cd, &collisionCallback);
 
   if (req.distance)
-    res.distance = distanceRobotHelper(robot, state, acm);
+    res.distance = distanceRobotHelper(robot, state, acm, req.verbose);
 }
 
 void collision_detection::CollisionWorldFCL::checkWorldCollision(const CollisionRequest &req, CollisionResult &res, const CollisionWorld &other_world) const
@@ -232,13 +232,14 @@ void collision_detection::CollisionWorldFCL::notifyObjectChange(const ObjectCons
   }
 }
 
-double collision_detection::CollisionWorldFCL::distanceRobotHelper(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix *acm) const
+double collision_detection::CollisionWorldFCL::distanceRobotHelper(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix *acm, bool verbose) const
 {
   const CollisionRobotFCL& robot_fcl = dynamic_cast<const CollisionRobotFCL&>(robot);
   FCLObject fcl_obj;
   robot_fcl.constructFCLObject(state, fcl_obj);
 
   CollisionRequest req;
+  req.verbose = verbose;
   CollisionResult res;
   CollisionData cd(&req, &res, acm);
   cd.enableGroup(robot.getRobotModel());
@@ -250,30 +251,31 @@ double collision_detection::CollisionWorldFCL::distanceRobotHelper(const Collisi
   return res.distance;
 }
 
-double collision_detection::CollisionWorldFCL::distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state) const
+double collision_detection::CollisionWorldFCL::distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state, bool verbose) const
 {
-  return distanceRobotHelper(robot, state, NULL);
+  return distanceRobotHelper(robot, state, NULL, verbose);
 }
 
-double collision_detection::CollisionWorldFCL::distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const
+double collision_detection::CollisionWorldFCL::distanceRobot(const CollisionRobot &robot, const robot_state::RobotState &state, const AllowedCollisionMatrix &acm, bool verbose) const
 {
-  return distanceRobotHelper(robot, state, &acm);
+  return distanceRobotHelper(robot, state, &acm, verbose);
 }
 
-double collision_detection::CollisionWorldFCL::distanceWorld(const CollisionWorld &world) const
+double collision_detection::CollisionWorldFCL::distanceWorld(const CollisionWorld &world, bool verbose) const
 {
-  return distanceWorldHelper(world, NULL);
+  return distanceWorldHelper(world, NULL, verbose);
 }
 
-double collision_detection::CollisionWorldFCL::distanceWorld(const CollisionWorld &world, const AllowedCollisionMatrix &acm) const
+double collision_detection::CollisionWorldFCL::distanceWorld(const CollisionWorld &world, const AllowedCollisionMatrix &acm, bool verbose) const
 {
-  return distanceWorldHelper(world, &acm);
+  return distanceWorldHelper(world, &acm, verbose);
 }
 
-double collision_detection::CollisionWorldFCL::distanceWorldHelper(const CollisionWorld &other_world, const AllowedCollisionMatrix *acm) const
+double collision_detection::CollisionWorldFCL::distanceWorldHelper(const CollisionWorld &other_world, const AllowedCollisionMatrix *acm, bool verbose) const
 {
   const CollisionWorldFCL& other_fcl_world = dynamic_cast<const CollisionWorldFCL&>(other_world);
   CollisionRequest req;
+  req.verbose = verbose;
   CollisionResult res;
   CollisionData cd(&req, &res, acm);
   manager_->distance(other_fcl_world.manager_.get(), &cd, &distanceCallback);


### PR DESCRIPTION
There were already facilities in place to output debug information for the distance checks, but they were not connected to the verbose flag like the collision checking equivalent functions were.

This changes no functionality unless you do a collision request with verbose=true.

Also also clarified some distance messages that had just been copy-pasted from their collision checking equivalent, I moved one message, and added one.

I do not think this needs to be back-ported.