### PR TITLE
remove default grasp from pick-pipeline

### DIFF
--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -510,48 +510,6 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
       }
     }
   }
-
-  if (goal.possible_grasps.empty())
-  {
-    planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
-
-    ROS_DEBUG_NAMED("manipulation", "Using default grasp poses");
-    goal.minimize_object_distance = true;
-
-    // add a number of default grasp points
-    // \todo add more!
-    moveit_msgs::Grasp g;
-    g.grasp_pose.header.frame_id = goal.target_name;
-    g.grasp_pose.pose.position.x = -0.2;
-    g.grasp_pose.pose.position.y = 0.0;
-    g.grasp_pose.pose.position.z = 0.0;
-    g.grasp_pose.pose.orientation.x = 0.0;
-    g.grasp_pose.pose.orientation.y = 0.0;
-    g.grasp_pose.pose.orientation.z = 0.0;
-    g.grasp_pose.pose.orientation.w = 1.0;
-
-    g.pre_grasp_approach.direction.header.frame_id = lscene->getPlanningFrame();
-    g.pre_grasp_approach.direction.vector.x = 1.0;
-    g.pre_grasp_approach.min_distance = 0.1;
-    g.pre_grasp_approach.desired_distance = 0.2;
-
-    g.post_grasp_retreat.direction.header.frame_id = lscene->getPlanningFrame();
-    g.post_grasp_retreat.direction.vector.z = 1.0;
-    g.post_grasp_retreat.min_distance = 0.1;
-    g.post_grasp_retreat.desired_distance = 0.2;
-
-    if (lscene->getRobotModel()->hasEndEffector(goal.end_effector))
-    {
-      g.pre_grasp_posture.joint_names = lscene->getRobotModel()->getEndEffector(goal.end_effector)->getJointModelNames();
-      g.pre_grasp_posture.points.resize(1);
-      g.pre_grasp_posture.points[0].positions.resize(g.pre_grasp_posture.joint_names.size(), std::numeric_limits<double>::max());
-
-      g.grasp_posture.joint_names = g.pre_grasp_posture.joint_names;
-      g.grasp_posture.points.resize(1);
-      g.grasp_posture.points[0].positions.resize(g.grasp_posture.joint_names.size(), -std::numeric_limits<double>::max());
-    }
-    goal.possible_grasps.push_back(g);
-  }
 }
 
 #include <class_loader/class_loader.h>


### PR DESCRIPTION
If a user uses the pick(std::string) interface that means the code
will call the external planning service. If this service is not available
or does not provide grasps, this block added a default grasp.

This is quite dangerous actually, because when the service is not available
this probably means that it hasn't been started or died. In this case the user
didn't get an error message but instead got a more or less random grasp
that got processed instead and that could induce unwanted movements of the manipulator.

Yes this changes semantics in a stable release, but I consider it to be a safety issue.

should be picked to j/k