### PR TITLE
Add hack for rostest debian corruption

### DIFF
--- a/.docker/ci-shadow-fixed/Dockerfile
+++ b/.docker/ci-shadow-fixed/Dockerfile
@@ -1,7 +1,7 @@
 # moveit/moveit:kinetic-ci-shadow-fixed
 # Sets up a base image to use for running Continuous Integration on Travis
 
-FROM moveit/moveit:kinetic-ci
+FROM ros:kinetic-ros-base
 MAINTAINER Dave Coleman dave@dav.ee
 
 ENV TERM xterm
@@ -12,12 +12,32 @@ RUN mkdir -p $CATKIN_WS/src
 WORKDIR $CATKIN_WS/src
 
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
-# Switch to shadow-fixed
-RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list && \
+RUN wstool init . && \
+    # Download moveit source so that we can get necessary dependencies
+    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+    wstool update && \
+    # Switch to shadow-fixed
+    echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list && \
     # Update apt-get because previous images clear this cache
     apt-get -qq update && \
+    # Temp hack, see https://github.com/ros/ros_comm/issues/904
+    apt-get -qq remove -y ros-${ROS_DISTRO}-rostest && \
     # Do a dist-upgrade to ensure our CI is building on top of the latest version of packages
     apt-get -qq dist-upgrade && \
+    # Install some base dependencies
+    apt-get -qq install -y \
+        # Required for rosdep command
+        sudo \
+        # Required for installing dependencies
+        python-rosdep \
+        # Preferred build tool
+        python-catkin-tools && \
+    # Download all dependencies of MoveIt!
+    rosdep update && \
+    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # Remove the source code from this container. TODO: in the future we may want to keep this here for further optimization of later containers
+    cd .. && \
+    rm -rf src/ && \
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -25,10 +25,7 @@ RUN wstool init . && \
         # Required for installing dependencies
         python-rosdep \
         # Preferred build tool
-        python-catkin-tools \
-        # Not sure if necessary:
-        ros-$ROS_DISTRO-rosbash \
-        ros-$ROS_DISTRO-rospack && \
+        python-catkin-tools && \
     # Download all dependencies of MoveIt!
     rosdep update && \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -32,5 +32,5 @@ RUN mv /bin/sh /bin/sh-old && \
 WORKDIR $CATKIN_WS
 ENV TERM xterm
 ENV PYTHONIOENCODING UTF-8
-RUN source /ros_entrypoint.sh && \
-    catkin build --no-status
+RUN catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    catkin build --jobs 1


### PR DESCRIPTION
Hack is for https://github.com/ros/ros_comm/issues/904

Also:

- Reduce memory footprint of ``shadow-fixed container`` by not depending on the ``ci`` container
- Force source CI to use 1 thread and show all output during build - hopefully this will stop the timeouts
- Make source CI build in release mode and install, to mimic the travis script builds
- Remove unnecessary rospack/rosbash dependencies 