### PR TITLE
[moveit_experimental] Fix incorrect dependency on FCL in kinetic

### DIFF
--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -42,6 +42,7 @@ catkin_package(
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
     ${OCTOMAP_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR}
   LIBRARIES
     moveit_collision_distance_field
     collision_detector_hybrid_plugin
@@ -56,11 +57,10 @@ catkin_package(
     pluginlib
   DEPENDS
     Boost
-    Eigen3
     urdfdom
     urdfdom_headers
     console_bridge
-    )
+)
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
                            ${Boost_INCLUDE_DIR}

--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -34,7 +34,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>assimp</build_depend>
-  <build_depend>fcl</build_depend>
+  <build_depend>libfcl-dev</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
@@ -52,7 +52,7 @@
   <run_depend>eigen</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>assimp</run_depend>
-  <run_depend>fcl</run_depend>
+  <run_depend>libfcl-dev</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend version_gte="0.3.4">geometric_shapes</run_depend>


### PR DESCRIPTION
Also: [moveit_experimental] Fix Eigen3 warning

fcl switched to libfcl-dev in kinetic, but somehow [Travis passed](https://travis-ci.org/ros-planning/moveit/jobs/162652412) but [Dockerhub did not](https://hub.docker.com/r/moveit/moveit/builds/bujkprszk2jbjpewwrenti6/)