### PR TITLE
improve comment on internal class member

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1448,7 +1448,7 @@ private:
   Eigen::Affine3d                       *global_collision_body_transforms_;  // this points to an element in transforms_, so it is aligned
   unsigned char                         *dirty_joint_transforms_;
 
-  /** \brief The attached bodies that are part of this state (from all links) */
+  /** \brief All attached bodies that are part of this state, indexed by their name */
   std::map<std::string, AttachedBody*>   attached_body_map_;
 
   /** \brief This event is called when there is a change in the attached bodies for this state;


### PR DESCRIPTION
I falsely assumed the map is indexed by the name of the *links*
the objects are attached to and it took me a while to find evidence
that this is not the case.

should be picked to i/j