### PR TITLE
Allow travis to pass only for shadow-fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
   matrix:
     - ROS_DISTRO="kinetic"  ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO="kinetic"  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
+# 27 Sep 2016 Kinetic branch depends on a change in pluginlib that is only in shadow-fixed and has not been synced yet. Remove after next sync
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic"  ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:


### PR DESCRIPTION
https://github.com/ros-planning/moveit/pull/215 requires a version of pluginlib that is released but not synced yet, so we can only depend on shadow-fixed for now