### PR TITLE
Add planGraspsAndPick method to move_group_interface

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
 add_library(${MOVEIT_LIB_NAME} src/move_group.cpp)
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects moveit_planning_scene_interface ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_move_group.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_py_bindings_tools)

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -661,14 +661,29 @@ public:
    */
   /**@{*/
 
-  /** \brief Pick up an object */
+  /** \brief Pick up an object
+
+      calls the external manipulation_msgs::GraspPlanning service "database_grasp_planning"
+      to compute possible grasps and uses a number of default grasps if it is not available */
   MoveItErrorCode pick(const std::string &object);
 
   /** \brief Pick up an object given a grasp pose */
   MoveItErrorCode pick(const std::string &object, const moveit_msgs::Grasp &grasp);
 
-  /** \brief Pick up an object given possible grasp poses */
+  /** \brief Pick up an object given possible grasp poses
+
+      if the vector is left empty this behaves like pick(const std::string &object) */
   MoveItErrorCode pick(const std::string &object, const std::vector<moveit_msgs::Grasp> &grasps);
+
+  /** \brief Pick up an object
+
+      calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
+  MoveItErrorCode planGraspsAndPick(const std::string &object);
+
+  /** \brief Pick up an object
+
+      calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
+  MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject &object);
 
   /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
   MoveItErrorCode place(const std::string &object);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -44,6 +44,7 @@
 #include <moveit/move_group_interface/move_group.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
 #include <moveit/trajectory_execution_manager/trajectory_execution_manager.h>
 #include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/robot_state/conversions.h>
@@ -53,6 +54,7 @@
 #include <moveit_msgs/ExecuteKnownTrajectory.h>
 #include <moveit_msgs/QueryPlannerInterfaces.h>
 #include <moveit_msgs/GetCartesianPath.h>
+#include <moveit_msgs/GraspPlanning.h>
 
 #include <actionlib/client/simple_action_client.h>
 #include <eigen_conversions/eigen_msg.h>
@@ -69,6 +71,8 @@ namespace planning_interface
 {
 
 const std::string MoveGroup::ROBOT_DESCRIPTION = "robot_description";    // name of the robot description (a param name, so it can be changed externally)
+
+const std::string GRASP_PLANNING_SERVICE_NAME = "plan_grasps"; // name of the service that can be used to plan grasps
 
 namespace
 {
@@ -145,6 +149,7 @@ public:
     execute_service_ = node_handle_.serviceClient<moveit_msgs::ExecuteKnownTrajectory>(move_group::EXECUTE_SERVICE_NAME);
     query_service_ = node_handle_.serviceClient<moveit_msgs::QueryPlannerInterfaces>(move_group::QUERY_PLANNERS_SERVICE_NAME);
     cartesian_path_service_ = node_handle_.serviceClient<moveit_msgs::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
+    plan_grasps_service_ = node_handle_.serviceClient<moveit_msgs::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 
     ROS_INFO_STREAM("Ready to take MoveGroup commands for group " << opt.group_name_ << ".");
   }
@@ -588,6 +593,47 @@ public:
       ROS_WARN_STREAM("Fail: " << pick_action_client_->getState().toString() << ": " << pick_action_client_->getState().getText());
       return MoveItErrorCode(pick_action_client_->getResult()->error_code);
     }
+  }
+
+  MoveItErrorCode planGraspsAndPick(const std::string &object)
+  {
+    moveit::planning_interface::PlanningSceneInterface psi;
+
+    std::map<std::string, moveit_msgs::CollisionObject> objects = psi.getObjects(std::vector<std::string>(1,object));
+
+    if (objects.size() < 1)
+    {
+      ROS_ERROR_STREAM("Asked for grasps for the object '" << object << "', but the object could not be found");
+      return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME);
+    }
+
+    return planGraspsAndPick(objects[object]);
+  }
+
+  MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject &object)
+  {
+    if (!plan_grasps_service_)
+    {
+      ROS_ERROR_STREAM("Grasp planning service '" << GRASP_PLANNING_SERVICE_NAME << "' is not available."
+                       " This has to be implemented and started separately.");
+      return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
+    }
+
+    moveit_msgs::GraspPlanning::Request request;
+    moveit_msgs::GraspPlanning::Response response;
+
+    request.group_name = opt_.group_name_;
+    request.target = object;
+    request.support_surfaces.push_back(support_surface_);
+
+    ROS_DEBUG("Calling grasp planner...");
+    if (!plan_grasps_service_.call(request, response) || response.error_code.val != moveit_msgs::MoveItErrorCodes::SUCCESS)
+    {
+      ROS_ERROR("Grasp planning failed. Unable to pick.");
+      return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
+    }
+
+    return pick(object.id, response.grasps);
   }
 
   MoveItErrorCode plan(Plan &plan)
@@ -1072,6 +1118,7 @@ private:
   ros::ServiceClient execute_service_;
   ros::ServiceClient query_service_;
   ros::ServiceClient cartesian_path_service_;
+  ros::ServiceClient plan_grasps_service_;
   boost::scoped_ptr<moveit_warehouse::ConstraintsStorage> constraints_storage_;
   boost::scoped_ptr<boost::thread> constraints_init_thread_;
   bool initializing_constraints_;
@@ -1194,6 +1241,16 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::pick(const std::string &object, const std::vector<moveit_msgs::Grasp> &grasps)
 {
   return impl_->pick(object, grasps);
+}
+
+moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::planGraspsAndPick(const std::string &object)
+{
+  return impl_->planGraspsAndPick(object);
+}
+
+moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::planGraspsAndPick(const moveit_msgs::CollisionObject &object)
+{
+  return impl_->planGraspsAndPick(object);
 }
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::place(const std::string &object)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -97,14 +97,14 @@ public:
     if (!getRobotModel())
     {
       std::string error = "Unable to construct robot model. Please make sure all needed information is on the parameter server.";
-      ROS_FATAL_STREAM(error);
+      ROS_FATAL_STREAM_NAMED("move_group_interface",error);
       throw std::runtime_error(error);
     }
 
     if (!getRobotModel()->hasJointModelGroup(opt.group_name_))
     {
       std::string error = "Group '" + opt.group_name_ + "' was not found.";
-      ROS_FATAL_STREAM(error);
+      ROS_FATAL_STREAM_NAMED("move_group_interface",error);
       throw std::runtime_error(error);
     }
 
@@ -151,13 +151,13 @@ public:
     cartesian_path_service_ = node_handle_.serviceClient<moveit_msgs::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
     plan_grasps_service_ = node_handle_.serviceClient<moveit_msgs::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 
-    ROS_INFO_STREAM("Ready to take MoveGroup commands for group " << opt.group_name_ << ".");
+    ROS_INFO_STREAM_NAMED("move_group_interface","Ready to take MoveGroup commands for group " << opt.group_name_ << ".");
   }
 
   template<typename T>
   void waitForAction(const T &action, const ros::Duration &wait_for_server, const std::string &name)
   {
-    ROS_DEBUG("Waiting for MoveGroup action server (%s)...", name.c_str());
+    ROS_DEBUG_NAMED("move_group_interface","Waiting for MoveGroup action server (%s)...", name.c_str());
 
     // in case ROS time is published, wait for the time data to arrive
     ros::Time start_time = ros::Time::now();
@@ -196,7 +196,7 @@ public:
     }
     else
     {
-      ROS_DEBUG("Connected to '%s'", name.c_str());
+      ROS_DEBUG_NAMED("move_group_interface","Connected to '%s'", name.c_str());
     }
   }
 
@@ -382,7 +382,7 @@ public:
     const std::string &eef = end_effector_link.empty() ? end_effector_link_ : end_effector_link;
     if (eef.empty())
     {
-      ROS_ERROR("No end-effector to set the pose for");
+      ROS_ERROR_NAMED("move_group_interface","No end-effector to set the pose for");
       return false;
     }
     else
@@ -414,7 +414,7 @@ public:
 
     // or return an error
     static const geometry_msgs::PoseStamped unknown;
-    ROS_ERROR("Pose for end effector '%s' not known.", eef.c_str());
+    ROS_ERROR_NAMED("move_group_interface","Pose for end effector '%s' not known.", eef.c_str());
     return unknown;
   }
 
@@ -429,7 +429,7 @@ public:
 
     // or return an error
     static const std::vector<geometry_msgs::PoseStamped> empty;
-    ROS_ERROR("Poses for end effector '%s' are not known.", eef.c_str());
+    ROS_ERROR_NAMED("move_group_interface","Poses for end effector '%s' are not known.", eef.c_str());
     return empty;
   }
 
@@ -462,7 +462,7 @@ public:
   {
     if (!current_state_monitor_)
     {
-      ROS_ERROR("Unable to monitor current robot state");
+      ROS_ERROR_NAMED("move_group_interface","Unable to monitor current robot state");
       return false;
     }
 
@@ -478,7 +478,7 @@ public:
   {
     if (!current_state_monitor_)
     {
-      ROS_ERROR("Unable to get current robot state");
+      ROS_ERROR_NAMED("move_group_interface","Unable to get current robot state");
       return false;
     }
 
@@ -487,7 +487,7 @@ public:
       current_state_monitor_->startStateMonitor();
 
     if (!current_state_monitor_->waitForCurrentState(opt_.group_name_, wait_seconds))
-      ROS_WARN("Joint values for monitored state are requested but the full state is not known");
+      ROS_WARN_NAMED("move_group_interface","Joint values for monitored state are requested but the full state is not known");
 
     current_state = current_state_monitor_->getCurrentState();
     return true;
@@ -514,7 +514,7 @@ public:
       location.place_pose = poses[i];
       locations.push_back(location);
     }
-    ROS_DEBUG("Move group interface has %u place locations", (unsigned int) locations.size());
+    ROS_DEBUG_NAMED("move_group_interface","Move group interface has %u place locations", (unsigned int) locations.size());
     return place(object, locations);
   }
 
@@ -522,12 +522,12 @@ public:
   {
     if (!place_action_client_)
     {
-      ROS_ERROR_STREAM("Place action client not found");
+      ROS_ERROR_STREAM_NAMED("move_group_interface","Place action client not found");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
     if (!place_action_client_->isServerConnected())
     {
-      ROS_ERROR_STREAM("Place action server not connected");
+      ROS_ERROR_STREAM_NAMED("move_group_interface","Place action server not connected");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
     moveit_msgs::PlaceGoal goal;
@@ -541,10 +541,10 @@ public:
     goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
 
     place_action_client_->sendGoal(goal);
-    ROS_DEBUG("Sent place goal with %d locations", (int) goal.place_locations.size());
+    ROS_DEBUG_NAMED("move_group_interface","Sent place goal with %d locations", (int) goal.place_locations.size());
     if (!place_action_client_->waitForResult())
     {
-      ROS_INFO_STREAM("Place action returned early");
+      ROS_INFO_STREAM_NAMED("move_group_interface","Place action returned early");
     }
     if (place_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
     {
@@ -552,7 +552,7 @@ public:
     }
     else
     {
-      ROS_WARN_STREAM("Fail: " << place_action_client_->getState().toString() << ": " << place_action_client_->getState().getText());
+      ROS_WARN_STREAM_NAMED("move_group_interface","Fail: " << place_action_client_->getState().toString() << ": " << place_action_client_->getState().getText());
       return MoveItErrorCode(place_action_client_->getResult()->error_code);
     }
   }
@@ -561,12 +561,12 @@ public:
   {
     if (!pick_action_client_)
     {
-      ROS_ERROR_STREAM("Pick action client not found");
+      ROS_ERROR_STREAM_NAMED("move_group_interface","Pick action client not found");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
     if (!pick_action_client_->isServerConnected())
     {
-      ROS_ERROR_STREAM("Pick action server not connected");
+      ROS_ERROR_STREAM_NAMED("move_group_interface","Pick action server not connected");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
     moveit_msgs::PickupGoal goal;
@@ -582,7 +582,7 @@ public:
     pick_action_client_->sendGoal(goal);
     if (!pick_action_client_->waitForResult())
     {
-      ROS_INFO_STREAM("Pickup action returned early");
+      ROS_INFO_STREAM_NAMED("move_group_interface","Pickup action returned early");
     }
     if (pick_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
     {
@@ -590,7 +590,7 @@ public:
     }
     else
     {
-      ROS_WARN_STREAM("Fail: " << pick_action_client_->getState().toString() << ": " << pick_action_client_->getState().getText());
+      ROS_WARN_STREAM_NAMED("move_group_interface","Fail: " << pick_action_client_->getState().toString() << ": " << pick_action_client_->getState().getText());
       return MoveItErrorCode(pick_action_client_->getResult()->error_code);
     }
   }
@@ -603,7 +603,7 @@ public:
 
     if (objects.size() < 1)
     {
-      ROS_ERROR_STREAM("Asked for grasps for the object '" << object << "', but the object could not be found");
+      ROS_ERROR_STREAM_NAMED("move_group_interface","Asked for grasps for the object '" << object << "', but the object could not be found");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME);
     }
 
@@ -614,7 +614,7 @@ public:
   {
     if (!plan_grasps_service_)
     {
-      ROS_ERROR_STREAM("Grasp planning service '" << GRASP_PLANNING_SERVICE_NAME << "' is not available."
+      ROS_ERROR_STREAM_NAMED("move_group_interface","Grasp planning service '" << GRASP_PLANNING_SERVICE_NAME << "' is not available."
                        " This has to be implemented and started separately.");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
@@ -626,10 +626,10 @@ public:
     request.target = object;
     request.support_surfaces.push_back(support_surface_);
 
-    ROS_DEBUG("Calling grasp planner...");
+    ROS_DEBUG_NAMED("move_group_interface","Calling grasp planner...");
     if (!plan_grasps_service_.call(request, response) || response.error_code.val != moveit_msgs::MoveItErrorCodes::SUCCESS)
     {
-      ROS_ERROR("Grasp planning failed. Unable to pick.");
+      ROS_ERROR_NAMED("move_group_interface","Grasp planning failed. Unable to pick.");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
 
@@ -658,7 +658,7 @@ public:
     move_action_client_->sendGoal(goal);
     if (!move_action_client_->waitForResult())
     {
-      ROS_INFO_STREAM("MoveGroup action returned early");
+      ROS_INFO_STREAM_NAMED("move_group_interface","MoveGroup action returned early");
     }
     if (move_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
     {
@@ -669,7 +669,7 @@ public:
     }
     else
     {
-      ROS_WARN_STREAM("Fail: " << move_action_client_->getState().toString() << ": " << move_action_client_->getState().getText());
+      ROS_WARN_STREAM_NAMED("move_group_interface","Fail: " << move_action_client_->getState().toString() << ": " << move_action_client_->getState().getText());
       return MoveItErrorCode(move_action_client_->getResult()->error_code);
     }
   }
@@ -702,7 +702,7 @@ public:
 
     if (!move_action_client_->waitForResult())
     {
-      ROS_INFO_STREAM("MoveGroup action returned early");
+      ROS_INFO_STREAM_NAMED("move_group_interface","MoveGroup action returned early");
     }
 
     if (move_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
@@ -711,7 +711,7 @@ public:
     }
     else
     {
-      ROS_INFO_STREAM(move_action_client_->getState().toString() << ": " << move_action_client_->getState().getText());
+      ROS_INFO_STREAM_NAMED("move_group_interface",move_action_client_->getState().toString() << ": " << move_action_client_->getState().getText());
       return MoveItErrorCode(move_action_client_->getResult()->error_code);
     }
   }
@@ -791,7 +791,7 @@ public:
     }
     if (l.empty())
     {
-      ROS_ERROR("No known link to attach object '%s' to", object.c_str());
+      ROS_ERROR_NAMED("move_group_interface","No known link to attach object '%s' to", object.c_str());
       return false;
     }
     moveit_msgs::AttachedCollisionObject aco;
@@ -874,13 +874,13 @@ public:
   void allowLooking(bool flag)
   {
     can_look_ = flag;
-    ROS_INFO("Looking around: %s", can_look_ ? "yes" : "no");
+    ROS_INFO_NAMED("move_group_interface","Looking around: %s", can_look_ ? "yes" : "no");
   }
 
   void allowReplanning(bool flag)
   {
     can_replan_ = flag;
-    ROS_INFO("Replanning: %s", can_replan_ ? "yes" : "no");
+    ROS_INFO_NAMED("move_group_interface","Replanning: %s", can_replan_ ? "yes" : "no");
   }
 
   void setReplanningDelay(double delay)
@@ -945,7 +945,7 @@ public:
         }
       }
       else
-        ROS_ERROR("Unable to construct goal representation");
+        ROS_ERROR_NAMED("move_group_interface","Unable to construct goal representation");
 
     if (path_constraints_)
       goal.request.path_constraints = *path_constraints_;
@@ -1064,11 +1064,11 @@ private:
     try
     {
       constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(host, port));
-      ROS_DEBUG("Connected to constraints database");
+      ROS_DEBUG_NAMED("move_group_interface","Connected to constraints database");
     }
     catch(std::runtime_error &ex)
     {
-      ROS_DEBUG("%s", ex.what());
+      ROS_DEBUG_NAMED("move_group_interface","%s", ex.what());
     }
     initializing_constraints_ = false;
   }
@@ -1549,7 +1549,7 @@ bool moveit::planning_interface::MoveGroup::setPoseTargets(const std::vector<geo
 {
   if (target.empty())
   {
-    ROS_ERROR("No pose specified as goal target");
+    ROS_ERROR_NAMED("move_group_interface","No pose specified as goal target");
     return false;
   }
   else
@@ -1738,7 +1738,7 @@ geometry_msgs::PoseStamped moveit::planning_interface::MoveGroup::getRandomPose(
   Eigen::Affine3d pose;
   pose.setIdentity();
   if (eef.empty())
-    ROS_ERROR("No end-effector specified");
+    ROS_ERROR_NAMED("move_group_interface","No end-effector specified");
   else
   {
     robot_state::RobotStatePtr current_state;
@@ -1763,7 +1763,7 @@ geometry_msgs::PoseStamped moveit::planning_interface::MoveGroup::getCurrentPose
   Eigen::Affine3d pose;
   pose.setIdentity();
   if (eef.empty())
-    ROS_ERROR("No end-effector specified");
+    ROS_ERROR_NAMED("move_group_interface","No end-effector specified");
   else
   {
     robot_state::RobotStatePtr current_state;
@@ -1786,7 +1786,7 @@ std::vector<double> moveit::planning_interface::MoveGroup::getCurrentRPY(const s
   std::vector<double> result;
   const std::string &eef = end_effector_link.empty() ? getEndEffectorLink() : end_effector_link;
   if (eef.empty())
-    ROS_ERROR("No end-effector specified");
+    ROS_ERROR_NAMED("move_group_interface","No end-effector specified");
   else
   {
     robot_state::RobotStatePtr current_state;


### PR DESCRIPTION
This utilizes the new GraspPlanning service and provides a way to make use of external grasp
planners without also adding default grasps.

The service definition is proposed in:
https://github.com/ros-planning/moveit_msgs/pull/32