### PR TITLE
Fix source timeout

### DIFF
--- a/.docker/ci-shadow-fixed/Dockerfile
+++ b/.docker/ci-shadow-fixed/Dockerfile
@@ -26,6 +26,8 @@ RUN wstool init . && \
     apt-get -qq dist-upgrade && \
     # Install some base dependencies
     apt-get -qq install -y \
+        # Some source builds require a package.xml be downloaded via wget from an external location
+        wget \
         # Required for rosdep command
         sudo \
         # Required for installing dependencies

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -20,6 +20,8 @@ RUN wstool init . && \
     apt-get -qq update && \
     # Install some base dependencies
     apt-get -qq install -y \
+        # Some source builds require a package.xml be downloaded via wget from an external location
+        wget \
         # Required for rosdep command
         sudo \
         # Required for installing dependencies

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -1,7 +1,7 @@
 # moveit/moveit:kinetic-source
 # Downloads the moveit source code, install remaining debian dependencies, and builds workspace
 
-FROM moveit/moveit:kinetic-ci
+FROM moveit/moveit:kinetic-ci-shadow-fixed
 MAINTAINER Dave Coleman dave@dav.ee
 
 ENV CATKIN_WS=/root/ws_moveit
@@ -33,4 +33,6 @@ WORKDIR $CATKIN_WS
 ENV TERM xterm
 ENV PYTHONIOENCODING UTF-8
 RUN catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
-    catkin build --jobs 1
+    # Status rate is limited so that just enough info is shown to keep Docker from timing out, but not too much
+    # such that the Docker log gets too long (another form of timeout)
+    catkin build --jobs 1 --limit-status-rate 0.001 --no-notify


### PR DESCRIPTION
Build source image on shadow-fixed
Add wget for downloading package.xml files

I know I keep tweaking the Docker build and I apologize. Its hard to work around Docker's restrictive timeout constraints for our huge moveit build.