### PR TITLE
Destroy kinematics plugins before their loader

### DIFF
--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -144,9 +144,9 @@ private:
 
   void configure(const Options &opt);
 
-  robot_model::RobotModelPtr model_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
   kinematics_plugin_loader::KinematicsPluginLoaderPtr kinematics_loader_;
+  robot_model::RobotModelPtr model_;
 
 };
 

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -144,9 +144,9 @@ private:
 
   void configure(const Options &opt);
 
+  robot_model::RobotModelPtr model_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
   kinematics_plugin_loader::KinematicsPluginLoaderPtr kinematics_loader_;
-  robot_model::RobotModelPtr model_;
 
 };
 

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -100,6 +100,8 @@ public:
 
   RobotModelLoader(const std::string &robot_description, bool load_kinematics_solvers = true);
 
+  ~RobotModelLoader();
+
   /** @brief Get the constructed planning_models::RobotModel */
   const robot_model::RobotModelPtr& getModel() const
   {

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -51,6 +51,13 @@ robot_model_loader::RobotModelLoader::RobotModelLoader(const Options &opt)
   configure(opt);
 }
 
+robot_model_loader::RobotModelLoader::~RobotModelLoader()
+{
+  model_.reset();
+  rdf_loader_.reset();
+  kinematics_loader_.reset();
+}
+
 namespace
 {
 

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -53,6 +53,11 @@ robot_model_loader::RobotModelLoader::RobotModelLoader(const Options &opt)
 
 robot_model_loader::RobotModelLoader::~RobotModelLoader()
 {
+  // Make sure we destroy the robot model first. It contains the loaded
+  // kinematics plugins, and those must be destroyed before the pluginlib class
+  // that implements them is destroyed (that happens when kinematics_loader_ is
+  // destroyed below). This is a workaround - ideally pluginlib would handle
+  // this better.
   model_.reset();
   rdf_loader_.reset();
   kinematics_loader_.reset();


### PR DESCRIPTION
In small test programs, I've been getting the following error:
```
[/kinematic_plugin_test] [1476222361.566864946]: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
```
I tracked this down to the order of the member variables in RobotModelLoader. Because the KinematicsPluginLoader is last, it gets destroyed before the robot model. The robot model contains shared pointers to the loaded kinematics plugins, so they haven't been destroyed yet. The kinematics plugin loader then gives the above "Severe Warning". Changing the order of variables corrects this.

To reproduce, compile the following program:
```
#include <ros/ros.h>
#include <moveit/robot_model_loader/robot_model_loader.h>
#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
#include <tf/transform_listener.h>

int main(int argc, char **argv) {
    ros::init(argc, argv, "kinematic_plugin_tests");

    ros::AsyncSpinner spinner(1);
    spinner.start();

    boost::shared_ptr<tf::TransformListener> tf(new tf::TransformListener(ros::Duration(10.0)));

    {
        //robot_model_loader::RobotModelLoader rml("robot_description", true);
        planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor(
            new planning_scene_monitor::PlanningSceneMonitor("robot_description", tf));
    }
    return 0;
}
```
Run it after calling `roslaunch moveit_resources test_environment.launch` in another window.