### PR TITLE
Disable validate trajectory feature temporarily

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1077,7 +1077,10 @@ void TrajectoryExecutionManager::execute(const ExecutionCompleteCallback &callba
   stopExecution(false);
 
   // check whether first trajectory starts at current robot state
-  if (trajectories_.size() && !validate(*trajectories_.front()))
+  // TODO(rhaschke): Issues were found with continuous joints and this new validate() feature.
+  // It has been disabled temporarily for the first Kinetic release
+  // See https://github.com/ros-planning/moveit/issues/283
+  if (false && trajectories_.size() && !validate(*trajectories_.front()))
   {
     last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
     if (auto_clear)

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -50,7 +50,7 @@ class PythonMoveGroupTest(unittest.TestCase):
         self.assertTrue(self.group.execute(plan1))
 
         # second plan should be invalid now (due to modified start point) and rejected
-        self.assertFalse(self.group.execute(plan2))
+        #self.assertFalse(self.group.execute(plan2))
 
         # newly planned trajectory should execute again
         plan3 = self.plan(current)


### PR DESCRIPTION
We want to release Kinetic asap but there have been reported issues with this feature https://github.com/ros-planning/moveit/issues/283#issuecomment-254042178

This is a temporary disable of that feature until the next Kinetic release, to allow more soak time.