### PR TITLE
enforce joint bounds for start state validation

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -896,55 +896,40 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext &cont
     ROS_WARN_NAMED("traj_execution", "Failed to validate trajectory: couldn't receive full current joint state within 1s");
     return false;
   }
-  current_state->enforceBounds();
 
-  // build a RobotState that can be used to compare current_state and the start state with enforced bounds
-  robot_state::RobotState bounded_start_state(*current_state);
   for (std::vector<moveit_msgs::RobotTrajectory>::const_iterator traj_it = context.trajectory_parts_.begin();
        traj_it != context.trajectory_parts_.end(); ++traj_it)
   {
     const std::vector<double> &positions = traj_it->joint_trajectory.points.front().positions;
     const std::vector<std::string> &joint_names = traj_it->joint_trajectory.joint_names;
     const std::size_t n = joint_names.size();
-
     if (positions.size() != n)
     {
       ROS_ERROR_NAMED("traj_execution", "Wrong trajectory: #joints: %zu != #positions: %zu", n, positions.size());
       return false;
     }
 
-    try
-    {
-      bounded_start_state.setVariablePositions(joint_names, positions);
-    }
-    catch(moveit::Exception& e)
-    {
-      ROS_ERROR_STREAM_NAMED("traj_execution", "Unknown joint in trajectory: " << e.what());
-      return false;
-    }
-  }
-  bounded_start_state.enforceBounds();
-
-  for (std::vector<moveit_msgs::RobotTrajectory>::const_iterator traj_it = context.trajectory_parts_.begin();
-       traj_it != context.trajectory_parts_.end(); ++traj_it)
-  {
-    const std::vector<double> &positions = traj_it->joint_trajectory.points.front().positions;
-    const std::vector<std::string> &joint_names = traj_it->joint_trajectory.joint_names;
-    const std::size_t n = joint_names.size();
-
     for (std::size_t i = 0; i < n; ++i)
     {
       const robot_model::JointModel *jm = current_state->getJointModel(joint_names[i]);
-      const robot_model::JointModel *jm_start = bounded_start_state.getJointModel(joint_names[i]);
+      if (!jm)
+      {
+        ROS_ERROR_STREAM_NAMED("traj_execution", "Unknown joint in trajectory: " << joint_names[i]);
+        return false;
+      }
 
       // TODO: check multi-DoF joints ?
-      if (fabs(current_state->getJointPositions(jm)[0] - bounded_start_state.getJointPositions(jm_start)[0]) > allowed_start_tolerance_)
+      double cur_position = current_state->getJointPositions(jm)[0];
+      double traj_position = positions[i];
+      // normalize positions and compare
+      jm->enforcePositionBounds(&cur_position);
+      jm->enforcePositionBounds(&traj_position);
+      if (fabs(cur_position - traj_position) > allowed_start_tolerance_)
       {
         ROS_ERROR_NAMED("traj_execution",
                         "\nInvalid Trajectory: start point deviates from current robot state more than %g"
                         "\njoint '%s': expected: %g, current: %g",
-                        allowed_start_tolerance_,
-                        joint_names[i].c_str(), positions[i], current_state->getJointPositions(jm)[0]);
+                        allowed_start_tolerance_, joint_names[i].c_str(), traj_position, cur_position);
         return false;
       }
     }


### PR DESCRIPTION
Without this, unlimited joints might get out of the bounds
in the trajectory and will fail the validation.

This resolves #283. In theory this deprecates #287 .
Feel free to improve the request, I pushed the request-branch to this repo.

The patch has been verified on our PR2.

Should be picked to j/k