### PR TITLE
wait a second before updating "current" in RViz

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -176,7 +176,10 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
 
   // update query start state to current if neccessary
   if (ui_->start_state_selection->currentText() == "<current>")
+  {
+    ros::Duration(1).sleep();
     useStartStateButtonClicked();
+  }
 }
 
 void MotionPlanningFrame::useStartStateButtonClicked()


### PR DESCRIPTION
This is a poor-man's-replacement for rhaschke's work that
waits for the current robot state. This can be removed after
his work is merged. (See https://github.com/ros-planning/moveit/pull/232)

Without the additional sleep the automatic update of the start state
will pick a point near the end of the executed trajectory instead of
the current state. Let's give the monitor a moment to catch up.

This is intended to be part of the next release because @rhaschke's code will probably not be in there.