### PR TITLE
Namespaced console output for planning_scene_monitor

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -490,6 +490,8 @@ private:
   // Callback for a new planning scene msg
   void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr &scene);
 
+  // Name of this class
+  const std::string name_ = "planning_scene_monitor";
 
   // Lock for state_update_pending_ and dt_state_update_
   boost::mutex state_pending_mutex_;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -196,7 +196,7 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
       }
       catch (moveit::ConstructException &e)
       {
-        ROS_ERROR("Configuration of planning scene failed");
+        ROS_ERROR_NAMED(name_, "Configuration of planning scene failed");
         scene_.reset();
         scene_const_ = scene_;
       }
@@ -209,7 +209,7 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
   }
   else
   {
-    ROS_ERROR("Robot model not loaded");
+    ROS_ERROR_NAMED(name_, "Robot model not loaded");
   }
 
   publish_planning_scene_frequency_ = 2.0;
@@ -262,7 +262,8 @@ void planning_scene_monitor::PlanningSceneMonitor::monitorDiffs(bool flag)
     {
       if (publish_planning_scene_)
       {
-        ROS_WARN("Diff monitoring was stopped while publishing planning scene diffs. Stopping planning scene diff publisher");
+        ROS_WARN_NAMED(name_, "Diff monitoring was stopped while publishing planning scene diffs. "
+                       "Stopping planning scene diff publisher");
         stopPublishingPlanningScene();
       }
       {
@@ -293,7 +294,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopPublishingPlanningScene()
     copy->join();
     monitorDiffs(false);
     planning_scene_publisher_.shutdown();
-    ROS_INFO("Stopped publishing maintained planning scene.");
+    ROS_INFO_NAMED(name_, "Stopped publishing maintained planning scene.");
   }
 }
 
@@ -303,7 +304,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startPublishingPlanningScene(
   if (!publish_planning_scene_ && scene_)
   {
     planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>(planning_scene_topic, 100, false);
-    ROS_INFO("Publishing maintained planning scene on '%s'", planning_scene_topic.c_str());
+    ROS_INFO_NAMED(name_, "Publishing maintained planning scene on '%s'", planning_scene_topic.c_str());
     monitorDiffs(true);
     publish_planning_scene_.reset(new boost::thread(boost::bind(&PlanningSceneMonitor::scenePublishingThread, this)));
   }
@@ -311,7 +312,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startPublishingPlanningScene(
 
 void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
 {
-  ROS_DEBUG("Started scene publishing thread ...");
+  ROS_DEBUG_NAMED(name_, "Started scene publishing thread ...");
 
   // publish the full planning scene
   moveit_msgs::PlanningScene msg;
@@ -321,7 +322,7 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
     scene_->getPlanningSceneMsg(msg);
   }
   planning_scene_publisher_.publish(msg);
-  ROS_DEBUG("Published the full planning scene: '%s'", msg.name.c_str());
+  ROS_DEBUG_NAMED(name_, "Published the full planning scene: '%s'", msg.name.c_str());
 
   do
   {
@@ -373,7 +374,7 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
       rate.reset();
       planning_scene_publisher_.publish(msg);
       if (is_full)
-        ROS_DEBUG("Published full planning scene: '%s'", msg.name.c_str());
+        ROS_DEBUG_NAMED(name_, "Published full planning scene: '%s'", msg.name.c_str());
       rate.sleep();
     }
   }
@@ -450,7 +451,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(con
   // Make sure client is connected to server
   if (!client.exists())
   {
-    ROS_DEBUG_STREAM("Waiting for service `" << service_name << "` to exist.");
+    ROS_DEBUG_STREAM_NAMED(name_,"Waiting for service `" << service_name << "` to exist.");
     client.waitForExistence(ros::Duration(5.0));
   }
 
@@ -460,7 +461,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(con
   }
   else
   {
-    ROS_WARN("Failed to call service %s, have you launched move_group? at %s:%d",
+    ROS_WARN_NAMED(name_, "Failed to call service %s, have you launched move_group? at %s:%d",
       service_name.c_str(),
       __FILE__,
       __LINE__);
@@ -643,7 +644,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeRobotLinksFromOctree()
     }
     if(!warned && ((ros::WallTime::now() - start) > ros::WallDuration(30.0)))
     {
-      ROS_WARN_STREAM_NAMED("planning_scene_monitor", "It is likely there are too many vertices in collision geometry");
+      ROS_WARN_STREAM_NAMED(name_, "It is likely there are too many vertices in collision geometry");
       warned = true;
     }
   }
@@ -730,7 +731,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeAttachedBodyFromOctree
     }
   }
   if (found)
-    ROS_DEBUG("Excluding attached body '%s' from monitored octomap", attached_body->getName().c_str());
+    ROS_DEBUG_NAMED(name_, "Excluding attached body '%s' from monitored octomap", attached_body->getName().c_str());
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::includeAttachedBodyInOctree(const robot_state::AttachedBody *attached_body)
@@ -745,7 +746,7 @@ void planning_scene_monitor::PlanningSceneMonitor::includeAttachedBodyInOctree(c
   {
     for (std::size_t k = 0 ; k < it->second.size() ; ++k)
       octomap_monitor_->forgetShape(it->second[k].first);
-    ROS_DEBUG("Including attached body '%s' in monitored octomap", attached_body->getName().c_str());
+    ROS_DEBUG_NAMED(name_, "Including attached body '%s' in monitored octomap", attached_body->getName().c_str());
     attached_body_shape_handles_.erase(it);
   }
 }
@@ -770,7 +771,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeWorldObjectFromOctree(
     }
   }
   if (found)
-    ROS_DEBUG("Excluding collision object '%s' from monitored octomap", obj->id_.c_str());
+    ROS_DEBUG_NAMED(name_, "Excluding collision object '%s' from monitored octomap", obj->id_.c_str());
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::includeWorldObjectInOctree(const collision_detection::World::ObjectConstPtr &obj)
@@ -785,7 +786,7 @@ void planning_scene_monitor::PlanningSceneMonitor::includeWorldObjectInOctree(co
   {
     for (std::size_t k = 0 ; k < it->second.size() ; ++k)
       octomap_monitor_->forgetShape(it->second[k].first);
-    ROS_DEBUG("Including collision object '%s' in monitored octomap", obj->id_.c_str());
+    ROS_DEBUG_NAMED(name_, "Including collision object '%s' in monitored octomap", obj->id_.c_str());
     collision_body_shape_handles_.erase(it);
   }
 }
@@ -852,12 +853,12 @@ void planning_scene_monitor::PlanningSceneMonitor::startSceneMonitor(const std::
 {
   stopSceneMonitor();
 
-  ROS_INFO("Starting scene monitor");
+  ROS_INFO_NAMED(name_, "Starting scene monitor");
   // listen for planning scene updates; these messages include transforms, so no need for filters
   if (!scene_topic.empty())
   {
     planning_scene_subscriber_ = root_nh_.subscribe(scene_topic, 100, &PlanningSceneMonitor::newPlanningSceneCallback, this);
-    ROS_INFO("Listening to '%s'", root_nh_.resolveName(scene_topic).c_str());
+    ROS_INFO_NAMED(name_, "Listening to '%s'", root_nh_.resolveName(scene_topic).c_str());
   }
 }
 
@@ -865,7 +866,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopSceneMonitor()
 {
   if (planning_scene_subscriber_)
   {
-    ROS_INFO("Stopping scene monitor");
+    ROS_INFO_NAMED(name_, "Stopping scene monitor");
     planning_scene_subscriber_.shutdown();
   }
 }
@@ -912,7 +913,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::getShapeTransformCache(const 
   }
   catch (tf::TransformException& ex)
   {
-    ROS_ERROR_THROTTLE(1, "Transform error: %s", ex.what());
+    ROS_ERROR_THROTTLE_NAMED(1, name_, "Transform error: %s", ex.what());
     return false;
   }
   return true;
@@ -923,7 +924,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startWorldGeometryMonitor(con
                                                                              const bool load_octomap_monitor)
 {
   stopWorldGeometryMonitor();
-  ROS_INFO("Starting world geometry monitor");
+  ROS_INFO_NAMED(name_, "Starting world geometry monitor");
 
   // listen for world geometry updates using message filters
   if (!collision_objects_topic.empty())
@@ -934,19 +935,22 @@ void planning_scene_monitor::PlanningSceneMonitor::startWorldGeometryMonitor(con
       collision_object_filter_ .reset(new tf::MessageFilter<moveit_msgs::CollisionObject>(*collision_object_subscriber_, *tf_, scene_->getPlanningFrame(), 1024));
       collision_object_filter_->registerCallback(boost::bind(&PlanningSceneMonitor::collisionObjectCallback, this, _1));
       collision_object_filter_->registerFailureCallback(boost::bind(&PlanningSceneMonitor::collisionObjectFailTFCallback, this, _1, _2));
-      ROS_INFO("Listening to '%s' using message notifier with target frame '%s'", root_nh_.resolveName(collision_objects_topic).c_str(), collision_object_filter_->getTargetFramesString().c_str());
+      ROS_INFO_NAMED(name_, "Listening to '%s' using message notifier with target frame '%s'",
+                     root_nh_.resolveName(collision_objects_topic).c_str(),
+                     collision_object_filter_->getTargetFramesString().c_str());
     }
     else
     {
       collision_object_subscriber_->registerCallback(boost::bind(&PlanningSceneMonitor::collisionObjectCallback, this, _1));
-      ROS_INFO("Listening to '%s'", root_nh_.resolveName(collision_objects_topic).c_str());
+      ROS_INFO_NAMED(name_, "Listening to '%s'", root_nh_.resolveName(collision_objects_topic).c_str());
     }
   }
 
   if (!planning_scene_world_topic.empty())
   {
     planning_scene_world_subscriber_ = root_nh_.subscribe(planning_scene_world_topic, 1, &PlanningSceneMonitor::newPlanningSceneWorldCallback, this);
-    ROS_INFO("Listening to '%s' for planning scene world geometry", root_nh_.resolveName(planning_scene_world_topic).c_str());
+    ROS_INFO_NAMED(name_, "Listening to '%s' for planning scene world geometry",
+                   root_nh_.resolveName(planning_scene_world_topic).c_str());
   }
 
   // Ocotomap monitor is optional
@@ -970,7 +974,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopWorldGeometryMonitor()
 {
   if (collision_object_subscriber_ || collision_object_filter_)
   {
-    ROS_INFO("Stopping world geometry monitor");
+    ROS_INFO_NAMED(name_, "Stopping world geometry monitor");
     collision_object_filter_.reset();
     collision_object_subscriber_.reset();
     planning_scene_world_subscriber_.shutdown();
@@ -978,7 +982,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopWorldGeometryMonitor()
   else
     if (planning_scene_world_subscriber_)
     {
-      ROS_INFO("Stopping world geometry monitor");
+      ROS_INFO_NAMED(name_, "Stopping world geometry monitor");
       planning_scene_world_subscriber_.shutdown();
     }
   if (octomap_monitor_)
@@ -1005,11 +1009,11 @@ void planning_scene_monitor::PlanningSceneMonitor::startStateMonitor(const std::
     {
       // using regular message filter as there's no header
       attached_collision_object_subscriber_ = root_nh_.subscribe(attached_objects_topic, 1024, &PlanningSceneMonitor::attachObjectCallback, this);
-      ROS_INFO("Listening to '%s' for attached collision objects", root_nh_.resolveName(attached_objects_topic).c_str());
+      ROS_INFO_NAMED(name_, "Listening to '%s' for attached collision objects", root_nh_.resolveName(attached_objects_topic).c_str());
     }
   }
   else
-    ROS_ERROR("Cannot monitor robot state because planning scene is not configured");
+    ROS_ERROR_NAMED(name_, "Cannot monitor robot state because planning scene is not configured");
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::stopStateMonitor()
@@ -1122,7 +1126,7 @@ void planning_scene_monitor::PlanningSceneMonitor::setStateUpdateFrequency(doubl
     if (state_update_pending_)
       update = true;
   }
-  ROS_INFO("Updating internal planning scene state at most every %lf seconds", dt_state_update_.toSec());
+  ROS_INFO_NAMED(name_, "Updating internal planning scene state at most every %lf seconds", dt_state_update_.toSec());
 
   if (update)
     updateSceneWithCurrentState();
@@ -1136,7 +1140,7 @@ void planning_scene_monitor::PlanningSceneMonitor::updateSceneWithCurrentState()
     if (!current_state_monitor_->haveCompleteState(missing) && (ros::Time::now() - current_state_monitor_->getMonitorStartTime()).toSec() > 1.0)
     {
       std::string missing_str = boost::algorithm::join(missing, ", ");
-      ROS_WARN_THROTTLE(1, "The complete state of the robot is not yet known.  Missing %s", missing_str.c_str());
+      ROS_WARN_THROTTLE_NAMED(1, name_, "The complete state of the robot is not yet known.  Missing %s", missing_str.c_str());
     }
 
     {
@@ -1148,7 +1152,7 @@ void planning_scene_monitor::PlanningSceneMonitor::updateSceneWithCurrentState()
     triggerSceneUpdateEvent(UPDATE_STATE);
   }
   else
-    ROS_ERROR_THROTTLE(1, "State monitor is not active. Unable to set the planning scene state");
+    ROS_ERROR_THROTTLE_NAMED(1, name_, "State monitor is not active. Unable to set the planning scene state");
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::addUpdateCallback(const boost::function<void(SceneUpdateType)> &fn)
@@ -1167,7 +1171,7 @@ void planning_scene_monitor::PlanningSceneMonitor::clearUpdateCallbacks()
 void planning_scene_monitor::PlanningSceneMonitor::setPlanningScenePublishingFrequency(double hz)
 {
   publish_planning_scene_frequency_ = hz;
-  ROS_DEBUG("Maximum frquency for publishing a planning scene is now %lf Hz", publish_planning_scene_frequency_);
+  ROS_DEBUG_NAMED(name_, "Maximum frquency for publishing a planning scene is now %lf Hz", publish_planning_scene_frequency_);
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::getUpdatedFrameTransforms(std::vector<geometry_msgs::TransformStamped> &transforms)
@@ -1188,7 +1192,7 @@ void planning_scene_monitor::PlanningSceneMonitor::getUpdatedFrameTransforms(std
     std::string err_string;
     if (tf_->getLatestCommonTime(target, all_frame_names[i], stamp, &err_string) != tf::NO_ERROR)
     {
-      ROS_WARN_STREAM("No transform available between frame '" << all_frame_names[i] << "' and planning frame '" <<
+      ROS_WARN_STREAM_NAMED(name_, "No transform available between frame '" << all_frame_names[i] << "' and planning frame '" <<
                       target << "' (" << err_string << ")");
       continue;
     }
@@ -1200,7 +1204,7 @@ void planning_scene_monitor::PlanningSceneMonitor::getUpdatedFrameTransforms(std
     }
     catch (tf::TransformException& ex)
     {
-      ROS_WARN_STREAM("Unable to transform object from frame '" << all_frame_names[i] << "' to planning frame '" <<
+      ROS_WARN_STREAM_NAMED(name_,"Unable to transform object from frame '" << all_frame_names[i] << "' to planning frame '" <<
                       target << "' (" << ex.what() << ")");
       continue;
     }
@@ -1253,23 +1257,23 @@ void planning_scene_monitor::PlanningSceneMonitor::configureCollisionMatrix(cons
 
   // first we do default collision operations
   if (!nh_.hasParam(robot_description_ + "_planning/default_collision_operations"))
-    ROS_DEBUG("No additional default collision operations specified");
+    ROS_DEBUG_NAMED(name_, "No additional default collision operations specified");
   else
   {
-    ROS_DEBUG("Reading additional default collision operations");
+    ROS_DEBUG_NAMED(name_, "Reading additional default collision operations");
 
     XmlRpc::XmlRpcValue coll_ops;
     nh_.getParam(robot_description_ + "_planning/default_collision_operations", coll_ops);
 
     if (coll_ops.getType() != XmlRpc::XmlRpcValue::TypeArray)
     {
-      ROS_WARN("default_collision_operations is not an array");
+      ROS_WARN_NAMED(name_, "default_collision_operations is not an array");
       return;
     }
 
     if (coll_ops.size() == 0)
     {
-      ROS_WARN("No collision operations in default collision operations");
+      ROS_WARN_NAMED(name_, "No collision operations in default collision operations");
       return;
     }
 
@@ -1277,7 +1281,7 @@ void planning_scene_monitor::PlanningSceneMonitor::configureCollisionMatrix(cons
     {
       if (!coll_ops[i].hasMember("object1") || !coll_ops[i].hasMember("object2") || !coll_ops[i].hasMember("operation"))
       {
-        ROS_WARN("All collision operations must have two objects and an operation");
+        ROS_WARN_NAMED(name_, "All collision operations must have two objects and an operation");
         continue;
       }
       acm.setEntry(std::string(coll_ops[i]["object1"]), std::string(coll_ops[i]["object2"]), std::string(coll_ops[i]["operation"]) == "disable");
@@ -1306,8 +1310,8 @@ void planning_scene_monitor::PlanningSceneMonitor::configureDefaultPadding()
   nh_.param(robot_description + "_planning/default_robot_link_padding", default_robot_link_padd_, std::map<std::string, double>());
   nh_.param(robot_description + "_planning/default_robot_link_scale", default_robot_link_scale_, std::map<std::string, double>());
 
-  ROS_DEBUG_STREAM_NAMED("planning_scene_monitor", "Loaded " << default_robot_link_padd_.size()
+  ROS_DEBUG_STREAM_NAMED(name_, "Loaded " << default_robot_link_padd_.size()
                          << " default link paddings");
-  ROS_DEBUG_STREAM_NAMED("planning_scene_monitor", "Loaded " << default_robot_link_scale_.size()
+  ROS_DEBUG_STREAM_NAMED(name_, "Loaded " << default_robot_link_scale_.size()
                          << " default link scales");
 }


### PR DESCRIPTION
Allows one to turn off noisy debug messages from planning scene monitor while keeping on debug for moveit_planning package.

Can be backported to I/J