### PR TITLE
renamed CSM::waitForCurrentState() to CSM::waitForCompleteState()

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -44,6 +44,7 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+#include <moveit/macros/deprecation.h>
 
 namespace planning_scene_monitor
 {
@@ -136,11 +137,15 @@ public:
    *  @return Returns the map from joint names to joint state values*/
   std::map<std::string, double> getCurrentStateValues() const;
 
-  /** @brief Wait for at most \e wait_time seconds until the complete current state is known. Return true if the full state is known */
-  bool waitForCurrentState(double wait_time) const;
+  /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
+  bool waitForCompleteState(double wait_time) const;
+  /** replaced by waitForCompleteState, will be removed in L-turtle: function waits for complete robot state */
+  MOVEIT_DEPRECATED bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
-  bool waitForCurrentState(const std::string &group, double wait_time) const;
+  bool waitForCompleteState(const std::string &group, double wait_time) const;
+  /** replaced by waitForCompleteState, will be removed in L-turtle: function waits for complete robot state */
+  MOVEIT_DEPRECATED bool waitForCurrentState(const std::string &group, double wait_time) const;
 
   /** @brief Get the time point when the monitor was started */
   const ros::Time& getMonitorStartTime() const

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -263,7 +263,7 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::D
   return result;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wait_time) const
+bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(double wait_time) const
 {
   double slept_time = 0.0;
   double sleep_step_s = std::min(0.05, wait_time / 10.0);
@@ -275,10 +275,14 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wai
   }
   return haveCompleteState();
 }
-
-bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std::string &group, double wait_time) const
+bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(double wait_time) const
 {
-  if (waitForCurrentState(wait_time))
+  waitForCompleteState(wait_time);
+}
+
+bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(const std::string &group, double wait_time) const
+{
+  if (waitForCompleteState(wait_time))
     return true;
   bool ok = true;
 
@@ -301,6 +305,11 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std:
       ok = false;
   }
   return ok;
+}
+
+bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const std::string &group, double wait_time) const
+{
+  waitForCompleteState(group, wait_time);
 }
 
 void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const sensor_msgs::JointStateConstPtr &joint_state)

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -878,7 +878,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext &cont
   ROS_DEBUG_NAMED("traj_execution", "Validating trajectory with allowed_start_tolerance %g", allowed_start_tolerance_);
 
   robot_state::RobotStatePtr current_state;
-  if (!csm_->waitForCurrentState(1.0) || !(current_state = csm_->getCurrentState()))
+  if (!csm_->waitForCompleteState(1.0) || !(current_state = csm_->getCurrentState()))
   {
     ROS_WARN_NAMED("traj_execution", "Failed to validate trajectory: couldn't receive full current joint state within 1s");
     return false;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -530,7 +530,7 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    current_state_monitor_->waitForCurrentState(opt_.group_name_, wait);
+    current_state_monitor_->waitForCompleteState(opt_.group_name_, wait);
     return true;
   }
 
@@ -546,7 +546,7 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    if (!current_state_monitor_->waitForCurrentState(opt_.group_name_, wait_seconds))
+    if (!current_state_monitor_->waitForCompleteState(opt_.group_name_, wait_seconds))
       ROS_WARN("Joint values for monitored state are requested but the full state is not known");
 
     current_state = current_state_monitor_->getCurrentState();

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -191,7 +191,7 @@ public:
     if (!current_state_monitor_->isActive())
     {
       current_state_monitor_->startStateMonitor();
-      if (!current_state_monitor_->waitForCurrentState(wait))
+      if (!current_state_monitor_->waitForCompleteState(wait))
         ROS_WARN("Joint values for monitored state are requested but the full state is not known");
     }
     return true;


### PR DESCRIPTION
.. to better reflect the actual semantics of the method.
To maintain API compatibility, the old function still exists, but is deprecated.

Again, this is extracted from #232.