### PR TITLE
Fix python movegroup usage

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -477,7 +477,7 @@ public:
   MoveGroupWrapper(const std::string &group_name, const std::string &robot_description) :
     MoveGroupInterfaceWrapper(group_name, robot_description)
   {
-    ROS_WARN("The MoveGroup class is deprecated and will go away in ROS lunar. Please use MoveGroupInterface instead.");
+    ROS_WARN("The MoveGroup class is deprecated and will be removed in ROS lunar. Please use MoveGroupInterface instead.");
   }
 
 };

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -1,9 +1,8 @@
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest)
 
-  # This test fails due to a ROS core bug: https://github.com/ros/ros_comm/pull/871
-  #add_rostest_gtest(test_cleanup cleanup.test cleanup.cpp)
-  #target_link_libraries(test_cleanup moveit_move_group_interface)
+  add_rostest_gtest(test_cleanup cleanup.test cleanup.cpp)
+  target_link_libraries(test_cleanup moveit_move_group_interface)
 
   add_rostest(python_move_group.test)
 endif()

--- a/moveit_ros/planning_interface/test/movegroup_interface.py
+++ b/moveit_ros/planning_interface/test/movegroup_interface.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
-from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroup
-group = MoveGroup("manipulator", "robot_description")
+from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroupInterface
+group = MoveGroupInterface("manipulator", "robot_description")

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -6,7 +6,7 @@ import rospy
 import rostest
 import os
 
-from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroup
+from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroupInterface
 
 
 class PythonMoveGroupTest(unittest.TestCase):
@@ -14,7 +14,7 @@ class PythonMoveGroupTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.group = MoveGroup(self.PLANNING_GROUP, "robot_description")
+        self.group = MoveGroupInterface(self.PLANNING_GROUP, "robot_description")
 
     @classmethod
     def tearDown(self):


### PR DESCRIPTION
replaced deprecated MoveGroup with MoveGroupInterface in python-based unit test
re-enabled c++ unit test