### PR TITLE
Remove an already-deleted moveit_ros_benchmark_gui from package.xml entry.

### DIFF
--- a/moveit_ros/moveit_ros/package.xml
+++ b/moveit_ros/moveit_ros/package.xml
@@ -23,7 +23,6 @@
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>moveit_ros_warehouse</run_depend>
   <run_depend>moveit_ros_benchmarks</run_depend>
-  <run_depend>moveit_ros_benchmarks_gui</run_depend>
   <run_depend>moveit_ros_robot_interaction</run_depend>
   <run_depend>moveit_ros_planning_interface</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>


### PR DESCRIPTION
Following https://github.com/ros-planning/moveit/pull/228

This change is required for `bloom` to make a release.