### PR TITLE
Rename chomp_interface to moveit_planners_chomp

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(chomp_interface)
+project(moveit_planners_chomp)
 
 add_definitions(-std=c++11)
 
@@ -23,7 +23,7 @@ find_package(Boost REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES chomp_interface
+  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp moveit_core pluginlib
 )
 
@@ -35,20 +35,20 @@ include_directories(
 
 add_library(${PROJECT_NAME} src/chomp_interface.cpp src/chomp_planning_context.cpp)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
-target_link_libraries(chomp_interface ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_library(chomp_planner_plugin src/chomp_plugin.cpp)
 set_target_properties(chomp_planner_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
-target_link_libraries(chomp_planner_plugin chomp_interface ${catkin_LIBRARIES})
+target_link_libraries(chomp_planner_plugin ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 install(FILES chomp_interface_plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(DIRECTORY include/${PROJECT_NAME}/
+install(DIRECTORY include/chomp_interface/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-install(TARGETS chomp_interface chomp_planner_plugin
+install(TARGETS ${PROJECT_NAME} chomp_planner_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -1,10 +1,10 @@
 <package>
-  <name>chomp_interface</name>
-  <description>The chomp_interface package</description>
+  <name>moveit_planners_chomp</name>
+  <description>The interface for using CHOMP within MoveIt!</description>
 
   <version>0.9.0</version>
   <author email="gjones@willowgarage.com">Gil Jones</author>
-  
+
   <maintainer email="chitt@live.in">Chittaranjan S Srinivas</maintainer>
 
   <license>BSD</license>
@@ -17,15 +17,13 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>moveit_experimental</build_depend>
-  
+
   <run_depend>roscpp</run_depend>
   <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>  
-  
+  <run_depend>pluginlib</run_depend>
+
   <export>
     <moveit_core plugin="${prefix}/chomp_interface_plugin_description.xml"/>
   </export>
 
 </package>
-
-


### PR DESCRIPTION
The [ompl_interface](https://github.com/ros-planning/moveit/tree/kinetic-devel/moveit_planners/ompl) folder is actually the package ``moveit_planners_ompl``. While I was updating the [list of moveit's packages](https://github.com/davetcoleman/moveit.ros.org/blob/b3522540426f63833eeaa7a7230592a9b383da5d/about/source_code.markdown) on the website yesterday I realized how inconsistent the naming convention is for the ``chomp_interface`` package:

> moveit - Metapackage
> moveit_core - Core functionality including RobotModel, RobotState, collision checking
> moveit_ros_planning - planning components, execution manager, plugin loaders
> moveit_ros_move_group - The move_group main node for using MoveIt! via ROS messages
> moveit_ros_planning_interface - Python and ROS msg interfaces to communicate with move_group
> moveit_ros_perception - Octomap and other perception plugins
> moveit_ros_manipulation - High level pick and place pipeline
> moveit_ros_robot_interaction - Interative marker tools for Rviz
> moveit_ros_visualization - Rviz tools
> moveit_ros_warehouse - Database plugins for storing scene and configuration data
> moveit_ros_benchmarks - Benchmarking using PlannerArena
> moveit_ros - Deprecated metapackage
> moveit_planners - Deprecated metapackage
> moveit_planners_ompl - Open Motion Planning Library plugin
> moveit_commander - terminal-based control interface using Python-like syntax
> moveit_setup_assistant - GUI for quickly setting up MoveIt!
> moveit_plugins - plugins for controller managers
> chomp_motion_planner - Gradient Optimization Techniques for Efficient Motion Planning
> **chomp_interface - adapter for using CHOMP with MoveIt!**

I'd like to rename that package to match ``moveit_planners_ompl`` while the chomp work is still very new and basically unused. Another future goal is probably to move the ``chomp_motion_planner`` into a separate repo in ``ros-planning``, similar to how ompl is external. But that is of much lower priority compared to renaming a package.

@ksatyaki