### PR TITLE
change find_package Eigen3 to 'Eigen 3' in chomp_interface

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_experimental
 )
 
-find_package(Eigen3 REQUIRED)
+find_package(Eigen 3 REQUIRED)
 
 find_package(Boost REQUIRED)
 


### PR DESCRIPTION
Since there isn't FindEigen3.cmake in cmake_modules of moveit on indigo branch, change this to find Eigen while require version greater than 3.