### PR TITLE
Add issue and pull requests templates for Github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+### Description
+
+Overview of your issue here.
+
+### Your environment
+* ROS Distro: [Indigo|Jade|Kinetic]
+* OS Version: e.g. Ubuntu 16.04
+* Source or Binary build?
+* If binary, which release version?
+* If source, which git commit or tag?
+
+### Steps to reproduce
+Tell us how to reproduce this issue. Attempt to provide a working demo, perhaps using Docker.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Backtrace or Console output
+
+Use [gist.github.com](gist.github.com) to copy-paste the console output or segfault backtrace using gdb.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### Description
+
+Please explain the changes you made, including a reference to the related issue if applicable
+
+### Checklist
+- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
+- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
+- [ ] Include a screenshot if changing a GUI
+- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
+- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
+
+Thank you!


### PR DESCRIPTION
Since clang-format is required now, I figured we should warn users with these templates