### PR TITLE
Increase the default discretization of collision checking motions

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -418,8 +418,9 @@ bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)
     {
       emitter << YAML::Key << "projection_evaluator";
       emitter << YAML::Value << projection_joints;
+      // OMPL collision checking discretization
       emitter << YAML::Key << "longest_valid_segment_fraction";
-      emitter << YAML::Value << "0.05";
+      emitter << YAML::Value << "0.01";
     }
 
     emitter << YAML::EndMap;


### PR DESCRIPTION
Many users have complained about collision checking missing small obstacles ([ref](https://bitbucket.org/ompl/ompl/issues/100/solution-path-may-slightly-touch-on-an)). This will change the default value new users use when setting up a robot with MoveIt!. I'd actually prefer smaller (I use 0.005 in my configs), but I figure increasing the collision checking planning time by 5x is a big enough change for now.

Interestingly, the old arm navigation used [0.001](http://wiki.ros.org/arm_navigation/Tutorials/tools/Understanding%20and%20adjusting%20the%20autogenerated%20arm_navigation%20application), a very small value.

I think we should just keep this in kinetic, though we could pick it to IJ.