### PR TITLE
Fix CHANGELOG encoding for 0.9.1 (Fix #318).

### DIFF
--- a/moveit_core/CHANGELOG.rst
+++ b/moveit_core/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog for package moveit_core
 ------------------
 * [feat] planning_scene updates: expose success state to caller. This is required to get the information back for the ApplyPlanningSceneService. `#296 <https://github.com/ros-planning/moveit_core/issues/297>`_
 * [sys] replaced cmake_modules dependency with eigen
-* Contributors: Michael Ferguson, Robert Haschke, Michael Gè´”rner, Isaac I. Y. Saito
+* Contributors: Michael Ferguson, Robert Haschke, Michael Goerner, Isaac I. Y. Saito
 
 0.8.1 (2016-05-19)
 ------------------
@@ -37,7 +37,7 @@ Changelog for package moveit_core
 * [sys] Install static libs `#251 <https://github.com/ros-planning/moveit_core/issues/251>`_
 * [enhance] Allow a RobotTrajectory to be initialized with a pointer joint model group `#245 <https://github.com/ros-planning/moveit_core/issues/245>`_
 * [doc] Better documentation and formatting `#244 <https://github.com/ros-planning/moveit_core/issues/244>`_
-* Contributors: Alexis Ballier, Bastian Gaspers, Christian Dornhege, Dave Coleman, Gary Servin, Ioan A Sucan, Isaac I.Y. Saito, Jim Mainprice, Levi Armstrong, Michael Ferguson, Mihai Pomarlan, Robert Haschke, Sachin Chitta, Sam Pfeiffer, Steven Peters, S√©verin Lemaignan, jrgnicho, ros-devel, simonschmeisser
+* Contributors: Alexis Ballier, Bastian Gaspers, Christian Dornhege, Dave Coleman, Gary Servin, Ioan A Sucan, Isaac I.Y. Saito, Jim Mainprice, Levi Armstrong, Michael Ferguson, Mihai Pomarlan, Robert Haschke, Sachin Chitta, Sam Pfeiffer, Steven Peters, Severin Lemaignan, jrgnicho, ros-devel, simonschmeisser
 
 0.6.15 (2015-01-20)
 -------------------


### PR DESCRIPTION
### Description

Quick fix to #318

@severin-lemaignan @v4hn Editor tools I'm using don't seem to handle correctly your name (I'll have to fix this in the near future). Hope this change would be ok for you for now.
### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
  - --> Not applicable; this is a fix.
- [x] Include a screenshot if changing a GUI
  - --> Not applicable; no GUI.
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
  - --> Since this encoding issue have happened multiple times, I have to think of adding a check.
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
  - --> Not applicable since this is required by kinetic-devel only.
