### PR TITLE
remove grasp service support from pick_place's fillGrasp

### DIFF
--- a/moveit_ros/manipulation/CMakeLists.txt
+++ b/moveit_ros/manipulation/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_ros_move_group
   dynamic_reconfigure
-  manipulation_msgs
   roscpp
   rosconsole
   tf

--- a/moveit_ros/manipulation/package.xml
+++ b/moveit_ros/manipulation/package.xml
@@ -24,13 +24,10 @@
   <build_depend>moveit_ros_move_group</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_msgs</build_depend>
-  <build_depend>manipulation_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>pluginlib</build_depend>
-  <build_depend>household_objects_database_msgs</build_depend>
-  <build_depend>manipulation_msgs</build_depend>
   <build_depend>eigen</build_depend>
 
   <run_depend>actionlib</run_depend>
@@ -43,8 +40,6 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>pluginlib</run_depend>
-  <run_depend>household_objects_database_msgs</run_depend>
-  <run_depend>manipulation_msgs</run_depend>
 
   <export>
     <moveit_ros_move_group plugin="${prefix}/pick_place_capability_plugin_description.xml"/>


### PR DESCRIPTION
The combination of the service support here and an optional hard-coded default grasp
is problematic because if the service is not available for any reason, but should be called,
the pick-request will end up with the hard-coded grasp.
This can create unexpected trajectories.

With MoveGroupInterface::planGraspsAndPick, a replacement for the removed functionality
is available.

This removes the dependencies on manipulation_msgs and household_objects_database_msgs.
(These were not even consistently specified in package.xml and CMakeLists.txt)

Should not be back-ported to retain current behavior.