### PR TITLE
clang-format: add SortIncludes: false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,6 +38,7 @@ TabWidth:        2
 UseTab:          Never
 BreakBeforeBraces: Allman
 IndentFunctionDeclarationAfterType: false
+SortIncludes: false
 SpacesInParentheses: false
 SpacesInAngles:  false
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
I have no idea whether this is compatible with clang-format 3.6,
but clang-format 3.9 keeps reordering my includes without this flag...

This is not the only change it makes, but the most drastic.
Could we come up with a more rigerous style file that does not invoke
different behavior between the different versions?