### PR TITLE
Fix xacro warnings in Kinetic

### DIFF
--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1000,7 +1000,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
 
   // Pair 3
   if (config_data_->urdf_from_xacro_)
-    addTemplateString("[URDF_LOAD_ATTRIBUTE]", "command=\"$(find xacro)/xacro.py '" + urdf_location + "'\"");
+    addTemplateString("[URDF_LOAD_ATTRIBUTE]", "command=\"$(find xacro)/xacro --inorder '" + urdf_location + "'\"");
   else
     addTemplateString("[URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 


### PR DESCRIPTION
The default template launch files in the setup assistant generate lots of warnings in kinetic, same logic as described https://github.com/ros-planning/moveit/pull/238

Should not be picked to I/J