### PR TITLE
Increase collision checking interval

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -420,7 +420,7 @@ bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)
       emitter << YAML::Value << projection_joints;
       // OMPL collision checking discretization
       emitter << YAML::Key << "longest_valid_segment_fraction";
-      emitter << YAML::Value << "0.01";
+      emitter << YAML::Value << "0.005";
     }
 
     emitter << YAML::EndMap;


### PR DESCRIPTION
I'm trying to improve the reliability of planning requests in the move_group_interface_tutorial as described in this [issue](https://github.com/ros-planning/moveit_tutorials/pull/34). I benchmarked two tests, 100 runs each:

1. Planning with orientation constraint
2. Planning around simple cuboid obstacle

I'm finding 3 problems:

- KPIECE solver is unreliable. Solution: remove projection_evaluator from ompl_planning.yaml (see https://github.com/ros-planning/moveit/issues/197)
- Planning time is too short. 10 seconds is much better than the 5 used by default for orientation
- longest_valid_segment_fraction (collision checking resolution) is too small

My results:
![collision_checking_peformance](https://cloud.githubusercontent.com/assets/561060/19875292/55c5ba48-9f91-11e6-98e0-f45d82afd0d3.png)

From this I recommend we change the default longest_valid_segment_fraction to **0.005**, even though I just recently had a similar PR for this that only went half way: https://github.com/ros-planning/moveit/commit/3c760fe2d1319dffb410e71729c5c548c9c4c842

Another option would be even finer at **0.001**, but 

1. that is only necessary for constraint planning and I think that is much less common
2. that is a much much bigger computational load
3. in my years of using moveit i've always used 0.005 for various robots (Jaco2, Baxter, PR2, HRP2)
