### PR TITLE
Change OptimizationObjective default message to Debug.

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -242,7 +242,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     optimizer = "PathLengthOptimizationObjective";
-    logInform("No optimization objective specified, defaulting to %s", optimizer.c_str());
+    logDebug("No optimization objective specified, defaulting to %s", optimizer.c_str());
   }
   else
   {


### PR DESCRIPTION
Reduces the verbosity of the planner configuration by setting the message to debug instead of info. As discussed in  #336 
