### PR TITLE
Improved RobotState feedback for setFromIK()

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1614,13 +1614,13 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup *jmg, co
   // Error check
   if (poses_in.size() != sub_groups.size())
   {
-    logError("Number of poses must be the same as number of sub-groups");
+    logError("Number of poses (%u) must be the same as number of sub-groups (%u)", poses_in.size(), sub_groups.size());
     return false;
   }
 
   if (tips_in.size() != sub_groups.size())
   {
-    logError("Number of tip names must be the same as number of sub-groups");
+    logError("Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(), sub_groups.size());
     return false;
   }
 
@@ -1707,7 +1707,8 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup *jmg, co
 
     if (pose_frame != solver_tip_frame)
     {
-      logError("Cannot compute IK for query pose reference frame '%s'", pose_frame.c_str());
+      logError("Cannot compute IK for query pose reference frame '%s', desired: '%s'", pose_frame.c_str(),
+               solver_tip_frame.c_str());
       return false;
     }
   }


### PR DESCRIPTION
When using ``setFromIKSubgroups()`` it is actually tricky because the ordering of poses and tips must correspond exactly to the ordering of subgroups in a planning group in your SRDF. A much larger change is required to fix this sloppy API, but this PR simply adds better debug info to allow users to work around it easier.

Also, this PR makes it easier to understand why a group like "both_arms" might have more than just two subgroups "left_arm" "right_arm" but also for example "left_arm_6dof" etc