### PR TITLE
Error message when requested target name does not exists

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -1407,6 +1407,7 @@ bool moveit::planning_interface::MoveGroup::setNamedTarget(const std::string &na
       impl_->setTargetType(JOINT);
       return true;
     }
+    ROS_ERROR_NAMED("move_group_interface", "The requested named target '%s' does not exist", name.c_str());
     return false;
   }
 }


### PR DESCRIPTION
We tested a new named target for our gripper, after an hour of searching we found out that the new target was not in our srdf. 
We expected that we get an error in this situation, so here is our suggestion.