### PR TITLE
WIP: Add colours to trajectory_visualisation display

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -122,7 +122,6 @@ protected:
   // Handle colouring of robot
   void setRobotColor(rviz::Robot* robot, const QColor &color);
   void unsetRobotColor(rviz::Robot* robot);
-  std_msgs::ColorRGBA robot_color;
 
   robot_trajectory::RobotTrajectoryPtr displaying_trajectory_message_;
   robot_trajectory::RobotTrajectoryPtr trajectory_message_to_display_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -105,6 +105,8 @@ private Q_SLOTS:
   void changedShowTrail();
   void changedTrajectoryTopic();
   void changedStateDisplayTime();
+  void changedRobotColor();
+  void enabledRobotColor();
 
 protected:
   /**
@@ -116,6 +118,11 @@ protected:
 
   // Handles actually drawing the robot along motion plans
   RobotStateVisualizationPtr display_path_robot_;
+
+  // Handle colouring of robot
+  void setRobotColor(rviz::Robot* robot, const QColor &color);
+  void unsetRobotColor(rviz::Robot* robot);
+  std_msgs::ColorRGBA robot_color;
 
   robot_trajectory::RobotTrajectoryPtr displaying_trajectory_message_;
   robot_trajectory::RobotTrajectoryPtr trajectory_message_to_display_;
@@ -145,6 +152,8 @@ protected:
   rviz::BoolProperty* loop_display_property_;
   rviz::BoolProperty* trail_display_property_;
   rviz::BoolProperty* interrupt_display_property_;
+  rviz::ColorProperty*  robot_color_property_;
+  rviz::BoolProperty* enable_robot_color_property_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -120,7 +120,7 @@ protected:
   RobotStateVisualizationPtr display_path_robot_;
 
   // Handle colouring of robot
-  void setRobotColor(rviz::Robot* robot, const QColor &color);
+  void setRobotColor(rviz::Robot* robot, const QColor& color);
   void unsetRobotColor(rviz::Robot* robot);
 
   robot_trajectory::RobotTrajectoryPtr displaying_trajectory_message_;
@@ -151,7 +151,7 @@ protected:
   rviz::BoolProperty* loop_display_property_;
   rviz::BoolProperty* trail_display_property_;
   rviz::BoolProperty* interrupt_display_property_;
-  rviz::ColorProperty*  robot_color_property_;
+  rviz::ColorProperty* robot_color_property_;
   rviz::BoolProperty* enable_robot_color_property_;
 };
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -99,13 +99,11 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property *widget, rviz::D
       "Interrupt Display", false,
       "Immediately show newly planned trajectory, interrupting the currently displayed one.", widget);
 
-  robot_color_property_ =
-    new rviz::ColorProperty("Robot Color", QColor(150, 50, 150), "The color of the animated robot",
-                            widget, SLOT( changedRobotColor() ), this );
+  robot_color_property_ = new rviz::ColorProperty(
+      "Robot Color", QColor(150, 50, 150), "The color of the animated robot", widget, SLOT(changedRobotColor()), this);
 
-  enable_robot_color_property_ =
-    new rviz::BoolProperty("Color Enabled", false, "Specifies whether robot coloring is enabled",
-                           widget, SLOT( enabledRobotColor() ), this);
+  enable_robot_color_property_ = new rviz::BoolProperty(
+      "Color Enabled", false, "Specifies whether robot coloring is enabled", widget, SLOT(enabledRobotColor()), this);
 }
 
 TrajectoryVisualization::~TrajectoryVisualization()
@@ -196,7 +194,7 @@ void TrajectoryVisualization::changedShowTrail()
     r->setCollisionVisible(display_path_collision_enabled_property_->getBool());
     r->setAlpha(robot_path_alpha_property_->getFloat());
     r->update(PlanningLinkUpdater(t->getWayPointPtr(i)));
-    if(enable_robot_color_property_->getBool())
+    if (enable_robot_color_property_->getBool())
       setRobotColor(r, robot_color_property_->getColor());
     r->setVisible(display_->isEnabled() && (!animating_path_ || i <= current_state_));
     trajectory_trail_[i] = r;
@@ -397,29 +395,28 @@ void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::Displ
 
 void TrajectoryVisualization::changedRobotColor()
 {
-  if(enable_robot_color_property_->getBool())
+  if (enable_robot_color_property_->getBool())
     setRobotColor(&(display_path_robot_->getRobot()), robot_color_property_->getColor());
 }
 
 void TrajectoryVisualization::enabledRobotColor()
 {
-  if(enable_robot_color_property_->getBool())
+  if (enable_robot_color_property_->getBool())
     setRobotColor(&(display_path_robot_->getRobot()), robot_color_property_->getColor());
   else
     unsetRobotColor(&(display_path_robot_->getRobot()));
 }
 
-void TrajectoryVisualization::unsetRobotColor(rviz::Robot* robot)
+void TrajectoryVisualization::unsetRobotColor(rviz::Robot *robot)
 {
-  for(auto& link : robot->getLinks())
+  for (auto &link : robot->getLinks())
     link.second->unsetColor();
 }
 
-void TrajectoryVisualization::setRobotColor(rviz::Robot* robot,
-                                            const QColor &color)
+void TrajectoryVisualization::setRobotColor(rviz::Robot *robot, const QColor &color)
 {
-  for(auto& link : robot->getLinks())
-    robot->getLink(link.first)->setColor( color.redF(), color.greenF(), color.blueF() );
+  for (auto &link : robot->getLinks())
+    robot->getLink(link.first)->setColor(color.redF(), color.greenF(), color.blueF());
 }
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -55,7 +55,7 @@
 
 namespace moveit_rviz_plugin
 {
-TrajectoryVisualization::TrajectoryVisualization(rviz::Property *widget, rviz::Display *display)
+TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::Display* display)
   : display_(display), widget_(widget), animating_path_(false), current_state_(-1)
 {
   trajectory_topic_property_ =
@@ -115,7 +115,7 @@ TrajectoryVisualization::~TrajectoryVisualization()
   display_path_robot_.reset();
 }
 
-void TrajectoryVisualization::onInitialize(Ogre::SceneNode *scene_node, rviz::DisplayContext *context,
+void TrajectoryVisualization::onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context,
                                            ros::NodeHandle update_nh)
 {
   // Save pointers for later use
@@ -147,6 +147,7 @@ void TrajectoryVisualization::onRobotModelLoaded(robot_model::RobotModelConstPtr
 
   // Load rviz robot
   display_path_robot_->load(*robot_model_->getURDF());
+  enabledRobotColor(); // force-refresh to account for saved display configuration
 }
 
 void TrajectoryVisualization::reset()
@@ -354,7 +355,7 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
   }
 }
 
-void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::DisplayTrajectory::ConstPtr &msg)
+void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::DisplayTrajectory::ConstPtr& msg)
 {
   // Error check
   if (!robot_state_ || !robot_model_)
@@ -407,13 +408,13 @@ void TrajectoryVisualization::enabledRobotColor()
     unsetRobotColor(&(display_path_robot_->getRobot()));
 }
 
-void TrajectoryVisualization::unsetRobotColor(rviz::Robot *robot)
+void TrajectoryVisualization::unsetRobotColor(rviz::Robot* robot)
 {
   for (auto &link : robot->getLinks())
     link.second->unsetColor();
 }
 
-void TrajectoryVisualization::setRobotColor(rviz::Robot *robot, const QColor &color)
+void TrajectoryVisualization::setRobotColor(rviz::Robot* robot, const QColor& color)
 {
   for (auto &link : robot->getLinks())
     robot->getLink(link.first)->setColor(color.redF(), color.greenF(), color.blueF());

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -105,7 +105,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property *widget, rviz::D
                             widget, SLOT( changedRobotColor() ), this );
 
   enable_robot_color_property_ =
-    new rviz::BoolProperty("Use color", true, "Specifies whether robot coloring is enabled",
+    new rviz::BoolProperty("Color Enabled", true, "Specifies whether robot coloring is enabled",
                            widget, SLOT( enabledRobotColor() ), this);
 }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -147,7 +147,7 @@ void TrajectoryVisualization::onRobotModelLoaded(robot_model::RobotModelConstPtr
 
   // Load rviz robot
   display_path_robot_->load(*robot_model_->getURDF());
-  enabledRobotColor(); // force-refresh to account for saved display configuration
+  enabledRobotColor();  // force-refresh to account for saved display configuration
 }
 
 void TrajectoryVisualization::reset()
@@ -189,7 +189,7 @@ void TrajectoryVisualization::changedShowTrail()
   trajectory_trail_.resize(t->getWayPointCount());
   for (std::size_t i = 0; i < trajectory_trail_.size(); ++i)
   {
-    rviz::Robot *r = new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), NULL);
+    rviz::Robot* r = new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), NULL);
     r->load(*robot_model_->getURDF());
     r->setVisualVisible(display_path_visual_enabled_property_->getBool());
     r->setCollisionVisible(display_path_collision_enabled_property_->getBool());
@@ -294,7 +294,7 @@ float TrajectoryVisualization::getStateDisplayTime()
     {
       t = boost::lexical_cast<float>(tm);
     }
-    catch (const boost::bad_lexical_cast &ex)
+    catch (const boost::bad_lexical_cast& ex)
     {
       state_display_time_property_->setStdString("0.05 s");
     }
@@ -410,13 +410,13 @@ void TrajectoryVisualization::enabledRobotColor()
 
 void TrajectoryVisualization::unsetRobotColor(rviz::Robot* robot)
 {
-  for (auto &link : robot->getLinks())
+  for (auto& link : robot->getLinks())
     link.second->unsetColor();
 }
 
 void TrajectoryVisualization::setRobotColor(rviz::Robot* robot, const QColor& color)
 {
-  for (auto &link : robot->getLinks())
+  for (auto& link : robot->getLinks())
     robot->getLink(link.first)->setColor(color.redF(), color.greenF(), color.blueF());
 }
 


### PR DESCRIPTION
### Description

I needed a way to overlay trajectory displays in an easy to distinguish way so I've added colouring to the trajectory_visualisation display. 

A video can be found here: 
https://www.youtube.com/watch?v=Vj0KNAOtFrw

![screenshot_2016-11-15_16-21-48](https://cloud.githubusercontent.com/assets/3524577/20324157/5b27bdaa-ab77-11e6-829d-6952783f9d44.png)

**Please note that this is a PR to discover interest for this feature.**
Code is probably very dirty and doesn't meet any of the merging requirements, I haven't even rebased it on the current codebase yet, it's a few weeks old. **If I get a few thumbs up, I'd gladly tidy things up to be merged!**

PS: I love this checklist :+1: 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)


