### PR TITLE
Fix capitalization of getWayPointDurationFromStart in RobotTrajectory

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -38,6 +38,7 @@
 #define MOVEIT_ROBOT_TRAJECTORY_KINEMATIC_TRAJECTORY_
 
 #include <moveit/macros/class_forward.h>
+#include <moveit/macros/deprecation.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <moveit_msgs/RobotState.h>
@@ -115,6 +116,8 @@ public:
    *  @return The duration from start; retuns -1.0 if index is out of range.
    */
   double getWayPointDurationFromStart(std::size_t index) const;
+
+  MOVEIT_DEPRECATED double getWaypointDurationFromStart(std::size_t index) const;
 
   double getWayPointDurationFromPrevious(std::size_t index) const
   {

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -114,7 +114,7 @@ public:
    *  @param  The waypoint index.
    *  @return The duration from start; retuns -1.0 if index is out of range.
    */
-  double getWaypointDurationFromStart(std::size_t index) const;
+  double getWayPointDurationFromStart(std::size_t index) const;
 
   double getWayPointDurationFromPrevious(std::size_t index) const
   {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -412,6 +412,11 @@ double robot_trajectory::RobotTrajectory::getWayPointDurationFromStart(std::size
   return time;
 }
 
+double robot_trajectory::RobotTrajectory::getWaypointDurationFromStart(std::size_t index) const
+{
+  return getWayPointDurationFromStart(index);
+}
+
 bool robot_trajectory::RobotTrajectory::getStateAtDurationFromStart(const double request_duration,
                                                                     robot_state::RobotStatePtr &output_state) const
 {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -399,7 +399,7 @@ void robot_trajectory::RobotTrajectory::findWayPointIndicesForDurationAfterStart
     blend = (duration - before_time) / duration_from_previous_[index];
 }
 
-double robot_trajectory::RobotTrajectory::getWaypointDurationFromStart(std::size_t index) const
+double robot_trajectory::RobotTrajectory::getWayPointDurationFromStart(std::size_t index) const
 {
   if (duration_from_previous_.empty())
     return 0.0;


### PR DESCRIPTION
So I spent some time yesterday trying to figure out why my code wouldn't compile. Turns out the `getWayPointDurationFromStart` function of `robot_trajectory::RobotTrajectory` wasn't using the same capitalization (Waypoint vs WayPoint) as all the other functions in the class. 

This PR fixes that but does keep the (deprecated using `MOVEIT_DEPRECATED` from `moveit/macros/deprecation.h`) old naming. I hope the deprecation is correct the way it is, but if not let me know.