### PR TITLE
Fix missing compatibility header for Wily

### DIFF
--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -38,6 +38,7 @@
 #define PR2_ARM_IK_H
 
 #include <urdf_model/model.h>
+#include <urdf/model.h>
 #include <Eigen/Core>
 #include <Eigen/LU>  // provides LU decomposition
 #include <kdl/chainiksolver.hpp>


### PR DESCRIPTION
Wily was still failing when building tests:

```
Errors     << moveit_core:make /root/ws_moveit/logs/moveit_core/build.make.001.log
In file included from /root/ws_moveit/src/moveit/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp:39:0:
/root/ws_moveit/src/moveit/moveit_core/constraint_samplers/test/pr2_arm_ik.h:170:34: error: ‘**urdf::JointConstSharedPtr**’ has not been declared
   void addJointToChainInfo(urdf::JointConstSharedPtr joint, moveit_msgs::KinematicSolverInfo &info);
                                  ^
/root/ws_moveit/src/moveit/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp: In member function ‘bool pr2_arm_kinematics::PR2ArmIK::init(const urdf::ModelInterface&, const string&, const string&)’:
/root/ws_moveit/src/moveit/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp:61:3: error: ‘**LinkConstSharedPtr**’ is not a member of ‘urdf’
   urdf::LinkConstSharedPtr link = robot_model.getLink(tip_name);
```

Need to include changes in https://github.com/ros/robot_model/pull/160