### PR TITLE
Revert "Ignore non-shadow-fixed build failure (#360)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=kinetic TEST=clang-format         UPSTREAM_WORKSPACE=moveit.rosinstall
-# Nov 15 2016: Non-shadow-fixed build allowed to fail until next ROS sync https://github.com/ros-planning/moveit/pull/319
-matrix:
-    allow_failures:
-          - env: ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:


### PR DESCRIPTION
The buildfarm synced yesterday, so this is no longer needed.