### PR TITLE
ompl_interface: uniform & simplified handling of the default planner

### DIFF
--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -61,8 +61,10 @@ struct PlannerConfigurationSettings
   /** \brief The group (as defined in the SRDF) this configuration is meant for */
   std::string group;
 
-  /* \brief Name of the configuration. If there is only one configuration, this should be the same as the group name.
-     If there are multiple configurations, the form "group_name[config_name]" is expected for the name. */
+  /* \brief Name of the configuration.
+
+     For a group's default configuration, this should be the same as the group name.
+     Otherwise, the form "group_name[config_name]" is expected for the name. */
   std::string name;
 
   /** \brief Key-value pairs of settings that get passed to the planning algorithm */

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -161,6 +161,11 @@ public:
   void printStatus();
 
 protected:
+  /** @brief Load planner configurations for specified group into planner_config */
+  bool loadPlannerConfiguration(const std::string &group_name, const std::string &planner_id,
+                                const std::map<std::string, std::string> &group_params,
+                                planning_interface::PlannerConfigurationSettings &planner_config);
+
   /** @brief Configure the planners*/
   void loadPlannerConfigurations();
 

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -380,10 +380,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       logWarn("Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
               req.group_name.c_str(), req.planner_id.c_str());
   }
-  else
-  {  // No planner_id specified, selecting default
-    pc = planner_configs_.find(req.group_name + "[default]");
-  }
+
   if (pc == planner_configs_.end())
   {
     pc = planner_configs_.find(req.group_name);


### PR DESCRIPTION
Eventually https://github.com/ros-planning/moveit/issues/197#issuecomment-257553968
made me look into this part of the code, and I cleaned it up a bit while I changed
ompl_interface to respect the default_planner_config setting ...

PR #340 introduced additional logic to select the configuration "group_name[default]" as
the default configuration and sets it to RRTConnect.
But there was already logic in place for this!
The previous default configuration is plainly called "group_name".

This basically reverts #340 and sets the (old and new) default config to RRTConnect.

Additionally, this unifies the default planner setup within the ompl_interface
with the variable "default_planner_config" that can be specified for
each group. This was previously only implemented in the RViz plugin
and could be retrieved via `MoveGroupInterface::getDefaultPlannerId`,
but is not set there by default.
As a result the planner specified in the variable was *always* selected in RViz,
but *never* when an innocent user requested a motionplan in their code,
without explicitly setting the default planner.