### PR TITLE
Fix typo in moveit_commander planning_scene_interface.py

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -151,7 +151,7 @@ class PlanningSceneInterface(object):
         
     def attach_mesh(self, link, name, pose = None, filename = '', size = (1, 1, 1), touch_links = []):
         aco = AttachedCollisionObject()
-        if pose!=None and not filename.empty():
+        if pose!=None and filename:
             aco.object = self.__make_mesh(name, pose, filename, size)
         else:
             aco.object = self.__make_existing(name)


### PR DESCRIPTION
### Description

Error occurs when filename `str` is given
```
'str' object has no attribute 'empty'
```

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

Thank you!

