### PR TITLE
Improved IPTP by fitting a cubic spline

### DIFF
--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MOVEIT_LIB_NAME moveit_trajectory_processing)
 
 add_library(${MOVEIT_LIB_NAME}
   src/iterative_time_parameterization.cpp
+  src/spline_parameterization.cpp
   src/trajectory_tools.cpp
 )
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline.h
@@ -1,0 +1,464 @@
+/*
+ * spline.h
+ *
+ * simple cubic spline interpolation library without external
+ * dependencies
+ *
+ * ---------------------------------------------------------------------
+ * Copyright (C) 2011, 2014 Tino Kluge (ttk448 at gmail.com)
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ *
+ */
+
+
+#ifndef TK_SPLINE_H
+#define TK_SPLINE_H
+
+#include <cstdio>
+#include <cassert>
+#include <vector>
+#include <algorithm>
+
+
+// unnamed namespace only because the implementation is in this
+// header file and we don't want to export symbols to the obj files
+namespace
+{
+
+namespace tk
+{
+
+// band matrix solver
+class band_matrix
+{
+private:
+    std::vector< std::vector<double> > m_upper;  // upper band
+    std::vector< std::vector<double> > m_lower;  // lower band
+public:
+    band_matrix() {};                             // constructor
+    band_matrix(int dim, int n_u, int n_l);       // constructor
+    ~band_matrix() {};                            // destructor
+    void resize(int dim, int n_u, int n_l);      // init with dim,n_u,n_l
+    int dim() const;                             // matrix dimension
+    int num_upper() const
+    {
+        return m_upper.size()-1;
+    }
+    int num_lower() const
+    {
+        return m_lower.size()-1;
+    }
+    // access operator
+    double & operator () (int i, int j);            // write
+    double   operator () (int i, int j) const;      // read
+    // we can store an additional diogonal (in m_lower)
+    double& saved_diag(int i);
+    double  saved_diag(int i) const;
+    void lu_decompose();
+    std::vector<double> r_solve(const std::vector<double>& b) const;
+    std::vector<double> l_solve(const std::vector<double>& b) const;
+    std::vector<double> lu_solve(const std::vector<double>& b,
+                                 bool is_lu_decomposed=false);
+
+};
+
+
+// spline interpolation
+class spline
+{
+public:
+    enum bd_type {
+        first_deriv = 1,
+        second_deriv = 2
+    };
+
+private:
+    std::vector<double> m_x,m_y;            // x,y coordinates of points
+    // interpolation parameters
+    // f(x) = a*(x-x_i)^3 + b*(x-x_i)^2 + c*(x-x_i) + y_i
+    std::vector<double> m_a,m_b,m_c;        // spline coefficients
+    double  m_b0, m_c0;                     // for left extrapol
+    bd_type m_left, m_right;
+    double  m_left_value, m_right_value;
+    bool    m_force_linear_extrapolation;
+
+public:
+    // set default boundary condition to be zero curvature at both ends
+    spline(): m_left(second_deriv), m_right(second_deriv),
+        m_left_value(0.0), m_right_value(0.0),
+        m_force_linear_extrapolation(false)
+    {
+        ;
+    }
+
+    // optional, but if called it has to come be before set_points()
+    void set_boundary(bd_type left, double left_value,
+                      bd_type right, double right_value,
+                      bool force_linear_extrapolation=false);
+    void set_points(const std::vector<double>& x,
+                    const std::vector<double>& y, bool cubic_spline=true);
+    double operator() (double x) const;
+    double deriv(int order, double x) const;
+};
+
+
+
+// ---------------------------------------------------------------------
+// implementation part, which could be separated into a cpp file
+// ---------------------------------------------------------------------
+
+
+// band_matrix implementation
+// -------------------------
+
+band_matrix::band_matrix(int dim, int n_u, int n_l)
+{
+    resize(dim, n_u, n_l);
+}
+void band_matrix::resize(int dim, int n_u, int n_l)
+{
+    assert(dim>0);
+    assert(n_u>=0);
+    assert(n_l>=0);
+    m_upper.resize(n_u+1);
+    m_lower.resize(n_l+1);
+    for(size_t i=0; i<m_upper.size(); i++) {
+        m_upper[i].resize(dim);
+    }
+    for(size_t i=0; i<m_lower.size(); i++) {
+        m_lower[i].resize(dim);
+    }
+}
+int band_matrix::dim() const
+{
+    if(m_upper.size()>0) {
+        return m_upper[0].size();
+    } else {
+        return 0;
+    }
+}
+
+
+// defines the new operator (), so that we can access the elements
+// by A(i,j), index going from i=0,...,dim()-1
+double & band_matrix::operator () (int i, int j)
+{
+    int k=j-i;       // what band is the entry
+    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+    assert( (-num_lower()<=k) && (k<=num_upper()) );
+    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+    if(k>=0)   return m_upper[k][i];
+    else	    return m_lower[-k][i];
+}
+double band_matrix::operator () (int i, int j) const
+{
+    int k=j-i;       // what band is the entry
+    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+    assert( (-num_lower()<=k) && (k<=num_upper()) );
+    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+    if(k>=0)   return m_upper[k][i];
+    else	    return m_lower[-k][i];
+}
+// second diag (used in LU decomposition), saved in m_lower
+double band_matrix::saved_diag(int i) const
+{
+    assert( (i>=0) && (i<dim()) );
+    return m_lower[0][i];
+}
+double & band_matrix::saved_diag(int i)
+{
+    assert( (i>=0) && (i<dim()) );
+    return m_lower[0][i];
+}
+
+// LR-Decomposition of a band matrix
+void band_matrix::lu_decompose()
+{
+    int  i_max,j_max;
+    int  j_min;
+    double x;
+
+    // preconditioning
+    // normalize column i so that a_ii=1
+    for(int i=0; i<this->dim(); i++) {
+        assert(this->operator()(i,i)!=0.0);
+        this->saved_diag(i)=1.0/this->operator()(i,i);
+        j_min=std::max(0,i-this->num_lower());
+        j_max=std::min(this->dim()-1,i+this->num_upper());
+        for(int j=j_min; j<=j_max; j++) {
+            this->operator()(i,j) *= this->saved_diag(i);
+        }
+        this->operator()(i,i)=1.0;          // prevents rounding errors
+    }
+
+    // Gauss LR-Decomposition
+    for(int k=0; k<this->dim(); k++) {
+        i_max=std::min(this->dim()-1,k+this->num_lower());  // num_lower not a mistake!
+        for(int i=k+1; i<=i_max; i++) {
+            assert(this->operator()(k,k)!=0.0);
+            x=-this->operator()(i,k)/this->operator()(k,k);
+            this->operator()(i,k)=-x;                         // assembly part of L
+            j_max=std::min(this->dim()-1,k+this->num_upper());
+            for(int j=k+1; j<=j_max; j++) {
+                // assembly part of R
+                this->operator()(i,j)=this->operator()(i,j)+x*this->operator()(k,j);
+            }
+        }
+    }
+}
+// solves Ly=b
+std::vector<double> band_matrix::l_solve(const std::vector<double>& b) const
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double> x(this->dim());
+    int j_start;
+    double sum;
+    for(int i=0; i<this->dim(); i++) {
+        sum=0;
+        j_start=std::max(0,i-this->num_lower());
+        for(int j=j_start; j<i; j++) sum += this->operator()(i,j)*x[j];
+        x[i]=(b[i]*this->saved_diag(i)) - sum;
+    }
+    return x;
+}
+// solves Rx=y
+std::vector<double> band_matrix::r_solve(const std::vector<double>& b) const
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double> x(this->dim());
+    int j_stop;
+    double sum;
+    for(int i=this->dim()-1; i>=0; i--) {
+        sum=0;
+        j_stop=std::min(this->dim()-1,i+this->num_upper());
+        for(int j=i+1; j<=j_stop; j++) sum += this->operator()(i,j)*x[j];
+        x[i]=( b[i] - sum ) / this->operator()(i,i);
+    }
+    return x;
+}
+
+std::vector<double> band_matrix::lu_solve(const std::vector<double>& b,
+        bool is_lu_decomposed)
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double>  x,y;
+    if(is_lu_decomposed==false) {
+        this->lu_decompose();
+    }
+    y=this->l_solve(b);
+    x=this->r_solve(y);
+    return x;
+}
+
+
+
+
+// spline implementation
+// -----------------------
+
+void spline::set_boundary(spline::bd_type left, double left_value,
+                          spline::bd_type right, double right_value,
+                          bool force_linear_extrapolation)
+{
+    assert(m_x.size()==0);          // set_points() must not have happened yet
+    m_left=left;
+    m_right=right;
+    m_left_value=left_value;
+    m_right_value=right_value;
+    m_force_linear_extrapolation=force_linear_extrapolation;
+}
+
+
+void spline::set_points(const std::vector<double>& x,
+                        const std::vector<double>& y, bool cubic_spline)
+{
+    assert(x.size()==y.size());
+    assert(x.size()>2);
+    m_x=x;
+    m_y=y;
+    int   n=x.size();
+    // TODO: maybe sort x and y, rather than returning an error
+    for(int i=0; i<n-1; i++) {
+        assert(m_x[i]<m_x[i+1]);
+    }
+
+    if(cubic_spline==true) { // cubic spline interpolation
+        // setting up the matrix and right hand side of the equation system
+        // for the parameters b[]
+        band_matrix A(n,1,1);
+        std::vector<double>  rhs(n);
+        for(int i=1; i<n-1; i++) {
+            A(i,i-1)=1.0/3.0*(x[i]-x[i-1]);
+            A(i,i)=2.0/3.0*(x[i+1]-x[i-1]);
+            A(i,i+1)=1.0/3.0*(x[i+1]-x[i]);
+            rhs[i]=(y[i+1]-y[i])/(x[i+1]-x[i]) - (y[i]-y[i-1])/(x[i]-x[i-1]);
+        }
+        // boundary conditions
+        if(m_left == spline::second_deriv) {
+            // 2*b[0] = f''
+            A(0,0)=2.0;
+            A(0,1)=0.0;
+            rhs[0]=m_left_value;
+        } else if(m_left == spline::first_deriv) {
+            // c[0] = f', needs to be re-expressed in terms of b:
+            // (2b[0]+b[1])(x[1]-x[0]) = 3 ((y[1]-y[0])/(x[1]-x[0]) - f')
+            A(0,0)=2.0*(x[1]-x[0]);
+            A(0,1)=1.0*(x[1]-x[0]);
+            rhs[0]=3.0*((y[1]-y[0])/(x[1]-x[0])-m_left_value);
+        } else {
+            assert(false);
+        }
+        if(m_right == spline::second_deriv) {
+            // 2*b[n-1] = f''
+            A(n-1,n-1)=2.0;
+            A(n-1,n-2)=0.0;
+            rhs[n-1]=m_right_value;
+        } else if(m_right == spline::first_deriv) {
+            // c[n-1] = f', needs to be re-expressed in terms of b:
+            // (b[n-2]+2b[n-1])(x[n-1]-x[n-2])
+            // = 3 (f' - (y[n-1]-y[n-2])/(x[n-1]-x[n-2]))
+            A(n-1,n-1)=2.0*(x[n-1]-x[n-2]);
+            A(n-1,n-2)=1.0*(x[n-1]-x[n-2]);
+            rhs[n-1]=3.0*(m_right_value-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
+        } else {
+            assert(false);
+        }
+
+        // solve the equation system to obtain the parameters b[]
+        m_b=A.lu_solve(rhs);
+
+        // calculate parameters a[] and c[] based on b[]
+        m_a.resize(n);
+        m_c.resize(n);
+        for(int i=0; i<n-1; i++) {
+            m_a[i]=1.0/3.0*(m_b[i+1]-m_b[i])/(x[i+1]-x[i]);
+            m_c[i]=(y[i+1]-y[i])/(x[i+1]-x[i])
+                   - 1.0/3.0*(2.0*m_b[i]+m_b[i+1])*(x[i+1]-x[i]);
+        }
+    } else { // linear interpolation
+        m_a.resize(n);
+        m_b.resize(n);
+        m_c.resize(n);
+        for(int i=0; i<n-1; i++) {
+            m_a[i]=0.0;
+            m_b[i]=0.0;
+            m_c[i]=(m_y[i+1]-m_y[i])/(m_x[i+1]-m_x[i]);
+        }
+    }
+
+    // for left extrapolation coefficients
+    m_b0 = (m_force_linear_extrapolation==false) ? m_b[0] : 0.0;
+    m_c0 = m_c[0];
+
+    // for the right extrapolation coefficients
+    // f_{n-1}(x) = b*(x-x_{n-1})^2 + c*(x-x_{n-1}) + y_{n-1}
+    double h=x[n-1]-x[n-2];
+    // m_b[n-1] is determined by the boundary condition
+    m_a[n-1]=0.0;
+    m_c[n-1]=3.0*m_a[n-2]*h*h+2.0*m_b[n-2]*h+m_c[n-2];   // = f'_{n-2}(x_{n-1})
+    if(m_force_linear_extrapolation==true)
+        m_b[n-1]=0.0;
+}
+
+double spline::operator() (double x) const
+{
+    size_t n=m_x.size();
+    // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+    std::vector<double>::const_iterator it;
+    it=std::lower_bound(m_x.begin(),m_x.end(),x);
+    int idx=std::max( int(it-m_x.begin())-1, 0);
+
+    double h=x-m_x[idx];
+    double interpol;
+    if(x<m_x[0]) {
+        // extrapolation to the left
+        interpol=(m_b0*h + m_c0)*h + m_y[0];
+    } else if(x>m_x[n-1]) {
+        // extrapolation to the right
+        interpol=(m_b[n-1]*h + m_c[n-1])*h + m_y[n-1];
+    } else {
+        // interpolation
+        interpol=((m_a[idx]*h + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+    }
+    return interpol;
+}
+
+double spline::deriv(int order, double x) const
+{
+    assert(order>0);
+
+    size_t n=m_x.size();
+    // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+    std::vector<double>::const_iterator it;
+    it=std::lower_bound(m_x.begin(),m_x.end(),x);
+    int idx=std::max( int(it-m_x.begin())-1, 0);
+
+    double h=x-m_x[idx];
+    double interpol;
+    if(x<m_x[0]) {
+        // extrapolation to the left
+        switch(order) {
+        case 1:
+            interpol=2.0*m_b0*h + m_c0;
+            break;
+        case 2:
+            interpol=2.0*m_b0*h;
+            break;
+        default:
+            interpol=0.0;
+            break;
+        }
+    } else if(x>m_x[n-1]) {
+        // extrapolation to the right
+        switch(order) {
+        case 1:
+            interpol=2.0*m_b[n-1]*h + m_c[n-1];
+            break;
+        case 2:
+            interpol=2.0*m_b[n-1];
+            break;
+        default:
+            interpol=0.0;
+            break;
+        }
+    } else {
+        // interpolation
+        switch(order) {
+        case 1:
+            interpol=(3.0*m_a[idx]*h + 2.0*m_b[idx])*h + m_c[idx];
+            break;
+        case 2:
+            interpol=6.0*m_a[idx]*h + 2.0*m_b[idx];
+            break;
+        case 3:
+            interpol=6.0*m_a[idx];
+            break;
+        default:
+            interpol=0.0;
+            break;
+        }
+    }
+    return interpol;
+}
+
+
+
+} // namespace tk
+
+
+} // namespace
+
+#endif /* TK_SPLINE_H */

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline.h
@@ -1,28 +1,40 @@
-/*
+/*********************************************************************
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2011, 2014 Tino Kluge
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name Tino Kluge nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL TINO KLUGE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tino Kluge (ttk448 at gmail.com)
+ *
  * spline.h
  *
  * simple cubic spline interpolation library without external
  * dependencies
  *
- * ---------------------------------------------------------------------
- * Copyright (C) 2011, 2014 Tino Kluge (ttk448 at gmail.com)
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * ---------------------------------------------------------------------
- *
  */
-
 
 #ifndef TK_SPLINE_H
 #define TK_SPLINE_H
@@ -32,433 +44,463 @@
 #include <vector>
 #include <algorithm>
 
-
 // unnamed namespace only because the implementation is in this
 // header file and we don't want to export symbols to the obj files
 namespace
 {
-
 namespace tk
 {
-
 // band matrix solver
 class band_matrix
 {
 private:
-    std::vector< std::vector<double> > m_upper;  // upper band
-    std::vector< std::vector<double> > m_lower;  // lower band
+  std::vector<std::vector<double> > m_upper;  // upper band
+  std::vector<std::vector<double> > m_lower;  // lower band
 public:
-    band_matrix() {};                             // constructor
-    band_matrix(int dim, int n_u, int n_l);       // constructor
-    ~band_matrix() {};                            // destructor
-    void resize(int dim, int n_u, int n_l);      // init with dim,n_u,n_l
-    int dim() const;                             // matrix dimension
-    int num_upper() const
-    {
-        return m_upper.size()-1;
-    }
-    int num_lower() const
-    {
-        return m_lower.size()-1;
-    }
-    // access operator
-    double & operator () (int i, int j);            // write
-    double   operator () (int i, int j) const;      // read
-    // we can store an additional diogonal (in m_lower)
-    double& saved_diag(int i);
-    double  saved_diag(int i) const;
-    void lu_decompose();
-    std::vector<double> r_solve(const std::vector<double>& b) const;
-    std::vector<double> l_solve(const std::vector<double>& b) const;
-    std::vector<double> lu_solve(const std::vector<double>& b,
-                                 bool is_lu_decomposed=false);
-
+  band_matrix(){};                         // constructor
+  band_matrix(int dim, int n_u, int n_l);  // constructor
+  ~band_matrix(){};                        // destructor
+  void resize(int dim, int n_u, int n_l);  // init with dim,n_u,n_l
+  int dim() const;                         // matrix dimension
+  int num_upper() const
+  {
+    return m_upper.size() - 1;
+  }
+  int num_lower() const
+  {
+    return m_lower.size() - 1;
+  }
+  // access operator
+  double& operator()(int i, int j);       // write
+  double operator()(int i, int j) const;  // read
+  // we can store an additional diogonal (in m_lower)
+  double& saved_diag(int i);
+  double saved_diag(int i) const;
+  void lu_decompose();
+  std::vector<double> r_solve(const std::vector<double>& b) const;
+  std::vector<double> l_solve(const std::vector<double>& b) const;
+  std::vector<double> lu_solve(const std::vector<double>& b, bool is_lu_decomposed = false);
 };
-
 
 // spline interpolation
 class spline
 {
 public:
-    enum bd_type {
-        first_deriv = 1,
-        second_deriv = 2
-    };
+  enum bd_type
+  {
+    first_deriv = 1,
+    second_deriv = 2
+  };
 
 private:
-    std::vector<double> m_x,m_y;            // x,y coordinates of points
-    // interpolation parameters
-    // f(x) = a*(x-x_i)^3 + b*(x-x_i)^2 + c*(x-x_i) + y_i
-    std::vector<double> m_a,m_b,m_c;        // spline coefficients
-    double  m_b0, m_c0;                     // for left extrapol
-    bd_type m_left, m_right;
-    double  m_left_value, m_right_value;
-    bool    m_force_linear_extrapolation;
+  std::vector<double> m_x, m_y;  // x,y coordinates of points
+  // interpolation parameters
+  // f(x) = a*(x-x_i)^3 + b*(x-x_i)^2 + c*(x-x_i) + y_i
+  std::vector<double> m_a, m_b, m_c;  // spline coefficients
+  double m_b0, m_c0;                  // for left extrapol
+  bd_type m_left, m_right;
+  double m_left_value, m_right_value;
+  bool m_force_linear_extrapolation;
 
 public:
-    // set default boundary condition to be zero curvature at both ends
-    spline(): m_left(second_deriv), m_right(second_deriv),
-        m_left_value(0.0), m_right_value(0.0),
-        m_force_linear_extrapolation(false)
-    {
-        ;
-    }
+  // set default boundary condition to be zero curvature at both ends
+  spline()
+    : m_left(second_deriv)
+    , m_right(second_deriv)
+    , m_left_value(0.0)
+    , m_right_value(0.0)
+    , m_force_linear_extrapolation(false)
+  {
+    ;
+  }
 
-    // optional, but if called it has to come be before set_points()
-    void set_boundary(bd_type left, double left_value,
-                      bd_type right, double right_value,
-                      bool force_linear_extrapolation=false);
-    void set_points(const std::vector<double>& x,
-                    const std::vector<double>& y, bool cubic_spline=true);
-    double operator() (double x) const;
-    double deriv(int order, double x) const;
+  // optional, but if called it has to come be before set_points()
+  void set_boundary(bd_type left, double left_value, bd_type right, double right_value,
+                    bool force_linear_extrapolation = false);
+  void set_points(const std::vector<double>& x, const std::vector<double>& y, bool cubic_spline = true);
+  double operator()(double x) const;
+  double deriv(int order, double x) const;
 };
-
-
 
 // ---------------------------------------------------------------------
 // implementation part, which could be separated into a cpp file
 // ---------------------------------------------------------------------
-
 
 // band_matrix implementation
 // -------------------------
 
 band_matrix::band_matrix(int dim, int n_u, int n_l)
 {
-    resize(dim, n_u, n_l);
+  resize(dim, n_u, n_l);
 }
 void band_matrix::resize(int dim, int n_u, int n_l)
 {
-    assert(dim>0);
-    assert(n_u>=0);
-    assert(n_l>=0);
-    m_upper.resize(n_u+1);
-    m_lower.resize(n_l+1);
-    for(size_t i=0; i<m_upper.size(); i++) {
-        m_upper[i].resize(dim);
-    }
-    for(size_t i=0; i<m_lower.size(); i++) {
-        m_lower[i].resize(dim);
-    }
+  assert(dim > 0);
+  assert(n_u >= 0);
+  assert(n_l >= 0);
+  m_upper.resize(n_u + 1);
+  m_lower.resize(n_l + 1);
+  for (size_t i = 0; i < m_upper.size(); i++)
+  {
+    m_upper[i].resize(dim);
+  }
+  for (size_t i = 0; i < m_lower.size(); i++)
+  {
+    m_lower[i].resize(dim);
+  }
 }
 int band_matrix::dim() const
 {
-    if(m_upper.size()>0) {
-        return m_upper[0].size();
-    } else {
-        return 0;
-    }
+  if (m_upper.size() > 0)
+  {
+    return m_upper[0].size();
+  }
+  else
+  {
+    return 0;
+  }
 }
-
 
 // defines the new operator (), so that we can access the elements
 // by A(i,j), index going from i=0,...,dim()-1
-double & band_matrix::operator () (int i, int j)
+double& band_matrix::operator()(int i, int j)
 {
-    int k=j-i;       // what band is the entry
-    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
-    assert( (-num_lower()<=k) && (k<=num_upper()) );
-    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
-    if(k>=0)   return m_upper[k][i];
-    else	    return m_lower[-k][i];
+  int k = j - i;  // what band is the entry
+  assert((i >= 0) && (i < dim()) && (j >= 0) && (j < dim()));
+  assert((-num_lower() <= k) && (k <= num_upper()));
+  // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+  if (k >= 0)
+    return m_upper[k][i];
+  else
+    return m_lower[-k][i];
 }
-double band_matrix::operator () (int i, int j) const
+double band_matrix::operator()(int i, int j) const
 {
-    int k=j-i;       // what band is the entry
-    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
-    assert( (-num_lower()<=k) && (k<=num_upper()) );
-    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
-    if(k>=0)   return m_upper[k][i];
-    else	    return m_lower[-k][i];
+  int k = j - i;  // what band is the entry
+  assert((i >= 0) && (i < dim()) && (j >= 0) && (j < dim()));
+  assert((-num_lower() <= k) && (k <= num_upper()));
+  // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+  if (k >= 0)
+    return m_upper[k][i];
+  else
+    return m_lower[-k][i];
 }
 // second diag (used in LU decomposition), saved in m_lower
 double band_matrix::saved_diag(int i) const
 {
-    assert( (i>=0) && (i<dim()) );
-    return m_lower[0][i];
+  assert((i >= 0) && (i < dim()));
+  return m_lower[0][i];
 }
-double & band_matrix::saved_diag(int i)
+double& band_matrix::saved_diag(int i)
 {
-    assert( (i>=0) && (i<dim()) );
-    return m_lower[0][i];
+  assert((i >= 0) && (i < dim()));
+  return m_lower[0][i];
 }
 
 // LR-Decomposition of a band matrix
 void band_matrix::lu_decompose()
 {
-    int  i_max,j_max;
-    int  j_min;
-    double x;
+  int i_max, j_max;
+  int j_min;
+  double x;
 
-    // preconditioning
-    // normalize column i so that a_ii=1
-    for(int i=0; i<this->dim(); i++) {
-        assert(this->operator()(i,i)!=0.0);
-        this->saved_diag(i)=1.0/this->operator()(i,i);
-        j_min=std::max(0,i-this->num_lower());
-        j_max=std::min(this->dim()-1,i+this->num_upper());
-        for(int j=j_min; j<=j_max; j++) {
-            this->operator()(i,j) *= this->saved_diag(i);
-        }
-        this->operator()(i,i)=1.0;          // prevents rounding errors
+  // preconditioning
+  // normalize column i so that a_ii=1
+  for (int i = 0; i < this->dim(); i++)
+  {
+    assert(this->operator()(i, i) != 0.0);
+    this->saved_diag(i) = 1.0 / this->operator()(i, i);
+    j_min = std::max(0, i - this->num_lower());
+    j_max = std::min(this->dim() - 1, i + this->num_upper());
+    for (int j = j_min; j <= j_max; j++)
+    {
+      this->operator()(i, j) *= this->saved_diag(i);
     }
+    this->operator()(i, i) = 1.0;  // prevents rounding errors
+  }
 
-    // Gauss LR-Decomposition
-    for(int k=0; k<this->dim(); k++) {
-        i_max=std::min(this->dim()-1,k+this->num_lower());  // num_lower not a mistake!
-        for(int i=k+1; i<=i_max; i++) {
-            assert(this->operator()(k,k)!=0.0);
-            x=-this->operator()(i,k)/this->operator()(k,k);
-            this->operator()(i,k)=-x;                         // assembly part of L
-            j_max=std::min(this->dim()-1,k+this->num_upper());
-            for(int j=k+1; j<=j_max; j++) {
-                // assembly part of R
-                this->operator()(i,j)=this->operator()(i,j)+x*this->operator()(k,j);
-            }
-        }
+  // Gauss LR-Decomposition
+  for (int k = 0; k < this->dim(); k++)
+  {
+    i_max = std::min(this->dim() - 1, k + this->num_lower());  // num_lower not a mistake!
+    for (int i = k + 1; i <= i_max; i++)
+    {
+      assert(this->operator()(k, k) != 0.0);
+      x = -this->operator()(i, k) / this->operator()(k, k);
+      this->operator()(i, k) = -x;  // assembly part of L
+      j_max = std::min(this->dim() - 1, k + this->num_upper());
+      for (int j = k + 1; j <= j_max; j++)
+      {
+        // assembly part of R
+        this->operator()(i, j) = this->operator()(i, j) + x * this->operator()(k, j);
+      }
     }
+  }
 }
 // solves Ly=b
 std::vector<double> band_matrix::l_solve(const std::vector<double>& b) const
 {
-    assert( this->dim()==(int)b.size() );
-    std::vector<double> x(this->dim());
-    int j_start;
-    double sum;
-    for(int i=0; i<this->dim(); i++) {
-        sum=0;
-        j_start=std::max(0,i-this->num_lower());
-        for(int j=j_start; j<i; j++) sum += this->operator()(i,j)*x[j];
-        x[i]=(b[i]*this->saved_diag(i)) - sum;
-    }
-    return x;
+  assert(this->dim() == (int)b.size());
+  std::vector<double> x(this->dim());
+  int j_start;
+  double sum;
+  for (int i = 0; i < this->dim(); i++)
+  {
+    sum = 0;
+    j_start = std::max(0, i - this->num_lower());
+    for (int j = j_start; j < i; j++)
+      sum += this->operator()(i, j) * x[j];
+    x[i] = (b[i] * this->saved_diag(i)) - sum;
+  }
+  return x;
 }
 // solves Rx=y
 std::vector<double> band_matrix::r_solve(const std::vector<double>& b) const
 {
-    assert( this->dim()==(int)b.size() );
-    std::vector<double> x(this->dim());
-    int j_stop;
-    double sum;
-    for(int i=this->dim()-1; i>=0; i--) {
-        sum=0;
-        j_stop=std::min(this->dim()-1,i+this->num_upper());
-        for(int j=i+1; j<=j_stop; j++) sum += this->operator()(i,j)*x[j];
-        x[i]=( b[i] - sum ) / this->operator()(i,i);
-    }
-    return x;
+  assert(this->dim() == (int)b.size());
+  std::vector<double> x(this->dim());
+  int j_stop;
+  double sum;
+  for (int i = this->dim() - 1; i >= 0; i--)
+  {
+    sum = 0;
+    j_stop = std::min(this->dim() - 1, i + this->num_upper());
+    for (int j = i + 1; j <= j_stop; j++)
+      sum += this->operator()(i, j) * x[j];
+    x[i] = (b[i] - sum) / this->operator()(i, i);
+  }
+  return x;
 }
 
-std::vector<double> band_matrix::lu_solve(const std::vector<double>& b,
-        bool is_lu_decomposed)
+std::vector<double> band_matrix::lu_solve(const std::vector<double>& b, bool is_lu_decomposed)
 {
-    assert( this->dim()==(int)b.size() );
-    std::vector<double>  x,y;
-    if(is_lu_decomposed==false) {
-        this->lu_decompose();
-    }
-    y=this->l_solve(b);
-    x=this->r_solve(y);
-    return x;
+  assert(this->dim() == (int)b.size());
+  std::vector<double> x, y;
+  if (is_lu_decomposed == false)
+  {
+    this->lu_decompose();
+  }
+  y = this->l_solve(b);
+  x = this->r_solve(y);
+  return x;
 }
-
-
-
 
 // spline implementation
 // -----------------------
 
-void spline::set_boundary(spline::bd_type left, double left_value,
-                          spline::bd_type right, double right_value,
+void spline::set_boundary(spline::bd_type left, double left_value, spline::bd_type right, double right_value,
                           bool force_linear_extrapolation)
 {
-    assert(m_x.size()==0);          // set_points() must not have happened yet
-    m_left=left;
-    m_right=right;
-    m_left_value=left_value;
-    m_right_value=right_value;
-    m_force_linear_extrapolation=force_linear_extrapolation;
+  assert(m_x.size() == 0);  // set_points() must not have happened yet
+  m_left = left;
+  m_right = right;
+  m_left_value = left_value;
+  m_right_value = right_value;
+  m_force_linear_extrapolation = force_linear_extrapolation;
 }
 
-
-void spline::set_points(const std::vector<double>& x,
-                        const std::vector<double>& y, bool cubic_spline)
+void spline::set_points(const std::vector<double>& x, const std::vector<double>& y, bool cubic_spline)
 {
-    assert(x.size()==y.size());
-    assert(x.size()>2);
-    m_x=x;
-    m_y=y;
-    int   n=x.size();
-    // TODO: maybe sort x and y, rather than returning an error
-    for(int i=0; i<n-1; i++) {
-        assert(m_x[i]<m_x[i+1]);
+  assert(x.size() == y.size());
+  assert(x.size() > 2);
+  m_x = x;
+  m_y = y;
+  int n = x.size();
+  // TODO: maybe sort x and y, rather than returning an error
+  for (int i = 0; i < n - 1; i++)
+  {
+    assert(m_x[i] < m_x[i + 1]);
+  }
+
+  if (cubic_spline == true)
+  {  // cubic spline interpolation
+    // setting up the matrix and right hand side of the equation system
+    // for the parameters b[]
+    band_matrix A(n, 1, 1);
+    std::vector<double> rhs(n);
+    for (int i = 1; i < n - 1; i++)
+    {
+      A(i, i - 1) = 1.0 / 3.0 * (x[i] - x[i - 1]);
+      A(i, i) = 2.0 / 3.0 * (x[i + 1] - x[i - 1]);
+      A(i, i + 1) = 1.0 / 3.0 * (x[i + 1] - x[i]);
+      rhs[i] = (y[i + 1] - y[i]) / (x[i + 1] - x[i]) - (y[i] - y[i - 1]) / (x[i] - x[i - 1]);
+    }
+    // boundary conditions
+    if (m_left == spline::second_deriv)
+    {
+      // 2*b[0] = f''
+      A(0, 0) = 2.0;
+      A(0, 1) = 0.0;
+      rhs[0] = m_left_value;
+    }
+    else if (m_left == spline::first_deriv)
+    {
+      // c[0] = f', needs to be re-expressed in terms of b:
+      // (2b[0]+b[1])(x[1]-x[0]) = 3 ((y[1]-y[0])/(x[1]-x[0]) - f')
+      A(0, 0) = 2.0 * (x[1] - x[0]);
+      A(0, 1) = 1.0 * (x[1] - x[0]);
+      rhs[0] = 3.0 * ((y[1] - y[0]) / (x[1] - x[0]) - m_left_value);
+    }
+    else
+    {
+      assert(false);
+    }
+    if (m_right == spline::second_deriv)
+    {
+      // 2*b[n-1] = f''
+      A(n - 1, n - 1) = 2.0;
+      A(n - 1, n - 2) = 0.0;
+      rhs[n - 1] = m_right_value;
+    }
+    else if (m_right == spline::first_deriv)
+    {
+      // c[n-1] = f', needs to be re-expressed in terms of b:
+      // (b[n-2]+2b[n-1])(x[n-1]-x[n-2])
+      // = 3 (f' - (y[n-1]-y[n-2])/(x[n-1]-x[n-2]))
+      A(n - 1, n - 1) = 2.0 * (x[n - 1] - x[n - 2]);
+      A(n - 1, n - 2) = 1.0 * (x[n - 1] - x[n - 2]);
+      rhs[n - 1] = 3.0 * (m_right_value - (y[n - 1] - y[n - 2]) / (x[n - 1] - x[n - 2]));
+    }
+    else
+    {
+      assert(false);
     }
 
-    if(cubic_spline==true) { // cubic spline interpolation
-        // setting up the matrix and right hand side of the equation system
-        // for the parameters b[]
-        band_matrix A(n,1,1);
-        std::vector<double>  rhs(n);
-        for(int i=1; i<n-1; i++) {
-            A(i,i-1)=1.0/3.0*(x[i]-x[i-1]);
-            A(i,i)=2.0/3.0*(x[i+1]-x[i-1]);
-            A(i,i+1)=1.0/3.0*(x[i+1]-x[i]);
-            rhs[i]=(y[i+1]-y[i])/(x[i+1]-x[i]) - (y[i]-y[i-1])/(x[i]-x[i-1]);
-        }
-        // boundary conditions
-        if(m_left == spline::second_deriv) {
-            // 2*b[0] = f''
-            A(0,0)=2.0;
-            A(0,1)=0.0;
-            rhs[0]=m_left_value;
-        } else if(m_left == spline::first_deriv) {
-            // c[0] = f', needs to be re-expressed in terms of b:
-            // (2b[0]+b[1])(x[1]-x[0]) = 3 ((y[1]-y[0])/(x[1]-x[0]) - f')
-            A(0,0)=2.0*(x[1]-x[0]);
-            A(0,1)=1.0*(x[1]-x[0]);
-            rhs[0]=3.0*((y[1]-y[0])/(x[1]-x[0])-m_left_value);
-        } else {
-            assert(false);
-        }
-        if(m_right == spline::second_deriv) {
-            // 2*b[n-1] = f''
-            A(n-1,n-1)=2.0;
-            A(n-1,n-2)=0.0;
-            rhs[n-1]=m_right_value;
-        } else if(m_right == spline::first_deriv) {
-            // c[n-1] = f', needs to be re-expressed in terms of b:
-            // (b[n-2]+2b[n-1])(x[n-1]-x[n-2])
-            // = 3 (f' - (y[n-1]-y[n-2])/(x[n-1]-x[n-2]))
-            A(n-1,n-1)=2.0*(x[n-1]-x[n-2]);
-            A(n-1,n-2)=1.0*(x[n-1]-x[n-2]);
-            rhs[n-1]=3.0*(m_right_value-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
-        } else {
-            assert(false);
-        }
+    // solve the equation system to obtain the parameters b[]
+    m_b = A.lu_solve(rhs);
 
-        // solve the equation system to obtain the parameters b[]
-        m_b=A.lu_solve(rhs);
-
-        // calculate parameters a[] and c[] based on b[]
-        m_a.resize(n);
-        m_c.resize(n);
-        for(int i=0; i<n-1; i++) {
-            m_a[i]=1.0/3.0*(m_b[i+1]-m_b[i])/(x[i+1]-x[i]);
-            m_c[i]=(y[i+1]-y[i])/(x[i+1]-x[i])
-                   - 1.0/3.0*(2.0*m_b[i]+m_b[i+1])*(x[i+1]-x[i]);
-        }
-    } else { // linear interpolation
-        m_a.resize(n);
-        m_b.resize(n);
-        m_c.resize(n);
-        for(int i=0; i<n-1; i++) {
-            m_a[i]=0.0;
-            m_b[i]=0.0;
-            m_c[i]=(m_y[i+1]-m_y[i])/(m_x[i+1]-m_x[i]);
-        }
+    // calculate parameters a[] and c[] based on b[]
+    m_a.resize(n);
+    m_c.resize(n);
+    for (int i = 0; i < n - 1; i++)
+    {
+      m_a[i] = 1.0 / 3.0 * (m_b[i + 1] - m_b[i]) / (x[i + 1] - x[i]);
+      m_c[i] = (y[i + 1] - y[i]) / (x[i + 1] - x[i]) - 1.0 / 3.0 * (2.0 * m_b[i] + m_b[i + 1]) * (x[i + 1] - x[i]);
     }
+  }
+  else
+  {  // linear interpolation
+    m_a.resize(n);
+    m_b.resize(n);
+    m_c.resize(n);
+    for (int i = 0; i < n - 1; i++)
+    {
+      m_a[i] = 0.0;
+      m_b[i] = 0.0;
+      m_c[i] = (m_y[i + 1] - m_y[i]) / (m_x[i + 1] - m_x[i]);
+    }
+  }
 
-    // for left extrapolation coefficients
-    m_b0 = (m_force_linear_extrapolation==false) ? m_b[0] : 0.0;
-    m_c0 = m_c[0];
+  // for left extrapolation coefficients
+  m_b0 = (m_force_linear_extrapolation == false) ? m_b[0] : 0.0;
+  m_c0 = m_c[0];
 
-    // for the right extrapolation coefficients
-    // f_{n-1}(x) = b*(x-x_{n-1})^2 + c*(x-x_{n-1}) + y_{n-1}
-    double h=x[n-1]-x[n-2];
-    // m_b[n-1] is determined by the boundary condition
-    m_a[n-1]=0.0;
-    m_c[n-1]=3.0*m_a[n-2]*h*h+2.0*m_b[n-2]*h+m_c[n-2];   // = f'_{n-2}(x_{n-1})
-    if(m_force_linear_extrapolation==true)
-        m_b[n-1]=0.0;
+  // for the right extrapolation coefficients
+  // f_{n-1}(x) = b*(x-x_{n-1})^2 + c*(x-x_{n-1}) + y_{n-1}
+  double h = x[n - 1] - x[n - 2];
+  // m_b[n-1] is determined by the boundary condition
+  m_a[n - 1] = 0.0;
+  m_c[n - 1] = 3.0 * m_a[n - 2] * h * h + 2.0 * m_b[n - 2] * h + m_c[n - 2];  // = f'_{n-2}(x_{n-1})
+  if (m_force_linear_extrapolation == true)
+    m_b[n - 1] = 0.0;
 }
 
-double spline::operator() (double x) const
+double spline::operator()(double x) const
 {
-    size_t n=m_x.size();
-    // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
-    std::vector<double>::const_iterator it;
-    it=std::lower_bound(m_x.begin(),m_x.end(),x);
-    int idx=std::max( int(it-m_x.begin())-1, 0);
+  size_t n = m_x.size();
+  // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+  std::vector<double>::const_iterator it;
+  it = std::lower_bound(m_x.begin(), m_x.end(), x);
+  int idx = std::max(int(it - m_x.begin()) - 1, 0);
 
-    double h=x-m_x[idx];
-    double interpol;
-    if(x<m_x[0]) {
-        // extrapolation to the left
-        interpol=(m_b0*h + m_c0)*h + m_y[0];
-    } else if(x>m_x[n-1]) {
-        // extrapolation to the right
-        interpol=(m_b[n-1]*h + m_c[n-1])*h + m_y[n-1];
-    } else {
-        // interpolation
-        interpol=((m_a[idx]*h + m_b[idx])*h + m_c[idx])*h + m_y[idx];
-    }
-    return interpol;
+  double h = x - m_x[idx];
+  double interpol;
+  if (x < m_x[0])
+  {
+    // extrapolation to the left
+    interpol = (m_b0 * h + m_c0) * h + m_y[0];
+  }
+  else if (x > m_x[n - 1])
+  {
+    // extrapolation to the right
+    interpol = (m_b[n - 1] * h + m_c[n - 1]) * h + m_y[n - 1];
+  }
+  else
+  {
+    // interpolation
+    interpol = ((m_a[idx] * h + m_b[idx]) * h + m_c[idx]) * h + m_y[idx];
+  }
+  return interpol;
 }
 
 double spline::deriv(int order, double x) const
 {
-    assert(order>0);
+  assert(order > 0);
 
-    size_t n=m_x.size();
-    // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
-    std::vector<double>::const_iterator it;
-    it=std::lower_bound(m_x.begin(),m_x.end(),x);
-    int idx=std::max( int(it-m_x.begin())-1, 0);
+  size_t n = m_x.size();
+  // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+  std::vector<double>::const_iterator it;
+  it = std::lower_bound(m_x.begin(), m_x.end(), x);
+  int idx = std::max(int(it - m_x.begin()) - 1, 0);
 
-    double h=x-m_x[idx];
-    double interpol;
-    if(x<m_x[0]) {
-        // extrapolation to the left
-        switch(order) {
-        case 1:
-            interpol=2.0*m_b0*h + m_c0;
-            break;
-        case 2:
-            interpol=2.0*m_b0*h;
-            break;
-        default:
-            interpol=0.0;
-            break;
-        }
-    } else if(x>m_x[n-1]) {
-        // extrapolation to the right
-        switch(order) {
-        case 1:
-            interpol=2.0*m_b[n-1]*h + m_c[n-1];
-            break;
-        case 2:
-            interpol=2.0*m_b[n-1];
-            break;
-        default:
-            interpol=0.0;
-            break;
-        }
-    } else {
-        // interpolation
-        switch(order) {
-        case 1:
-            interpol=(3.0*m_a[idx]*h + 2.0*m_b[idx])*h + m_c[idx];
-            break;
-        case 2:
-            interpol=6.0*m_a[idx]*h + 2.0*m_b[idx];
-            break;
-        case 3:
-            interpol=6.0*m_a[idx];
-            break;
-        default:
-            interpol=0.0;
-            break;
-        }
+  double h = x - m_x[idx];
+  double interpol;
+  if (x < m_x[0])
+  {
+    // extrapolation to the left
+    switch (order)
+    {
+      case 1:
+        interpol = 2.0 * m_b0 * h + m_c0;
+        break;
+      case 2:
+        interpol = 2.0 * m_b0 * h;
+        break;
+      default:
+        interpol = 0.0;
+        break;
     }
-    return interpol;
+  }
+  else if (x > m_x[n - 1])
+  {
+    // extrapolation to the right
+    switch (order)
+    {
+      case 1:
+        interpol = 2.0 * m_b[n - 1] * h + m_c[n - 1];
+        break;
+      case 2:
+        interpol = 2.0 * m_b[n - 1];
+        break;
+      default:
+        interpol = 0.0;
+        break;
+    }
+  }
+  else
+  {
+    // interpolation
+    switch (order)
+    {
+      case 1:
+        interpol = (3.0 * m_a[idx] * h + 2.0 * m_b[idx]) * h + m_c[idx];
+        break;
+      case 2:
+        interpol = 6.0 * m_a[idx] * h + 2.0 * m_b[idx];
+        break;
+      case 3:
+        interpol = 6.0 * m_a[idx];
+        break;
+      default:
+        interpol = 0.0;
+        break;
+    }
+  }
+  return interpol;
 }
 
+}  // namespace tk
 
-
-} // namespace tk
-
-
-} // namespace
+}  // namespace
 
 #endif /* TK_SPLINE_H */

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline_parameterization.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2011, Willow Garage, Inc.
+ *  Copyright (c) 2016, Delft University of Technology
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,9 +14,9 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
+ *   * Neither the name of Delft University of Technology nor the names
+ *     of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -32,7 +32,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ken Anderson */
+/* Author: Ruben Burger (r.b.burger@tudelft.nl)
+ *
+ * Based on iterative_time_parameterization.h, by Ken Anderson
+ */
 
 #ifndef MOVEIT_TRAJECTORY_PROCESSING_SPLINE_SMOOTHER_
 #define MOVEIT_TRAJECTORY_PROCESSING_SPLINE_SMOOTHER_

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline_parameterization.h
@@ -37,8 +37,8 @@
  * Based on iterative_time_parameterization.h, by Ken Anderson
  */
 
-#ifndef MOVEIT_TRAJECTORY_PROCESSING_SPLINE_SMOOTHER_
-#define MOVEIT_TRAJECTORY_PROCESSING_SPLINE_SMOOTHER_
+#ifndef MOVEIT_TRAJECTORY_PROCESSING_SPLINE_PARAMETERIZATION_
+#define MOVEIT_TRAJECTORY_PROCESSING_SPLINE_PARAMETERIZATION_
 
 #include <trajectory_msgs/JointTrajectory.h>
 #include <moveit_msgs/JointLimits.h>

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/spline_parameterization.h
@@ -1,0 +1,73 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ken Anderson */
+
+#ifndef MOVEIT_TRAJECTORY_PROCESSING_SPLINE_SMOOTHER_
+#define MOVEIT_TRAJECTORY_PROCESSING_SPLINE_SMOOTHER_
+
+#include <trajectory_msgs/JointTrajectory.h>
+#include <moveit_msgs/JointLimits.h>
+#include <moveit_msgs/RobotState.h>
+#include <moveit/robot_trajectory/robot_trajectory.h>
+
+namespace trajectory_processing
+{
+/// \brief This class  modifies the timestamps of a trajectory to respect
+/// velocity and acceleration constraints.
+class SplineParameterization
+{
+public:
+  SplineParameterization(unsigned int max_iterations = 100, double max_time_change_per_it = .01);
+  ~SplineParameterization();
+
+  bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
+                         const double max_acceleration_scaling_factor = 1.0) const;
+
+private:
+  unsigned int max_iterations_;    /// @brief maximum number of iterations to find solution
+  double max_time_change_per_it_;  /// @brief maximum allowed time change per iteration in seconds
+
+  void applyVelocityConstraints(robot_trajectory::RobotTrajectory& rob_trajectory, std::vector<double>& time_diff,
+                                const double max_velocity_scaling_factor) const;
+
+  void applyAccelerationConstraints(robot_trajectory::RobotTrajectory& rob_trajectory, std::vector<double>& time_diff,
+                                    const double max_acceleration_scaling_factor) const;
+
+  double findT1(const double d1, const double d2, double t1, const double t2, const double a_max) const;
+  double findT2(const double d1, const double d2, const double t1, double t2, const double a_max) const;
+};
+}
+
+#endif

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -189,11 +189,7 @@ void updateTrajectory(robot_trajectory::RobotTrajectory &rob_trajectory, const s
   if (time_diff.empty())
     return;
 
-  double time_sum = 0.0;
-
-  robot_state::RobotStatePtr prev_waypoint;
   robot_state::RobotStatePtr curr_waypoint;
-  robot_state::RobotStatePtr next_waypoint;
 
   const robot_model::JointModelGroup *group = rob_trajectory.getGroup();
   const std::vector<std::string> &vars = group->getVariableNames();
@@ -201,7 +197,7 @@ void updateTrajectory(robot_trajectory::RobotTrajectory &rob_trajectory, const s
 
   int num_points = rob_trajectory.getWayPointCount();
 
-  rob_trajectory.setWayPointDurationFromPrevious(0, time_sum);
+  rob_trajectory.setWayPointDurationFromPrevious(0, 0.0);
 
   // Times
   for (int i = 1; i < num_points; ++i)
@@ -212,84 +208,6 @@ void updateTrajectory(robot_trajectory::RobotTrajectory &rob_trajectory, const s
   if (num_points <= 1)
     return;
 
-  // Accelerations
-  for (int i = 0; i < num_points; ++i)
-  {
-    curr_waypoint = rob_trajectory.getWayPointPtr(i);
-
-    if (i > 0)
-      prev_waypoint = rob_trajectory.getWayPointPtr(i - 1);
-
-    if (i < num_points - 1)
-      next_waypoint = rob_trajectory.getWayPointPtr(i + 1);
-
-    for (std::size_t j = 0; j < vars.size(); ++j)
-    {
-      double q1;
-      double q2;
-      double q3;
-      double dt1;
-      double dt2;
-
-      if (i == 0)
-      {
-        // First point
-        q1 = next_waypoint->getVariablePosition(idx[j]);
-        q2 = curr_waypoint->getVariablePosition(idx[j]);
-        q3 = q1;
-
-        dt1 = dt2 = time_diff[i];
-      }
-      else if (i < num_points - 1)
-      {
-        // middle points
-        q1 = prev_waypoint->getVariablePosition(idx[j]);
-        q2 = curr_waypoint->getVariablePosition(idx[j]);
-        q3 = next_waypoint->getVariablePosition(idx[j]);
-
-        dt1 = time_diff[i - 1];
-        dt2 = time_diff[i];
-      }
-      else
-      {
-        // last point
-        q1 = prev_waypoint->getVariablePosition(idx[j]);
-        q2 = curr_waypoint->getVariablePosition(idx[j]);
-        q3 = q1;
-
-        dt1 = dt2 = time_diff[i - 1];
-      }
-
-      double v1, v2, a;
-
-      bool start_velocity = false;
-      if (dt1 == 0.0 || dt2 == 0.0)
-      {
-        v1 = 0.0;
-        v2 = 0.0;
-        a = 0.0;
-      }
-      else
-      {
-        if (i == 0)
-        {
-          if (curr_waypoint->hasVelocities())
-          {
-            start_velocity = true;
-            v1 = curr_waypoint->getVariableVelocity(idx[j]);
-          }
-        }
-        v1 = start_velocity ? v1 : (q2 - q1) / dt1;
-        // v2 = (q3-q2)/dt2;
-        v2 = start_velocity ? v1 : (q3 - q2) / dt2;  // Needed to ensure continuous velocity for first point
-        a = 2.0 * (v2 - v1) / (dt1 + dt2);
-      }
-
-      curr_waypoint->setVariableVelocity(idx[j], (v2 + v1) / 2.0);
-      curr_waypoint->setVariableAcceleration(idx[j], a);
-    }
-  }
-
   // Spline fitting using GPL lib
   for (std::size_t j = 0; j < vars.size(); ++j)
   {
@@ -297,7 +215,6 @@ void updateTrajectory(robot_trajectory::RobotTrajectory &rob_trajectory, const s
     for (int i = 0; i < num_points; ++i)
     {
       curr_waypoint = rob_trajectory.getWayPointPtr(i);
-
       y.push_back(curr_waypoint->getVariablePosition(idx[j]));
       x.push_back(rob_trajectory.getWaypointDurationFromStart(i));
     }
@@ -306,16 +223,11 @@ void updateTrajectory(robot_trajectory::RobotTrajectory &rob_trajectory, const s
     s.set_boundary(tk::spline::first_deriv, 0.0, tk::spline::first_deriv, 0.0, false);
     s.set_points(x, y);
 
-    curr_waypoint = rob_trajectory.getWayPointPtr(0);
-    curr_waypoint->setVariableVelocity(idx[j], s.deriv(1, 0.0));
-    curr_waypoint->setVariableAcceleration(idx[j], s.deriv(2, 0.0));
-
-    for (int i = 1; i < num_points; ++i)
+    for (int i = 0; i < num_points; ++i)
     {
       curr_waypoint = rob_trajectory.getWayPointPtr(i);
-
-        curr_waypoint->setVariableVelocity(idx[j], s.deriv(1, x[i]));
-        curr_waypoint->setVariableAcceleration(idx[j], s.deriv(2, x[i]));
+      curr_waypoint->setVariableVelocity(idx[j], s.deriv(1, x[i]));
+      curr_waypoint->setVariableAcceleration(idx[j], s.deriv(2, x[i]));
     }
   }
 }

--- a/moveit_core/trajectory_processing/src/spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/spline_parameterization.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2009, Willow Garage, Inc.
+ *  Copyright (c) 2016, Delft University of Technology
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,9 +14,9 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
+ *   * Neither the name of Delft University of Technology nor the names
+ *     of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -32,7 +32,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ken Anderson */
+/* Author: Ruben Burger (r.b.burger@tudelft.nl)
+ *
+ * Based on iterative_time_parameterization.cpp
+ */
 
 #include <moveit/trajectory_processing/spline_parameterization.h>
 #include <moveit/trajectory_processing/spline.h>

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCE_FILES
   src/fix_start_state_collision.cpp
   src/fix_start_state_path_constraints.cpp
   src/fix_workspace_bounds.cpp
-  src/add_time_parameterization.cpp)
+  src/add_time_parameterization.cpp
+  src/add_spline_parameterization.cpp)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_spline_parameterization.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2016, Delft University of Technology
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,9 +14,9 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
+ *   * Neither the name of Delft University of Technology nor the names
+ *     of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -32,7 +32,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Ruben Burger (r.b.burger@tudelft.nl)
+ *
+ * Based on add_time_parameterization.h, by Ioan Sucan
+ */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/trajectory_processing/spline_parameterization.h>

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_spline_parameterization.cpp
@@ -1,0 +1,79 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan */
+
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <moveit/trajectory_processing/spline_parameterization.h>
+#include <class_loader/class_loader.h>
+#include <ros/console.h>
+
+namespace default_planner_request_adapters
+{
+class AddSplineParameterization : public planning_request_adapter::PlanningRequestAdapter
+{
+public:
+  AddSplineParameterization() : planning_request_adapter::PlanningRequestAdapter()
+  {
+  }
+
+  virtual std::string getDescription() const
+  {
+    return "Add Spline Time Parameterization";
+  }
+
+  virtual bool adaptAndPlan(const PlannerFn &planner, const planning_scene::PlanningSceneConstPtr &planning_scene,
+                            const planning_interface::MotionPlanRequest &req,
+                            planning_interface::MotionPlanResponse &res,
+                            std::vector<std::size_t> &added_path_index) const
+  {
+    bool result = planner(planning_scene, req, res);
+    if (result && res.trajectory_)
+    {
+      ROS_DEBUG("Running '%s'", getDescription().c_str());
+      if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
+                                         req.max_acceleration_scaling_factor))
+        ROS_WARN("Spline time parametrization for the solution path failed.");
+    }
+
+    return result;
+  }
+
+private:
+  trajectory_processing::SplineParameterization time_param_;
+};
+}
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddSplineParameterization,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -30,4 +30,9 @@
     </description>
   </class>
 
+  <class name="default_planner_request_adapters/AddSplineParameterization" type="default_planner_request_adapters::AddSplineParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+    </description>
+  </class>
+
 </library>


### PR DESCRIPTION
As discussed in #160. I have used a GPL licensed spline fitting library ([this one](https://github.com/ttk592/spline)) to improve the performance of the iterative parabolic time parameterization algorithm that is used by MoveIt!. Unfortunately, the acceleration limits are still not satisfied completely, but it appears to be a step up from the previous approach.

Problems:

- The license. I am not too well versed in the what/why/how of open source licensing but I don't think GPL and BSD are compatible. Perhaps someone more knowledgeable on this front can offer some insight? If anyone is aware of a BSD licensed spline library that'd be great.

- The acceleration boundary conditions are not 0. This causes the waves you see between the first and second waypoints in the following figure:
![splinefit](https://cloud.githubusercontent.com/assets/8699378/21184312/33698338-c20c-11e6-99ab-a99bc47166d9.png)