### PR TITLE
update link transforms in UnionConstraintSampler::project too

### DIFF
--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -151,7 +151,13 @@ bool constraint_samplers::UnionConstraintSampler::sample(robot_state::RobotState
 bool constraint_samplers::UnionConstraintSampler::project(robot_state::RobotState &state, unsigned int max_attempts)
 {
   for (std::size_t i = 0; i < samplers_.size(); ++i)
+  {
+    // ConstraintSampler::project returns states with dirty link transforms (because it only writes values)
+    // but requires a state with clean link transforms as input. This means that we need to clean the link
+    // transforms between calls to ConstraintSampler::sample.
+    state.updateLinkTransforms();
     if (!samplers_[i]->project(state, max_attempts))
       return false;
+  }
   return true;
 }


### PR DESCRIPTION
This extends #186 (0119d584bd77a754ed5108d0b222cbcb76326863).

Scott Paulin found that the UnionConstraintSampler should explicitly
update the LinkTransforms of the returned samples, because one of the
other samplers could require them to be valid.

Back then, we missed that the sampler also provides a `project` method
that has the same limitation. So I update the transforms there too.

This should be picked to j/k.

I triggered this today by adding a JointConstraint and an OrientationConstraint
as PathConstraints to a planning request.

**Update**: The JointConstraint alone is enough to trigger this, according to a mail on the mailing list.


Here's a stack-trace to reveal the calling code:

```
    quat=..., ks=..., max_attempts=4)
    at /home/v4hn/ros/indigo/moveit/src/moveit/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp:416
    reference_state=..., max_attempts=4, project=true)
    at /home/v4hn/ros/indigo/moveit/src/moveit/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp:562
    max_attempts=4)
    at /home/v4hn/ros/indigo/moveit/src/moveit/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp:586
    max_attempts=4)
    at /home/v4hn/ros/indigo/moveit/src/moveit/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp:159
    gls=0x7fffac051690, new_goal=0x7fffa4005450)
```