### PR TITLE
moveit_kinematics: should not be compiled with c++11 in indigo

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_kinematics)
 find_package(catkin REQUIRED)
-
-add_compile_options(-std=c++11)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
This should never have been merged into indigo.
- We do not support cmake 2.8.12 in indigo either.

@130s: this should fix the build failure in saucy you reported.