### PR TITLE
[indigo][moveit_setup_assistant] Fix Saucy build.

### DIFF
--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_setup_assistant)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Indigo-[Saucy build](http://repositories.ros.org/status_page/ros_indigo_default.html?q=moveit) is all green except `moveit_setup_assistant`. Error (see at the bottom) looks similar with what #388 solved (required cmake version is not available on Saucy), which I did pretty much the same in this PR.

Same as https://github.com/ros-planning/moveit/pull/388#issuecomment-269115724, neither Travis nor ROS prerelease test won't check Saucy build AFAIK. So I suggest to merge as long as Travis passes.

Error on ROS buildfarm: http://build.ros.org/view/Ibin_uS64/job/Ibin_uS64__moveit_setup_assistant__ubuntu_saucy_amd64__binary/3/console
```
00:09:11.516 # set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
00:09:11.517 if [ -f "/opt/ros/indigo/setup.sh" ]; then . "/opt/ros/indigo/setup.sh"; fi && \
00:09:11.517 	dh_auto_configure -- \
00:09:11.517 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
00:09:11.517 		-DCMAKE_INSTALL_PREFIX="/opt/ros/indigo" \
00:09:11.517 		-DCMAKE_PREFIX_PATH="/opt/ros/indigo"
00:09:11.738 	mkdir -p obj-x86_64-linux-gnu
00:09:11.740 	cd obj-x86_64-linux-gnu
00:09:11.740 	cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_BUILD_BINARY_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo -DCMAKE_PREFIX_PATH=/opt/ros/indigo
00:09:11.771 CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
00:09:11.771   CMake 2.8.12 or higher is required.  You are running version 2.8.11.2
00:09:11.771 
00:09:11.771 
00:09:11.771 -- Configuring incomplete, errors occurred!
00:09:11.778 dh_auto_configure: cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_BUILD_BINARY_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo -DCMAKE_PREFIX_PATH=/opt/ros/indigo returned exit code 1
00:09:11.779 make[1]: *** [override_dh_auto_configure] Error 2
00:09:11.779 make[1]: Leaving directory `/tmp/binarydeb/ros-indigo-moveit-setup-assistant-0.7.5'
00:09:11.783 make: *** [build] Error 2
00:09:11.783 dpkg-buildpackage: error: debian/rules build gave error exit status 2
00:09:11.786 E: Building failed
00:09:11.793 Traceback (most recent call last):
00:09:11.793   File "/tmp/ros_buildfarm/ros_buildfarm/binarydeb_job.py", line 133, in build_binarydeb
00:09:11.793     subprocess.check_call(cmd, cwd=source_dir)
00:09:11.793   File "/usr/lib/python3.3/subprocess.py", line 547, in check_call
00:09:11.795     raise CalledProcessError(retcode, cmd)
00:09:11.795 subprocess.CalledProcessError: Command '['apt-src', 'build', 'ros-indigo-moveit-setup-assistant']' returned non-zero exit status 1
00:09:11.796 # END SUBSECTION
```
