### PR TITLE
[indigo] add correct version to all libraries so files

### DIFF
--- a/moveit_core/background_processing/CMakeLists.txt
+++ b/moveit_core/background_processing/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_background_processing)
 
 add_library(${MOVEIT_LIB_NAME} src/background_processing.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/world.cpp
   src/world_diff.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/collision_robot_fcl.cpp
   src/collision_world_fcl.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/default_constraint_samplers.cpp
   src/union_constraint_sampler.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_state

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/find_internal_points.cpp
   src/propagation_distance_field.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/dynamics_solver/CMakeLists.txt
+++ b/moveit_core/dynamics_solver/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_dynamics_solver)
 
 add_library(${MOVEIT_LIB_NAME} src/dynamics_solver.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/exceptions/CMakeLists.txt
+++ b/moveit_core/exceptions/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_exceptions)
 
 add_library(${MOVEIT_LIB_NAME} src/exceptions.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_kinematic_constraints)
 add_library(${MOVEIT_LIB_NAME}
   src/kinematic_constraint.cpp
   src/utils.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_model moveit_kinematics_base moveit_robot_state moveit_collision_detection_fcl

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_kinematics_base)
 
 add_library(${MOVEIT_LIB_NAME} src/kinematics_base.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/kinematics_metrics/CMakeLists.txt
+++ b/moveit_core/kinematics_metrics/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_kinematics_metrics)
 
 add_library(${MOVEIT_LIB_NAME} src/kinematics_metrics.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/planning_interface/CMakeLists.txt
+++ b/moveit_core/planning_interface/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/planning_interface.cpp
   src/planning_response.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state moveit_robot_trajectory ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/planning_request_adapter/CMakeLists.txt
+++ b/moveit_core/planning_request_adapter/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_planning_request_adapter)
 
 add_library(${MOVEIT_LIB_NAME} src/planning_request_adapter.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_planning_scene ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_planning_scene)
 
 add_library(${MOVEIT_LIB_NAME} src/planning_scene.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_model

--- a/moveit_core/profiler/CMakeLists.txt
+++ b/moveit_core/profiler/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_profiler)
 
 add_library(${MOVEIT_LIB_NAME} src/profiler.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/revolute_joint_model.cpp
   src/robot_model.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_profiler moveit_exceptions moveit_kinematics_base ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/conversions.cpp
   src/robot_state.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model moveit_kinematics_base moveit_transforms ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/moveit_core/robot_trajectory/CMakeLists.txt
+++ b/moveit_core/robot_trajectory/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_robot_trajectory)
 
 add_library(${MOVEIT_LIB_NAME} src/robot_trajectory.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/iterative_time_parameterization.cpp
   src/trajectory_tools.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state moveit_robot_trajectory ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/transforms/CMakeLists.txt
+++ b/moveit_core/transforms/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_transforms)
 
 add_library(${MOVEIT_LIB_NAME} src/transforms.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_experimental/collision_distance_field/CMakeLists.txt
+++ b/moveit_experimental/collision_distance_field/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(${MOVEIT_LIB_NAME}
 )
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} moveit_msgs_gencpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -23,7 +23,7 @@ if(CATKIN_ENABLE_TESTING)
 endif()
 
 add_library(collision_detector_hybrid_plugin src/collision_detector_hybrid_plugin_loader.cpp)
-set_target_properties(collision_detector_hybrid_plugin PROPERTIES VERSION 0.7.3)
+set_target_properties(collision_detector_hybrid_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(collision_detector_hybrid_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME})
 
 install(TARGETS ${MOVEIT_LIB_NAME} collision_detector_hybrid_plugin

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/CMakeLists.txt
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_kinematics_cache)
 add_library(${MOVEIT_LIB_NAME}
   src/kinematics_cache.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} moveit_msgs_gencpp)
 

--- a/moveit_experimental/kinematics_constraint_aware/CMakeLists.txt
+++ b/moveit_experimental/kinematics_constraint_aware/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_kinematics_constraint_aware)
 
 add_library(${MOVEIT_LIB_NAME} src/kinematics_constraint_aware.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} moveit_msgs_gencpp)
 

--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_kdl_kinematics_plugin)
 add_library(${MOVEIT_LIB_NAME} src/kdl_kinematics_plugin.cpp
   src/chainiksolver_pos_nr_jl_mimic.cpp
   src/chainiksolver_vel_pinv_mimic.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
 

--- a/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_lma_kinematics_plugin)
 add_library(${MOVEIT_LIB_NAME} src/lma_kinematics_plugin.cpp
   src/chainiksolver_pos_lma_jl_mimic.cpp
   src/chainiksolver_vel_pinv_mimic.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
 

--- a/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_srv_kinematics_plugin)
 
 add_library(${MOVEIT_LIB_NAME} src/srv_kinematics_plugin.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
 

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -29,11 +29,11 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/chomp_interface.cpp src/chomp_planning_context.cpp)
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_library(chomp_planner_plugin src/chomp_plugin.cpp)
-set_target_properties(chomp_planner_plugin PROPERTIES VERSION 0.7.3)
+set_target_properties(chomp_planner_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(chomp_planner_plugin ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 install(FILES chomp_interface_plugin_description.xml

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(${PROJECT_NAME}
   src/chomp_optimizer.cpp
   src/chomp_planner.cpp
 )
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/detail/constrained_goal_sampler.cpp
   src/detail/ompl_console.cpp
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 find_package(OpenMP)
 
@@ -37,7 +37,7 @@ target_link_libraries(moveit_demo_construct_constraints_database ${MOVEIT_LIB_NA
 set_target_properties(moveit_demo_construct_constraints_database PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
 add_library(moveit_ompl_planner_plugin src/ompl_planner_manager.cpp)
-set_target_properties(moveit_ompl_planner_plugin PROPERTIES VERSION 0.7.3)
+set_target_properties(moveit_ompl_planner_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(moveit_ompl_planner_plugin ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} moveit_ompl_planner moveit_ompl_planner_plugin

--- a/moveit_plugins/moveit_controller_manager_example/CMakeLists.txt
+++ b/moveit_plugins/moveit_controller_manager_example/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
 include_directories(include)
 
 add_library(${PROJECT_NAME} src/moveit_controller_manager_example.cpp)
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/moveit_plugins/moveit_fake_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_fake_controller_manager/CMakeLists.txt
@@ -32,7 +32,7 @@ include_directories(include)
 add_library(${PROJECT_NAME}
    src/moveit_fake_controller_manager.cpp
    src/moveit_fake_controllers.cpp)
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 add_library(${PROJECT_NAME}_plugin
   src/controller_manager_plugin.cpp
 )
-set_target_properties(${PROJECT_NAME}_plugin PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME}_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_plugin
   ${catkin_LIBRARIES} ${Boost_LIBRARIES}
 )
@@ -33,7 +33,7 @@ target_link_libraries(${PROJECT_NAME}_plugin
 add_library(${PROJECT_NAME}_trajectory_plugin
   src/joint_trajectory_controller_plugin.cpp
 )
-set_target_properties(${PROJECT_NAME}_trajectory_plugin PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME}_trajectory_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin
   ${catkin_LIBRARIES} ${Boost_LIBRARIES}
 )

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package(
 include_directories(include)
 
 add_library(${PROJECT_NAME} src/moveit_simple_controller_manager.cpp)
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/moveit_ros/benchmarks/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_benchmark_execution)
 
 add_library(${MOVEIT_LIB_NAME} src/benchmark_execution.cpp src/benchmarks_utils.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(moveit_run_benchmark src/run_benchmarks.cpp)

--- a/moveit_ros/manipulation/move_group_pick_place_capability/CMakeLists.txt
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(src)
 add_library(${MOVEIT_LIB_NAME}
   src/pick_place_action_capability.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_pick_place_planner ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/moveit_ros/manipulation/pick_place/CMakeLists.txt
+++ b/moveit_ros/manipulation/pick_place/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/pick.cpp
   src/place.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(moveit_move_group_capabilities_base
   src/move_group_context.cpp
   src/move_group_capability.cpp
   )
-set_target_properties(moveit_move_group_capabilities_base PROPERTIES VERSION 0.7.3)
+set_target_properties(moveit_move_group_capabilities_base PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 add_dependencies(moveit_move_group_capabilities_base ${catkin_EXPORTED_TARGETS}) # wait until all *_msgs packages are finished being built
 
 add_executable(move_group src/move_group.cpp)
@@ -59,7 +59,7 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/apply_planning_scene_service_capability.cpp
   src/default_capabilities/clear_octomap_service_capability.cpp
   )
-set_target_properties(moveit_move_group_default_capabilities PROPERTIES VERSION 0.7.3)
+set_target_properties(moveit_move_group_default_capabilities PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 add_dependencies(moveit_move_group_default_capabilities ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(moveit_move_group_capabilities_base ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
@@ -3,14 +3,14 @@ set(MOVEIT_LIB_NAME moveit_depth_image_octomap_updater)
 add_library(${MOVEIT_LIB_NAME}_core
   src/depth_image_octomap_updater.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_lazy_free_space_updater moveit_mesh_filter moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_dependencies(${MOVEIT_LIB_NAME}_core ${sensor_msgs_EXPORTED_TARGETS})
 
 add_library(${MOVEIT_LIB_NAME} src/updater_plugin.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}_core ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/lazy_free_space_updater.cpp
   )
 
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/gl_renderer.cpp
   src/gl_mesh.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} glut GLEW)
 

--- a/moveit_ros/perception/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/perception/occupancy_map_monitor/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/occupancy_map_monitor.cpp
   src/occupancy_map_updater.cpp
   )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/perception/point_containment_filter/CMakeLists.txt
+++ b/moveit_ros/perception/point_containment_filter/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_point_containment_filter)
 
 add_library(${MOVEIT_LIB_NAME} src/shape_mask.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
@@ -1,13 +1,13 @@
 set(MOVEIT_LIB_NAME moveit_pointcloud_octomap_updater)
 
 add_library(${MOVEIT_LIB_NAME}_core src/pointcloud_octomap_updater.cpp)
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_point_containment_filter moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES LINK_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/perception/semantic_world/CMakeLists.txt
+++ b/moveit_ros/perception/semantic_world/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_BUILD_TYPE Debug)
 set(MOVEIT_LIB_NAME moveit_semantic_world)
 
 add_library(${MOVEIT_LIB_NAME} src/semantic_world.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
 

--- a/moveit_ros/planning/collision_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/collision_plugin_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_collision_plugin_loader)
 
 add_library(${MOVEIT_LIB_NAME} src/collision_plugin_loader.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/planning/constraint_sampler_manager_loader/CMakeLists.txt
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_constraint_sampler_manager_loader)
 
 add_library(${MOVEIT_LIB_NAME} src/constraint_sampler_manager_loader.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_kinematics_plugin_loader)
 
 add_library(${MOVEIT_LIB_NAME} src/kinematics_plugin_loader.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/planning/plan_execution/CMakeLists.txt
+++ b/moveit_ros/planning/plan_execution/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_plan_execution)
 add_library(${MOVEIT_LIB_NAME}
   src/plan_with_sensing.cpp
   src/plan_execution.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_planning_pipeline
   moveit_trajectory_execution_manager

--- a/moveit_ros/planning/planning_pipeline/CMakeLists.txt
+++ b/moveit_ros/planning/planning_pipeline/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_planning_pipeline)
 
 add_library(${MOVEIT_LIB_NAME} src/planning_pipeline.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCE_FILES
   src/add_time_parameterization.cpp)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(moveit_list_request_adapter_plugins src/list.cpp)

--- a/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
+++ b/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/planning_scene_monitor.cpp
   src/current_state_monitor.cpp
   src/trajectory_monitor.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_model_loader
   moveit_collision_plugin_loader

--- a/moveit_ros/planning/rdf_loader/CMakeLists.txt
+++ b/moveit_ros/planning/rdf_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_rdf_loader)
 
 add_library(${MOVEIT_LIB_NAME} src/rdf_loader.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/planning/robot_model_loader/CMakeLists.txt
+++ b/moveit_ros/planning/robot_model_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_robot_model_loader)
 
 add_library(${MOVEIT_LIB_NAME} src/robot_model_loader.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader moveit_kinematics_plugin_loader ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)

--- a/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
+++ b/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_trajectory_execution_manager)
 
 add_library(${MOVEIT_LIB_NAME} src/trajectory_execution_manager.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_planning_scene_monitor moveit_robot_model_loader ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${moveit_ros_planning_EXPORTED_TARGETS}) # don't build until necessary msgs are finish
 
@@ -9,7 +9,7 @@ install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
 
 add_library(test_controller_manager_plugin test/test_moveit_controller_manager_plugin.cpp)
-set_target_properties(test_controller_manager_plugin PROPERTIES VERSION 0.7.3)
+set_target_properties(test_controller_manager_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(test_controller_manager_plugin ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(test_controller_manager test/test_app.cpp)

--- a/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_common_planning_interface_objects)
 
 add_library(${MOVEIT_LIB_NAME} src/common_objects.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -1,13 +1,13 @@
 set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
 add_library(${MOVEIT_LIB_NAME} src/move_group.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects moveit_planning_scene_interface ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_move_group.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_py_bindings_tools)
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 add_dependencies(${MOVEIT_LIB_NAME}_python ${catkin_EXPORTED_TARGETS})
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_move_group_interface PREFIX "")
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})

--- a/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(MOVEIT_LIB_NAME moveit_planning_scene_interface)
 
 add_library(${MOVEIT_LIB_NAME} src/planning_scene_interface.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_planning_scene_interface.cpp)
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_py_bindings_tools)
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_planning_scene_interface PREFIX "")
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})

--- a/moveit_ros/planning_interface/py_bindings_tools/CMakeLists.txt
+++ b/moveit_ros/planning_interface/py_bindings_tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_py_bindings_tools)
 
 add_library(${MOVEIT_LIB_NAME} src/roscpp_initializer.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
@@ -10,7 +10,7 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 
 add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_roscpp_initializer.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_roscpp_initializer PREFIX "")
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 

--- a/moveit_ros/planning_interface/robot_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/robot_interface/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_robot_interface)
 add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_robot_interface.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME}_python ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES}
   moveit_common_planning_interface_objects moveit_py_bindings_tools)
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_robot_interface PREFIX "")
 set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/locked_robot_state.cpp
   src/interaction_handler.cpp
   src/robot_interaction.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 catkin_add_gtest(locked_robot_state_test test/locked_robot_state_test.cpp)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -28,14 +28,14 @@ set(SOURCE_FILES
 
 set(MOVEIT_LIB_NAME moveit_motion_planning_rviz_plugin)
 add_library(${MOVEIT_LIB_NAME}_core ${SOURCE_FILES} ${MOC_SOURCES} ${UIC_FILES})
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
   ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -6,11 +6,11 @@ set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
 add_library(${MOVEIT_LIB_NAME}_core
   src/planning_scene_display.cpp
   ${MOC_SOURCES})
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
@@ -4,11 +4,11 @@ qt4_wrap_cpp(MOC_SOURCES include/moveit/robot_state_rviz_plugin/robot_state_disp
 
 set(MOVEIT_LIB_NAME moveit_robot_state_rviz_plugin)
 add_library(${MOVEIT_LIB_NAME}_core src/robot_state_display.cpp ${MOC_SOURCES})
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/trajectory_visualization.cpp
   ${MOC_SOURCES}
 )
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   ${catkin_LIBRARIES}

--- a/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(${MOVEIT_LIB_NAME}_core
   src/trajectory_display.cpp
   ${MOC_SOURCES}
 )
-set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
@@ -24,7 +24,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}_core
 
 # Plugin Initializer
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/warehouse/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/warehouse/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/trajectory_constraints_storage.cpp
   src/state_storage.cpp
   src/warehouse_connector.cpp)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(moveit_warehouse_broadcast src/broadcast.cpp)

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -80,7 +80,7 @@ add_library(${PROJECT_NAME}_tools
   src/tools/file_loader.cpp
   src/tools/moveit_config_data.cpp
 )
-set_target_properties(${PROJECT_NAME}_tools PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME}_tools PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_tools
   ${YAML}
   ${catkin_LIBRARIES}
@@ -108,7 +108,7 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/author_information_widget.cpp
   ${HEADERS}
 )
-set_target_properties(${PROJECT_NAME}_widgets PROPERTIES VERSION 0.7.3)
+set_target_properties(${PROJECT_NAME}_widgets PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_widgets
   ${PROJECT_NAME}_tools
   ${QT_LIBRARIES}


### PR DESCRIPTION
current `indigo-devel` version is `0.7.5`, otherwise versions and so file names are `0.7.3` and `libmoveit_.....so.0.7.3` because there are diff between #383 and #273.
This PR wants to fix this diff.
