### PR TITLE
moveit_core: remove UTF char from v4hn's name in changelog.

### DIFF
--- a/moveit_core/CHANGELOG.rst
+++ b/moveit_core/CHANGELOG.rst
@@ -24,7 +24,7 @@ Changelog for package moveit_core
   - 2.*acos(theta/2) only covers half range
   - need to consider sign of quaternion axis w.r.t. rotation axis
 * [sys] re-use travis config from jade-devel
-* Contributors: Dave Coleman, Robert Haschke, hamalMarino, Michael Gè´”rner
+* Contributors: Dave Coleman, Robert Haschke, hamalMarino, Michael Goerner
 
 0.7.1 (2016-04-14)
 ------------------


### PR DESCRIPTION
As per subject.

Made DOC job for Indigo fail ([job/Idoc__moveit__ubuntu_trusty_amd64/3](http://build.ros.org/job/Idoc__moveit__ubuntu_trusty_amd64/3/console) fi).
