### PR TITLE
Addition of Set Joint Model Group Velocities and Accelerations Functions

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -629,6 +629,7 @@ as the new values that correspond to the group */
   /** \brief For a given group, copy the position values of the variables that make up the group into another location,
    * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
    * RobotState itself, so we copy instead of returning a pointer.*/
+
   void copyJointGroupPositions(const std::string& joint_group_name, std::vector<double>& gstate) const
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
@@ -677,6 +678,224 @@ as the new values that correspond to the group */
    * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
    * RobotState itself, so we copy instead of returning a pointer.*/
   void copyJointGroupPositions(const JointModelGroup* group, Eigen::VectorXd& values) const;
+
+  /** @} */
+
+  /** \name Getting and setting group velocities
+   *  @{
+   */
+
+  /** \brief Given velocities for the variables that make up a group, in the order found in the group (including values
+of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupVelocities(const std::string& joint_group_name, const double* gstate)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      setJointGroupVelocities(jmg, gstate);
+  }
+
+  /** \brief Given velocities for the variables that make up a group, in the order found in the group (including values
+of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupVelocities(const std::string& joint_group_name, const std::vector<double>& gstate)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      setJointGroupVelocities(jmg, &gstate[0]);
+  }
+
+  /** \brief Given velocities for the variables that make up a group, in the order found in the group (including values
+of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupVelocities(const JointModelGroup* group, const std::vector<double>& gstate)
+  {
+    setJointGroupVelocities(group, &gstate[0]);
+  }
+
+  /** \brief Given velocities for the variables that make up a group, in the order found in the group (including values
+of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupVelocities(const JointModelGroup* group, const double* gstate);
+
+  /** \brief Given velocities for the variables that make up a group, in the order found in the group (including values
+of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupVelocities(const std::string& joint_group_name, const Eigen::VectorXd& values)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      setJointGroupVelocities(jmg, values);
+  }
+
+  /** \brief Given velocities for the variables that make up a group, in the order found in the group (including values
+of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupVelocities(const JointModelGroup* group, const Eigen::VectorXd& values);
+
+  /** \brief For a given group, copy the velocity values of the variables that make up the group into another location,
+   * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
+   * RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupVelocities(const std::string& joint_group_name, std::vector<double>& gstate) const
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+    {
+      gstate.resize(jmg->getVariableCount());
+      copyJointGroupVelocities(jmg, &gstate[0]);
+    }
+  }
+
+  /** \brief For a given group, copy the velocity values of the variables that make up the group into another location,
+   * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
+   * RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupVelocities(const std::string& joint_group_name, double* gstate) const
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      copyJointGroupVelocities(jmg, gstate);
+  }
+
+  /** \brief For a given group, copy the velocity values of the variables that make up the group into another location,
+   * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
+   * RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupVelocities(const JointModelGroup* group, std::vector<double>& gstate) const
+  {
+    gstate.resize(group->getVariableCount());
+    copyJointGroupVelocities(group, &gstate[0]);
+  }
+
+  /** \brief For a given group, copy the velocity values of the variables that make up the group into another location,
+   * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
+   * RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupVelocities(const JointModelGroup* group, double* gstate) const;
+
+  /** \brief For a given group, copy the velocity values of the variables that make up the group into another location,
+   * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
+   * RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupVelocities(const std::string& joint_group_name, Eigen::VectorXd& values) const
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      copyJointGroupVelocities(jmg, values);
+  }
+
+  /** \brief For a given group, copy the velocity values of the variables that make up the group into another location,
+   * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
+   * RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupVelocities(const JointModelGroup* group, Eigen::VectorXd& values) const;
+
+  /** @} */
+
+  /** \name Getting and setting group accelerations
+   *  @{
+   */
+
+  /** \brief Given accelerations for the variables that make up a group, in the order found in the group (including
+values of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupAccelerations(const std::string& joint_group_name, const double* gstate)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      setJointGroupAccelerations(jmg, gstate);
+  }
+
+  /** \brief Given accelerations for the variables that make up a group, in the order found in the group (including
+values of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupAccelerations(const std::string& joint_group_name, const std::vector<double>& gstate)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      setJointGroupAccelerations(jmg, &gstate[0]);
+  }
+
+  /** \brief Given accelerations for the variables that make up a group, in the order found in the group (including
+values of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupAccelerations(const JointModelGroup* group, const std::vector<double>& gstate)
+  {
+    setJointGroupAccelerations(group, &gstate[0]);
+  }
+
+  /** \brief Given accelerations for the variables that make up a group, in the order found in the group (including
+values of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupAccelerations(const JointModelGroup* group, const double* gstate);
+
+  /** \brief Given accelerations for the variables that make up a group, in the order found in the group (including
+values of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupAccelerations(const std::string& joint_group_name, const Eigen::VectorXd& values)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      setJointGroupAccelerations(jmg, values);
+  }
+
+  /** \brief Given accelerations for the variables that make up a group, in the order found in the group (including
+values of mimic joints), set those
+as the new values that correspond to the group */
+  void setJointGroupAccelerations(const JointModelGroup* group, const Eigen::VectorXd& values);
+
+  /** \brief For a given group, copy the acceleration values of the variables that make up the group into another
+   * location, in the order that the variables are found in the group. This is not necessarily a contiguous block of
+   * memory in the RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupAccelerations(const std::string& joint_group_name, std::vector<double>& gstate) const
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+    {
+      gstate.resize(jmg->getVariableCount());
+      copyJointGroupAccelerations(jmg, &gstate[0]);
+    }
+  }
+
+  /** \brief For a given group, copy the acceleration values of the variables that make up the group into another
+   * location, in the order that the variables are found in the group. This is not necessarily a contiguous block of
+   * memory in the RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupAccelerations(const std::string& joint_group_name, double* gstate) const
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      copyJointGroupAccelerations(jmg, gstate);
+  }
+
+  /** \brief For a given group, copy the acceleration values of the variables that make up the group into another
+   * location, in the order that the variables are found in the group. This is not necessarily a contiguous block of
+   * memory in the RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupAccelerations(const JointModelGroup* group, std::vector<double>& gstate) const
+  {
+    gstate.resize(group->getVariableCount());
+    copyJointGroupAccelerations(group, &gstate[0]);
+  }
+
+  /** \brief For a given group, copy the acceleration values of the variables that make up the group into another
+   * location, in the order that the variables are found in the group. This is not necessarily a contiguous block of
+   * memory in the RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupAccelerations(const JointModelGroup* group, double* gstate) const;
+
+  /** \brief For a given group, copy the acceleration values of the variables that make up the group into another
+   * location, in the order that the variables are found in the group. This is not necessarily a contiguous block of
+   * memory in the RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupAccelerations(const std::string& joint_group_name, Eigen::VectorXd& values) const
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+      copyJointGroupAccelerations(jmg, values);
+  }
+
+  /** \brief For a given group, copy the acceleration values of the variables that make up the group into another
+   * location, in the order that the variables are found in the group. This is not necessarily a contiguous block of
+   * memory in the RobotState itself, so we copy instead of returning a pointer.*/
+  void copyJointGroupAccelerations(const JointModelGroup* group, Eigen::VectorXd& values) const;
+
+  /** @} */
+
+  /** \name Setting from Inverse Kinematics
+   *  @{
+   */
 
   /**
    * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -629,7 +629,6 @@ as the new values that correspond to the group */
   /** \brief For a given group, copy the position values of the variables that make up the group into another location,
    * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
    * RobotState itself, so we copy instead of returning a pointer.*/
-
   void copyJointGroupPositions(const std::string& joint_group_name, std::vector<double>& gstate) const
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -455,6 +455,84 @@ void moveit::core::RobotState::copyJointGroupPositions(const JointModelGroup* gr
     values(i) = position_[il[i]];
 }
 
+void moveit::core::RobotState::setJointGroupVelocities(const JointModelGroup* group, const double* gstate)
+{
+  markVelocity();
+  const std::vector<int>& il = group->getVariableIndexList();
+  if (group->isContiguousWithinState())
+    memcpy(velocity_ + il[0], gstate, group->getVariableCount() * sizeof(double));
+  else
+  {
+    for (std::size_t i = 0; i < il.size(); ++i)
+      velocity_[il[i]] = gstate[i];
+  }
+}
+
+void moveit::core::RobotState::setJointGroupVelocities(const JointModelGroup* group, const Eigen::VectorXd& values)
+{
+  markVelocity();
+  const std::vector<int>& il = group->getVariableIndexList();
+  for (std::size_t i = 0; i < il.size(); ++i)
+    velocity_[il[i]] = values(i);
+}
+
+void moveit::core::RobotState::copyJointGroupVelocities(const JointModelGroup* group, double* gstate) const
+{
+  const std::vector<int>& il = group->getVariableIndexList();
+  if (group->isContiguousWithinState())
+    memcpy(gstate, velocity_ + il[0], group->getVariableCount() * sizeof(double));
+  else
+    for (std::size_t i = 0; i < il.size(); ++i)
+      gstate[i] = velocity_[il[i]];
+}
+
+void moveit::core::RobotState::copyJointGroupVelocities(const JointModelGroup* group, Eigen::VectorXd& values) const
+{
+  const std::vector<int>& il = group->getVariableIndexList();
+  values.resize(il.size());
+  for (std::size_t i = 0; i < il.size(); ++i)
+    values(i) = velocity_[il[i]];
+}
+
+void moveit::core::RobotState::setJointGroupAccelerations(const JointModelGroup* group, const double* gstate)
+{
+  markAcceleration();
+  const std::vector<int>& il = group->getVariableIndexList();
+  if (group->isContiguousWithinState())
+    memcpy(acceleration_ + il[0], gstate, group->getVariableCount() * sizeof(double));
+  else
+  {
+    for (std::size_t i = 0; i < il.size(); ++i)
+      acceleration_[il[i]] = gstate[i];
+  }
+}
+
+void moveit::core::RobotState::setJointGroupAccelerations(const JointModelGroup* group, const Eigen::VectorXd& values)
+{
+  markAcceleration();
+  const std::vector<int>& il = group->getVariableIndexList();
+  for (std::size_t i = 0; i < il.size(); ++i)
+    acceleration_[il[i]] = values(i);
+}
+
+void moveit::core::RobotState::copyJointGroupAccelerations(const JointModelGroup* group, double* gstate) const
+{
+  const std::vector<int>& il = group->getVariableIndexList();
+  if (group->isContiguousWithinState())
+    memcpy(gstate, acceleration_ + il[0], group->getVariableCount() * sizeof(double));
+  else
+    for (std::size_t i = 0; i < il.size(); ++i)
+      gstate[i] = acceleration_[il[i]];
+}
+
+void moveit::core::RobotState::copyJointGroupAccelerations(const JointModelGroup* group, Eigen::VectorXd& values) const
+{
+  const std::vector<int>& il = group->getVariableIndexList();
+  values.resize(il.size());
+  for (std::size_t i = 0; i < il.size(); ++i)
+    values(i) = acceleration_[il[i]];
+}
+
 void moveit::core::RobotState::update(bool force)
 {
   // make sure we do everything from scratch if needed


### PR DESCRIPTION
### Description
Copies the functionality used for setting and copying position values to a joint model group, but for velocities and accelerations. These are strictly helper functions for modifying the internal data of a RobotState more efficiently.  

### Checklist
- [X] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

Thank you!
