### PR TITLE
Change planning_scene service warning to an INFO message

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -476,7 +476,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(con
   }
   else
   {
-    ROS_WARN_NAMED(LOGNAME, "Failed to call service %s, have you launched move_group? at %s:%d", service_name.c_str(),
+    ROS_INFO_NAMED(LOGNAME, "Failed to call service %s, have you launched move_group? at %s:%d", service_name.c_str(),
                    __FILE__, __LINE__);
     return false;
   }


### PR DESCRIPTION
Something that has forever frustrated me is the warning when using a PlanningScene Rviz display:

> ros.moveit_ros_planning.planning_scene_monitor: Failed to call service get_planning_scene, have you launched move_group?

I would like to turn this into an INFO instead of a WARN, because often I startup Rviz in a separate terminal window from MoveGroup or whatever ROS node I'm using that publishes the planning scene.

Should be picked to J/K