### PR TITLE
PS: Don't reset color information of existing objects when new entries are added

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1310,7 +1310,8 @@ void planning_scene::PlanningScene::removeAllCollisionObjects()
 {
   const std::vector<std::string>& object_ids = world_->getObjectIds();
   for (std::size_t i = 0; i < object_ids.size(); ++i)
-    if (object_ids[i] != OCTOMAP_NS){
+    if (object_ids[i] != OCTOMAP_NS)
+    {
       world_->removeObject(object_ids[i]);
       removeObjectColor(object_ids[i]);
       removeObjectType(object_ids[i]);
@@ -1697,7 +1698,8 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
     {
       removeAllCollisionObjects();
     }
-    else {
+    else
+    {
       world_->removeObject(object.id);
       removeObjectColor(object.id);
       removeObjectType(object.id);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1215,12 +1215,8 @@ bool planning_scene::PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::P
   }
 
   // if any colors have been specified, replace the ones we have with the specified ones
-  if (!scene_msg.object_colors.empty())
-  {
-    object_colors_.reset();
-    for (std::size_t i = 0; i < scene_msg.object_colors.size(); ++i)
-      setObjectColor(scene_msg.object_colors[i].id, scene_msg.object_colors[i].color);
-  }
+  for (std::size_t i = 0; i < scene_msg.object_colors.size(); ++i)
+    setObjectColor(scene_msg.object_colors[i].id, scene_msg.object_colors[i].color);
 
   // process collision object updates
   for (std::size_t i = 0; i < scene_msg.world.collision_objects.size(); ++i)
@@ -1313,8 +1309,10 @@ void planning_scene::PlanningScene::removeAllCollisionObjects()
 {
   const std::vector<std::string>& object_ids = world_->getObjectIds();
   for (std::size_t i = 0; i < object_ids.size(); ++i)
-    if (object_ids[i] != OCTOMAP_NS)
+    if (object_ids[i] != OCTOMAP_NS){
       world_->removeObject(object_ids[i]);
+      removeObjectColor(object_ids[i]);
+    }
 }
 
 void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::OctomapWithPose& map)
@@ -1697,8 +1695,10 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
     {
       removeAllCollisionObjects();
     }
-    else
+    else {
       world_->removeObject(object.id);
+      removeObjectColor(object.id);
+    }
     return true;
   }
   else if (object.operation == moveit_msgs::CollisionObject::MOVE)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -498,6 +498,7 @@ void planning_scene::PlanningScene::pushDiffs(const PlanningScenePtr& scene)
       {
         scene->world_->removeObject(it->first);
         scene->removeObjectColor(it->first);
+        scene->removeObjectType(it->first);
       }
       else
       {
@@ -1312,6 +1313,7 @@ void planning_scene::PlanningScene::removeAllCollisionObjects()
     if (object_ids[i] != OCTOMAP_NS){
       world_->removeObject(object_ids[i]);
       removeObjectColor(object_ids[i]);
+      removeObjectType(object_ids[i]);
     }
 }
 
@@ -1698,6 +1700,7 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
     else {
       world_->removeObject(object.id);
       removeObjectColor(object.id);
+      removeObjectType(object.id);
     }
     return true;
   }


### PR DESCRIPTION
This implements a fix for #408.

When adding two different objects with color information one after the other (in two different PlanningScene updates), the color information of the first update is lost and overwritten during the second update.
As a result the color specified in the first update is lost and the existing (the first) object changes back to default-green in RViz.

In order to avoid memory leaks, I added explicit remove operations upon object removal.
However, this slightly changes current behavior: If you add an object with color information, remove it, and later on add that object back *without* specifying a color, the previous color was still cached - That is, unless any other PlanningScene update with color information was received in between.
Because of the changed behavior I would not backport this to i/j.

While I read through the code I found the explicit removal operations where missing for `ObjectType`s too, so I added these in a second commit.

Notice that both remove functions do nothing if the entry is not present, so calling them cannot break anything here.