### PR TITLE
[moveit_ros] Missing test_depend.

### DIFF
--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -44,4 +44,6 @@
   <run_depend>tf_conversions</run_depend>
   <run_depend>python</run_depend>
 
+  <test_depend>moveit_resources</test_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 if (CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources)
   find_package(rostest)
 
   add_rostest_gtest(test_cleanup cleanup.test cleanup.cpp)


### PR DESCRIPTION
`moveit_resources` is used in multiple tests under `moveit_ros/planning_interface` ([here](https://github.com/ros-planning/moveit/blob/23d09fe7abbd77098657654bfb67fe8f8e409ff3/moveit_ros/planning_interface/test/python_move_group.test#L2), [here](https://github.com/ros-planning/moveit/blob/4bc43c56ca2a5293f3ef8d55796ec586cfde5f69/moveit_ros/planning_interface/test/cleanup.test#L2), [here](https://github.com/ros-planning/moveit/blob/4bc43c56ca2a5293f3ef8d55796ec586cfde5f69/moveit_ros/planning_interface/test/robot_state_update.test#L2)). 

I assume it's been luckily never an issue probably because the dependency has been met before the test jobs reach moveit_ros?.

I think this can be backported to IJ as well.