### PR TITLE
fix Qt4 compatibility for setup assistant

### DIFF
--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -300,7 +300,7 @@ void SortFilterProxyModel::sort(int column, Qt::SortOrder order)
     if (prev_idx < 0)
       prev_idx = sort_columns_.size() - 1;
     // remove old entries
-    sort_columns_.takeAt(prev_idx);
+    sort_columns_.remove(prev_idx);
     sort_orders_.remove(prev_idx);
     // add new entries at front
     sort_columns_.insert(0, column);

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -270,8 +270,10 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& src_left, const QModelInd
 
   for (int i = 0, end = sort_columns_.size(); i < end && sort_columns_[i] >= 0; ++i)
   {
-    QVariant value_left = m->data(m->index(row_left, sort_columns_[i]));
-    QVariant value_right = m->data(m->index(row_right, sort_columns_[i]));
+    int sc = sort_columns_[i];
+    int role = sc == 2 ? Qt::CheckStateRole : Qt::DisplayRole;
+    QVariant value_left = m->data(m->index(row_left, sc), role);
+    QVariant value_right = m->data(m->index(row_right, sc), role);
 
     if (value_left == value_right)
       continue;

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -252,8 +252,10 @@ bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& s
 
 // define a fallback comparison operator for QVariants
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-namespace {
-bool operator<(const QVariant& left, const QVariant& right) {
+namespace
+{
+bool operator<(const QVariant& left, const QVariant& right)
+{
   if (left.userType() == QVariant::Type::Int)
     return left.toInt() < right.toInt();
   else

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -192,7 +192,9 @@ QVariant CollisionLinearModel::headerData(int section, Qt::Orientation orientati
 
 SortFilterProxyModel::SortFilterProxyModel(QObject* parent) : QSortFilterProxyModel(parent), show_all_(false)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   connect(this, SIGNAL(sourceModelChanged()), this, SLOT(initSorting()));
+#endif
 
   // by default: sort by link A (col 0), then link B (col 1)
   sort_columns_ << 0 << 1;
@@ -247,6 +249,18 @@ bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& s
   return m->data(m->index(source_row, 0, source_parent), Qt::DisplayRole).toString().contains(regexp) ||
          m->data(m->index(source_row, 1, source_parent), Qt::DisplayRole).toString().contains(regexp);
 }
+
+// define a fallback comparison operator for QVariants
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+namespace {
+bool operator<(const QVariant& left, const QVariant& right) {
+  if (left.userType() == QVariant::Type::Int)
+    return left.toInt() < right.toInt();
+  else
+    return left.toString() < right.toString();
+}
+}
+#endif
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& src_left, const QModelIndex& src_right) const
 {

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -358,13 +358,12 @@ void DefaultCollisionsWidget::loadCollisionTable()
 #endif
   }
 
-  // notice changes to the model
+// notice changes to the model
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   connect(model_, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)), this,
           SLOT(collisionsChanged(QModelIndex)));
 #else
-  connect(model_, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this,
-          SLOT(collisionsChanged(QModelIndex)));
+  connect(model_, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(collisionsChanged(QModelIndex)));
 #endif
 }
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -359,8 +359,13 @@ void DefaultCollisionsWidget::loadCollisionTable()
   }
 
   // notice changes to the model
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   connect(model_, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)), this,
           SLOT(collisionsChanged(QModelIndex)));
+#else
+  connect(model_, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this,
+          SLOT(collisionsChanged(QModelIndex)));
+#endif
 }
 
 void DefaultCollisionsWidget::collisionsChanged(const QModelIndex& index)


### PR DESCRIPTION
As pointed out by @v4hn in https://github.com/ros-planning/moveit/pull/394#issuecomment-271185733, recent commit #394 broke Qt4 support for MSA. This is an attempt to fix it.
@v4hn I don't have a Trusty system around anymore. Could you please test this?
Feel free to push any necessary changes directly to this shared branch.
