### PR TITLE
[FIX][moveit_ros_planning_interface] Install test directory so that tutorial for testing can be run

### DIFF
--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -8,3 +8,7 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest(python_move_group.test)
 endif()
+
+install(FILE python_move_group.py python_move_group.test
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
At [Running Tests In MoveIt!](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html#integration-test) tutorial, the test command fails as follows. This PR fixes it.

```
$ rostest moveit_ros_planning_interface python_move_group.test
[python_move_group.test] is neither a launch file in package [moveit_ros_planning_interface] nor is [moveit_ros_planning_interface] a launch file name
$ rospack find moveit_ros_planning_interface
/opt/ros/kinetic/share/moveit_ros_planning_interface
$ ll `find /opt/ros/kinetic -iname moveit_ros_planning_interface`
/opt/ros/kinetic/lib/python2.7/dist-packages/moveit_ros_planning_interface:
total 676K
drwxr-xr-x 189 root root  20K Jan  5 23:47 ../
drwxr-xr-x   2 root root 4.0K Jan  5 23:47 ./
lrwxrwxrwx   1 root root   37 Jan  4 21:41 _moveit_move_group_interface.so -> _moveit_move_group_interface.so.0.9.3
-rw-r--r--   1 root root 414K Jan  4 21:41 _moveit_move_group_interface.so.0.9.3
lrwxrwxrwx   1 root root   41 Jan  4 21:41 _moveit_planning_scene_interface.so -> _moveit_planning_scene_interface.so.0.9.3
-rw-r--r--   1 root root  88K Jan  4 21:41 _moveit_planning_scene_interface.so.0.9.3
lrwxrwxrwx   1 root root   32 Jan  4 21:41 _moveit_robot_interface.so -> _moveit_robot_interface.so.0.9.3
-rw-r--r--   1 root root 124K Jan  4 21:41 _moveit_robot_interface.so.0.9.3
lrwxrwxrwx   1 root root   35 Jan  4 21:41 _moveit_roscpp_initializer.so -> _moveit_roscpp_initializer.so.0.9.3
-rw-r--r--   1 root root  19K Jan  4 21:41 _moveit_roscpp_initializer.so.0.9.3
-rw-r--r--   1 root root  173 Jan  4 21:41 __init__.pyc
-rw-r--r--   1 root root    0 Nov 16 13:57 __init__.py

/opt/ros/kinetic/share/moveit_ros_planning_interface:
total 32K
drwxr-xr-x   3 root root 4.0K Jan  5 23:47 ./
drwxr-xr-x   2 root root 4.0K Jan  5 23:47 cmake/
drwxr-xr-x 379 root root  20K Nov 17 19:32 ../
-rw-r--r--   1 root root 1.8K Nov 16 13:57 package.xml
$ rosversion moveit_ros_planning_interface
0.9.3
$ lsb_release -a|grep Rele
No LSB modules are available.
Release:        16.04
```
