### PR TITLE
install planning_interface python test

### DIFF
--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -8,3 +8,6 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest(python_move_group.test)
   add_rostest(robot_state_update.test)
 endif()
+
+install(PROGRAMS python_move_group.py DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)
+install(FILES python_move_group.test DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)


### PR DESCRIPTION
Supersedes #414.

This test is reference in the tutorials and should also work with installed workspaces
http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html#integration-test

This should also be picked to i/j