### PR TITLE
mgi: show correct include path in doxygen

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -79,7 +79,9 @@ public:
 
 MOVEIT_CLASS_FORWARD(MoveGroupInterface);
 
-/** \brief Client class to conveniently use the ROS interfaces provided by the move_group node.
+/** \class MoveGroupInterface move_group_interface.h moveit/planning_interface/move_group_interface.h
+
+    \brief Client class to conveniently use the ROS interfaces provided by the move_group node.
 
     This class includes many default settings to make things easy to use. */
 class MoveGroupInterface


### PR DESCRIPTION
The documentation generated by osrf includes a broken
include path for this class, so let's set it to the correct
include explicitly.

This came up on answers.ros.org:
http://answers.ros.org/question/252157/where-is-the-document-for-namespace-of-move_group_interface/?answer=252189#post-id-252189

http://www.stack.nl/~dimitri/doxygen/manual/faq.html#faq_code_inc shows the correct syntax to fix this.

I tested it locally and it yields the correct documentation