### PR TITLE
address gcc6 build error

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -133,12 +133,12 @@ catkin_package(
     )
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR}
-                           ${Boost_INCLUDE_DIR}
                            ${LIBFCL_INCLUDE_DIRS}
                            )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${VERSION_FILE_PATH}
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
                     ${console_bridge_INCLUDE_DIRS}
                     ${urdfdom_INCLUDE_DIRS}


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`,
as including '-isystem /usr/include' breaks with gcc6, cf.,
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for this package in the same way
it was addressed in various other ROS packages. A list of related
commits and pull requests is at:

      https://github.com/ros/rosdistro/issues/12783

This patch should be better cherry-picked to indigo-devel since it's the base for the current meta-ros layer for Yocto.