### PR TITLE
Handle multiple shapes in an attached collision object

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -983,9 +983,9 @@ const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::st
     return identity_transform;
   }
   if (tf.size() > 1)
-    logWarn("There are multiple geometries associated to attached body '%s'. Returning the transform for the first "
-            "one.",
-            id.c_str());
+    logDebug("There are multiple geometries associated to attached body '%s'. Returning the transform for the first "
+             "one.",
+             id.c_str());
   return tf[0];
 }
 
@@ -996,7 +996,7 @@ bool moveit::core::RobotState::knowsFrameTransform(const std::string& id) const
   if (robot_model_->hasLinkModel(id))
     return true;
   std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
-  return it != attached_body_map_.end() && it->second->getGlobalCollisionBodyTransforms().size() == 1;
+  return it != attached_body_map_.end() && it->second->getGlobalCollisionBodyTransforms().size() >= 1;
 }
 
 void moveit::core::RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,


### PR DESCRIPTION
Objects with multiple collision shapes leave the question what the object's
internal frame is, because a pose is specified *for each shape* individually.

The RobotState::getFrameTransform function handled this by returning the first
registered pose as frame of reference.
This is a perfectly valid approach, so I changed the warning there to a debug message.

RobotState::knowsFrameTransform, however, returned false if asked whether the state knows the
transform for the object. That's inconsistant behavior: if `getFrameTransform` returns a valid result,
then the indicator should also reflect that.

Among other things, the pick-pipeline fails with objects with multiple collision shapes
without this change. I consider this a bug-fix, so I request to merge this into indigo (and forward-port it).