### PR TITLE
address gcc6 build error

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -127,11 +127,11 @@ catkin_package(
     )
 
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS}
-                           ${Boost_INCLUDE_DIR}
                            )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${VERSION_FILE_PATH}
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
                     ${console_bridge_INCLUDE_DIRS}
                     ${urdfdom_INCLUDE_DIRS}

--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -65,10 +65,10 @@ catkin_package(
     )
 
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS}
-                           ${Boost_INCLUDE_DIR}
                            )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS} 
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS} 
                     ${console_bridge_INCLUDE_DIRS} 
                     ${urdfdom_INCLUDE_DIRS} 

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -41,11 +41,11 @@ catkin_package(
 )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
 )
 include_directories(SYSTEM
                     ${EIGEN3_INCLUDE_DIRS}
-                    ${Boost_INCLUDE_DIRS}
 )
 
 link_directories(${Boost_LIBRARY_DIRS})

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -32,10 +32,8 @@ catkin_package(
     moveit_core
 )
 
-include_directories(SYSTEM
-                    ${Boost_INCLUDE_DIRS})
-
 include_directories(ompl_interface/include
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
                     ${OMPL_INCLUDE_DIRS})
 

--- a/moveit_plugins/moveit_controller_manager_example/CMakeLists.txt
+++ b/moveit_plugins/moveit_controller_manager_example/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost REQUIRED thread)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
 find_package(catkin COMPONENTS

--- a/moveit_plugins/moveit_fake_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_fake_controller_manager/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost REQUIRED thread)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
 find_package(catkin COMPONENTS

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost REQUIRED thread)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
 find_package(catkin COMPONENTS

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package(
 include_directories(benchmarks/include)
 
 include_directories(${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/moveit_ros/benchmarks_gui/CMakeLists.txt
+++ b/moveit_ros/benchmarks_gui/CMakeLists.txt
@@ -36,7 +36,7 @@ catkin_package()
 include_directories(include)
 
 include_directories(${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/moveit_ros/manipulation/CMakeLists.txt
+++ b/moveit_ros/manipulation/CMakeLists.txt
@@ -36,10 +36,10 @@ catkin_package(
 include_directories(pick_place/include)
 include_directories(move_group_pick_place_capability/include)
 
-include_directories(${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM
-                    ${EIGEN_INCLUDE_DIRS}
+include_directories(${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM
+                    ${EIGEN_INCLUDE_DIRS})
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -27,10 +27,8 @@ catkin_package(
 )
 
 include_directories(include)
-include_directories(${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM
-                    ${Boost_INCLUDE_DIRS}
-                    )
+include_directories(${catkin_INCLUDE_DIRS}
+                    ${Boost_INCLUDE_DIRS})
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -66,12 +66,12 @@ include_directories(mesh_filter/include
                     occupancy_map_monitor/include
                     pointcloud_octomap_updater/include
                     semantic_world/include
+                    ${OpenCV_INCLUDE_DIRS}
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
                     )
 include_directories(SYSTEM
-                    ${OpenCV_INCLUDE_DIRS}
                     ${EIGEN_INCLUDE_DIRS}
-                    ${Boost_INCLUDE_DIRS}
                     ${GLEW_INCLUDE_DIR}
                     ${GLUT_INCLUDE_DIR}
                     )

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -22,9 +22,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 find_package(Eigen REQUIRED)
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-
-include(${QT_USE_FILE})
 
 generate_dynamic_reconfigure_options(
   "planning_scene_monitor/cfg/PlanningSceneMonitorDynamicReconfigure.cfg"

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -25,7 +25,6 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>angles</build_depend>
   <build_depend>cmake_modules</build_depend>
-  <build_depend>libqt4-dev</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_perception</run_depend>
@@ -33,7 +32,6 @@
   <run_depend>actionlib</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>angles</run_depend>
-  <run_depend>libqt4</run_depend>
 
   <export>
     <moveit_core plugin="${prefix}/planning_request_adapters_plugin_description.xml"/>

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -63,7 +63,7 @@ void planning_scene_monitor::TrajectoryMonitor::setSamplingFrequency(double samp
 
 bool planning_scene_monitor::TrajectoryMonitor::isActive() const
 {
-  return record_states_thread_;
+  return static_cast<bool>(record_states_thread_);
 }
 
 void planning_scene_monitor::TrajectoryMonitor::startTrajectoryMonitor()

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -55,13 +55,13 @@ catkin_package(
     )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS})
 
 include_directories(SYSTEM
                     ${EIGEN_INCLUDE_DIRS}
-		    ${Boost_INCLUDE_DIRS}
                     ${PYTHON_INCLUDE_DIRS})
-		
+
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -28,9 +28,9 @@ catkin_package(
     )
 
 include_directories(include
+                    ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS})
 
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 add_library(${MOVEIT_LIB_NAME}

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -62,10 +62,10 @@ include_directories(rviz_plugin_render_tools/include
                     planning_scene_rviz_plugin/include
                     motion_planning_rviz_plugin/include
                     trajectory_rviz_plugin/include
-		    ${catkin_INCLUDE_DIRS})
+                    ${Boost_INCLUDE_DIRS}
+                    ${catkin_INCLUDE_DIRS})
 
 include_directories(SYSTEM
-                    ${Boost_INCLUDE_DIRS}
                     ${QT_INCLUDE_DIR}
                     ${OGRE_INCLUDE_DIRS})
 

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -25,8 +25,7 @@ catkin_package(
     warehouse_ros)
 
 include_directories(warehouse/include)
-include_directories(${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 include_directories(include)
 
 find_package(Boost REQUIRED COMPONENTS thread filesystem system program_options)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`,
as including '-isystem /usr/include' breaks with gcc6, cf.,
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for this package in almost the same way
it was addressed in various other ROS packages. A list of related
commits and pull requests is at:

    https://github.com/ros/rosdistro/issues/12783

Particularly when searching for the Boost library CMake sets
Boost_INCLUDE_DIRS to @SYSROOT@/usr/include which should be
avoided in the `-isystem` option of gcc.
The same goes for OpenCV.

Fortunately neither Boost nor OpenCV trigger build warnings when their include dirs are not marked as system ones.