### PR TITLE
move_group.cpp: seg fault bug fix

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -188,9 +188,9 @@ public:
         {
           queue->callAvailable();
         }
-        else
+        else // in case of nodelets and specific callback queue implementations
         {
-          ros::spinOnce();
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
         }
       }
     }
@@ -205,9 +205,9 @@ public:
         {
           queue->callAvailable();
         }
-        else
+        else // in case of nodelets and specific callback queue implementations
         {
-          ros::spinOnce();
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
         }
       }
     }
@@ -246,9 +246,9 @@ public:
         {
           queue->callAvailable();
         }
-        else
+        else // in case of nodelets and specific callback queue implementations
         {
-          ros::spinOnce();
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
         }
       }
     }
@@ -264,9 +264,9 @@ public:
         {
           queue->callAvailable();
         }
-        else
+        else // in case of nodelets and specific callback queue implementations
         {
-          ros::spinOnce();
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
         }
       }
     }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -183,7 +183,15 @@ public:
       {
         ros::WallDuration(0.001).sleep();
         // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
-        ((ros::CallbackQueue*)node_handle_.getCallbackQueue())->callAvailable();
+        ros::CallbackQueue* queue = dynamic_cast<ros::CallbackQueue*>(node_handle_.getCallbackQueue());
+        if (queue)
+        {
+          queue->callAvailable();
+        }
+        else
+        {
+          ros::spinOnce();
+        }
       }
     }
     else  // wait with timeout
@@ -192,7 +200,15 @@ public:
       {
         ros::WallDuration(0.001).sleep();
         // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
-        ((ros::CallbackQueue*)node_handle_.getCallbackQueue())->callAvailable();
+        ros::CallbackQueue* queue = dynamic_cast<ros::CallbackQueue*>(node_handle_.getCallbackQueue());
+        if (queue)
+        {
+          queue->callAvailable();
+        }
+        else
+        {
+          ros::spinOnce();
+        }
       }
     }
 
@@ -225,7 +241,15 @@ public:
       {
         ros::WallDuration(0.001).sleep();
         // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
-        ((ros::CallbackQueue*)node_handle_.getCallbackQueue())->callAvailable();
+        ros::CallbackQueue* queue = dynamic_cast<ros::CallbackQueue*>(node_handle_.getCallbackQueue());
+        if (queue)
+        {
+          queue->callAvailable();
+        }
+        else
+        {
+          ros::spinOnce();
+        }
       }
     }
     else  // wait with timeout
@@ -235,7 +259,15 @@ public:
       {
         ros::WallDuration(0.001).sleep();
         // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
-        ((ros::CallbackQueue*)node_handle_.getCallbackQueue())->callAvailable();
+        ros::CallbackQueue* queue = dynamic_cast<ros::CallbackQueue*>(node_handle_.getCallbackQueue());
+        if (queue)
+        {
+          queue->callAvailable();
+        }
+        else
+        {
+          ros::spinOnce();
+        }
       }
     }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -191,7 +191,7 @@ public:
         else  // in case of nodelets and specific callback queue implementations
         {
           ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
-+                                                      "handling.");
+                                                      "handling.");
         }
       }
     }
@@ -209,7 +209,7 @@ public:
         else  // in case of nodelets and specific callback queue implementations
         {
           ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
-+                                                      "handling.");
+                                                      "handling.");
         }
       }
     }
@@ -251,7 +251,7 @@ public:
         else  // in case of nodelets and specific callback queue implementations
         {
           ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
-+                                                      "handling.");
+                                                      "handling.");
         }
       }
     }
@@ -270,7 +270,7 @@ public:
         else  // in case of nodelets and specific callback queue implementations
         {
           ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
-+                                                      "handling.");
+                                                      "handling.");
         }
       }
     }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -188,9 +188,10 @@ public:
         {
           queue->callAvailable();
         }
-        else // in case of nodelets and specific callback queue implementations
+        else  // in case of nodelets and specific callback queue implementations
         {
-          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
++                                                      "handling.");
         }
       }
     }
@@ -205,9 +206,10 @@ public:
         {
           queue->callAvailable();
         }
-        else // in case of nodelets and specific callback queue implementations
+        else  // in case of nodelets and specific callback queue implementations
         {
-          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
++                                                      "handling.");
         }
       }
     }
@@ -246,9 +248,10 @@ public:
         {
           queue->callAvailable();
         }
-        else // in case of nodelets and specific callback queue implementations
+        else  // in case of nodelets and specific callback queue implementations
         {
-          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
++                                                      "handling.");
         }
       }
     }
@@ -264,9 +267,10 @@ public:
         {
           queue->callAvailable();
         }
-        else // in case of nodelets and specific callback queue implementations
+        else  // in case of nodelets and specific callback queue implementations
         {
-          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue handling.");
+          ROS_WARN_ONCE_NAMED("move_group_interface", "Non-default CallbackQueue: Waiting for external queue "
++                                                      "handling.");
         }
       }
     }


### PR DESCRIPTION
### Description
Fixed a bug with casting CallbackQueueInterface * to ros::CallbackQueue * without a check.
Without this additional check, creating an instance of MoveGroup in a nodelet causes a segmentation fault, because of different CallbackQueue implementations (nodelet::detail::CallbackQueue).

https://github.com/ros-planning/moveit/issues/425

