### PR TITLE
Replace const_cast with static_cast where possible

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -202,7 +202,7 @@ public:
   const Eigen::Affine3d& getFrameTransform(robot_state::RobotState& state, const std::string& id) const
   {
     state.updateLinkTransforms();
-    return getFrameTransform(const_cast<const robot_state::RobotState&>(state), id);
+    return getFrameTransform(static_cast<const robot_state::RobotState&>(state), id);
   }
 
   /** \brief Get the transform corresponding to the frame \e id. This will be known if \e id is a link name, an attached
@@ -366,7 +366,7 @@ public:
   bool isStateColliding(robot_state::RobotState& state, const std::string& group = "", bool verbose = false) const
   {
     state.updateCollisionBodyTransforms();
-    return isStateColliding(const_cast<const robot_state::RobotState&>(state), group, verbose);
+    return isStateColliding(static_cast<const robot_state::RobotState&>(state), group, verbose);
   }
 
   /** \brief Check if a given state is in collision (with the environment or self collision)
@@ -396,7 +396,7 @@ public:
                       robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    checkCollision(req, res, const_cast<const robot_state::RobotState&>(kstate));
+    checkCollision(req, res, static_cast<const robot_state::RobotState&>(kstate));
   }
 
   /** \brief Check whether a specified state (\e kstate) is in collision. The collision transforms of \e kstate are
@@ -411,7 +411,7 @@ public:
                       robot_state::RobotState& kstate, const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    checkCollision(req, res, const_cast<const robot_state::RobotState&>(kstate), acm);
+    checkCollision(req, res, static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
@@ -449,7 +449,7 @@ public:
                               collision_detection::CollisionResult& res, robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, const_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
   }
 
   /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
@@ -460,7 +460,7 @@ public:
                               const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, const_cast<const robot_state::RobotState&>(kstate), acm);
+    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
@@ -484,7 +484,7 @@ public:
                           robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, const_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
   }
 
   /** \brief Check whether a specified state (\e kstate) is in self collision */
@@ -501,7 +501,7 @@ public:
                           robot_state::RobotState& kstate, const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, const_cast<const robot_state::RobotState&>(kstate), acm);
+    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief Check whether a specified state (\e kstate) is in self collision, with respect to a given
@@ -528,7 +528,7 @@ public:
   void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    getCollidingLinks(links, const_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
   }
 
   /** \brief Get the names of the links that are involved in collisions for the state \e kstate */
@@ -543,7 +543,7 @@ public:
                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    getCollidingLinks(links, const_cast<const robot_state::RobotState&>(kstate), acm);
+    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
@@ -574,7 +574,7 @@ public:
                          robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    getCollidingPairs(contacts, const_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
@@ -583,7 +583,7 @@ public:
                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    getCollidingPairs(contacts, const_cast<const robot_state::RobotState&>(kstate), acm);
+    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
@@ -604,7 +604,7 @@ public:
   double distanceToCollision(robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    return distanceToCollision(const_cast<const robot_state::RobotState&>(kstate));
+    return distanceToCollision(static_cast<const robot_state::RobotState&>(kstate));
   }
 
   /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions)
@@ -619,7 +619,7 @@ public:
   double distanceToCollisionUnpadded(robot_state::RobotState& kstate) const
   {
     kstate.updateCollisionBodyTransforms();
-    return distanceToCollisionUnpadded(const_cast<const robot_state::RobotState&>(kstate));
+    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(kstate));
   }
 
   /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring
@@ -635,7 +635,7 @@ public:
                              const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    return distanceToCollision(const_cast<const robot_state::RobotState&>(kstate), acm);
+    return distanceToCollision(static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions
@@ -652,7 +652,7 @@ public:
                                      const collision_detection::AllowedCollisionMatrix& acm) const
   {
     kstate.updateCollisionBodyTransforms();
-    return distanceToCollisionUnpadded(const_cast<const robot_state::RobotState&>(kstate), acm);
+    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(kstate), acm);
   }
 
   /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -686,7 +686,7 @@ collision_detection::AllowedCollisionMatrix& planning_scene::PlanningScene::getA
 const robot_state::Transforms& planning_scene::PlanningScene::getTransforms()
 {
   getCurrentStateNonConst().update();
-  return const_cast<const PlanningScene*>(this)->getTransforms();
+  return static_cast<const PlanningScene*>(this)->getTransforms();
 }
 
 robot_state::Transforms& planning_scene::PlanningScene::getTransformsNonConst()

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1184,8 +1184,8 @@ as the new values that correspond to the group */
                    Eigen::MatrixXd& jacobian, bool use_quaternion_representation = false)
   {
     updateLinkTransforms();
-    return const_cast<const RobotState*>(this)->getJacobian(group, link, reference_point_position, jacobian,
-                                                            use_quaternion_representation);
+    return static_cast<const RobotState*>(this)->getJacobian(group, link, reference_point_position, jacobian,
+                                                             use_quaternion_representation);
   }
 
   /** \brief Compute the Jacobian with reference to the last link of a specified group. If the group is not a chain, an
@@ -1207,7 +1207,7 @@ as the new values that correspond to the group */
                               const Eigen::Vector3d& reference_point_position = Eigen::Vector3d(0.0, 0.0, 0.0))
   {
     updateLinkTransforms();
-    return const_cast<const RobotState*>(this)->getJacobian(group, reference_point_position);
+    return static_cast<const RobotState*>(this)->getJacobian(group, reference_point_position);
   }
 
   /** \brief Given a twist for a particular link (\e tip), compute the corresponding velocity for every variable and
@@ -1221,7 +1221,7 @@ as the new values that correspond to the group */
                                const LinkModel* tip)
   {
     updateLinkTransforms();
-    const_cast<const RobotState*>(this)->computeVariableVelocity(jmg, qdot, twist, tip);
+    static_cast<const RobotState*>(this)->computeVariableVelocity(jmg, qdot, twist, tip);
   }
 
   /** \brief Given the velocities for the variables in this group (\e qdot) and an amount of time (\e dt),
@@ -1604,7 +1604,7 @@ as the new values that correspond to the group */
   void computeAABB(std::vector<double>& aabb)
   {
     updateLinkTransforms();
-    const_cast<const RobotState*>(this)->computeAABB(aabb);
+    static_cast<const RobotState*>(this)->computeAABB(aabb);
   }
 
   /** \brief Return the instance of a random number generator */
@@ -1647,7 +1647,7 @@ as the new values that correspond to the group */
                        bool include_attached = false)
   {
     updateCollisionBodyTransforms();
-    const_cast<const RobotState*>(this)->getRobotMarkers(arr, link_names, color, ns, dur, include_attached);
+    static_cast<const RobotState*>(this)->getRobotMarkers(arr, link_names, color, ns, dur, include_attached);
   }
 
   /** @brief Get a MarkerArray that fully describes the robot markers for a given robot.
@@ -1665,7 +1665,7 @@ as the new values that correspond to the group */
                        bool include_attached = false)
   {
     updateCollisionBodyTransforms();
-    const_cast<const RobotState*>(this)->getRobotMarkers(arr, link_names, include_attached);
+    static_cast<const RobotState*>(this)->getRobotMarkers(arr, link_names, include_attached);
   }
 
   void printStatePositions(std::ostream& out = std::cout) const;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -974,7 +974,7 @@ bool moveit::core::RobotState::clearAttachedBody(const std::string& id)
 const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::string& id)
 {
   updateLinkTransforms();
-  return const_cast<const RobotState*>(this)->getFrameTransform(id);
+  return static_cast<const RobotState*>(this)->getFrameTransform(id);
 }
 
 const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::string& id) const

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -594,12 +594,12 @@ public:
 
   operator const planning_scene::PlanningSceneConstPtr&() const
   {
-    return const_cast<const PlanningSceneMonitor*>(planning_scene_monitor_.get())->getPlanningScene();
+    return static_cast<const PlanningSceneMonitor*>(planning_scene_monitor_.get())->getPlanningScene();
   }
 
   const planning_scene::PlanningSceneConstPtr& operator->() const
   {
-    return const_cast<const PlanningSceneMonitor*>(planning_scene_monitor_.get())->getPlanningScene();
+    return static_cast<const PlanningSceneMonitor*>(planning_scene_monitor_.get())->getPlanningScene();
   }
 
 protected:


### PR DESCRIPTION
This PR replaces `const_cast` with `static_cast` where possible. A `const_cast` is normally an indication of an API problem somewhere. The replaced casts only add `const`, so a `static_cast` will do just fine, with the added benefit that it doesn't look like dangerous things are happening.

Should be fine to pick to I/J. No API or ABI changes.