### PR TITLE
[Jade] Move a metapackage moveit_runtime from moveit_metapackage repo.

### DIFF
--- a/moveit_runtime/CMakeLists.txt
+++ b/moveit_runtime/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(moveit_runtime)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/moveit_runtime/package.xml
+++ b/moveit_runtime/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package>
+  <name>moveit_runtime</name>
+  <version>0.7.6</version>
+  <description>moveit_runtime meta package contains MoveIt! packages that are essential for its runtime (e.g. running MoveIt! on robots).</description>
+
+  <author email="gm130s@gmail.com">Isaac I. Y. Saito</author>
+  <maintainer email="gm130s@gmail.com">Isaac I. Y. Saito</maintainer>
+
+  <license>BSD</license>
+  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://wiki.ros.org/moveit_runtime</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>moveit_core</run_depend>
+  <run_depend>moveit_planners</run_depend>
+  <run_depend>moveit_plugins</run_depend>
+  <run_depend>moveit_ros_manipulation</run_depend>
+  <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_ros_perception</run_depend>
+  <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>moveit_ros_planning_interface</run_depend>
+  <run_depend>moveit_ros_warehouse</run_depend>
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
Cherrypicking the change of https://github.com/ros-planning/moveit/pull/422. 

Note that for Jade (and Kinetic too), in addition to dropping `moveit_full` as suggested in https://github.com/ros-planning/moveit/pull/422#issue-202663652, we need to drop `moveit_full_pr2` as its dependency, moveit_pr2 is not met yet. Related https://github.com/ros-planning/moveit_pr2/issues/71
- J http://repositories.ros.org/status_page/ros_jade_default.html?q=moveit_pr2
- K http://repositories.ros.org/status_page/ros_kinetic_default.html?q=moveit_pr2
