### PR TITLE
Implementing getLinkNames function for MoveGroup interface.

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -173,6 +173,9 @@ public:
   /** \brief Get vector of names of joints available in move group */
   const std::vector<std::string>& getJointNames();
 
+  /** \brief Get vector of names of links available in move group */
+  const std::vector<std::string>& getLinkNames();
+
   /** \brief Get the joint angles for targets specified by name */
   std::map<std::string, double> getNamedTargetValues(const std::string& name);
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -1509,6 +1509,11 @@ const std::vector<std::string>& moveit::planning_interface::MoveGroup::getJointN
   return impl_->getJointModelGroup()->getVariableNames();
 }
 
+const std::vector<std::string>& moveit::planning_interface::MoveGroup::getLinkNames()
+{
+  return impl_->getJointModelGroup()->getLinkModelNames();
+}
+
 std::map<std::string, double> moveit::planning_interface::MoveGroup::getNamedTargetValues(const std::string& name)
 {
   std::map<std::string, std::vector<double> >::const_iterator it = remembered_joint_values_.find(name);


### PR DESCRIPTION
Adds a convenience method to get all link names of a move group via the MoveGroup interface without the need to access the robot model hierarchy. This facilitates the configuration of allowed collisions between the move group and objects in the planning scene.