### PR TITLE
Iterative cubic spline

### DIFF
--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MOVEIT_LIB_NAME moveit_trajectory_processing)
 
 add_library(${MOVEIT_LIB_NAME}
   src/iterative_time_parameterization.cpp
+  src/iterative_spline_parameterization.cpp
   src/trajectory_tools.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
@@ -14,3 +15,8 @@ install(TARGETS ${MOVEIT_LIB_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_time_parameterization test/test_time_parameterization.cpp)
+  target_link_libraries(test_time_parameterization ${MOVEIT_LIB_NAME})
+endif()

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -17,6 +17,8 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
   catkin_add_gtest(test_time_parameterization test/test_time_parameterization.cpp)
-  target_link_libraries(test_time_parameterization ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_time_parameterization ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -1,0 +1,64 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  Copyright (c) 2017, Ken Anderson
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ken Anderson */
+
+#ifndef MOVEIT_TRAJECTORY_PROCESSING_ITERATIVE_SPLINE_PARAMETERIZATION__
+#define MOVEIT_TRAJECTORY_PROCESSING_ITERATIVE_SPLINE_PARAMETERIZATION__
+
+#include <trajectory_msgs/JointTrajectory.h>
+#include <moveit_msgs/JointLimits.h>
+#include <moveit_msgs/RobotState.h>
+#include <moveit/robot_trajectory/robot_trajectory.h>
+
+namespace trajectory_processing
+{
+/// \brief This class  modifies the timestamps of a trajectory to respect
+/// velocity and acceleration constraints.
+class IterativeSplineParameterization
+{
+public:
+  IterativeSplineParameterization(double max_time_change_per_it = .01);
+  ~IterativeSplineParameterization();
+
+  bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
+                         const double max_acceleration_scaling_factor = 1.0) const;
+
+private:
+  double max_time_change_per_it_;  /// @brief maximum allowed time change per iteration in seconds
+};
+}
+
+#endif

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -50,12 +50,12 @@ namespace trajectory_processing
 /// A default jerk constraint is also enforced, which may be
 /// overridden when the model supports this in the future.
 /// Initial/final velocities and accelerations may also be specified.
-/// 
+///
 /// This algorithm repeatedly fits a cubic spline, adjusts the timing intervals,
 /// and repeats until all constraints are satisfied.
-/// When finished, each trajectory waypoint will have the time set, 
+/// When finished, each trajectory waypoint will have the time set,
 /// as well as the velocities and accelerations for each joint.
-/// Since we fit to a cubic spline, the position, velocity, and 
+/// Since we fit to a cubic spline, the position, velocity, and
 /// acceleration will be continuous and within bounds.
 /// The jerk will be discontinuous, but within bounds.
 ///
@@ -76,8 +76,8 @@ public:
 
 private:
   double max_time_change_per_it_;  /// @brief maximum allowed time change per iteration in seconds
-  bool add_points_;  /// @brief if true, add two points to trajectory (first and last segments).
-                     /// If false, move the 2nd and 2nd-last points.
+  bool add_points_;                /// @brief if true, add two points to trajectory (first and last segments).
+                                   /// If false, move the 2nd and 2nd-last points.
 };
 }
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -47,10 +47,13 @@ namespace trajectory_processing
 {
 /// \brief This class  modifies the timestamps of a trajectory to respect
 /// velocity and acceleration constraints.
+/// The second and second-last point locations need to move to allow 
+/// velocity and acceleration matching.  
+/// By default, two points are added to leave the original trajectory unaffected.
 class IterativeSplineParameterization
 {
 public:
-  IterativeSplineParameterization(double max_time_change_per_it = .01);
+  IterativeSplineParameterization(double max_time_change_per_it = .01, bool add_points = true);
   ~IterativeSplineParameterization();
 
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
@@ -58,6 +61,7 @@ public:
 
 private:
   double max_time_change_per_it_;  /// @brief maximum allowed time change per iteration in seconds
+  bool add_points_;  /// @brief if true, add two points to trajectory (first and last segments).  If false, move the 2nd and 2nd last points.
 };
 }
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -50,6 +50,8 @@ namespace trajectory_processing
 /// The second and second-last point locations need to move to allow 
 /// velocity and acceleration matching.  
 /// By default, two points are added to leave the original trajectory unaffected.
+/// If points are not added, the trajectory could potentially be faster,
+/// but the 2nd and 2nd-last points should be re-checked for collisions.
 class IterativeSplineParameterization
 {
 public:

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -45,15 +45,24 @@
 
 namespace trajectory_processing
 {
-/// \brief This class modifies the timestamps of a trajectory
+/// \brief This class sets the timestamps of a trajectory
 /// to enforce velocity and acceleration constraints.
 /// A default jerk constraint is also enforced, which may be
 /// overridden when the model supports this in the future.
-/// The second and second-last point locations need to move to allow
-/// matching velocity and acceleration at endpoints.
+/// Initial/final velocities and accelerations may also be specified.
+/// 
+/// This algorithm repeatedly fits a cubic spline.
+/// So to match the velocity and acceleration at the endpoints,
+/// the second and second-last point locations need to move.
 /// By default, two points are added to leave the original trajectory unaffected.
 /// If points are not added, the trajectory could potentially be faster,
 /// but the 2nd and 2nd-last points should be re-checked for collisions.
+///
+/// When finished, each trajectory point will have the time set, 
+/// as well as the velocities and accelerations for each joint.
+/// The velocities and accelerations are fit to a cubic spline,
+/// so position, velocity, and acceleration will be continuous and within bounds.
+/// The jerk will be discontinuous, but within bounds.
 class IterativeSplineParameterization
 {
 public:

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -46,11 +46,9 @@
 namespace trajectory_processing
 {
 /// \brief This class sets the timestamps of a trajectory
-/// to enforce velocity, acceleration, and optionally jerk constraints.
+/// to enforce velocity, acceleration constraints.
 /// Initial/final velocities and accelerations may be specified in the trajectory.
 /// Velocity and acceleration limits are specified in the model.
-/// A jerk constraint may be passed into the contructor, which may be
-/// overridden when the model supports this in the future.
 ///
 /// This algorithm repeatedly fits a cubic spline, adjusts the timing intervals,
 /// and repeats until all constraints are satisfied.
@@ -58,57 +56,33 @@ namespace trajectory_processing
 /// as well as the velocities and accelerations for each joint.
 /// Since we fit to a cubic spline, the position, velocity, and
 /// acceleration will be continuous and within bounds.
-/// The jerk will be discontinuous, but within bounds.
+/// The jerk will be discontinuous.
 ///
-/// If jerk is disabled, then initial/final acceleration matching
-/// will be disabled.
-/// You would use this if you want to allow bang-bang style control
-/// where the controller can go from min acceleration to max acceleration
-/// instantaneously.
-/// In other words, discontinuity in the acceleration curve allowed.
-/// Since the acceleration can change instantly, matching the initial and final
-/// acceleration is unneccessary.
-/// This will get the shortest paths and should be comparable to 'optimal'
-/// methods that have a trapazoidal velocity curve.
-///
-/// However, jerk is enabled by default.
 /// To match the velocity and acceleration at the endpoints,
 /// the second and second-last point locations need to move.
 /// By default, two extra points are added to leave the original trajectory unaffected.
 /// If points are not added, the trajectory could potentially be faster,
 /// but the 2nd and 2nd-last points should be re-checked for collisions.
-/// The downside of enforcing jerk is that if the limits are low,
-/// there will be visible oscilation
-/// around what you may expect as the 'optimal' velocity curve.
-/// Increasing the jerk limits will reduce oscilation and speed up execution.
 ///
 /// Migration notes:  If migrating from Iterative Parabolic Time Parameterization,
 /// be aware that the velocity and acceleration limits are more strictly enforced
 /// using this technique.
 /// This means that time-parameterizing the same trajectory with the same
 /// velocity and acceleration limits, will result in a longer trajectory.
-/// Similarly, enforcing jerk will cause the trajectory to be longer.
 /// If this is a problem, try retuning (increasing) the limits.
 ///
 class IterativeSplineParameterization
 {
 public:
-  IterativeSplineParameterization(bool enable_jerk = true, double max_jerk = 50.0, bool add_points = true,
-                                  double max_time_change_per_it = .01);
+  IterativeSplineParameterization(bool add_points = true);
   ~IterativeSplineParameterization();
 
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
-                         const double max_acceleration_scaling_factor = 1.0,
-                         const double max_jerk_scaling_factor = 1.0) const;
+                         const double max_acceleration_scaling_factor = 1.0) const;
 
 private:
-  bool jerk_enabled_;          /// @brief If true, enable jerk and initial/final acceleration matching
-  double max_jerk_;            /// @brief The maximum jerk limit.
-                               /// Only active if jerk is enabled.
-  bool add_points_;            /// @brief If true, add two points to trajectory (first and last segments).
-                               /// If false, move the 2nd and 2nd-last points.
-                               /// Only active if jerk is enabled.
-  double time_change_factor_;  /// @brief multiplicative factor to change time intervals each iteration (>1.0)
+  bool add_points_;  /// @brief If true, add two points to trajectory (first and last segments).
+                     /// If false, move the 2nd and 2nd-last points.
 };
 }
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -82,6 +82,14 @@ namespace trajectory_processing
 /// around what you may expect as the 'optimal' velocity curve.
 /// Increasing the jerk limits will reduce oscilation and speed up execution.
 ///
+/// Migration notes:  If migrating from Iterative Parabolic Time Parameterization,
+/// be aware that the velocity and acceleration limits are more strictly enforced
+/// using this technique.
+/// This means that time-parameterizing the same trajectory with the same 
+/// velocity and acceleration limits, will result in a longer trajectory.  
+/// Similarly, enforcing jerk will cause the trajectory to be longer.  
+/// If this is a problem, try retuning (increasing) the limits.
+///
 class IterativeSplineParameterization
 {
 public:

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -85,9 +85,9 @@ namespace trajectory_processing
 /// Migration notes:  If migrating from Iterative Parabolic Time Parameterization,
 /// be aware that the velocity and acceleration limits are more strictly enforced
 /// using this technique.
-/// This means that time-parameterizing the same trajectory with the same 
-/// velocity and acceleration limits, will result in a longer trajectory.  
-/// Similarly, enforcing jerk will cause the trajectory to be longer.  
+/// This means that time-parameterizing the same trajectory with the same
+/// velocity and acceleration limits, will result in a longer trajectory.
+/// Similarly, enforcing jerk will cause the trajectory to be longer.
 /// If this is a problem, try retuning (increasing) the limits.
 ///
 class IterativeSplineParameterization

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -51,18 +51,20 @@ namespace trajectory_processing
 /// overridden when the model supports this in the future.
 /// Initial/final velocities and accelerations may also be specified.
 /// 
-/// This algorithm repeatedly fits a cubic spline.
-/// So to match the velocity and acceleration at the endpoints,
+/// This algorithm repeatedly fits a cubic spline, adjusts the timing intervals,
+/// and repeats until all constraints are satisfied.
+/// When finished, each trajectory waypoint will have the time set, 
+/// as well as the velocities and accelerations for each joint.
+/// Since we fit to a cubic spline, the position, velocity, and 
+/// acceleration will be continuous and within bounds.
+/// The jerk will be discontinuous, but within bounds.
+///
+/// To match the velocity and acceleration at the endpoints,
 /// the second and second-last point locations need to move.
 /// By default, two points are added to leave the original trajectory unaffected.
 /// If points are not added, the trajectory could potentially be faster,
 /// but the 2nd and 2nd-last points should be re-checked for collisions.
 ///
-/// When finished, each trajectory point will have the time set, 
-/// as well as the velocities and accelerations for each joint.
-/// The velocities and accelerations are fit to a cubic spline,
-/// so position, velocity, and acceleration will be continuous and within bounds.
-/// The jerk will be discontinuous, but within bounds.
 class IterativeSplineParameterization
 {
 public:

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -46,10 +46,11 @@
 namespace trajectory_processing
 {
 /// \brief This class sets the timestamps of a trajectory
-/// to enforce velocity and acceleration constraints.
-/// A default jerk constraint is also enforced, which may be
+/// to enforce velocity, acceleration, and optionally jerk constraints.
+/// Initial/final velocities and accelerations may be specified in the trajectory.
+/// Velocity and acceleration limits are specified in the model.
+/// A jerk constraint may be passed into the contructor, which may be
 /// overridden when the model supports this in the future.
-/// Initial/final velocities and accelerations may also be specified.
 ///
 /// This algorithm repeatedly fits a cubic spline, adjusts the timing intervals,
 /// and repeats until all constraints are satisfied.
@@ -59,25 +60,47 @@ namespace trajectory_processing
 /// acceleration will be continuous and within bounds.
 /// The jerk will be discontinuous, but within bounds.
 ///
+/// If jerk is disabled, then initial/final acceleration matching
+/// will be disabled.
+/// You would use this if you want to allow bang-bang style control
+/// where the controller can go from min acceleration to max acceleration
+/// instantaneously.
+/// In other words, discontinuity in the acceleration curve allowed.
+/// Since the acceleration can change instantly, matching the initial and final
+/// acceleration is unneccessary.
+/// This will get the shortest paths and should be comparable to 'optimal'
+/// methods that have a trapazoidal velocity curve.
+///
+/// However, jerk is enabled by default.
 /// To match the velocity and acceleration at the endpoints,
 /// the second and second-last point locations need to move.
-/// By default, two points are added to leave the original trajectory unaffected.
+/// By default, two extra points are added to leave the original trajectory unaffected.
 /// If points are not added, the trajectory could potentially be faster,
 /// but the 2nd and 2nd-last points should be re-checked for collisions.
+/// The downside of enforcing jerk is that if the limits are low,
+/// there will be visible oscilation
+/// around what you may expect as the 'optimal' velocity curve.
+/// Increasing the jerk limits will reduce oscilation and speed up execution.
 ///
 class IterativeSplineParameterization
 {
 public:
-  IterativeSplineParameterization(double max_time_change_per_it = .01, bool add_points = true);
+  IterativeSplineParameterization(bool enable_jerk = true, double max_jerk = 9.0, bool add_points = true,
+                                  double max_time_change_per_it = .01);
   ~IterativeSplineParameterization();
 
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
-                         const double max_acceleration_scaling_factor = 1.0) const;
+                         const double max_acceleration_scaling_factor = 1.0,
+                         const double max_jerk_scaling_factor = 1.0) const;
 
 private:
-  double max_time_change_per_it_;  /// @brief maximum allowed time change per iteration in seconds
-  bool add_points_;                /// @brief if true, add two points to trajectory (first and last segments).
-                                   /// If false, move the 2nd and 2nd-last points.
+  bool jerk_enabled_;          /// @brief If true, enable jerk and initial/final acceleration matching
+  double max_jerk_;            /// @brief The maximum jerk limit.
+                               /// Only active if jerk is enabled.
+  bool add_points_;            /// @brief If true, add two points to trajectory (first and last segments).
+                               /// If false, move the 2nd and 2nd-last points.
+                               /// Only active if jerk is enabled.
+  double time_change_factor_;  /// @brief multiplicative factor to change time intervals each iteration (>1.0)
 };
 }
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -45,12 +45,12 @@
 
 namespace trajectory_processing
 {
-/// \brief This class modifies the timestamps of a trajectory 
+/// \brief This class modifies the timestamps of a trajectory
 /// to enforce velocity and acceleration constraints.
-/// A default jerk constraint is also enforced, which may be 
+/// A default jerk constraint is also enforced, which may be
 /// overridden when the model supports this in the future.
-/// The second and second-last point locations need to move to allow 
-/// matching velocity and acceleration at endpoints.  
+/// The second and second-last point locations need to move to allow
+/// matching velocity and acceleration at endpoints.
 /// By default, two points are added to leave the original trajectory unaffected.
 /// If points are not added, the trajectory could potentially be faster,
 /// but the 2nd and 2nd-last points should be re-checked for collisions.
@@ -65,7 +65,8 @@ public:
 
 private:
   double max_time_change_per_it_;  /// @brief maximum allowed time change per iteration in seconds
-  bool add_points_;  /// @brief if true, add two points to trajectory (first and last segments).  If false, move the 2nd and 2nd last points.
+  bool add_points_;  /// @brief if true, add two points to trajectory (first and last segments).
+                     /// If false, move the 2nd and 2nd-last points.
 };
 }
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -93,7 +93,7 @@ namespace trajectory_processing
 class IterativeSplineParameterization
 {
 public:
-  IterativeSplineParameterization(bool enable_jerk = true, double max_jerk = 9.0, bool add_points = true,
+  IterativeSplineParameterization(bool enable_jerk = true, double max_jerk = 50.0, bool add_points = true,
                                   double max_time_change_per_it = .01);
   ~IterativeSplineParameterization();
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -45,10 +45,12 @@
 
 namespace trajectory_processing
 {
-/// \brief This class  modifies the timestamps of a trajectory to respect
-/// velocity and acceleration constraints.
+/// \brief This class modifies the timestamps of a trajectory 
+/// to enforce velocity and acceleration constraints.
+/// A default jerk constraint is also enforced, which may be 
+/// overridden when the model supports this in the future.
 /// The second and second-last point locations need to move to allow 
-/// velocity and acceleration matching.  
+/// matching velocity and acceleration at endpoints.  
 /// By default, two points are added to leave the original trajectory unaffected.
 /// If points are not added, the trajectory could potentially be faster,
 /// but the 2nd and 2nd-last points should be re-checked for collisions.

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -210,7 +210,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   }
   if (num_points < 4)
   {
-    printf("number of waypoints %f, needs to be greater than 3.\n", TFACTOR);
+    printf("number of waypoints %d, needs to be greater than 3.\n", num_points);
     return false;
   }
   for (unsigned j = 0; j < num_joints; j++)
@@ -258,7 +258,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   }
 
   // Move points to satisfy initial/final acceleration
-  int loop = 1;
+  loop = 1;
   while (loop)
   {
     loop = 0;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -306,8 +306,8 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   }
 
   // Initialize times
-  // 0.01 to prevent divide-by-zero
-  std::vector<double> time_diff(trajectory.getWayPointCount() - 1, 0.01);
+  // epsilon to prevent divide-by-zero
+  std::vector<double> time_diff(trajectory.getWayPointCount() - 1, std::numeric_limits<double>::epsilon());
   for (unsigned int j = 0; j < num_joints; j++)
     init_times(num_points, &time_diff[0], &t2[j].positions[0], t2[j].max_velocity, t2[j].min_velocity);
 
@@ -482,7 +482,7 @@ static void init_times(const int n, double dt[], const double x[], const double 
       time = (dx / max_velocity);
     else
       time = (dx / min_velocity);
-    time += 0.001;  // prevent divide-by-zero
+    time += std::numeric_limits<double>::epsilon();  // prevent divide-by-zero
 
     if (dt[i] < time)
       dt[i] = time;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -1,0 +1,403 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Ken Anderson
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ken Anderson */
+
+/*
+  Code to time parameterize a trajectory into a cubic spline
+  while respecting velocity, acceleration, and jerk constraints.
+*/
+
+#include <moveit/trajectory_processing/iterative_spline_parameterization.h>
+#include <moveit_msgs/JointLimits.h>
+#include <console_bridge/console.h>
+#include <moveit/robot_state/conversions.h>
+#include <vector>
+
+#define VLIMIT 1.0  // default
+#define ALIMIT 1.0  // default
+#define JLIMIT 1.0  // default
+
+namespace trajectory_processing {
+
+static void fit_cubic_spline(const int n, const double dt[], 
+        const double x[], double x1[], double x2[]);
+static void adjust_two_positions(const int n, const double dt[], 
+        double x[], double x1[], double x2[], 
+        const double x2_i, const double x2_f);
+static void init_times(const int n, double dt[], double x[], double max_velocity);
+static int fit_spline_and_adjust_times(const int n, double dt[], 
+        const double x[], double x1[], double x2[], 
+        const double vlimit, const double alimit, const double jlimit,
+        const double tfactor);
+
+// The path of a single joint: positions, velocities, and accelerations
+struct SingleJointTrajectory {
+  std::vector<double> positions;   // joint's position at time[x]
+  std::vector<double> velocities;
+  std::vector<double> accelerations;
+  double initial_velocity;
+  double final_velocity;
+  double initial_acceleration;
+  double final_acceleration;
+  double max_velocity;
+  double max_acceleration;
+  double max_jerk;
+};
+
+IterativeSplineParameterization::IterativeSplineParameterization( double max_time_change_per_it)
+  : max_time_change_per_it_(max_time_change_per_it)
+{
+}
+
+IterativeSplineParameterization::~IterativeSplineParameterization()
+{
+}
+
+bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
+                                                               const double max_velocity_scaling_factor,
+                                                               const double max_acceleration_scaling_factor) const
+{
+  if (trajectory.empty())
+    return true;
+
+  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  if (!group)
+  {
+    logError("It looks like the planner did not set the group the plan was computed for");
+    return false;
+  }
+  const robot_model::RobotModel& rmodel = group->getParentModel();
+  const std::vector<int>& idx = group->getVariableIndexList();
+  const std::vector<std::string>& vars = group->getVariableNames();
+  double acceleration_scaling_factor = 1.0;
+  double velocity_scaling_factor = 1.0;
+
+  // Set scaling factors
+  if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
+    acceleration_scaling_factor = max_acceleration_scaling_factor;
+  else if (max_acceleration_scaling_factor == 0.0)
+    logDebug("A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
+             acceleration_scaling_factor);
+  else
+    logWarn("Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
+            max_acceleration_scaling_factor, acceleration_scaling_factor);
+
+  if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
+    velocity_scaling_factor = max_velocity_scaling_factor;
+  else if (max_velocity_scaling_factor == 0.0)
+    logDebug("A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.", velocity_scaling_factor);
+  else
+    logWarn("Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.", max_velocity_scaling_factor,
+            velocity_scaling_factor);
+
+
+  // No wrapped angles.
+  trajectory.unwind();
+
+  // Duplicate 1st and last point 
+  // (required to force acceleration to zero at endpoints)
+  //FIXME trajectory.points.insert(trajectory.points.begin(), trajectory.points[0]);
+  //FIXME trajectory.points.push_back(trajectory.points[trajectory.points.size()-1]);
+  
+  const unsigned num_points = trajectory.getWayPointCount();
+  const unsigned num_joints = group->getVariableCount();
+
+  // the time difference between adjacent points
+  std::vector<double> time_diff(trajectory.getWayPointCount() - 1, 0.0);
+
+  // JointTrajectory indexes in [point][joint] order.
+  // We need [joint][point] order to solve efficiently,
+  // so convert form here.
+  
+  std::vector<SingleJointTrajectory> t2(num_joints);
+
+  for (unsigned j=0; j<num_joints; j++) {
+    const robot_model::VariableBounds& bounds = rmodel.getVariableBounds(vars[j]);
+
+    t2[j].positions.resize(num_points);
+    t2[j].velocities.resize(num_points);
+    t2[j].accelerations.resize(num_points);
+    t2[j].initial_velocity = trajectory.getWayPointPtr(0)->getVariableVelocity(idx[j]);
+    t2[j].final_velocity = trajectory.getWayPointPtr(num_points-1)->getVariableVelocity(idx[j]);
+    t2[j].initial_acceleration = trajectory.getWayPointPtr(0)->getVariableAcceleration(idx[j]);
+    t2[j].final_acceleration = trajectory.getWayPointPtr(num_points-1)->getVariableAcceleration(idx[j]);
+
+    t2[j].max_velocity = VLIMIT;
+    if (bounds.velocity_bounded_)
+      t2[j].max_velocity = std::min(fabs(bounds.max_velocity_), fabs(bounds.min_velocity_));
+    t2[j].max_velocity *= velocity_scaling_factor;
+
+    t2[j].max_acceleration = ALIMIT;
+    if (bounds.acceleration_bounded_)
+      t2[j].max_acceleration = std::min(fabs(bounds.max_acceleration_), fabs(bounds.min_acceleration_));
+    t2[j].max_acceleration *= acceleration_scaling_factor;
+
+    t2[j].max_jerk = JLIMIT;
+  }
+
+  for (unsigned i=0; i<num_points; i++) {
+    for (unsigned j=0; j<num_joints; j++) {
+      t2[j].positions[i] = trajectory.getWayPointPtr(i)->getVariablePosition(idx[j]);
+      t2[j].velocities[i] = trajectory.getWayPointPtr(i)->getVariableVelocity(idx[j]);
+      t2[j].accelerations[i] = trajectory.getWayPointPtr(i)->getVariableAcceleration(idx[j]);
+    }
+  }
+
+  // Error check
+  for (unsigned j=0; j<num_joints; j++) {
+    if (fabs(t2[j].velocities[0]) > t2[j].max_velocity) {
+      printf("Initial velocity %f out of bounds\n", t2[j].velocities[0]);
+      return false;
+    } else if (fabs(t2[j].velocities[num_points-1]) > t2[j].max_velocity) {
+      printf("Final velocity %f out of bounds\n", t2[j].velocities[num_points-1]);
+      return false;
+    } else if (fabs(t2[j].accelerations[0]) > t2[j].max_acceleration) {
+      printf("Initial acceleration %f out of bounds\n", t2[j].accelerations[0]);
+      return false;
+    } else if (fabs(t2[j].accelerations[num_points-1]) > t2[j].max_acceleration) {
+      printf("Final acceleration %f out of bounds\n", t2[j].accelerations[num_points-1]);
+      return false;
+    }
+  }
+  
+  // Initialize
+  for (unsigned j=0; j<num_joints; j++)
+    init_times(num_points, &time_diff[0], &t2[j].positions[0], t2[j].max_velocity);
+  
+    // Fit initial spline with initial/final velocity
+    for (unsigned j=0; j<num_joints; j++) {
+      while (fit_spline_and_adjust_times(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0], &t2[j].accelerations[0], t2[j].max_velocity, t2[j].max_acceleration, t2[j].max_jerk, max_time_change_per_it_))
+        {} // repeat until no more adjustments
+    }
+  
+    // Move points to satisfy initial/final acceleration
+    int loop = 1;
+    while (loop) {
+      loop = 0;
+      for (unsigned j=0; j<num_joints; j++) {
+        adjust_two_positions(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0], &t2[j].accelerations[0], t2[j].initial_acceleration, t2[j].final_acceleration);
+        while (fit_spline_and_adjust_times(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0], &t2[j].accelerations[0], t2[j].max_velocity, t2[j].max_acceleration, t2[j].max_jerk, max_time_change_per_it_))
+          loop = 1; // repeat until no more adjustments
+    }
+  }
+  
+  // Convert back to JointTrajectory form
+  for (unsigned i=1; i<num_points; i++)
+    trajectory.setWayPointDurationFromPrevious(0, time_diff[i-1]);
+  for (unsigned i=0; i<num_points; i++) {
+    for (unsigned j=0; j<num_joints; j++) {
+      trajectory.getWayPointPtr(i)->setVariablePosition(idx[j], t2[j].positions[i]);
+      trajectory.getWayPointPtr(i)->setVariableVelocity(idx[j], t2[j].velocities[i]);
+      trajectory.getWayPointPtr(i)->setVariableAcceleration(idx[j], t2[j].accelerations[i]);
+    }
+  }
+
+  return true;
+}
+
+//////// Internal functions //////////////
+
+/*
+  Fit a 'clamped' cubic spline over a series of points.
+  A cubic spline ensures continuous function across positions,
+  1st derivative (velocities), and 2nd derivative (accelerations).
+  'Clamped' means the first derivative at the endpoints is specified.
+
+  Fitting a cubic spline involves solving a series of linear equations.
+  The general form is:
+    (tj-t_(j-1))*x"_(j-1) + 2*(t_(j+1)-t_(j-1))*xj" + (t_(j+1)-tj)*x"_j+1) = (x_(j+1)-xj)/(t_(j+1)-tj) - (xj-x_(j-1))/(tj-t_(j-1))
+  And the first and last segment equations are clamped to specified values.
+
+  Represented in matrix form:
+  [ 2*(t1-t0)   (t1-t0)                              0              ][x0"]       [(x1-x0)/(t1-t0) - t1_i           ]
+  [ t1-t0       2*(t2-t0)   t2-t1                                   ][x1"]       [(x2-x1)/(t2-t1) - (x1-x0)/(t1-t0)]
+  [             t2-t1       2*(t3-t1)   t3-t2                       ][x2"] = 6 * [(x3-x2)/(t3/t2) - (x2-x1)/(t2-t1)]
+  [                       ...         ...         ...               ][...]       [...                              ]
+  [ 0                                    tN-t_(N-1)  2*(tN-t_(N-1)) ][xN"]       [t1_f - (xN-x_(N-1))/(tN-t_(N-1)) ]
+
+  This matrix is tridiagonal, which can be solved solved in O(N) time 
+  using the tridiagonal algorithm.  
+  There is a forward propogation pass followed by a backsubstitution pass.
+
+  n is the number of points
+  dt contains the time difference between each point (size=n-1)
+  x  contains the positions                          (size=n)
+  x1 contains the 1st derivative (velocities)        (size=n)
+     x1[0] and x1[n-1] MUST be specified.
+  x2 contains the 2nd derivative (accelerations)     (size=n)
+  x1 and x2 are filled in by the algorithm.
+*/
+
+static void fit_cubic_spline(const int n, const double dt[], 
+        const double x[], double x1[], double x2[])
+{
+  int i;
+  const double x1_i = x1[0], x1_f = x1[n-1];
+
+  // Tridiagonal alg - forward sweep
+  // x1 and x2 used to store the temporary coefficients c and d
+  // (will get overwritten during backsubstitution)
+  double *c = x1, *d = x2;
+  c[0] = 0.5;
+  d[0] = (3.0 * (x[1]-x[0]) / dt[0] - x1_i) / dt[0];
+  for (i=1; i<=n-2; i++) { 
+    const double dt2 = dt[i-1] + dt[i];
+    const double a = dt[i-1] / dt2;
+    const double denom = 2.0 - a*c[i-1];
+    c[i] = (1.0-a) / denom;
+    d[i] = 6.0 * ((x[i+1]-x[i])/dt[i] - (x[i]-x[i-1])/dt[i-1]) / dt2;
+    d[i] = (d[i] - a*d[i-1]) / denom;
+  }
+  const double denom = dt[n-2] * (2.0 - c[n-2]);
+  d[n-1] = 6.0 * (x1_f - (x[n-1]-x[n-2])/dt[n-2]);
+  d[n-1] = (d[n-1] - dt[n-2] * d[n-2]) / denom;
+
+  // Tridiagonal alg - backsubstitution sweep
+  // 2nd derivative
+  x2[n-1] = d[n-1];
+  for (i=n-2; i>=0; i--) 
+    x2[i] = d[i] - c[i]*x2[i+1];
+
+  // 1st derivative
+  x1[0] = x1_i;
+  for (i=1; i<n-1; i++)
+    x1[i] = (x[i+1]-x[i])/dt[i] - (2*x2[i] + x2[i+1])*dt[i]/6.0;
+  x1[n-1] = x1_f;
+}
+
+/*
+  Modify the value of x[1] and x[N-2]
+  so that 2nd derivative starts and ends at specified value.
+  This involves fitting the spline twice, 
+  then solving for the specified value.
+
+  x2_i and x2_f are the (initial and final) 2nd derivative at 0 and N-1
+*/
+
+static void adjust_two_positions(const int n, const double dt[], 
+        double x[], double x1[], double x2[], 
+        const double x2_i, const double x2_f)
+{
+  //printf("Find Intersection\n");
+  x[1] = x[0];
+  x[n-2] = x[n-3];
+  fit_cubic_spline(n, dt, x, x1, x2);
+  double a0 = x2[0];
+  double b0 = x2[n-1];
+
+  x[1] = x[2];
+  x[n-2] = x[n-1];
+  fit_cubic_spline(n, dt, x, x1, x2);
+  double a2 = x2[0];
+  double b2 = x2[n-1];
+
+  // we can solve this with linear equation (use two-point form)
+  x[1]   = x[0]   + ((x[2]-x[0]) / (a2-a0)) * (x2_i - a0);
+  x[n-2] = x[n-3] + ((x[n-1]-x[n-3]) / (b2-b0)) * (x2_f - b0);
+}
+
+/*
+  Initialize times to approximate going max velocity between positions.
+*/
+
+static void init_times(const int n, double dt[], double x[], double max_velocity)
+{
+  int i;
+  for (i=1; i<n; i++) {
+    const double min_dt = fabs((x[i]-x[i-1]) / max_velocity);
+    if (dt[i-1] < min_dt)
+      dt[i-1] = min_dt;
+  }
+}
+
+/*
+  Fit a spline, then check each interval to see if bounds are met.
+  If all bounds met (no time adjustments made), return 0.
+  If bounds not met (time adjustments made), slightly increase the 
+  surrounding time intervals and return 1.
+
+  n is the number of points
+  dt contains the time difference between each point (size=n-1)
+  x  contains the positions                          (size=n)
+  x1 contains the 1st derivative (velocities)        (size=n)
+     x1[0] and x1[n-1] MUST be specified.
+  x2 contains the 2nd derivative (accelerations)     (size=n)
+  vlimit is the max velocity for this joint.
+  alimit is the max acceleration for this joint.
+  jlimit is the max jerk for this joint.
+  tfactor is the time adjustment (multiplication) factor.
+  x1 and x2 are filled in by the algorithm.
+*/
+
+static int fit_spline_and_adjust_times(const int n, double dt[], 
+        const double x[], double x1[], double x2[], 
+        const double vlimit, const double alimit, const double jlimit,
+        const double tfactor)
+{
+  int i, ret = 0;
+
+  fit_cubic_spline(n, dt, x, x1, x2);
+
+  for (i=0; i<n; i++) {
+    double vel, acc, jrk = 0.0;
+
+    // NOTE -- dt[i-1] changes, so don't use it
+    vel = x1[i];
+    acc = x2[i];
+    //printf("vel %f acc %f ", vel, acc);
+
+    if (fabs(vel) > vlimit || fabs(acc) > alimit) {
+      if (i>0) { dt[i-1] *= tfactor; }
+      if (i<n) { dt[i]   *= tfactor; }
+      ret = 1;
+      //printf("extended %d to %f\n", i, dt[i]);
+
+    // Jerk is not continuous, it is constant for each segment
+    } else if (i<n-1) {
+      jrk = (x2[i+1]-x2[i]) / dt[i];
+      //printf(" jrk %f", jrk);
+
+      if (fabs(jrk) > jlimit) {
+        dt[i] *= tfactor;
+        ret = 1;
+      }
+    }
+    //printf("\n");
+
+  }
+  return ret;
+}
+
+}

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -41,7 +41,7 @@
 #include <vector>
 
 static const double VLIMIT = 1.0;  // default if not specified in model
-static const double ALIMIT = 3.0;  // default if not specified in model
+static const double ALIMIT = 1.0;  // default if not specified in model
 
 namespace trajectory_processing
 {

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -275,7 +275,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
 
   // Convert back to JointTrajectory form
   for (unsigned i = 1; i < num_points; i++)
-    trajectory.setWayPointDurationFromPrevious(0, time_diff[i - 1]);
+    trajectory.setWayPointDurationFromPrevious(i, time_diff[i - 1]);
   for (unsigned i = 0; i < num_points; i++)
   {
     for (unsigned j = 0; j < num_joints; j++)

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -49,22 +49,20 @@
 #define ALIMIT 1.0  // default
 #define JLIMIT 1.0  // default
 
-namespace trajectory_processing {
-
-static void fit_cubic_spline(const int n, const double dt[], 
-        const double x[], double x1[], double x2[]);
-static void adjust_two_positions(const int n, const double dt[], 
-        double x[], double x1[], double x2[], 
-        const double x2_i, const double x2_f);
+namespace trajectory_processing
+{
+static void fit_cubic_spline(const int n, const double dt[], const double x[], double x1[], double x2[]);
+static void adjust_two_positions(const int n, const double dt[], double x[], double x1[], double x2[],
+                                 const double x2_i, const double x2_f);
 static void init_times(const int n, double dt[], const double x[], const double max_velocity);
-static int fit_spline_and_adjust_times(const int n, double dt[], 
-        const double x[], double x1[], double x2[], 
-        const double vlimit, const double alimit, const double jlimit,
-        const double tfactor);
+static int fit_spline_and_adjust_times(const int n, double dt[], const double x[], double x1[], double x2[],
+                                       const double vlimit, const double alimit, const double jlimit,
+                                       const double tfactor);
 
 // The path of a single joint: positions, velocities, and accelerations
-struct SingleJointTrajectory {
-  std::vector<double> positions;   // joint's position at time[x]
+struct SingleJointTrajectory
+{
+  std::vector<double> positions;  // joint's position at time[x]
   std::vector<double> velocities;
   std::vector<double> accelerations;
   double initial_velocity;
@@ -76,9 +74,8 @@ struct SingleJointTrajectory {
   double max_jerk;
 };
 
-IterativeSplineParameterization::IterativeSplineParameterization( double max_time_change_per_it, bool add_points)
-  : max_time_change_per_it_(max_time_change_per_it),
-    add_points_(add_points)
+IterativeSplineParameterization::IterativeSplineParameterization(double max_time_change_per_it, bool add_points)
+  : max_time_change_per_it_(max_time_change_per_it), add_points_(add_points)
 {
 }
 
@@ -87,8 +84,8 @@ IterativeSplineParameterization::~IterativeSplineParameterization()
 }
 
 bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
-                                                               const double max_velocity_scaling_factor,
-                                                               const double max_acceleration_scaling_factor) const
+                                                        const double max_velocity_scaling_factor,
+                                                        const double max_acceleration_scaling_factor) const
 {
   if (trajectory.empty())
     return true;
@@ -125,53 +122,62 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     logWarn("Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.", max_velocity_scaling_factor,
             velocity_scaling_factor);
 
-
   // No wrapped angles.
   trajectory.unwind();
 
   // Insert 2nd and 2nd-last points
   // (required to force acceleration to specified values at endpoints)
-  if (add_points_ && trajectory.getWayPointCount() >= 2) {
+  if (add_points_ && trajectory.getWayPointCount() >= 2)
+  {
     robot_state::RobotState point = trajectory.getWayPoint(0);
     robot_state::RobotStatePtr p0, p1;
 
     p0 = trajectory.getWayPointPtr(0);
     p1 = trajectory.getWayPointPtr(1);
-    for (unsigned j=0; j<num_joints; j++) {
-      point.setVariablePosition(idx[j], (9*p0->getVariablePosition(idx[j]) + 1*p1->getVariablePosition(idx[j])) / 10);
-      point.setVariableVelocity(idx[j], (9*p0->getVariableVelocity(idx[j]) + 1*p1->getVariableVelocity(idx[j])) / 10);
-      point.setVariableAcceleration(idx[j], (9*p0->getVariableAcceleration(idx[j])+ 1*p1->getVariableAcceleration(idx[j])) / 10);
+    for (unsigned j = 0; j < num_joints; j++)
+    {
+      point.setVariablePosition(idx[j],
+                                (9 * p0->getVariablePosition(idx[j]) + 1 * p1->getVariablePosition(idx[j])) / 10);
+      point.setVariableVelocity(idx[j],
+                                (9 * p0->getVariableVelocity(idx[j]) + 1 * p1->getVariableVelocity(idx[j])) / 10);
+      point.setVariableAcceleration(
+          idx[j], (9 * p0->getVariableAcceleration(idx[j]) + 1 * p1->getVariableAcceleration(idx[j])) / 10);
     }
     trajectory.insertWayPoint(1, point, 0.0);
     num_points++;
 
-    p0 = trajectory.getWayPointPtr(num_points-2);
-    p1 = trajectory.getWayPointPtr(num_points-1);
-    for (unsigned j=0; j<num_joints; j++) {
-      point.setVariablePosition(idx[j], (1*p0->getVariablePosition(idx[j]) + 9*p1->getVariablePosition(idx[j])) / 10);
-      point.setVariableVelocity(idx[j], (1*p0->getVariableVelocity(idx[j]) + 9*p1->getVariableVelocity(idx[j])) / 10);
-      point.setVariableAcceleration(idx[j], (1*p0->getVariableAcceleration(idx[j]) + 9*p1->getVariableAcceleration(idx[j])) / 10);
+    p0 = trajectory.getWayPointPtr(num_points - 2);
+    p1 = trajectory.getWayPointPtr(num_points - 1);
+    for (unsigned j = 0; j < num_joints; j++)
+    {
+      point.setVariablePosition(idx[j],
+                                (1 * p0->getVariablePosition(idx[j]) + 9 * p1->getVariablePosition(idx[j])) / 10);
+      point.setVariableVelocity(idx[j],
+                                (1 * p0->getVariableVelocity(idx[j]) + 9 * p1->getVariableVelocity(idx[j])) / 10);
+      point.setVariableAcceleration(
+          idx[j], (1 * p0->getVariableAcceleration(idx[j]) + 9 * p1->getVariableAcceleration(idx[j])) / 10);
     }
-    trajectory.insertWayPoint(num_points-1, point, 0.0);
+    trajectory.insertWayPoint(num_points - 1, point, 0.0);
     num_points++;
   }
-  
+
   // JointTrajectory indexes in [point][joint] order.
   // We need [joint][point] order to solve efficiently,
   // so convert form here.
-  
+
   std::vector<SingleJointTrajectory> t2(num_joints);
 
-  for (unsigned j=0; j<num_joints; j++) {
+  for (unsigned j = 0; j < num_joints; j++)
+  {
     const robot_model::VariableBounds& bounds = rmodel.getVariableBounds(vars[j]);
 
     t2[j].positions.resize(num_points);
     t2[j].velocities.resize(num_points);
     t2[j].accelerations.resize(num_points);
     t2[j].initial_velocity = trajectory.getWayPointPtr(0)->getVariableVelocity(idx[j]);
-    t2[j].final_velocity = trajectory.getWayPointPtr(num_points-1)->getVariableVelocity(idx[j]);
+    t2[j].final_velocity = trajectory.getWayPointPtr(num_points - 1)->getVariableVelocity(idx[j]);
     t2[j].initial_acceleration = trajectory.getWayPointPtr(0)->getVariableAcceleration(idx[j]);
-    t2[j].final_acceleration = trajectory.getWayPointPtr(num_points-1)->getVariableAcceleration(idx[j]);
+    t2[j].final_acceleration = trajectory.getWayPointPtr(num_points - 1)->getVariableAcceleration(idx[j]);
 
     t2[j].max_velocity = VLIMIT;
     if (bounds.velocity_bounded_)
@@ -186,8 +192,10 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     t2[j].max_jerk = JLIMIT;
   }
 
-  for (unsigned i=0; i<num_points; i++) {
-    for (unsigned j=0; j<num_joints; j++) {
+  for (unsigned i = 0; i < num_points; i++)
+  {
+    for (unsigned j = 0; j < num_joints; j++)
+    {
       t2[j].positions[i] = trajectory.getWayPointPtr(i)->getVariablePosition(idx[j]);
       t2[j].velocities[i] = trajectory.getWayPointPtr(i)->getVariableVelocity(idx[j]);
       t2[j].accelerations[i] = trajectory.getWayPointPtr(i)->getVariableAcceleration(idx[j]);
@@ -195,58 +203,79 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   }
 
   // Error check
-  if (max_time_change_per_it_ <= 1.0) {
+  if (max_time_change_per_it_ <= 1.0)
+  {
     printf("max time change is %f, needs to be higher than 1.0.\n", max_time_change_per_it_);
     return false;
   }
-  if (num_points < 4) {
+  if (num_points < 4)
+  {
     printf("number of waypoints %f, needs to be greater than 3.\n", TFACTOR);
     return false;
   }
-  for (unsigned j=0; j<num_joints; j++) {
-    if (fabs(t2[j].velocities[0]) > t2[j].max_velocity) {
+  for (unsigned j = 0; j < num_joints; j++)
+  {
+    if (fabs(t2[j].velocities[0]) > t2[j].max_velocity)
+    {
       printf("Initial velocity %f out of bounds\n", t2[j].velocities[0]);
       return false;
-    } else if (fabs(t2[j].velocities[num_points-1]) > t2[j].max_velocity) {
-      printf("Final velocity %f out of bounds\n", t2[j].velocities[num_points-1]);
+    }
+    else if (fabs(t2[j].velocities[num_points - 1]) > t2[j].max_velocity)
+    {
+      printf("Final velocity %f out of bounds\n", t2[j].velocities[num_points - 1]);
       return false;
-    } else if (fabs(t2[j].accelerations[0]) > t2[j].max_acceleration) {
+    }
+    else if (fabs(t2[j].accelerations[0]) > t2[j].max_acceleration)
+    {
       printf("Initial acceleration %f out of bounds\n", t2[j].accelerations[0]);
       return false;
-    } else if (fabs(t2[j].accelerations[num_points-1]) > t2[j].max_acceleration) {
-      printf("Final acceleration %f out of bounds\n", t2[j].accelerations[num_points-1]);
+    }
+    else if (fabs(t2[j].accelerations[num_points - 1]) > t2[j].max_acceleration)
+    {
+      printf("Final acceleration %f out of bounds\n", t2[j].accelerations[num_points - 1]);
       return false;
     }
   }
-  
+
   // The time difference between adjacent points
   // 0.001 to prevent divide-by-zero
   std::vector<double> time_diff(trajectory.getWayPointCount() - 1, 0.001);
-  for (unsigned j=0; j<num_joints; j++)
+  for (unsigned j = 0; j < num_joints; j++)
     init_times(num_points, &time_diff[0], &t2[j].positions[0], t2[j].max_velocity);
-  
-    // Fit initial spline
-    for (unsigned j=0; j<num_joints; j++) {
-      while (fit_spline_and_adjust_times(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0], &t2[j].accelerations[0], t2[j].max_velocity, t2[j].max_acceleration, t2[j].max_jerk, max_time_change_per_it_))
-        {} // repeat until no more adjustments
-    }
-  
-    // Move points to satisfy initial/final acceleration
-    int loop = 1;
-    while (loop) {
-      loop = 0;
-      for (unsigned j=0; j<num_joints; j++) {
-        adjust_two_positions(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0], &t2[j].accelerations[0], t2[j].initial_acceleration, t2[j].final_acceleration);
-        while (fit_spline_and_adjust_times(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0], &t2[j].accelerations[0], t2[j].max_velocity, t2[j].max_acceleration, t2[j].max_jerk, max_time_change_per_it_))
-          loop = 1; // repeat until no more adjustments
+
+  // Fit initial spline
+  for (unsigned j = 0; j < num_joints; j++)
+  {
+    while (fit_spline_and_adjust_times(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0],
+                                       &t2[j].accelerations[0], t2[j].max_velocity, t2[j].max_acceleration,
+                                       t2[j].max_jerk, max_time_change_per_it_))
+    {
+    }  // repeat until no more adjustments
+  }
+
+  // Move points to satisfy initial/final acceleration
+  int loop = 1;
+  while (loop)
+  {
+    loop = 0;
+    for (unsigned j = 0; j < num_joints; j++)
+    {
+      adjust_two_positions(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0],
+                           &t2[j].accelerations[0], t2[j].initial_acceleration, t2[j].final_acceleration);
+      while (fit_spline_and_adjust_times(num_points, &time_diff[0], &t2[j].positions[0], &t2[j].velocities[0],
+                                         &t2[j].accelerations[0], t2[j].max_velocity, t2[j].max_acceleration,
+                                         t2[j].max_jerk, max_time_change_per_it_))
+        loop = 1;  // repeat until no more adjustments
     }
   }
-  
+
   // Convert back to JointTrajectory form
-  for (unsigned i=1; i<num_points; i++)
-    trajectory.setWayPointDurationFromPrevious(0, time_diff[i-1]);
-  for (unsigned i=0; i<num_points; i++) {
-    for (unsigned j=0; j<num_joints; j++) {
+  for (unsigned i = 1; i < num_points; i++)
+    trajectory.setWayPointDurationFromPrevious(0, time_diff[i - 1]);
+  for (unsigned i = 0; i < num_points; i++)
+  {
+    for (unsigned j = 0; j < num_joints; j++)
+    {
       trajectory.getWayPointPtr(i)->setVariablePosition(idx[j], t2[j].positions[i]);
       trajectory.getWayPointPtr(i)->setVariableVelocity(idx[j], t2[j].velocities[i]);
       trajectory.getWayPointPtr(i)->setVariableAcceleration(idx[j], t2[j].accelerations[i]);
@@ -266,8 +295,9 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
 
   Fitting a cubic spline involves solving a series of linear equations.
   The general form for each segment is:
-    (tj-t_(j-1))*x"_(j-1) + 2*(t_(j+1)-t_(j-1))*xj" + (t_(j+1)-tj)*x"_j+1) = (x_(j+1)-xj)/(t_(j+1)-tj) - (xj-x_(j-1))/(tj-t_(j-1))
-  And the first and last segment equations are clamped to specified values: t1_i and t1_f.
+    (tj-t_(j-1))*x"_(j-1) + 2*(t_(j+1)-t_(j-1))*x"j + (t_(j+1)-tj)*x"_j+1) = 
+          (x_(j+1)-xj)/(t_(j+1)-tj) -(xj-x_(j-1))/(tj-t_(j-1))
+  And the first and last segment equations are clamped to specified values: x1_i and x1_f.
 
   Represented in matrix form:
   [ 2*(t1-t0)   (t1-t0)                              0              ][x0"]       [(x1-x0)/(t1-t0) - t1_i           ]
@@ -276,8 +306,8 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   [                       ...         ...         ...               ][...]       [...                              ]
   [ 0                                    tN-t_(N-1)  2*(tN-t_(N-1)) ][xN"]       [t1_f - (xN-x_(N-1))/(tN-t_(N-1)) ]
 
-  This matrix is tridiagonal, which can be solved solved in O(N) time 
-  using the tridiagonal algorithm.  
+  This matrix is tridiagonal, which can be solved solved in O(N) time
+  using the tridiagonal algorithm.
   There is a forward propogation pass followed by a backsubstitution pass.
 
   n is the number of points
@@ -289,72 +319,71 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   x1 and x2 are filled in by the algorithm.
 */
 
-static void fit_cubic_spline(const int n, const double dt[], 
-        const double x[], double x1[], double x2[])
+static void fit_cubic_spline(const int n, const double dt[], const double x[], double x1[], double x2[])
 {
   int i;
-  const double x1_i = x1[0], x1_f = x1[n-1];
+  const double x1_i = x1[0], x1_f = x1[n - 1];
 
   // Tridiagonal alg - forward sweep
   // x1 and x2 used to store the temporary coefficients c and d
   // (will get overwritten during backsubstitution)
   double *c = x1, *d = x2;
   c[0] = 0.5;
-  d[0] = 3.0 * ((x[1]-x[0]) / dt[0] - x1_i) / dt[0];
-  for (i=1; i<=n-2; i++) { 
-    const double dt2 = dt[i-1] + dt[i];
-    const double a = dt[i-1] / dt2;
-    const double denom = 2.0 - a*c[i-1];
-    c[i] = (1.0-a) / denom;
-    d[i] = 6.0 * ((x[i+1]-x[i])/dt[i] - (x[i]-x[i-1])/dt[i-1]) / dt2;
-    d[i] = (d[i] - a*d[i-1]) / denom;
+  d[0] = 3.0 * ((x[1] - x[0]) / dt[0] - x1_i) / dt[0];
+  for (i = 1; i <= n - 2; i++)
+  {
+    const double dt2 = dt[i - 1] + dt[i];
+    const double a = dt[i - 1] / dt2;
+    const double denom = 2.0 - a * c[i - 1];
+    c[i] = (1.0 - a) / denom;
+    d[i] = 6.0 * ((x[i + 1] - x[i]) / dt[i] - (x[i] - x[i - 1]) / dt[i - 1]) / dt2;
+    d[i] = (d[i] - a * d[i - 1]) / denom;
   }
-  const double denom = dt[n-2] * (2.0 - c[n-2]);
-  d[n-1] = 6.0 * (x1_f - (x[n-1]-x[n-2])/dt[n-2]);
-  d[n-1] = (d[n-1] - dt[n-2] * d[n-2]) / denom;
+  const double denom = dt[n - 2] * (2.0 - c[n - 2]);
+  d[n - 1] = 6.0 * (x1_f - (x[n - 1] - x[n - 2]) / dt[n - 2]);
+  d[n - 1] = (d[n - 1] - dt[n - 2] * d[n - 2]) / denom;
 
   // Tridiagonal alg - backsubstitution sweep
   // 2nd derivative
-  x2[n-1] = d[n-1];
-  for (i=n-2; i>=0; i--) 
-    x2[i] = d[i] - c[i]*x2[i+1];
+  x2[n - 1] = d[n - 1];
+  for (i = n - 2; i >= 0; i--)
+    x2[i] = d[i] - c[i] * x2[i + 1];
 
   // 1st derivative
   x1[0] = x1_i;
-  for (i=1; i<n-1; i++)
-    x1[i] = (x[i+1]-x[i])/dt[i] - (2*x2[i] + x2[i+1])*dt[i]/6.0;
-  x1[n-1] = x1_f;
+  for (i = 1; i < n - 1; i++)
+    x1[i] = (x[i + 1] - x[i]) / dt[i] - (2 * x2[i] + x2[i + 1]) * dt[i] / 6.0;
+  x1[n - 1] = x1_f;
 }
 
 /*
   Modify the value of x[1] and x[N-2]
   so that 2nd derivative starts and ends at specified value.
-  This involves fitting the spline twice, 
+  This involves fitting the spline twice,
   then solving for the specified value.
 
   x2_i and x2_f are the (initial and final) 2nd derivative at 0 and N-1
 */
 
-static void adjust_two_positions(const int n, const double dt[], 
-        double x[], double x1[], double x2[], 
-        const double x2_i, const double x2_f)
+static void adjust_two_positions(const int n, const double dt[], double x[], double x1[], double x2[],
+                                 const double x2_i, const double x2_f)
 {
-  //printf("Find Intersection\n");
+  // printf("Find Intersection\n");
   x[1] = x[0];
-  x[n-2] = x[n-3];
+  x[n - 2] = x[n - 3];
   fit_cubic_spline(n, dt, x, x1, x2);
   double a0 = x2[0];
-  double b0 = x2[n-1];
+  double b0 = x2[n - 1];
 
   x[1] = x[2];
-  x[n-2] = x[n-1];
+  x[n - 2] = x[n - 1];
   fit_cubic_spline(n, dt, x, x1, x2);
   double a2 = x2[0];
-  double b2 = x2[n-1];
+  double b2 = x2[n - 1];
 
   // we can solve this with linear equation (use two-point form)
-  x[1]   = x[0]   + ((x[2]-x[0]) / (a2-a0)) * (x2_i - a0);
-  x[n-2] = x[n-3] + ((x[n-1]-x[n-3]) / (b2-b0)) * (x2_f - b0);
+  x[1] = x[0] + ((x[2] - x[0]) / (a2 - a0)) * (x2_i - a0);
+  x[n - 2] = x[n - 3] + ((x[n - 1] - x[n - 3]) / (b2 - b0)) * (x2_f - b0);
 }
 
 /*
@@ -365,8 +394,9 @@ static void adjust_two_positions(const int n, const double dt[],
 static void init_times(const int n, double dt[], const double x[], const double max_velocity)
 {
   int i;
-  for (i=0; i<n-1; i++) {
-    double time = fabs((x[i+1]-x[i]) / max_velocity);
+  for (i = 0; i < n - 1; i++)
+  {
+    double time = fabs((x[i + 1] - x[i]) / max_velocity);
     if (dt[i] < time)
       dt[i] = time;
   }
@@ -375,7 +405,7 @@ static void init_times(const int n, double dt[], const double x[], const double 
 /*
   Fit a spline, then check each interval to see if bounds are met.
   If all bounds met (no time adjustments made), return 0.
-  If bounds not met (time adjustments made), slightly increase the 
+  If bounds not met (time adjustments made), slightly increase the
   surrounding time intervals and return 1.
 
   n is the number of points
@@ -391,43 +421,51 @@ static void init_times(const int n, double dt[], const double x[], const double 
   x1 and x2 are filled in by the algorithm.
 */
 
-static int fit_spline_and_adjust_times(const int n, double dt[], 
-        const double x[], double x1[], double x2[], 
-        const double vlimit, const double alimit, const double jlimit,
-        const double tfactor)
+static int fit_spline_and_adjust_times(const int n, double dt[], const double x[], double x1[], double x2[],
+                                       const double vlimit, const double alimit, const double jlimit,
+                                       const double tfactor)
 {
   int i, ret = 0;
 
   fit_cubic_spline(n, dt, x, x1, x2);
 
-  for (i=0; i<n; i++) {
+  for (i = 0; i < n; i++)
+  {
     double vel, acc, jrk = 0.0;
 
     // NOTE -- dt[i-1] changes, so don't use it
     vel = x1[i];
     acc = x2[i];
-    //printf("vel %f acc %f ", vel, acc);
+    // printf("vel %f acc %f ", vel, acc);
 
-    if (fabs(vel) > vlimit || fabs(acc) > alimit) {
-      if (i>0) { dt[i-1] *= tfactor; }
-      if (i<n) { dt[i]   *= tfactor; }
+    if (fabs(vel) > vlimit || fabs(acc) > alimit)
+    {
+      if (i > 0)
+      {
+        dt[i - 1] *= tfactor;
+      }
+      if (i < n)
+      {
+        dt[i] *= tfactor;
+      }
       ret = 1;
-      //printf("extended %d to %f\n", i, dt[i]);
+      // printf("extended %d to %f\n", i, dt[i]);
 
-    // Jerk is not continuous, it is constant for each segment
-    } else if (i<n-1) {
-      jrk = (x2[i+1]-x2[i]) / dt[i];
-      //printf(" jrk %f", jrk);
+      // Jerk is not continuous, it is constant for each segment
+    }
+    else if (i < n - 1)
+    {
+      jrk = (x2[i + 1] - x2[i]) / dt[i];
+      // printf(" jrk %f", jrk);
 
-      if (fabs(jrk) > jlimit) {
+      if (fabs(jrk) > jlimit)
+      {
         dt[i] *= tfactor;
         ret = 1;
       }
     }
-    //printf("\n");
-
+    // printf("\n");
   }
   return ret;
 }
-
 }

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -46,8 +46,8 @@
 #include <vector>
 
 #define VLIMIT 1.0  // default
-#define ALIMIT 1.0  // default
-#define JLIMIT 1.0  // default
+#define ALIMIT 3.0  // default
+#define JLIMIT 9.0  // default
 
 namespace trajectory_processing
 {
@@ -75,7 +75,7 @@ struct SingleJointTrajectory
 };
 
 IterativeSplineParameterization::IterativeSplineParameterization(double max_time_change_per_it, bool add_points)
-  : max_time_change_per_it_(max_time_change_per_it), add_points_(add_points)
+  : max_time_change_per_it_(1.0 + max_time_change_per_it), add_points_(add_points)
 {
 }
 

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -187,26 +187,14 @@ TEST(TestTimeParameterization, TestIterativeSpline)
   ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 5.0);
 }
 
-TEST(TestTimeParameterization, TestIterativeSplineJerk)
+TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
 {
-  trajectory_processing::IterativeSplineParameterization time_parameterization(true, 9.0, false);
+  trajectory_processing::IterativeSplineParameterization time_parameterization(true);
   EXPECT_EQ(initStraightTrajectory(trajectory), 0);
 
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
-  std::cout << "IterativeSplineParameterization with Jerk took " << (ros::WallTime::now() - wt).toSec() << std::endl;
-  printTrajectory(trajectory);
-  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 6.0);
-}
-
-TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
-{
-  trajectory_processing::IterativeSplineParameterization time_parameterization(true, 9.0, true);
-  EXPECT_EQ(initStraightTrajectory(trajectory), 0);
-
-  ros::WallTime wt = ros::WallTime::now();
-  EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
-  std::cout << "IterativeSplineParameterization with Jerk and added points took " << (ros::WallTime::now() - wt).toSec()
+  std::cout << "IterativeSplineParameterization with added points took " << (ros::WallTime::now() - wt).toSec()
             << std::endl;
   printTrajectory(trajectory);
   ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 5.0);
@@ -214,7 +202,7 @@ TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
 
 TEST(TestTimeParameterization, TestRepeatedPoint)
 {
-  trajectory_processing::IterativeSplineParameterization time_parameterization(true, 9.0, true);
+  trajectory_processing::IterativeSplineParameterization time_parameterization(true);
   EXPECT_EQ(initRepeatedPointTrajectory(trajectory), 0);
 
   ros::WallTime wt = ros::WallTime::now();

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -142,6 +142,7 @@ TEST(TestTimeParameterization, TestIterativeParabolic)
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeParabolicTimeParameterization  took " << (ros::WallTime::now() - wt).toSec() << std::endl;
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
 }
 
@@ -155,6 +156,7 @@ TEST(TestTimeParameterization, TestIterativeSpline)
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization took " << (ros::WallTime::now() - wt).toSec() << std::endl;
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
 }
 
@@ -168,6 +170,7 @@ TEST(TestTimeParameterization, TestIterativeSplineJerk)
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization with Jerk took " << (ros::WallTime::now() - wt).toSec() << std::endl;
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
 }
 
@@ -182,6 +185,7 @@ TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization with Jerk and added points took " << (ros::WallTime::now() - wt).toSec()
             << std::endl;
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
 }
 

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -52,7 +52,6 @@ moveit::core::RobotModelConstPtr loadModel();
 moveit::core::RobotModelConstPtr rmodel = loadModel();
 robot_trajectory::RobotTrajectory trajectory(rmodel, "right_arm");
 
-
 // Load pr2.  Take a look at test/ in planning_scene, robot_mode,
 // and robot_state for inspiration.
 moveit::core::RobotModelConstPtr loadModel()
@@ -108,7 +107,7 @@ int initRepeatedPointTrajectory(robot_trajectory::RobotTrajectory& trajectory)
 // Can specify init/final velocity/acceleration,
 // but not all time parameterization methods may accept it.
 int initStraightTrajectory(robot_trajectory::RobotTrajectory& trajectory, double vel_i = 0.0, double vel_f = 0.0,
-                   double acc_i = 0.0, double acc_f = 0.0)
+                           double acc_i = 0.0, double acc_f = 0.0)
 {
   const int num = 10;
   const double max = 2.0;
@@ -220,11 +219,10 @@ TEST(TestTimeParameterization, TestRepeatedPoint)
 
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
-  //std::cout << " took " << (ros::WallTime::now() - wt).toSec() << std::endl;
+  // std::cout << " took " << (ros::WallTime::now() - wt).toSec() << std::endl;
   printTrajectory(trajectory);
   ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 0.001);
 }
-
 
 int main(int argc, char** argv)
 {

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -45,6 +45,14 @@
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
+// Function declarations
+moveit::core::RobotModelConstPtr loadModel();
+
+// Static variables used in all tests
+moveit::core::RobotModelConstPtr rmodel = loadModel();
+robot_trajectory::RobotTrajectory trajectory(rmodel, "right_arm");
+
+
 // Load pr2.  Take a look at test/ in planning_scene, robot_mode,
 // and robot_state for inspiration.
 moveit::core::RobotModelConstPtr loadModel()
@@ -86,6 +94,7 @@ int initRepeatedPointTrajectory(robot_trajectory::RobotTrajectory& trajectory)
   const std::vector<int>& idx = group->getVariableIndexList();
   moveit::core::RobotState state(trajectory.getRobotModel());
 
+  trajectory.clear();
   for (i = 0; i < num; i++)
   {
     state.setVariablePosition(idx[0], 1.0);
@@ -115,6 +124,7 @@ int initStraightTrajectory(robot_trajectory::RobotTrajectory& trajectory, double
   const std::vector<int>& idx = group->getVariableIndexList();
   moveit::core::RobotState state(trajectory.getRobotModel());
 
+  trajectory.clear();
   for (i = 0; i < num; i++)
   {
     state.setVariablePosition(idx[0], i * max / num);
@@ -156,8 +166,6 @@ void printTrajectory(robot_trajectory::RobotTrajectory& trajectory)
 
 TEST(TestTimeParameterization, TestIterativeParabolic)
 {
-  moveit::core::RobotModelConstPtr robot_model = loadModel();
-  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
   trajectory_processing::IterativeParabolicTimeParameterization time_parameterization;
   EXPECT_EQ(initStraightTrajectory(trajectory), 0);
 
@@ -170,8 +178,6 @@ TEST(TestTimeParameterization, TestIterativeParabolic)
 
 TEST(TestTimeParameterization, TestIterativeSpline)
 {
-  moveit::core::RobotModelConstPtr robot_model = loadModel();
-  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
   trajectory_processing::IterativeSplineParameterization time_parameterization(false);
   EXPECT_EQ(initStraightTrajectory(trajectory), 0);
 
@@ -184,8 +190,6 @@ TEST(TestTimeParameterization, TestIterativeSpline)
 
 TEST(TestTimeParameterization, TestIterativeSplineJerk)
 {
-  moveit::core::RobotModelConstPtr robot_model = loadModel();
-  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
   trajectory_processing::IterativeSplineParameterization time_parameterization(true, 9.0, false);
   EXPECT_EQ(initStraightTrajectory(trajectory), 0);
 
@@ -198,8 +202,6 @@ TEST(TestTimeParameterization, TestIterativeSplineJerk)
 
 TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
 {
-  moveit::core::RobotModelConstPtr robot_model = loadModel();
-  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
   trajectory_processing::IterativeSplineParameterization time_parameterization(true, 9.0, true);
   EXPECT_EQ(initStraightTrajectory(trajectory), 0);
 
@@ -213,8 +215,6 @@ TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
 
 TEST(TestTimeParameterization, TestRepeatedPoint)
 {
-  moveit::core::RobotModelConstPtr robot_model = loadModel();
-  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
   trajectory_processing::IterativeSplineParameterization time_parameterization(true, 9.0, true);
   EXPECT_EQ(initRepeatedPointTrajectory(trajectory), 0);
 

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -142,8 +142,8 @@ TEST(TestTimeParameterization, TestIterativeParabolic)
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeParabolicTimeParameterization  took " << (ros::WallTime::now() - wt).toSec() << std::endl;
-  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 3.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSpline)
@@ -156,8 +156,8 @@ TEST(TestTimeParameterization, TestIterativeSpline)
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization took " << (ros::WallTime::now() - wt).toSec() << std::endl;
-  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 5.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineJerk)
@@ -170,8 +170,8 @@ TEST(TestTimeParameterization, TestIterativeSplineJerk)
   ros::WallTime wt = ros::WallTime::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization with Jerk took " << (ros::WallTime::now() - wt).toSec() << std::endl;
-  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 5.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
@@ -185,8 +185,8 @@ TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization with Jerk and added points took " << (ros::WallTime::now() - wt).toSec()
             << std::endl;
-  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 4.0);
   printTrajectory(trajectory);
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 5.0);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -1,0 +1,158 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Ken Anderson
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ken Anderson */
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <boost/filesystem/path.hpp>
+#include <urdf_parser/urdf_parser.h>
+#include <moveit_resources/config.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_trajectory/robot_trajectory.h>
+#include <moveit/trajectory_processing/iterative_spline_parameterization.h>
+#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+
+
+// Load pr2.  Take a look at test/ in planning_scene, robot_mode, 
+// and robot_state for inspiration.
+moveit::core::RobotModelConstPtr loadModel()
+{
+  moveit::core::RobotModelConstPtr robot_model;
+  urdf::ModelInterfaceSharedPtr urdf_model;
+  srdf::ModelSharedPtr srdf_model;
+  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+  std::string xml_string;
+  std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
+  EXPECT_TRUE(xml_file.is_open());
+  while (xml_file.good())
+  {
+    std::string line;
+    std::getline(xml_file, line);
+    xml_string += (line + "\n");
+  }
+  xml_file.close();
+  urdf_model = urdf::parseURDF(xml_string);
+  srdf_model.reset(new srdf::Model());
+  srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
+  robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
+  return robot_model;
+}
+
+// Initialize one-joint, straight-line trajectory
+// Can specify init/final velocity/acceleration,
+// but not all time parameterization methods may accept it.
+int initTrajectory(robot_trajectory::RobotTrajectory &trajectory,
+  double vel_i = 0.0, double vel_f = 0.0, 
+  double acc_i = 0.0, double acc_f = 0.0)
+{
+  const int num = 10;
+  const double max = 2.0;
+  unsigned i;
+
+  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  if (!group)
+  {
+    logError("Need to set the group");
+    return -1;
+  }
+  const std::vector<int>& idx = group->getVariableIndexList();
+  moveit::core::RobotState state(trajectory.getRobotModel());
+
+  state.setVariableVelocity(idx[0], vel_i);
+  state.setVariableAcceleration(idx[0], acc_i);
+
+  for (i=0; i<num; i++) {
+    state.setVariablePosition(idx[0], i * max / num);
+    trajectory.addSuffixWayPoint(state, 0.0);
+  }
+
+  state.setVariablePosition(idx[0], max);
+  state.setVariableVelocity(idx[0], vel_f);
+  state.setVariableAcceleration(idx[0], acc_f);
+  trajectory.addSuffixWayPoint(state, 0.0);
+
+  return 0;
+}
+
+void printTrajectory(robot_trajectory::RobotTrajectory &trajectory)
+{
+  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const std::vector<int>& idx = group->getVariableIndexList();
+  unsigned int count = trajectory.getWayPointCount();
+
+  std::cout << "trajectory length is " << trajectory.getWayPointDurationFromStart(count-1) << " seconds." << std::endl;
+  std::cout << "  Trajectory Points" << std::endl;
+  for (unsigned i=0; i<count; i++) {
+    robot_state::RobotStatePtr point = trajectory.getWayPointPtr(i);
+    printf("  waypoint %2d time %6.2f pos %6.2f vel %6.2f acc %6.2f \n", i, 
+          trajectory.getWayPointDurationFromStart(i), 
+          point->getVariablePosition(idx[0]), 
+          point->getVariableVelocity(idx[0]), 
+          point->getVariableAcceleration(idx[0]));
+  }
+}
+
+TEST(TestTimeParameterization, TestIterativeParabolic)
+{
+  moveit::core::RobotModelConstPtr robot_model = loadModel();
+  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
+  trajectory_processing::IterativeParabolicTimeParameterization time_parameterization;
+  EXPECT_EQ(initTrajectory(trajectory), 0);
+
+  ros::WallTime wt = ros::WallTime::now();
+  EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
+  std::cout << "IterativeParabolicTimeParameterization  took " << (ros::WallTime::now() - wt).toSec() << std::endl;
+  printTrajectory(trajectory);
+}
+
+TEST(TestTimeParameterization, TestIterativeSpline)
+{
+  moveit::core::RobotModelConstPtr robot_model = loadModel();
+  robot_trajectory::RobotTrajectory trajectory(robot_model, "right_arm");
+  trajectory_processing::IterativeSplineParameterization time_parameterization;
+  EXPECT_EQ(initTrajectory(trajectory), 0);
+
+  ros::WallTime wt = ros::WallTime::now();
+  EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
+  std::cout << "IterativeSplineParameterization took " << (ros::WallTime::now() - wt).toSec() << std::endl;
+  printTrajectory(trajectory);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -45,8 +45,7 @@
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
-
-// Load pr2.  Take a look at test/ in planning_scene, robot_mode, 
+// Load pr2.  Take a look at test/ in planning_scene, robot_mode,
 // and robot_state for inspiration.
 moveit::core::RobotModelConstPtr loadModel()
 {
@@ -74,9 +73,8 @@ moveit::core::RobotModelConstPtr loadModel()
 // Initialize one-joint, straight-line trajectory
 // Can specify init/final velocity/acceleration,
 // but not all time parameterization methods may accept it.
-int initTrajectory(robot_trajectory::RobotTrajectory &trajectory,
-  double vel_i = 0.0, double vel_f = 0.0, 
-  double acc_i = 0.0, double acc_f = 0.0)
+int initTrajectory(robot_trajectory::RobotTrajectory& trajectory, double vel_i = 0.0, double vel_f = 0.0,
+                   double acc_i = 0.0, double acc_f = 0.0)
 {
   const int num = 10;
   const double max = 2.0;
@@ -94,7 +92,8 @@ int initTrajectory(robot_trajectory::RobotTrajectory &trajectory,
   state.setVariableVelocity(idx[0], vel_i);
   state.setVariableAcceleration(idx[0], acc_i);
 
-  for (i=0; i<num; i++) {
+  for (i = 0; i < num; i++)
+  {
     state.setVariablePosition(idx[0], i * max / num);
     trajectory.addSuffixWayPoint(state, 0.0);
   }
@@ -107,21 +106,21 @@ int initTrajectory(robot_trajectory::RobotTrajectory &trajectory,
   return 0;
 }
 
-void printTrajectory(robot_trajectory::RobotTrajectory &trajectory)
+void printTrajectory(robot_trajectory::RobotTrajectory& trajectory)
 {
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   const std::vector<int>& idx = group->getVariableIndexList();
   unsigned int count = trajectory.getWayPointCount();
 
-  std::cout << "trajectory length is " << trajectory.getWayPointDurationFromStart(count-1) << " seconds." << std::endl;
+  std::cout << "trajectory length is " << trajectory.getWayPointDurationFromStart(count - 1) << " seconds."
+            << std::endl;
   std::cout << "  Trajectory Points" << std::endl;
-  for (unsigned i=0; i<count; i++) {
+  for (unsigned i = 0; i < count; i++)
+  {
     robot_state::RobotStatePtr point = trajectory.getWayPointPtr(i);
-    printf("  waypoint %2d time %6.2f pos %6.2f vel %6.2f acc %6.2f \n", i, 
-          trajectory.getWayPointDurationFromStart(i), 
-          point->getVariablePosition(idx[0]), 
-          point->getVariableVelocity(idx[0]), 
-          point->getVariableAcceleration(idx[0]));
+    printf("  waypoint %2d time %6.2f pos %6.2f vel %6.2f acc %6.2f \n", i, trajectory.getWayPointDurationFromStart(i),
+           point->getVariablePosition(idx[0]), point->getVariableVelocity(idx[0]),
+           point->getVariableAcceleration(idx[0]));
   }
 }
 

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -86,11 +86,9 @@ int initTrajectory(robot_trajectory::RobotTrajectory& trajectory, double vel_i =
     logError("Need to set the group");
     return -1;
   }
+  // leave initial velocity/acceleration unset
   const std::vector<int>& idx = group->getVariableIndexList();
   moveit::core::RobotState state(trajectory.getRobotModel());
-
-  state.setVariableVelocity(idx[0], vel_i);
-  state.setVariableAcceleration(idx[0], acc_i);
 
   for (i = 0; i < num; i++)
   {
@@ -98,9 +96,8 @@ int initTrajectory(robot_trajectory::RobotTrajectory& trajectory, double vel_i =
     trajectory.addSuffixWayPoint(state, 0.0);
   }
 
+  // leave final velocity/acceleration unset
   state.setVariablePosition(idx[0], max);
-  state.setVariableVelocity(idx[0], vel_f);
-  state.setVariableAcceleration(idx[0], acc_f);
   trajectory.addSuffixWayPoint(state, 0.0);
 
   return 0;
@@ -171,7 +168,7 @@ TEST(TestTimeParameterization, TestIterativeSplineJerk)
   EXPECT_TRUE(time_parameterization.computeTimeStamps(trajectory));
   std::cout << "IterativeSplineParameterization with Jerk took " << (ros::WallTime::now() - wt).toSec() << std::endl;
   printTrajectory(trajectory);
-  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 5.0);
+  ASSERT_LT(trajectory.getWayPointDurationFromStart(trajectory.getWayPointCount() - 1), 6.0);
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineJerkAddPoints)

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCE_FILES
   src/fix_start_state_collision.cpp
   src/fix_start_state_path_constraints.cpp
   src/fix_workspace_bounds.cpp
-  src/add_time_parameterization.cpp)
+  src/add_time_parameterization.cpp
+  src/add_iterative_spline_parameterization.cpp)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -1,0 +1,80 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2017, Ken Anderson
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ken Anderson, based off add_iterative_spline_parameterization.cpp by Ioan Sucan */
+
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <moveit/trajectory_processing/iterative_spline_parameterization.h>
+#include <class_loader/class_loader.h>
+#include <ros/console.h>
+
+namespace default_planner_request_adapters
+{
+class AddSplineParameterization : public planning_request_adapter::PlanningRequestAdapter
+{
+public:
+  AddSplineParameterization() : planning_request_adapter::PlanningRequestAdapter()
+  {
+  }
+
+  virtual std::string getDescription() const
+  {
+    return "Add Time Parameterization";
+  }
+
+  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                            const planning_interface::MotionPlanRequest& req,
+                            planning_interface::MotionPlanResponse& res,
+                            std::vector<std::size_t>& added_path_index) const
+  {
+    bool result = planner(planning_scene, req, res);
+    if (result && res.trajectory_)
+    {
+      ROS_DEBUG("Running '%s'", getDescription().c_str());
+      if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
+                                         req.max_acceleration_scaling_factor))
+        ROS_WARN("Time parametrization for the solution path failed.");
+    }
+
+    return result;
+  }
+
+private:
+  trajectory_processing::IterativeSplineParameterization time_param_;
+};
+}
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddSplineParameterization,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -42,10 +42,10 @@
 
 namespace default_planner_request_adapters
 {
-class AddSplineParameterization : public planning_request_adapter::PlanningRequestAdapter
+class AddIterativeSplineParameterization : public planning_request_adapter::PlanningRequestAdapter
 {
 public:
-  AddSplineParameterization() : planning_request_adapter::PlanningRequestAdapter()
+  AddIterativeSplineParameterization() : planning_request_adapter::PlanningRequestAdapter()
   {
   }
 
@@ -76,5 +76,5 @@ private:
 };
 }
 
-CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddSplineParameterization,
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddIterativeSplineParameterization,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -33,7 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ken Anderson, based off add_iterative_spline_parameterization.cpp by Ioan Sucan */
+/* Author: Ken Anderson, based off add_time_parameterization.cpp by Ioan Sucan */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -30,4 +30,9 @@
     </description>
   </class>
 
+  <class name="default_planner_request_adapters/AddIterativeSplineParameterization" type="default_planner_request_adapters::AddIterativeSplineParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+    </description>
+  </class>
+
 </library>


### PR DESCRIPTION
### Description

Ruben's idea of fitting a cubic spline to a trajectory is a very good one: #382 .  Forcing the trajectory to a cubic should prevent the controller from overfitting the data, the problem presented here: #160 .  

I've taken the concept a little further by repeatedly fitting the spline and adjusting timestamps until all constraints are satisfied.  This is similar to the way IPTP works, but instead of using local averages, the instantaneous values are used instead.

This technique is presented as another trajectory time parameterization class that can be used instead of IPTP.  It also adds some simple unit tests.  Initial/final velocity and acceleration can be specified.  The constraints imposed are velocity, acceleration, and jerk.  Here is a straight-line trajectory of 11 points:

![spline](https://cloud.githubusercontent.com/assets/13836992/22851156/694ae6e6-efe7-11e6-9a98-c2103960b3b8.png)

Ruben graciously provided some sample trajectories using RRT-Connect with a Kuka IIWA in a fairly cluttered scene. The trajectories have between 25 and 70 waypoints.  These are the resulting spline trajectories (this is the calculated/interpolated spline curves, it is not data from an executing robot or simulation).

![trajectory_1](https://cloud.githubusercontent.com/assets/13836992/22851161/7a9645d0-efe7-11e6-87d4-04fdd8286696.png)

![trajectory_2](https://cloud.githubusercontent.com/assets/13836992/22851162/7a9cb76c-efe7-11e6-817c-f28e53eb4ed7.png)

![trajectory_3](https://cloud.githubusercontent.com/assets/13836992/22851163/7aa4c1aa-efe7-11e6-9036-9fd4365affed.png)

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

Thank you!
