### PR TITLE
simplify widget handling

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -55,7 +55,6 @@
 #endif
 
 #include <moveit_msgs/DisplayTrajectory.h>
-#include <QDockWidget>
 
 namespace Ogre
 {
@@ -234,7 +233,6 @@ protected:
 
   // the planning frame
   MotionPlanningFrame* frame_;
-  QDockWidget* frame_dock_;
 
   // robot interaction
   robot_interaction::RobotInteractionPtr robot_interaction_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -83,7 +83,6 @@ MotionPlanningDisplay::MotionPlanningDisplay()
   , text_to_display_(NULL)
   , private_handle_("~")
   , frame_(NULL)
-  , frame_dock_(NULL)
   , menu_handler_start_(new interactive_markers::MenuHandler)
   , menu_handler_goal_(new interactive_markers::MenuHandler)
   , int_marker_display_(NULL)
@@ -186,7 +185,6 @@ MotionPlanningDisplay::~MotionPlanningDisplay()
 
   delete text_to_display_;
   delete int_marker_display_;
-  delete frame_dock_;
 }
 
 void MotionPlanningDisplay::onInitialize()
@@ -226,8 +224,7 @@ void MotionPlanningDisplay::onInitialize()
   // immediately switch to next trajectory display after planning
   connect(frame_, SIGNAL(planningFinished()), trajectory_visual_.get(), SLOT(interruptCurrentDisplay()));
 
-  if (window_context)
-    frame_dock_ = window_context->addPane("Motion Planning", frame_);
+  setAssociatedWidget(frame_);
 
   int_marker_display_ = context_->getDisplayFactory()->make("rviz/InteractiveMarkers");
   int_marker_display_->initialize(context_);
@@ -1214,7 +1211,6 @@ void MotionPlanningDisplay::onEnable()
 
   query_robot_start_->setVisible(query_start_state_property_->getBool());
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
-  frame_->enable();
 
   int_marker_display_->setEnabled(true);
   int_marker_display_->setFixedFrame(fixed_frame_);
@@ -1231,7 +1227,6 @@ void MotionPlanningDisplay::onDisable()
 
   query_robot_start_->setVisible(false);
   query_robot_goal_->setVisible(false);
-  frame_->disable();
   text_to_display_->setVisible(false);
 
   PlanningSceneDisplay::onDisable();


### PR DESCRIPTION
This change connects the Motion Planning display with its widget and fixes these glitches:

Currently the Motion Planning panel is visible when RViz is started and the Motion Planning display is disabled:
![pic2](https://cloud.githubusercontent.com/assets/18333271/22893168/4ad6c4e8-f215-11e6-83f9-8c2609861931.png)

After enabling and disabling the checkbox in the display panel the Motion Planning display is minimized: 
![pic1](https://cloud.githubusercontent.com/assets/18333271/22893200/5af4415c-f215-11e6-9801-326e5d291e25.png)

When the Motion Planning in the toolbar is disabled, nothing is visible when changing the entry in the display panel:
![pic3](https://cloud.githubusercontent.com/assets/18333271/22893215/60613ce4-f215-11e6-9b22-4ed21e4858fe.png)

The changes of this pull request mirrors the way the image display handles this problem. 
