### PR TITLE
Remove "catch (...)" instances, catch std::exception instead of std::runtime_error

### DIFF
--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -77,13 +77,9 @@ void moveit::tools::BackgroundProcessing::processingThread()
         fn();
         logDebug("moveit.background: Done executing '%s'", action_name.c_str());
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         logError("Exception caught while processing action '%s': %s", action_name.c_str(), ex.what());
-      }
-      catch (...)
-      {
-        logError("Exception caught while processing action '%s'", action_name.c_str());
       }
       processing_ = false;
       if (queue_change_event_)

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -90,15 +90,9 @@ bool callAdapter1(const PlanningRequestAdapter* adapter, const planning_interfac
   {
     return adapter->adaptAndPlan(planner, planning_scene, req, res, added_path_index);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     logError("Exception caught executing *final* adapter '%s': %s", adapter->getDescription().c_str(), ex.what());
-    added_path_index.clear();
-    return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res);
-  }
-  catch (...)
-  {
-    logError("Exception caught executing *final* adapter '%s'", adapter->getDescription().c_str());
     added_path_index.clear();
     return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res);
   }
@@ -113,15 +107,9 @@ bool callAdapter2(const PlanningRequestAdapter* adapter, const PlanningRequestAd
   {
     return adapter->adaptAndPlan(planner, planning_scene, req, res, added_path_index);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     logError("Exception caught executing *next* adapter '%s': %s", adapter->getDescription().c_str(), ex.what());
-    added_path_index.clear();
-    return planner(planning_scene, req, res);
-  }
-  catch (...)
-  {
-    logError("Exception caught executing *next* adapter '%s'", adapter->getDescription().c_str());
     added_path_index.clear();
     return planner(planning_scene, req, res);
   }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -90,8 +90,9 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
         inv_t = t2fixed_frame.inverse();
         use_inv_t = true;
       }
-      catch (std::runtime_error&)
+      catch (std::exception& ex)
       {
+        logError("Caught %s", ex.what());
         error = true;
       }
     else

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -114,7 +114,7 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR("MoveItFakeControllerManager: Unable to parse controller information");
+        ROS_ERROR("MoveItFakeControllerManager: Caught unknown exception while parsing controller information");
       }
     }
   }
@@ -179,7 +179,8 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR_ONCE_NAMED("loadInitialJointValues", "Unable to parse initial pose information.");
+        ROS_ERROR_ONCE_NAMED("loadInitialJointValues", "Caught unknown exception while reading initial pose "
+                                                       "information.");
       }
     }
 

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -163,7 +163,7 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR_STREAM_NAMED("manager", "Unable to parse controller information");
+        ROS_ERROR_STREAM_NAMED("manager", "Caught unknown exception while parsing controller information");
       }
     }
   }

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -152,7 +152,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
       {
         ok = psws_.getPlanningSceneWorld(pswwm, options_.scene);
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         ROS_ERROR("%s", ex.what());
       }
@@ -178,7 +178,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
     {
       ok = pss_.getPlanningScene(pswm, options_.scene);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("%s", ex.what());
     }
@@ -210,7 +210,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
   {
     pss_.getPlanningQueriesNames(options_.query_regex, planning_queries_names, options_.scene);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("%s", ex.what());
   }
@@ -267,7 +267,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
       {
         got_robot_state = rs_.getRobotState(robot_state, state_name);
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         ROS_ERROR("%s", ex.what());
       }
@@ -344,7 +344,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
         {
           got_constraints = cs_.getConstraints(constr, cnames[i]);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }
@@ -423,7 +423,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
         {
           got_constraints = tcs_.getTrajectoryConstraints(constr, cnames[i]);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -305,7 +305,7 @@ bool BenchmarkExecutor::initializeBenchmarks(const BenchmarkOptions& opts, movei
       return false;
     }
   }
-  catch (std::runtime_error& e)
+  catch (std::exception& e)
   {
     ROS_ERROR("Failed to initialize benchmark server: '%s'", e.what());
     return false;
@@ -586,7 +586,7 @@ bool BenchmarkExecutor::loadPlanningScene(const std::string& scene_name, moveit_
     else
       ROS_ERROR("Failed to find planning scene '%s'", scene_name.c_str());
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("Error loading planning scene: %s", ex.what());
   }
@@ -605,7 +605,7 @@ bool BenchmarkExecutor::loadQueries(const std::string& regex, const std::string&
   {
     pss_->getPlanningQueriesNames(regex, query_names, scene_name);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("Error loading motion planning queries: %s", ex.what());
     return false;
@@ -624,7 +624,7 @@ bool BenchmarkExecutor::loadQueries(const std::string& regex, const std::string&
     {
       pss_->getPlanningQuery(planning_query, scene_name, query_names[i]);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("Error loading motion planning query '%s': %s", query_names[i].c_str(), ex.what());
       continue;
@@ -662,7 +662,7 @@ bool BenchmarkExecutor::loadStates(const std::string& regex, std::vector<StartSt
             start_states.push_back(start_state);
           }
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("Runtime error when loading state '%s': %s", state_names[i].c_str(), ex.what());
           continue;
@@ -697,7 +697,7 @@ bool BenchmarkExecutor::loadPathConstraints(const std::string& regex, std::vecto
           constraints.push_back(constraint);
         }
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         ROS_ERROR("Runtime error when loading path constraint '%s': %s", cnames[i].c_str(), ex.what());
         continue;
@@ -733,7 +733,7 @@ bool BenchmarkExecutor::loadTrajectoryConstraints(const std::string& regex,
           constraints.push_back(constraint);
         }
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         ROS_ERROR("Runtime error when loading trajectory constraint '%s': %s", cnames[i].c_str(), ex.what());
         continue;

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -97,13 +97,9 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback_PlanOnly(const 
     planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);
     plan = pick_place_->planPick(ps, *goal);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
-  }
-  catch (...)
-  {
-    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (plan)
@@ -140,13 +136,9 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback_PlanOnly(const m
     planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);
     plan = pick_place_->planPlace(ps, *goal);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
-  }
-  catch (...)
-  {
-    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (plan)
@@ -187,13 +179,9 @@ bool move_group::MoveGroupPickPlaceAction::planUsingPickPlace_Pickup(const movei
   {
     pick_plan = pick_place_->planPick(plan.planning_scene_, goal);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
-  }
-  catch (...)
-  {
-    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (pick_plan)
@@ -233,13 +221,9 @@ bool move_group::MoveGroupPickPlaceAction::planUsingPickPlace_Place(const moveit
   {
     place_plan = pick_place_->planPlace(plan.planning_scene_, goal);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
-  }
-  catch (...)
-  {
-    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (place_plan)

--- a/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -196,14 +196,9 @@ void ManipulationPipeline::processingThread(unsigned int index)
             solution_callback_();
         }
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         ROS_ERROR_NAMED("manipulation", "[%s:%u] %s", name_.c_str(), index, ex.what());
-      }
-      catch (...)
-      {
-        ROS_ERROR_NAMED("manipulation", "[%s:%u] Caught unknown exception while processing manipulation stage",
-                        name_.c_str(), index);
       }
       queue_access_lock_.lock();
     }

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -165,14 +165,9 @@ void move_group::MoveGroupMoveAction::executeMoveCallback_PlanOnly(const moveit_
   {
     context_->planning_pipeline_->generatePlan(the_scene, goal->request, res);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("Planning pipeline threw an exception: %s", ex.what());
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
-  }
-  catch (...)
-  {
-    ROS_ERROR("Planning pipeline threw an exception");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
 
@@ -193,14 +188,9 @@ bool move_group::MoveGroupMoveAction::planUsingPlanningPipeline(const planning_i
   {
     solved = context_->planning_pipeline_->generatePlan(plan.planning_scene_, req, res);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("Planning pipeline threw an exception: %s", ex.what());
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
-  }
-  catch (...)
-  {
-    ROS_ERROR("Planning pipeline threw an exception");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
   if (res.trajectory_)

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -64,14 +64,9 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
     solved = context_->planning_pipeline_->generatePlan(ps, req.motion_plan_request, mp_res);
     mp_res.getMessage(res.motion_plan_response);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("Planning pipeline threw an exception: %s", ex.what());
-    res.motion_plan_response.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
-  }
-  catch (...)
-  {
-    ROS_ERROR("Planning pipeline threw an exception");
     res.motion_plan_response.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
 

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -506,6 +506,7 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
   catch (...)
   {
     tree_->unlockRead();
+    ROS_ERROR("Internal error while parsing depth data");
     return;
   }
   tree_->unlockRead();

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -151,9 +151,9 @@ void TransformProvider::updateTransforms()
       handle2context_[contextIt->first]->mutex_.unlock();
       continue;
     }
-    catch (...)
+    catch (std::exception& ex)
     {
-      ROS_ERROR("unknwon tf error");
+      ROS_ERROR("Caught %s while updating transforms", ex.what());
     }
     poseTFToEigen(out_pose, transformation);
     handle2context_[contextIt->first]->mutex_.lock();

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -241,14 +241,9 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
       solved = context ? context->solve(res) : false;
     }
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("Exception caught: '%s'", ex.what());
-    return false;
-  }
-  catch (...)
-  {
-    ROS_ERROR("Unknown exception thrown by planner");
     return false;
   }
   bool valid = true;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -441,9 +441,9 @@ void TrajectoryExecutionManager::continuousExecutionThread()
           {
             h = controller_manager_->getControllerHandle(context->controllers_[i]);
           }
-          catch (...)
+          catch (std::exception& ex)
           {
-            ROS_ERROR_NAMED("traj_execution", "Exception caught when retrieving controller handle");
+            ROS_ERROR_NAMED("traj_execution", "%s caught when retrieving controller handle", ex.what());
           }
           if (!h)
           {
@@ -471,9 +471,9 @@ void TrajectoryExecutionManager::continuousExecutionThread()
             {
               ok = handles[i]->sendTrajectory(context->trajectory_parts_[i]);
             }
-            catch (...)
+            catch (std::exception& ex)
             {
-              ROS_ERROR_NAMED("traj_execution", "Exception caught when sending trajectory to controller");
+              ROS_ERROR_NAMED("traj_execution", "Caught %s when sending trajectory to controller", ex.what());
             }
             if (!ok)
             {
@@ -482,9 +482,9 @@ void TrajectoryExecutionManager::continuousExecutionThread()
                 {
                   handles[j]->cancelExecution();
                 }
-                catch (...)
+                catch (std::exception& ex)
                 {
-                  ROS_ERROR_NAMED("traj_execution", "Exception caught when canceling execution");
+                  ROS_ERROR_NAMED("traj_execution", "Caught %s when canceling execution", ex.what());
                 }
               ROS_ERROR_NAMED("traj_execution", "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
                               context->trajectory_parts_.size(), handles[i]->getName().c_str());
@@ -1073,9 +1073,9 @@ void TrajectoryExecutionManager::stopExecutionInternal()
     {
       active_handles_[i]->cancelExecution();
     }
-    catch (...)
+    catch (std::exception& ex)
     {
-      ROS_ERROR_NAMED("traj_execution", "Exception caught when canceling execution.");
+      ROS_ERROR_NAMED("traj_execution", "Caught %s when canceling execution.", ex.what());
     }
 }
 
@@ -1263,9 +1263,9 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
           {
             h = controller_manager_->getControllerHandle(context.controllers_[i]);
           }
-          catch (...)
+          catch (std::exception& ex)
           {
-            ROS_ERROR_NAMED("traj_execution", "Exception caught when retrieving controller handle");
+            ROS_ERROR_NAMED("traj_execution", "Caught %s when retrieving controller handle", ex.what());
           }
           if (!h)
           {
@@ -1286,9 +1286,9 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
           {
             ok = active_handles_[i]->sendTrajectory(context.trajectory_parts_[i]);
           }
-          catch (...)
+          catch (std::exception& ex)
           {
-            ROS_ERROR_NAMED("traj_execution", "Exception caught when sending trajectory to controller");
+            ROS_ERROR_NAMED("traj_execution", "Caught %s when sending trajectory to controller", ex.what());
           }
           if (!ok)
           {
@@ -1297,9 +1297,9 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
               {
                 active_handles_[j]->cancelExecution();
               }
-              catch (...)
+              catch (std::exception& ex)
               {
-                ROS_ERROR_NAMED("traj_execution", "Exception caught when canceling execution");
+                ROS_ERROR_NAMED("traj_execution", "Caught %s when canceling execution", ex.what());
               }
             ROS_ERROR_NAMED("traj_execution", "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
                             context.trajectory_parts_.size(), active_handles_[i]->getName().c_str());

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1263,7 +1263,7 @@ private:
         constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
       }
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR_NAMED("move_group_interface", "%s", ex.what());
     }

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -799,13 +799,9 @@ void RobotInteraction::processingThread()
           {
             ih->handleEndEffector(eef, feedback);
           }
-          catch (std::runtime_error& ex)
+          catch (std::exception& ex)
           {
             ROS_ERROR("Exception caught while handling end-effector update: %s", ex.what());
-          }
-          catch (...)
-          {
-            ROS_ERROR("Exception caught while handling end-effector update");
           }
           marker_access_lock_.lock();
         }
@@ -819,13 +815,9 @@ void RobotInteraction::processingThread()
           {
             ih->handleJoint(vj, feedback);
           }
-          catch (std::runtime_error& ex)
+          catch (std::exception& ex)
           {
             ROS_ERROR("Exception caught while handling joint update: %s", ex.what());
-          }
-          catch (...)
-          {
-            ROS_ERROR("Exception caught while handling joint update");
           }
           marker_access_lock_.lock();
         }
@@ -838,26 +830,18 @@ void RobotInteraction::processingThread()
           {
             ih->handleGeneric(g, feedback);
           }
-          catch (std::runtime_error& ex)
+          catch (std::exception& ex)
           {
             ROS_ERROR("Exception caught while handling joint update: %s", ex.what());
-          }
-          catch (...)
-          {
-            ROS_ERROR("Exception caught while handling joint update");
           }
           marker_access_lock_.lock();
         }
         else
           ROS_ERROR("Unknown marker class ('%s') for marker '%s'", marker_class.c_str(), feedback->marker_name.c_str());
       }
-      catch (std::runtime_error& ex)
+      catch (std::exception& ex)
       {
         ROS_ERROR("Exception caught while processing event: %s", ex.what());
-      }
-      catch (...)
-      {
-        ROS_ERROR("Exception caught while processing event");
       }
     }
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -158,7 +158,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
     {
       waitForAction(object_recognition_client_, nh_, ros::Duration(3.0), OBJECT_RECOGNITION_ACTION);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       //      ROS_ERROR("Object recognition action: %s", ex.what());
       object_recognition_client_.reset();
@@ -168,7 +168,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   {
     planning_scene_interface_.reset(new moveit::planning_interface::PlanningSceneInterface());
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("%s", ex.what());
   }
@@ -187,7 +187,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
       semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
     }
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     ROS_ERROR("%s", ex.what());
   }
@@ -304,7 +304,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("%s", ex.what());
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -138,7 +138,7 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
         return;
       }
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       planning_display_->addMainLoopJob(
           boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -128,7 +128,7 @@ void MotionPlanningFrame::triggerObjectDetection()
     {
       waitForAction(object_recognition_client_, nh_, ros::Duration(3.0), OBJECT_RECOGNITION_ACTION);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("Object recognition action: %s", ex.what());
       return;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -423,7 +423,7 @@ void MotionPlanningFrame::computeSaveSceneButtonClicked()
       planning_scene_storage_->removePlanningScene(msg.name);
       planning_scene_storage_->addPlanningScene(msg);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("%s", ex.what());
     }
@@ -444,7 +444,7 @@ void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene
         planning_scene_storage_->removePlanningQuery(scene, query_name);
       planning_scene_storage_->addPlanningQuery(mreq, scene, query_name);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("%s", ex.what());
     }
@@ -468,7 +468,7 @@ void MotionPlanningFrame::computeDeleteSceneButtonClicked()
         {
           planning_scene_storage_->removePlanningScene(scene);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }
@@ -481,7 +481,7 @@ void MotionPlanningFrame::computeDeleteSceneButtonClicked()
         {
           planning_scene_storage_->removePlanningScene(scene);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }
@@ -507,7 +507,7 @@ void MotionPlanningFrame::computeDeleteQueryButtonClicked()
         {
           planning_scene_storage_->removePlanningQuery(scene, query_name);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }
@@ -579,7 +579,7 @@ void MotionPlanningFrame::computeLoadSceneButtonClicked()
         {
           got_ps = planning_scene_storage_->getPlanningScene(scene_m, scene);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }
@@ -633,7 +633,7 @@ void MotionPlanningFrame::computeLoadQueryButtonClicked()
         {
           got_q = planning_scene_storage_->getPlanningQuery(mp, scene, query_name);
         }
-        catch (std::runtime_error& ex)
+        catch (std::exception& ex)
         {
           ROS_ERROR("%s", ex.what());
         }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -82,7 +82,7 @@ void MotionPlanningFrame::loadStoredStates(const std::string& pattern)
   {
     robot_state_storage_->getKnownRobotStates(pattern, names);
   }
-  catch (std::runtime_error& ex)
+  catch (std::exception& ex)
   {
     QMessageBox::warning(this, "Cannot query the database",
                          QString("Wrongly formatted regular expression for robot states: ").append(ex.what()));
@@ -100,7 +100,7 @@ void MotionPlanningFrame::loadStoredStates(const std::string& pattern)
     {
       got_state = robot_state_storage_->getRobotState(rs, names[i]);
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("%s", ex.what());
     }
@@ -154,7 +154,7 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const robot_state::RobotSt
           {
             robot_state_storage_->addRobotState(msg, name, planning_display_->getRobotModel()->getName());
           }
-          catch (std::runtime_error& ex)
+          catch (std::exception& ex)
           {
             ROS_ERROR("Cannot save robot state on the database: %s", ex.what());
           }
@@ -231,7 +231,7 @@ void MotionPlanningFrame::removeStateButtonClicked()
             robot_state_storage_->removeRobotState(name);
             robot_states_.erase(name);
           }
-          catch (std::runtime_error& ex)
+          catch (std::exception& ex)
           {
             ROS_ERROR("%s", ex.what());
           }

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -247,13 +247,9 @@ void PlanningSceneDisplay::executeMainLoopJobs()
     {
       fn();
     }
-    catch (std::runtime_error& ex)
+    catch (std::exception& ex)
     {
       ROS_ERROR("Exception caught executing main loop job: %s", ex.what());
-    }
-    catch (...)
-    {
-      ROS_ERROR("Exception caught executing main loop job");
     }
     main_loop_jobs_lock_.lock();
   }
@@ -346,9 +342,9 @@ void PlanningSceneDisplay::renderPlanningScene()
           static_cast<OctreeVoxelColorMode>(octree_coloring_property_->getOptionInt()),
           scene_alpha_property_->getFloat());
     }
-    catch (...)
+    catch (std::exception& ex)
     {
-      ROS_ERROR("Exception thrown while rendering planning scene");
+      ROS_ERROR("Caught %s while rendering planning scene", ex.what());
     }
     planning_scene_needs_render_ = false;
     planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());


### PR DESCRIPTION
### Description
This adds the changes discussed on #270.

I have left only a couple of `catch (...)` instances where I think the changes can be omitted or I wasn't very comfortable with the change.

General logic copied over from the issue:
```
try
{
...
}
catch (std::runtime_error &ex)
{
    logError("Exception caught while processing action '%s': %s", action_name.c_str(), ex.what());
}
catch (...)
{
     logError("Exception caught while processing action '%s'", action_name.c_str()); // here important stuff may remain hidden
}
```

My proposed solution for the pattern above is this:

```
try
{
...
}
catch (std::exception &ex) // since std::runtime_exception < std::exception
{
    logError("Exception caught while processing action '%s': %s", action_name.c_str(), ex.what());
}
```

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

Thank you!
