### PR TITLE
Always update initial robot state to prevent dirty robot state error.

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -77,6 +77,7 @@ ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::
   , use_state_validity_cache_(true)
   , simplify_solutions_(true)
 {
+  complete_initial_robot_state_.update();
   ompl_simple_setup_->getStateSpace()->computeSignature(space_signature_);
   ompl_simple_setup_->getStateSpace()->setStateSamplerAllocator(
       boost::bind(&ModelBasedPlanningContext::allocPathConstrainedSampler, this, _1));
@@ -387,6 +388,7 @@ void ompl_interface::ModelBasedPlanningContext::setCompleteInitialState(
     const robot_state::RobotState& complete_initial_robot_state)
 {
   complete_initial_robot_state_ = complete_initial_robot_state;
+  complete_initial_robot_state_.update();
 }
 
 void ompl_interface::ModelBasedPlanningContext::clear()


### PR DESCRIPTION
The class `ModelBasedPlanningContext` uses the initial robot state  `complete_initial_robot_state_`. This robot state might be dirty if transforms are not up to date, which can cause errors while planning. To prevent this the robot state needs to be updated after initialization and reset.
