### PR TITLE
fixed numpy.ndarray indices bug (from #86)

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -102,8 +102,8 @@ class PlanningSceneInterface(object):
         mesh = Mesh()
         for face in scene.meshes[0].faces:
             triangle = MeshTriangle()
-            if len(face.indices) == 3:
-                triangle.vertex_indices = [face.indices[0], face.indices[1], face.indices[2]]
+            if len(face) == 3:
+                triangle.vertex_indices = [face[0], face[1], face[2]]
             mesh.triangles.append(triangle)
         for vertex in scene.meshes[0].vertices:
             point = Point()

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -93,26 +93,32 @@ class PlanningSceneInterface(object):
     def __make_mesh(self, name, pose, filename, scale = (1, 1, 1)):
         co = CollisionObject()
         scene = pyassimp.load(filename)
-        if not scene.meshes:
+        if not scene.meshes or len(scene.meshes) == 0:
             raise MoveItCommanderException("There are no meshes in the file")
+        if len(scene.meshes[0].faces) == 0:
+            raise MoveItCommanderException("There are no faces in the mesh")
         co.operation = CollisionObject.ADD
         co.id = name
         co.header = pose.header
         
         mesh = Mesh()
-        for face in scene.meshes[0].faces:
-            triangle = MeshTriangle()
-            if hasattr(face, '__len__'):
+        first_face = scene.meshes[0].faces[0]
+        if hasattr(first_face, '__len__'):
+            for face in scene.meshes[0].faces:
                 if len(face) == 3:
+                    triangle = MeshTriangle()
                     triangle.vertex_indices = [face[0], face[1], face[2]]
-            elif hasattr(face, 'indices'):
+                    mesh.triangles.append(triangle)
+        elif hasattr(first_face, 'indices'):
+            for face in scene.meshes[0].faces:
                 if len(face.indices) == 3:
+                    triangle = MeshTriangle()
                     triangle.vertex_indices = [face.indices[0],
                                                face.indices[1],
                                                face.indices[2]]
-            else:
-                raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
-            mesh.triangles.append(triangle)
+                    mesh.triangles.append(triangle)
+        else:
+            raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
         for vertex in scene.meshes[0].vertices:
             point = Point()
             point.x = vertex[0]*scale[0]

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -102,10 +102,10 @@ class PlanningSceneInterface(object):
         mesh = Mesh()
         for face in scene.meshes[0].faces:
             triangle = MeshTriangle()
-            if hasattr(face, '__len__') :
+            if hasattr(face, '__len__'):
                 if len(face) == 3:
                     triangle.vertex_indices = [face[0], face[1], face[2]]
-            elif hasattr(face, 'indices') 
+            elif hasattr(face, 'indices'):
                 if len(face.indices) == 3:
                     triangle.vertex_indices = [face.indices[0],
                                                face.indices[1],

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -102,8 +102,14 @@ class PlanningSceneInterface(object):
         mesh = Mesh()
         for face in scene.meshes[0].faces:
             triangle = MeshTriangle()
-            if len(face) == 3:
+            if hasattr(face, '__len__') and len(face) == 3:
                 triangle.vertex_indices = [face[0], face[1], face[2]]
+            elif hasattr(face, 'indices') and len(face.indices) == 3:
+                triangle.vertex_indices = [face.indices[0],
+                                           face.indices[1],
+                                           face.indices[2]]
+            else:
+              raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
             mesh.triangles.append(triangle)
         for vertex in scene.meshes[0].vertices:
             point = Point()

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -102,12 +102,14 @@ class PlanningSceneInterface(object):
         mesh = Mesh()
         for face in scene.meshes[0].faces:
             triangle = MeshTriangle()
-            if hasattr(face, '__len__') and len(face) == 3:
-                triangle.vertex_indices = [face[0], face[1], face[2]]
-            elif hasattr(face, 'indices') and len(face.indices) == 3:
-                triangle.vertex_indices = [face.indices[0],
-                                           face.indices[1],
-                                           face.indices[2]]
+            if hasattr(face, '__len__') :
+                if len(face) == 3:
+                    triangle.vertex_indices = [face[0], face[1], face[2]]
+            elif hasattr(face, 'indices') 
+                if len(face.indices) == 3:
+                    triangle.vertex_indices = [face.indices[0],
+                                               face.indices[1],
+                                               face.indices[2]]
             else:
               raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
             mesh.triangles.append(triangle)

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -111,7 +111,7 @@ class PlanningSceneInterface(object):
                                                face.indices[1],
                                                face.indices[2]]
             else:
-              raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
+                raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
             mesh.triangles.append(triangle)
         for vertex in scene.meshes[0].vertices:
             point = Point()


### PR DESCRIPTION
### Description

A fix for the numpy.ndarray indices bug, the second bug described in #86.

This fix was proposed by @lifangda01 in the same issue.

I was unsure what to do about clang-format, since it seems that it's for C++ only.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

Thank you!
