### PR TITLE
[indigo] cherry-pick #377 (Add set_max_acceleration_scaling_factor to moveit_commander).

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -429,6 +429,13 @@ class MoveGroupCommander(object):
         else:
             raise MoveItCommanderException("Expected value in the range from 0 to 1 for scaling factor" )
 
+    def set_max_acceleration_scaling_factor(self, value):
+        """ Set a scaling factor for optionally reducing the maximum joint acceleration. Allowed values are in (0,1]. """
+        if value > 0 and value <= 1:
+            self._g.set_max_acceleration_scaling_factor(value)
+        else:
+            raise MoveItCommanderException("Expected value in the range from 0 to 1 for scaling factor" )
+
     def go(self, joints = None, wait = True):
         """ Set the target of the group and then move the group to the specified target """
         if type(joints) is bool:

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -568,6 +568,7 @@ static void wrap_move_group_interface()
   MoveGroupClass.def("set_workspace", &MoveGroupWrapper::setWorkspace);
   MoveGroupClass.def("set_planning_time", &MoveGroupWrapper::setPlanningTime);
   MoveGroupClass.def("get_planning_time", &MoveGroupWrapper::getPlanningTime);
+  MoveGroupClass.def("set_max_acceleration_scaling_factor", &MoveGroupWrapper::setMaxAccelerationScalingFactor);
   MoveGroupClass.def("set_max_velocity_scaling_factor", &MoveGroupWrapper::setMaxVelocityScalingFactor);
   MoveGroupClass.def("set_planner_id", &MoveGroupWrapper::setPlannerId);
   MoveGroupClass.def("set_num_planning_attempts", &MoveGroupWrapper::setNumPlanningAttempts);


### PR DESCRIPTION
#377 against `jade-devel` was ported to kinetic-devel in #385 but never to indigo, so is this.
#437 seems also relevant, and is included in this PR.

Squashed into a single commit.