### PR TITLE
correct "simplify widget handling"

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -39,6 +39,7 @@
 
 #include <rviz/display.h>
 #include <rviz/selection/selection_manager.h>
+#include <rviz/panel_dock_widget.h>
 #include <moveit/planning_scene_rviz_plugin/planning_scene_display.h>
 #include <moveit/rviz_plugin_render_tools/trajectory_visualization.h>
 #include <std_msgs/String.h>
@@ -55,7 +56,6 @@
 #endif
 
 #include <moveit_msgs/DisplayTrajectory.h>
-#include <QDockWidget>
 
 namespace Ogre
 {
@@ -166,6 +166,7 @@ private Q_SLOTS:
   void changedMetricsTextHeight();
   void changedWorkspace();
   void resetInteractiveMarkers();
+  void motionPanelVisibilityChange(bool enable);
 
 protected:
   enum LinkDisplayStatus
@@ -234,7 +235,7 @@ protected:
 
   // the planning frame
   MotionPlanningFrame* frame_;
-  QDockWidget* frame_dock_;
+  rviz::PanelDockWidget* frame_dock_;
 
   // robot interaction
   robot_interaction::RobotInteractionPtr robot_interaction_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -55,6 +55,7 @@
 #endif
 
 #include <moveit_msgs/DisplayTrajectory.h>
+#include <QDockWidget>
 
 namespace Ogre
 {
@@ -233,6 +234,7 @@ protected:
 
   // the planning frame
   MotionPlanningFrame* frame_;
+  QDockWidget* frame_dock_;
 
   // robot interaction
   robot_interaction::RobotInteractionPtr robot_interaction_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -227,7 +227,11 @@ void MotionPlanningDisplay::onInitialize()
   connect(frame_, SIGNAL(planningFinished()), trajectory_visual_.get(), SLOT(interruptCurrentDisplay()));
 
   if (window_context)
+  {
     frame_dock_ = window_context->addPane("Motion Planning", frame_);
+    connect(frame_dock_, SIGNAL(visibilityChanged(bool)), this, SLOT(motionPanelVisibilityChange(bool)));
+    frame_dock_->setIcon(getIcon());
+  }
 
   int_marker_display_ = context_->getDisplayFactory()->make("rviz/InteractiveMarkers");
   int_marker_display_->initialize(context_);
@@ -247,6 +251,12 @@ void MotionPlanningDisplay::onInitialize()
         new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_R), context_->getWindowManager()->getParentWindow());
     connect(im_reset_shortcut, SIGNAL(activated()), this, SLOT(resetInteractiveMarkers()));
   }
+}
+
+void MotionPlanningDisplay::motionPanelVisibilityChange(bool enable)
+{
+  if (enable)
+    setEnabled(true);
 }
 
 void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -83,6 +83,7 @@ MotionPlanningDisplay::MotionPlanningDisplay()
   , text_to_display_(NULL)
   , private_handle_("~")
   , frame_(NULL)
+  , frame_dock_(NULL)
   , menu_handler_start_(new interactive_markers::MenuHandler)
   , menu_handler_goal_(new interactive_markers::MenuHandler)
   , int_marker_display_(NULL)
@@ -185,6 +186,7 @@ MotionPlanningDisplay::~MotionPlanningDisplay()
 
   delete text_to_display_;
   delete int_marker_display_;
+  delete frame_dock_;
 }
 
 void MotionPlanningDisplay::onInitialize()
@@ -224,7 +226,8 @@ void MotionPlanningDisplay::onInitialize()
   // immediately switch to next trajectory display after planning
   connect(frame_, SIGNAL(planningFinished()), trajectory_visual_.get(), SLOT(interruptCurrentDisplay()));
 
-  setAssociatedWidget(frame_);
+  if (window_context)
+    frame_dock_ = window_context->addPane("Motion Planning", frame_);
 
   int_marker_display_ = context_->getDisplayFactory()->make("rviz/InteractiveMarkers");
   int_marker_display_->initialize(context_);
@@ -1211,6 +1214,7 @@ void MotionPlanningDisplay::onEnable()
 
   query_robot_start_->setVisible(query_start_state_property_->getBool());
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
+  frame_->enable();
 
   int_marker_display_->setEnabled(true);
   int_marker_display_->setFixedFrame(fixed_frame_);
@@ -1227,6 +1231,7 @@ void MotionPlanningDisplay::onDisable()
 
   query_robot_start_->setVisible(false);
   query_robot_goal_->setVisible(false);
+  frame_->disable();
   text_to_display_->setVisible(false);
 
   PlanningSceneDisplay::onDisable();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -443,12 +443,14 @@ void MotionPlanningFrame::enable()
   ui_->object_status->setText("");
 
   // activate the frame
+  parentWidget()->show();
   show();
 }
 
 void MotionPlanningFrame::disable()
 {
   move_group_.reset();
+  parentWidget()->hide();
   hide();
 }
 


### PR DESCRIPTION
 The changes from the pull request #442 leads to an error.

Hiding the docking area when the motion planning panel is part of it disabled the whole display including the motion planning  *scene* that is displayed in the main window.

So instead of relying on the setAssociatedWidget mechanism, we have to implement the wanted behavior ourselves.