### PR TITLE
rviz panel: Don't add object marker if the wrong tab is selected

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -84,6 +84,14 @@ class MotionPlanningDisplay;
 
 const std::string OBJECT_RECOGNITION_ACTION = "/recognize_objects";
 
+static const std::string TAB_CONTEXT = "Context";
+static const std::string TAB_PLANNING = "Planning";
+static const std::string TAB_MANIPULATION = "Manipulation";
+static const std::string TAB_OBJECTS = "Scene Objects";
+static const std::string TAB_SCENES = "Stored Scenes";
+static const std::string TAB_STATES = "Stored States";
+static const std::string TAB_STATUS = "Status";
+
 class MotionPlanningFrame : public QWidget
 {
   friend class MotionPlanningDisplay;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -454,9 +454,9 @@ void MotionPlanningFrame::disable()
 
 void MotionPlanningFrame::tabChanged(int index)
 {
-  if (scene_marker_ && ui_->tabWidget->tabText(index) != "Scene Objects")
+  if (scene_marker_ && ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS)
     scene_marker_.reset();
-  else if (ui_->tabWidget->tabText(index) == "Scene Objects")
+  else if (ui_->tabWidget->tabText(index).toStdString() == TAB_OBJECTS)
     selectedCollisionObjectChanged();
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -268,7 +268,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
         else
           ui_->object_status->setText("ERROR: '" + sel[0]->text() + "' should be a collision object but it is not");
       }
-      if (update_scene_marker && ui_->tabWidget->tabText(ui_->tabWidget->currentIndex()) == "Scene Objects")
+      if (update_scene_marker && ui_->tabWidget->tabText(ui_->tabWidget->currentIndex()).toStdString() == TAB_OBJECTS)
       {
         createSceneInteractiveMarker();
       }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -268,7 +268,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
         else
           ui_->object_status->setText("ERROR: '" + sel[0]->text() + "' should be a collision object but it is not");
       }
-      if (update_scene_marker)
+      if (update_scene_marker && ui_->tabWidget->tabText(ui_->tabWidget->currentIndex()) == "Scene Objects")
       {
         createSceneInteractiveMarker();
       }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1433,7 +1433,7 @@
          <item>
           <widget class="QGroupBox" name="groupBox_17">
            <property name="title">
-            <string>Current  State</string>
+            <string>Current State</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_16">
             <item row="0" column="0">


### PR DESCRIPTION
The panel maintains an interactive marker by which the user can move
objects around in the planning scene.
Previously, this marker was created/updated whenever an object
was selected in the "Scene Objects" tab and geometry updates are received.

However, the marker should only be visible if the user actually
*wants* to manipulate the selected object, i.e. the correct tab is actually
active right now.

Because of the broken condition, the marker reappeared after
the user had selected an object (the marker appeared), selected a different tab
(the marker disappears), and the panel's planning scene monitor
received a geometry update afterwards. (This includes TRANSFORM updates that
are triggered by almost every interaction with move_group)

This should be cherry-picked to j/k.

Here's a screenshot that illustrates the glitch. Notice that the marker is active although the "Manipulation" tab is selected.

![wrong_im](https://cloud.githubusercontent.com/assets/680358/23481857/58c32528-fecd-11e6-95b4-017e7dac3864.png)
