### PR TITLE
Fix usability bugs in RobotState display

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -377,6 +377,7 @@ void RobotStateDisplay::onEnable()
     robot_->setVisible(true);
   }
   calculateOffsetPosition();
+  changedRobotStateTopic();
 }
 
 // ******************************************************************************************
@@ -384,6 +385,7 @@ void RobotStateDisplay::onEnable()
 // ******************************************************************************************
 void RobotStateDisplay::onDisable()
 {
+  robot_state_subscriber_.shutdown();
   if (robot_)
     robot_->setVisible(false);
   Display::onDisable();


### PR DESCRIPTION
I just tried to make use of this display for the first time
and now I keep wondering how people managed to use it in the first place...

Over here it segfaults when pressing Enter after changing the topic
and it does not connect to the topic when the display becomes enabled.

These patches address both problems.

Should be picked to jade.