### PR TITLE
MoveGroupInterface: add public interface to construct the MotionPlanRequest

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -47,6 +47,7 @@
 #include <moveit_msgs/Constraints.h>
 #include <moveit_msgs/Grasp.h>
 #include <moveit_msgs/PlaceLocation.h>
+#include <moveit_msgs/MotionPlanRequest.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <boost/shared_ptr.hpp>
 #include <tf/tf.h>
@@ -716,6 +717,10 @@ public:
 
   /** \brief Specify whether the robot is allowed to replan if it detects changes in the environment */
   void allowReplanning(bool flag);
+
+  /** \brief Build the MotionPlanRequest that would be sent to the move_group action with plan() or move() and store it
+      in \e request */
+  void constructMotionPlanRequest(moveit_msgs::MotionPlanRequest& request);
 
   /**@}*/
 


### PR DESCRIPTION
The MoveGroupInterface is meant to abstract away the ROS interfaces
used to communicate with the `move_group` node.
Nevertheless, it can be helpful to get the MotionPlanRequest that is
generated by the interface.