### PR TITLE
Add definition of getStateUpdateFrequency in planningSceneMonitor.

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -298,7 +298,13 @@ public:
   void setStateUpdateFrequency(double hz);
 
   /** @brief Get the maximum frequency (Hz) at which the current state of the planning scene is updated.*/
-  double getStateUpdateFrequency();
+  double getStateUpdateFrequency() const
+  {
+    if (!dt_state_update_.isZero())
+      return 1.0 / dt_state_update_.toSec();
+    else
+      return 0.0;
+  }
 
   /** @brief Start the scene monitor
    *  @param scene_topic The name of the planning scene topic


### PR DESCRIPTION
As per title. definition was found to be missing: #456 

This should be cherry picked to both Jade and Kinetic as it's missing there as well.
