### PR TITLE
improve RobotState display [kinetic]

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -372,6 +372,7 @@ void RobotStateDisplay::onEnable()
   Display::onEnable();
   load_robot_model_ = true;  // allow loading of robot model in update()
   calculateOffsetPosition();
+  changedRobotStateTopic();
 }
 
 // ******************************************************************************************
@@ -379,6 +380,7 @@ void RobotStateDisplay::onEnable()
 // ******************************************************************************************
 void RobotStateDisplay::onDisable()
 {
+  robot_state_subscriber_.shutdown();
   if (robot_)
     robot_->setVisible(false);
   Display::onDisable();

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -288,10 +288,10 @@ void RobotStateDisplay::changedRobotSceneAlpha()
 void RobotStateDisplay::changedRobotStateTopic()
 {
   robot_state_subscriber_.shutdown();
-  robot_state_subscriber_ = root_nh_.subscribe(robot_state_topic_property_->getStdString(), 10,
-                                               &RobotStateDisplay::newRobotStateCallback, this);
   robot_->clear();
-  loadRobotModel();
+  load_robot_model_ = true;
+  robot_state_subscriber_ = root_nh_.subscribe(robot_state_topic_property_->getTopicStd(), 10,
+                                               &RobotStateDisplay::newRobotStateCallback, this);
 }
 
 void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotStateConstPtr& state_msg)


### PR DESCRIPTION
This is the sister request to https://github.com/ros-planning/moveit/pull/455 .
The mentioned segfault appears on my (non-ubuntu) system with kinetic, so I'm not sure
how reproducible this is. Either way it probably makes sense to mark the required setup
of the robot model before connecting again.