### PR TITLE
address gcc6 build error (kinetic-devel)

### DIFF
--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -71,11 +71,11 @@ catkin_package(
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
-		    )
+                    ${Boost_INCLUDE_DIRS}
+)
 include_directories(SYSTEM
                     ${EIGEN3_INCLUDE_DIRS}
-                    ${Boost_INCLUDE_DIRS}
-                    )
+)
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})


### PR DESCRIPTION
This is a continuation for #423.

Somehow I overlooked the moveit_ros/planning package which also needs the same treatment.