### PR TITLE
Fixing warehouse services

### DIFF
--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -133,11 +133,26 @@ int main(int argc, char** argv)
   int port;
   node.param<std::string>("warehouse_host", host, "localhost");
   node.param<int>("warehouse_port", port, 33829);
+  warehouse_ros::DatabaseConnection::Ptr conn;
 
-  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
-  conn->setParams(host, port, 5.0);
+  try
+  {
+    conn = moveit_warehouse::loadDatabase();
+    conn->setParams(host, port, 5.0);
 
-  ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);
+    ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);
+    if (!conn->connect())
+    {
+      ROS_ERROR("Failed to connect to DB");
+      return 1;
+    }
+  }
+  catch (std::exception& ex)
+  {
+      ROS_ERROR("%s", ex.what());
+      return 1;
+  }
+
   moveit_warehouse::RobotStateStorage rs(conn);
 
   std::vector<std::string> names;

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -143,14 +143,14 @@ int main(int argc, char** argv)
     ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);
     if (!conn->connect())
     {
-      ROS_ERROR("Failed to connect to DB");
+      ROS_ERROR("Failed to connect to DB on %s:%d", host.c_str(), port);
       return 1;
     }
   }
   catch (std::exception& ex)
   {
-      ROS_ERROR("%s", ex.what());
-      return 1;
+    ROS_ERROR("%s", ex.what());
+    return 1;
   }
 
   moveit_warehouse::RobotStateStorage rs(conn);


### PR DESCRIPTION
### Description

When launching the warehouse services, I got an error connecting to the warehouse which was due to not having the appropriate try/catch and also missing the conn->connect() call. With this pr, services are advertised correctly.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] I tried on Kinetic but I think it should be cherry-picked to other current ROS branches (Indigo, Jade)

Thank you!
