### PR TITLE
Renaming of display doesn't change panel name

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -93,6 +93,8 @@ public:
   virtual void update(float wall_dt, float ros_dt);
   virtual void reset();
 
+  void setName(const QString& name);
+
   robot_state::RobotStateConstPtr getQueryStartState() const
   {
     return query_start_state_->getState();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -228,7 +228,7 @@ void MotionPlanningDisplay::onInitialize()
 
   if (window_context)
   {
-    frame_dock_ = window_context->addPane("Motion Planning", frame_);
+    frame_dock_ = window_context->addPane(getName(), frame_);
     connect(frame_dock_, SIGNAL(visibilityChanged(bool)), this, SLOT(motionPanelVisibilityChange(bool)));
     frame_dock_->setIcon(getIcon());
   }
@@ -303,6 +303,13 @@ void MotionPlanningDisplay::reset()
 
   query_robot_start_->setVisible(query_start_state_property_->getBool());
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
+}
+
+void MotionPlanningDisplay::setName(const QString& name)
+{
+  BoolProperty::setName(name);
+  frame_dock_->setWindowTitle(name);
+  frame_dock_->setObjectName(name);
 }
 
 void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent, const std::string&)


### PR DESCRIPTION
Renaming the Motion Planning Display doesn't change the name of the Motion Planning Panel
right now.

These changes overrides the function setName of the display class, since we don't have a associated widget
the setName function from display doesn't work.
