### PR TITLE
Cherry pick into kinetic from #482 renameDisplay

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -95,6 +95,8 @@ public:
   virtual void update(float wall_dt, float ros_dt);
   virtual void reset();
 
+  void setName(const QString& name);
+
   robot_state::RobotStateConstPtr getQueryStartState() const
   {
     return query_start_state_->getState();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -227,7 +227,7 @@ void MotionPlanningDisplay::onInitialize()
 
   if (window_context)
   {
-    frame_dock_ = window_context->addPane("Motion Planning", frame_);
+    frame_dock_ = window_context->addPane(getName(), frame_);
     connect(frame_dock_, SIGNAL(visibilityChanged(bool)), this, SLOT(motionPanelVisibilityChange(bool)));
     frame_dock_->setIcon(getIcon());
   }
@@ -302,6 +302,13 @@ void MotionPlanningDisplay::reset()
 
   query_robot_start_->setVisible(query_start_state_property_->getBool());
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
+}
+
+void MotionPlanningDisplay::setName(const QString& name)
+{
+  BoolProperty::setName(name);
+  frame_dock_->setWindowTitle(name);
+  frame_dock_->setObjectName(name);
 }
 
 void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent, const std::string&)


### PR DESCRIPTION
Renaming of display doesn't change panel name

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

Thank you!

Cherry picking from indigo #482 to kinetic
