### PR TITLE
New panel with a slider to control the visualized trajectory

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -310,6 +310,7 @@ void MotionPlanningDisplay::setName(const QString& name)
   BoolProperty::setName(name);
   frame_dock_->setWindowTitle(name);
   frame_dock_->setObjectName(name);
+  trajectory_visual_->setName(name);
 }
 
 void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent, const std::string&)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MOVEIT_LIB_NAME moveit_rviz_plugin_render_tools)
 # Header files that need Qt Moc pre-processing for use with Qt signals, etc:
 set( headers
   include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+  include/moveit/rviz_plugin_render_tools/trajectory_panel.h
 )
 
 # Convert the Qt Signals and Slots for QWidget events
@@ -17,6 +18,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/planning_link_updater.cpp
   src/octomap_render.cpp
   src/trajectory_visualization.cpp
+  src/trajectory_panel.cpp
   ${MOC_SOURCES}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2015, University of Colorado, Boulder
+ *  Copyright (c) 2017, Yannick Jonetzko
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *   * Neither the name of Willow Garage nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
@@ -32,63 +32,62 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Dave Coleman
-   Desc:   Wraps a trajectory_visualization playback class for Rviz into a stand alone display
-*/
+/* Author: Yannick Jonetzko */
 
-#ifndef MOVEIT_TRAJECTORY_RVIZ_PLUGIN__TRAJECTORY_DISPLAY
-#define MOVEIT_TRAJECTORY_RVIZ_PLUGIN__TRAJECTORY_DISPLAY
+#ifndef MOVEIT_TRAJECTORY_RVIZ_PLUGIN_TRAJECTORY_PANEL_
+#define MOVEIT_TRAJECTORY_RVIZ_PLUGIN_TRAJECTORY_PANEL_
 
-#include <rviz/display.h>
-#include <moveit/rviz_plugin_render_tools/trajectory_visualization.h>
 #include <ros/ros.h>
-#include <moveit/rdf_loader/rdf_loader.h>
 
-namespace rviz
-{
-class StringProperty;
-}
+#include <rviz/panel.h>
+
+#include <QSlider>
+#include <QLabel>
+#include <QPushButton>
 
 namespace moveit_rviz_plugin
 {
-class TrajectoryDisplay : public rviz::Display
+class TrajectoryPanel : public rviz::Panel
 {
   Q_OBJECT
-  // friend class TrajectoryVisualization; // allow the visualization class to access the display
 
 public:
-  TrajectoryDisplay();
+  TrajectoryPanel(QWidget* parent = 0);
 
-  virtual ~TrajectoryDisplay();
+  virtual ~TrajectoryPanel();
 
-  void loadRobotModel();
+  void onInitialize();
+  void onEnable();
+  void onDisable();
+  void update(int way_point_count);
 
-  virtual void update(float wall_dt, float ros_dt);
-  virtual void reset();
+  // Switches between pause and play mode
+  void pauseButton(bool check);
 
-  // overrides from Display
-  virtual void onInitialize();
-  virtual void onEnable();
-  virtual void onDisable();
-  void setName(const QString& name);
+  void setSliderPosition(int position);
+
+  int getSliderPosition() const
+  {
+    return slider_->sliderPosition();
+  }
+
+  bool isPaused() const
+  {
+    return paused_;
+  }
 
 private Q_SLOTS:
-  /**
-   * \brief Slot Event Functions
-   */
-  void changedRobotDescription();
+  void sliderValueChanged(int value);
+  void buttonClicked();
 
 protected:
-  // The trajectory playback component
-  TrajectoryVisualizationPtr trajectory_visual_;
+  QSlider* slider_;
+  QLabel* maximum_label_;
+  QLabel* minimum_label_;
+  QPushButton* button_;
 
-  // Load robot model
-  rdf_loader::RDFLoaderPtr rdf_loader_;
-  robot_model::RobotModelConstPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
-
-  // Properties
-  rviz::StringProperty* robot_description_property_;
+  bool paused_;
+  int last_way_point_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -39,7 +39,9 @@
 
 #include <moveit/macros/class_forward.h>
 #include <rviz/display.h>
+#include <rviz/panel_dock_widget.h>
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
+#include <moveit/rviz_plugin_render_tools/trajectory_panel.h>
 #include <ros/ros.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
@@ -86,6 +88,7 @@ public:
   void onRobotModelLoaded(robot_model::RobotModelConstPtr robot_model);
   void onEnable();
   void onDisable();
+  void setName(const QString& name);
 
 public Q_SLOTS:
   void interruptCurrentDisplay();
@@ -104,6 +107,7 @@ private Q_SLOTS:
   void changedStateDisplayTime();
   void changedRobotColor();
   void enabledRobotColor();
+  void trajectorySliderPanelVisibilityChange(bool enable);
 
 protected:
   /**
@@ -138,6 +142,8 @@ protected:
   Ogre::SceneNode* scene_node_;
   rviz::DisplayContext* context_;
   ros::NodeHandle update_nh_;
+  TrajectoryPanel* trajectory_slider_panel_;
+  rviz::PanelDockWidget* trajectory_slider_dock_panel_;
 
   // Properties
   rviz::BoolProperty* display_path_visual_enabled_property_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -1,0 +1,141 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Yannick Jonetzko
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yannick Jonetzko */
+
+#include <moveit/rviz_plugin_render_tools/trajectory_panel.h>
+#include <QHBoxLayout>
+
+namespace moveit_rviz_plugin
+{
+TrajectoryPanel::TrajectoryPanel(QWidget* parent) : Panel(parent)
+{
+}
+
+TrajectoryPanel::~TrajectoryPanel()
+{
+}
+
+void TrajectoryPanel::onInitialize()
+{
+  slider_ = new QSlider(Qt::Horizontal);
+  slider_->setTickInterval(1);
+  slider_->setMinimum(0);
+  slider_->setMaximum(0);
+  slider_->setTickPosition(QSlider::TicksBelow);
+  slider_->setPageStep(1);
+  connect(slider_, SIGNAL(valueChanged(int)), this, SLOT(sliderValueChanged(int)));
+
+  maximum_label_ = new QLabel(QString::number(slider_->maximum()));
+  minimum_label_ = new QLabel(QString::number(slider_->minimum()));
+  minimum_label_->setFixedWidth(20);
+
+  button_ = new QPushButton();
+  button_->setText("Pause");
+  button_->setEnabled(false);
+  connect(button_, SIGNAL(clicked()), this, SLOT(buttonClicked()));
+
+  QHBoxLayout* layout = new QHBoxLayout;
+  layout->addWidget(new QLabel("Waypoint:"));
+  layout->addWidget(minimum_label_);
+  layout->addWidget(slider_);
+  layout->addWidget(maximum_label_);
+  layout->addWidget(button_);
+  setLayout(layout);
+
+  paused_ = false;
+  parentWidget()->setVisible(false);
+}
+
+void TrajectoryPanel::onEnable()
+{
+  show();
+  parentWidget()->show();
+}
+
+void TrajectoryPanel::onDisable()
+{
+  hide();
+  paused_ = false;
+  parentWidget()->hide();
+}
+
+void TrajectoryPanel::update(int way_point_count)
+{
+  if (way_point_count != 0)
+  {
+    last_way_point_ = way_point_count - 1;
+    paused_ = false;
+    button_->setEnabled(true);
+    slider_->setSliderPosition(0);
+    slider_->setMaximum(way_point_count - 1);
+    maximum_label_->setText(QString::number(way_point_count - 1));
+  }
+}
+
+void TrajectoryPanel::pauseButton(bool pause)
+{
+  if (pause)
+  {
+    button_->setText("Play");
+    paused_ = true;
+  }
+  else
+  {
+    button_->setText("Pause");
+    paused_ = false;
+    if (slider_->sliderPosition() == last_way_point_)
+      slider_->setSliderPosition(0);
+  }
+}
+
+void TrajectoryPanel::setSliderPosition(int position)
+{
+  slider_->setSliderPosition(position);
+}
+
+void TrajectoryPanel::sliderValueChanged(int value)
+{
+  minimum_label_->setText(QString::number(value));
+}
+
+void TrajectoryPanel::buttonClicked()
+{
+  if (paused_)
+    pauseButton(false);
+  else
+    pauseButton(true);
+}
+
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -350,15 +350,19 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
     }
     else if (displaying_trajectory_message_)
     {
-      if (trajectory_slider_panel_->isVisible() && !loop_display_property_->getBool() &&
-          trajectory_slider_panel_->getSliderPosition() == displaying_trajectory_message_->getWayPointCount() - 1)
-      {  // show the last waypoint if the slider is enabled
-        display_path_robot_->update(
-            displaying_trajectory_message_->getWayPointPtr(displaying_trajectory_message_->getWayPointCount() - 1));
-      }
-      else if (loop_display_property_->getBool() || trajectory_slider_panel_->isVisible())
+      if (loop_display_property_->getBool())
       {  // do loop? -> start over too
         animating_path_ = true;
+      }
+      else if (trajectory_slider_panel_->isVisible())
+      {
+        if (trajectory_slider_panel_->getSliderPosition() == displaying_trajectory_message_->getWayPointCount() - 1)
+        {  // show the last waypoint if the slider is enabled
+          display_path_robot_->update(
+              displaying_trajectory_message_->getWayPointPtr(displaying_trajectory_message_->getWayPointCount() - 1));
+        }
+        else
+          animating_path_ = true;
       }
     }
     trajectory_message_to_display_.reset();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -49,11 +49,18 @@
 #include <rviz/properties/color_property.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <rviz/robot/robot_link.h>
+#include <rviz/display_context.h>
+#include <rviz/window_manager_interface.h>
 
 namespace moveit_rviz_plugin
 {
 TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::Display* display)
-  : display_(display), widget_(widget), animating_path_(false), current_state_(-1)
+  : display_(display)
+  , widget_(widget)
+  , animating_path_(false)
+  , current_state_(-1)
+  , trajectory_slider_panel_(NULL)
+  , trajectory_slider_dock_panel_(NULL)
 {
   trajectory_topic_property_ =
       new rviz::RosTopicProperty("Trajectory Topic", "/move_group/display_planned_path",
@@ -110,6 +117,8 @@ TrajectoryVisualization::~TrajectoryVisualization()
   displaying_trajectory_message_.reset();
 
   display_path_robot_.reset();
+  if (trajectory_slider_dock_panel_)
+    delete trajectory_slider_dock_panel_;
 }
 
 void TrajectoryVisualization::onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context,
@@ -125,6 +134,23 @@ void TrajectoryVisualization::onInitialize(Ogre::SceneNode* scene_node, rviz::Di
   display_path_robot_->setVisualVisible(display_path_visual_enabled_property_->getBool());
   display_path_robot_->setCollisionVisible(display_path_collision_enabled_property_->getBool());
   display_path_robot_->setVisible(false);
+
+  rviz::WindowManagerInterface* window_context = context_->getWindowManager();
+  if (window_context)
+  {
+    trajectory_slider_panel_ = new TrajectoryPanel(window_context->getParentWindow());
+    trajectory_slider_dock_panel_ =
+        window_context->addPane(display_->getName() + " - Slider", trajectory_slider_panel_);
+    trajectory_slider_dock_panel_->setIcon(display_->getIcon());
+    connect(trajectory_slider_dock_panel_, SIGNAL(visibilityChanged(bool)), this,
+            SLOT(trajectorySliderPanelVisibilityChange(bool)));
+    trajectory_slider_panel_->onInitialize();
+  }
+}
+
+void TrajectoryVisualization::setName(const QString& name)
+{
+  trajectory_slider_dock_panel_->setWindowTitle(name + " - Slider");
 }
 
 void TrajectoryVisualization::onRobotModelLoaded(robot_model::RobotModelConstPtr robot_model)
@@ -175,6 +201,8 @@ void TrajectoryVisualization::clearTrajectoryTrail()
 void TrajectoryVisualization::changedLoopDisplay()
 {
   display_path_robot_->setVisible(display_->isEnabled() && displaying_trajectory_message_ && animating_path_);
+  if (loop_display_property_->getBool())
+    trajectory_slider_panel_->pauseButton(false);
 }
 
 void TrajectoryVisualization::changedShowTrail()
@@ -272,6 +300,7 @@ void TrajectoryVisualization::onDisable()
     trajectory_trail_[i]->setVisible(false);
   displaying_trajectory_message_.reset();
   animating_path_ = false;
+  trajectory_slider_panel_->onDisable();
 }
 
 void TrajectoryVisualization::interruptCurrentDisplay()
@@ -317,10 +346,20 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       animating_path_ = true;
       displaying_trajectory_message_ = trajectory_message_to_display_;
       changedShowTrail();
+      trajectory_slider_panel_->update(trajectory_message_to_display_->getWayPointCount());
     }
-    else if (loop_display_property_->getBool() && displaying_trajectory_message_)
-    {  // do loop? -> start over too
-      animating_path_ = true;
+    else if (displaying_trajectory_message_)
+    {
+      if (trajectory_slider_panel_->isVisible() && !loop_display_property_->getBool() &&
+          trajectory_slider_panel_->getSliderPosition() == displaying_trajectory_message_->getWayPointCount() - 1)
+      {  // show the last waypoint if the slider is enabled
+        display_path_robot_->update(
+            displaying_trajectory_message_->getWayPointPtr(displaying_trajectory_message_->getWayPointCount() - 1));
+      }
+      else if (loop_display_property_->getBool() || trajectory_slider_panel_->isVisible())
+      {  // do loop? -> start over too
+        animating_path_ = true;
+      }
     }
     trajectory_message_to_display_.reset();
 
@@ -330,6 +369,7 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       current_state_time_ = std::numeric_limits<float>::infinity();
       display_path_robot_->update(displaying_trajectory_message_->getFirstWayPointPtr());
       display_path_robot_->setVisible(display_->isEnabled());
+      trajectory_slider_panel_->setSliderPosition(0);
     }
   }
 
@@ -340,9 +380,13 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       tm = displaying_trajectory_message_->getWayPointDurationFromPrevious(current_state_ + 1);
     if (current_state_time_ > tm)
     {
-      ++current_state_;
+      if (trajectory_slider_panel_->isVisible() && trajectory_slider_panel_->isPaused())
+        current_state_ = trajectory_slider_panel_->getSliderPosition();
+      else
+        ++current_state_;
       if ((std::size_t)current_state_ < displaying_trajectory_message_->getWayPointCount())
       {
+        trajectory_slider_panel_->setSliderPosition(current_state_);
         display_path_robot_->update(displaying_trajectory_message_->getWayPointPtr(current_state_));
         for (std::size_t i = 0; i < trajectory_trail_.size(); ++i)
           trajectory_trail_[i]->setVisible(i <= current_state_);
@@ -351,6 +395,8 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       {
         animating_path_ = false;  // animation finished
         display_path_robot_->setVisible(loop_display_property_->getBool());
+        if (!loop_display_property_->getBool())
+          trajectory_slider_panel_->pauseButton(true);
       }
       current_state_time_ = 0.0f;
     }
@@ -425,6 +471,14 @@ void TrajectoryVisualization::setRobotColor(rviz::Robot* robot, const QColor& co
   const LinksMap& links = robot->getLinks();
   for (LinksMap::const_iterator it = links.begin(); it != links.end(); it++)
     it->second->setColor(color.redF(), color.greenF(), color.blueF());
+}
+
+void TrajectoryVisualization::trajectorySliderPanelVisibilityChange(bool enable)
+{
+  if (enable)
+    trajectory_slider_panel_->onEnable();
+  else
+    trajectory_slider_panel_->onDisable();
 }
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -108,6 +108,12 @@ void TrajectoryDisplay::update(float wall_dt, float ros_dt)
   trajectory_visual_->update(wall_dt, ros_dt);
 }
 
+void TrajectoryDisplay::setName(const QString& name)
+{
+  BoolProperty::setName(name);
+  trajectory_visual_->setName(name);
+}
+
 void TrajectoryDisplay::changedRobotDescription()
 {
   loadRobotModel();


### PR DESCRIPTION
The new panel includes a slider to control the animated planned path.
It allows to display single waypoints of the trajectory.
There is a play/pause button which starts or pauses the animation at the current waypoint.
Pressing the play button after the animation is finished replays the trajectory.
This can also be used to pause the loop mode.

The panel is integrated into the trajectory visualization and is switched off by default.
That means the Trajectory display and the MotionPlanning display support this new panel and it can be activated in rviz' "Panels" menu entry.
The current behavior of loop and trail is retained.

This [video](https://tams.informatik.uni-hamburg.de/people/goerner/files/slider.mp4) shows the features of the slider.