### PR TITLE
[CI] Add ROS Lunar.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=kinetic TEST=clang-format         UPSTREAM_WORKSPACE=moveit.rosinstall
+    - ROS_DISTRO=lunar   ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
+    - ROS_DISTRO=lunar   ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
+    - ROS_DISTRO=lunar   TEST=clang-format         UPSTREAM_WORKSPACE=moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:


### PR DESCRIPTION
In [lunar/Migration](http://wiki.ros.org/lunar/Migration), there's `robot_model` metapkg split. For now I doubt that it would affect CI jobs for Lunar in MoveIt!, but in case job fails then that might be one thing to look at.

----

**TODOs** from @davetcoleman at https://github.com/ros-planning/moveit/pull/503#issuecomment-306454552

- [x] Create Lunar-specific MoveIt Docker images for [ci](https://github.com/ros-planning/moveit/blob/kinetic-devel/.docker/ci-shadow-fixed/Dockerfile) and [ci-shadow-fixed](https://github.com/ros-planning/moveit/blob/kinetic-devel/.docker/ci-shadow-fixed/Dockerfile). Since we aren't forking for lunar (yet) we should name them something like ``ci-lunar`` and ``ci-shadow-fixed-lunar`` in the ``kinetic-devel`` branch --> Done in #520
- [x] Set these up to auto-build on our [docker hub](https://hub.docker.com/r/moveit/moveit/builds/)
- [ ] merge this PR

I can create these PRs now but am not able to test them locally currently