### PR TITLE
add BOOST_MATH_DISABLE_FLOAT128

### DIFF
--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.12)
 project(moveit_ros_visualization)
 
 add_compile_options(-std=c++11)
+
+# definition needed for boost/math/constants/constants.hpp included by Ogre to compile
 add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(moveit_ros_visualization)
 
 add_compile_options(-std=c++11)
+add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.12)
 project(moveit_setup_assistant)
 
 add_compile_options(-std=c++11)
+
+# definition needed for boost/math/constants/constants.hpp included by Ogre to compile
 add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(moveit_setup_assistant)
 
 add_compile_options(-std=c++11)
+add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
### Description

This fixes #504 the compilation issue on Ubuntu Zesty and Debian Stretch.
This change is only for lunar and doesn't need to be cherry-picked into other branches 

Note: I settled for this solution because it seemed the least intrusive to me. There are several other fixes that could be considered:
- By changing the `-std=c++11` flag to `-std=gnu++11` in the `add_compile_option()` call but I preferred to keep the flags consistent across all packages of the moveit repository.
- By using (but needs to bump cmake minimum version to 3.0.2):
```
set(CMAKE_CXX_STANDARD 11)`
set(CMAKE_CXX_STANDARD_REQUIRED ON)
```

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code): **didn't change code**
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/): **doesn't apply**
- [x] Include a screenshot if changing a GUI: **doesn't apply**
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html): **doesn't apply**
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic): **not needed**

Thank you!
