### PR TITLE
[MSA] Open a directory where setup_assistant.launch was started.

### DIFF
--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -47,6 +47,7 @@
 #include <QPushButton>
 #include <QCloseEvent>
 #include <QMessageBox>
+#include <QString>
 #include <pluginlib/class_loader.h>  // for loading all avail kinematic planners
 // Rviz
 #include <rviz/render_panel.h>
@@ -105,6 +106,16 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
   {
     ssw_->stack_path_->setPath(args["config_pkg"].as<std::string>());
     ssw_->select_mode_->btn_exist_->click();
+  }
+  else
+  {
+    // Open the directory where the MSA was started from.
+    // cf. http://stackoverflow.com/a/7413516/577001
+    QString pwdir("");
+    char* pwd;
+    pwd = getenv("PWD");
+    pwdir.append(pwd);
+    ssw_->stack_path_->setPath(pwdir);
   }
 
   // Add Navigation Buttons (but do not load widgets yet except start screen)


### PR DESCRIPTION
**Issue**
When editing an existing moveit_config pkg, MSA opens the location of MSA package, which is useless.

**Approach with the suggested change**
Opens the directory where `setup_assistant.launch` was started, which is often where the existing moveit_config package you'd like to edit is located.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] <s>Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)</s> --> Not applicable.
- [x] <s>Include a screenshot if changing a GUI</s> --> No new component is added. Only behavoral change.
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic) --> Should be portable to JK.
