### PR TITLE
RViz - Trajectory trail step size

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -155,10 +155,10 @@ protected:
   rviz::FloatProperty* robot_path_alpha_property_;
   rviz::BoolProperty* loop_display_property_;
   rviz::BoolProperty* trail_display_property_;
+  rviz::IntProperty* trail_step_size_property_;
   rviz::BoolProperty* interrupt_display_property_;
   rviz::ColorProperty* robot_color_property_;
   rviz::BoolProperty* enable_robot_color_property_;
-  rviz::IntProperty* trail_step_size_property_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -53,6 +53,7 @@ namespace rviz
 class Robot;
 class Shape;
 class Property;
+class IntProperty;
 class StringProperty;
 class BoolProperty;
 class FloatProperty;
@@ -103,6 +104,7 @@ private Q_SLOTS:
   void changedRobotPathAlpha();
   void changedLoopDisplay();
   void changedShowTrail();
+  void changedTrailStepSize();
   void changedTrajectoryTopic();
   void changedStateDisplayTime();
   void changedRobotColor();
@@ -156,6 +158,7 @@ protected:
   rviz::BoolProperty* interrupt_display_property_;
   rviz::ColorProperty* robot_color_property_;
   rviz::BoolProperty* enable_robot_color_property_;
+  rviz::IntProperty* trail_step_size_property_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -155,10 +155,10 @@ protected:
   rviz::FloatProperty* robot_path_alpha_property_;
   rviz::BoolProperty* loop_display_property_;
   rviz::BoolProperty* trail_display_property_;
-  rviz::IntProperty* trail_step_size_property_;
   rviz::BoolProperty* interrupt_display_property_;
   rviz::ColorProperty* robot_color_property_;
   rviz::BoolProperty* enable_robot_color_property_;
+  rviz::IntProperty* trail_step_size_property_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -100,10 +100,6 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   trail_display_property_ =
       new rviz::BoolProperty("Show Trail", false, "Show a path trail", widget, SLOT(changedShowTrail()), this);
 
-  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
-                                                                          "shown in the trajectory trail.",
-  trail_step_size_property_->setMin(1);
-
   interrupt_display_property_ = new rviz::BoolProperty(
       "Interrupt Display", false,
       "Immediately show newly planned trajectory, interrupting the currently displayed one.", widget);
@@ -113,6 +109,10 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
 
   enable_robot_color_property_ = new rviz::BoolProperty(
       "Color Enabled", false, "Specifies whether robot coloring is enabled", widget, SLOT(enabledRobotColor()), this);
+  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
+                                                                          "shown in the trajectory trail.",
+                                                    widget, SLOT(changedTrailStepSize()), this);
+  trail_step_size_property_->setMin(1);
 }
 
 TrajectoryVisualization::~TrajectoryVisualization()

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -100,6 +100,10 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   trail_display_property_ =
       new rviz::BoolProperty("Show Trail", false, "Show a path trail", widget, SLOT(changedShowTrail()), this);
 
+  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
+                                                                          "shown in the trajectory trail.",
+  trail_step_size_property_->setMin(1);
+
   interrupt_display_property_ = new rviz::BoolProperty(
       "Interrupt Display", false,
       "Immediately show newly planned trajectory, interrupting the currently displayed one.", widget);
@@ -109,10 +113,6 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
 
   enable_robot_color_property_ = new rviz::BoolProperty(
       "Color Enabled", false, "Specifies whether robot coloring is enabled", widget, SLOT(enabledRobotColor()), this);
-  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
-                                                                          "shown in the trajectory trail.",
-                                                    widget, SLOT(changedTrailStepSize()), this);
-  trail_step_size_property_->setMin(1);
 }
 
 TrajectoryVisualization::~TrajectoryVisualization()

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -109,7 +109,9 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
 
   enable_robot_color_property_ = new rviz::BoolProperty(
       "Color Enabled", false, "Specifies whether robot coloring is enabled", widget, SLOT(enabledRobotColor()), this);
-  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples shown in the trajectory trail.", widget, SLOT(changedTrailStepSize()), this);
+  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
+                                                                          "shown in the trajectory trail.",
+                                                    widget, SLOT(changedTrailStepSize()), this);
   trail_step_size_property_->setMin(1);
 }
 
@@ -221,11 +223,11 @@ void TrajectoryVisualization::changedShowTrail()
     return;
 
   int stepsize = trail_step_size_property_->getInt();
-  //always include last trajectory point
-  trajectory_trail_.resize((int) std::ceil((t->getWayPointCount() + stepsize - 1) / (float) stepsize));
+  // always include last trajectory point
+  trajectory_trail_.resize((int)std::ceil((t->getWayPointCount() + stepsize - 1) / (float)stepsize));
   for (std::size_t i = 0; i < trajectory_trail_.size(); i++)
   {
-    int waypoint_i = std::min(i * stepsize, t->getWayPointCount() - 1); //limit to last trajectory point
+    int waypoint_i = std::min(i * stepsize, t->getWayPointCount() - 1);  // limit to last trajectory point
     rviz::Robot* r = new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), NULL);
     r->load(*robot_model_->getURDF());
     r->setVisualVisible(display_path_visual_enabled_property_->getBool());
@@ -241,7 +243,7 @@ void TrajectoryVisualization::changedShowTrail()
 
 void TrajectoryVisualization::changedTrailStepSize()
 {
-  if(trail_display_property_->getBool())
+  if (trail_display_property_->getBool())
     changedShowTrail();
 }
 
@@ -406,7 +408,9 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
         trajectory_slider_panel_->setSliderPosition(current_state_);
         display_path_robot_->update(displaying_trajectory_message_->getWayPointPtr(current_state_));
         for (std::size_t i = 0; i < trajectory_trail_.size(); ++i)
-          trajectory_trail_[i]->setVisible(std::min(waypoint_count - 1, static_cast<int>(i) * trail_step_size_property_->getInt()) <= current_state_);
+          trajectory_trail_[i]->setVisible(
+              std::min(waypoint_count - 1, static_cast<int>(i) * trail_step_size_property_->getInt()) <=
+              current_state_);
       }
       else
       {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -100,6 +100,11 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   trail_display_property_ =
       new rviz::BoolProperty("Show Trail", false, "Show a path trail", widget, SLOT(changedShowTrail()), this);
 
+  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
+                                                                          "shown in the trajectory trail.",
+                                                    widget, SLOT(changedTrailStepSize()), this);
+  trail_step_size_property_->setMin(1);
+
   interrupt_display_property_ = new rviz::BoolProperty(
       "Interrupt Display", false,
       "Immediately show newly planned trajectory, interrupting the currently displayed one.", widget);
@@ -109,10 +114,6 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
 
   enable_robot_color_property_ = new rviz::BoolProperty(
       "Color Enabled", false, "Specifies whether robot coloring is enabled", widget, SLOT(enabledRobotColor()), this);
-  trail_step_size_property_ = new rviz::IntProperty("Trail Step Size", 1, "Specifies the step size of the samples "
-                                                                          "shown in the trajectory trail.",
-                                                    widget, SLOT(changedTrailStepSize()), this);
-  trail_step_size_property_->setMin(1);
 }
 
 TrajectoryVisualization::~TrajectoryVisualization()


### PR DESCRIPTION
Adds an integer parameter **Trail Step Size** to the section _Motion Planning_->_Planned Path_ in RViz to adjust the density of visualized trajectory trails.
Since very dense trajectory trails can be difficult to recognize this parameter enables an easy way to make them arbitrarily sparse.
This is especially useful for creating snapshots or for other demonstration purposes. 

By default the step size is 1 so that every trajectory point is displayed.
With higher numbers the intermittent steps are hidden except for the first and last trajectory points.

The following pictures show examples of the default setting and the trail step size set to 4.

![dense_trail](https://cloud.githubusercontent.com/assets/4572766/26308784/d6f43ae6-3efa-11e7-9a25-00cbcdf04201.png)

![sparse_trail](https://cloud.githubusercontent.com/assets/4572766/26308783/d6ec6cd0-3efa-11e7-9703-29ccaec1fff6.png)