### PR TITLE
ikfast_kinematics_plugin: Fix for urdfdom1.x (Lunar)

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -363,7 +363,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, co
 
   ROS_DEBUG_STREAM_NAMED("ikfast", "Reading joints and links from URDF");
 
-  urdf::LinkSharedPtr link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while (link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast", "Link %s", link->name.c_str());


### PR DESCRIPTION
Don't needlessly cast away const.

Without this fix, compilation fails on platforms with urdfdom1.x (ROS Lunar on Ubuntu Yakkety, Ubuntu Zesty and Debian Stretch). This is because on urdfdom1.x, `urdf::LinkSharedPtr` etc. have switched from `boost::shared_ptr` to `std::shared_ptr`, which of course isn't compatible with `boost::const_pointer_cast`.

Unfortunately, all ikfast plugins have to be regenerated (using `update_ikfast_plugin.sh`) before being released into Lunar.

This fix is safe to merge into indigo, jade, kinetic and lunar.

Also see uos/katana_driver#22.