### PR TITLE
ikfast_kinematics_plugin: Add c++11 compile option

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(_PACKAGE_NAME_)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib


### PR DESCRIPTION
This is required for Kinetic.