### PR TITLE
Fixed doc-comment for robot_state::computeAABB

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1588,11 +1588,11 @@ as the new values that correspond to the group */
   /** @} */
 
   /** \brief Compute an axis-aligned bounding box that contains the current state.
-      The format for \e aabb is (minx, miny, minz, maxx, maxy, maxz) */
+      The format for \e aabb is (minx, maxx, miny, maxy, minz, maxz) */
   void computeAABB(std::vector<double>& aabb) const;
 
   /** \brief Compute an axis-aligned bounding box that contains the current state.
-      The format for \e aabb is (minx, miny, minz, maxx, maxy, maxz) */
+      The format for \e aabb is (minx, maxx, miny, maxy, minz, maxz) */
   void computeAABB(std::vector<double>& aabb)
   {
     updateLinkTransforms();


### PR DESCRIPTION
### Description

The docstring says the format of the vector is `(minx, miny, minz, maxx, maxy, maxz)`, but according to both the method's implementation and use in moveit, the format is rather `(minx, maxx, miny, maxy, minz, maxz)`.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic) -- definitely

Thank you!
