### PR TITLE
[Indigo] checks for empty name arrays messages before parsing the robot state message data (cherrypick #499)

### DIFF
--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -328,10 +328,20 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
 static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_msgs::RobotState& robot_state,
                                              RobotState& state, bool copy_attached_bodies)
 {
+  bool valid;
+  const moveit_msgs::RobotState& rs = robot_state;
+
+  if (rs.joint_state.name.empty() && rs.multi_dof_joint_state.joint_names.empty())
+  {
+    logError("Found empty JointState message");
+    return false;
+  }
+
   bool result1 = _jointStateToRobotState(robot_state.joint_state, state);
   bool result2 = _multiDOFJointsToRobotState(robot_state.multi_dof_joint_state, state, tf);
+  valid = result1 || result2;
 
-  if (copy_attached_bodies)
+  if (valid && copy_attached_bodies)
   {
     if (!robot_state.is_diff)
       state.clearAttachedBodies();
@@ -339,7 +349,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
       _msgToAttachedBody(tf, robot_state.attached_collision_objects[i], state);
   }
 
-  return result1 && result2;
+  return valid;
 }
 }
 }


### PR DESCRIPTION
Cherry-pick of #499 that fixes #496