### PR TITLE
Plan Execution never returns if trajectory fails validation.

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1151,6 +1151,8 @@ void TrajectoryExecutionManager::execute(const ExecutionCompleteCallback& callba
     last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
     if (auto_clear)
       clear();
+    if (callback)
+      callback(last_execution_status_);
     return;
   }
 


### PR DESCRIPTION
### Description

If the trajectory fails validation (i.e. doesn't start at current robot state), there is never an update to the execution status causing plan_execution::PlanExecution::executeAndMonitor to loop indefinitely and never return.  I have added this callback.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic) -- Yes.
