### PR TITLE
Test if frame_dock_ exists in case of no window_context

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -186,7 +186,8 @@ MotionPlanningDisplay::~MotionPlanningDisplay()
 
   delete text_to_display_;
   delete int_marker_display_;
-  delete frame_dock_;
+  if (frame_dock_)
+    delete frame_dock_;
 }
 
 void MotionPlanningDisplay::onInitialize()
@@ -308,8 +309,11 @@ void MotionPlanningDisplay::reset()
 void MotionPlanningDisplay::setName(const QString& name)
 {
   BoolProperty::setName(name);
-  frame_dock_->setWindowTitle(name);
-  frame_dock_->setObjectName(name);
+  if (frame_dock_)
+  {
+    frame_dock_->setWindowTitle(name);
+    frame_dock_->setObjectName(name);
+  }
   trajectory_visual_->setName(name);
 }
 


### PR DESCRIPTION
This is a similar situation as in the pull request #523.

In the onInitialize function the frame_dock_ panel is only created if window_context exists.
Later on in the setName function the pointer is used without checking for existence.