### PR TITLE
[Future TODO] moveit_ros_planning: switch from TinyXML to TinyXML2

### DIFF
--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -40,7 +40,7 @@
 #include <moveit/macros/class_forward.h>
 #include <urdf/model.h>
 #include <srdfdom/model.h>
-#include <tinyxml.h>
+#include <tinyxml2.h>
 
 namespace rdf_loader
 {
@@ -61,7 +61,7 @@ public:
   RDFLoader(const std::string& urdf_string, const std::string& srdf_string);
 
   /** \brief Initialize the robot model from a parsed XML representation of the URDF and SRDF */
-  RDFLoader(TiXmlDocument* urdf_doc, TiXmlDocument* srdf_doc);
+  RDFLoader(tinyxml2::XMLDocument* urdf_doc, tinyxml2::XMLDocument* srdf_doc);
 
   /** @brief Get the resolved parameter name for the robot description */
   const std::string& getRobotDescription() const

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -50,6 +50,8 @@
 #include <streambuf>
 #include <algorithm>
 
+using namespace tinyxml2;
+
 rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
@@ -116,7 +118,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& urdf_string, const std::stri
   }
 }
 
-rdf_loader::RDFLoader::RDFLoader(TiXmlDocument* urdf_doc, TiXmlDocument* srdf_doc)
+rdf_loader::RDFLoader::RDFLoader(XMLDocument* urdf_doc, XMLDocument* srdf_doc)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("RDFLoader(XML)");

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -67,7 +67,7 @@ public:
     {
     }
 
-    Options(TiXmlDocument* urdf_doc, TiXmlDocument* srdf_doc)
+    Options(tinyxml2::XMLDocument* urdf_doc, tinyxml2::XMLDocument* srdf_doc)
       : urdf_doc_(urdf_doc), srdf_doc_(srdf_doc), load_kinematics_solvers_(true)
     {
     }
@@ -82,7 +82,7 @@ public:
     std::string urdf_string_, srdf_string_;
 
     /** @brief The parsed XML content of the URDF and SRDF documents. */
-    TiXmlDocument *urdf_doc_, *srdf_doc_;
+    tinyxml2::XMLDocument *urdf_doc_, *srdf_doc_;
 
     /** @brief Flag indicating whether the kinematics solvers should be loaded as well, using specified ROS parameters
      */


### PR DESCRIPTION
The library TinyXML is considered to be unmaintained and
since all future development is focused on TinyXML2 this
patch updates moveit_ros_planning to use TinyXML2.

depends on https://github.com/ros/robot_model/pull/205