### PR TITLE
fix simple_controller_manager includes

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -6,8 +6,6 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost REQUIRED thread)
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
 
 find_package(catkin COMPONENTS
   moveit_core
@@ -17,6 +15,11 @@ find_package(catkin COMPONENTS
   control_msgs
   REQUIRED)
 
+include_directories(include)
+
+include_directories(${Boost_INCLUDE_DIRS})
+link_directories(${Boost_LIBRARY_DIRS})
+
 include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
@@ -25,8 +28,6 @@ catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS moveit_core actionlib control_msgs
     )
-
-include_directories(include)
 
 add_library(${PROJECT_NAME} src/moveit_simple_controller_manager.cpp)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.7.3)


### PR DESCRIPTION
simple_controller_manager: fix include order

The local header files of the packages should always be preferred.
Otherwise the same headers installed to /opt/ros/*/include would be used.