### PR TITLE
robot display: Don't reload robot model upon topic change

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -292,10 +292,14 @@ void RobotStateDisplay::changedRobotSceneAlpha()
 void RobotStateDisplay::changedRobotStateTopic()
 {
   robot_state_subscriber_.shutdown();
+
+  // reset model to default state, we don't want to show previous messages
+  if (static_cast<bool>(kstate_))
+    kstate_->setToDefaultValues();
+  update_state_ = true;
+
   robot_state_subscriber_ = root_nh_.subscribe(robot_state_topic_property_->getStdString(), 10,
                                                &RobotStateDisplay::newRobotStateCallback, this);
-  robot_->clear();
-  loadRobotModel();
 }
 
 void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotStateConstPtr& state_msg)


### PR DESCRIPTION
Instead just reset it to the default configuration.
This avoids needless urdf-parsing and retains a valid kstate_.
For changes to the robot description parameter,
there is a separate callback function.

On Ubuntu 14.04 indigo this also fixes a segfault during startup,
that seems to be related to calling loadRobotModel() twice in a row.

This should be forward ported to j/k.

Fixes #528 
