### PR TITLE
make Isaac happier

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -120,6 +120,11 @@ public:
     return query_goal_state_;
   }
 
+  void dropVisualizedTrajectory()
+  {
+    trajectory_visual_->dropTrajectory();
+  }
+
   void setQueryStartState(const robot_state::RobotState& start);
   void setQueryGoalState(const robot_state::RobotState& goal);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -389,6 +389,8 @@ void MotionPlanningFrame::configureForPlanning()
   move_group_->setMaxVelocityScalingFactor(ui_->velocity_scaling_factor->value());
   move_group_->setMaxAccelerationScalingFactor(ui_->acceleration_scaling_factor->value());
   configureWorkspace();
+  if (static_cast<bool>(planning_display_))
+    planning_display_->dropVisualizedTrajectory();
 }
 
 void MotionPlanningFrame::remotePlanCallback(const std_msgs::EmptyConstPtr& msg)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -91,6 +91,8 @@ public:
   void onDisable();
   void setName(const QString& name);
 
+  void dropTrajectory();
+
 public Q_SLOTS:
   void interruptCurrentDisplay();
 
@@ -131,6 +133,7 @@ protected:
   std::vector<rviz::Robot*> trajectory_trail_;
   ros::Subscriber trajectory_topic_sub_;
   bool animating_path_;
+  bool drop_displaying_trajectory_;
   int current_state_;
   float current_state_time_;
   boost::mutex update_trajectory_message_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -94,7 +94,7 @@ void TrajectoryPanel::onDisable()
 
 void TrajectoryPanel::update(int way_point_count)
 {
-  int max_way_point = std::max(0, way_point_count-1);
+  int max_way_point = std::max(0, way_point_count - 1);
 
   slider_->setEnabled(way_point_count != 0);
   button_->setEnabled(way_point_count != 0);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -55,6 +55,7 @@ void TrajectoryPanel::onInitialize()
   slider_->setMaximum(0);
   slider_->setTickPosition(QSlider::TicksBelow);
   slider_->setPageStep(1);
+  slider_->setEnabled(false);
   connect(slider_, SIGNAL(valueChanged(int)), this, SLOT(sliderValueChanged(int)));
 
   maximum_label_ = new QLabel(QString::number(slider_->maximum()));
@@ -93,15 +94,16 @@ void TrajectoryPanel::onDisable()
 
 void TrajectoryPanel::update(int way_point_count)
 {
-  if (way_point_count != 0)
-  {
-    last_way_point_ = way_point_count - 1;
-    paused_ = false;
-    button_->setEnabled(true);
-    slider_->setSliderPosition(0);
-    slider_->setMaximum(way_point_count - 1);
-    maximum_label_->setText(QString::number(way_point_count - 1));
-  }
+  int max_way_point = std::max(0, way_point_count-1);
+
+  slider_->setEnabled(way_point_count != 0);
+  button_->setEnabled(way_point_count != 0);
+
+  last_way_point_ = max_way_point;
+  paused_ = false;
+  slider_->setSliderPosition(0);
+  slider_->setMaximum(max_way_point);
+  maximum_label_->setText(QString::number(max_way_point));
 }
 
 void TrajectoryPanel::pauseButton(bool pause)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -59,6 +59,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   : display_(display)
   , widget_(widget)
   , animating_path_(false)
+  , drop_displaying_trajectory_(false)
   , current_state_(-1)
   , trajectory_slider_panel_(NULL)
   , trajectory_slider_dock_panel_(NULL)
@@ -349,8 +350,21 @@ float TrajectoryVisualization::getStateDisplayTime()
   }
 }
 
+void TrajectoryVisualization::dropTrajectory()
+{
+  drop_displaying_trajectory_ = true;
+}
+
 void TrajectoryVisualization::update(float wall_dt, float ros_dt)
 {
+  if (drop_displaying_trajectory_)
+  {
+    animating_path_ = false;
+    displaying_trajectory_message_.reset();
+    display_path_robot_->setVisible(false);
+    trajectory_slider_panel_->update(0);
+    drop_displaying_trajectory_ = false;
+  }
   if (!animating_path_)
   {  // finished last animation?
     boost::mutex::scoped_lock lock(update_trajectory_message_);


### PR DESCRIPTION
rviz display: stop trajectory visualization on new plan

It can be confusing to see the old trajectory even though
the user already requested a new plan.

This is especially annoying in case the second planning request fails!

Fixes #526

Should be forward-picked to j/k