### PR TITLE
add Qt-moc guards for boost 1.64 compatibility

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -42,7 +42,6 @@
 #include <rviz/panel_dock_widget.h>
 #include <moveit/planning_scene_rviz_plugin/planning_scene_display.h>
 #include <moveit/rviz_plugin_render_tools/trajectory_visualization.h>
-#include <std_msgs/String.h>
 
 #ifndef Q_MOC_RUN
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
@@ -52,10 +51,12 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/kinematics_metrics/kinematics_metrics.h>
 #include <moveit/dynamics_solver/dynamics_solver.h>
-#include <ros/ros.h>
-#endif
 
+#include <ros/ros.h>
+
+#include <std_msgs/String.h>
 #include <moveit_msgs/DisplayTrajectory.h>
+#endif
 
 #include <memory>
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -54,10 +54,11 @@
 #include <moveit_msgs/MotionPlanRequest.h>
 #include <actionlib/client/simple_action_client.h>
 #include <object_recognition_msgs/ObjectRecognitionAction.h>
-#endif
 
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
+#endif
+
 #include <map>
 #include <string>
 #include <memory>

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
@@ -37,7 +37,9 @@
 #ifndef MOVEIT_TRAJECTORY_RVIZ_PLUGIN_TRAJECTORY_PANEL_
 #define MOVEIT_TRAJECTORY_RVIZ_PLUGIN_TRAJECTORY_PANEL_
 
+#ifndef Q_MOC_RUN
 #include <ros/ros.h>
+#endif
 
 #include <rviz/panel.h>
 

--- a/moveit_setup_assistant/src/tools/collision_linear_model.h
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.h
@@ -40,9 +40,13 @@
 #include <QAbstractProxyModel>
 #include <QSortFilterProxyModel>
 #include <QVector>
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/compute_default_collisions.h>
+#endif
 
 #include "collision_matrix_model.h"
+
 class CollisionLinearModel : public QAbstractProxyModel
 {
   Q_OBJECT

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.h
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.h
@@ -38,7 +38,10 @@
 #define MOVEIT_ROS_MOVEIT_SETUP_ASSISTANT_WIDGETS_COLLISION_MATRIX_MODEL_
 
 #include <QAbstractTableModel>
+
+#ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/compute_default_collisions.h>
+#endif
 
 class QItemSelection;
 


### PR DESCRIPTION
I know boost 1.64 is still far in the future for Ubuntu users, but other
distributions already see this (or will in the near future).

I know this is probably impossible to test for others.
If CI succeeds, this should be good enough for this request.

boost added some more constructs that moc fails to parse recently.
Now Qt's moc fails when any **message header** is included without the guard.

The corresponding error message is

AutoMoc: Error: moc process for moveit_rviz_plugin_render_tools_autogen/QDX35O74K6/moc_trajectory_panel.cpp failed:
/usr/include/boost/predef/language/stdc.h:52: Parse error at "defined"