### PR TITLE
Modify ikfast_template for getPositionIK single solution results

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -201,7 +201,7 @@ public:
    * @return True if a valid set of solutions was found, false otherwise.
    */
   bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
-                     std::vector<std::vector<double> >& solutions, kinematics::KinematicsResult& result,
+                     std::vector<std::vector<double>>& solutions, kinematics::KinematicsResult& result,
                      const kinematics::KinematicsQueryOptions& options) const;
 
   /**
@@ -1006,9 +1006,10 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
     return false;
   }
 
-  if(ik_seed_state.size() < num_joints_)
+  if (ik_seed_state.size() < num_joints_)
   {
-    ROS_ERROR_STREAM("ik_seed_state only has "<<ik_seed_state.size()<<" entries, this ikfast solver requires "<<num_joints_);
+    ROS_ERROR_STREAM("ik_seed_state only has " << ik_seed_state.size() << " entries, this ikfast solver requires "
+                                               << num_joints_);
     return false;
   }
 
@@ -1019,13 +1020,13 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
     if (joint_has_limits_vector_[i] && ((ik_seed_state[i] < (joint_min_vector_[i] - LIMIT_TOLERANCE)) ||
                                         (ik_seed_state[i] > (joint_max_vector_[i] + LIMIT_TOLERANCE))))
     {
-       ROS_DEBUG_STREAM_NAMED("ikseed", "Not in limits! " << i << " value " << ik_seed_state[i] << " has limit: "
-                                                          << joint_has_limits_vector_[i] << "  being  "
-                                                             << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
-          return false;
-        }
-      }
-      
+      ROS_DEBUG_STREAM_NAMED("ikseed", "Not in limits! " << i << " value " << ik_seed_state[i]
+                                                         << " has limit: " << joint_has_limits_vector_[i] << "  being  "
+                                                         << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
+      return false;
+    }
+  }
+
   std::vector<double> vfree(free_params_.size());
   for (std::size_t i = 0; i < free_params_.size(); ++i)
   {
@@ -1076,11 +1077,11 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
         solution_found = true;
         getSolution(solutions, s, solution_obey_limits);
         double dist = 0;
-        for(size_t i=0; i< ik_seed_state.size(); ++i)
+        for (size_t i = 0; i < ik_seed_state.size(); ++i)
         {
           dist += fabs(ik_seed_state[i] - solution_obey_limits[i]);
         }
-  
+
         ROS_DEBUG_STREAM_NAMED("ikfast", "Dist " << s << " dist " << dist);
         solutions_obey_limits.push_back(solution_obey_limits);
         dists.push_back(dist);
@@ -1095,28 +1096,27 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
   // Sort the solutions under limits and find the one that is closest to ik_seed_state
   if (solution_found)
   {
-
     bool swap_flag = true;
     std::vector<double> temp_sol;
     double temp_dist;
     for (std::size_t i = 0; i < solutions_obey_limits.size(); ++i)
     {
       swap_flag = false;
-      for (std::size_t j = 0; j < solutions_obey_limits.size()-1; ++j)
+      for (std::size_t j = 0; j < solutions_obey_limits.size() - 1; ++j)
       {
-        if (dists[j+1]<dists[j])
+        if (dists[j + 1] < dists[j])
         {
           temp_sol = solutions_obey_limits[j];
           temp_dist = dists[j];
-          solutions_obey_limits[j] = solutions_obey_limits[j+1];
-          solutions_obey_limits[j+1] = temp_sol;
-          dists[j] = dists[j+1];
-          dists[j+1] = temp_dist;
+          solutions_obey_limits[j] = solutions_obey_limits[j + 1];
+          solutions_obey_limits[j + 1] = temp_sol;
+          dists[j] = dists[j + 1];
+          dists[j + 1] = temp_dist;
           swap_flag = true;
         }
       }
     }
-    solution = solutions_obey_limits[0];       
+    solution = solutions_obey_limits[0];
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     return true;
   }
@@ -1127,7 +1127,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
 
 bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                            const std::vector<double>& ik_seed_state,
-                                           std::vector<std::vector<double> >& solutions,
+                                           std::vector<std::vector<double>>& solutions,
                                            kinematics::KinematicsResult& result,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
@@ -1165,7 +1165,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
   tf::poseMsgToKDL(ik_poses[0], frame);
 
   // solving ik
-  std::vector<IkSolutionList<IkReal> > solution_set;
+  std::vector<IkSolutionList<IkReal>> solution_set;
   IkSolutionList<IkReal> ik_solutions;
   std::vector<double> vfree;
   int numsol = 0;

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -1043,17 +1043,17 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
   ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
 
   // struct for storing and sorting solutions
-  struct limit_obeying_sol
+  struct LimitObeyingSol
   {
     std::vector<double> value;
     double dist_from_seed;
 
-    bool operator<(const limit_obeying_sol& a) const
+    bool operator<(const LimitObeyingSol& a) const
     {
       return dist_from_seed < a.dist_from_seed;
     }
   };
-  std::vector<limit_obeying_sol> solutions_obey_limits;
+  std::vector<LimitObeyingSol> solutions_obey_limits;
 
   if (numsol)
   {

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -576,31 +576,28 @@ void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal>& solutions
   // ROS_ERROR("%f %d",solution[2],vsolfree.size());
 }
 
-double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const
+
+double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_state, std::vector<double> &solution) const
 {
-  double dist_sqr = 0;
+  double dist_abs = 0;
   std::vector<double> ss = ik_seed_state;
-  for (size_t i = 0; i < ik_seed_state.size(); ++i)
+  for(size_t i=0; i< ik_seed_state.size(); ++i)
   {
-    while (ss[i] > 2 * M_PI)
-    {
-      ss[i] -= 2 * M_PI;
-    }
-    while (ss[i] < 2 * M_PI)
-    {
-      ss[i] += 2 * M_PI;
-    }
-    while (solution[i] > 2 * M_PI)
-    {
-      solution[i] -= 2 * M_PI;
-    }
-    while (solution[i] < 2 * M_PI)
-    {
-      solution[i] += 2 * M_PI;
-    }
-    dist_sqr += fabs(ik_seed_state[i] - solution[i]);
+    while(ss[i] > M_PI) {
+     ss[i] -= 2*M_PI;
+   }
+   while(ss[i] < -1*M_PI) {
+     ss[i] += 2*M_PI;
+   }
+   while(solution[i] > M_PI) {
+     solution[i] -= 2*M_PI;
+   }
+   while(solution[i] < -1*M_PI) {
+     solution[i] += 2*M_PI;
+   }
+       dist_abs += fabs(ss[i] - solution[i]);
   }
-  return dist_sqr;
+  return dist_abs;
 }
 
 // void IKFastKinematicsPlugin::getOrderedSolutions(const std::vector<double> &ik_seed_state,

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -201,7 +201,7 @@ public:
    * @return True if a valid set of solutions was found, false otherwise.
    */
   bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
-                     std::vector<std::vector<double>>& solutions, kinematics::KinematicsResult& result,
+                     std::vector<std::vector<double> >& solutions, kinematics::KinematicsResult& result,
                      const kinematics::KinematicsQueryOptions& options) const;
 
   /**
@@ -578,29 +578,29 @@ void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal>& solutions
 
 double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const
 {
-  double dist_abs = 0;
+  double dist_sqr = 0;
   std::vector<double> ss = ik_seed_state;
-  for (std::size_t i = 0; i < ik_seed_state.size(); ++i)
+  for (size_t i = 0; i < ik_seed_state.size(); ++i)
   {
-    while (ss[i] > M_PI)
+    while (ss[i] > 2 * M_PI)
     {
       ss[i] -= 2 * M_PI;
     }
-    while (ss[i] < -1 * M_PI)
+    while (ss[i] < 2 * M_PI)
     {
       ss[i] += 2 * M_PI;
     }
-    while (solution[i] > M_PI)
+    while (solution[i] > 2 * M_PI)
     {
       solution[i] -= 2 * M_PI;
     }
-    while (solution[i] < -1 * M_PI)
+    while (solution[i] < 2 * M_PI)
     {
       solution[i] += 2 * M_PI;
     }
-    dist_abs += fabs(ss[i] - solution[i]);
+    dist_sqr += fabs(ik_seed_state[i] - solution[i]);
   }
-  return dist_abs;
+  return dist_sqr;
 }
 
 // void IKFastKinematicsPlugin::getOrderedSolutions(const std::vector<double> &ik_seed_state,
@@ -1006,6 +1006,26 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
     return false;
   }
 
+  if(ik_seed_state.size() < num_joints_)
+  {
+    ROS_ERROR_STREAM("ik_seed_state only has "<<ik_seed_state.size()<<" entries, this ikfast solver requires "<<num_joints_);
+    return false;
+  }
+
+  // Check if seed is in bound
+  for (unsigned int i = 0; i < ik_seed_state.size(); i++)
+  {
+    // Add tolerance to limit check
+    if (joint_has_limits_vector_[i] && ((ik_seed_state[i] < (joint_min_vector_[i] - LIMIT_TOLERANCE)) ||
+                                        (ik_seed_state[i] > (joint_max_vector_[i] + LIMIT_TOLERANCE))))
+    {
+       ROS_DEBUG_STREAM_NAMED("ikseed", "Not in limits! " << i << " value " << ik_seed_state[i] << " has limit: "
+                                                          << joint_has_limits_vector_[i] << "  being  "
+                                                             << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
+          return false;
+        }
+      }
+      
   std::vector<double> vfree(free_params_.size());
   for (std::size_t i = 0; i < free_params_.size(); ++i)
   {
@@ -1027,7 +1047,6 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
 
   if (numsol)
   {
-    int numsol_obey_limits = 0;
     std::vector<double> solution_obey_limits;
     for (int s = 0; s < numsol; ++s)
     {
@@ -1056,7 +1075,12 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
         // All elements of this solution obey limits
         solution_found = true;
         getSolution(solutions, s, solution_obey_limits);
-        double dist = harmonize(ik_seed_state, solution_obey_limits);
+        double dist = 0;
+        for(size_t i=0; i< ik_seed_state.size(); ++i)
+        {
+          dist += fabs(ik_seed_state[i] - solution_obey_limits[i]);
+        }
+  
         ROS_DEBUG_STREAM_NAMED("ikfast", "Dist " << s << " dist " << dist);
         solutions_obey_limits.push_back(solution_obey_limits);
         dists.push_back(dist);
@@ -1071,27 +1095,28 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
   // Sort the solutions under limits and find the one that is closest to ik_seed_state
   if (solution_found)
   {
+
     bool swap_flag = true;
     std::vector<double> temp_sol;
     double temp_dist;
     for (std::size_t i = 0; i < solutions_obey_limits.size(); ++i)
     {
       swap_flag = false;
-      for (std::size_t j = 0; j < solutions_obey_limits.size() - 1; ++j)
+      for (std::size_t j = 0; j < solutions_obey_limits.size()-1; ++j)
       {
-        if (dists[j + 1] < dists[j])
+        if (dists[j+1]<dists[j])
         {
           temp_sol = solutions_obey_limits[j];
           temp_dist = dists[j];
-          solutions_obey_limits[j] = solutions_obey_limits[j + 1];
-          solutions_obey_limits[j + 1] = temp_sol;
-          dists[j] = dists[j + 1];
-          dists[j + 1] = temp_dist;
+          solutions_obey_limits[j] = solutions_obey_limits[j+1];
+          solutions_obey_limits[j+1] = temp_sol;
+          dists[j] = dists[j+1];
+          dists[j+1] = temp_dist;
           swap_flag = true;
         }
       }
     }
-    solution = solutions_obey_limits[0];
+    solution = solutions_obey_limits[0];       
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     return true;
   }
@@ -1102,7 +1127,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
 
 bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                            const std::vector<double>& ik_seed_state,
-                                           std::vector<std::vector<double>>& solutions,
+                                           std::vector<std::vector<double> >& solutions,
                                            kinematics::KinematicsResult& result,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
@@ -1140,7 +1165,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
   tf::poseMsgToKDL(ik_poses[0], frame);
 
   // solving ik
-  std::vector<IkSolutionList<IkReal>> solution_set;
+  std::vector<IkSolutionList<IkReal> > solution_set;
   IkSolutionList<IkReal> ik_solutions;
   std::vector<double> vfree;
   int numsol = 0;

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -201,7 +201,7 @@ public:
    * @return True if a valid set of solutions was found, false otherwise.
    */
   bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
-                     std::vector<std::vector<double> >& solutions, kinematics::KinematicsResult& result,
+                     std::vector<std::vector<double>>& solutions, kinematics::KinematicsResult& result,
                      const kinematics::KinematicsQueryOptions& options) const;
 
   /**
@@ -576,26 +576,29 @@ void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal>& solutions
   // ROS_ERROR("%f %d",solution[2],vsolfree.size());
 }
 
-
-double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_state, std::vector<double> &solution) const
+double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const
 {
   double dist_abs = 0;
   std::vector<double> ss = ik_seed_state;
-  for(size_t i=0; i< ik_seed_state.size(); ++i)
+  for (size_t i = 0; i < ik_seed_state.size(); ++i)
   {
-    while(ss[i] > M_PI) {
-     ss[i] -= 2*M_PI;
-   }
-   while(ss[i] < -1*M_PI) {
-     ss[i] += 2*M_PI;
-   }
-   while(solution[i] > M_PI) {
-     solution[i] -= 2*M_PI;
-   }
-   while(solution[i] < -1*M_PI) {
-     solution[i] += 2*M_PI;
-   }
-       dist_abs += fabs(ss[i] - solution[i]);
+    while (ss[i] > M_PI)
+    {
+      ss[i] -= 2 * M_PI;
+    }
+    while (ss[i] < -1 * M_PI)
+    {
+      ss[i] += 2 * M_PI;
+    }
+    while (solution[i] > M_PI)
+    {
+      solution[i] -= 2 * M_PI;
+    }
+    while (solution[i] < -1 * M_PI)
+    {
+      solution[i] += 2 * M_PI;
+    }
+    dist_abs += fabs(ss[i] - solution[i]);
   }
   return dist_abs;
 }
@@ -1049,8 +1052,9 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
       if (obeys_limits)
       {
         // All elements of thi solution obey limits
-        getSolution(solutions,s,solution_obey_limits);
-        solutions_obey_limits.push_back(solution_obey_limits);  
+        solution_found = true;
+        getSolution(solutions, s, solution_obey_limits);
+        solutions_obey_limits.push_back(solution_obey_limits);
       }
     }
   }
@@ -1059,40 +1063,41 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
     ROS_DEBUG_STREAM_NAMED("ikfast", "No IK solution");
   }
 
-// Among the solutions under limits, find the one that is closest to ik_seed_state
+  // Among the solutions under limits, find the one that is closest to ik_seed_state
   if (solutions_obey_limits.size() != 0)
   {
+    double mindist = DBL_MAX;
+    int minindex = -1;
+    std::vector<double> sol;
 
-  double mindist = DBL_MAX;
-  int minindex = -1;
-  std::vector<double> sol;
+    for (size_t i = 0; i < solutions_obey_limits.size(); ++i)
+    {
+      sol = solutions_obey_limits[i];
+      double dist = harmonize(ik_seed_state, sol);
+      ROS_INFO_STREAM_NAMED("ikfast", "Dist " << i << " dist " << dist);
 
-  for(size_t i=0; i < solutions_obey_limits.size(); ++i)
-  {
-    sol = solutions_obey_limits[i];
-    double dist = harmonize(ik_seed_state, sol);
-    ROS_INFO_STREAM_NAMED("ikfast","Dist " << i << " dist " << dist);
-
-    if(minindex == -1 || dist<mindist){
-      minindex = i;
-      mindist = dist;
+      if (minindex == -1 || dist < mindist)
+      {
+        minindex = i;
+        mindist = dist;
+      }
     }
-  }
-  if(minindex >= 0){
-    solution = solutions_obey_limits[minindex];
-    harmonize(ik_seed_state, solution);
-  }
+    if (minindex >= 0)
+    {
+      solution = solutions_obey_limits[minindex];
+      harmonize(ik_seed_state, solution);
+    }
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     return true;
   }
-  
+
   error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return false;
 }
 
 bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                            const std::vector<double>& ik_seed_state,
-                                           std::vector<std::vector<double> >& solutions,
+                                           std::vector<std::vector<double>>& solutions,
                                            kinematics::KinematicsResult& result,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
@@ -1130,7 +1135,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
   tf::poseMsgToKDL(ik_poses[0], frame);
 
   // solving ik
-  std::vector<IkSolutionList<IkReal> > solution_set;
+  std::vector<IkSolutionList<IkReal>> solution_set;
   IkSolutionList<IkReal> ik_solutions;
   std::vector<double> vfree;
   int numsol = 0;


### PR DESCRIPTION
### Description

IKfast moveit plugin is expected to return the solution (when called with getPositionIK(ik_pose, ik_seed_state, solution, error_code,options)) which is closest solution to the ik_seed_state. Originally, the code was returning the first solution it could find. Modified the template to return the closest solution satisfying the joint limits after harmonizing it(returning the solution between -pi to pi).

@shaun-edwards! Can you please have a look?
