### PR TITLE
MSA: support loading xacros that use Jade+ extensions on Indigo

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -168,6 +168,9 @@ public:
   /// Path relative to urdf package (note: this may be same as urdf_path_)
   std::string urdf_pkg_relative_path_;
 
+  /// Flag indicating whether Jade+ extensions should be enabled when loading xacro
+  bool urdf_requires_jade_xacro_;
+
   /// Flag indicating whether the URDF was loaded from .xacro format
   bool urdf_from_xacro_;
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -258,6 +258,7 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
   emitter << YAML::Value << YAML::BeginMap;
   emitter << YAML::Key << "package" << YAML::Value << urdf_pkg_name_;
   emitter << YAML::Key << "relative_path" << YAML::Value << urdf_pkg_relative_path_;
+  emitter << YAML::Key << "use_jade_xacro" << YAML::Value << urdf_requires_jade_xacro_;
   emitter << YAML::EndMap;
 
   /// SRDF Path Location
@@ -925,8 +926,8 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
     YAML::Node doc;
     loadYaml(input_stream, doc);
 
-    yaml_node_t title_node, urdf_node, package_node, srdf_node, relative_node, config_node, timestamp_node,
-        author_name_node, author_email_node;
+    yaml_node_t title_node, urdf_node, package_node, jade_xacro_node, srdf_node, relative_node, config_node,
+        timestamp_node, author_name_node, author_email_node;
 
     // Get title node
     if (title_node = findValue(doc, "moveit_setup_assistant_config"))
@@ -952,6 +953,15 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
         else
         {
           return false;  // if we do not find this value we cannot continue
+        }
+        // should Jade+ xacro extensions be enabled for this package?
+        if (jade_xacro_node = findValue(*urdf_node, "use_jade_xacro"))
+        {
+          *jade_xacro_node >> urdf_requires_jade_xacro_;
+        }
+        else
+        {
+          // value for this node is not required
         }
       }
       // SRDF Properties

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -151,7 +151,7 @@ void loadYaml(std::istream& in_stream, YAML::Node& doc_out)
 // ******************************************************************************************
 // Constructor
 // ******************************************************************************************
-MoveItConfigData::MoveItConfigData() : config_pkg_generated_timestamp_(0)
+MoveItConfigData::MoveItConfigData() : config_pkg_generated_timestamp_(0), urdf_requires_jade_xacro_(false)
 {
   // Create an instance of SRDF writer and URDF model for all widgets to share
   srdf_.reset(new srdf::SRDFWriter());

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -258,7 +258,8 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
   emitter << YAML::Value << YAML::BeginMap;
   emitter << YAML::Key << "package" << YAML::Value << urdf_pkg_name_;
   emitter << YAML::Key << "relative_path" << YAML::Value << urdf_pkg_relative_path_;
-  emitter << YAML::Key << "use_jade_xacro" << YAML::Value << urdf_requires_jade_xacro_;
+  if (urdf_requires_jade_xacro_)
+    emitter << YAML::Key << "use_jade_xacro" << YAML::Value << urdf_requires_jade_xacro_;
   emitter << YAML::EndMap;
 
   /// SRDF Path Location

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1002,7 +1002,16 @@ void ConfigurationFilesWidget::loadTemplateStrings()
 
   // Pair 3
   if (config_data_->urdf_from_xacro_)
-    addTemplateString("[URDF_LOAD_ATTRIBUTE]", "command=\"$(find xacro)/xacro.py '" + urdf_location + "'\"");
+  {
+    // Always use xacro if urdf was actually converted from one
+    std::string cmd = "$(find xacro)/xacro.py";
+
+    // but only enable Jade+ xacro extensions if needed
+    if (config_data_->urdf_requires_jade_xacro_)
+      cmd += " --inorder";
+
+    addTemplateString("[URDF_LOAD_ATTRIBUTE]", "command=\"" + cmd + " '" + urdf_location + "'\"");
+  }
   else
     addTemplateString("[URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -156,6 +156,9 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   // Add it to the urdf LoadPathWidget's layout instead of to the left_layout,
   // as we want this widget to appear on the urdf LoadPathWidget only.
   chk_use_jade_xacro_ = new QCheckBox("Enable Jade+ xacro extensions", urdf_file_);
+  chk_use_jade_xacro_->setToolTip("Enables the use of the xacro extensions that are available on ROS Jade and\n"
+                                  "newer in ROS Indigo. Enable this if the xacro that will be loaded makes use\n"
+                                  "of any of those features.");
   urdf_file_->layout()->addWidget(chk_use_jade_xacro_);
 
   // Load settings box ---------------------------------------------

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -152,6 +152,12 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   urdf_file_->hide();                         // user needs to select option before this is shown
   left_layout->addWidget(urdf_file_);
 
+  // Checkbox to enable Jade+ xacro extensions when loading xacros.
+  // Add it to the urdf LoadPathWidget's layout instead of to the left_layout,
+  // as we want this widget to appear on the urdf LoadPathWidget only.
+  chk_use_jade_xacro_ = new QCheckBox("Enable Jade+ xacro extensions", urdf_file_);
+  urdf_file_->layout()->addWidget(chk_use_jade_xacro_);
+
   // Load settings box ---------------------------------------------
   QHBoxLayout* load_files_layout = new QHBoxLayout();
 
@@ -351,7 +357,7 @@ bool StartScreenWidget::loadExistingFiles()
     return false;  // error occured
 
   // Load the URDF
-  if (!loadURDFFile(config_data_->urdf_path_))
+  if (!loadURDFFile(config_data_->urdf_path_, config_data_->urdf_requires_jade_xacro_))
     return false;  // error occured
 
   // Get the SRDF path using the loaded .setup_assistant data and check it
@@ -416,6 +422,8 @@ bool StartScreenWidget::loadNewFiles()
 {
   // Get URDF file path
   config_data_->urdf_path_ = urdf_file_->getPath();
+  // Check whether user wants to enable Jade+ Xacro extensions (only used when actually loading a XACRO)
+  config_data_->urdf_requires_jade_xacro_ = chk_use_jade_xacro_->isChecked();
 
   // Check that box is filled out
   if (config_data_->urdf_path_.empty())
@@ -443,7 +451,7 @@ bool StartScreenWidget::loadNewFiles()
   QApplication::processEvents();
 
   // Load the URDF to the parameter server and check that it is correct format
-  if (!loadURDFFile(config_data_->urdf_path_))
+  if (!loadURDFFile(config_data_->urdf_path_, config_data_->urdf_requires_jade_xacro_))
     return false;  // error occurred
 
   // Progress Indicator
@@ -490,7 +498,7 @@ bool StartScreenWidget::loadNewFiles()
 // ******************************************************************************************
 // Load URDF File to Parameter Server
 // ******************************************************************************************
-bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path)
+bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, bool use_jade_xacro)
 {
   // check that URDF can be loaded
   std::ifstream urdf_stream(urdf_file_path.c_str());
@@ -506,6 +514,11 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path)
   if (urdf_file_path.find(".xacro") != std::string::npos)
   {
     std::string cmd("rosrun xacro xacro.py ");
+
+    // enable Jade+ xacro extensions
+    if (use_jade_xacro)
+      cmd += "--inorder ";
+
     cmd += urdf_file_path;
     ROS_INFO("Running '%s'...", cmd.c_str());
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -40,6 +40,7 @@
 #include <QWidget>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QCheckBox>
 #include <QLabel>
 #include <QProgressBar>
 
@@ -84,6 +85,7 @@ public:
   LoadPathWidget* stack_path_;
   LoadPathWidget* urdf_file_;
   // LoadPathWidget *srdf_file_;
+  QCheckBox* chk_use_jade_xacro_;
   QPushButton* btn_load_;
   QLabel* next_label_;
   QProgressBar* progress_bar_;
@@ -141,7 +143,7 @@ private:
   bool loadExistingFiles();
 
   /// Load URDF File to Parameter Server
-  bool loadURDFFile(const std::string& urdf_file_path);
+  bool loadURDFFile(const std::string& urdf_file_path, bool use_jade_xacro = false);
 
   /// Load SRDF File
   bool loadSRDFFile(const std::string& srdf_file_path);


### PR DESCRIPTION
This adds a checkbox to the Setup Assistant urdf loading widget on the start screen that allows users to enable 'Jade+ extensions' in xacro on Indigo installations. This is needed to support loading xacros that make use of those extensions.

The choice is persisted (`.setup_assistant`) so loading a config pkg that was created with the option enabled will enable them automatically. Bw-compatibility with existing config pkgs is maintained, as absence of the setting will just make the MSA use the default (`false`).

Extensions are also enabled in `planning_context.launch` if needed.

Screenshot of UI change:

![msa_enable_jade_xacro_sshot](https://user-images.githubusercontent.com/4550046/27587768-eb6cfa78-5b45-11e7-881c-f49295eeca5b.png)

Ref #511.

As xacro on Jade and newer ROS releases enables those extensions by default, these changes do not need to be cherry-picked to any other MoveIt versions.
