### PR TITLE
Optional forced use of JointModelStateSpaceFactory

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -184,7 +184,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
   {
     // the set of planning parameters that can be specific for the group (inherited by configurations of that group)
     static const std::string KNOWN_GROUP_PARAMS[] = { "projection_evaluator", "longest_valid_segment_fraction",
-                                                      "force_joint_model_state_space" };
+                                                      "enforce_joint_model_state_space" };
 
     // get parameters specific for the robot planning group
     std::map<std::string, std::string> specific_group_params;

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -183,7 +183,8 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
   for (std::size_t i = 0; i < group_names.size(); ++i)
   {
     // the set of planning parameters that can be specific for the group (inherited by configurations of that group)
-    static const std::string KNOWN_GROUP_PARAMS[] = { "projection_evaluator", "longest_valid_segment_fraction" };
+    static const std::string KNOWN_GROUP_PARAMS[] = { "projection_evaluator", "longest_valid_segment_fraction",
+                                                      "force_joint_model_state_space" };
 
     // get parameters specific for the robot planning group
     std::map<std::string, std::string> specific_group_params;

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -367,9 +367,15 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     }
   }
 
-  // Check for forced use of JointModelStateSpace
+  // Check if sampling in JointModelStateSpace is enforced for this group by user.
+  // This is done by setting 'enforce_joint_model_state_space' to 'true' for the desired group in ompl_planning.yaml.
+  //
+  // Some planning problems like orientation path constraints are represented in PoseModelStateSpace and sampled via IK.
+  // However consecutive IK solutions are not checked for proximity at the moment and sometimes happen to be flipped,
+  // leading to invalid trajectories. This workaround lets the user prevent this problem by forcing rejection sampling
+  // in JointModelStateSpace.
   StateSpaceFactoryTypeSelector factory_selector;
-  std::map<std::string, std::string>::const_iterator it = pc->second.config.find("force_joint_model_state_space");
+  std::map<std::string, std::string>::const_iterator it = pc->second.config.find("enforce_joint_model_state_space");
 
   if (it != pc->second.config.end() && boost::lexical_cast<bool>(it->second))
     factory_selector = boost::bind(&PlanningContextManager::getStateSpaceFactory1, this, _1,


### PR DESCRIPTION
Adds an optional ompl group parameter 'force_joint_model_state_space' to enforce the use of JointModelStateSpaceFactory for problem representation. This is convenient to work around issues with planning problems represented in PoseModelStateSpace, as is the case with some cartesian path planning scenarios.