### PR TITLE
[setup_assistant] Fix for lunar

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -172,7 +172,7 @@ public:
   bool urdf_from_xacro_;
 
   /// URDF robot model
-  boost::shared_ptr<urdf::Model> urdf_model_;
+  urdf::ModelSharedPtr urdf_model_;
 
   // ******************************************************************************************
   // SRDF Data


### PR DESCRIPTION
Fix for https://github.com/ros-planning/moveit/issues/506

This PR corresponds to this change in [robot_model](https://github.com/ros/robot_model/pull/206) that has just been released into kinetic & lunar. This should be safe to be merged now, and should not be backported.