### PR TITLE
Chomp use PlanningScene

### DIFF
--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
@@ -48,7 +48,7 @@ MOVEIT_CLASS_FORWARD(CHOMPInterface);
 class CHOMPInterface : public chomp::ChompPlanner
 {
 public:
-  CHOMPInterface();
+  CHOMPInterface(const ros::NodeHandle& nh = ros::NodeHandle("~"));
 
   const chomp::ChompParameters& getParams() const
   {

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -38,7 +38,7 @@
 
 namespace chomp_interface
 {
-CHOMPInterface::CHOMPInterface() : ChompPlanner()
+CHOMPInterface::CHOMPInterface(const ros::NodeHandle& nh) : ChompPlanner(), nh_(nh)
 {
   loadParams();
 }

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -86,6 +86,7 @@ public:
     }
 
     planning_contexts_.at(req.group_name)->setMotionPlanRequest(req);
+    planning_contexts_.at(req.group_name)->setPlanningScene(planning_scene);
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     return planning_contexts_.at(req.group_name);
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -112,7 +112,6 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     return false;
   }
   ROS_INFO("Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
-  ROS_INFO("Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
   optimizer.optimize();
   ROS_INFO("Optimization actually took %f sec to run", (ros::WallTime::now() - create_time).toSec());
   create_time = ros::WallTime::now();


### PR DESCRIPTION
### Description

This PR includes some first steps to get Chomp planner to avoid collisions. It partially addresses #305 

This code requires that the "global" PlanningScene uses the "Hybrid" collision checker from moveit-experimental. I will open a separate PR against moveit-resources to add this to the example

Status after this fix:
- chomp knows there are collisions
- it tries and sometimes manages to avoid them
- there is a ROS_ERROR informing you that the path still contains collisions (even if it doesn't)
- but it will still return SUCCESS (unconditionally)

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)


