### PR TITLE
Change getCurrentExpectedTrajectory index so collision detection is s…

### DIFF
--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -271,7 +271,9 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
 bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionPlan& plan,
                                                          const std::pair<int, int>& path_segment)
 {
-  if (path_segment.first >= 0 && plan.plan_components_[path_segment.first].trajectory_monitoring_)
+  if (path_segment.first >= 0 &&
+      plan.plan_components_[path_segment.first].trajectory_monitoring_)  // If path_segment.second <= 0, the function
+                                                                         // will fallback to check the entire trajectory
   {
     planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);  // lock the scene so that it
                                                                                          // does not modify the world

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -271,8 +271,7 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
 bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionPlan& plan,
                                                          const std::pair<int, int>& path_segment)
 {
-  if (path_segment.first >= 0 &&
-      plan.plan_components_[path_segment.first].trajectory_monitoring_)
+  if (path_segment.first >= 0 && plan.plan_components_[path_segment.first].trajectory_monitoring_)
   {
     planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);  // lock the scene so that it
                                                                                          // does not modify the world

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -271,7 +271,7 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
 bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionPlan& plan,
                                                          const std::pair<int, int>& path_segment)
 {
-  if (path_segment.first >= 0 && path_segment.second >= 0 &&
+  if (path_segment.first >= 0 &&
       plan.plan_components_[path_segment.first].trajectory_monitoring_)
   {
     planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);  // lock the scene so that it

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1500,7 +1500,7 @@ std::pair<int, int> TrajectoryExecutionManager::getCurrentExpectedTrajectoryInde
   if (current_context_ < 0)
     return std::make_pair(-1, -1);
   if (time_index_.empty())
-    return std::make_pair((int)current_context_, 0);  //Should still verify even if we don't know where we are in the trajectory
+    return std::make_pair((int)current_context_, -1);
   std::vector<ros::Time>::const_iterator it =
       std::lower_bound(time_index_.begin(), time_index_.end(), ros::Time::now());
   int pos = it - time_index_.begin();

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1500,7 +1500,7 @@ std::pair<int, int> TrajectoryExecutionManager::getCurrentExpectedTrajectoryInde
   if (current_context_ < 0)
     return std::make_pair(-1, -1);
   if (time_index_.empty())
-    return std::make_pair((int)current_context_, -1);
+    return std::make_pair((int)current_context_, 0);  //Should still verify even if we don't know where we are in the trajectory
   std::vector<ros::Time>::const_iterator it =
       std::lower_bound(time_index_.begin(), time_index_.end(), ros::Time::now());
   int pos = it - time_index_.begin();


### PR DESCRIPTION
…till performed even if the path timing is not known

Following this [issue](https://github.com/ros-planning/moveit_ros/issues/700)

I understand that the entire path is verified, not what's remaining but that's probably the best we can do since we are talking about a case where we don't know where we are in the trajectory.

The change would probably help on versions other than kinetic.
