### PR TITLE
add backward compatibility patch for indigo

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -14,13 +14,17 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES
-  CATKIN_DEPENDS moveit_core 
+  CATKIN_DEPENDS moveit_core
   DEPENDS Boost
 )
+
+# support indigo's ros_control - This can be removed upon EOL indigo
+if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")
+  add_definitions(-DMOVEIT_ROS_CONTROL_INTERFACE_OLD_ROS_CONTROL)
+endif()
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 


### PR DESCRIPTION
At [the last developer meeting](https://discourse.ros.org/t/maintainer-meeting-recap-march-7th/1442) we agreed to allow patches that support to compile the `kinetic-devel` branch on ROS indigo.

I worked on that on the side and actually it's quite possible by now if you know what you're doing.
The only problems that are left are the API change in `ros_control` and https://github.com/ros/robot_model/pull/210 .

This patch adds preprocessor magic to support the old `ros_control` API.