### PR TITLE
MultiDoFJointTrajectory only trajectory support

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1323,7 +1323,8 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
     for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
     {
       ros::Duration d(0.0);
-      if (! (context.trajectory_parts_[i].joint_trajectory.points.empty() && context.trajectory_parts_[i].multi_dof_joint_trajectory.points.empty()))
+      if (!(context.trajectory_parts_[i].joint_trajectory.points.empty() &&
+            context.trajectory_parts_[i].multi_dof_joint_trajectory.points.empty()))
       {
         if (context.trajectory_parts_[i].joint_trajectory.header.stamp > current_time)
           d = context.trajectory_parts_[i].joint_trajectory.header.stamp - current_time;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1323,7 +1323,7 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
     for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
     {
       ros::Duration d(0.0);
-      if (!context.trajectory_parts_[i].joint_trajectory.points.empty())
+      if (! (context.trajectory_parts_[i].joint_trajectory.points.empty() && context.trajectory_parts_[i].multi_dof_joint_trajectory.points.empty()))
       {
         if (context.trajectory_parts_[i].joint_trajectory.header.stamp > current_time)
           d = context.trajectory_parts_[i].joint_trajectory.header.stamp - current_time;


### PR DESCRIPTION
### Description

At the moment, if a trajectory with MultiDoFJointTrajectory points but no JointTrajectory point is sent to the executePart function, the whole [trajectory duration estimation](https://github.com/ros-planning/moveit/blob/3f00880b726833805364f4afa91fedc49478d35c/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp#L1328-L1344) part is skipped. This PR addresses that.
The entire calculation is already supporting the case, it's just a matter of allowing it to process.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

