### PR TITLE
remove render_shapes for attached objects when the RobotStateDispla gets disabled

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -139,6 +139,8 @@ void RobotStateVisualization::setVisible(bool visible)
 {
   visible_ = visible;
   robot_.setVisible(visible);
+  if (!visible)
+    render_shapes_->clear();
 }
 
 void RobotStateVisualization::setVisualVisible(bool visible)


### PR DESCRIPTION
this fixes a crash on the first update after reenabling the plugin:
OGRE EXCEPTION(5:ItemIdentityException): SceneNode 'rviz' not found. in SceneManager::getSceneNode at /build/ogre-1.9-mqY1wq/ogre-1.9-1.9.0+dfsg1/OgreMain/src/OgreSceneManager.cpp (line 920)

### Description

You can trigger the crash in rviz (or any other application loading the RobotState or PlanningScene rviz plugin) by attaching an object and then toggling the "enable" checkbox. It will crash on the first RobotState update after reenabling when it calls render_shapes_.clear(). Apparently some more nodes get deleted/removed once the plugin is disabled and it subsequently does not find them.

Please note that
 * I don't understand the issue fully but this fixes the crash and does not seem to have any negative side effects
 * That region of the code should receive some more love
 * There is a similar (but purely visual) issue that the attached object does not disappear if I disable  both the visual as well as the collision model of the robot (https://github.com/ros-planning/moveit/issues/512)

