### PR TITLE
remove references to TinyXML

### DIFF
--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -40,7 +40,8 @@
 #include <moveit/macros/class_forward.h>
 #include <urdf/model.h>
 #include <srdfdom/model.h>
-#include <tinyxml.h>
+
+class TiXmlDocument;
 
 namespace rdf_loader
 {

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -37,7 +37,6 @@
 #include <moveit/setup_assistant/tools/compute_default_collisions.h>
 #include <boost/math/special_functions/binomial.hpp>  // for statistics at end
 #include <boost/thread.hpp>
-#include <tinyxml.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/assign.hpp>


### PR DESCRIPTION
### Description

I noticed that several packages were using tinyxml symbols but were not explictely fingind it or linking against it. I modified the package.xml and CMakeLists of the relevant packages and hopefully didnt miss any.