### PR TITLE
RobotStateVisualization: clear before load to avoid segfault

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -59,6 +59,9 @@ RobotStateVisualization::RobotStateVisualization(Ogre::SceneNode* root_node, rvi
 
 void RobotStateVisualization::load(const urdf::ModelInterface& descr, bool visual, bool collision)
 {
+  // clear previously loaded model
+  clear();
+
   robot_.load(descr, visual, collision);
   robot_.setVisualVisible(visual_visible_);
   robot_.setCollisionVisible(collision_visible_);
@@ -68,8 +71,8 @@ void RobotStateVisualization::load(const urdf::ModelInterface& descr, bool visua
 
 void RobotStateVisualization::clear()
 {
-  robot_.clear();
   render_shapes_->clear();
+  robot_.clear();
 }
 
 void RobotStateVisualization::setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color)


### PR DESCRIPTION
This addresses the segfault reported by @simonschmeisser in https://github.com/ros-planning/moveit/pull/565 .

rviz::Robot deletes its complete SceneNode structure in the `load()` method.
However, `RobotStateVisualization::render_shapes_` keeps raw pointers
to some of these nodes (the attached objects), so these should be cleared
to avoid broken pointers.

Additionally the order of clearing was bad: the attached objects should
be removed first, and `rviz::Robot` only afterwards to avoid similar problems.

Should be cherry-picked to `indigo-devel`.