### PR TITLE
set default planner by default in indigo's MoveGroup

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -131,6 +131,8 @@ public:
       end_effector_link_ = joint_model_group_->getLinkModelNames().back();
     pose_reference_frame_ = getRobotModel()->getModelFrame();
 
+    setPlannerId(getDefaultPlannerId(opt.group_name_));
+
     trajectory_event_publisher_ = node_handle_.advertise<std_msgs::String>(
         trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC, 1, false);
     attached_object_publisher_ = node_handle_.advertise<moveit_msgs::AttachedCollisionObject>(


### PR DESCRIPTION
#568 reminded me of this problem, and somewhat increased the pressure to change this...

This patch makes the `MoveGroup` interface behave the same as the RViz plugin
when the user specified a `default_planner_config` in their `ompl_planning.yaml`

Before, the RViz plugin automatically selected the default planner automatically, but the MoveGroup left the planner id unspecified in the MoveGroup action goals. The move_group node received the request with the unspecified field but didn't respect the parameter in indigo and uses `LBKPIECE1` even if the user specified a different default planner for the group.

To circumvent the old default planner `LBKPIECE1` in indigo, the user has to set the default planner **explicitly for each `MoveGroup`** using

```
group.setPlannerId(group.getDefaultPlannerId(group.getName()));
```

If they forget it for one instance, all planning requests from this instance will use the LBKPIECE1 planner config, usually resulting in rather complicated trajectories and apparently in some cases in weird segfaults.

Note that `move_group` respects the selected default in kinetic-devel and chooses that one whenever the planner id is not specified in a request. Thus, this patch is pretty redundant there.
Personally, I don't see the need to pick this to kinetic, but I don't oppose it either. I'll leave the choice to the person who merges this request.

Lastly, let me point out that this could also be addressed in `indigo-devel`'s `move_group` node. I preferred to leave the semantics of an empty "planner_id" field in a MoveGroup untouched in the LTS release, especially because we already broke with it in the `kinetic-devel` branch.