### PR TITLE
RobotState: Changed multi-waypoint version of computeCartesianPath to…

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1735,6 +1735,17 @@ private:
                       std::vector<std::string>& missing_variables) const;
   void getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0, bool last) const;
 
+  /**
+   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
+   * computed. If two adjacent trajectory points have distance > \e jump_threshold * average, the trajectory is cut of
+   * at this point.
+   * @param group The joint model group of the robot state.
+   * @param traj The trajectory that should be tested.
+   * @param jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @return The fraction of the trajectory that passed.
+   */
+  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
+
   /** \brief This function is only called in debug mode */
   bool checkJointTransforms(const JointModel* joint) const;
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1925,9 +1925,6 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   traj.clear();
   traj.push_back(RobotStatePtr(new RobotState(*this)));
 
-  std::vector<double> dist_vector;
-  double total_dist = 0.0;
-
   double last_valid_percentage = 0.0;
   Eigen::Quaterniond start_quaternion(start_pose.rotation());
   Eigen::Quaterniond target_quaternion(rotated_target.rotation());
@@ -1941,35 +1938,46 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
     if (setFromIK(group, pose, link->getName(), 1, 0.0, validCallback, options))
     {
       traj.push_back(RobotStatePtr(new RobotState(*this)));
-
-      // compute the distance to the previous point (infinity norm)
-      if (test_joint_space_jump)
-      {
-        double dist_prev_point = traj.back()->distance(*traj[traj.size() - 2], group);
-        dist_vector.push_back(dist_prev_point);
-        total_dist += dist_prev_point;
-      }
     }
     else
       break;
     last_valid_percentage = percentage;
   }
 
-  if (test_joint_space_jump && !dist_vector.empty())
+  if (test_joint_space_jump)
   {
-    // compute the average distance between the states we looked at
-    double thres = jump_threshold * (total_dist / (double)dist_vector.size());
-    for (std::size_t i = 0; i < dist_vector.size(); ++i)
-      if (dist_vector[i] > thres)
-      {
-        logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
-        last_valid_percentage = (double)i / (double)steps;
-        traj.resize(i);
-        break;
-      }
+    last_valid_percentage *= testJointSpaceJump(group, traj, jump_threshold);
   }
 
   return last_valid_percentage;
+}
+
+double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                                    double jump_threshold)
+{
+  std::vector<double> dist_vector;
+  dist_vector.reserve(traj.size() - 1);
+  double total_dist = 0.0;
+  for (std::size_t i = 1; i < traj.size(); ++i)
+  {
+    double dist_prev_point = traj[i]->distance(*traj[i - 1], group);
+    dist_vector.push_back(dist_prev_point);
+    total_dist += dist_prev_point;
+  }
+
+  double percentage = 1.0;
+  // compute the average distance between the states we looked at
+  double thres = jump_threshold * (total_dist / (double)dist_vector.size());
+  for (std::size_t i = 0; i < dist_vector.size(); ++i)
+    if (dist_vector[i] > thres)
+    {
+      logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+      percentage = (double)i / (double)dist_vector.size();
+      traj.resize(i);
+      break;
+    }
+
+  return percentage;
 }
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
@@ -1982,9 +1990,11 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   double percentage_solved = 0.0;
   for (std::size_t i = 0; i < waypoints.size(); ++i)
   {
+    // Don't test joint space jumps for every waypoint, test them later on the whole trajectory.
+    static const double no_joint_space_jump_test = 0.0;
     std::vector<RobotStatePtr> waypoint_traj;
     double wp_percentage_solved = computeCartesianPath(group, waypoint_traj, link, waypoints[i], global_reference_frame,
-                                                       max_step, jump_threshold, validCallback, options);
+                                                       max_step, no_joint_space_jump_test, validCallback, options);
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
       percentage_solved = (double)(i + 1) / (double)waypoints.size();
@@ -2002,6 +2012,11 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
       traj.insert(traj.end(), start, waypoint_traj.end());
       break;
     }
+  }
+
+  if (jump_threshold > 0.0)
+  {
+    percentage_solved *= testJointSpaceJump(group, traj, jump_threshold);
   }
 
   return percentage_solved;


### PR DESCRIPTION
… test joint space jumps after all waypoints are generated.

This removes the minimum addition of 4 extra waypoints for every waypoint.
Added new private member testJointSpaceJump to reuse code in the single- and multi-waypoint case.

### Description

In reference to #570
