### PR TITLE
MoveGroupInterface: Fixed computeCartesianPath to use selected end-effector.

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -941,6 +941,7 @@ public:
     req.jump_threshold = jump_threshold;
     req.path_constraints = path_constraints;
     req.avoid_collisions = avoid_collisions;
+    req.link_name = getEndEffectorLink();
 
     if (cartesian_path_service_.call(req, res))
     {


### PR DESCRIPTION
### Description
Currently computeCartesianPath of MoveGroupInterface ignores the end-effector link set by setEndEffectorLink. It uses the CartesianPathService which has a field link_name to provide this utility.
After this fix the provided poses are correctly transformed to the tip of the ik chain.

Like I wrote in #577, this could potentially break workaround user code, if they manually transform poses to the ik tip before giving them to computeCartesianPath and also calling setEndEffectorLink with their actual intended end-effector link. If their end-effector set by setEndEffectorLink or setEndEffector is the same as the ik chain tip, nothing will change.
