### PR TITLE
workaround for https://github.com/ros-planning/moveit/issues/86

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -44,8 +44,8 @@ from exception import MoveItCommanderException
 try:
     from pyassimp import pyassimp
 except:
-    # support pyassimp > 3.0
-    import pyassimp
+    pyassimp = False
+    print("Failed to import pyassimp")
 
 # This is going to have more functionality; (feel free to add some!)
 # This class will include simple Python code for publishing messages for a planning scene
@@ -92,6 +92,8 @@ class PlanningSceneInterface(object):
     
     def __make_mesh(self, name, pose, filename, scale = (1, 1, 1)):
         co = CollisionObject()
+        if pyassimp is False:
+            raise MoveItCommanderException("Pyassimp needs patch https://launchpadlibrarian.net/319496602/patchPyassim.txt")
         scene = pyassimp.load(filename)
         if not scene.meshes or len(scene.meshes) == 0:
             raise MoveItCommanderException("There are no meshes in the file")

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -44,8 +44,12 @@ from exception import MoveItCommanderException
 try:
     from pyassimp import pyassimp
 except:
-    pyassimp = False
-    print("Failed to import pyassimp")
+    # support pyassimp > 3.0
+    try:
+        import pyassimp
+    except:
+        pyassimp = False
+        print("Failed to import pyassimp")
 
 # This is going to have more functionality; (feel free to add some!)
 # This class will include simple Python code for publishing messages for a planning scene

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -49,7 +49,7 @@ except:
         import pyassimp
     except:
         pyassimp = False
-        print("Failed to import pyassimp")
+        print("Failed to import pyassimp, see https://github.com/ros-planning/moveit/issues/86 for more info")
 
 # This is going to have more functionality; (feel free to add some!)
 # This class will include simple Python code for publishing messages for a planning scene


### PR DESCRIPTION
this PR just to skip import pyassimp, so if you need to build mesh, we have problem
But I think this still useful, because we can at least, start moveit_commander, until https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1589949
 is get merged.