### PR TITLE
IKConstraintSampler: Fixed transform from end-effector to ik chain tip.

### DIFF
--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -521,6 +521,9 @@ protected:
   std::string ik_frame_;                                          /**< \brief Holds the base from of the IK solver */
   bool transform_ik_; /**< \brief True if the frame associated with the kinematic model is different than the base frame
                          of the IK solver */
+  bool need_eef_to_ik_tip_transform_; /**< \brief True if the tip frame of the inverse kinematic is different than the
+                                        frame of the end effector */
+  Eigen::Affine3d eef_to_ik_tip_transform_; /**< \brief Holds the transformation from end effector to IK tip frame */
 };
 }
 

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -475,10 +475,6 @@ public:
     return absolute_z_axis_tolerance_;
   }
 
-  /** \brief Change this constraint to a different link, applying a specified rotation to the constraint region.
-      This should be used for links that are associated to each other via fixed transforms */
-  void swapLinkModel(const robot_model::LinkModel* new_link, const Eigen::Matrix3d& update);
-
 protected:
   const robot_model::LinkModel* link_model_;    /**< \brief The target link model */
   Eigen::Matrix3d desired_rotation_matrix_;     /**< \brief The desired rotation matrix in the tf frame */
@@ -641,10 +637,6 @@ public:
       return false;
     return mobile_frame_;
   }
-
-  /** \brief Change this constraint to a different link, applying a specified transform to the constraint region.
-      This should be used for links that are associated to each other via fixed transforms */
-  void swapLinkModel(const robot_model::LinkModel* new_link, const Eigen::Affine3d& update);
 
 protected:
   Eigen::Vector3d offset_;                         /**< \brief The target offset */

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -369,16 +369,6 @@ bool kinematic_constraints::PositionConstraint::configure(const moveit_msgs::Pos
   return !constraint_region_.empty();
 }
 
-void kinematic_constraints::PositionConstraint::swapLinkModel(const robot_model::LinkModel* new_link,
-                                                              const Eigen::Affine3d& update)
-{
-  if (!enabled())
-    return;
-  link_model_ = new_link;
-  for (std::size_t i = 0; i < constraint_region_pose_.size(); ++i)
-    constraint_region_pose_[i] = constraint_region_pose_[i] * update;
-}
-
 bool kinematic_constraints::PositionConstraint::equal(const KinematicConstraint& other, double margin) const
 {
   if (other.getType() != type_)
@@ -560,16 +550,6 @@ bool kinematic_constraints::OrientationConstraint::configure(const moveit_msgs::
     logWarn("Near-zero value for absolute_z_axis_tolerance");
 
   return link_model_ != NULL;
-}
-
-void kinematic_constraints::OrientationConstraint::swapLinkModel(const robot_model::LinkModel* new_link,
-                                                                 const Eigen::Matrix3d& update)
-{
-  if (!enabled())
-    return;
-  link_model_ = new_link;
-  desired_rotation_matrix_ = desired_rotation_matrix_ * update;
-  desired_rotation_matrix_inv_ = desired_rotation_matrix_.inverse();
 }
 
 bool kinematic_constraints::OrientationConstraint::equal(const KinematicConstraint& other, double margin) const


### PR DESCRIPTION
Previously the transform was done before sampling poses, which only works for pure orientation constraints.
Now transforms after each sample.
Removed no longer needed methods swapLinkModel. They are no longer used anywhere in moveit and at least the position constraint version is not working as intended.

Fixes setPoseTarget part of #577.