### PR TITLE
robotStateMsgToRobotState: is_diff==true => not empty

### DIFF
--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -332,7 +332,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
   bool valid;
   const moveit_msgs::RobotState& rs = robot_state;
 
-  if (rs.joint_state.name.empty() && rs.multi_dof_joint_state.joint_names.empty())
+  if (!rs.is_diff && rs.joint_state.name.empty() && rs.multi_dof_joint_state.joint_names.empty())
   {
     logError("Found empty JointState message");
     return false;


### PR DESCRIPTION
In case the incoming RobotStateMsg is a diff, the joint fields are allowed to be empty.
This is used to change attached objects and it's an intended use-pattern in MoveIt to modify the current state with some (possibly) incoming state (see e.g. [the fix_start_state_bounds adapter](https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp#L85))

This needs to be cherry-picked indigo due to #518 .

Fixes #579