### PR TITLE
MoveGroupInterface: Fixed computeCartesianPath to use selected end-effector

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -898,6 +898,7 @@ public:
     req.jump_threshold = jump_threshold;
     req.path_constraints = path_constraints;
     req.avoid_collisions = avoid_collisions;
+    req.link_name = getEndEffectorLink();
 
     if (cartesian_path_service_.call(req, res))
     {


### PR DESCRIPTION

Indigo backport of #580 