### PR TITLE
RobotState rviz previewer: First message from e.g. latching publishers is not applied to robot state correctly

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -393,7 +393,8 @@ void RobotStateDisplay::update(float wall_dt, float ros_dt)
 {
   Display::update(wall_dt, ros_dt);
 
-  if (load_robot_model_) {
+  if (load_robot_model_)
+  {
     loadRobotModel();
     changedRobotStateTopic();
   }

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -398,7 +398,7 @@ void RobotStateDisplay::update(float wall_dt, float ros_dt)
     loadRobotModel();
     changedRobotStateTopic();
   }
-    
+
   calculateOffsetPosition();
   if (robot_ && update_state_)
   {

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -376,7 +376,6 @@ void RobotStateDisplay::onEnable()
   Display::onEnable();
   load_robot_model_ = true;  // allow loading of robot model in update()
   calculateOffsetPosition();
-  changedRobotStateTopic();
 }
 
 // ******************************************************************************************
@@ -394,9 +393,11 @@ void RobotStateDisplay::update(float wall_dt, float ros_dt)
 {
   Display::update(wall_dt, ros_dt);
 
-  if (load_robot_model_)
+  if (load_robot_model_) {
     loadRobotModel();
-
+    changedRobotStateTopic();
+  }
+    
   calculateOffsetPosition();
   if (robot_ && update_state_)
   {


### PR DESCRIPTION
Fixes #595

Note: I am not familiar with the problems that leaded to the delayed loading of the robot model so please review this solution especially regarding thread contexts of the methods..