### PR TITLE
Adapt pick pipeline to function without object

### DIFF
--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -124,6 +124,12 @@ bool executeAttachObject(const ManipulationPlanSharedDataConstPtr& shared_plan_d
                          const trajectory_msgs::JointTrajectory& detach_posture,
                          const plan_execution::ExecutableMotionPlan* motion_plan)
 {
+  if (shared_plan_data->diff_attached_object_.object.id.empty())
+  {
+    // the user did not provide an object to attach, so just return successfully
+    return true;
+  }
+
   ROS_DEBUG_NAMED("manipulation", "Applying attached object diff to maintained planning scene (attaching/detaching "
                                   "object to end effector)");
   bool ok = false;

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -745,7 +745,7 @@ public:
   /** \brief Pick up an object
 
       calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
-  MoveItErrorCode planGraspsAndPick(const std::string& object);
+  MoveItErrorCode planGraspsAndPick(const std::string& object = "");
 
   /** \brief Pick up an object
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -746,6 +746,10 @@ public:
 
   MoveItErrorCode planGraspsAndPick(const std::string& object)
   {
+    if (object.empty())
+    {
+      return planGraspsAndPick(moveit_msgs::CollisionObject());
+    }
     moveit::planning_interface::PlanningSceneInterface psi;
 
     std::map<std::string, moveit_msgs::CollisionObject> objects = psi.getObjects(std::vector<std::string>(1, object));


### PR DESCRIPTION
Giving an empty object into the picking pipeline was not supported before. `executeAttachObject` was given an empty object and returned false. This aborted the pick action server right after closing the gripper. To work around this, return true whenever an empty string is given as object id. 

In addition `planGraspsAndPick` was changed, so that it can take an empty string. In that case an empty `moveit_msgs::CollisionObject` is created for the further steps. Also, an empty string is now the default value for `planGraspsAndPick`. 

This change helps with the gpd integration. 