### PR TITLE
Adapt pick pipeline to function without object (#599)

### DIFF
--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -124,6 +124,12 @@ bool executeAttachObject(const ManipulationPlanSharedDataConstPtr& shared_plan_d
                          const trajectory_msgs::JointTrajectory& detach_posture,
                          const plan_execution::ExecutableMotionPlan* motion_plan)
 {
+  if (shared_plan_data->diff_attached_object_.object.id.empty())
+  {
+    // the user did not provide an object to attach, so just return successfully
+    return true;
+  }
+
   ROS_DEBUG_NAMED("manipulation", "Applying attached object diff to maintained planning scene (attaching/detaching "
                                   "object to end effector)");
   bool ok = false;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -703,6 +703,10 @@ public:
 
   MoveItErrorCode planGraspsAndPick(const std::string& object)
   {
+    if (object.empty())
+    {
+      return planGraspsAndPick(moveit_msgs::CollisionObject());
+    }
     moveit::planning_interface::PlanningSceneInterface psi;
 
     std::map<std::string, moveit_msgs::CollisionObject> objects = psi.getObjects(std::vector<std::string>(1, object));


### PR DESCRIPTION
This is a selective backport and does not add the `""` default parameter for `planGraspsAndPick`.

Dave stated in https://github.com/ros-planning/moveit/pull/599#issuecomment-326664176 that he does not think it belongs in indigo.
I agree that we should not add the default parameter there.
But apart from that the patch adds support for an edge-case that was previously unused and does not break anything.

I would like to see this part back in indigo.