### PR TITLE
Cached ik kinematics plugin

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -22,13 +22,11 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(trac_ik_kinematics_plugin)
-if(trac_ik_kinematics_plugin_FOUND)
-    include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
-    link_directories(${trac_ik_kinematics_plugin_PREFIX}/lib)
-else()
+if(NOT trac_ik_kinematics_plugin_FOUND)
     set(TRAC_BEGIN "<!--")
     set(TRAC_END "-->")
 endif()
+
 find_package(ur_kinematics QUIET)
 if(NOT ur_kinematics_FOUND)
     set(UR_BEGIN "<!--")

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -22,19 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(trac_ik_kinematics_plugin)
-if(NOT trac_ik_kinematics_plugin_FOUND)
-    set(TRAC_BEGIN "<!--")
-    set(TRAC_END "-->")
-endif()
-
 find_package(ur_kinematics QUIET)
-if(NOT ur_kinematics_FOUND)
-    set(UR_BEGIN "<!--")
-    set(UR_END "-->")
-endif()
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cached_ik_kinematics_plugin_description.xml.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cached_ik_kinematics_plugin_description.xml" @ONLY)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -51,7 +51,6 @@ catkin_package(
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${OMPL_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
 )
 include_directories(SYSTEM

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -25,7 +25,18 @@ find_package(trac_ik_kinematics_plugin)
 if(trac_ik_kinematics_plugin_FOUND)
     include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
     link_directories(${trac_ik_kinematics_plugin_PREFIX}/lib)
+else()
+    set(TRAC_BEGIN "<!--")
+    set(TRAC_END "-->")
 endif()
+find_package(ur_kinematics QUIET)
+if(NOT ur_kinematics_FOUND)
+    set(UR_BEGIN "<!--")
+    set(UR_END "-->")
+endif()
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cached_ik_kinematics_plugin_description.xml.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cached_ik_kinematics_plugin_description.xml" @ONLY)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost)
+find_package(ompl REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_planning
@@ -21,6 +22,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   tf_conversions
 )
+# optional dependency:
+find_package(catkin COMPONENTS trac_ik_kinematics_plugin)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)
@@ -29,6 +32,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     kdl_kinematics_plugin/include
     lma_kinematics_plugin/include
     srv_kinematics_plugin/include
+    cached_ik_kinematics_plugin/include
 )
 
 catkin_package(
@@ -45,6 +49,7 @@ catkin_package(
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
+                    ${OMPL_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
 )
 include_directories(SYSTEM
@@ -58,11 +63,13 @@ add_subdirectory(kdl_kinematics_plugin)
 add_subdirectory(lma_kinematics_plugin)
 add_subdirectory(srv_kinematics_plugin)
 add_subdirectory(ikfast_kinematics_plugin)
+add_subdirectory(cached_ik_kinematics_plugin)
 
 install(
   FILES
     kdl_kinematics_plugin_description.xml
     lma_kinematics_plugin_description.xml
     srv_kinematics_plugin_description.xml
+    cached_ik_kinematics_plugin_description.xml
   DESTINATION
     ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -68,6 +68,6 @@ install(
     kdl_kinematics_plugin_description.xml
     lma_kinematics_plugin_description.xml
     srv_kinematics_plugin_description.xml
-    "${CMAKE_CURRENT_BINARY_DIR}/cached_ik_kinematics_plugin_description.xml"
+    cached_ik_kinematics_plugin_description.xml
   DESTINATION
     ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -9,7 +9,6 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost)
-find_package(ompl REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_planning

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT ur_kinematics_FOUND)
 endif()
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cached_ik_kinematics_plugin_description.xml.in"
-    "${CMAKE_CURRENT_SOURCE_DIR}/cached_ik_kinematics_plugin_description.xml" @ONLY)
+    "${CMAKE_CURRENT_BINARY_DIR}/cached_ik_kinematics_plugin_description.xml" @ONLY)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)
@@ -82,6 +82,6 @@ install(
     kdl_kinematics_plugin_description.xml
     lma_kinematics_plugin_description.xml
     srv_kinematics_plugin_description.xml
-    cached_ik_kinematics_plugin_description.xml
+    "${CMAKE_CURRENT_BINARY_DIR}/cached_ik_kinematics_plugin_description.xml"
   DESTINATION
     ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -19,9 +19,13 @@ find_package(catkin REQUIRED COMPONENTS
   urdf
   tf
   tf_conversions
-  OPTIONAL_COMPONENTS
-  trac_ik_kinematics_plugin
 )
+
+find_package(trac_ik_kinematics_plugin)
+if(trac_ik_kinematics_plugin_FOUND)
+    include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
+    link_directories(${trac_ik_kinematics_plugin_PREFIX}/lib)
+endif()
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(moveit_kinematics)
-find_package(catkin REQUIRED)
 
 add_compile_options(-std=c++11)
 
@@ -20,9 +19,9 @@ find_package(catkin REQUIRED COMPONENTS
   urdf
   tf
   tf_conversions
+  OPTIONAL_COMPONENTS
+  trac_ik_kinematics_plugin
 )
-# optional dependency:
-find_package(catkin COMPONENTS trac_ik_kinematics_plugin)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -25,7 +25,6 @@ install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DEST
 
 # This is just for testing purposes; the arms from Universal Robots have
 # analytic solvers, so caching just adds extra overhead.
-find_package(ur_kinematics QUIET)
 if(ur_kinematics_FOUND)
     include_directories(${ur_kinematics_INCLUDE_DIRS})
     foreach(UR 3 5 10)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -1,0 +1,56 @@
+find_package(Boost COMPONENTS filesystem program_options REQUIRED)
+
+set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_base)
+add_library(${MOVEIT_LIB_NAME} src/ik_cache.cpp)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+target_link_libraries(${MOVEIT_LIB_NAME}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${catkin_LIBRARIES})
+install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+
+set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_plugin)
+add_library(${MOVEIT_LIB_NAME} src/cached_ik_kinematics_plugin.cpp)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+target_link_libraries(${MOVEIT_LIB_NAME}
+    moveit_cached_ik_kinematics_base
+    moveit_kdl_kinematics_plugin
+    moveit_srv_kinematics_plugin
+    ${OMPL_LIBRARIES}
+    ${catkin_LIBRARIES})
+if(trac_ik_kinematics_plugin_FOUND)
+    target_link_libraries(${MOVEIT_LIB_NAME} trac_ik_kinematics_plugin)
+    set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_DEFINITIONS "CACHED_IK_KINEMATICS_TRAC_IK")
+endif()
+install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+# This is just for testing purposes; the arms from Universal Robots have
+# analytic solvers, so caching just adds extra overhead.
+find_package(ur_kinematics QUIET)
+if(ur_kinematics_FOUND)
+    include_directories(${ur_kinematics_INCLUDE_DIRS})
+    foreach(UR 3 5 10)
+        set(MOVEIT_LIB_NAME moveit_cached_ur${UR}_kinematics_plugin)
+        add_library(${MOVEIT_LIB_NAME} src/cached_ur_kinematics_plugin.cpp)
+        set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+        find_library(ur${UR}_pluginlib ur${UR}_moveit_plugin PATHS ${ur_kinematics_LIBRARY_DIRS})
+        target_link_libraries(${MOVEIT_LIB_NAME}
+            moveit_cached_ik_kinematics_base
+            ${ur${UR}_pluginlib}
+            ${OMPL_LIBRARIES}
+            ${catkin_LIBRARIES})
+        install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+    endforeach()
+endif()
+
+# not sure why this is necessary: it should already be part of ${catkin_LIBRARIES}
+find_library(MOVEIT_ROBOT_MODEL_LOADER_LIBRARY moveit_robot_model_loader)
+add_executable(measure_ik_call_cost src/measure_ik_call_cost.cpp)
+target_link_libraries(measure_ik_call_cost
+    ${catkin_LIBRARIES}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${MOVEIT_ROBOT_MODEL_LOADER_LIBRARY})
+install(TARGETS measure_ik_call_cost DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(${MOVEIT_LIB_NAME}
     moveit_cached_ik_kinematics_base
     moveit_kdl_kinematics_plugin
     moveit_srv_kinematics_plugin
-    ${OMPL_LIBRARIES}
     ${catkin_LIBRARIES})
 if(trac_ik_kinematics_plugin_FOUND)
     target_link_libraries(${MOVEIT_LIB_NAME} trac_ik_kinematics_plugin)
@@ -37,14 +36,11 @@ if(ur_kinematics_FOUND)
         target_link_libraries(${MOVEIT_LIB_NAME}
             moveit_cached_ik_kinematics_base
             ${ur${UR}_pluginlib}
-            ${OMPL_LIBRARIES}
             ${catkin_LIBRARIES})
         install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
     endforeach()
 endif()
 
-# not sure why this is necessary: it should already be part of ${catkin_LIBRARIES}
-find_library(MOVEIT_ROBOT_MODEL_LOADER_LIBRARY moveit_robot_model_loader)
 add_executable(measure_ik_call_cost src/measure_ik_call_cost.cpp)
 target_link_libraries(measure_ik_call_cost
     ${catkin_LIBRARIES}

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 if(trac_ik_kinematics_plugin_FOUND)
-    include_directories(${trac_ik_kinematics_INCLUDE_DIRS})
+    include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
     link_directories(${trac_ik_kinematics_plugin_PREFIX}/lib)
 endif(trac_ik_kinematics_plugin_FOUND)
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -8,6 +8,10 @@ target_link_libraries(${MOVEIT_LIB_NAME}
     ${catkin_LIBRARIES})
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
+if(trac_ik_kinematics_plugin_FOUND)
+    include_directories(${trac_ik_kinematics_INCLUDE_DIRS})
+    link_directories(${trac_ik_kinematics_plugin_PREFIX}/lib)
+endif(trac_ik_kinematics_plugin_FOUND)
 
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_plugin)
 add_library(${MOVEIT_LIB_NAME} src/cached_ik_kinematics_plugin.cpp)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/README.md
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/README.md
@@ -1,0 +1,80 @@
+# Cached IK Kinematics Plugin
+
+* Author: Mark Moll, Rice University
+
+The Cached IK Kinematics Plugin creates a persistent cache of IK solutions. This cache is then used to speed up any other IK solver. A call to an IK solver will use a similar state in the cache as a seed for the IK solver. If that fails to return a solution, the IK solver is called again with the user-specified seed state. New IK solutions that are sufficiently different from states in the cache are added to the cache. Periodically, the cache is saved to disk.
+
+## Basic Usage
+
+To use the Cached IK Kinematics Plugin, you need to modify the file `kinematics.yaml` for your robot. Change lines like these:
+
+    manipulator:
+      kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+
+to this:
+
+    manipulator:
+      kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+      # optional parameters for caching:
+      max_cache_size: 10000
+      min_pose_distance: 1
+      min_joint_config_distance: 4
+
+The cache size can be controlled with an absolute cap (`max_cache_size`) or with a distance threshold on the end effector pose (`min_pose_distance`) or robot joint state (`min_joint_config_distance`). Normally, the cache files are saved to the current working directory (which is usually `${HOME}/.ros`, not the directory where you ran `roslaunch`), in a subdirectory for each robot. Possible values for `kinematics_solver` are:
+
+- `cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin`: a wrapper for the default KDL IK solver.
+- `cached_ik_kinematics_plugin/CachedSrvKinematicsPlugin`: a wrapper for the solver that uses ROS service calls to communicate with external IK solvers.
+- `cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin`: a wrapper for the TRAC IK solver. This solver is only available if the TRAC IK kinematics plugin is detected at compile time.
+- `cached_ik_kinematics_plugin/CachedUR5KinematicsPlugin`: a wrapper for the analytic IK solver for the UR5 arm (similar solvers exist for the UR3 and UR10). This is only for illustrative purposes; the caching just adds extra overhead to the solver.
+
+## Measuring IK Solver Performance
+
+To evaluate IK solver performance and to facilitate tuning of the caching parameters there is a program called `measure_ik_call_cost`. This program can be run like so:
+
+    roslaunch moveit_kinematics measure_ik_call_cost.launch robot:=fetch
+
+This will look for the `fetch_moveit_config` package. The IK solver is then called 10,000 times for each planning group. At each iteration the IK solver will attempt to recover a randomly sampled configuration given a corresponding end effector position. The default joint positions are used as the seed state. By changing the parameters in `kinematics.yaml` you can create different cache files (the cache file names include the parameter settings) and measure the performance. The performance is measured by the average time to call the IK solver and the number of times the IK solver failed to return a solution. It will also report the percentage of random configurations that are in self-collision. Those configurations are skipped for IK solver calls.
+
+For the Fetch robot we get the following numbers for average time per IK call, measured over 10,000 calls:
+
+|                | KDL, no caching | KDL, cached | TRAC-IK, no caching | TRAC-IK, cached |
+|----------------|-----------------|-------------|---------------------|-----------------|
+| arm            | 0.00396232      | 0.00292258  | 0.000577042         | 0.000583098     |
+| arm with torso | 0.0130856       | 0.00846116  | 0.00133652          | 0.00124825      |
+
+This illustrates two points: (1) if the IK solver is slow, significant improvements can be obtained with caching, and (2) if the IK solver is fast, then caching doesn't improve performance much and can actually make it worse. Note that these numbers were obtained with the default cache parameters for `min_pose_distance` and `min_joint_config_distance`; performance can potentially be improved by tuning these parameters for a given robot.
+
+Below is a complete list of all arguments:
+
+- `robot`: the name of the corresponding MoveIt! config package
+- `group`: the joint group to measure (by default performance is reported for all joint groups)
+- `tip`: the name of the end effector (by default the default end effectors are used)
+- `num`: the number of IK calls per joint group
+- `reset_to_default`: whether to reset to default values before calling IK (rather than seed the solver with the correct IK solution). By default this parameter is set to `true`. Set to `false` to speed up filling the cache (but performance numbers are meaningless in this case).
+
+## Advanced Usage: Creating Wrappers for Other IK Solvers
+
+The Cached IK Kinematics Plugin is implemented as a wrapper around classed derived from the [`kinematics::KinematicsBase` abstract base class](http://docs.ros.org/latest-lts/api/moveit_core/html/classkinematics_1_1KinematicsBase.html). Wrappers for the `kdl_kinematics_plugin::KDLKinematicsPlugin` and `srv_kinematics_plugin::SrvKinematicsPlugin` classes are already included in the plugin. For any other solver, you can create a new kinematics plugin. The C++ code for doing so is extremely simple; here is the code to create a wrapper for the KDL solver:
+
+    #include "cached_ik_kinematics_plugin.h"
+    #include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
+    #include <pluginlib/class_list_macros.h>
+    PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>, kinematics::KinematicsBase);
+
+In the catkin `package.xml` file for your plugin, you add these lines just before `</package>`:
+
+    <export>
+      <moveit_core plugin="${prefix}/my_ik_plugin.xml"/>
+    </export>
+
+Next, create the file my_ik_plugin.xml with the following contents:
+
+    <library path="lib/libmy_ik_plugin">
+      <class name="cached_ik_kinematics_plugin/CachedMyKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<my_kinematics_plugin::MyKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+        <description>
+          A kinematics plugin for persistently caching IK solutions computed with the KDL kinematics plugin.
+        </description>
+      </class>
+    </library>
+
+**Note:** For IK solvers that implement the multi-tip API, use the `cached_ik_kinematics_plugin::CachedMultiTipIKKinematicsPlugin` wrapper class instead of `cached_ik_kinematics_plugin::CachedIKKinematicsPlugin`.

--- a/moveit_kinematics/cached_ik_kinematics_plugin/config/kdl.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/config/kdl.yaml
@@ -1,0 +1,30 @@
+arm:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+arm_left:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+arm_right:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+arm_with_torso:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+head:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+left_arm:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+left_arm_hand:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+left_gripper:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+left_leg:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+manipulator:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+right_arm:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+right_arm_hand:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+right_gripper:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+right_leg:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+torso:
+    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/config/kdl_cached.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/config/kdl_cached.yaml
@@ -1,0 +1,75 @@
+arm:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+arm_left:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+arm_right:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+arm_with_torso:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+head:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+left_arm:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+left_arm_hand:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+left_gripper:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+left_leg:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+manipulator:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+right_arm:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+right_arm_hand:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+right_gripper:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+right_leg:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+torso:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/config/trac.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/config/trac.yaml
@@ -1,0 +1,30 @@
+arm:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+arm_left:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+arm_right:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+arm_with_torso:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+head:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+left_arm:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+left_arm_hand:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+left_gripper:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+left_leg:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+manipulator:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+right_arm:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+right_arm_hand:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+right_gripper:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+right_leg:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+torso:
+    kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/config/trac_cached.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/config/trac_cached.yaml
@@ -1,0 +1,75 @@
+arm:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+arm_left:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+arm_right:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+arm_with_torso:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+head:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+left_arm:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+left_arm_hand:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+left_gripper:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+left_leg:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+manipulator:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+right_arm:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+right_arm_hand:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+right_gripper:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+right_leg:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin
+torso:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/config/ur5.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/config/ur5.yaml
@@ -1,0 +1,2 @@
+manipulator:
+    kinematics_solver: ur_kinematics/UR5KinematicsPlugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/config/ur5_cached.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/config/ur5_cached.yaml
@@ -1,0 +1,5 @@
+manipulator:
+    max_cache_size: 10000
+    min_joint_config_distance: 4
+    min_pose_distance: 1
+    kinematics_solver: cached_ik_kinematics_plugin/CachedUR5KinematicsPlugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -1,0 +1,245 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mark Moll */
+
+#include <chrono>
+#include <cstdlib>
+
+namespace cached_ik_kinematics_plugin
+{
+
+    template<class KinematicsPlugin>
+    CachedIKKinematicsPlugin<KinematicsPlugin>::CachedIKKinematicsPlugin()
+    {
+    }
+
+    template<class KinematicsPlugin>
+    CachedIKKinematicsPlugin<KinematicsPlugin>::~CachedIKKinematicsPlugin()
+    {
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(
+        const std::string &robot_description,
+        const std::string &group_name,
+        const std::string &base_frame,
+        const std::string &tip_frame,
+        double search_discretization)
+    {
+        // call initialize method of wrapped class
+        if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
+        {
+          ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
+                          "failed to initialized caching plugin");
+          return false;
+        }
+
+        cache_.initializeCache(robot_description, group_name, base_frame + tip_frame,
+                              KinematicsPlugin::getJointNames().size());
+        return true;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(
+        const std::string &robot_description,
+        const std::string &group_name,
+        const std::string &base_frame,
+        const std::vector<std::string> &tip_frames,
+        double search_discretization)
+    {
+        // call initialize method of wrapped class
+        if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames, search_discretization))
+        {
+            ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
+                            "failed to initialized caching plugin");
+            return false;
+        }
+
+        std::string cache_name = base_frame;
+        std::accumulate(tip_frames.begin(), tip_frames.end(), cache_name);
+        CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.initializeCache(
+            robot_description, group_name, cache_name, KinematicsPlugin::getJointNames().size());
+        return true;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(
+        const geometry_msgs::Pose &ik_pose,
+        const std::vector<double> &ik_seed_state,
+        std::vector<double> &solution,
+        moveit_msgs::MoveItErrorCodes &error_code,
+        const KinematicsQueryOptions &options) const
+    {
+        Pose pose(ik_pose);
+        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
+        bool solutionFound =
+            KinematicsPlugin::getPositionIK(ik_pose, nearest.second, solution, error_code, options) ||
+            KinematicsPlugin::getPositionIK(ik_pose, ik_seed_state, solution, error_code, options);
+        if (solutionFound)
+            cache_.updateCache(nearest, pose, solution);
+        return solutionFound;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+        const geometry_msgs::Pose &ik_pose,
+        const std::vector<double> &ik_seed_state,
+        double timeout,
+        std::vector<double> &solution,
+        moveit_msgs::MoveItErrorCodes &error_code,
+        const KinematicsQueryOptions &options) const
+    {
+        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+        Pose pose(ik_pose);
+        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
+        bool solutionFound =
+            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, error_code, options);
+        if (!solutionFound)
+        {
+            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution, error_code, options);
+        }
+        if (solutionFound)
+            cache_.updateCache(nearest, pose, solution);
+        return solutionFound;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+        const geometry_msgs::Pose &ik_pose,
+        const std::vector<double> &ik_seed_state,
+        double timeout,
+        const std::vector<double> &consistency_limits,
+        std::vector<double> &solution,
+        moveit_msgs::MoveItErrorCodes &error_code,
+        const KinematicsQueryOptions &options) const
+    {
+        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+        Pose pose(ik_pose);
+        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
+        bool solutionFound =
+            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits, solution, error_code, options);
+        if (!solutionFound)
+        {
+            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits, solution, error_code, options);
+        }
+        if (solutionFound)
+            cache_.updateCache(nearest, pose, solution);
+        return solutionFound;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+        const geometry_msgs::Pose &ik_pose,
+        const std::vector<double> &ik_seed_state,
+        double timeout,
+        std::vector<double> &solution,
+        const IKCallbackFn &solution_callback,
+        moveit_msgs::MoveItErrorCodes &error_code,
+        const KinematicsQueryOptions &options) const
+    {
+        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+        Pose pose(ik_pose);
+        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
+        bool solutionFound =
+            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, solution_callback, error_code, options);
+        if (!solutionFound)
+        {
+            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution, solution_callback, error_code, options);
+        }
+        if (solutionFound)
+            cache_.updateCache(nearest, pose, solution);
+        return solutionFound;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+        const geometry_msgs::Pose &ik_pose,
+        const std::vector<double> &ik_seed_state,
+        double timeout,
+        const std::vector<double> &consistency_limits,
+        std::vector<double> &solution,
+        const IKCallbackFn &solution_callback,
+        moveit_msgs::MoveItErrorCodes &error_code,
+        const KinematicsQueryOptions &options) const
+    {
+        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+        Pose pose(ik_pose);
+        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
+        bool solutionFound =
+            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits, solution, solution_callback, error_code, options);
+        if (!solutionFound)
+        {
+            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits, solution, solution_callback, error_code, options);
+        }
+        if (solutionFound)
+            cache_.updateCache(nearest, pose, solution);
+        return solutionFound;
+    }
+
+    template<class KinematicsPlugin>
+    bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+        const std::vector<geometry_msgs::Pose> &ik_poses,
+        const std::vector<double> &ik_seed_state,
+        double timeout,
+        const std::vector<double> &consistency_limits,
+        std::vector<double> &solution,
+        const IKCallbackFn &solution_callback,
+        moveit_msgs::MoveItErrorCodes &error_code,
+        const KinematicsQueryOptions &options,
+        const moveit::core::RobotState *context_state) const
+    {
+        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+        std::vector<Pose> poses(ik_poses.size());
+        for (unsigned int i = 0; i < poses.size(); ++i)
+            poses[i] = Pose(ik_poses[i]);
+        const IKEntry &nearest = CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.getBestApproximateIKSolution(poses);
+        bool solutionFound =
+            KinematicsPlugin::searchPositionIK(ik_poses, nearest.second, timeout, consistency_limits, solution, solution_callback, error_code, options, context_state);
+        if (!solutionFound)
+        {
+            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+            solutionFound = KinematicsPlugin::searchPositionIK(ik_poses, ik_seed_state, diff.count(), consistency_limits, solution, solution_callback, error_code, options, context_state);
+        }
+
+        if (solutionFound)
+            CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.updateCache(nearest, poses, solution);
+        return solutionFound;
+    }
+
+}

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2017, Rice University
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Mark Moll */
 
@@ -39,207 +39,186 @@
 
 namespace cached_ik_kinematics_plugin
 {
+template <class KinematicsPlugin>
+CachedIKKinematicsPlugin<KinematicsPlugin>::CachedIKKinematicsPlugin()
+{
+}
 
-    template<class KinematicsPlugin>
-    CachedIKKinematicsPlugin<KinematicsPlugin>::CachedIKKinematicsPlugin()
-    {
-    }
+template <class KinematicsPlugin>
+CachedIKKinematicsPlugin<KinematicsPlugin>::~CachedIKKinematicsPlugin()
+{
+}
 
-    template<class KinematicsPlugin>
-    CachedIKKinematicsPlugin<KinematicsPlugin>::~CachedIKKinematicsPlugin()
-    {
-    }
+template <class KinematicsPlugin>
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& robot_description,
+                                                            const std::string& group_name,
+                                                            const std::string& base_frame, const std::string& tip_frame,
+                                                            double search_discretization)
+{
+  // call initialize method of wrapped class
+  if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
+  {
+    ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "failed to initialized caching plugin");
+    return false;
+  }
 
-    template<class KinematicsPlugin>
-    bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(
-        const std::string &robot_description,
-        const std::string &group_name,
-        const std::string &base_frame,
-        const std::string &tip_frame,
-        double search_discretization)
-    {
-        // call initialize method of wrapped class
-        if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
-        {
-          ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
-                          "failed to initialized caching plugin");
-          return false;
-        }
+  cache_.initializeCache(robot_description, group_name, base_frame + tip_frame,
+                         KinematicsPlugin::getJointNames().size());
+  return true;
+}
 
-        cache_.initializeCache(robot_description, group_name, base_frame + tip_frame,
-                              KinematicsPlugin::getJointNames().size());
-        return true;
-    }
+template <class KinematicsPlugin>
+bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& robot_description,
+                                                                    const std::string& group_name,
+                                                                    const std::string& base_frame,
+                                                                    const std::vector<std::string>& tip_frames,
+                                                                    double search_discretization)
+{
+  // call initialize method of wrapped class
+  if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames, search_discretization))
+  {
+    ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "failed to initialized caching plugin");
+    return false;
+  }
 
-    template<class KinematicsPlugin>
-    bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(
-        const std::string &robot_description,
-        const std::string &group_name,
-        const std::string &base_frame,
-        const std::vector<std::string> &tip_frames,
-        double search_discretization)
-    {
-        // call initialize method of wrapped class
-        if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames, search_discretization))
-        {
-            ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
-                            "failed to initialized caching plugin");
-            return false;
-        }
+  std::string cache_name = base_frame;
+  std::accumulate(tip_frames.begin(), tip_frames.end(), cache_name);
+  CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.initializeCache(robot_description, group_name, cache_name,
+                                                                     KinematicsPlugin::getJointNames().size());
+  return true;
+}
 
-        std::string cache_name = base_frame;
-        std::accumulate(tip_frames.begin(), tip_frames.end(), cache_name);
-        CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.initializeCache(
-            robot_description, group_name, cache_name, KinematicsPlugin::getJointNames().size());
-        return true;
-    }
+template <class KinematicsPlugin>
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                               const std::vector<double>& ik_seed_state,
+                                                               std::vector<double>& solution,
+                                                               moveit_msgs::MoveItErrorCodes& error_code,
+                                                               const KinematicsQueryOptions& options) const
+{
+  Pose pose(ik_pose);
+  const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
+  bool solutionFound = KinematicsPlugin::getPositionIK(ik_pose, nearest.second, solution, error_code, options) ||
+                       KinematicsPlugin::getPositionIK(ik_pose, ik_seed_state, solution, error_code, options);
+  if (solutionFound)
+    cache_.updateCache(nearest, pose, solution);
+  return solutionFound;
+}
 
-    template<class KinematicsPlugin>
-    bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(
-        const geometry_msgs::Pose &ik_pose,
-        const std::vector<double> &ik_seed_state,
-        std::vector<double> &solution,
-        moveit_msgs::MoveItErrorCodes &error_code,
-        const KinematicsQueryOptions &options) const
-    {
-        Pose pose(ik_pose);
-        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
-        bool solutionFound =
-            KinematicsPlugin::getPositionIK(ik_pose, nearest.second, solution, error_code, options) ||
-            KinematicsPlugin::getPositionIK(ik_pose, ik_seed_state, solution, error_code, options);
-        if (solutionFound)
-            cache_.updateCache(nearest, pose, solution);
-        return solutionFound;
-    }
+template <class KinematicsPlugin>
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                                  const std::vector<double>& ik_seed_state,
+                                                                  double timeout, std::vector<double>& solution,
+                                                                  moveit_msgs::MoveItErrorCodes& error_code,
+                                                                  const KinematicsQueryOptions& options) const
+{
+  std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+  Pose pose(ik_pose);
+  const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
+  bool solutionFound =
+      KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, error_code, options);
+  if (!solutionFound)
+  {
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+    solutionFound =
+        KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution, error_code, options);
+  }
+  if (solutionFound)
+    cache_.updateCache(nearest, pose, solution);
+  return solutionFound;
+}
 
-    template<class KinematicsPlugin>
-    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-        const geometry_msgs::Pose &ik_pose,
-        const std::vector<double> &ik_seed_state,
-        double timeout,
-        std::vector<double> &solution,
-        moveit_msgs::MoveItErrorCodes &error_code,
-        const KinematicsQueryOptions &options) const
-    {
-        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
-        Pose pose(ik_pose);
-        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
-        bool solutionFound =
-            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, error_code, options);
-        if (!solutionFound)
-        {
-            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution, error_code, options);
-        }
-        if (solutionFound)
-            cache_.updateCache(nearest, pose, solution);
-        return solutionFound;
-    }
+template <class KinematicsPlugin>
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+    const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+    const std::vector<double>& consistency_limits, std::vector<double>& solution,
+    moveit_msgs::MoveItErrorCodes& error_code, const KinematicsQueryOptions& options) const
+{
+  std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+  Pose pose(ik_pose);
+  const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
+  bool solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits,
+                                                          solution, error_code, options);
+  if (!solutionFound)
+  {
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+    solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits,
+                                                       solution, error_code, options);
+  }
+  if (solutionFound)
+    cache_.updateCache(nearest, pose, solution);
+  return solutionFound;
+}
 
-    template<class KinematicsPlugin>
-    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-        const geometry_msgs::Pose &ik_pose,
-        const std::vector<double> &ik_seed_state,
-        double timeout,
-        const std::vector<double> &consistency_limits,
-        std::vector<double> &solution,
-        moveit_msgs::MoveItErrorCodes &error_code,
-        const KinematicsQueryOptions &options) const
-    {
-        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
-        Pose pose(ik_pose);
-        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
-        bool solutionFound =
-            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits, solution, error_code, options);
-        if (!solutionFound)
-        {
-            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits, solution, error_code, options);
-        }
-        if (solutionFound)
-            cache_.updateCache(nearest, pose, solution);
-        return solutionFound;
-    }
+template <class KinematicsPlugin>
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                                  const std::vector<double>& ik_seed_state,
+                                                                  double timeout, std::vector<double>& solution,
+                                                                  const IKCallbackFn& solution_callback,
+                                                                  moveit_msgs::MoveItErrorCodes& error_code,
+                                                                  const KinematicsQueryOptions& options) const
+{
+  std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+  Pose pose(ik_pose);
+  const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
+  bool solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, solution_callback,
+                                                          error_code, options);
+  if (!solutionFound)
+  {
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+    solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution,
+                                                       solution_callback, error_code, options);
+  }
+  if (solutionFound)
+    cache_.updateCache(nearest, pose, solution);
+  return solutionFound;
+}
 
-    template<class KinematicsPlugin>
-    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-        const geometry_msgs::Pose &ik_pose,
-        const std::vector<double> &ik_seed_state,
-        double timeout,
-        std::vector<double> &solution,
-        const IKCallbackFn &solution_callback,
-        moveit_msgs::MoveItErrorCodes &error_code,
-        const KinematicsQueryOptions &options) const
-    {
-        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
-        Pose pose(ik_pose);
-        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
-        bool solutionFound =
-            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, solution_callback, error_code, options);
-        if (!solutionFound)
-        {
-            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution, solution_callback, error_code, options);
-        }
-        if (solutionFound)
-            cache_.updateCache(nearest, pose, solution);
-        return solutionFound;
-    }
+template <class KinematicsPlugin>
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+    const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+    const std::vector<double>& consistency_limits, std::vector<double>& solution, const IKCallbackFn& solution_callback,
+    moveit_msgs::MoveItErrorCodes& error_code, const KinematicsQueryOptions& options) const
+{
+  std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+  Pose pose(ik_pose);
+  const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
+  bool solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits,
+                                                          solution, solution_callback, error_code, options);
+  if (!solutionFound)
+  {
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+    solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits,
+                                                       solution, solution_callback, error_code, options);
+  }
+  if (solutionFound)
+    cache_.updateCache(nearest, pose, solution);
+  return solutionFound;
+}
 
-    template<class KinematicsPlugin>
-    bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-        const geometry_msgs::Pose &ik_pose,
-        const std::vector<double> &ik_seed_state,
-        double timeout,
-        const std::vector<double> &consistency_limits,
-        std::vector<double> &solution,
-        const IKCallbackFn &solution_callback,
-        moveit_msgs::MoveItErrorCodes &error_code,
-        const KinematicsQueryOptions &options) const
-    {
-        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
-        Pose pose(ik_pose);
-        const IKEntry &nearest = cache_.getBestApproximateIKSolution(pose);
-        bool solutionFound =
-            KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits, solution, solution_callback, error_code, options);
-        if (!solutionFound)
-        {
-            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-            solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits, solution, solution_callback, error_code, options);
-        }
-        if (solutionFound)
-            cache_.updateCache(nearest, pose, solution);
-        return solutionFound;
-    }
+template <class KinematicsPlugin>
+bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
+    const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state, double timeout,
+    const std::vector<double>& consistency_limits, std::vector<double>& solution, const IKCallbackFn& solution_callback,
+    moveit_msgs::MoveItErrorCodes& error_code, const KinematicsQueryOptions& options,
+    const moveit::core::RobotState* context_state) const
+{
+  std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
+  std::vector<Pose> poses(ik_poses.size());
+  for (unsigned int i = 0; i < poses.size(); ++i)
+    poses[i] = Pose(ik_poses[i]);
+  const IKEntry& nearest = CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.getBestApproximateIKSolution(poses);
+  bool solutionFound =
+      KinematicsPlugin::searchPositionIK(ik_poses, nearest.second, timeout, consistency_limits, solution,
+                                         solution_callback, error_code, options, context_state);
+  if (!solutionFound)
+  {
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
+    solutionFound = KinematicsPlugin::searchPositionIK(ik_poses, ik_seed_state, diff.count(), consistency_limits,
+                                                       solution, solution_callback, error_code, options, context_state);
+  }
 
-    template<class KinematicsPlugin>
-    bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-        const std::vector<geometry_msgs::Pose> &ik_poses,
-        const std::vector<double> &ik_seed_state,
-        double timeout,
-        const std::vector<double> &consistency_limits,
-        std::vector<double> &solution,
-        const IKCallbackFn &solution_callback,
-        moveit_msgs::MoveItErrorCodes &error_code,
-        const KinematicsQueryOptions &options,
-        const moveit::core::RobotState *context_state) const
-    {
-        std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
-        std::vector<Pose> poses(ik_poses.size());
-        for (unsigned int i = 0; i < poses.size(); ++i)
-            poses[i] = Pose(ik_poses[i]);
-        const IKEntry &nearest = CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.getBestApproximateIKSolution(poses);
-        bool solutionFound =
-            KinematicsPlugin::searchPositionIK(ik_poses, nearest.second, timeout, consistency_limits, solution, solution_callback, error_code, options, context_state);
-        if (!solutionFound)
-        {
-            std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-            solutionFound = KinematicsPlugin::searchPositionIK(ik_poses, ik_seed_state, diff.count(), consistency_limits, solution, solution_callback, error_code, options, context_state);
-        }
-
-        if (solutionFound)
-            CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.updateCache(nearest, poses, solution);
-        return solutionFound;
-    }
-
+  if (solutionFound)
+    CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.updateCache(nearest, poses, solution);
+  return solutionFound;
+}
 }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -64,6 +64,12 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& r
 
   cache_.initializeCache(robot_description, group_name, base_frame + tip_frame,
                          KinematicsPlugin::getJointNames().size());
+
+  // for debugging purposes:
+  // kdl_kinematics_plugin::KDLKinematicsPlugin fk;
+  // fk.initialize(robot_description, group_name, base_frame, tip_frame, search_discretization);
+  // cache_.verifyCache(fk);
+
   return true;
 }
 
@@ -97,11 +103,11 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(const geometry_ms
 {
   Pose pose(ik_pose);
   const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
-  bool solutionFound = KinematicsPlugin::getPositionIK(ik_pose, nearest.second, solution, error_code, options) ||
-                       KinematicsPlugin::getPositionIK(ik_pose, ik_seed_state, solution, error_code, options);
-  if (solutionFound)
+  bool solution_found = KinematicsPlugin::getPositionIK(ik_pose, nearest.second, solution, error_code, options) ||
+                        KinematicsPlugin::getPositionIK(ik_pose, ik_seed_state, solution, error_code, options);
+  if (solution_found)
     cache_.updateCache(nearest, pose, solution);
-  return solutionFound;
+  return solution_found;
 }
 
 template <class KinematicsPlugin>
@@ -114,17 +120,17 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry
   std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
   Pose pose(ik_pose);
   const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
-  bool solutionFound =
+  bool solution_found =
       KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, error_code, options);
-  if (!solutionFound)
+  if (!solution_found)
   {
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-    solutionFound =
+    solution_found =
         KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution, error_code, options);
   }
-  if (solutionFound)
+  if (solution_found)
     cache_.updateCache(nearest, pose, solution);
-  return solutionFound;
+  return solution_found;
 }
 
 template <class KinematicsPlugin>
@@ -136,17 +142,17 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
   std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
   Pose pose(ik_pose);
   const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
-  bool solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits,
-                                                          solution, error_code, options);
-  if (!solutionFound)
+  bool solution_found = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits,
+                                                           solution, error_code, options);
+  if (!solution_found)
   {
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-    solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits,
-                                                       solution, error_code, options);
+    solution_found = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits,
+                                                        solution, error_code, options);
   }
-  if (solutionFound)
+  if (solution_found)
     cache_.updateCache(nearest, pose, solution);
-  return solutionFound;
+  return solution_found;
 }
 
 template <class KinematicsPlugin>
@@ -160,17 +166,17 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry
   std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
   Pose pose(ik_pose);
   const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
-  bool solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution, solution_callback,
-                                                          error_code, options);
-  if (!solutionFound)
+  bool solution_found = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, solution,
+                                                           solution_callback, error_code, options);
+  if (!solution_found)
   {
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-    solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution,
-                                                       solution_callback, error_code, options);
+    solution_found = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), solution,
+                                                        solution_callback, error_code, options);
   }
-  if (solutionFound)
+  if (solution_found)
     cache_.updateCache(nearest, pose, solution);
-  return solutionFound;
+  return solution_found;
 }
 
 template <class KinematicsPlugin>
@@ -182,17 +188,17 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
   std::chrono::time_point<std::chrono::system_clock> start(std::chrono::system_clock::now());
   Pose pose(ik_pose);
   const IKEntry& nearest = cache_.getBestApproximateIKSolution(pose);
-  bool solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits,
-                                                          solution, solution_callback, error_code, options);
-  if (!solutionFound)
+  bool solution_found = KinematicsPlugin::searchPositionIK(ik_pose, nearest.second, timeout, consistency_limits,
+                                                           solution, solution_callback, error_code, options);
+  if (!solution_found)
   {
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-    solutionFound = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits,
-                                                       solution, solution_callback, error_code, options);
+    solution_found = KinematicsPlugin::searchPositionIK(ik_pose, ik_seed_state, diff.count(), consistency_limits,
+                                                        solution, solution_callback, error_code, options);
   }
-  if (solutionFound)
+  if (solution_found)
     cache_.updateCache(nearest, pose, solution);
-  return solutionFound;
+  return solution_found;
 }
 
 template <class KinematicsPlugin>
@@ -207,18 +213,19 @@ bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
   for (unsigned int i = 0; i < poses.size(); ++i)
     poses[i] = Pose(ik_poses[i]);
   const IKEntry& nearest = CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.getBestApproximateIKSolution(poses);
-  bool solutionFound =
+  bool solution_found =
       KinematicsPlugin::searchPositionIK(ik_poses, nearest.second, timeout, consistency_limits, solution,
                                          solution_callback, error_code, options, context_state);
-  if (!solutionFound)
+  if (!solution_found)
   {
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start;
-    solutionFound = KinematicsPlugin::searchPositionIK(ik_poses, ik_seed_state, diff.count(), consistency_limits,
-                                                       solution, solution_callback, error_code, options, context_state);
+    solution_found =
+        KinematicsPlugin::searchPositionIK(ik_poses, ik_seed_state, diff.count(), consistency_limits, solution,
+                                           solution_callback, error_code, options, context_state);
   }
 
-  if (solutionFound)
+  if (solution_found)
     CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.updateCache(nearest, poses, solution);
-  return solutionFound;
+  return solution_found;
 }
 }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -62,8 +62,16 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& r
     return false;
   }
 
+  IKCache::Options opts;
+  int max_cache_size;  // rosparam can't handle unsigned int
+  kinematics::KinematicsBase::lookupParam("max_cache_size", max_cache_size, static_cast<int>(opts.max_cache_size));
+  opts.max_cache_size = max_cache_size;
+  kinematics::KinematicsBase::lookupParam("min_pose_distance", opts.min_pose_distance, 1.0);
+  kinematics::KinematicsBase::lookupParam("min_joint_config_distance", opts.min_joint_config_distance, 1.0);
+  kinematics::KinematicsBase::lookupParam<std::string>("cached_ik_path", opts.cached_ik_path, "");
+
   cache_.initializeCache(robot_description, group_name, base_frame + tip_frame,
-                         KinematicsPlugin::getJointNames().size());
+                         KinematicsPlugin::getJointNames().size(), opts);
 
   // for debugging purposes:
   // kdl_kinematics_plugin::KDLKinematicsPlugin fk;

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -53,6 +53,17 @@ namespace cached_ik_kinematics_plugin
 class IKCache
 {
 public:
+  struct Options
+  {
+    Options() : max_cache_size(5000), min_pose_distance(1.0), min_joint_config_distance(1.0), cached_ik_path("")
+    {
+    }
+    unsigned int max_cache_size;
+    double min_pose_distance;
+    double min_joint_config_distance;
+    std::string cached_ik_path;
+  };
+
   /**
     \brief class to represent end effector pose
 
@@ -87,7 +98,7 @@ public:
   const IKEntry& getBestApproximateIKSolution(const std::vector<Pose>& poses) const;
   /** initialize cache, read from disk if found */
   void initializeCache(const std::string& robot_description, const std::string& group_name,
-                       const std::string& cache_name, const unsigned int num_joints);
+                       const std::string& cache_name, const unsigned int num_joints, Options opts = Options());
   /**
     insert (pose,config) as an entry if it's different enough from the
     most similar cache entry

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2017, Rice University
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Mark Moll */
 
@@ -49,221 +49,181 @@
 
 namespace cached_ik_kinematics_plugin
 {
-    /// \brief A cache of inverse kinematic solutions
-    class IKCache
-    {
-    public:
-        /// \brief class to represent end effector pose
-        ///
-        /// tf2::Transform stores orientation as a matrix, so we define our
-        /// own pose class that maps more directly to geometry_msgs::Pose and
-        // for which we can more easily define a distance metric.
-        struct Pose
-        {
-            Pose() = default;
-            Pose(const geometry_msgs::Pose& pose);
-            tf2::Vector3 position;
-            tf2::Quaternion orientation;
-            /// compute the distance between this pose and another pose
-            double distance(const Pose &pose) const;
-        };
+/// \brief A cache of inverse kinematic solutions
+class IKCache
+{
+public:
+  /// \brief class to represent end effector pose
+  ///
+  /// tf2::Transform stores orientation as a matrix, so we define our
+  /// own pose class that maps more directly to geometry_msgs::Pose and
+  // for which we can more easily define a distance metric.
+  struct Pose
+  {
+    Pose() = default;
+    Pose(const geometry_msgs::Pose& pose);
+    tf2::Vector3 position;
+    tf2::Quaternion orientation;
+    /// compute the distance between this pose and another pose
+    double distance(const Pose& pose) const;
+  };
 
-        /// the IK cache entries are simply a pair formed by a vector of poses
-        /// (one for each end effector) and a configuration that achieves those
-        /// poses
-        using IKEntry = std::pair<std::vector<Pose>, std::vector<double>>;
+  /// the IK cache entries are simply a pair formed by a vector of poses
+  /// (one for each end effector) and a configuration that achieves those
+  /// poses
+  using IKEntry = std::pair<std::vector<Pose>, std::vector<double>>;
 
-        IKCache();
-        ~IKCache();
-        IKCache(const IKCache &) = default;
+  IKCache();
+  ~IKCache();
+  IKCache(const IKCache&) = default;
 
-        /// get the entry from the IK cache that best matches a given pose
-        const IKEntry & getBestApproximateIKSolution(const Pose &pose) const;
-        /// get the entry from the IK cache that best matches a given vector of poses
-        const IKEntry & getBestApproximateIKSolution(const std::vector<Pose> &poses) const;
-        /// initialize cache, read from disk if found
-        void initializeCache(const std::string &robot_description, const std::string &group_name,
-                             const std::string &cache_name, const unsigned int num_joints);
-        /// insert (pose,config) as an entry if it's different enough from the
-        /// most similar cache entry
-        void updateCache(const IKEntry &nearest, const Pose &pose, const std::vector<double> &config) const;
-        /// insert (pose,config) as an entry if it's different enough from the
-        /// most similar cache entry
-        void updateCache(const IKEntry &nearest, const std::vector<Pose> &poses, const std::vector<double> &config) const;
+  /// get the entry from the IK cache that best matches a given pose
+  const IKEntry& getBestApproximateIKSolution(const Pose& pose) const;
+  /// get the entry from the IK cache that best matches a given vector of poses
+  const IKEntry& getBestApproximateIKSolution(const std::vector<Pose>& poses) const;
+  /// initialize cache, read from disk if found
+  void initializeCache(const std::string& robot_description, const std::string& group_name,
+                       const std::string& cache_name, const unsigned int num_joints);
+  /// insert (pose,config) as an entry if it's different enough from the
+  /// most similar cache entry
+  void updateCache(const IKEntry& nearest, const Pose& pose, const std::vector<double>& config) const;
+  /// insert (pose,config) as an entry if it's different enough from the
+  /// most similar cache entry
+  void updateCache(const IKEntry& nearest, const std::vector<Pose>& poses, const std::vector<double>& config) const;
 
-    protected:
-        /// compute the distance between two joint configurations
-        double configDistance2(const std::vector<double> &config1, const std::vector<double> &config2) const;
-        /// save current state of cache to disk
-        void saveCache() const;
-        /// verify with forward kinematics that that the cache entries are correct
-        void verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin &fk) const;
+protected:
+  /// compute the distance between two joint configurations
+  double configDistance2(const std::vector<double>& config1, const std::vector<double>& config2) const;
+  /// save current state of cache to disk
+  void saveCache() const;
+  /// verify with forward kinematics that that the cache entries are correct
+  void verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const;
 
-        /// number of joints in the system
-        unsigned int numJoints_;
+  /// number of joints in the system
+  unsigned int numJoints_;
 
-        /// for all cache entries, the poses are at least minPoseDistance_ apart ...
-        double minPoseDistance_;
-        /// ... or the configurations are at least minConfigDistance2_^.5 apart.
-        double minConfigDistance2_;
-        /// maximum size of the cache
-        unsigned int maxCacheSize_;
-        /// file name for loading / saving cache
-        boost::filesystem::path cacheFileName_;
+  /// for all cache entries, the poses are at least minPoseDistance_ apart ...
+  double minPoseDistance_;
+  /// ... or the configurations are at least minConfigDistance2_^.5 apart.
+  double minConfigDistance2_;
+  /// maximum size of the cache
+  unsigned int maxCacheSize_;
+  /// file name for loading / saving cache
+  boost::filesystem::path cacheFileName_;
 
-        // the IK methods are declared const in the base class, but the
-        // wrapped methods need to modify the cache, so the next four members
-        // are mutable
-        /// cache of IK solutions
-        mutable std::vector<IKEntry> ikCache_;
-        /// nearest neighbor data structure over IK cache entries
-        mutable ompl::NearestNeighborsGNAT<IKEntry*> ikNN_;
-        /// size of the cache when it was last saved
-        mutable unsigned int lastSavedCacheSize_{0};
-        /// mutex for changing IK cache
-        mutable std::mutex lock_;
-    };
+  // the IK methods are declared const in the base class, but the
+  // wrapped methods need to modify the cache, so the next four members
+  // are mutable
+  /// cache of IK solutions
+  mutable std::vector<IKEntry> ikCache_;
+  /// nearest neighbor data structure over IK cache entries
+  mutable ompl::NearestNeighborsGNAT<IKEntry*> ikNN_;
+  /// size of the cache when it was last saved
+  mutable unsigned int lastSavedCacheSize_{ 0 };
+  /// mutex for changing IK cache
+  mutable std::mutex lock_;
+};
 
-    /// a container of IK caches for cases where there is no fixed base frame
-    class IKCacheMap : public std::unordered_map<std::string, IKCache*>
-    {
-    public:
-        using IKEntry = IKCache::IKEntry;
-        using Pose = IKCache::Pose;
+/// a container of IK caches for cases where there is no fixed base frame
+class IKCacheMap : public std::unordered_map<std::string, IKCache*>
+{
+public:
+  using IKEntry = IKCache::IKEntry;
+  using Pose = IKCache::Pose;
 
-        IKCacheMap(const std::string &robot_description, const std::string &group_name, unsigned int num_joints);
-        ~IKCacheMap();
-        /// get the entry from the IK cache that best matches a given vector of
-        /// poses, with a specified set of fixed and active tip links
-        const IKEntry & getBestApproximateIKSolution(const std::vector<std::string> &fixed,
-            const std::vector<std::string> &active, const std::vector<Pose> &poses) const;
-        /// insert (pose,config) as an entry if it's different enough from the
-        /// most similar cache entry
-        void updateCache(const IKEntry &nearest, const std::vector<std::string> &fixed,
-            const std::vector<std::string> &active, const std::vector<Pose> &poses,
-            const std::vector<double> &config);
+  IKCacheMap(const std::string& robot_description, const std::string& group_name, unsigned int num_joints);
+  ~IKCacheMap();
+  /// get the entry from the IK cache that best matches a given vector of
+  /// poses, with a specified set of fixed and active tip links
+  const IKEntry& getBestApproximateIKSolution(const std::vector<std::string>& fixed,
+                                              const std::vector<std::string>& active,
+                                              const std::vector<Pose>& poses) const;
+  /// insert (pose,config) as an entry if it's different enough from the
+  /// most similar cache entry
+  void updateCache(const IKEntry& nearest, const std::vector<std::string>& fixed,
+                   const std::vector<std::string>& active, const std::vector<Pose>& poses,
+                   const std::vector<double>& config);
 
-    protected:
-        std::string getKey(const std::vector<std::string> &fixed, const std::vector<std::string> &active) const;
-        std::string robotDescription_;
-        std::string groupName_;
-        unsigned int numJoints_;
-    };
+protected:
+  std::string getKey(const std::vector<std::string>& fixed, const std::vector<std::string>& active) const;
+  std::string robotDescription_;
+  std::string groupName_;
+  unsigned int numJoints_;
+};
 
-    /// Caching wrapper for kinematics::KinematicsBase-derived IK solvers.
-    template<class KinematicsPlugin>
-    class CachedIKKinematicsPlugin : public KinematicsPlugin
-    {
-    public:
-        using Pose = IKCache::Pose;
-        using IKEntry = IKCache::IKEntry;
-        using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
-        using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
+/// Caching wrapper for kinematics::KinematicsBase-derived IK solvers.
+template <class KinematicsPlugin>
+class CachedIKKinematicsPlugin : public KinematicsPlugin
+{
+public:
+  using Pose = IKCache::Pose;
+  using IKEntry = IKCache::IKEntry;
+  using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
+  using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
 
-        CachedIKKinematicsPlugin();
+  CachedIKKinematicsPlugin();
 
-        ~CachedIKKinematicsPlugin();
+  ~CachedIKKinematicsPlugin();
 
-        // virtual methods that need to be wrapped:
+  // virtual methods that need to be wrapped:
 
-        bool getPositionIK(
-            const geometry_msgs::Pose &ik_pose,
-            const std::vector<double> &ik_seed_state,
-            std::vector<double> &solution,
-            moveit_msgs::MoveItErrorCodes &error_code,
-            const KinematicsQueryOptions &options=KinematicsQueryOptions()
-        ) const override;
+  bool getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                     std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                     const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-        bool initialize(
-            const std::string &robot_description,
-            const std::string &group_name,
-            const std::string &base_frame,
-            const std::string &tip_frame,
-            double search_discretization
-        ) override;
+  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
+                  const std::string& tip_frame, double search_discretization) override;
 
-        bool searchPositionIK(
-            const geometry_msgs::Pose &ik_pose,
-            const std::vector<double> &ik_seed_state,
-            double timeout,
-            std::vector<double> &solution,
-            moveit_msgs::MoveItErrorCodes &error_code,
-            const KinematicsQueryOptions &options=KinematicsQueryOptions()
-        ) const override;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                        const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-        bool searchPositionIK(
-            const geometry_msgs::Pose &ik_pose,
-            const std::vector<double> &ik_seed_state,
-            double timeout,
-            const std::vector<double> &consistency_limits,
-            std::vector<double> &solution,
-            moveit_msgs::MoveItErrorCodes &error_code,
-            const KinematicsQueryOptions &options=KinematicsQueryOptions()
-        ) const override;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        moveit_msgs::MoveItErrorCodes& error_code,
+                        const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-        bool searchPositionIK(
-            const geometry_msgs::Pose &ik_pose,
-            const std::vector<double> &ik_seed_state,
-            double timeout,
-            std::vector<double> &solution,
-            const IKCallbackFn &solution_callback,
-            moveit_msgs::MoveItErrorCodes &error_code,
-            const KinematicsQueryOptions &options=KinematicsQueryOptions()
-        ) const override;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                        moveit_msgs::MoveItErrorCodes& error_code,
+                        const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-        bool searchPositionIK(
-            const geometry_msgs::Pose &ik_pose,
-            const std::vector<double> &ik_seed_state,
-            double timeout,
-            const std::vector<double> &consistency_limits,
-            std::vector<double> &solution,
-            const IKCallbackFn &solution_callback,
-            moveit_msgs::MoveItErrorCodes &error_code,
-            const KinematicsQueryOptions &options=KinematicsQueryOptions()
-        ) const override;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+                        const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-    protected:
-        IKCache cache_;
-    };
+protected:
+  IKCache cache_;
+};
 
-    /// Caching wrapper for IK solvers that implement the multi-tip API.
-    ///
-    /// Most solvers don't implement this, so the CachedIKKinematicsPlugin
-    /// base class simply doesn't wrap the relevant methods and the
-    /// implementation in the abstract base class will be called. Ideally,
-    /// the two cache wrapper classes would be combined, but it's tricky to
-    /// call a method in kinematics::KinematicsBase or KinematicsPlugin
-    /// depending on whether KinematicsPlugin has overridden that method or
-    /// not (although it can be done with some template meta-programming).
-    template<class KinematicsPlugin>
-    class CachedMultiTipIKKinematicsPlugin : public CachedIKKinematicsPlugin<KinematicsPlugin>
-    {
-    public:
-        using Pose = IKCache::Pose;
-        using IKEntry = IKCache::IKEntry;
-        using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
-        using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
+/// Caching wrapper for IK solvers that implement the multi-tip API.
+///
+/// Most solvers don't implement this, so the CachedIKKinematicsPlugin
+/// base class simply doesn't wrap the relevant methods and the
+/// implementation in the abstract base class will be called. Ideally,
+/// the two cache wrapper classes would be combined, but it's tricky to
+/// call a method in kinematics::KinematicsBase or KinematicsPlugin
+/// depending on whether KinematicsPlugin has overridden that method or
+/// not (although it can be done with some template meta-programming).
+template <class KinematicsPlugin>
+class CachedMultiTipIKKinematicsPlugin : public CachedIKKinematicsPlugin<KinematicsPlugin>
+{
+public:
+  using Pose = IKCache::Pose;
+  using IKEntry = IKCache::IKEntry;
+  using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
+  using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
 
-        bool initialize(
-            const std::string &robot_description,
-            const std::string &group_name,
-            const std::string &base_frame,
-            const std::vector<std::string> &tip_frames,
-            double search_discretization
-        ) override;
+  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
+                  const std::vector<std::string>& tip_frames, double search_discretization) override;
 
-        bool searchPositionIK(
-            const std::vector<geometry_msgs::Pose> &ik_poses,
-            const std::vector<double> &ik_seed_state,
-            double timeout,
-            const std::vector<double> &consistency_limits,
-            std::vector<double> &solution,
-            const IKCallbackFn &solution_callback,
-            moveit_msgs::MoveItErrorCodes &error_code,
-            const KinematicsQueryOptions &options=KinematicsQueryOptions(),
-            const moveit::core::RobotState *context_state=nullptr
-        ) const override;
-    };
+  bool searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
+                        double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+                        const KinematicsQueryOptions& options = KinematicsQueryOptions(),
+                        const moveit::core::RobotState* context_state = nullptr) const override;
+};
 }
 
 #include "cached_ik_kinematics_plugin-inl.h"

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -1,0 +1,270 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mark Moll */
+
+#ifndef MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_PLUGIN_
+#define MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_PLUGIN_
+
+#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <ompl/datastructures/NearestNeighborsGNAT.h>
+#include <boost/filesystem.hpp>
+#include <unordered_map>
+#include <mutex>
+#include <utility>
+
+namespace cached_ik_kinematics_plugin
+{
+    /// \brief A cache of inverse kinematic solutions
+    class IKCache
+    {
+    public:
+        /// \brief class to represent end effector pose
+        ///
+        /// tf2::Transform stores orientation as a matrix, so we define our
+        /// own pose class that maps more directly to geometry_msgs::Pose and
+        // for which we can more easily define a distance metric.
+        struct Pose
+        {
+            Pose() = default;
+            Pose(const geometry_msgs::Pose& pose);
+            tf2::Vector3 position;
+            tf2::Quaternion orientation;
+            /// compute the distance between this pose and another pose
+            double distance(const Pose &pose) const;
+        };
+
+        /// the IK cache entries are simply a pair formed by a vector of poses
+        /// (one for each end effector) and a configuration that achieves those
+        /// poses
+        using IKEntry = std::pair<std::vector<Pose>, std::vector<double>>;
+
+        IKCache();
+        ~IKCache();
+        IKCache(const IKCache &) = default;
+
+        /// get the entry from the IK cache that best matches a given pose
+        const IKEntry & getBestApproximateIKSolution(const Pose &pose) const;
+        /// get the entry from the IK cache that best matches a given vector of poses
+        const IKEntry & getBestApproximateIKSolution(const std::vector<Pose> &poses) const;
+        /// initialize cache, read from disk if found
+        void initializeCache(const std::string &robot_description, const std::string &group_name,
+                             const std::string &cache_name, const unsigned int num_joints);
+        /// insert (pose,config) as an entry if it's different enough from the
+        /// most similar cache entry
+        void updateCache(const IKEntry &nearest, const Pose &pose, const std::vector<double> &config) const;
+        /// insert (pose,config) as an entry if it's different enough from the
+        /// most similar cache entry
+        void updateCache(const IKEntry &nearest, const std::vector<Pose> &poses, const std::vector<double> &config) const;
+
+    protected:
+        /// compute the distance between two joint configurations
+        double configDistance2(const std::vector<double> &config1, const std::vector<double> &config2) const;
+        /// save current state of cache to disk
+        void saveCache() const;
+        /// verify with forward kinematics that that the cache entries are correct
+        void verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin &fk) const;
+
+        /// number of joints in the system
+        unsigned int numJoints_;
+
+        /// for all cache entries, the poses are at least minPoseDistance_ apart ...
+        double minPoseDistance_;
+        /// ... or the configurations are at least minConfigDistance2_^.5 apart.
+        double minConfigDistance2_;
+        /// maximum size of the cache
+        unsigned int maxCacheSize_;
+        /// file name for loading / saving cache
+        boost::filesystem::path cacheFileName_;
+
+        // the IK methods are declared const in the base class, but the
+        // wrapped methods need to modify the cache, so the next four members
+        // are mutable
+        /// cache of IK solutions
+        mutable std::vector<IKEntry> ikCache_;
+        /// nearest neighbor data structure over IK cache entries
+        mutable ompl::NearestNeighborsGNAT<IKEntry*> ikNN_;
+        /// size of the cache when it was last saved
+        mutable unsigned int lastSavedCacheSize_{0};
+        /// mutex for changing IK cache
+        mutable std::mutex lock_;
+    };
+
+    /// a container of IK caches for cases where there is no fixed base frame
+    class IKCacheMap : public std::unordered_map<std::string, IKCache*>
+    {
+    public:
+        using IKEntry = IKCache::IKEntry;
+        using Pose = IKCache::Pose;
+
+        IKCacheMap(const std::string &robot_description, const std::string &group_name, unsigned int num_joints);
+        ~IKCacheMap();
+        /// get the entry from the IK cache that best matches a given vector of
+        /// poses, with a specified set of fixed and active tip links
+        const IKEntry & getBestApproximateIKSolution(const std::vector<std::string> &fixed,
+            const std::vector<std::string> &active, const std::vector<Pose> &poses) const;
+        /// insert (pose,config) as an entry if it's different enough from the
+        /// most similar cache entry
+        void updateCache(const IKEntry &nearest, const std::vector<std::string> &fixed,
+            const std::vector<std::string> &active, const std::vector<Pose> &poses,
+            const std::vector<double> &config);
+
+    protected:
+        std::string getKey(const std::vector<std::string> &fixed, const std::vector<std::string> &active) const;
+        std::string robotDescription_;
+        std::string groupName_;
+        unsigned int numJoints_;
+    };
+
+    /// Caching wrapper for kinematics::KinematicsBase-derived IK solvers.
+    template<class KinematicsPlugin>
+    class CachedIKKinematicsPlugin : public KinematicsPlugin
+    {
+    public:
+        using Pose = IKCache::Pose;
+        using IKEntry = IKCache::IKEntry;
+        using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
+        using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
+
+        CachedIKKinematicsPlugin();
+
+        ~CachedIKKinematicsPlugin();
+
+        // virtual methods that need to be wrapped:
+
+        bool getPositionIK(
+            const geometry_msgs::Pose &ik_pose,
+            const std::vector<double> &ik_seed_state,
+            std::vector<double> &solution,
+            moveit_msgs::MoveItErrorCodes &error_code,
+            const KinematicsQueryOptions &options=KinematicsQueryOptions()
+        ) const override;
+
+        bool initialize(
+            const std::string &robot_description,
+            const std::string &group_name,
+            const std::string &base_frame,
+            const std::string &tip_frame,
+            double search_discretization
+        ) override;
+
+        bool searchPositionIK(
+            const geometry_msgs::Pose &ik_pose,
+            const std::vector<double> &ik_seed_state,
+            double timeout,
+            std::vector<double> &solution,
+            moveit_msgs::MoveItErrorCodes &error_code,
+            const KinematicsQueryOptions &options=KinematicsQueryOptions()
+        ) const override;
+
+        bool searchPositionIK(
+            const geometry_msgs::Pose &ik_pose,
+            const std::vector<double> &ik_seed_state,
+            double timeout,
+            const std::vector<double> &consistency_limits,
+            std::vector<double> &solution,
+            moveit_msgs::MoveItErrorCodes &error_code,
+            const KinematicsQueryOptions &options=KinematicsQueryOptions()
+        ) const override;
+
+        bool searchPositionIK(
+            const geometry_msgs::Pose &ik_pose,
+            const std::vector<double> &ik_seed_state,
+            double timeout,
+            std::vector<double> &solution,
+            const IKCallbackFn &solution_callback,
+            moveit_msgs::MoveItErrorCodes &error_code,
+            const KinematicsQueryOptions &options=KinematicsQueryOptions()
+        ) const override;
+
+        bool searchPositionIK(
+            const geometry_msgs::Pose &ik_pose,
+            const std::vector<double> &ik_seed_state,
+            double timeout,
+            const std::vector<double> &consistency_limits,
+            std::vector<double> &solution,
+            const IKCallbackFn &solution_callback,
+            moveit_msgs::MoveItErrorCodes &error_code,
+            const KinematicsQueryOptions &options=KinematicsQueryOptions()
+        ) const override;
+
+    protected:
+        IKCache cache_;
+    };
+
+    /// Caching wrapper for IK solvers that implement the multi-tip API.
+    ///
+    /// Most solvers don't implement this, so the CachedIKKinematicsPlugin
+    /// base class simply doesn't wrap the relevant methods and the
+    /// implementation in the abstract base class will be called. Ideally,
+    /// the two cache wrapper classes would be combined, but it's tricky to
+    /// call a method in kinematics::KinematicsBase or KinematicsPlugin
+    /// depending on whether KinematicsPlugin has overridden that method or
+    /// not (although it can be done with some template meta-programming).
+    template<class KinematicsPlugin>
+    class CachedMultiTipIKKinematicsPlugin : public CachedIKKinematicsPlugin<KinematicsPlugin>
+    {
+    public:
+        using Pose = IKCache::Pose;
+        using IKEntry = IKCache::IKEntry;
+        using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
+        using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
+
+        bool initialize(
+            const std::string &robot_description,
+            const std::string &group_name,
+            const std::string &base_frame,
+            const std::vector<std::string> &tip_frames,
+            double search_discretization
+        ) override;
+
+        bool searchPositionIK(
+            const std::vector<geometry_msgs::Pose> &ik_poses,
+            const std::vector<double> &ik_seed_state,
+            double timeout,
+            const std::vector<double> &consistency_limits,
+            std::vector<double> &solution,
+            const IKCallbackFn &solution_callback,
+            moveit_msgs::MoveItErrorCodes &error_code,
+            const KinematicsQueryOptions &options=KinematicsQueryOptions(),
+            const moveit::core::RobotState *context_state=nullptr
+        ) const override;
+    };
+}
+
+#include "cached_ik_kinematics_plugin-inl.h"
+#endif

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -1,0 +1,132 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mark Moll */
+
+// This file is a slightly modified version of <ompl/datastructures/GreedyKCenters.h>
+
+#ifndef MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_GREEDY_K_CENTERS_
+#define MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_GREEDY_K_CENTERS_
+
+#include <functional>
+#include <boost/numeric/ublas/matrix.hpp>
+
+namespace cached_ik_kinematics_plugin
+{
+/** \brief An instance of this class can be used to greedily select a given
+    number of representatives from a set of data points that are all far
+    apart from each other. */
+template <typename _T>
+class GreedyKCenters
+{
+public:
+  /** \brief The definition of a distance function */
+  using DistanceFunction = std::function<double(const _T&, const _T&)>;
+  /** \brief A matrix type for storing distances between points and centers */
+  using Matrix = boost::numeric::ublas::matrix<double>;
+
+  GreedyKCenters() = default;
+
+  virtual ~GreedyKCenters() = default;
+
+  /** \brief Set the distance function to use */
+  void setDistanceFunction(const DistanceFunction& distFun)
+  {
+    distFun_ = distFun;
+  }
+
+  /** \brief Get the distance function used */
+  const DistanceFunction& getDistanceFunction() const
+  {
+    return distFun_;
+  }
+
+  /** \brief Greedy algorithm for selecting k centers
+      \param data a vector of data points
+      \param k the desired number of centers
+      \param centers a vector of length k containing the indices into
+          data of the k centers
+      \param dists a matrix such that dists(i,j) is the distance
+          between data[i] and data[center[j]]
+  */
+  void kcenters(const std::vector<_T>& data, unsigned int k, std::vector<unsigned int>& centers, Matrix& dists)
+  {
+    // array containing the minimum distance between each data point
+    // and the centers computed so far
+    std::vector<double> minDist(data.size(), std::numeric_limits<double>::infinity());
+
+    centers.clear();
+    centers.reserve(k);
+    if (dists.size1() < data.size() || dists.size2() < k)
+      dists.resize(std::max(2 * dists.size1() + 1, data.size()), k, false);
+    // first center is picked randomly
+    centers.push_back(std::uniform_int_distribution<size_t>{ 0, data.size() - 1 }(generator_));
+    for (unsigned i = 1; i < k; ++i)
+    {
+      unsigned ind;
+      const _T& center = data[centers[i - 1]];
+      double maxDist = -std::numeric_limits<double>::infinity();
+      for (unsigned j = 0; j < data.size(); ++j)
+      {
+        if ((dists(j, i - 1) = distFun_(data[j], center)) < minDist[j])
+          minDist[j] = dists(j, i - 1);
+        // the j-th center is the one furthest away from center 0,..,j-1
+        if (minDist[j] > maxDist)
+        {
+          ind = j;
+          maxDist = minDist[j];
+        }
+      }
+      // no more centers available
+      if (maxDist < std::numeric_limits<double>::epsilon())
+        break;
+      centers.push_back(ind);
+    }
+
+    const _T& center = data[centers.back()];
+    unsigned i = centers.size() - 1;
+    for (unsigned j = 0; j < data.size(); ++j)
+      dists(j, i) = distFun_(data[j], center);
+  }
+
+protected:
+  /** \brief The used distance function */
+  DistanceFunction distFun_;
+
+  /** Random number generator used to select first center */
+  std::mt19937 generator_{ std::random_device{}() };
+};
+}
+
+#endif

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -40,6 +40,7 @@
 #define MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_GREEDY_K_CENTERS_
 
 #include <functional>
+#include <random>
 #include <boost/numeric/ublas/matrix.hpp>
 
 namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighbors.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighbors.h
@@ -1,0 +1,120 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan */
+
+// This file is a slightly modified version of <ompl/datastructures/NearestNeighbors.h>
+
+#ifndef MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_NEAREST_NEIGHBORS_
+#define MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_NEAREST_NEIGHBORS_
+
+#include <vector>
+#include <functional>
+
+namespace cached_ik_kinematics_plugin
+{
+/** \brief Abstract representation of a container that can perform nearest neighbors queries */
+template <typename _T>
+class NearestNeighbors
+{
+public:
+  /** \brief The definition of a distance function */
+  typedef std::function<double(const _T&, const _T&)> DistanceFunction;
+
+  NearestNeighbors() = default;
+
+  virtual ~NearestNeighbors() = default;
+
+  /** \brief Set the distance function to use */
+  virtual void setDistanceFunction(const DistanceFunction& distFun)
+  {
+    distFun_ = distFun;
+  }
+
+  /** \brief Get the distance function used */
+  const DistanceFunction& getDistanceFunction() const
+  {
+    return distFun_;
+  }
+
+  /** \brief Return true if the solutions reported by this data structure
+      are sorted, when calling nearestK / nearestR. */
+  virtual bool reportsSortedResults() const = 0;
+
+  /** \brief Clear the datastructure */
+  virtual void clear() = 0;
+
+  /** \brief Add an element to the datastructure */
+  virtual void add(const _T& data) = 0;
+
+  /** \brief Add a vector of points */
+  virtual void add(const std::vector<_T>& data)
+  {
+    for (auto elt = data.begin(); elt != data.end(); ++elt)
+      add(*elt);
+  }
+
+  /** \brief Remove an element from the datastructure */
+  virtual bool remove(const _T& data) = 0;
+
+  /** \brief Get the nearest neighbor of a point */
+  virtual _T nearest(const _T& data) const = 0;
+
+  /** \brief Get the k-nearest neighbors of a point
+   *
+   * All the nearest neighbor structures currently return the neighbors in
+   * sorted order, but this is not required.
+   */
+  virtual void nearestK(const _T& data, std::size_t k, std::vector<_T>& nbh) const = 0;
+
+  /** \brief Get the nearest neighbors of a point, within a specified radius
+   *
+   * All the nearest neighbor structures currently return the neighbors in
+   * sorted order, but this is not required.
+   */
+  virtual void nearestR(const _T& data, double radius, std::vector<_T>& nbh) const = 0;
+
+  /** \brief Get the number of elements in the datastructure */
+  virtual std::size_t size() const = 0;
+
+  /** \brief Get all the elements in the datastructure */
+  virtual void list(std::vector<_T>& data) const = 0;
+
+protected:
+  /** \brief The used distance function */
+  DistanceFunction distFun_;
+};
+}
+
+#endif

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -1,0 +1,725 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mark Moll, Bryant Gipson */
+
+// This file is a slightly modified version of <ompl/datastructures/NearestNeighborsGNAT.h>
+
+#ifndef MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_NEAREST_NEIGHBORS_GNAT_
+#define MOVEIT_ROS_PLANNING_CACHED_IK_KINEMATICS_NEAREST_NEIGHBORS_GNAT_
+
+#include "NearestNeighbors.h"
+#include "GreedyKCenters.h"
+#include <moveit/exceptions/exceptions.h>
+#include <unordered_set>
+#include <queue>
+#include <algorithm>
+#include <utility>
+
+namespace cached_ik_kinematics_plugin
+{
+/** \brief Geometric Near-neighbor Access Tree (GNAT), a data
+    structure for nearest neighbor search.
+
+    If GNAT_SAMPLER is defined, then extra code will be enabled to sample
+    elements from the GNAT with probability inversely proportial to their
+    local density.
+
+    @par External documentation
+    S. Brin, Near neighbor search in large metric spaces, in <em>Proc. 21st
+    Conf. on Very Large Databases (VLDB)</em>, pp. 574–584, 1995.
+
+    B. Gipson, M. Moll, and L.E. Kavraki, Resolution independent density
+     estimation for motion planning in high-dimensional spaces, in
+    <em>IEEE Intl. Conf. on Robotics and Automation</em>, 2013.
+    [[PDF]](http://kavrakilab.org/sites/default/files/2013%20resolution%20independent%20density%20estimation%20for%20motion.pdf)
+*/
+template <typename _T>
+class NearestNeighborsGNAT : public NearestNeighbors<_T>
+{
+protected:
+  // \cond IGNORE
+  // internally, we use a priority queue for nearest neighbors, paired
+  // with their distance to the query point
+  using DataDist = std::pair<const _T*, double>;
+  struct DataDistCompare
+  {
+    bool operator()(const DataDist& d0, const DataDist& d1)
+    {
+      return d0.second < d1.second;
+    }
+  };
+  using NearQueue = std::priority_queue<DataDist, std::vector<DataDist>, DataDistCompare>;
+
+  // another internal data structure is a priority queue of nodes to
+  // check next for possible nearest neighbors
+  class Node;
+  using NodeDist = std::pair<Node*, double>;
+  struct NodeDistCompare
+  {
+    bool operator()(const NodeDist& n0, const NodeDist& n1) const
+    {
+      return (n0.second - n0.first->maxRadius_) > (n1.second - n1.first->maxRadius_);
+    }
+  };
+  using NodeQueue = std::priority_queue<NodeDist, std::vector<NodeDist>, NodeDistCompare>;
+  // \endcond
+
+public:
+  NearestNeighborsGNAT(unsigned int degree = 8, unsigned int minDegree = 4, unsigned int maxDegree = 12,
+                       unsigned int maxNumPtsPerLeaf = 50, unsigned int removedCacheSize = 500,
+                       bool rebalancing = false)
+    : NearestNeighbors<_T>()
+    , degree_(degree)
+    , minDegree_(std::min(degree, minDegree))
+    , maxDegree_(std::max(maxDegree, degree))
+    , maxNumPtsPerLeaf_(maxNumPtsPerLeaf)
+    , rebuildSize_(rebalancing ? maxNumPtsPerLeaf * degree : std::numeric_limits<std::size_t>::max())
+    , removedCacheSize_(removedCacheSize)
+  {
+  }
+
+  ~NearestNeighborsGNAT() override
+  {
+    if (tree_)
+      delete tree_;
+  }
+  // \brief Set the distance function to use
+  void setDistanceFunction(const typename NearestNeighbors<_T>::DistanceFunction& distFun) override
+  {
+    NearestNeighbors<_T>::setDistanceFunction(distFun);
+    pivotSelector_.setDistanceFunction(distFun);
+    if (tree_)
+      rebuildDataStructure();
+  }
+
+  void clear() override
+  {
+    if (tree_)
+    {
+      delete tree_;
+      tree_ = nullptr;
+    }
+    size_ = 0;
+    removed_.clear();
+    if (rebuildSize_ != std::numeric_limits<std::size_t>::max())
+      rebuildSize_ = maxNumPtsPerLeaf_ * degree_;
+  }
+
+  bool reportsSortedResults() const override
+  {
+    return true;
+  }
+
+  void add(const _T& data) override
+  {
+    if (tree_)
+    {
+      if (isRemoved(data))
+        rebuildDataStructure();
+      tree_->add(*this, data);
+    }
+    else
+    {
+      tree_ = new Node(degree_, maxNumPtsPerLeaf_, data);
+      size_ = 1;
+    }
+  }
+  void add(const std::vector<_T>& data) override
+  {
+    if (tree_)
+      NearestNeighbors<_T>::add(data);
+    else if (!data.empty())
+    {
+      tree_ = new Node(degree_, maxNumPtsPerLeaf_, data[0]);
+      for (unsigned int i = 1; i < data.size(); ++i)
+        tree_->data_.push_back(data[i]);
+      size_ += data.size();
+      if (tree_->needToSplit(*this))
+        tree_->split(*this);
+    }
+  }
+  // \brief Rebuild the internal data structure.
+  void rebuildDataStructure()
+  {
+    std::vector<_T> lst;
+    list(lst);
+    clear();
+    add(lst);
+  }
+  // \brief Remove data from the tree.
+  // The element won't actually be removed immediately, but just marked
+  // for removal in the removed_ cache. When the cache is full, the tree
+  // will be rebuilt and the elements marked for removal will actually
+  // be removed.
+  bool remove(const _T& data) override
+  {
+    if (size_ == 0u)
+      return false;
+    NearQueue nbhQueue;
+    // find data in tree
+    bool isPivot = nearestKInternal(data, 1, nbhQueue);
+    const _T* d = nbhQueue.top().first;
+    if (*d != data)
+      return false;
+    removed_.insert(d);
+    size_--;
+    // if we removed a pivot or if the capacity of removed elements
+    // has been reached, we rebuild the entire GNAT
+    if (isPivot || removed_.size() >= removedCacheSize_)
+      rebuildDataStructure();
+    return true;
+  }
+
+  _T nearest(const _T& data) const override
+  {
+    if (size_)
+    {
+      NearQueue nbhQueue;
+      nearestKInternal(data, 1, nbhQueue);
+      if (!nbhQueue.empty())
+        return *nbhQueue.top().first;
+    }
+    throw moveit::Exception("No elements found in nearest neighbors data structure");
+  }
+
+  // Return the k nearest neighbors in sorted order
+  void nearestK(const _T& data, std::size_t k, std::vector<_T>& nbh) const override
+  {
+    nbh.clear();
+    if (k == 0)
+      return;
+    if (size_)
+    {
+      NearQueue nbhQueue;
+      nearestKInternal(data, k, nbhQueue);
+      postprocessNearest(nbhQueue, nbh);
+    }
+  }
+
+  // Return the nearest neighbors within distance \c radius in sorted order
+  void nearestR(const _T& data, double radius, std::vector<_T>& nbh) const override
+  {
+    nbh.clear();
+    if (size_)
+    {
+      NearQueue nbhQueue;
+      nearestRInternal(data, radius, nbhQueue);
+      postprocessNearest(nbhQueue, nbh);
+    }
+  }
+
+  std::size_t size() const override
+  {
+    return size_;
+  }
+
+  void list(std::vector<_T>& data) const override
+  {
+    data.clear();
+    data.reserve(size());
+    if (tree_)
+      tree_->list(*this, data);
+  }
+
+  // \brief Print a GNAT structure (mostly useful for debugging purposes).
+  friend std::ostream& operator<<(std::ostream& out, const NearestNeighborsGNAT<_T>& gnat)
+  {
+    if (gnat.tree_)
+    {
+      out << *gnat.tree_;
+      if (!gnat.removed_.empty())
+      {
+        out << "Elements marked for removal:\n";
+        for (typename std::unordered_set<const _T*>::const_iterator it = gnat.removed_.begin();
+             it != gnat.removed_.end(); it++)
+          out << **it << '\t';
+        out << std::endl;
+      }
+    }
+    return out;
+  }
+
+  // for debugging purposes
+  void integrityCheck()
+  {
+    std::vector<_T> lst;
+    std::unordered_set<const _T*> tmp;
+    // get all elements, including those marked for removal
+    removed_.swap(tmp);
+    list(lst);
+    // check if every element marked for removal is also in the tree
+    for (typename std::unordered_set<const _T*>::iterator it = tmp.begin(); it != tmp.end(); it++)
+    {
+      unsigned int i;
+      for (i = 0; i < lst.size(); ++i)
+        if (lst[i] == **it)
+          break;
+      if (i == lst.size())
+      {
+        // an element marked for removal is not actually in the tree
+        std::cout << "***** FAIL!! ******\n" << *this << '\n';
+        for (unsigned int j = 0; j < lst.size(); ++j)
+          std::cout << lst[j] << '\t';
+        std::cout << std::endl;
+      }
+      assert(i != lst.size());
+    }
+    // restore
+    removed_.swap(tmp);
+    // get elements in the tree with elements marked for removal purged from the list
+    list(lst);
+    if (lst.size() != size_)
+      std::cout << "#########################################\n" << *this << std::endl;
+    assert(lst.size() == size_);
+  }
+
+protected:
+  using GNAT = NearestNeighborsGNAT<_T>;
+
+  // Return true iff data has been marked for removal.
+  bool isRemoved(const _T& data) const
+  {
+    return !removed_.empty() && removed_.find(&data) != removed_.end();
+  }
+
+  // \brief Return in nbhQueue the k nearest neighbors of data.
+  // For k=1, return true if the nearest neighbor is a pivot.
+  // (which is important during removal; removing pivots is a
+  // special case).
+  bool nearestKInternal(const _T& data, std::size_t k, NearQueue& nbhQueue) const
+  {
+    bool isPivot;
+    double dist;
+    NodeDist nodeDist;
+    NodeQueue nodeQueue;
+
+    dist = NearestNeighbors<_T>::distFun_(data, tree_->pivot_);
+    isPivot = tree_->insertNeighborK(nbhQueue, k, tree_->pivot_, data, dist);
+    tree_->nearestK(*this, data, k, nbhQueue, nodeQueue, isPivot);
+    while (!nodeQueue.empty())
+    {
+      dist = nbhQueue.top().second;  // note the difference with nearestRInternal
+      nodeDist = nodeQueue.top();
+      nodeQueue.pop();
+      if (nbhQueue.size() == k &&
+          (nodeDist.second > nodeDist.first->maxRadius_ + dist || nodeDist.second < nodeDist.first->minRadius_ - dist))
+        continue;
+      nodeDist.first->nearestK(*this, data, k, nbhQueue, nodeQueue, isPivot);
+    }
+    return isPivot;
+  }
+  // \brief Return in nbhQueue the elements that are within distance radius of data.
+  void nearestRInternal(const _T& data, double radius, NearQueue& nbhQueue) const
+  {
+    double dist = radius;  // note the difference with nearestKInternal
+    NodeQueue nodeQueue;
+    NodeDist nodeDist;
+
+    tree_->insertNeighborR(nbhQueue, radius, tree_->pivot_, NearestNeighbors<_T>::distFun_(data, tree_->pivot_));
+    tree_->nearestR(*this, data, radius, nbhQueue, nodeQueue);
+    while (!nodeQueue.empty())
+    {
+      nodeDist = nodeQueue.top();
+      nodeQueue.pop();
+      if (nodeDist.second > nodeDist.first->maxRadius_ + dist || nodeDist.second < nodeDist.first->minRadius_ - dist)
+        continue;
+      nodeDist.first->nearestR(*this, data, radius, nbhQueue, nodeQueue);
+    }
+  }
+  // \brief Convert the internal data structure used for storing neighbors
+  // to the vector that NearestNeighbor API requires.
+  void postprocessNearest(NearQueue& nbhQueue, std::vector<_T>& nbh) const
+  {
+    typename std::vector<_T>::reverse_iterator it;
+    nbh.resize(nbhQueue.size());
+    for (it = nbh.rbegin(); it != nbh.rend(); it++, nbhQueue.pop())
+      *it = *nbhQueue.top().first;
+  }
+
+  // The class used internally to define the GNAT.
+  class Node
+  {
+  public:
+    // \brief Construct a node of given degree with at most
+    // \e capacity data elements and with given pivot.
+    Node(int degree, int capacity, _T pivot)
+      : degree_(degree)
+      , pivot_(std::move(pivot))
+      , minRadius_(std::numeric_limits<double>::infinity())
+      , maxRadius_(-minRadius_)
+      , minRange_(degree, minRadius_)
+      , maxRange_(degree, maxRadius_)
+    {
+      // The "+1" is needed because we add an element before we check whether to split
+      data_.reserve(capacity + 1);
+    }
+
+    ~Node()
+    {
+      for (unsigned int i = 0; i < children_.size(); ++i)
+        delete children_[i];
+    }
+
+    // \brief Update minRadius_ and maxRadius_, given that an element
+    // was added with distance dist to the pivot.
+    void updateRadius(double dist)
+    {
+      if (minRadius_ > dist)
+        minRadius_ = dist;
+#ifndef GNAT_SAMPLER
+      if (maxRadius_ < dist)
+        maxRadius_ = dist;
+#else
+      if (maxRadius_ < dist)
+      {
+        maxRadius_ = dist;
+        activity_ = 0;
+      }
+      else
+        activity_ = std::max(-32, activity_ - 1);
+#endif
+    }
+    // \brief Update minRange_[i] and maxRange_[i], given that an
+    // element was added to the i-th child of the parent that has
+    // distance dist to this Node's pivot.
+    void updateRange(unsigned int i, double dist)
+    {
+      if (minRange_[i] > dist)
+        minRange_[i] = dist;
+      if (maxRange_[i] < dist)
+        maxRange_[i] = dist;
+    }
+    // Add an element to the tree rooted at this node.
+    void add(GNAT& gnat, const _T& data)
+    {
+      if (children_.empty())
+      {
+        data_.push_back(data);
+        gnat.size_++;
+        if (needToSplit(gnat))
+        {
+          if (!gnat.removed_.empty())
+            gnat.rebuildDataStructure();
+          else if (gnat.size_ >= gnat.rebuildSize_)
+          {
+            gnat.rebuildSize_ <<= 1;
+            gnat.rebuildDataStructure();
+          }
+          else
+            split(gnat);
+        }
+      }
+      else
+      {
+        std::vector<double> dist(children_.size());
+        double minDist = dist[0] = gnat.distFun_(data, children_[0]->pivot_);
+        int minInd = 0;
+
+        for (unsigned int i = 1; i < children_.size(); ++i)
+          if ((dist[i] = gnat.distFun_(data, children_[i]->pivot_)) < minDist)
+          {
+            minDist = dist[i];
+            minInd = i;
+          }
+        for (unsigned int i = 0; i < children_.size(); ++i)
+          children_[i]->updateRange(minInd, dist[i]);
+        children_[minInd]->updateRadius(minDist);
+        children_[minInd]->add(gnat, data);
+      }
+    }
+    // Return true iff the node needs to be split into child nodes.
+    bool needToSplit(const GNAT& gnat) const
+    {
+      unsigned int sz = data_.size();
+      return sz > gnat.maxNumPtsPerLeaf_ && sz > degree_;
+    }
+    // \brief The split operation finds pivot elements for the child
+    // nodes and moves each data element of this node to the appropriate
+    // child node.
+    void split(GNAT& gnat)
+    {
+      typename GreedyKCenters<_T>::Matrix dists(data_.size(), degree_);
+      std::vector<unsigned int> pivots;
+
+      children_.reserve(degree_);
+      gnat.pivotSelector_.kcenters(data_, degree_, pivots, dists);
+      for (unsigned int& pivot : pivots)
+        children_.push_back(new Node(degree_, gnat.maxNumPtsPerLeaf_, data_[pivot]));
+      degree_ = pivots.size();  // in case fewer than degree_ pivots were found
+      for (unsigned int j = 0; j < data_.size(); ++j)
+      {
+        unsigned int k = 0;
+        for (unsigned int i = 1; i < degree_; ++i)
+          if (dists(j, i) < dists(j, k))
+            k = i;
+        Node* child = children_[k];
+        if (j != pivots[k])
+        {
+          child->data_.push_back(data_[j]);
+          child->updateRadius(dists(j, k));
+        }
+        for (unsigned int i = 0; i < degree_; ++i)
+          children_[i]->updateRange(k, dists(j, i));
+      }
+
+      for (unsigned int i = 0; i < degree_; ++i)
+      {
+        // make sure degree lies between minDegree_ and maxDegree_
+        children_[i]->degree_ =
+            std::min(std::max((unsigned int)((degree_ * children_[i]->data_.size()) / data_.size()), gnat.minDegree_),
+                     gnat.maxDegree_);
+        // singleton
+        if (children_[i]->minRadius_ >= std::numeric_limits<double>::infinity())
+          children_[i]->minRadius_ = children_[i]->maxRadius_ = 0.;
+      }
+      // this does more than clear(); it also sets capacity to 0 and frees the memory
+      std::vector<_T> tmp;
+      data_.swap(tmp);
+      // check if new leaves need to be split
+      for (unsigned int i = 0; i < degree_; ++i)
+        if (children_[i]->needToSplit(gnat))
+          children_[i]->split(gnat);
+    }
+
+    // Insert data in nbh if it is a near neighbor. Return true iff data was added to nbh.
+    bool insertNeighborK(NearQueue& nbh, std::size_t k, const _T& data, const _T& key, double dist) const
+    {
+      if (nbh.size() < k)
+      {
+        nbh.push(std::make_pair(&data, dist));
+        return true;
+      }
+      if (dist < nbh.top().second || (dist < std::numeric_limits<double>::epsilon() && data == key))
+      {
+        nbh.pop();
+        nbh.push(std::make_pair(&data, dist));
+        return true;
+      }
+      return false;
+    }
+
+    // \brief Compute the k nearest neighbors of data in the tree.
+    // For k=1, isPivot is true if the nearest neighbor is a pivot
+    // (which is important during removal; removing pivots is a
+    // special case). The nodeQueue, which contains other Nodes
+    // that need to be checked for nearest neighbors, is updated.
+    void nearestK(const GNAT& gnat, const _T& data, std::size_t k, NearQueue& nbh, NodeQueue& nodeQueue,
+                  bool& isPivot) const
+    {
+      for (unsigned int i = 0; i < data_.size(); ++i)
+        if (!gnat.isRemoved(data_[i]))
+        {
+          if (insertNeighborK(nbh, k, data_[i], data, gnat.distFun_(data, data_[i])))
+            isPivot = false;
+        }
+      if (!children_.empty())
+      {
+        double dist;
+        Node* child;
+        std::vector<double> distToPivot(children_.size());
+        std::vector<int> permutation(children_.size());
+        for (unsigned int i = 0; i < permutation.size(); ++i)
+          permutation[i] = i;
+        std::random_shuffle(permutation.begin(), permutation.end());
+
+        for (unsigned int i = 0; i < children_.size(); ++i)
+          if (permutation[i] >= 0)
+          {
+            child = children_[permutation[i]];
+            distToPivot[permutation[i]] = gnat.distFun_(data, child->pivot_);
+            if (insertNeighborK(nbh, k, child->pivot_, data, distToPivot[permutation[i]]))
+              isPivot = true;
+            if (nbh.size() == k)
+            {
+              dist = nbh.top().second;  // note difference with nearestR
+              for (unsigned int j = 0; j < children_.size(); ++j)
+                if (permutation[j] >= 0 && i != j &&
+                    (distToPivot[permutation[i]] - dist > child->maxRange_[permutation[j]] ||
+                     distToPivot[permutation[i]] + dist < child->minRange_[permutation[j]]))
+                  permutation[j] = -1;
+            }
+          }
+
+        dist = nbh.top().second;
+        for (unsigned int i = 0; i < children_.size(); ++i)
+          if (permutation[i] >= 0)
+          {
+            child = children_[permutation[i]];
+            if (nbh.size() < k || (distToPivot[permutation[i]] - dist <= child->maxRadius_ &&
+                                   distToPivot[permutation[i]] + dist >= child->minRadius_))
+              nodeQueue.push(std::make_pair(child, distToPivot[permutation[i]]));
+          }
+      }
+    }
+    // Insert data in nbh if it is a near neighbor.
+    void insertNeighborR(NearQueue& nbh, double r, const _T& data, double dist) const
+    {
+      if (dist <= r)
+        nbh.push(std::make_pair(&data, dist));
+    }
+    // \brief Return all elements that are within distance r in nbh.
+    // The nodeQueue, which contains other Nodes that need to
+    // be checked for nearest neighbors, is updated.
+    void nearestR(const GNAT& gnat, const _T& data, double r, NearQueue& nbh, NodeQueue& nodeQueue) const
+    {
+      double dist = r;  // note difference with nearestK
+
+      for (unsigned int i = 0; i < data_.size(); ++i)
+        if (!gnat.isRemoved(data_[i]))
+          insertNeighborR(nbh, r, data_[i], gnat.distFun_(data, data_[i]));
+      if (!children_.empty())
+      {
+        Node* child;
+        std::vector<double> distToPivot(children_.size());
+        std::vector<int> permutation(children_.size());
+        for (unsigned int i = 0; i < permutation.size(); ++i)
+          permutation[i] = i;
+        std::random_shuffle(permutation.begin(), permutation.end());
+
+        for (unsigned int i = 0; i < children_.size(); ++i)
+          if (permutation[i] >= 0)
+          {
+            child = children_[permutation[i]];
+            distToPivot[i] = gnat.distFun_(data, child->pivot_);
+            insertNeighborR(nbh, r, child->pivot_, distToPivot[i]);
+            for (unsigned int j = 0; j < children_.size(); ++j)
+              if (permutation[j] >= 0 && i != j &&
+                  (distToPivot[i] - dist > child->maxRange_[permutation[j]] ||
+                   distToPivot[i] + dist < child->minRange_[permutation[j]]))
+                permutation[j] = -1;
+          }
+
+        for (unsigned int i = 0; i < children_.size(); ++i)
+          if (permutation[i] >= 0)
+          {
+            child = children_[permutation[i]];
+            if (distToPivot[i] - dist <= child->maxRadius_ && distToPivot[i] + dist >= child->minRadius_)
+              nodeQueue.push(std::make_pair(child, distToPivot[i]));
+          }
+      }
+    }
+
+    void list(const GNAT& gnat, std::vector<_T>& data) const
+    {
+      if (!gnat.isRemoved(pivot_))
+        data.push_back(pivot_);
+      for (unsigned int i = 0; i < data_.size(); ++i)
+        if (!gnat.isRemoved(data_[i]))
+          data.push_back(data_[i]);
+      for (unsigned int i = 0; i < children_.size(); ++i)
+        children_[i]->list(gnat, data);
+    }
+
+    friend std::ostream& operator<<(std::ostream& out, const Node& node)
+    {
+      out << "\ndegree:\t" << node.degree_;
+      out << "\nminRadius:\t" << node.minRadius_;
+      out << "\nmaxRadius:\t" << node.maxRadius_;
+      out << "\nminRange:\t";
+      for (unsigned int i = 0; i < node.minRange_.size(); ++i)
+        out << node.minRange_[i] << '\t';
+      out << "\nmaxRange: ";
+      for (unsigned int i = 0; i < node.maxRange_.size(); ++i)
+        out << node.maxRange_[i] << '\t';
+      out << "\npivot:\t" << node.pivot_;
+      out << "\ndata: ";
+      for (unsigned int i = 0; i < node.data_.size(); ++i)
+        out << node.data_[i] << '\t';
+      out << "\nthis:\t" << &node;
+      out << "\nchildren:\n";
+      for (unsigned int i = 0; i < node.children_.size(); ++i)
+        out << node.children_[i] << '\t';
+      out << '\n';
+      for (unsigned int i = 0; i < node.children_.size(); ++i)
+        out << *node.children_[i] << '\n';
+      return out;
+    }
+
+    // Number of child nodes
+    unsigned int degree_;
+    // Data element stored in this Node
+    const _T pivot_;
+    // Minimum distance between the pivot element and the elements stored in data_
+    double minRadius_;
+    // Maximum distance between the pivot element and the elements stored in data_
+    double maxRadius_;
+    // \brief The i-th element in minRange_ is the minimum distance between the
+    // pivot and any data_ element in the i-th child node of this node's parent.
+    std::vector<double> minRange_;
+    // \brief The i-th element in maxRange_ is the maximum distance between the
+    // pivot and any data_ element in the i-th child node of this node's parent.
+    std::vector<double> maxRange_;
+    // \brief The data elements stored in this node (in addition to the pivot
+    // element). An internal node has no elements stored in data_.
+    std::vector<_T> data_;
+    // \brief The child nodes of this node. By definition, only internal nodes
+    // have child nodes.
+    std::vector<Node*> children_;
+  };
+
+  // \brief The data structure containing the elements stored in this structure.
+  Node* tree_{ nullptr };
+  // The desired degree of each node.
+  unsigned int degree_;
+  // \brief After splitting a Node, each child Node has degree equal to
+  // the default degree times the fraction of data elements from the
+  // original node that got assigned to that child Node. However, its
+  // degree can be no less than minDegree_.
+  unsigned int minDegree_;
+  // \brief After splitting a Node, each child Node has degree equal to
+  // the default degree times the fraction of data elements from the
+  // original node that got assigned to that child Node. However, its
+  // degree can be no larger than maxDegree_.
+  unsigned int maxDegree_;
+  // \brief Maximum number of elements allowed to be stored in a Node before
+  // it needs to be split into several nodes.
+  unsigned int maxNumPtsPerLeaf_;
+  // \brief Number of elements stored in the tree.
+  std::size_t size_{ 0 };
+  // \brief If size_ exceeds rebuildSize_, the tree will be rebuilt (and
+  // automatically rebalanced), and rebuildSize_ will be doubled.
+  std::size_t rebuildSize_;
+  // \brief Maximum number of removed elements that can be stored in the
+  // removed_ cache. If the cache is full, the tree will be rebuilt with
+  // the elements in removed_ actually removed from the tree.
+  std::size_t removedCacheSize_;
+  // \brief The data structure used to split data into subtrees.
+  GreedyKCenters<_T> pivotSelector_;
+  // \brief Cache of removed elements.
+  std::unordered_set<const _T*> removed_;
+};
+}
+
+#endif

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -565,8 +565,9 @@ protected:
             {
               dist = nbh.top().second;  // note difference with nearestR
               for (unsigned int j = 0; j < children_.size(); ++j)
-                if (permutation[j] >= 0 && i != j && (distToPivot[permutation[i]] - dist > child->maxRange_[permutation[j]] ||
-                                                      distToPivot[permutation[i]] + dist < child->minRange_[permutation[j]]))
+                if (permutation[j] >= 0 && i != j &&
+                    (distToPivot[permutation[i]] - dist > child->maxRange_[permutation[j]] ||
+                     distToPivot[permutation[i]] + dist < child->minRange_[permutation[j]]))
                   permutation[j] = -1;
             }
           }
@@ -614,9 +615,8 @@ protected:
             distToPivot[i] = gnat.distFun_(data, child->pivot_);
             insertNeighborR(nbh, r, child->pivot_, distToPivot[i]);
             for (unsigned int j = 0; j < children_.size(); ++j)
-              if (permutation[j] >= 0 && i != j &&
-                  (distToPivot[i] - dist > child->maxRange_[permutation[j]] ||
-                   distToPivot[i] + dist < child->minRange_[permutation[j]]))
+              if (permutation[j] >= 0 && i != j && (distToPivot[i] - dist > child->maxRange_[permutation[j]] ||
+                                                    distToPivot[i] + dist < child->minRange_[permutation[j]]))
                 permutation[j] = -1;
           }
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -565,9 +565,8 @@ protected:
             {
               dist = nbh.top().second;  // note difference with nearestR
               for (unsigned int j = 0; j < children_.size(); ++j)
-                if (permutation[j] >= 0 && i != j &&
-                    (distToPivot[permutation[i]] - dist > child->maxRange_[permutation[j]] ||
-                     distToPivot[permutation[i]] + dist < child->minRange_[permutation[j]]))
+                if (permutation[j] >= 0 && i != j && (distToPivot[permutation[i]] - dist > child->maxRange_[permutation[j]] ||
+                                                      distToPivot[permutation[i]] + dist < child->minRange_[permutation[j]]))
                   permutation[j] = -1;
             }
           }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/launch/measure_ik_call_cost.launch
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/launch/measure_ik_call_cost.launch
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="robot" doc="Name of the robot"/>
+  <arg name="group" default="all" doc="Name of the planning group"/>
+  <arg name="tip" default="default" doc="Name of the end effector links (separated by ':' if there's more than one)"/>
+  <arg name="num" default="10000" doc="Number of IK calls to evaluate"/>
+  <arg name="reset_to_default" default="true" doc="Whether to reset to default values before calling IK (rather than seed the solver with the correct IK solution)"/>
+  <arg name="kinematics" default="false"/>
+  <arg name="kinematics_path" default="false" doc="path to file with additional kinematics parameters that override the ones in the default kinematics.yaml"/>
+  <arg name="output_dir_override" default="false"/>
+  <arg name="output_dir" default="false" doc="output directory for cache files"/>
+  <include file="$(eval find(arg('robot') + '_moveit_config') + '/launch/planning_context.launch')">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <node name="measure_ik_call_cost"
+        pkg="moveit_kinematics"
+        type="measure_ik_call_cost"
+        respawn="false"
+        output="screen"
+        required="true"
+        args="--group $(arg group) --tip $(arg tip) --num $(arg num) --reset_to_default $(arg reset_to_default)">
+    <rosparam command="load"
+              file="$(eval find(arg('robot') + '_moveit_config') + '/config/kinematics.yaml')"/>
+    <rosparam command="load" file="$(arg kinematics_path)" if="$(arg kinematics)"/>
+    <rosparam param="cached_ik_path" if="$(arg output_dir_override)" subst_value="True">$(arg output_dir)</rosparam>
+    <rosparam param="cached_ik_path" unless="$(arg output_dir_override)" subst_value="True">$(arg robot)</rosparam>
+  </node>
+</launch>

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ik_kinematics_plugin.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ik_kinematics_plugin.cpp
@@ -1,0 +1,57 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mark Moll */
+
+#include <moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h>
+#include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
+// compilation error: KDL and LMA kinematics plugins declare same types
+//#include <moveit/lma_kinematics_plugin/lma_kinematics_plugin.h>
+#include <moveit/srv_kinematics_plugin/srv_kinematics_plugin.h>
+
+#include <pluginlib/class_list_macros.h>
+// register CachedIKKinematicsPlugin<KDLKinematicsPlugin> as a KinematicsBase implementation
+PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>, kinematics::KinematicsBase);
+
+// register CachedIKKinematicsPlugin<SrvKinematicsPlugin> as a KinematicsBase implementation
+// PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<lma_kinematics_plugin::LMAKinematicsPlugin>, kinematics::KinematicsBase);
+
+// register CachedIKKinematicsPlugin<SrvKinematicsPlugin> as a KinematicsBase implementation
+PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<srv_kinematics_plugin::SrvKinematicsPlugin>, kinematics::KinematicsBase);
+
+#ifdef CACHED_IK_KINEMATICS_TRAC_IK
+#include <trac_ik/trac_ik_kinematics_plugin.hpp>
+// register CachedIKKinematicsPlugin<TRAC_IKKinematicsPlugin> as a KinematicsBase implementation
+PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>, kinematics::KinematicsBase);
+#endif

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ik_kinematics_plugin.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ik_kinematics_plugin.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2017, Rice University
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Mark Moll */
 
@@ -42,16 +42,23 @@
 
 #include <pluginlib/class_list_macros.h>
 // register CachedIKKinematicsPlugin<KDLKinematicsPlugin> as a KinematicsBase implementation
-PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>, kinematics::KinematicsBase);
+PLUGINLIB_EXPORT_CLASS(
+    cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>,
+    kinematics::KinematicsBase);
 
 // register CachedIKKinematicsPlugin<SrvKinematicsPlugin> as a KinematicsBase implementation
-// PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<lma_kinematics_plugin::LMAKinematicsPlugin>, kinematics::KinematicsBase);
+// PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<lma_kinematics_plugin::LMAKinematicsPlugin>,
+// kinematics::KinematicsBase);
 
 // register CachedIKKinematicsPlugin<SrvKinematicsPlugin> as a KinematicsBase implementation
-PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<srv_kinematics_plugin::SrvKinematicsPlugin>, kinematics::KinematicsBase);
+PLUGINLIB_EXPORT_CLASS(
+    cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<srv_kinematics_plugin::SrvKinematicsPlugin>,
+    kinematics::KinematicsBase);
 
 #ifdef CACHED_IK_KINEMATICS_TRAC_IK
 #include <trac_ik/trac_ik_kinematics_plugin.hpp>
 // register CachedIKKinematicsPlugin<TRAC_IKKinematicsPlugin> as a KinematicsBase implementation
-PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>, kinematics::KinematicsBase);
+PLUGINLIB_EXPORT_CLASS(
+    cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>,
+    kinematics::KinematicsBase);
 #endif

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ur_kinematics_plugin.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ur_kinematics_plugin.cpp
@@ -1,0 +1,43 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mark Moll */
+
+#include <moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h>
+#include <ur_kinematics/ur_moveit_plugin.h>
+
+#include <pluginlib/class_list_macros.h>
+// register CachedIKKinematicsPlugin<URKinematicsPlugin> as a KinematicsBase implementation
+PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>, kinematics::KinematicsBase);
+

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ur_kinematics_plugin.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ur_kinematics_plugin.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2017, Rice University
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Mark Moll */
 
@@ -39,5 +39,5 @@
 
 #include <pluginlib/class_list_macros.h>
 // register CachedIKKinematicsPlugin<URKinematicsPlugin> as a KinematicsBase implementation
-PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>, kinematics::KinematicsBase);
-
+PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>,
+                       kinematics::KinematicsBase);

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -1,0 +1,357 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mark Moll */
+
+#include <boost/filesystem/fstream.hpp>
+#include <chrono>
+#include <cstdlib>
+#include <numeric>
+
+#include <moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h>
+
+namespace cached_ik_kinematics_plugin
+{
+    IKCache::IKCache()
+    {
+        // set distance function for nearest-neighbor queries
+        ikNN_.setDistanceFunction([this](const IKEntry *entry1, const IKEntry *entry2)
+                                  {
+                                      double dist = 0.;
+                                      for (unsigned int i = 0; i < entry1->first.size(); ++i)
+                                          dist += entry1->first[i].distance(entry2->first[i]);
+                                      return dist;
+                                  });
+    }
+
+    IKCache::~IKCache()
+    {
+        if (!ikCache_.empty())
+            saveCache();
+    }
+
+    void IKCache::initializeCache(
+        const std::string &robot_description,
+        const std::string &group_name,
+        const std::string &cache_name,
+        const unsigned int num_joints)
+    {
+        // read ROS parameters
+        ros::NodeHandle node_handle("~");
+        int maxCacheSize; // node_handle.param(...) doesn't handle unsigned ints
+        node_handle.param(group_name+"/max_cache_size", maxCacheSize, 5000);
+        maxCacheSize_ = maxCacheSize;
+        ikCache_.reserve(maxCacheSize_);
+        node_handle.param(group_name+"/min_pose_distance", minPoseDistance_, 1.);
+        node_handle.param(group_name+"/min_joint_config_distance", minConfigDistance2_, 1.);
+        minConfigDistance2_ *= minConfigDistance2_;
+        std::string cached_ik_path;
+        node_handle.param("cached_ik_path", cached_ik_path, std::string());
+
+        // use mutex lock for rest of initialization
+        std::lock_guard<std::mutex> slock(lock_);
+        // determine cache file name
+        boost::filesystem::path prefix(!cached_ik_path.empty() ? cached_ik_path : boost::filesystem::current_path());
+        // create cache directory if necessary
+        boost::filesystem::create_directories(prefix);
+
+        cacheFileName_ = prefix / (robot_description + group_name + "_" + cache_name +
+            "_" + std::to_string(maxCacheSize_) + "_" + std::to_string(minPoseDistance_) +
+            "_" + std::to_string(std::sqrt(minConfigDistance2_)) + ".ikcache");
+
+        ikCache_.clear();
+        ikNN_.clear();
+        lastSavedCacheSize_ = 0;
+        if (boost::filesystem::exists(cacheFileName_))
+        {
+            // read cache
+            boost::filesystem::ifstream cacheFile(cacheFileName_, std::ios_base::binary | std::ios_base::in);
+            cacheFile.read((char*)&lastSavedCacheSize_, sizeof(unsigned int));
+            unsigned int numDofs;
+            cacheFile.read((char*)&numDofs, sizeof(unsigned int));
+            unsigned int numTips;
+            cacheFile.read((char*)&numTips, sizeof(unsigned int));
+
+            ROS_INFO_NAMED("cached_ik_kinematics_plugin",
+                "Found %d IK solutions for a %d-dof system with %d end effectors in %s",
+                lastSavedCacheSize_, numDofs, numTips, cacheFileName_.string().c_str());
+
+            unsigned int positionSize = 3 * sizeof(tf2Scalar);
+            unsigned int orientationSize = 4 * sizeof(tf2Scalar);
+            unsigned int poseSize = positionSize + orientationSize;
+            unsigned int configSize = numDofs * sizeof(double);
+            unsigned int offsetConf = poseSize * numTips;
+            unsigned int bufsize = offsetConf + configSize;
+            char *buffer = new char[bufsize * lastSavedCacheSize_];
+            IKEntry entry;
+            entry.first.resize(numTips);
+            entry.second.resize(numDofs);
+            cacheFile.read(buffer, bufsize * lastSavedCacheSize_);
+            ikCache_.reserve(lastSavedCacheSize_);
+
+            for (unsigned i = 0; i < lastSavedCacheSize_; ++i)
+            {
+                for (auto &pose : entry.first)
+                {
+                    memcpy(&pose.position[0], buffer, positionSize);
+                    memcpy(&pose.orientation[0], buffer + positionSize, orientationSize);
+                    buffer += poseSize;
+                }
+                memcpy(&entry.second[0], buffer, configSize);
+                buffer += configSize;
+                ikCache_.push_back(entry);
+            }
+            std::vector<IKEntry*> ikEntryPtrs(lastSavedCacheSize_);
+            for (unsigned int i = 0; i < lastSavedCacheSize_; ++i)
+                ikEntryPtrs[i] = &ikCache_[i];
+            ikNN_.add(ikEntryPtrs);
+            // for debugging purposes:
+            //verifyCache();
+        }
+
+        numJoints_ = num_joints;
+
+        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
+                       "cache file %s initialized!",
+                       cacheFileName_.string().c_str());
+    }
+
+    double IKCache::configDistance2(
+        const std::vector<double> &config1, const std::vector<double> &config2) const
+    {
+        double dist = 0., diff;
+        for (unsigned int i = 0; i < config1.size(); ++i)
+        {
+            diff = config1[i] - config2[i];
+            dist += diff * diff;
+        }
+        return dist;
+    }
+
+    const IKCache::IKEntry &
+    IKCache::getBestApproximateIKSolution(const Pose &pose) const
+    {
+        if (ikCache_.empty())
+        {
+            static IKEntry dummy = std::make_pair(std::vector<Pose>(1, pose), std::vector<double>(numJoints_, 0.));
+            return dummy;
+        }
+        IKEntry query = std::make_pair(std::vector<Pose>(1, pose), std::vector<double>());
+        return *ikNN_.nearest(&query);
+    }
+
+    const IKCache::IKEntry &
+    IKCache::getBestApproximateIKSolution(const std::vector<Pose> &poses) const
+    {
+        if (ikCache_.empty())
+        {
+            static IKEntry dummy = std::make_pair(poses, std::vector<double>(numJoints_, 0.));
+            return dummy;
+        }
+        IKEntry query = std::make_pair(poses, std::vector<double>());
+        return *ikNN_.nearest(&query);
+    }
+
+    void IKCache::updateCache(
+        const IKEntry &nearest, const Pose &pose, const std::vector<double> &config) const
+    {
+        if (ikCache_.size() < ikCache_.capacity() &&
+            (nearest.first[0].distance(pose) > minPoseDistance_ || configDistance2(nearest.second, config) > minConfigDistance2_))
+        {
+            std::lock_guard<std::mutex> slock(lock_);
+            ikCache_.emplace_back(std::vector<Pose>(1u, pose), config);
+            ikNN_.add(&ikCache_.back());
+            if (ikCache_.size() >= lastSavedCacheSize_ + 500u || ikCache_.size() == maxCacheSize_)
+                saveCache();
+        }
+    }
+
+    void IKCache::updateCache(
+        const IKEntry &nearest, const std::vector<Pose> &poses, const std::vector<double> &config) const
+    {
+        if (ikCache_.size() < ikCache_.capacity())
+        {
+            bool addToCache = configDistance2(nearest.second, config) > minConfigDistance2_;
+            if (!addToCache)
+            {
+                double dist = 0.;
+                for (unsigned int i = 0; i < poses.size(); ++i)
+                {
+                    dist += nearest.first[i].distance(poses[i]);
+                    if (dist > minPoseDistance_)
+                    {
+                        addToCache = true;
+                        break;
+                    }
+                }
+            }
+            if (addToCache)
+            {
+                std::lock_guard<std::mutex> slock(lock_);
+                ikCache_.emplace_back(poses, config);
+                ikNN_.add(&ikCache_.back());
+                if (ikCache_.size() >= lastSavedCacheSize_ + 500u || ikCache_.size() == maxCacheSize_)
+                    saveCache();
+            }
+        }
+    }
+
+    void IKCache::saveCache() const
+    {
+        if (cacheFileName_.empty())
+            ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
+                "can't save cache before initialization");
+
+        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
+            "writing %ld IK solutions to %s",
+            ikCache_.size(), cacheFileName_.string().c_str());
+
+        boost::filesystem::ofstream cacheFile(cacheFileName_, std::ios_base::binary | std::ios_base::out);
+        unsigned int positionSize = 3 * sizeof(tf2Scalar);
+        unsigned int orientationSize = 4 * sizeof(tf2Scalar);
+        unsigned int poseSize = positionSize + orientationSize;
+        unsigned int numTips = ikCache_[0].first.size();
+        unsigned int configSize = ikCache_[0].second.size() * sizeof(double);
+        unsigned int offsetConf = numTips * poseSize;
+        unsigned int bufsize = offsetConf + configSize;
+        char *buffer = new char[bufsize];
+
+        // write number of IK entries and size of each configuration first
+        lastSavedCacheSize_ = ikCache_.size();
+        cacheFile.write((char*)&lastSavedCacheSize_, sizeof(unsigned int));
+        unsigned int sz = ikCache_[0].second.size();
+        cacheFile.write((char*)&sz, sizeof(unsigned int));
+        cacheFile.write((char*)&numTips, sizeof(unsigned int));
+        for (const auto &entry : ikCache_)
+        {
+            for (unsigned int i = 0; i < numTips; ++i)
+            {
+                memcpy(buffer + i * poseSize, &entry.first[i].position[0], positionSize);
+                memcpy(buffer + i * poseSize + positionSize, &entry.first[i].orientation[0], orientationSize);
+            }
+            memcpy(buffer + offsetConf, &entry.second[0], configSize);
+            cacheFile.write(buffer, bufsize);
+        }
+    }
+
+    void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin &fk) const
+    {
+        std::vector<std::string> tipNames(fk.getTipFrames());
+        std::vector<geometry_msgs::Pose> poses(tipNames.size());
+        double error, max_error = 0.;
+
+        for (const auto &entry : ikCache_)
+        {
+            fk.getPositionFK(tipNames, entry.second, poses);
+            error = 0.;
+            for (unsigned int i = 0; i < poses.size(); ++i)
+                error += entry.first[i].distance(poses[i]);
+            error /= (double)poses.size();
+            if (error > max_error)
+                max_error = error;
+            if (error > 1e-4)
+                ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
+                    "Cache entry is invalid, error = %g", error);
+        }
+        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
+            "Max. error in cache entries is %g", max_error);
+    }
+
+    IKCache::Pose::Pose(const geometry_msgs::Pose& pose)
+    {
+        position.setX(pose.position.x);
+        position.setY(pose.position.y);
+        position.setZ(pose.position.z);
+        orientation = tf2::Quaternion(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+    }
+
+    double IKCache::Pose::distance(const Pose &pose) const
+    {
+        return (position - pose.position).length() + (orientation.angleShortestPath(pose.orientation));
+    }
+
+
+    IKCacheMap::IKCacheMap(const std::string &robot_description, const std::string &group_name, unsigned int num_joints)
+        : robotDescription_(robot_description), groupName_(group_name), numJoints_(num_joints)
+    {
+    }
+
+    IKCacheMap::~IKCacheMap()
+    {
+        for (auto &cache : *this)
+            delete cache.second;
+    }
+
+    const IKCache::IKEntry &
+    IKCacheMap::getBestApproximateIKSolution(const std::vector<std::string> &fixed, const std::vector<std::string> &active,
+                                          const std::vector<Pose> &poses) const
+    {
+        auto key(getKey(fixed, active));
+        auto it = find(key);
+        if (it != end())
+            return it->second->getBestApproximateIKSolution(poses);
+        else
+        {
+            static IKEntry dummy = std::make_pair(poses, std::vector<double>(numJoints_, 0.));
+            return dummy;
+        }
+    }
+
+    void IKCacheMap::updateCache(
+        const IKEntry &nearest, const std::vector<std::string> &fixed, const std::vector<std::string> &active,
+        const std::vector<Pose> &poses, const std::vector<double> &config)
+    {
+        auto key(getKey(fixed, active));
+        auto it = find(key);
+        if (it != end())
+            it->second->updateCache(nearest, poses, config);
+        else
+        {
+            value_type val = std::make_pair(key, nullptr);
+            auto it = insert(val).first;
+            it->second = new IKCache;
+            it->second->initializeCache(robotDescription_, groupName_, key, numJoints_);
+        }
+    }
+
+    std::string IKCacheMap::getKey(const std::vector<std::string> &fixed, const std::vector<std::string> &active) const
+    {
+        std::string key;
+        std::accumulate(fixed.begin(), fixed.end(), key);
+        key += '_';
+        std::accumulate(active.begin(), active.end(), key);
+        return key;
+    }
+
+}

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -61,19 +61,15 @@ IKCache::~IKCache()
 }
 
 void IKCache::initializeCache(const std::string& robot_description, const std::string& group_name,
-                              const std::string& cache_name, const unsigned int num_joints)
+                              const std::string& cache_name, const unsigned int num_joints, Options opts)
 {
   // read ROS parameters
-  ros::NodeHandle node_handle("~");
-  int max_cache_size;  // node_handle.param(...) doesn't handle unsigned ints
-  node_handle.param(group_name + "/max_cache_size", max_cache_size, 5000);
-  max_cache_size_ = max_cache_size;
+  max_cache_size_ = opts.max_cache_size;
   ik_cache_.reserve(max_cache_size_);
-  node_handle.param(group_name + "/min_pose_distance", min_pose_distance_, 1.);
-  node_handle.param(group_name + "/min_joint_config_distance", min_config_distance2_, 1.);
+  min_pose_distance_ = opts.min_pose_distance;
+  min_config_distance2_ = opts.min_joint_config_distance;
   min_config_distance2_ *= min_config_distance2_;
-  std::string cached_ik_path;
-  node_handle.param("cached_ik_path", cached_ik_path, std::string());
+  std::string cached_ik_path = opts.cached_ik_path;
 
   // use mutex lock for rest of initialization
   std::lock_guard<std::mutex> slock(lock_);

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2017, Rice University
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Mark Moll */
 
@@ -43,315 +43,299 @@
 
 namespace cached_ik_kinematics_plugin
 {
-    IKCache::IKCache()
+IKCache::IKCache()
+{
+  // set distance function for nearest-neighbor queries
+  ikNN_.setDistanceFunction([this](const IKEntry* entry1, const IKEntry* entry2) {
+    double dist = 0.;
+    for (unsigned int i = 0; i < entry1->first.size(); ++i)
+      dist += entry1->first[i].distance(entry2->first[i]);
+    return dist;
+  });
+}
+
+IKCache::~IKCache()
+{
+  if (!ikCache_.empty())
+    saveCache();
+}
+
+void IKCache::initializeCache(const std::string& robot_description, const std::string& group_name,
+                              const std::string& cache_name, const unsigned int num_joints)
+{
+  // read ROS parameters
+  ros::NodeHandle node_handle("~");
+  int maxCacheSize;  // node_handle.param(...) doesn't handle unsigned ints
+  node_handle.param(group_name + "/max_cache_size", maxCacheSize, 5000);
+  maxCacheSize_ = maxCacheSize;
+  ikCache_.reserve(maxCacheSize_);
+  node_handle.param(group_name + "/min_pose_distance", minPoseDistance_, 1.);
+  node_handle.param(group_name + "/min_joint_config_distance", minConfigDistance2_, 1.);
+  minConfigDistance2_ *= minConfigDistance2_;
+  std::string cached_ik_path;
+  node_handle.param("cached_ik_path", cached_ik_path, std::string());
+
+  // use mutex lock for rest of initialization
+  std::lock_guard<std::mutex> slock(lock_);
+  // determine cache file name
+  boost::filesystem::path prefix(!cached_ik_path.empty() ? cached_ik_path : boost::filesystem::current_path());
+  // create cache directory if necessary
+  boost::filesystem::create_directories(prefix);
+
+  cacheFileName_ =
+      prefix / (robot_description + group_name + "_" + cache_name + "_" + std::to_string(maxCacheSize_) + "_" +
+                std::to_string(minPoseDistance_) + "_" + std::to_string(std::sqrt(minConfigDistance2_)) + ".ikcache");
+
+  ikCache_.clear();
+  ikNN_.clear();
+  lastSavedCacheSize_ = 0;
+  if (boost::filesystem::exists(cacheFileName_))
+  {
+    // read cache
+    boost::filesystem::ifstream cacheFile(cacheFileName_, std::ios_base::binary | std::ios_base::in);
+    cacheFile.read((char*)&lastSavedCacheSize_, sizeof(unsigned int));
+    unsigned int numDofs;
+    cacheFile.read((char*)&numDofs, sizeof(unsigned int));
+    unsigned int numTips;
+    cacheFile.read((char*)&numTips, sizeof(unsigned int));
+
+    ROS_INFO_NAMED("cached_ik_kinematics_plugin",
+                   "Found %d IK solutions for a %d-dof system with %d end effectors in %s", lastSavedCacheSize_,
+                   numDofs, numTips, cacheFileName_.string().c_str());
+
+    unsigned int positionSize = 3 * sizeof(tf2Scalar);
+    unsigned int orientationSize = 4 * sizeof(tf2Scalar);
+    unsigned int poseSize = positionSize + orientationSize;
+    unsigned int configSize = numDofs * sizeof(double);
+    unsigned int offsetConf = poseSize * numTips;
+    unsigned int bufsize = offsetConf + configSize;
+    char* buffer = new char[bufsize * lastSavedCacheSize_];
+    IKEntry entry;
+    entry.first.resize(numTips);
+    entry.second.resize(numDofs);
+    cacheFile.read(buffer, bufsize * lastSavedCacheSize_);
+    ikCache_.reserve(lastSavedCacheSize_);
+
+    for (unsigned i = 0; i < lastSavedCacheSize_; ++i)
     {
-        // set distance function for nearest-neighbor queries
-        ikNN_.setDistanceFunction([this](const IKEntry *entry1, const IKEntry *entry2)
-                                  {
-                                      double dist = 0.;
-                                      for (unsigned int i = 0; i < entry1->first.size(); ++i)
-                                          dist += entry1->first[i].distance(entry2->first[i]);
-                                      return dist;
-                                  });
+      for (auto& pose : entry.first)
+      {
+        memcpy(&pose.position[0], buffer, positionSize);
+        memcpy(&pose.orientation[0], buffer + positionSize, orientationSize);
+        buffer += poseSize;
+      }
+      memcpy(&entry.second[0], buffer, configSize);
+      buffer += configSize;
+      ikCache_.push_back(entry);
     }
+    std::vector<IKEntry*> ikEntryPtrs(lastSavedCacheSize_);
+    for (unsigned int i = 0; i < lastSavedCacheSize_; ++i)
+      ikEntryPtrs[i] = &ikCache_[i];
+    ikNN_.add(ikEntryPtrs);
+    // for debugging purposes:
+    // verifyCache();
+  }
 
-    IKCache::~IKCache()
+  numJoints_ = num_joints;
+
+  ROS_INFO_NAMED("cached_ik_kinematics_plugin", "cache file %s initialized!", cacheFileName_.string().c_str());
+}
+
+double IKCache::configDistance2(const std::vector<double>& config1, const std::vector<double>& config2) const
+{
+  double dist = 0., diff;
+  for (unsigned int i = 0; i < config1.size(); ++i)
+  {
+    diff = config1[i] - config2[i];
+    dist += diff * diff;
+  }
+  return dist;
+}
+
+const IKCache::IKEntry& IKCache::getBestApproximateIKSolution(const Pose& pose) const
+{
+  if (ikCache_.empty())
+  {
+    static IKEntry dummy = std::make_pair(std::vector<Pose>(1, pose), std::vector<double>(numJoints_, 0.));
+    return dummy;
+  }
+  IKEntry query = std::make_pair(std::vector<Pose>(1, pose), std::vector<double>());
+  return *ikNN_.nearest(&query);
+}
+
+const IKCache::IKEntry& IKCache::getBestApproximateIKSolution(const std::vector<Pose>& poses) const
+{
+  if (ikCache_.empty())
+  {
+    static IKEntry dummy = std::make_pair(poses, std::vector<double>(numJoints_, 0.));
+    return dummy;
+  }
+  IKEntry query = std::make_pair(poses, std::vector<double>());
+  return *ikNN_.nearest(&query);
+}
+
+void IKCache::updateCache(const IKEntry& nearest, const Pose& pose, const std::vector<double>& config) const
+{
+  if (ikCache_.size() < ikCache_.capacity() && (nearest.first[0].distance(pose) > minPoseDistance_ ||
+                                                configDistance2(nearest.second, config) > minConfigDistance2_))
+  {
+    std::lock_guard<std::mutex> slock(lock_);
+    ikCache_.emplace_back(std::vector<Pose>(1u, pose), config);
+    ikNN_.add(&ikCache_.back());
+    if (ikCache_.size() >= lastSavedCacheSize_ + 500u || ikCache_.size() == maxCacheSize_)
+      saveCache();
+  }
+}
+
+void IKCache::updateCache(const IKEntry& nearest, const std::vector<Pose>& poses,
+                          const std::vector<double>& config) const
+{
+  if (ikCache_.size() < ikCache_.capacity())
+  {
+    bool addToCache = configDistance2(nearest.second, config) > minConfigDistance2_;
+    if (!addToCache)
     {
-        if (!ikCache_.empty())
-            saveCache();
-    }
-
-    void IKCache::initializeCache(
-        const std::string &robot_description,
-        const std::string &group_name,
-        const std::string &cache_name,
-        const unsigned int num_joints)
-    {
-        // read ROS parameters
-        ros::NodeHandle node_handle("~");
-        int maxCacheSize; // node_handle.param(...) doesn't handle unsigned ints
-        node_handle.param(group_name+"/max_cache_size", maxCacheSize, 5000);
-        maxCacheSize_ = maxCacheSize;
-        ikCache_.reserve(maxCacheSize_);
-        node_handle.param(group_name+"/min_pose_distance", minPoseDistance_, 1.);
-        node_handle.param(group_name+"/min_joint_config_distance", minConfigDistance2_, 1.);
-        minConfigDistance2_ *= minConfigDistance2_;
-        std::string cached_ik_path;
-        node_handle.param("cached_ik_path", cached_ik_path, std::string());
-
-        // use mutex lock for rest of initialization
-        std::lock_guard<std::mutex> slock(lock_);
-        // determine cache file name
-        boost::filesystem::path prefix(!cached_ik_path.empty() ? cached_ik_path : boost::filesystem::current_path());
-        // create cache directory if necessary
-        boost::filesystem::create_directories(prefix);
-
-        cacheFileName_ = prefix / (robot_description + group_name + "_" + cache_name +
-            "_" + std::to_string(maxCacheSize_) + "_" + std::to_string(minPoseDistance_) +
-            "_" + std::to_string(std::sqrt(minConfigDistance2_)) + ".ikcache");
-
-        ikCache_.clear();
-        ikNN_.clear();
-        lastSavedCacheSize_ = 0;
-        if (boost::filesystem::exists(cacheFileName_))
+      double dist = 0.;
+      for (unsigned int i = 0; i < poses.size(); ++i)
+      {
+        dist += nearest.first[i].distance(poses[i]);
+        if (dist > minPoseDistance_)
         {
-            // read cache
-            boost::filesystem::ifstream cacheFile(cacheFileName_, std::ios_base::binary | std::ios_base::in);
-            cacheFile.read((char*)&lastSavedCacheSize_, sizeof(unsigned int));
-            unsigned int numDofs;
-            cacheFile.read((char*)&numDofs, sizeof(unsigned int));
-            unsigned int numTips;
-            cacheFile.read((char*)&numTips, sizeof(unsigned int));
-
-            ROS_INFO_NAMED("cached_ik_kinematics_plugin",
-                "Found %d IK solutions for a %d-dof system with %d end effectors in %s",
-                lastSavedCacheSize_, numDofs, numTips, cacheFileName_.string().c_str());
-
-            unsigned int positionSize = 3 * sizeof(tf2Scalar);
-            unsigned int orientationSize = 4 * sizeof(tf2Scalar);
-            unsigned int poseSize = positionSize + orientationSize;
-            unsigned int configSize = numDofs * sizeof(double);
-            unsigned int offsetConf = poseSize * numTips;
-            unsigned int bufsize = offsetConf + configSize;
-            char *buffer = new char[bufsize * lastSavedCacheSize_];
-            IKEntry entry;
-            entry.first.resize(numTips);
-            entry.second.resize(numDofs);
-            cacheFile.read(buffer, bufsize * lastSavedCacheSize_);
-            ikCache_.reserve(lastSavedCacheSize_);
-
-            for (unsigned i = 0; i < lastSavedCacheSize_; ++i)
-            {
-                for (auto &pose : entry.first)
-                {
-                    memcpy(&pose.position[0], buffer, positionSize);
-                    memcpy(&pose.orientation[0], buffer + positionSize, orientationSize);
-                    buffer += poseSize;
-                }
-                memcpy(&entry.second[0], buffer, configSize);
-                buffer += configSize;
-                ikCache_.push_back(entry);
-            }
-            std::vector<IKEntry*> ikEntryPtrs(lastSavedCacheSize_);
-            for (unsigned int i = 0; i < lastSavedCacheSize_; ++i)
-                ikEntryPtrs[i] = &ikCache_[i];
-            ikNN_.add(ikEntryPtrs);
-            // for debugging purposes:
-            //verifyCache();
+          addToCache = true;
+          break;
         }
-
-        numJoints_ = num_joints;
-
-        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
-                       "cache file %s initialized!",
-                       cacheFileName_.string().c_str());
+      }
     }
-
-    double IKCache::configDistance2(
-        const std::vector<double> &config1, const std::vector<double> &config2) const
+    if (addToCache)
     {
-        double dist = 0., diff;
-        for (unsigned int i = 0; i < config1.size(); ++i)
-        {
-            diff = config1[i] - config2[i];
-            dist += diff * diff;
-        }
-        return dist;
+      std::lock_guard<std::mutex> slock(lock_);
+      ikCache_.emplace_back(poses, config);
+      ikNN_.add(&ikCache_.back());
+      if (ikCache_.size() >= lastSavedCacheSize_ + 500u || ikCache_.size() == maxCacheSize_)
+        saveCache();
     }
+  }
+}
 
-    const IKCache::IKEntry &
-    IKCache::getBestApproximateIKSolution(const Pose &pose) const
+void IKCache::saveCache() const
+{
+  if (cacheFileName_.empty())
+    ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "can't save cache before initialization");
+
+  ROS_INFO_NAMED("cached_ik_kinematics_plugin", "writing %ld IK solutions to %s", ikCache_.size(),
+                 cacheFileName_.string().c_str());
+
+  boost::filesystem::ofstream cacheFile(cacheFileName_, std::ios_base::binary | std::ios_base::out);
+  unsigned int positionSize = 3 * sizeof(tf2Scalar);
+  unsigned int orientationSize = 4 * sizeof(tf2Scalar);
+  unsigned int poseSize = positionSize + orientationSize;
+  unsigned int numTips = ikCache_[0].first.size();
+  unsigned int configSize = ikCache_[0].second.size() * sizeof(double);
+  unsigned int offsetConf = numTips * poseSize;
+  unsigned int bufsize = offsetConf + configSize;
+  char* buffer = new char[bufsize];
+
+  // write number of IK entries and size of each configuration first
+  lastSavedCacheSize_ = ikCache_.size();
+  cacheFile.write((char*)&lastSavedCacheSize_, sizeof(unsigned int));
+  unsigned int sz = ikCache_[0].second.size();
+  cacheFile.write((char*)&sz, sizeof(unsigned int));
+  cacheFile.write((char*)&numTips, sizeof(unsigned int));
+  for (const auto& entry : ikCache_)
+  {
+    for (unsigned int i = 0; i < numTips; ++i)
     {
-        if (ikCache_.empty())
-        {
-            static IKEntry dummy = std::make_pair(std::vector<Pose>(1, pose), std::vector<double>(numJoints_, 0.));
-            return dummy;
-        }
-        IKEntry query = std::make_pair(std::vector<Pose>(1, pose), std::vector<double>());
-        return *ikNN_.nearest(&query);
+      memcpy(buffer + i * poseSize, &entry.first[i].position[0], positionSize);
+      memcpy(buffer + i * poseSize + positionSize, &entry.first[i].orientation[0], orientationSize);
     }
+    memcpy(buffer + offsetConf, &entry.second[0], configSize);
+    cacheFile.write(buffer, bufsize);
+  }
+}
 
-    const IKCache::IKEntry &
-    IKCache::getBestApproximateIKSolution(const std::vector<Pose> &poses) const
-    {
-        if (ikCache_.empty())
-        {
-            static IKEntry dummy = std::make_pair(poses, std::vector<double>(numJoints_, 0.));
-            return dummy;
-        }
-        IKEntry query = std::make_pair(poses, std::vector<double>());
-        return *ikNN_.nearest(&query);
-    }
+void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const
+{
+  std::vector<std::string> tipNames(fk.getTipFrames());
+  std::vector<geometry_msgs::Pose> poses(tipNames.size());
+  double error, max_error = 0.;
 
-    void IKCache::updateCache(
-        const IKEntry &nearest, const Pose &pose, const std::vector<double> &config) const
-    {
-        if (ikCache_.size() < ikCache_.capacity() &&
-            (nearest.first[0].distance(pose) > minPoseDistance_ || configDistance2(nearest.second, config) > minConfigDistance2_))
-        {
-            std::lock_guard<std::mutex> slock(lock_);
-            ikCache_.emplace_back(std::vector<Pose>(1u, pose), config);
-            ikNN_.add(&ikCache_.back());
-            if (ikCache_.size() >= lastSavedCacheSize_ + 500u || ikCache_.size() == maxCacheSize_)
-                saveCache();
-        }
-    }
+  for (const auto& entry : ikCache_)
+  {
+    fk.getPositionFK(tipNames, entry.second, poses);
+    error = 0.;
+    for (unsigned int i = 0; i < poses.size(); ++i)
+      error += entry.first[i].distance(poses[i]);
+    error /= (double)poses.size();
+    if (error > max_error)
+      max_error = error;
+    if (error > 1e-4)
+      ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "Cache entry is invalid, error = %g", error);
+  }
+  ROS_INFO_NAMED("cached_ik_kinematics_plugin", "Max. error in cache entries is %g", max_error);
+}
 
-    void IKCache::updateCache(
-        const IKEntry &nearest, const std::vector<Pose> &poses, const std::vector<double> &config) const
-    {
-        if (ikCache_.size() < ikCache_.capacity())
-        {
-            bool addToCache = configDistance2(nearest.second, config) > minConfigDistance2_;
-            if (!addToCache)
-            {
-                double dist = 0.;
-                for (unsigned int i = 0; i < poses.size(); ++i)
-                {
-                    dist += nearest.first[i].distance(poses[i]);
-                    if (dist > minPoseDistance_)
-                    {
-                        addToCache = true;
-                        break;
-                    }
-                }
-            }
-            if (addToCache)
-            {
-                std::lock_guard<std::mutex> slock(lock_);
-                ikCache_.emplace_back(poses, config);
-                ikNN_.add(&ikCache_.back());
-                if (ikCache_.size() >= lastSavedCacheSize_ + 500u || ikCache_.size() == maxCacheSize_)
-                    saveCache();
-            }
-        }
-    }
+IKCache::Pose::Pose(const geometry_msgs::Pose& pose)
+{
+  position.setX(pose.position.x);
+  position.setY(pose.position.y);
+  position.setZ(pose.position.z);
+  orientation = tf2::Quaternion(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+}
 
-    void IKCache::saveCache() const
-    {
-        if (cacheFileName_.empty())
-            ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
-                "can't save cache before initialization");
+double IKCache::Pose::distance(const Pose& pose) const
+{
+  return (position - pose.position).length() + (orientation.angleShortestPath(pose.orientation));
+}
 
-        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
-            "writing %ld IK solutions to %s",
-            ikCache_.size(), cacheFileName_.string().c_str());
+IKCacheMap::IKCacheMap(const std::string& robot_description, const std::string& group_name, unsigned int num_joints)
+  : robotDescription_(robot_description), groupName_(group_name), numJoints_(num_joints)
+{
+}
 
-        boost::filesystem::ofstream cacheFile(cacheFileName_, std::ios_base::binary | std::ios_base::out);
-        unsigned int positionSize = 3 * sizeof(tf2Scalar);
-        unsigned int orientationSize = 4 * sizeof(tf2Scalar);
-        unsigned int poseSize = positionSize + orientationSize;
-        unsigned int numTips = ikCache_[0].first.size();
-        unsigned int configSize = ikCache_[0].second.size() * sizeof(double);
-        unsigned int offsetConf = numTips * poseSize;
-        unsigned int bufsize = offsetConf + configSize;
-        char *buffer = new char[bufsize];
+IKCacheMap::~IKCacheMap()
+{
+  for (auto& cache : *this)
+    delete cache.second;
+}
 
-        // write number of IK entries and size of each configuration first
-        lastSavedCacheSize_ = ikCache_.size();
-        cacheFile.write((char*)&lastSavedCacheSize_, sizeof(unsigned int));
-        unsigned int sz = ikCache_[0].second.size();
-        cacheFile.write((char*)&sz, sizeof(unsigned int));
-        cacheFile.write((char*)&numTips, sizeof(unsigned int));
-        for (const auto &entry : ikCache_)
-        {
-            for (unsigned int i = 0; i < numTips; ++i)
-            {
-                memcpy(buffer + i * poseSize, &entry.first[i].position[0], positionSize);
-                memcpy(buffer + i * poseSize + positionSize, &entry.first[i].orientation[0], orientationSize);
-            }
-            memcpy(buffer + offsetConf, &entry.second[0], configSize);
-            cacheFile.write(buffer, bufsize);
-        }
-    }
+const IKCache::IKEntry& IKCacheMap::getBestApproximateIKSolution(const std::vector<std::string>& fixed,
+                                                                 const std::vector<std::string>& active,
+                                                                 const std::vector<Pose>& poses) const
+{
+  auto key(getKey(fixed, active));
+  auto it = find(key);
+  if (it != end())
+    return it->second->getBestApproximateIKSolution(poses);
+  else
+  {
+    static IKEntry dummy = std::make_pair(poses, std::vector<double>(numJoints_, 0.));
+    return dummy;
+  }
+}
 
-    void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin &fk) const
-    {
-        std::vector<std::string> tipNames(fk.getTipFrames());
-        std::vector<geometry_msgs::Pose> poses(tipNames.size());
-        double error, max_error = 0.;
+void IKCacheMap::updateCache(const IKEntry& nearest, const std::vector<std::string>& fixed,
+                             const std::vector<std::string>& active, const std::vector<Pose>& poses,
+                             const std::vector<double>& config)
+{
+  auto key(getKey(fixed, active));
+  auto it = find(key);
+  if (it != end())
+    it->second->updateCache(nearest, poses, config);
+  else
+  {
+    value_type val = std::make_pair(key, nullptr);
+    auto it = insert(val).first;
+    it->second = new IKCache;
+    it->second->initializeCache(robotDescription_, groupName_, key, numJoints_);
+  }
+}
 
-        for (const auto &entry : ikCache_)
-        {
-            fk.getPositionFK(tipNames, entry.second, poses);
-            error = 0.;
-            for (unsigned int i = 0; i < poses.size(); ++i)
-                error += entry.first[i].distance(poses[i]);
-            error /= (double)poses.size();
-            if (error > max_error)
-                max_error = error;
-            if (error > 1e-4)
-                ROS_ERROR_NAMED("cached_ik_kinematics_plugin",
-                    "Cache entry is invalid, error = %g", error);
-        }
-        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
-            "Max. error in cache entries is %g", max_error);
-    }
-
-    IKCache::Pose::Pose(const geometry_msgs::Pose& pose)
-    {
-        position.setX(pose.position.x);
-        position.setY(pose.position.y);
-        position.setZ(pose.position.z);
-        orientation = tf2::Quaternion(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
-    }
-
-    double IKCache::Pose::distance(const Pose &pose) const
-    {
-        return (position - pose.position).length() + (orientation.angleShortestPath(pose.orientation));
-    }
-
-
-    IKCacheMap::IKCacheMap(const std::string &robot_description, const std::string &group_name, unsigned int num_joints)
-        : robotDescription_(robot_description), groupName_(group_name), numJoints_(num_joints)
-    {
-    }
-
-    IKCacheMap::~IKCacheMap()
-    {
-        for (auto &cache : *this)
-            delete cache.second;
-    }
-
-    const IKCache::IKEntry &
-    IKCacheMap::getBestApproximateIKSolution(const std::vector<std::string> &fixed, const std::vector<std::string> &active,
-                                          const std::vector<Pose> &poses) const
-    {
-        auto key(getKey(fixed, active));
-        auto it = find(key);
-        if (it != end())
-            return it->second->getBestApproximateIKSolution(poses);
-        else
-        {
-            static IKEntry dummy = std::make_pair(poses, std::vector<double>(numJoints_, 0.));
-            return dummy;
-        }
-    }
-
-    void IKCacheMap::updateCache(
-        const IKEntry &nearest, const std::vector<std::string> &fixed, const std::vector<std::string> &active,
-        const std::vector<Pose> &poses, const std::vector<double> &config)
-    {
-        auto key(getKey(fixed, active));
-        auto it = find(key);
-        if (it != end())
-            it->second->updateCache(nearest, poses, config);
-        else
-        {
-            value_type val = std::make_pair(key, nullptr);
-            auto it = insert(val).first;
-            it->second = new IKCache;
-            it->second->initializeCache(robotDescription_, groupName_, key, numJoints_);
-        }
-    }
-
-    std::string IKCacheMap::getKey(const std::vector<std::string> &fixed, const std::vector<std::string> &active) const
-    {
-        std::string key;
-        std::accumulate(fixed.begin(), fixed.end(), key);
-        key += '_';
-        std::accumulate(active.begin(), active.end(), key);
-        return key;
-    }
-
+std::string IKCacheMap::getKey(const std::vector<std::string>& fixed, const std::vector<std::string>& active) const
+{
+  std::string key;
+  std::accumulate(fixed.begin(), fixed.end(), key);
+  key += '_';
+  std::accumulate(active.begin(), active.end(), key);
+  return key;
+}
 }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -1,0 +1,154 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mark Moll */
+
+#include <cstring>
+#include <chrono>
+#include <ros/ros.h>
+#include <boost/program_options.hpp>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+namespace po = boost::program_options;
+
+int main(int argc, char *argv[])
+{
+    std::string group;
+    std::string tip;
+    unsigned int num;
+    bool reset_to_default;
+    po::options_description desc("Options");
+    desc.add_options()
+        ("help", "show help message")
+        ("group", po::value<std::string>(&group)->default_value("all"), "name of planning group")
+        ("tip", po::value<std::string>(&tip)->default_value("default"), "name of the end effector in the planning group")
+        ("num", po::value<unsigned int>(&num)->default_value(100000), "number of IK solutions to compute")
+        ("reset_to_default", po::value<bool>(&reset_to_default)->default_value(true), "wether to reset IK seed to default state. If set to false, the seed is the correct IK solution (to accelerate filling the cache).")
+    ;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help") != 0u)
+    {
+        std::cout << desc << "\n";
+        return 1;
+    }
+
+    ros::init(argc, argv, "measure_ik_call_cost");
+    ros::AsyncSpinner spinner(1);
+    spinner.start();
+
+    robot_model_loader::RobotModelLoader robot_model_loader;
+    robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+    planning_scene::PlanningScene planning_scene(kinematic_model);
+    robot_state::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
+    collision_detection::CollisionRequest collision_request;
+    collision_detection::CollisionResult collision_result;
+    std::vector<double> joint_values;
+    std::chrono::duration<double> ik_time;
+    std::chrono::time_point<std::chrono::system_clock> start, end;
+    std::vector<robot_state::JointModelGroup*> groups;
+    std::vector<std::string> end_effectors;
+
+    if (group == "all")
+        groups = kinematic_model->getJointModelGroups();
+    else
+        groups.push_back(kinematic_model->getJointModelGroup(group));
+
+    for (const auto &group : groups)
+    {
+        // skip group if there's no IK solver
+        if (group->getSolverInstance() == nullptr) continue;
+
+        if (tip == "default")
+            group->getEndEffectorTips(end_effectors);
+        else
+            end_effectors = std::vector<std::string>(1, tip);
+
+        // perform first IK call to load the cache, so that the time for loading is not included in
+        // average IK call time
+        kinematic_state.setToDefaultValues();
+        EigenSTL::vector_Affine3d default_eef_states;
+        for (const auto &end_effector : end_effectors)
+            default_eef_states.push_back(kinematic_state.getGlobalLinkTransform(end_effector));
+        if (end_effectors.size() == 1)
+            kinematic_state.setFromIK(group, default_eef_states[0], end_effectors[0], 1, 0.1);
+        else
+            kinematic_state.setFromIK(group, default_eef_states, end_effectors, 1, 0.1);
+
+        bool found_ik;
+        unsigned int num_failed_calls = 0, num_self_collisions = 0;
+        EigenSTL::vector_Affine3d end_effector_states(end_effectors.size());
+        unsigned int i = 0;
+        while (i < num)
+        {
+            kinematic_state.setToRandomPositions(group);
+            collision_result.clear();
+            planning_scene.checkSelfCollision(collision_request, collision_result);
+            if (collision_result.collision)
+            {
+                ++num_self_collisions;
+                continue;
+            }
+            for (unsigned j = 0; j < end_effectors.size(); ++j)
+                end_effector_states[j] = kinematic_state.getGlobalLinkTransform(end_effectors[j]);
+            if (reset_to_default)
+                kinematic_state.setToDefaultValues();
+            start = std::chrono::system_clock::now();
+            if (end_effectors.size() == 1)
+                found_ik = kinematic_state.setFromIK(group, end_effector_states[0], end_effectors[0], 10, 0.1);
+            else
+                found_ik = kinematic_state.setFromIK(group, end_effector_states, end_effectors, 10, 0.1);
+            ik_time += std::chrono::system_clock::now() - start;
+            if (!found_ik)
+                num_failed_calls++;
+            ++i;
+            if (i % 100 == 0)
+                ROS_INFO_NAMED("measure_ik_call_cost",
+            "Avg. time per IK solver call is %g after %d calls. %g%% of calls failed to return a solution. %g%% of random joint configurations were ignored due to self-collisions.",
+            ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
+            100. * num_self_collisions / (num_self_collisions + i));
+        }
+        ROS_INFO_NAMED("measure_ik_call_cost", "Summary for group %s: %g %g %g",
+            group->getName().c_str(), ik_time.count() / (double)i,
+            100. * num_failed_calls / i,
+            100. * num_self_collisions / (num_self_collisions + i));
+    }
+
+    ros::shutdown();
+    return 0;
+}

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2017, Rice University
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Mark Moll */
 
@@ -43,112 +43,113 @@
 
 namespace po = boost::program_options;
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    std::string group;
-    std::string tip;
-    unsigned int num;
-    bool reset_to_default;
-    po::options_description desc("Options");
-    desc.add_options()
-        ("help", "show help message")
-        ("group", po::value<std::string>(&group)->default_value("all"), "name of planning group")
-        ("tip", po::value<std::string>(&tip)->default_value("default"), "name of the end effector in the planning group")
-        ("num", po::value<unsigned int>(&num)->default_value(100000), "number of IK solutions to compute")
-        ("reset_to_default", po::value<bool>(&reset_to_default)->default_value(true), "wether to reset IK seed to default state. If set to false, the seed is the correct IK solution (to accelerate filling the cache).")
-    ;
+  std::string group;
+  std::string tip;
+  unsigned int num;
+  bool reset_to_default;
+  po::options_description desc("Options");
+  desc.add_options()("help", "show help message")("group", po::value<std::string>(&group)->default_value("all"),
+                                                  "name of planning group")(
+      "tip", po::value<std::string>(&tip)->default_value("default"), "name of the end effector in the planning group")(
+      "num", po::value<unsigned int>(&num)->default_value(100000),
+      "number of IK solutions to compute")("reset_to_default", po::value<bool>(&reset_to_default)->default_value(true),
+                                           "wether to reset IK seed to default state. If set to false, the seed is the "
+                                           "correct IK solution (to accelerate filling the cache).");
 
-    po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, argv, desc), vm);
+  po::notify(vm);
 
-    if (vm.count("help") != 0u)
-    {
-        std::cout << desc << "\n";
-        return 1;
-    }
+  if (vm.count("help") != 0u)
+  {
+    std::cout << desc << "\n";
+    return 1;
+  }
 
-    ros::init(argc, argv, "measure_ik_call_cost");
-    ros::AsyncSpinner spinner(1);
-    spinner.start();
+  ros::init(argc, argv, "measure_ik_call_cost");
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
 
-    robot_model_loader::RobotModelLoader robot_model_loader;
-    robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
-    planning_scene::PlanningScene planning_scene(kinematic_model);
-    robot_state::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
-    collision_detection::CollisionRequest collision_request;
-    collision_detection::CollisionResult collision_result;
-    std::vector<double> joint_values;
-    std::chrono::duration<double> ik_time;
-    std::chrono::time_point<std::chrono::system_clock> start, end;
-    std::vector<robot_state::JointModelGroup*> groups;
-    std::vector<std::string> end_effectors;
+  robot_model_loader::RobotModelLoader robot_model_loader;
+  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  planning_scene::PlanningScene planning_scene(kinematic_model);
+  robot_state::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
+  collision_detection::CollisionRequest collision_request;
+  collision_detection::CollisionResult collision_result;
+  std::vector<double> joint_values;
+  std::chrono::duration<double> ik_time;
+  std::chrono::time_point<std::chrono::system_clock> start, end;
+  std::vector<robot_state::JointModelGroup*> groups;
+  std::vector<std::string> end_effectors;
 
-    if (group == "all")
-        groups = kinematic_model->getJointModelGroups();
+  if (group == "all")
+    groups = kinematic_model->getJointModelGroups();
+  else
+    groups.push_back(kinematic_model->getJointModelGroup(group));
+
+  for (const auto& group : groups)
+  {
+    // skip group if there's no IK solver
+    if (group->getSolverInstance() == nullptr)
+      continue;
+
+    if (tip == "default")
+      group->getEndEffectorTips(end_effectors);
     else
-        groups.push_back(kinematic_model->getJointModelGroup(group));
+      end_effectors = std::vector<std::string>(1, tip);
 
-    for (const auto &group : groups)
+    // perform first IK call to load the cache, so that the time for loading is not included in
+    // average IK call time
+    kinematic_state.setToDefaultValues();
+    EigenSTL::vector_Affine3d default_eef_states;
+    for (const auto& end_effector : end_effectors)
+      default_eef_states.push_back(kinematic_state.getGlobalLinkTransform(end_effector));
+    if (end_effectors.size() == 1)
+      kinematic_state.setFromIK(group, default_eef_states[0], end_effectors[0], 1, 0.1);
+    else
+      kinematic_state.setFromIK(group, default_eef_states, end_effectors, 1, 0.1);
+
+    bool found_ik;
+    unsigned int num_failed_calls = 0, num_self_collisions = 0;
+    EigenSTL::vector_Affine3d end_effector_states(end_effectors.size());
+    unsigned int i = 0;
+    while (i < num)
     {
-        // skip group if there's no IK solver
-        if (group->getSolverInstance() == nullptr) continue;
-
-        if (tip == "default")
-            group->getEndEffectorTips(end_effectors);
-        else
-            end_effectors = std::vector<std::string>(1, tip);
-
-        // perform first IK call to load the cache, so that the time for loading is not included in
-        // average IK call time
+      kinematic_state.setToRandomPositions(group);
+      collision_result.clear();
+      planning_scene.checkSelfCollision(collision_request, collision_result);
+      if (collision_result.collision)
+      {
+        ++num_self_collisions;
+        continue;
+      }
+      for (unsigned j = 0; j < end_effectors.size(); ++j)
+        end_effector_states[j] = kinematic_state.getGlobalLinkTransform(end_effectors[j]);
+      if (reset_to_default)
         kinematic_state.setToDefaultValues();
-        EigenSTL::vector_Affine3d default_eef_states;
-        for (const auto &end_effector : end_effectors)
-            default_eef_states.push_back(kinematic_state.getGlobalLinkTransform(end_effector));
-        if (end_effectors.size() == 1)
-            kinematic_state.setFromIK(group, default_eef_states[0], end_effectors[0], 1, 0.1);
-        else
-            kinematic_state.setFromIK(group, default_eef_states, end_effectors, 1, 0.1);
-
-        bool found_ik;
-        unsigned int num_failed_calls = 0, num_self_collisions = 0;
-        EigenSTL::vector_Affine3d end_effector_states(end_effectors.size());
-        unsigned int i = 0;
-        while (i < num)
-        {
-            kinematic_state.setToRandomPositions(group);
-            collision_result.clear();
-            planning_scene.checkSelfCollision(collision_request, collision_result);
-            if (collision_result.collision)
-            {
-                ++num_self_collisions;
-                continue;
-            }
-            for (unsigned j = 0; j < end_effectors.size(); ++j)
-                end_effector_states[j] = kinematic_state.getGlobalLinkTransform(end_effectors[j]);
-            if (reset_to_default)
-                kinematic_state.setToDefaultValues();
-            start = std::chrono::system_clock::now();
-            if (end_effectors.size() == 1)
-                found_ik = kinematic_state.setFromIK(group, end_effector_states[0], end_effectors[0], 10, 0.1);
-            else
-                found_ik = kinematic_state.setFromIK(group, end_effector_states, end_effectors, 10, 0.1);
-            ik_time += std::chrono::system_clock::now() - start;
-            if (!found_ik)
-                num_failed_calls++;
-            ++i;
-            if (i % 100 == 0)
-                ROS_INFO_NAMED("measure_ik_call_cost",
-            "Avg. time per IK solver call is %g after %d calls. %g%% of calls failed to return a solution. %g%% of random joint configurations were ignored due to self-collisions.",
-            ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
-            100. * num_self_collisions / (num_self_collisions + i));
-        }
-        ROS_INFO_NAMED("measure_ik_call_cost", "Summary for group %s: %g %g %g",
-            group->getName().c_str(), ik_time.count() / (double)i,
-            100. * num_failed_calls / i,
-            100. * num_self_collisions / (num_self_collisions + i));
+      start = std::chrono::system_clock::now();
+      if (end_effectors.size() == 1)
+        found_ik = kinematic_state.setFromIK(group, end_effector_states[0], end_effectors[0], 10, 0.1);
+      else
+        found_ik = kinematic_state.setFromIK(group, end_effector_states, end_effectors, 10, 0.1);
+      ik_time += std::chrono::system_clock::now() - start;
+      if (!found_ik)
+        num_failed_calls++;
+      ++i;
+      if (i % 100 == 0)
+        ROS_INFO_NAMED("measure_ik_call_cost",
+                       "Avg. time per IK solver call is %g after %d calls. %g%% of calls failed to return a solution. "
+                       "%g%% of random joint configurations were ignored due to self-collisions.",
+                       ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
+                       100. * num_self_collisions / (num_self_collisions + i));
     }
+    ROS_INFO_NAMED("measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
+                   ik_time.count() / (double)i, 100. * num_failed_calls / i,
+                   100. * num_self_collisions / (num_self_collisions + i));
+  }
 
-    ros::shutdown();
-    return 0;
+  ros::shutdown();
+  return 0;
 }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/test.sh
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/test.sh
@@ -5,7 +5,7 @@ for robot in abb_irb2400 abb_irb6640 cob fetch hironx nao nextage pepper pr2 ur5
     done
     if [[ ${robot} == "ur5_robotiq85" ]]; then
         for kinematics in ur5 ur5_cached; do
-            roslaunch moveit_kinematics measure_ik_call_cost.launch robot:=${robot} num:=100 kinematics:=true kinematics_path:=src/moveit/moveit_kinematics/cached_ik_kinematics_plugin/config/${kinematics}.yaml 2>&1 | grep Summary | cut -f 7-10 -d' '` | sed "s/^/${robot} ${kinematics} /"
+            roslaunch moveit_kinematics measure_ik_call_cost.launch robot:=${robot} num:=100 kinematics:=true kinematics_path:=src/moveit/moveit_kinematics/cached_ik_kinematics_plugin/config/${kinematics}.yaml 2>&1 | grep Summary | cut -f 7-10 -d' ' | sed "s/^/${robot} ${kinematics} /"
         done
     fi
 done

--- a/moveit_kinematics/cached_ik_kinematics_plugin/test.sh
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+for robot in abb_irb2400 abb_irb6640 cob fetch hironx nao nextage pepper pr2 ur5_robotiq85 vs060; do
+    for kinematics in kdl kdl_cached trac trac_cached; do
+        roslaunch moveit_kinematics measure_ik_call_cost.launch robot:=${robot} num:=10000 kinematics:=true kinematics_path:=src/moveit/moveit_kinematics/cached_ik_kinematics_plugin/config/${kinematics}.yaml 2>&1 | grep Summary | cut -f 7-10 -d' ' | sed "s/^/${robot} ${kinematics} /"
+    done
+    if [[ ${robot} == "ur5_robotiq85" ]]; then
+        for kinematics in ur5 ur5_cached; do
+            roslaunch moveit_kinematics measure_ik_call_cost.launch robot:=${robot} num:=100 kinematics:=true kinematics_path:=src/moveit/moveit_kinematics/cached_ik_kinematics_plugin/config/${kinematics}.yaml 2>&1 | grep Summary | cut -f 7-10 -d' '` | sed "s/^/${robot} ${kinematics} /"
+        done
+    fi
+done

--- a/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
@@ -1,0 +1,38 @@
+<library path="lib/libmoveit_cached_ik_kinematics_plugin">
+  <class name="cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+    <description>
+      A kinematics plugin for persistently caching IK solutions computed with the KDL kinematics plugin.
+    </description>
+  </class>
+  <class name="cached_ik_kinematics_plugin/CachedSrvKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<srv_kinematics_plugin::SrvKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+    <description>
+      A kinematics plugin for persistently caching IK solutions computed with the Srv kinematics plugin.
+    </description>
+  </class>
+  <class name="cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+    <description>
+      A kinematics plugin for persistently caching IK solutions computed with the TRAC kinematics plugin.
+    </description>
+  </class>
+</library>
+<library path="lib/libmoveit_cached_ur3_kinematics_plugin">
+  <class name="cached_ik_kinematics_plugin/CachedUR3KinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+    <description>
+      A kinematics plugin for persistently caching IK solutions computed with the UR3 kinematics plugin.
+    </description>
+  </class>
+</library>
+<library path="lib/libmoveit_cached_ur5_kinematics_plugin">
+  <class name="cached_ik_kinematics_plugin/CachedUR5KinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+    <description>
+      A kinematics plugin for persistently caching IK solutions computed with the UR5 kinematics plugin.
+    </description>
+  </class>
+</library>
+<library path="lib/libmoveit_cached_ur10_kinematics_plugin">
+  <class name="cached_ik_kinematics_plugin/CachedUR10KinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+    <description>
+      A kinematics plugin for persistently caching IK solutions computed with the UR10 kinematics plugin.
+    </description>
+  </class>
+</library>

--- a/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
@@ -9,13 +9,13 @@
       A kinematics plugin for persistently caching IK solutions computed with the Srv kinematics plugin.
     </description>
   </class>
-  @TRAC_BEGIN@<class name="cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+  <!--<class name="cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
     <description>
       A kinematics plugin for persistently caching IK solutions computed with the TRAC kinematics plugin.
     </description>
-  </class>@TRAC_END@
+  </class>-->
 </library>
-@UR_BEGIN@<library path="lib/libmoveit_cached_ur3_kinematics_plugin">
+<!--<library path="lib/libmoveit_cached_ur3_kinematics_plugin">
   <class name="cached_ik_kinematics_plugin/CachedUR3KinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
     <description>
       A kinematics plugin for persistently caching IK solutions computed with the UR3 kinematics plugin.
@@ -35,4 +35,4 @@
       A kinematics plugin for persistently caching IK solutions computed with the UR10 kinematics plugin.
     </description>
   </class>
-</library>@UR_END@
+</library>-->

--- a/moveit_kinematics/cached_ik_kinematics_plugin_description.xml.in
+++ b/moveit_kinematics/cached_ik_kinematics_plugin_description.xml.in
@@ -9,13 +9,13 @@
       A kinematics plugin for persistently caching IK solutions computed with the Srv kinematics plugin.
     </description>
   </class>
-  <class name="cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
+  @TRAC_BEGIN@<class name="cached_ik_kinematics_plugin/CachedTRACKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<trac_ik_kinematics_plugin::TRAC_IKKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
     <description>
       A kinematics plugin for persistently caching IK solutions computed with the TRAC kinematics plugin.
     </description>
-  </class>
+  </class>@TRAC_END@
 </library>
-<library path="lib/libmoveit_cached_ur3_kinematics_plugin">
+@UR_BEGIN@<library path="lib/libmoveit_cached_ur3_kinematics_plugin">
   <class name="cached_ik_kinematics_plugin/CachedUR3KinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
     <description>
       A kinematics plugin for persistently caching IK solutions computed with the UR3 kinematics plugin.
@@ -35,4 +35,4 @@
       A kinematics plugin for persistently caching IK solutions computed with the UR10 kinematics plugin.
     </description>
   </class>
-</library>
+</library>@UR_END@

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -35,6 +35,7 @@
     <moveit_core plugin="${prefix}/kdl_kinematics_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/lma_kinematics_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/srv_kinematics_plugin_description.xml"/>
+    <moveit_core plugin="${prefix}/cached_ik_kinematics_plugin_description.xml"/>
   </export>
 
 </package>


### PR DESCRIPTION
### Description

Added a kinematics plugin that caches IK solutions. It wraps around existing IK solvers. The [kinematics configuration tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/pr2_tutorials/kinematics/src/doc/kinematics_configuration.html) could be updated with some of the documentation I put in `moveit/moveit_kinematics/cached_ik_kinematics_plugin/README.md`.

### Checklist
- [X] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!