### PR TITLE
add moveit_fake_controller_manager to run_depend of moveit_config_pkg_template/package.xml.template

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -17,6 +17,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_fake_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>


### PR DESCRIPTION
moveit_setup_assistant generate launch file using fake controller, but the package.xml does not incude this package
https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/fake_moveit_controller_manager.launch.xml#L4