### PR TITLE
create_ikfast_moveit_plugin: fixed directory variable for templates that were moved to ikfast_kinematics_plugin

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/CMakeLists.txt
@@ -16,5 +16,5 @@ install(
   DIRECTORY
     templates
   DESTINATION
-    ${CATKIN_PACKAGE_SHARE_DESTINATION}
+    ${CATKIN_PACKAGE_SHARE_DESTINATION}/ikfast_kinematics_plugin
 )

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -52,6 +52,7 @@ from lxml import etree
 import shutil
 
 plugin_gen_pkg = 'moveit_kinematics'  # package containing this file
+plugin_sub_dir = 'ikfast_kinematics_plugin' # sub directory which contains the template directory
 # Allowed search modes, see SEARCH_MODE enum in template file
 search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT' ]
 
@@ -181,7 +182,7 @@ if __name__ == '__main__':
 
    # Get template folder location
    try:
-      plugin_gen_dir = roslib.packages.get_pkg_dir(plugin_gen_pkg)
+      plugin_gen_dir = os.path.join(roslib.packages.get_pkg_dir(plugin_gen_pkg), plugin_sub_dir)
    except:
       print '\nERROR: can\'t find package '+plugin_gen_pkg+' \n'
       sys.exit(-1)


### PR DESCRIPTION
Apparently this was never changed after the move to the moveit_kinematics package.

Needs cherry-picking to indigo.
