### PR TITLE
Bug fixes in moveit_commander/robot.py

### DIFF
--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -118,9 +118,7 @@ class RobotCommander(object):
                 raise MoveItCommanderException("There is no known group containing joint %s. Cannot move." % self._name)
             gc = self._robot.get_group(group)
             if gc is not None:
-                if not self._robot._is_group_initialized[gc.get_name()]:
-                    gc.set_joint_value_target(gc.get_current_joint_values())
-                    self._robot._is_group_initialized[gc.get_name()] = True
+                gc.set_joint_value_target(gc.get_current_joint_values())
                 gc.set_joint_value_target(self._name, position)
                 return gc.go(wait)
             return False
@@ -150,7 +148,6 @@ class RobotCommander(object):
         self._r = _moveit_robot_interface.RobotInterface(robot_description)
         self._groups = {}
         self._joint_owner_groups = {}
-        self._is_group_initialized = dict(zip(self._r.get_group_names(), [False]*len(self._r.get_group_names())))
 
     def get_planning_frame(self):
         """


### PR DESCRIPTION
### Description

1. `_joint_owner_groups` had a typo (line 152)

2. `RobotCommander.get_default_owner_group` was incorrectly called (line 116)

3. When executing a motion command (RobotCommander.Joint.move) the target values for **other** joints should be updated only once, at the beginning. Originally line 121 `   gc.set_joint_value_target(gc.get_current_joint_values())` updated target values for all the joints in the group, which is not correct and resulted in a drift of unrelated joints due to forces of gravity, etc. Whenever the group in a robot is used first, joint values are updated (lines 121-123, 153), but for subsequent movements unrelated joints (i.e. **not** a target joint) are left unchanged, only target joint is moving.

