### PR TITLE
operate attached_collision_object by service call

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1223,6 +1223,10 @@ bool planning_scene::PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::P
   for (std::size_t i = 0; i < scene_msg.world.collision_objects.size(); ++i)
     result &= processCollisionObjectMsg(scene_msg.world.collision_objects[i]);
 
+  // process attached collision object updates
+  for (std::size_t i = 0; i < scene_msg.world.attached_collision_objects.size(); ++i)
+    result &= processAttachedCollisionObjectMsg(scene_msg.world.attached_collision_objects[i]);
+
   // if an octomap was specified, replace the one we have with that one
   if (!scene_msg.world.octomap.octomap.data.empty())
     processOctomapMsg(scene_msg.world.octomap);
@@ -1268,6 +1272,8 @@ bool planning_scene::PlanningScene::processPlanningSceneWorldMsg(const moveit_ms
   bool result = true;
   for (std::size_t i = 0; i < world.collision_objects.size(); ++i)
     result &= processCollisionObjectMsg(world.collision_objects[i]);
+  for (std::size_t i = 0; i < scene_msg.world.attached_collision_objects.size(); ++i)
+    result &= processAttachedCollisionObjectMsg(scene_msg.world.attached_collision_objects[i]);
   processOctomapMsg(world.octomap);
   return result;
 }


### PR DESCRIPTION
### Description

Requires https://github.com/ros-planning/moveit_msgs/pull/40

Currently, `collision_objects` can be updated by `ApplyPlanningScene` service,
but `attached_collision_objects` are unavailable.
This PR enable us to do `attached_collision_object` operation, which can be done by publishing topic, by `ApplyPlanningScene` service call.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
