### PR TITLE
benchmarks: always prefer local header over system installations

### DIFF
--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ catkin_package(
   INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/include
 )
 
-include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_LIST_DIR}/include)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_library(${MOVEIT_LIB_NAME} src/BenchmarkOptions.cpp


### PR DESCRIPTION
Before, on systems with package installations of MoveIt,
the sources of this module included headers from /opt/ros/kinetic/include/ ...
instead of the local ones.

I found this by `sudo chmod o-r /opt/ros/kinetic/include/moveit` before building the local workspace.