### PR TITLE
moveit_core: export DEPENDS on LIBFCL

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -126,6 +126,7 @@ catkin_package(
   DEPENDS
     Boost
     EIGEN3
+    LIBFCL
     OCTOMAP
     console_bridge
     urdfdom

--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -33,7 +33,6 @@
   <build_depend>eigen</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>assimp</build_depend>
-  <build_depend>libfcl-dev</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
@@ -51,7 +50,6 @@
   <run_depend>eigen</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>assimp</run_depend>
-  <run_depend>libfcl-dev</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend version_gte="0.3.4">geometric_shapes</run_depend>


### PR DESCRIPTION
We export headers that include fcl, so this has to be exported.

This is required to properly overlay a system installation of fcl with a package in the local `catkin` workspace. Without it `moveit_experimental` will include system headers instead.