### PR TITLE
Really ignore pyc files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ CATKIN_IGNORE
 
 # Continous Integration
 .moveit_ci
+
+*.pyc


### PR DESCRIPTION
They're in the `.gitignore` twice already, but I think the regex is not matching files in sub dirs properly for some reason.

Without this, after running `moveit_commander` in a source build:

```shell
$ git status
On branch kinetic-devel
Your branch is up-to-date with 'origin/kinetic-devel'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	moveit_commander/src/moveit_commander/conversions.pyc
	moveit_commander/src/moveit_commander/exception.pyc
	moveit_commander/src/moveit_commander/interpreter.pyc
	moveit_commander/src/moveit_commander/move_group.pyc
	moveit_commander/src/moveit_commander/planning_scene_interface.pyc
	moveit_commander/src/moveit_commander/robot.pyc
	moveit_commander/src/moveit_commander/roscpp_initializer.pyc
```

After:

```shell
$ git status
On branch kinetic-devel
Your branch is up-to-date with 'origin/kinetic-devel'.

nothing to commit, working tree clean
```
