### PR TITLE
Fix MotionPlanning Display auto-active bug

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -176,7 +176,6 @@ private Q_SLOTS:
   void changedMetricsTextHeight();
   void changedWorkspace();
   void resetInteractiveMarkers();
-  void motionPanelVisibilityChange(bool enable);
 
 protected:
   enum LinkDisplayStatus

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -231,7 +231,6 @@ void MotionPlanningDisplay::onInitialize()
   if (window_context)
   {
     frame_dock_ = window_context->addPane(getName(), frame_);
-    connect(frame_dock_, SIGNAL(visibilityChanged(bool)), this, SLOT(motionPanelVisibilityChange(bool)));
     frame_dock_->setIcon(getIcon());
   }
 
@@ -253,12 +252,6 @@ void MotionPlanningDisplay::onInitialize()
         new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_R), context_->getWindowManager()->getParentWindow());
     connect(im_reset_shortcut, SIGNAL(activated()), this, SLOT(resetInteractiveMarkers()));
   }
-}
-
-void MotionPlanningDisplay::motionPanelVisibilityChange(bool enable)
-{
-  if (enable)
-    setEnabled(true);
 }
 
 void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)


### PR DESCRIPTION
The MotionPlanning display got activated every time RViz was started, even though it was disabled in the configuration.

This behavior was caused by a function that enabled the display whenever the MotionPlanning panel was added in RViz. 
When starting RViz the configuration of the MotionPlanning display is loaded before the MotionPlanning panel. In affect the display got disabled by the configuration, but when the panel is activated on startup it would enable the display again. 

To fix this issue the function and its calls were removed.
The display's state behaves according to the configuration on startup, but the display does not get enabled anymore when adding the panel.

Fixes #633.