### PR TITLE
Fixes connection problem with mongodb first time it creates the database

### DIFF
--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -133,12 +133,14 @@ int main(int argc, char** argv)
   int port;
   node.param<std::string>("warehouse_host", host, "localhost");
   node.param<int>("warehouse_port", port, 33829);
+
+  ros::Duration(10.0).sleep();
   warehouse_ros::DatabaseConnection::Ptr conn;
 
   try
   {
     conn = moveit_warehouse::loadDatabase();
-    conn->setParams(host, port, 5.0);
+    conn->setParams(host, port, 150.0);
 
     ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);
     if (!conn->connect())
@@ -153,6 +155,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
+  ROS_INFO("Successfully connected to warehouse on %s:%d", host.c_str(), port);
   moveit_warehouse::RobotStateStorage rs(conn);
 
   std::vector<std::string> names;


### PR DESCRIPTION
### Description

This solves issue #648. It turns out that the first time a robot is launched it takes a lot of time creating the  mongo db (from 100 to 150 seconds). So I added an initial sleep to allow moveit to load and increased the timeout to connect to the database and it does now manage to connect after a while. I also added a confirmation message when it connects successfully.  