### PR TITLE
Fix set start state to current

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ CATKIN_IGNORE
 
 # Continous Integration
 .moveit_ci
+
+*.pyc

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -809,6 +809,9 @@ public:
   /** \brief Get the current state of the robot */
   robot_state::RobotStatePtr getCurrentState();
 
+  /** \brief Get the start state for the motion plan */
+  robot_state::RobotStatePtr getStartState();
+
   /** \brief Get the pose for the end-effector \e end_effector_link.
       If \e end_effector_link is empty (the default value) then the end-effector reported by getEndEffectorLink() is
      assumed */

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -420,7 +420,15 @@ public:
 
   void setStartStateToCurrentState()
   {
-    considered_start_state_.reset();
+    robot_state::RobotStatePtr current_state;
+    if (getCurrentState(current_state))
+    {
+      considered_start_state_.reset(new moveit::core::RobotState(*current_state));
+    }
+    else
+    {
+      ROS_WARN("Unable to get current state, skip setting start state");
+    }
   }
 
   robot_state::RobotStatePtr getStartState()
@@ -2112,6 +2120,11 @@ robot_state::RobotStatePtr moveit::planning_interface::MoveGroupInterface::getCu
   robot_state::RobotStatePtr current_state;
   impl_->getCurrentState(current_state);
   return current_state;
+}
+
+robot_state::RobotStatePtr moveit::planning_interface::MoveGroupInterface::getStartState()
+{
+  return impl_->getStartState();
 }
 
 void moveit::planning_interface::MoveGroupInterface::rememberJointValues(const std::string& name,


### PR DESCRIPTION
### Description
Actually sets the start state to the current state.  Previously it would only reset the pointer.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!
