### PR TITLE
Get msgs from Planning Scene

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -51,6 +51,7 @@
 #include <moveit_msgs/RobotTrajectory.h>
 #include <moveit_msgs/Constraints.h>
 #include <moveit_msgs/PlanningSceneComponents.h>
+#include <octomap_msgs/OctomapWithPose.h>
 #include <boost/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <boost/concept_check.hpp>
@@ -689,6 +690,29 @@ public:
       this will be a complete planning scene message */
   void getPlanningSceneMsg(moveit_msgs::PlanningScene& scene, const moveit_msgs::PlanningSceneComponents& comp) const;
 
+  /** \brief Construct a message (\e collision_object) with the collision object data from the planning_scene for the
+   * requested object*/
+  void getCollisionObjectMsg(moveit_msgs::CollisionObject& collision_obj, const std::string& ns) const;
+
+  /** \brief Construct a vector of messages (\e collision_objects) with the collision object data for all objects in
+   * planning_scene */
+  void getCollisionObjectMsgs(std::vector<moveit_msgs::CollisionObject>& collision_objs) const;
+
+  /** \brief Construct a message (\e attached_collision_object) with the attached collision object data from the
+   * planning_scene for the requested object*/
+  //void getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj, 
+  //                                   const std::string& ns) const;
+
+  /** \brief Construct a vector of messages (\e attached_collision_objects) with the attached collision object data for
+   * all objects in planning_scene */
+  //void getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
+
+  /** \brief Construct a message (\e octomap) with the octomap data from the planning_scene */
+  void getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const;
+
+  /** \brief Construct a vector of messages (\e object_colors) with the colors of the objects from the planning_scene */
+  void getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const;
+
   /** \brief Apply changes to this planning scene as diffs, even if the message itself is not marked as being a diff
      (is_diff
       member). A parent is not required to exist. However, the existing data in the planning instance is not cleared.
@@ -936,11 +960,6 @@ private:
   /* helper function to create a RobotModel from a urdf/srdf. */
   static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
                                                      const srdf::ModelConstSharedPtr& srdf_model);
-
-  void getPlanningSceneMsgCollisionObject(moveit_msgs::PlanningScene& scene, const std::string& ns) const;
-  void getPlanningSceneMsgCollisionObjects(moveit_msgs::PlanningScene& scene) const;
-  void getPlanningSceneMsgOctomap(moveit_msgs::PlanningScene& scene) const;
-  void getPlanningSceneMsgObjectColors(moveit_msgs::PlanningScene& scene_msg) const;
 
   MOVEIT_CLASS_FORWARD(CollisionDetector);
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -692,26 +692,26 @@ public:
 
   /** \brief Construct a message (\e collision_object) with the collision object data from the planning_scene for the
    * requested object*/
-  void getCollisionObjectMsg(moveit_msgs::CollisionObject& collision_obj, const std::string& ns) const;
+  bool getCollisionObjectMsg(moveit_msgs::CollisionObject& collision_obj, const std::string& ns) const;
 
   /** \brief Construct a vector of messages (\e collision_objects) with the collision object data for all objects in
    * planning_scene */
-  void getCollisionObjectMsgs(std::vector<moveit_msgs::CollisionObject>& collision_objs) const;
+  bool getCollisionObjectMsgs(std::vector<moveit_msgs::CollisionObject>& collision_objs) const;
 
   /** \brief Construct a message (\e attached_collision_object) with the attached collision object data from the
    * planning_scene for the requested object*/
-  void getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj,
+  bool getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj,
                                      const std::string& ns) const;
 
   /** \brief Construct a vector of messages (\e attached_collision_objects) with the attached collision object data for
    * all objects in planning_scene */
-  void getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
+  bool getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
 
   /** \brief Construct a message (\e octomap) with the octomap data from the planning_scene */
-  void getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const;
+  bool getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const;
 
   /** \brief Construct a vector of messages (\e object_colors) with the colors of the objects from the planning_scene */
-  void getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const;
+  bool getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const;
 
   /** \brief Apply changes to this planning scene as diffs, even if the message itself is not marked as being a diff
      (is_diff

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -700,7 +700,7 @@ public:
 
   /** \brief Construct a message (\e attached_collision_object) with the attached collision object data from the
    * planning_scene for the requested object*/
-  void getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj, 
+  void getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj,
                                      const std::string& ns) const;
 
   /** \brief Construct a vector of messages (\e attached_collision_objects) with the attached collision object data for

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -700,12 +700,12 @@ public:
 
   /** \brief Construct a message (\e attached_collision_object) with the attached collision object data from the
    * planning_scene for the requested object*/
-  //void getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj, 
-  //                                   const std::string& ns) const;
+  void getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj, 
+                                     const std::string& ns) const;
 
   /** \brief Construct a vector of messages (\e attached_collision_objects) with the attached collision object data for
    * all objects in planning_scene */
-  //void getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
+  void getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
 
   /** \brief Construct a message (\e octomap) with the octomap data from the planning_scene */
   void getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -847,7 +847,8 @@ void planning_scene::PlanningScene::getCollisionObjectMsg(moveit_msgs::Collision
   }
 }
 
-void planning_scene::PlanningScene::getCollisionObjectMsgs(std::vector<moveit_msgs::CollisionObject>& collision_objs) const
+void planning_scene::PlanningScene::getCollisionObjectMsgs(
+    std::vector<moveit_msgs::CollisionObject>& collision_objs) const
 {
   collision_objs.clear();
   const std::vector<std::string>& ns = world_->getObjectIds();
@@ -860,8 +861,8 @@ void planning_scene::PlanningScene::getCollisionObjectMsgs(std::vector<moveit_ms
     }
 }
 
-void planning_scene::PlanningScene::getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj,
-                                                          const std::string& ns) const
+void planning_scene::PlanningScene::getAttachedCollisionObjectMsg(
+    moveit_msgs::AttachedCollisionObject& attached_collision_obj, const std::string& ns) const
 {
   std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs;
   getAttachedCollisionObjectMsgs(attached_collision_objs);
@@ -875,7 +876,8 @@ void planning_scene::PlanningScene::getAttachedCollisionObjectMsg(moveit_msgs::A
   }
 }
 
-void planning_scene::PlanningScene::getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const
+void planning_scene::PlanningScene::getAttachedCollisionObjectMsgs(
+    std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const
 {
   std::vector<const moveit::core::AttachedBody*> attached_bodies;
   getCurrentState().getAttachedBodies(attached_bodies);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -42,6 +42,7 @@
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/exceptions/exceptions.h>
+#include <moveit/robot_state/attached_body.h>
 #include <octomap_msgs/conversions.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <memory>
@@ -857,6 +858,28 @@ void planning_scene::PlanningScene::getCollisionObjectMsgs(std::vector<moveit_ms
       getCollisionObjectMsg(co, ns[i]);
       collision_objs.push_back(co);
     }
+}
+
+void planning_scene::PlanningScene::getAttachedCollisionObjectMsg(moveit_msgs::AttachedCollisionObject& attached_collision_obj,
+                                                          const std::string& ns) const
+{
+  std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs;
+  getAttachedCollisionObjectMsgs(attached_collision_objs);
+  for (std::size_t i = 0; i < attached_collision_objs.size(); ++i)
+  {
+    if (attached_collision_objs[i].object.id == ns)
+    {
+      attached_collision_obj = attached_collision_objs[i];
+      return;
+    }
+  }
+}
+
+void planning_scene::PlanningScene::getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const
+{
+  std::vector<const moveit::core::AttachedBody*> attached_bodies;
+  getCurrentState().getAttachedBodies(attached_bodies);
+  attachedBodiesToAttachedCollisionObjectMsgs(attached_bodies, attached_collision_objs);
 }
 
 void planning_scene::PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const

--- a/moveit_core/robot_state/include/moveit/robot_state/conversions.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/conversions.h
@@ -89,8 +89,9 @@ void robotStateToRobotStateMsg(const RobotState& state, moveit_msgs::RobotState&
  * @param attached_bodies The input MoveIt! attached body objects
  * @param attached_collision_objs The resultant AttachedCollisionObject messages
  */
-void attachedBodiesToAttachedCollisionObjectMsgs(const std::vector<const AttachedBody*>& attached_bodies,
-                                          std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs);
+void attachedBodiesToAttachedCollisionObjectMsgs(
+    const std::vector<const AttachedBody*>& attached_bodies,
+    std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs);
 /**
  * @brief Convert a MoveIt! robot state to a joint state message
  * @param state The input MoveIt! robot state object

--- a/moveit_core/robot_state/include/moveit/robot_state/conversions.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/conversions.h
@@ -85,6 +85,13 @@ void robotStateToRobotStateMsg(const RobotState& state, moveit_msgs::RobotState&
                                bool copy_attached_bodies = true);
 
 /**
+ * @brief Convert AttachedBodies to AttachedCollisionObjects
+ * @param attached_bodies The input MoveIt! attached body objects
+ * @param attached_collision_objs The resultant AttachedCollisionObject messages
+ */
+void attachedBodiesToAttachedCollisionObjectMsgs(const std::vector<const AttachedBody*>& attached_bodies,
+                                          std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs);
+/**
  * @brief Convert a MoveIt! robot state to a joint state message
  * @param state The input MoveIt! robot state object
  * @param robot_state The resultant JointState message

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -390,8 +390,8 @@ void moveit::core::robotStateToRobotStateMsg(const RobotState& state, moveit_msg
 {
   robotStateToJointStateMsg(state, robot_state.joint_state);
   _robotStateToMultiDOFJointState(state, robot_state.multi_dof_joint_state);
-  
-    if (copy_attached_bodies)
+
+  if (copy_attached_bodies)
   {
     std::vector<const AttachedBody*> attached_bodies;
     state.getAttachedBodies(attached_bodies);
@@ -399,12 +399,13 @@ void moveit::core::robotStateToRobotStateMsg(const RobotState& state, moveit_msg
   }
 }
 
-void moveit::core::attachedBodiesToAttachedCollisionObjectMsgs(const std::vector<const AttachedBody*>& attached_bodies,
-                                          std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs)
+void moveit::core::attachedBodiesToAttachedCollisionObjectMsgs(
+    const std::vector<const AttachedBody*>& attached_bodies,
+    std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs)
 {
   attached_collision_objs.resize(attached_bodies.size());
   for (std::size_t i = 0; i < attached_bodies.size(); ++i)
-      _attachedBodyToMsg(*attached_bodies[i], attached_collision_objs[i]);
+    _attachedBodyToMsg(*attached_bodies[i], attached_collision_objs[i]);
 }
 
 void moveit::core::robotStateToJointStateMsg(const RobotState& state, sensor_msgs::JointState& joint_state)

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -390,15 +390,21 @@ void moveit::core::robotStateToRobotStateMsg(const RobotState& state, moveit_msg
 {
   robotStateToJointStateMsg(state, robot_state.joint_state);
   _robotStateToMultiDOFJointState(state, robot_state.multi_dof_joint_state);
-
-  if (copy_attached_bodies)
+  
+    if (copy_attached_bodies)
   {
     std::vector<const AttachedBody*> attached_bodies;
     state.getAttachedBodies(attached_bodies);
-    robot_state.attached_collision_objects.resize(attached_bodies.size());
-    for (std::size_t i = 0; i < attached_bodies.size(); ++i)
-      _attachedBodyToMsg(*attached_bodies[i], robot_state.attached_collision_objects[i]);
+    attachedBodiesToAttachedCollisionObjectMsgs(attached_bodies, robot_state.attached_collision_objects);
   }
+}
+
+void moveit::core::attachedBodiesToAttachedCollisionObjectMsgs(const std::vector<const AttachedBody*>& attached_bodies,
+                                          std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs)
+{
+  attached_collision_objs.resize(attached_bodies.size());
+  for (std::size_t i = 0; i < attached_bodies.size(); ++i)
+      _attachedBodyToMsg(*attached_bodies[i], attached_collision_objs[i]);
 }
 
 void moveit::core::robotStateToJointStateMsg(const RobotState& state, sensor_msgs::JointState& joint_state)


### PR DESCRIPTION
### Description
Issue #644 

- Added functionality to get CollisionObject(s) and ObjectColor(s) and the Octomap as ROS msgs from the Planning Scene object. This involved replacing existing private methods for those functions.
- Also added functions to get AttachedCollisionObject(s). For this I added to conversions.h/.cpp
- Note: the format for getCollisionObjects() basically involves getting the IDs for all of the objects and then iterating through the IDs and retrieving each CollisionObject msg separately using its ID. For getAttachedCollisionObjects(), it sort of works the opposite way. To get a single AttachedCollisionObject, you retrieve all of the AttachedCollisionObjects and then iterate through all the objects and look for the one with the right ID.
- If the above doesn't make sense, just ignore it

### Checklist
- [x ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a 
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

