### PR TITLE
[kinetic-devel] Fix create_ikfast_moveit_plugin to comply with format 2 (package.xml)

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -289,7 +289,7 @@ if __name__ == '__main__':
       return missing_deps
 
    update_deps(build_deps, "build_depend", package_xml.getroot())
-   update_deps(run_deps, "run_depend", package_xml.getroot())
+   update_deps(run_deps, "exec_depend", package_xml.getroot())
 
    # Check that plugin definition file is in the export list
    new_export = etree.Element("moveit_core", \

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -30,6 +30,8 @@
   <run_depend>pluginlib</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>collada_urdf</run_depend>
+
 
   <export>
     <moveit_core plugin="${prefix}/kdl_kinematics_plugin_description.xml"/>

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -30,7 +30,6 @@
   <run_depend>pluginlib</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
-  <run_depend>collada_urdf</run_depend>
 
 
   <export>


### PR DESCRIPTION
### Description
Fixes the [create_ikfast_moveit_plugin.py](https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py) script so that it complies with format 2 of the `package.xml`.
This implies changing the `run_depend` tag into `exec_depend` tag.
Please do note that the [`package.xml` template](https://github.com/ros-infrastructure/catkin_pkg/blob/master/src/catkin_pkg/templates/package.xml.in#L2) of `catkin_create_pkg` if format 2 by default.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)