### PR TITLE
replace explicit use of Arial with default font

### DIFF
--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -41,6 +41,7 @@
 #include <QApplication>
 #include <QSplitter>
 #include <QRegExp>
+#include <QGuiApplication>
 // ROS
 #include "configuration_files_widget.h"
 #include <srdfdom/model.h>  // use their struct datastructures
@@ -149,7 +150,7 @@ ConfigurationFilesWidget::ConfigurationFilesWidget(QWidget* parent,
 
   // Success label
   success_label_ = new QLabel(this);
-  QFont success_label_font("Arial", 12, QFont::Bold);
+  QFont success_label_font(QGuiApplication::font().family(), 12, QFont::Bold);
   success_label_->setFont(success_label_font);
   success_label_->hide();  // only show once the files have been generated
   success_label_->setText("Configuration package generated successfully!");

--- a/moveit_setup_assistant/src/widgets/double_list_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/double_list_widget.cpp
@@ -43,6 +43,7 @@
 #include <QMessageBox>
 #include <QString>
 #include <QHeaderView>
+#include <QGuiApplication>
 #include "double_list_widget.h"
 
 namespace moveit_setup_assistant
@@ -59,7 +60,7 @@ DoubleListWidget::DoubleListWidget(QWidget* parent, moveit_setup_assistant::Move
 
   // Label ------------------------------------------------
   title_ = new QLabel("", this);  // specify the title from the parent widget
-  QFont group_title_font("Arial", 12, QFont::Bold);
+  QFont group_title_font(QGuiApplication::font().family(), 12, QFont::Bold);
   title_->setFont(group_title_font);
   layout->addWidget(title_);
 

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -39,6 +39,7 @@
 #include <QMessageBox>
 #include <QFormLayout>
 #include <QString>
+#include <QGuiApplication>
 #include "group_edit_widget.h"
 #include <pluginlib/class_loader.h>  // for loading all avail kinematic planners
 
@@ -55,7 +56,7 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, moveit_setup_assistant::MoveIt
 
   // Label ------------------------------------------------
   title_ = new QLabel(this);  // specify the title from the parent widget
-  QFont group_title_font("Arial", 12, QFont::Bold);
+  QFont group_title_font(QGuiApplication::font().family(), 12, QFont::Bold);
   title_->setFont(group_title_font);
   layout->addWidget(title_);
 
@@ -97,12 +98,12 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, moveit_setup_assistant::MoveIt
   QVBoxLayout* new_buttons_layout = new QVBoxLayout();
 
   QLabel* save_and_add = new QLabel("Next, Add Components To Group:", this);
-  QFont save_and_add_font("Arial", 12, QFont::Bold);
+  QFont save_and_add_font(QGuiApplication::font().family(), 12, QFont::Bold);
   save_and_add->setFont(save_and_add_font);
   new_buttons_layout->addWidget(save_and_add);
 
   QLabel* add_subtitle = new QLabel("Recommended: ", this);
-  QFont add_subtitle_font("Arial", 10, QFont::Bold);
+  QFont add_subtitle_font(QGuiApplication::font().family(), 10, QFont::Bold);
   add_subtitle->setFont(add_subtitle_font);
   new_buttons_layout->addWidget(add_subtitle);
 

--- a/moveit_setup_assistant/src/widgets/header_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/header_widget.cpp
@@ -38,6 +38,7 @@
 #include <QFont>
 #include <QFileDialog>
 #include <QVBoxLayout>
+#include <QGuiApplication>
 #include "header_widget.h"
 
 namespace moveit_setup_assistant
@@ -57,7 +58,7 @@ HeaderWidget::HeaderWidget(const std::string& title, const std::string& instruct
   // Page Title
   QLabel* page_title = new QLabel(this);
   page_title->setText(title.c_str());
-  QFont page_title_font("Arial", 18, QFont::Bold);
+  QFont page_title_font(QGuiApplication::font().family(), 18, QFont::Bold);
   page_title->setFont(page_title_font);
   page_title->setWordWrap(true);
   layout->addWidget(page_title);
@@ -107,7 +108,7 @@ LoadPathWidget::LoadPathWidget(const std::string& title, const std::string& inst
   // Widget Title
   QLabel* widget_title = new QLabel(this);
   widget_title->setText(title.c_str());
-  QFont widget_title_font("Arial", 12, QFont::Bold);
+  QFont widget_title_font(QGuiApplication::font().family(), 12, QFont::Bold);
   widget_title->setFont(widget_title_font);
   layout->addWidget(widget_title);
   layout->setAlignment(widget_title, Qt::AlignTop);

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -42,6 +42,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QString>
+#include <QGuiApplication>
 #include "kinematic_chain_widget.h"
 
 namespace moveit_setup_assistant
@@ -57,7 +58,7 @@ KinematicChainWidget::KinematicChainWidget(QWidget* parent, moveit_setup_assista
 
   // Label ------------------------------------------------
   title_ = new QLabel("", this);  // specify the title from the parent widget
-  QFont group_title_font("Arial", 12, QFont::Bold);
+  QFont group_title_font(QGuiApplication::font().family(), 12, QFont::Bold);
   title_->setFont(group_title_font);
   layout->addWidget(title_);
 

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -164,8 +164,7 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
   QRect textRect(option.rect.x() + 10, option.rect.y(), option.rect.width() - 10, option.rect.height());
 
   QFont textFont(painter->font());
-  textFont.setPixelSize(14);    // Set font size
-  textFont.setFamily(QGuiApplication::font().family());  // Helvetica Neue");
+  textFont.setPixelSize(14);  // Set font size
   painter->setFont(textFont);
 
   // Font color

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -36,6 +36,7 @@
 
 #include "navigation_widget.h"
 #include <QDebug>
+#include <QGuiApplication>
 #include <iostream>
 
 namespace moveit_setup_assistant
@@ -164,7 +165,7 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
 
   QFont textFont(painter->font());
   textFont.setPixelSize(14);    // Set font size
-  textFont.setFamily("Arial");  // Helvetica Neue");
+  textFont.setFamily(QGuiApplication::font().family());  // Helvetica Neue");
   painter->setFont(textFont);
 
   // Font color

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -64,6 +64,7 @@
 #include <QLineEdit>
 #include <QTreeWidgetItem>
 #include <QHeaderView>
+#include <QGuiApplication>
 // Cycle checking
 #include <boost/utility.hpp>
 #include <boost/graph/adjacency_list.hpp>
@@ -287,8 +288,8 @@ void PlanningGroupsWidget::loadGroupsTree()
 void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it, QTreeWidgetItem* parent)
 {
   // Fonts for tree
-  const QFont top_level_font("Arial", 11, QFont::Bold);
-  const QFont type_font("Arial", 11, QFont::Normal, QFont::StyleItalic);
+  const QFont top_level_font(QGuiApplication::font().family(), 11, QFont::Bold);
+  const QFont type_font(QGuiApplication::font().family(), 11, QFont::Normal, QFont::StyleItalic);
 
   QTreeWidgetItem* group;
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -45,6 +45,7 @@
 #include <QFont>
 #include <QFileDialog>
 #include <QTextEdit>
+#include <QGuiApplication>
 // ROS
 #include <ros/ros.h>
 #include <ros/package.h>  // for getting file path for loadng images
@@ -174,7 +175,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
 
   // Next step instructions
   next_label_ = new QLabel(this);
-  QFont next_label_font("Arial", 11, QFont::Bold);
+  QFont next_label_font(QGuiApplication::font().family(), 11, QFont::Bold);
   next_label_->setFont(next_label_font);
   // next_label_->setWordWrap(true);
   next_label_->setText("Success! Use the left navigation pane to continue.");
@@ -776,7 +777,7 @@ SelectModeWidget::SelectModeWidget(QWidget* parent) : QFrame(parent)
   // Widget Title
   QLabel* widget_title = new QLabel(this);
   widget_title->setText("Choose mode:");
-  QFont widget_title_font("Arial", 12, QFont::Bold);
+  QFont widget_title_font(QGuiApplication::font().family(), 12, QFont::Bold);
   widget_title->setFont(widget_title_font);
   layout->addWidget(widget_title);
   layout->setAlignment(widget_title, Qt::AlignTop);


### PR DESCRIPTION
### Description

This pull request replaces uses of `"Arial"` with the default application font from Qt with `QGuiApplication::font()`.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] ~~Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)~~
- [ ] ~~Include a screenshot if changing a GUI~~
- [ ] ~~Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)~~
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
  - I think this should be cherry-picked to indigo as well, but that's up to the maintainers.