### PR TITLE
make operator bool() explicit in MoveItErrorCode

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -63,18 +63,26 @@ public:
   MoveItErrorCode()
   {
     val = 0;
-  };
+  }
   MoveItErrorCode(int code)
   {
     val = code;
-  };
+  }
   MoveItErrorCode(const moveit_msgs::MoveItErrorCodes& code)
   {
     val = code.val;
-  };
-  operator bool() const
+  }
+  explicit operator bool() const
   {
     return val == moveit_msgs::MoveItErrorCodes::SUCCESS;
+  }
+  bool operator==(const int c) const
+  {
+    return val == c;
+  }
+  bool operator!=(const int c) const
+  {
+    return val != c;
   }
 };
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -235,19 +235,19 @@ public:
     convertListToPose(pose, msg.pose);
     msg.header.frame_id = getPoseReferenceFrame();
     msg.header.stamp = ros::Time::now();
-    return place(object_name, msg);
+    return place(object_name, msg) == MoveItErrorCode::SUCCESS;
   }
 
   bool placeLocation(const std::string& object_name, const std::string& location_str)
   {
     std::vector<moveit_msgs::PlaceLocation> locations(1);
     py_bindings_tools::deserializeMsg(location_str, locations[0]);
-    return place(object_name, locations);
+    return place(object_name, locations) == MoveItErrorCode::SUCCESS;
   }
 
   bool placeAnywhere(const std::string& object_name)
   {
-    return place(object_name);
+    return place(object_name) == MoveItErrorCode::SUCCESS;
   }
 
   void convertListToArrayOfPoses(const bp::list& poses, std::vector<geometry_msgs::Pose>& msg)
@@ -361,12 +361,12 @@ public:
 
   bool movePython()
   {
-    return move();
+    return move() == MoveItErrorCode::SUCCESS;
   }
 
   bool asyncMovePython()
   {
-    return asyncMove();
+    return asyncMove() == MoveItErrorCode::SUCCESS;
   }
 
   bool attachObjectPython(const std::string& object_name, const std::string& link_name, const bp::list& touch_links)
@@ -378,14 +378,14 @@ public:
   {
     MoveGroupInterface::Plan plan;
     py_bindings_tools::deserializeMsg(plan_str, plan.trajectory_);
-    return execute(plan);
+    return execute(plan) == MoveItErrorCode::SUCCESS;
   }
 
   bool asyncExecutePython(const std::string& plan_str)
   {
     MoveGroupInterface::Plan plan;
     py_bindings_tools::deserializeMsg(plan_str, plan.trajectory_);
-    return asyncExecute(plan);
+    return asyncExecute(plan) == MoveItErrorCode::SUCCESS;
   }
 
   std::string getPlanPython()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -138,7 +138,7 @@ void MotionPlanningFrame::computeExecuteButtonClicked()
   if (move_group_ && current_plan_)
   {
     ui_->stop_button->setEnabled(true);  // enable stopping
-    bool success = move_group_->execute(*current_plan_);
+    bool success = move_group_->execute(*current_plan_) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
     onFinishedExecution(success);
   }
 }
@@ -152,7 +152,7 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   // to suppress a warning, we pass an empty state (which encodes "start from current state")
   move_group_->setStartStateToCurrentState();
   ui_->stop_button->setEnabled(true);
-  bool success = move_group_->move();
+  bool success = move_group_->move() == moveit::planning_interface::MoveItErrorCode::SUCCESS;
   onFinishedExecution(success);
   ui_->plan_and_execute_button->setEnabled(true);
 }


### PR DESCRIPTION
### Description

this protects from bugs in code comparing one of the anonymous enums defined in moveit_msgs::MoveItErrrorCodes to the struct. Previously comparing

MoveItErrorCode::PLANNING_FAILED == MoveItErrorCode(MoveItErrorCode::PLANNING_FAILED)

would always return "false" except for MoveItErrorCode::SUCCESS. The reason is that the class MoveItErrorCode was implicitly downcast (via operator bool())
to a bool and then compared to the enum value which was also downcast first to int and then to bool.

This has led to some hard to catch bugs in code like the following in our software:

MoveItErrorCode ret = plan(...);
if (ret == MoveItErrorCode::NO_IK_SOLUTION) { // always false
    ROS_ERROR("No ik solution found but you'll never know");
}

I think preserving some of the type safety is worth adding a bit of explicitness in the two other files that needed changes.


### Checklist
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

this breaks compatibility of some valid code for the sake of safety. I guess it should not be cherry-picked

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
