### PR TITLE
In harmonize function: Fix angle in [-2Pi; 2PI]

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -586,7 +586,7 @@ double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_stat
     {
       ss[i] -= 2 * M_PI;
     }
-    while (ss[i] < 2 * M_PI)
+    while (ss[i] < -2 * M_PI)
     {
       ss[i] += 2 * M_PI;
     }
@@ -594,7 +594,7 @@ double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_stat
     {
       solution[i] -= 2 * M_PI;
     }
-    while (solution[i] < 2 * M_PI)
+    while (solution[i] < -2 * M_PI)
     {
       solution[i] += 2 * M_PI;
     }


### PR DESCRIPTION
### Description

Hi,
I am reporting a minor bug about the harmonize function for the ik_fast_kinematics_plugin.

A minus sign was missing in order to properly limit the angles in [-2PI; 2PI]
It is fixed with this pull request. 

About the test, the code of the harmonize function was tested quickly in Matlab and returned the expected angles in [-2PI; 2PI].

Regards,
Yoann.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
