### PR TITLE
always return true in MoveGroupPlanService callback

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -59,7 +59,7 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
   try
   {
     planning_interface::MotionPlanResponse mp_res;
-    solved = context_->planning_pipeline_->generatePlan(ps, req.motion_plan_request, mp_res);
+    context_->planning_pipeline_->generatePlan(ps, req.motion_plan_request, mp_res);
     mp_res.getMessage(res.motion_plan_response);
   }
   catch (std::runtime_error& ex)
@@ -73,7 +73,7 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
     res.motion_plan_response.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
 
-  return solved;
+  return true;
 }
 
 #include <class_loader/class_loader.h>


### PR DESCRIPTION
This is a proposal PR of #673.
With this PR, I get valid `error_code` such as `-1` when planning is failed.

I made this PR for `indigo-devel` because I only check in `indigo`.
I have no idea if the same issue happens in `kinetic` and others.

I'm not sure if we should always return `true` or not.
If you have better idea, feel free to tell me. 