### PR TITLE
remove unused deprecated pluginlib macro

### DIFF
--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -214,5 +214,4 @@ void mesh_filter::DepthSelfFiltering::depthCb(const sensor_msgs::ImageConstPtr& 
 }
 
 #include <pluginlib/class_list_macros.h>
-// PLUGINLIB_DECLARE_CLASS (mesh_filter, DepthSelfFiltering, mesh_filter::DepthSelfFiltering, nodelet::Nodelet)
-PLUGINLIB_EXPORT_CLASS(mesh_filter::DepthSelfFiltering, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(mesh_filter::DepthSelfFiltering, nodelet::Nodelet)


### PR DESCRIPTION
### Description

When auditing packages using deprecated pluginlib macros I found this commented out instance. This PR removes it