### PR TITLE
New isValidVelocityMove() for checking time between two waypoints given velocity

### DIFF
--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -763,7 +763,7 @@ bool JointModelGroup::isValidVelocityMove(const double* from_joint_pose, const d
     double max_dtheta = dt * max_velocity;
     if (dtheta > max_dtheta)
     {
-      ROS_DEBUG_NAMED(LOGNAME, "Not valid velocity move because of joint '%u'. ", i);
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "Not valid velocity move because of joint " << i);
       return false;
     }
   }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1552,6 +1552,15 @@ as the new values that correspond to the group */
    */
   bool isValidVelocityMove(const RobotState& other, const JointModelGroup* group, double dt) const;
 
+  /**
+   * \brief Check that the time to move between two waypoints is sufficient given velocity limits
+   */
+  bool isValidVelocityMove(const JointModelGroup* group, const std::vector<double>& from_joint_pose,
+                           const std::vector<double>& to_joint_pose, double dt) const;
+
+  bool isValidVelocityMove(const JointModelGroup* group, const double* from_joint_pose, const double* to_joint_pose,
+                           std::size_t array_size, double dt) const;
+
   /** @} */
 
   /** \name Managing attached bodies

--- a/moveit_planners/chomp/README.md
+++ b/moveit_planners/chomp/README.md
@@ -1,3 +1,3 @@
 ## CHOMP Motion Planner
 
-See [Chomp Interface Tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/chomp_interface_tutorial.html)
+See [Chomp Interface Tutorial](https://ros-planning.github.io/moveit_tutorials/doc/chomp_planner/chomp_planner_tutorial.html)


### PR DESCRIPTION
This is a more computationally efficient version of the previously used isValidVelocityMove() functions added in https://github.com/ros-planning/moveit/pull/294

This allows faster Descartes-type functionality 