### PR TITLE
Allow wait time to be specified for getCurrentState()

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -274,7 +274,13 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros:
     state_update_condition_.wait_for(lock, boost::chrono::nanoseconds((timeout - elapsed).toNSec()));
     elapsed = ros::WallTime::now() - start;
     if (elapsed > timeout)
+    {
+      ROS_INFO_STREAM("More than " << elapsed.toSec() << " seconds has passed to update robot state (joint angles)."
+                                   << "(longer than the allowed " << wait_time << " seconds)."
+                                   << " Synchronize the clocks between systems and check the connection if your are "
+                                      "running ros across multiple machines.");
       return false;
+    }
   }
   return true;
 }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -275,10 +275,8 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros:
     elapsed = ros::WallTime::now() - start;
     if (elapsed > timeout)
     {
-      ROS_INFO_STREAM("More than " << elapsed.toSec() << " seconds has passed to update robot state (joint angles)."
-                                   << "(longer than the allowed " << wait_time << " seconds)."
-                                   << " Synchronize the clocks between systems and check the connection if your are "
-                                      "running ros across multiple machines.");
+      ROS_INFO_STREAM("Didn't received robot state (joint angles) with recent timestamp within " << wait_time << " seconds.\n"
+                      << "Check clock synchronization if your are running ROS across multiple machines!");
       return false;
     }
   }

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -806,8 +806,8 @@ public:
   /** \brief Get the current joint values for the joints planned for by this instance (see getJoints()) */
   std::vector<double> getCurrentJointValues();
 
-  /** \brief Get the current state of the robot */
-  robot_state::RobotStatePtr getCurrentState();
+  /** \brief Get the current state of the robot within the duration specified by wait. */
+  robot_state::RobotStatePtr getCurrentState(double wait = 1);
 
   /** \brief Get the pose for the end-effector \e end_effector_link.
       If \e end_effector_link is empty (the default value) then the end-effector reported by getEndEffectorLink() is

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -2107,10 +2107,10 @@ unsigned int moveit::planning_interface::MoveGroupInterface::getVariableCount() 
   return impl_->getJointModelGroup()->getVariableCount();
 }
 
-robot_state::RobotStatePtr moveit::planning_interface::MoveGroupInterface::getCurrentState()
+robot_state::RobotStatePtr moveit::planning_interface::MoveGroupInterface::getCurrentState(double wait)
 {
   robot_state::RobotStatePtr current_state;
-  impl_->getCurrentState(current_state);
+  impl_->getCurrentState(current_state, wait);
   return current_state;
 }
 


### PR DESCRIPTION
1. Improve user feedback - if using MoveIt! on two separate computers the clock can get out of sync and ``getCurrentState()`` will report no joint values when in reality it is getting joint values, the time difference is just greater than the default 1. This is common when a realtime robot PC is disconnected from the internet for weeks/months.

2. Allow the MoveGroupInterface ``getCurrentState()`` to specify a wait period greater than the default 1 second, so that if you do have the above problem you can quickly debug it / override it by allow timestamps that are greater.

This would have saved @liuxin00738 many frustrated hours debugging MoveIt!, he and I prepared this change together and tested it on hardware. 