### PR TITLE
don't crash on empty robot_description in RobotState plugin

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -400,7 +400,7 @@ void RobotStateDisplay::update(float wall_dt, float ros_dt)
   }
 
   calculateOffsetPosition();
-  if (robot_ && update_state_)
+  if (robot_ && update_state_ && kstate_)
   {
     update_state_ = false;
     kstate_->update();


### PR DESCRIPTION
when starting robot_state_display with an empty robot_description it will crash
as kstate_ is not checked before attempting to update it. Changing to an empty
robot_description later on seems to be handled more gracefully on a higher level
and does not crash

How to reproduce:
roscore
rviz
add RobotState plugin
observe crash

### Checklist
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic) - Yes, simple fix for crash

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
