### PR TITLE
Avoid segfault when validating a multidof-only trajectory

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -951,6 +951,16 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
 
   for (const auto& trajectory : context.trajectory_parts_)
   {
+    if (!trajectory.multi_dof_joint_trajectory.points.empty())
+    {
+      ROS_WARN_NAMED("traj_execution", "Validation of MultiDOFJointTrajectory is not implemented.");
+      // go on to check joint_trajectory component though
+    }
+    if (trajectory.joint_trajectory.points.empty())
+    {
+      // There is nothing to check
+      continue;
+    }
     const std::vector<double>& positions = trajectory.joint_trajectory.points.front().positions;
     const std::vector<std::string>& joint_names = trajectory.joint_trajectory.joint_names;
     const std::size_t n = joint_names.size();
@@ -969,7 +979,6 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         return false;
       }
 
-      // TODO: check multi-DoF joints ?
       double cur_position = current_state->getJointPositions(jm)[0];
       double traj_position = positions[i];
       // normalize positions and compare


### PR DESCRIPTION
Also warn that MultiDOFJointTrajectory validation is not supported

Fixes #539

Should be backported to indigo.