### PR TITLE
Make operator bool() explicit

### DIFF
--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -68,7 +68,7 @@ struct ExecutionStatus
     return status_;
   }
 
-  operator bool() const
+  explicit operator bool() const
   {
     return status_ == SUCCEEDED;
   }


### PR DESCRIPTION
this is not as likely to cause bugs as the respective change in #670
as there is an implicit operator Value() [1] that gets used for comparison

still I think this should be explicit

[1] Value being the name of the enum