### PR TITLE
moveit_ros_perception: make OpenGL parts optional

### DIFF
--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -3,18 +3,25 @@ project(moveit_ros_perception)
 
 add_compile_options(-std=c++11)
 
+option(WITH_OPENGL "Build the parts that depends on OpenGL" ON)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
 find_package(Boost REQUIRED thread signals)
 
-find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
-find_package(GLUT REQUIRED)
-if (OPENGL_FOUND)
-  set(gl_LIBS ${gl_LIBS} ${OPENGL_LIBRARIES})
-endif(OPENGL_FOUND)
+if(WITH_OPENGL)
+  find_package(OpenGL REQUIRED)
+  find_package(GLEW REQUIRED)
+  find_package(GLUT REQUIRED)
+  if (OPENGL_FOUND)
+    set(gl_LIBS ${gl_LIBS} ${OPENGL_LIBRARIES})
+  endif(OPENGL_FOUND)
+  set(perception_GL_INCLUDE_DIRS "mesh_filter/include" "depth_image_octomap_updater/include")
+  set(SYSTEM_GL_INCLUDE_DIRS ${GLEW_INCLUDE_DIR} ${GLUT_INCLUDE_DIR})
+endif(BUILD_OPENGL)
+
 if(APPLE)
   find_package(X11 REQUIRED)
 endif(APPLE)
@@ -47,13 +54,12 @@ find_package(OpenCV)
 
 catkin_package(
   INCLUDE_DIRS
-    mesh_filter/include
     lazy_free_space_updater/include
-    depth_image_octomap_updater/include
     point_containment_filter/include
     occupancy_map_monitor/include
     pointcloud_octomap_updater/include
     semantic_world/include
+    ${perception_GL_INCLUDE_DIRS}
     ${OCTOMAP_INCLUDE_DIRS}
   LIBRARIES
     moveit_lazy_free_space_updater
@@ -70,21 +76,19 @@ catkin_package(
     EIGEN3
 )
 
-include_directories(mesh_filter/include
-                    lazy_free_space_updater/include
-                    depth_image_octomap_updater/include
+include_directories(lazy_free_space_updater/include
                     point_containment_filter/include
                     occupancy_map_monitor/include
                     pointcloud_octomap_updater/include
                     semantic_world/include
+                    ${perception_GL_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
                     )
 include_directories(SYSTEM
                     ${OpenCV_INCLUDE_DIRS}
                     ${EIGEN3_INCLUDE_DIRS}
-                    ${GLEW_INCLUDE_DIR}
-                    ${GLUT_INCLUDE_DIR}
+                    ${SYSTEM_GL_INCLUDE_DIR}
                     ${X11_INCLUDE_DIR}
                     )
 
@@ -96,8 +100,10 @@ add_subdirectory(lazy_free_space_updater)
 add_subdirectory(point_containment_filter)
 add_subdirectory(occupancy_map_monitor)
 add_subdirectory(pointcloud_octomap_updater)
-add_subdirectory(mesh_filter)
-add_subdirectory(depth_image_octomap_updater)
+if (BUILD_OPENGL)
+  add_subdirectory(mesh_filter)
+  add_subdirectory(depth_image_octomap_updater)
+endif(BUILD_OPENGL)
 
 add_subdirectory(semantic_world)
 


### PR DESCRIPTION
### Description

We make OpenGL parts optional, but build everything by default.

This commit is motivated by the work on the OpenEmbedded layer for ROS, a cross-compilation tool chain environment for ROS packages. We would like to allow to use moveit_ros_perception in embedded systems without OpenGL support.

Dmitry Rozhkov is the original author of this patch. I ported the patch from indigo to the current kinetic branch and elaborated the commit message.

### Checklist
- [x] Code Formatting: clang-format does not apply to CMakeLists.txt. [clang-format](http://moveit.ros.org/documentation/contributing/code) clearly states that this is limited to .h, .hpp and .cpp files. There is no enforced syntax convention for CMakeLists.txt.
- [x] Documentation: I checked the existing moveit documentation and they are focussed on its use. So, the best documentation to consider documenting the build configuration would be http://moveit.ros.org/install/source/. However, I think the user base of the feature is small, and developers are likely going to look into the CMakeLists.txt file when they encounter the issue and then they will find the configuration option quite immediately.
- [x] Screenshot: Not applicable.
- [x] Testing: It is special requirement from only a few users so far, so a test is not strictly needed. I will check the complexity of adding to compile it twice with and without the `BUILD_OPENGL` feature.
- [x] Backporting: It is special requirement from only a few users so far, so this does not cherry-picked to other current ROS branches (Indigo, Jade, Kinetic).