### PR TITLE
Fixed bugs in computation of AABB in LinkModel and RobotState.

### DIFF
--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_robot_model)
 
 add_library(${MOVEIT_LIB_NAME}
+  src/aabb.cpp
   src/fixed_joint_model.cpp
   src/floating_joint_model.cpp
   src/joint_model.cpp

--- a/moveit_core/robot_model/include/moveit/robot_model/aabb.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/aabb.h
@@ -1,0 +1,57 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2013, Ioan A. Sucan
+*  Copyright (c) 2013, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Martin Pecka */
+
+#ifndef MOVEIT_CORE_AABB_H
+#define MOVEIT_CORE_AABB_H
+
+#include <Eigen/Geometry>
+
+namespace moveit {
+namespace core {
+
+/** \brief Represents an axis-aligned bounding box. */
+class AABB : public Eigen::AlignedBox3d
+{
+public:
+  /** \brief Extend with a box transformed by the given transform. */
+  void extendWithTransformedBox(const Eigen::Affine3d &transform, const Eigen::Vector3d &box);
+};
+
+}
+}
+
+#endif //MOVEIT_CORE_AABB_H

--- a/moveit_core/robot_model/include/moveit/robot_model/aabb.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/aabb.h
@@ -40,18 +40,18 @@
 
 #include <Eigen/Geometry>
 
-namespace moveit {
-namespace core {
-
+namespace moveit
+{
+namespace core
+{
 /** \brief Represents an axis-aligned bounding box. */
 class AABB : public Eigen::AlignedBox3d
 {
 public:
   /** \brief Extend with a box transformed by the given transform. */
-  void extendWithTransformedBox(const Eigen::Affine3d &transform, const Eigen::Vector3d &box);
+  void extendWithTransformedBox(const Eigen::Affine3d& transform, const Eigen::Vector3d& box);
 };
-
 }
 }
 
-#endif //MOVEIT_CORE_AABB_H
+#endif  // MOVEIT_CORE_AABB_H

--- a/moveit_core/robot_model/include/moveit/robot_model/aabb.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/aabb.h
@@ -1,7 +1,6 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2013, Ioan A. Sucan
 *  Copyright (c) 2013, Willow Garage, Inc.
 *  All rights reserved.
 *
@@ -35,8 +34,8 @@
 
 /* Author: Martin Pecka */
 
-#ifndef MOVEIT_CORE_AABB_H
-#define MOVEIT_CORE_AABB_H
+#ifndef MOVEIT_ROBOT_MODEL_AABB_H
+#define MOVEIT_ROBOT_MODEL_AABB_H
 
 #include <Eigen/Geometry>
 
@@ -54,4 +53,4 @@ public:
 }
 }
 
-#endif  // MOVEIT_CORE_AABB_H
+#endif  // MOVEIT_ROBOT_MODEL_AABB_H

--- a/moveit_core/robot_model/include/moveit/robot_model/link_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/link_model.h
@@ -181,6 +181,12 @@ public:
     return shape_extents_;
   }
 
+  /** \brief Get the offset of the center of the bounding box of this link when the link is positioned at origin. */
+  const Eigen::Vector3d& getCenteredBoundingBoxOffset() const
+  {
+    return centered_bounding_box_offset_;
+  }
+
   /** \brief Get the set of links that are attached to this one via fixed transforms */
   const LinkTransformMap& getAssociatedFixedTransforms() const
   {
@@ -248,8 +254,11 @@ private:
   /** \brief The collision geometry of the link */
   std::vector<shapes::ShapeConstPtr> shapes_;
 
-  /** \brief The extents if shape (dimensions of axis aligned bounding box when shape is at origin */
+  /** \brief The extents of shape (dimensions of axis aligned bounding box when shape is at origin). */
   Eigen::Vector3d shape_extents_;
+
+  /** \brief Center of the axis aligned bounding box with size shape_extents_ (zero if symmetric along all axes). */
+  Eigen::Vector3d centered_bounding_box_offset_;
 
   /** \brief Filename associated with the visual geometry mesh of this link. If empty, no mesh was used. */
   std::string visual_mesh_filename_;

--- a/moveit_core/robot_model/include/moveit/robot_model/link_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/link_model.h
@@ -182,10 +182,7 @@ public:
   }
 
   /** \brief Get the offset of the center of the bounding box of this link when the link is positioned at origin. */
-  const Eigen::Vector3d& getCenteredBoundingBoxOffset() const
-  {
-    return centered_bounding_box_offset_;
-  }
+  const Eigen::Vector3d getCenteredBoundingBoxOffset() const;
 
   /** \brief Get the set of links that are attached to this one via fixed transforms */
   const LinkTransformMap& getAssociatedFixedTransforms() const
@@ -256,9 +253,6 @@ private:
 
   /** \brief The extents of shape (dimensions of axis aligned bounding box when shape is at origin). */
   Eigen::Vector3d shape_extents_;
-
-  /** \brief Center of the axis aligned bounding box with size shape_extents_ (zero if symmetric along all axes). */
-  Eigen::Vector3d centered_bounding_box_offset_;
 
   /** \brief Filename associated with the visual geometry mesh of this link. If empty, no mesh was used. */
   std::string visual_mesh_filename_;

--- a/moveit_core/robot_model/src/aabb.cpp
+++ b/moveit_core/robot_model/src/aabb.cpp
@@ -1,7 +1,6 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2013, Ioan A. Sucan
 *  Copyright (c) 2013, Willow Garage, Inc.
 *  All rights reserved.
 *

--- a/moveit_core/robot_model/src/aabb.cpp
+++ b/moveit_core/robot_model/src/aabb.cpp
@@ -1,0 +1,67 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2013, Ioan A. Sucan
+*  Copyright (c) 2013, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Martin Pecka */
+
+#include <moveit/robot_model/aabb.h>
+
+void moveit::core::AABB::extendWithTransformedBox(const Eigen::Affine3d &transform, const Eigen::Vector3d &box) {
+  Eigen::Vector3d center = box / 2.0;
+  Eigen::Vector3d maxCorner = transform * center;
+  center = -center;
+  Eigen::Vector3d minCorner = transform * center;
+
+  // minCorner is the minimum corner and maxCorner is the maximum corner before applying transform;
+  // but the transform can make another corner maximum/minimum in the AABB frame, so we need to check for all 8 corners
+
+  // now we walk around all the box's 8 vertices by changing 1 coordinate a time
+  Eigen::Vector3d corner = maxCorner;
+  extend(corner);
+  corner[0] = minCorner[0];
+  extend(corner);
+  corner[1] = minCorner[1];
+  extend(corner);
+  corner[2] = minCorner[2];  // corner == minCorner
+  extend(corner);
+
+  corner[1] = maxCorner[1];
+  extend(corner);
+  corner[0] = maxCorner[0];
+  extend(corner);
+  corner[1] = minCorner[1];
+  extend(corner);
+  corner[2] = maxCorner[2];
+  extend(corner);
+}

--- a/moveit_core/robot_model/src/aabb.cpp
+++ b/moveit_core/robot_model/src/aabb.cpp
@@ -37,7 +37,8 @@
 
 #include <moveit/robot_model/aabb.h>
 
-void moveit::core::AABB::extendWithTransformedBox(const Eigen::Affine3d &transform, const Eigen::Vector3d &box) {
+void moveit::core::AABB::extendWithTransformedBox(const Eigen::Affine3d& transform, const Eigen::Vector3d& box)
+{
   Eigen::Vector3d center = box / 2.0;
   Eigen::Vector3d maxCorner = transform * center;
   center = -center;

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -85,19 +85,19 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
          collision_origin_transform_[i].translation().norm() < std::numeric_limits<double>::epsilon()) ?
             1 :
             0;
-    Eigen::Vector3d ei = shapes::computeShapeExtents(shapes_[i].get());
-    Eigen::Affine3d t = collision_origin_transform_[i];
+    Eigen::Vector3d extents = shapes::computeShapeExtents(shapes_[i].get());
+    Eigen::Affine3d transform = collision_origin_transform_[i];
 
     if (shapes_[i]->type != shapes::MESH)
     {
-      aabb.extendWithTransformedBox(t, ei);
+      aabb.extendWithTransformedBox(transform, extents);
     }
     else
     {
       const shapes::Mesh* mesh = dynamic_cast<const shapes::Mesh*>(shapes_[i].get());
       for (unsigned int j = 0; j < mesh->vertex_count; ++j)
       {
-        aabb.extend(t * Eigen::Map<Eigen::Vector3d>(&mesh->vertices[3 * j]));
+        aabb.extend(transform * Eigen::Map<Eigen::Vector3d>(&mesh->vertices[3 * j]));
       }
     }
   }

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -88,12 +88,14 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
     Eigen::Vector3d ei = shapes::computeShapeExtents(shapes_[i].get());
     Eigen::Affine3d t = collision_origin_transform_[i];
 
-    if (shapes_[i]->type != shapes::MESH) {
+    if (shapes_[i]->type != shapes::MESH)
+    {
       aabb.extendWithTransformedBox(t, ei);
     }
-    else {
-      const shapes::Mesh *mesh = dynamic_cast<const shapes::Mesh*>(shapes_[i].get());
-      for(unsigned int j = 0; j < mesh->vertex_count ; ++j)
+    else
+    {
+      const shapes::Mesh* mesh = dynamic_cast<const shapes::Mesh*>(shapes_[i].get());
+      for (unsigned int j = 0; j < mesh->vertex_count; ++j)
       {
         aabb.extend(t * Eigen::Map<Eigen::Vector3d>(&mesh->vertices[3 * j]));
       }

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -97,15 +97,17 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
          collision_origin_transform_[i].translation().norm() < std::numeric_limits<double>::epsilon()) ?
             1 :
             0;
-    Eigen::Vector3d extents = shapes::computeShapeExtents(shapes_[i].get());
     Eigen::Affine3d transform = collision_origin_transform_[i];
 
     if (shapes_[i]->type != shapes::MESH)
     {
+      Eigen::Vector3d extents = shapes::computeShapeExtents(shapes_[i].get());
       aabb.extendWithTransformedBox(transform, extents);
     }
     else
     {
+      // we cannot use shapes::computeShapeExtents() for meshes, since that method does not provide information about
+      // the offset of the mesh origin
       const shapes::Mesh* mesh = dynamic_cast<const shapes::Mesh*>(shapes_[i].get());
       for (unsigned int j = 0; j < mesh->vertex_count; ++j)
       {

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -48,7 +48,7 @@
  *
  * This global variable is used to retain ABI compatibility for indigo. The kinetic version uses a member variable.
  */
-std::map<const moveit::core::LinkModel* const, const Eigen::Vector3d> centered_bounding_box_offsets;
+std::map<const moveit::core::LinkModel* const, Eigen::Vector3d> centered_bounding_box_offsets;
 boost::mutex mutex_centered_bounding_box_offsets;
 
 moveit::core::LinkModel::LinkModel(const std::string& name)
@@ -116,9 +116,7 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
 
   {
     boost::lock_guard<boost::mutex> lock(mutex_centered_bounding_box_offsets);
-    // cannot use [] assignment, because the value type is const
-    centered_bounding_box_offsets.insert(
-        std::pair<const moveit::core::LinkModel* const, const Eigen::Vector3d>(this, aabb.center()));
+    centered_bounding_box_offsets[this] = aabb.center();
   }
   shape_extents_ = aabb.sizes();
 }

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -43,7 +43,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
 
-
 /** \brief Center of the axis aligned bounding box per link (zero if symmetric along all axes). Always lock the
  * mutex_centered_bounding_box_offsets when working with this map!
  *
@@ -132,7 +131,8 @@ void moveit::core::LinkModel::setVisualMesh(const std::string& visual_mesh, cons
   visual_mesh_scale_ = scale;
 }
 
-const Eigen::Vector3d moveit::core::LinkModel::getCenteredBoundingBoxOffset() const {
+const Eigen::Vector3d moveit::core::LinkModel::getCenteredBoundingBoxOffset() const
+{
   Eigen::Vector3d offset;
   boost::lock_guard<boost::mutex> lock(mutex_centered_bounding_box_offsets);
 

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -117,7 +117,9 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
 
   {
     boost::lock_guard<boost::mutex> lock(mutex_centered_bounding_box_offsets);
-    centered_bounding_box_offsets[this] = aabb.center();
+    // cannot use [] assignment, because the value type is const
+    centered_bounding_box_offsets.insert(
+        std::pair<const moveit::core::LinkModel* const, const Eigen::Vector3d>(this, aabb.center()));
   }
   shape_extents_ = aabb.sizes();
 }

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -26,4 +26,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)
   target_link_libraries(test_robot_state_complex ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+
+  catkin_add_gtest(test_aabb test/test_aabb.cpp)
+  target_link_libraries(test_aabb ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1994,37 +1994,37 @@ void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
 {
   BOOST_VERIFY(checkLinkTransforms());
 
-  aabb.clear();
-  core::AABB _aabb;
+  core::AABB bounding_box;
   std::vector<const LinkModel*> links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (std::size_t i = 0; i < links.size(); ++i)
   {
-    Eigen::Affine3d t = getGlobalLinkTransform(links[i]);  // intentional copy, we will translate
-    const Eigen::Vector3d& e = links[i]->getShapeExtentsAtOrigin();
-    t.translate(links[i]->getCenteredBoundingBoxOffset());
-    _aabb.extendWithTransformedBox(t, e);
+    Eigen::Affine3d transform = getGlobalLinkTransform(links[i]);  // intentional copy, we will translate
+    const Eigen::Vector3d& extents = links[i]->getShapeExtentsAtOrigin();
+    transform.translate(links[i]->getCenteredBoundingBoxOffset());
+    bounding_box.extendWithTransformedBox(transform, extents);
   }
   for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
        it != attached_body_map_.end(); ++it)
   {
-    const EigenSTL::vector_Affine3d& ts = it->second->getGlobalCollisionBodyTransforms();
-    const std::vector<shapes::ShapeConstPtr>& ss = it->second->getShapes();
-    for (std::size_t i = 0; i < ts.size(); ++i)
+    const EigenSTL::vector_Affine3d& transforms = it->second->getGlobalCollisionBodyTransforms();
+    const std::vector<shapes::ShapeConstPtr>& shapes = it->second->getShapes();
+    for (std::size_t i = 0; i < transforms.size(); ++i)
     {
-      Eigen::Vector3d e = shapes::computeShapeExtents(ss[i].get());
-      _aabb.extendWithTransformedBox(ts[i], e);
+      Eigen::Vector3d extents = shapes::computeShapeExtents(shapes[i].get());
+      bounding_box.extendWithTransformedBox(transforms[i], extents);
     }
   }
 
+  aabb.clear();
   aabb.resize(6, 0.0);
-  if (!_aabb.isEmpty())
+  if (!bounding_box.isEmpty())
   {
-    aabb[0] = _aabb.min()[0];
-    aabb[1] = _aabb.max()[0];
-    aabb[2] = _aabb.min()[1];
-    aabb[3] = _aabb.max()[1];
-    aabb[4] = _aabb.min()[2];
-    aabb[5] = _aabb.max()[2];
+    aabb[0] = bounding_box.min()[0];
+    aabb[1] = bounding_box.max()[0];
+    aabb[2] = bounding_box.min()[1];
+    aabb[3] = bounding_box.max()[1];
+    aabb[4] = bounding_box.min()[2];
+    aabb[5] = bounding_box.max()[2];
   }
 }
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -42,6 +42,7 @@
 #include <moveit/backtrace/backtrace.h>
 #include <moveit/profiler/profiler.h>
 #include <boost/bind.hpp>
+#include <moveit/robot_model/aabb.h>
 
 moveit::core::RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)
@@ -1989,53 +1990,19 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   return percentage_solved;
 }
 
-namespace
-{
-static inline void updateAABB(const Eigen::Affine3d& t, const Eigen::Vector3d& e, std::vector<double>& aabb)
-{
-  Eigen::Vector3d v = e / 2.0;
-  Eigen::Vector3d c2 = t * v;
-  v = -v;
-  Eigen::Vector3d c1 = t * v;
-  if (aabb.empty())
-  {
-    aabb.resize(6);
-    aabb[0] = c1.x();
-    aabb[2] = c1.y();
-    aabb[4] = c1.z();
-    aabb[1] = c2.x();
-    aabb[3] = c2.y();
-    aabb[5] = c2.z();
-  }
-  else
-  {
-    if (aabb[0] > c1.x())
-      aabb[0] = c1.x();
-    if (aabb[2] > c1.y())
-      aabb[2] = c1.y();
-    if (aabb[4] > c1.z())
-      aabb[4] = c1.z();
-    if (aabb[1] < c2.x())
-      aabb[1] = c2.x();
-    if (aabb[3] < c2.y())
-      aabb[3] = c2.y();
-    if (aabb[5] < c2.z())
-      aabb[5] = c2.z();
-  }
-}
-}
-
 void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
 {
   BOOST_VERIFY(checkLinkTransforms());
 
   aabb.clear();
+  core::AABB _aabb;
   std::vector<const LinkModel*> links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (std::size_t i = 0; i < links.size(); ++i)
   {
-    const Eigen::Affine3d& t = getGlobalLinkTransform(links[i]);
+    Eigen::Affine3d t = getGlobalLinkTransform(links[i]); // intentional copy, we will translate
     const Eigen::Vector3d& e = links[i]->getShapeExtentsAtOrigin();
-    updateAABB(t, e, aabb);
+    t.translate(links[i]->getCenteredBoundingBoxOffset());
+    _aabb.extendWithTransformedBox(t, e);
   }
   for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
        it != attached_body_map_.end(); ++it)
@@ -2045,11 +2012,20 @@ void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
     for (std::size_t i = 0; i < ts.size(); ++i)
     {
       Eigen::Vector3d e = shapes::computeShapeExtents(ss[i].get());
-      updateAABB(ts[i], e, aabb);
+      _aabb.extendWithTransformedBox(ts[i], e);
     }
   }
-  if (aabb.empty())
-    aabb.resize(6, 0.0);
+
+  aabb.resize(6, 0.0);
+  if (!_aabb.isEmpty())
+  {
+    aabb[0] = _aabb.min()[0];
+    aabb[1] = _aabb.max()[0];
+    aabb[2] = _aabb.min()[1];
+    aabb[3] = _aabb.max()[1];
+    aabb[4] = _aabb.min()[2];
+    aabb[5] = _aabb.max()[2];
+  }
 }
 
 void moveit::core::RobotState::printStatePositions(std::ostream& out) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1999,7 +1999,7 @@ void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
   std::vector<const LinkModel*> links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (std::size_t i = 0; i < links.size(); ++i)
   {
-    Eigen::Affine3d t = getGlobalLinkTransform(links[i]); // intentional copy, we will translate
+    Eigen::Affine3d t = getGlobalLinkTransform(links[i]);  // intentional copy, we will translate
     const Eigen::Vector3d& e = links[i]->getShapeExtentsAtOrigin();
     t.translate(links[i]->getCenteredBoundingBoxOffset());
     _aabb.extendWithTransformedBox(t, e);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2019,12 +2019,10 @@ void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
   aabb.resize(6, 0.0);
   if (!bounding_box.isEmpty())
   {
-    aabb[0] = bounding_box.min()[0];
-    aabb[1] = bounding_box.max()[0];
-    aabb[2] = bounding_box.min()[1];
-    aabb[3] = bounding_box.max()[1];
-    aabb[4] = bounding_box.min()[2];
-    aabb[5] = bounding_box.max()[2];
+    // The following is a shorthand for something like:
+    // aabb[0, 2, 4] = bounding_box.min(); aabb[1, 3, 5] = bounding_box.max();
+    Eigen::Map<Eigen::VectorXd, Eigen::Unaligned, Eigen::InnerStride<2> >(aabb.data(), 3) = bounding_box.min();
+    Eigen::Map<Eigen::VectorXd, Eigen::Unaligned, Eigen::InnerStride<2> >(aabb.data() + 1, 3) = bounding_box.max();
   }
 }
 

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -1,0 +1,275 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/** \author Martin Pecka*/
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit_resources/config.h>
+#include <urdf_parser/urdf_parser.h>
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
+
+class TestAABB : public testing::Test
+{
+protected:
+
+  std::string readFileToString(boost::filesystem::path path) const
+  {
+    std::string file_string;
+    std::fstream file(path.string().c_str(), std::fstream::in);
+    if (file.is_open())
+    {
+      std::string line;
+      while (file.good())
+      {
+        std::getline(file, line);
+        file_string += (line + "\n");
+      }
+      file.close();
+    }
+    return file_string;
+  }
+
+  virtual void SetUp()
+  {
+  };
+
+  robot_state::RobotState loadModel(const std::string urdf, const std::string srdf)
+  {
+    boost::shared_ptr<urdf::ModelInterface> parsed_urdf(urdf::parseURDF(urdf));
+    if (!parsed_urdf)
+      throw std::runtime_error("Cannot parse URDF.");
+
+    boost::shared_ptr<srdf::Model> parsed_srdf(new srdf::Model());
+    bool srdf_ok = parsed_srdf->initString(*parsed_urdf, srdf);
+    if (!srdf_ok)
+      throw std::runtime_error("Cannot parse URDF.");
+
+    robot_model::RobotModelPtr model(new robot_model::RobotModel(parsed_urdf, parsed_srdf));
+    robot_state::RobotState robot_state = robot_state::RobotState(model);
+    robot_state.setToDefaultValues();
+    robot_state.update(true);
+
+    return robot_state;
+  }
+
+  virtual void TearDown()
+  {
+  }
+
+};
+
+TEST_F(TestAABB, TestPR2) {
+  // Contains a link with mesh geometry that is not centered
+
+  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+
+  const std::string PR2_URDF = this->readFileToString(res_path / "pr2_description/urdf/robot.xml");
+  const std::string PR2_SRDF = this->readFileToString(res_path / "pr2_description/srdf/robot.xml");
+
+  robot_state::RobotState pr2_state = this->loadModel(PR2_URDF, PR2_SRDF);
+
+  const Eigen::Vector3d &extentsBaseFootprint = pr2_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin();
+  // values taken from moveit_resources/pr2_description/urdf/robot.xml
+  EXPECT_NEAR(extentsBaseFootprint[0], 0.001, 1e-4);
+  EXPECT_NEAR(extentsBaseFootprint[1], 0.001, 1e-4);
+  EXPECT_NEAR(extentsBaseFootprint[2], 0.001, 1e-4);
+
+  const Eigen::Vector3d &offsetBaseFootprint = pr2_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset();
+  EXPECT_NEAR(offsetBaseFootprint[0], 0.0, 1e-4);
+  EXPECT_NEAR(offsetBaseFootprint[1], 0.0, 1e-4);
+  EXPECT_NEAR(offsetBaseFootprint[2], 0.071, 1e-4);
+
+  const Eigen::Vector3d &extentsBaseLink = pr2_state.getLinkModel("base_link")->getShapeExtentsAtOrigin();
+  // values computed from moveit_resources/pr2_description/urdf/meshes/base_v0/base_L.stl in e.g. Meshlab
+  EXPECT_NEAR(extentsBaseLink[0], 0.668242, 1e-4);
+  EXPECT_NEAR(extentsBaseLink[1], 0.668242, 1e-4);
+  EXPECT_NEAR(extentsBaseLink[2], 0.656175, 1e-4);
+
+  const Eigen::Vector3d &offsetBaseLink = pr2_state.getLinkModel("base_link")->getCenteredBoundingBoxOffset();
+  EXPECT_NEAR(offsetBaseLink[0], 0.0, 1e-4);
+  EXPECT_NEAR(offsetBaseLink[1], 0.0, 1e-4);
+  EXPECT_NEAR(offsetBaseLink[2], 0.656175 / 2, 1e-4); // The 3D mesh isn't centered, but is whole above z axis
+
+  std::vector<double> pr2_aabb;
+  pr2_state.computeAABB(pr2_aabb);
+  ASSERT_EQ(pr2_aabb.size(), 6);
+
+  EXPECT_NEAR(pr2_aabb[0], -0.3376, 1e-4);
+  EXPECT_NEAR(pr2_aabb[1], 0.6397, 1e-4);
+  EXPECT_NEAR(pr2_aabb[2], -0.6682 / 2, 1e-4);
+  EXPECT_NEAR(pr2_aabb[3], 0.6682 / 2, 1e-4);
+  EXPECT_NEAR(pr2_aabb[4], 0.0044, 1e-4);
+  EXPECT_NEAR(pr2_aabb[5], 1.6328, 1e-4);
+
+  // To visualize bbox of the PR2, you can uncomment this code.
+  /*
+  for (std::size_t i = 0; i < 3; ++i) {
+    double dim = pr2_aabb[2*i+1] - pr2_aabb[2*i];
+    double center = dim/2;
+    std::cout << dim << ", " << (pr2_aabb[2*i+1] - center) << std::endl;
+  }
+  // */
+
+}
+
+TEST_F(TestAABB, TestSimple) {
+  // Contains a link with simple geometry and an offset in the collision link
+
+  const std::string SIMPLE_URDF = "<?xml version='1.0' ?>"
+      "<robot name='simple'>"
+      "  <link name='base_link'>"
+      "    <collision>"
+      "      <origin rpy='0 0 0' xyz='0 0 0'/>"
+      "      <geometry>"
+      "        <mesh filename='package://moveit_resources/pr2_description/urdf/meshes/base_v0/base_L.stl'/>"
+      "      </geometry>"
+      "    </collision>"
+      "  </link>"
+      "  <link name='base_footprint'>"
+      "    <collision>"
+      "      <origin rpy='0 0 0' xyz='0 0 0.071'/>"
+      "      <geometry>"
+      "        <box size='0.001 0.001 0.001'/>"
+      "      </geometry>"
+      "    </collision>"
+      "  </link>"
+      "  <joint name='base_footprint_joint' type='fixed'>"
+      "    <origin rpy='0 0 0' xyz='0 0 0.051'/>"
+      "    <child link='base_link'/>"
+      "    <parent link='base_footprint'/>"
+      "  </joint>"
+      "</robot>";
+
+  const std::string SIMPLE_SRDF = "<?xml version='1.0'?>"
+      "<robot name='simple'>  "
+      "  <virtual_joint name='world_joint' type='planar' parent_frame='odom_combined' child_link='base_footprint'/>   "
+      "  <group name='base'>"
+      "    <joint name='world_joint'/>"
+      "  </group>    "
+      "</robot>";
+
+  robot_state::RobotState simple_state = this->loadModel(SIMPLE_URDF, SIMPLE_SRDF);
+
+  std::vector<double> simple_aabb;
+  simple_state.computeAABB(simple_aabb);
+
+  ASSERT_EQ(simple_aabb.size(), 6);
+  EXPECT_NEAR(simple_aabb[0], -0.6682 / 2, 1e-4);
+  EXPECT_NEAR(simple_aabb[1], 0.6682 / 2, 1e-4);
+  EXPECT_NEAR(simple_aabb[2], -0.6682 / 2, 1e-4);
+  EXPECT_NEAR(simple_aabb[3], 0.6682 / 2, 1e-4);
+  EXPECT_NEAR(simple_aabb[4], 0.0510, 1e-4);
+  EXPECT_NEAR(simple_aabb[5], 0.7071, 1e-4);
+
+}
+
+TEST_F(TestAABB, TestComplex)
+{
+  // Contains a link with simple geometry and an offset and rotation in the collision link
+
+  const std::string COMPLEX_URDF = "<?xml version='1.0' ?>"
+      "<robot name='complex'>"
+      "  <link name='base_link'>"
+      "    <collision>"
+      "      <origin rpy='0 0 1.5708' xyz='5.0 0 1.0'/>"
+      "      <geometry>"
+      "        <box size='1.0 0.1 0.1' />"
+      "      </geometry>"
+      "    </collision>"
+      "    <collision>"
+      "      <origin rpy='0 0 1.5708' xyz='4.0 0 1.0'/>"
+      "      <geometry>"
+      "        <box size='1.0 0.1 0.1' />"
+      "      </geometry>"
+      "    </collision>"
+      "  </link>"
+      "  <link name='base_footprint'>"
+      "    <collision>"
+      "      <origin rpy='0 1.5708 0' xyz='-5.0 0 -1.0'/>"
+      "      <geometry>"
+      "        <box size='0.1 1.0 0.1' />"
+      "      </geometry>"
+      "    </collision>"
+      "  </link>"
+      "  <joint name='base_footprint_joint' type='fixed'>"
+      "    <origin rpy='0 0 1.5708' xyz='0 0 1'/>"
+      "    <child link='base_link'/>"
+      "    <parent link='base_footprint'/>"
+      "  </joint>"
+      "</robot>";
+
+  const std::string COMPLEX_SRDF = "<?xml version='1.0'?>"
+      "<robot name='complex'>  "
+      "  <virtual_joint name='world_joint' type='planar' parent_frame='odom_combined' child_link='base_footprint'/>   "
+      "  <group name='base'>"
+      "    <joint name='world_joint'/>"
+      "  </group>    "
+      "</robot>";
+
+  robot_state::RobotState complex_state = this->loadModel(COMPLEX_URDF, COMPLEX_SRDF);
+
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[0], 0.1, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[1], 1.0, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[2], 0.1, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[0], -5.0, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[1],  0.0, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[2], -1.0, 1e-4);
+
+  EXPECT_NEAR(complex_state.getLinkModel("base_link")->getShapeExtentsAtOrigin()[0], 1.1, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_link")->getShapeExtentsAtOrigin()[1], 1.0, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_link")->getShapeExtentsAtOrigin()[2], 0.1, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_link")->getCenteredBoundingBoxOffset()[0], 4.5, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_link")->getCenteredBoundingBoxOffset()[1], 0.0, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_link")->getCenteredBoundingBoxOffset()[2], 1.0, 1e-4);
+
+  std::vector<double> complex_aabb;
+  complex_state.computeAABB(complex_aabb);
+
+  ASSERT_EQ(complex_aabb.size(), 6);
+  EXPECT_NEAR(complex_aabb[0], -5.05, 1e-4);
+  EXPECT_NEAR(complex_aabb[1],  0.5, 1e-4);
+  EXPECT_NEAR(complex_aabb[2], -0.5, 1e-4);
+  EXPECT_NEAR(complex_aabb[3],  5.05, 1e-4);
+  EXPECT_NEAR(complex_aabb[4],  -1.05, 1e-4);
+  EXPECT_NEAR(complex_aabb[5],  2.05, 1e-4);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -66,11 +66,11 @@ protected:
 
   robot_state::RobotState loadModel(const std::string urdf, const std::string srdf)
   {
-    boost::shared_ptr<urdf::ModelInterface> parsed_urdf(urdf::parseURDF(urdf));
+    urdf::ModelInterfaceSharedPtr parsed_urdf(urdf::parseURDF(urdf));
     if (!parsed_urdf)
       throw std::runtime_error("Cannot parse URDF.");
 
-    boost::shared_ptr<srdf::Model> parsed_srdf(new srdf::Model());
+    srdf::ModelSharedPtr parsed_srdf(new srdf::Model());
     bool srdf_ok = parsed_srdf->initString(*parsed_urdf, srdf);
     if (!srdf_ok)
       throw std::runtime_error("Cannot parse URDF.");

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -45,7 +45,6 @@
 class TestAABB : public testing::Test
 {
 protected:
-
   std::string readFileToString(boost::filesystem::path path) const
   {
     std::string file_string;
@@ -63,9 +62,7 @@ protected:
     return file_string;
   }
 
-  virtual void SetUp()
-  {
-  };
+  virtual void SetUp(){};
 
   robot_state::RobotState loadModel(const std::string urdf, const std::string srdf)
   {
@@ -89,10 +86,10 @@ protected:
   virtual void TearDown()
   {
   }
-
 };
 
-TEST_F(TestAABB, TestPR2) {
+TEST_F(TestAABB, TestPR2)
+{
   // Contains a link with mesh geometry that is not centered
 
   boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
@@ -102,27 +99,27 @@ TEST_F(TestAABB, TestPR2) {
 
   robot_state::RobotState pr2_state = this->loadModel(PR2_URDF, PR2_SRDF);
 
-  const Eigen::Vector3d &extentsBaseFootprint = pr2_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin();
+  const Eigen::Vector3d& extentsBaseFootprint = pr2_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin();
   // values taken from moveit_resources/pr2_description/urdf/robot.xml
   EXPECT_NEAR(extentsBaseFootprint[0], 0.001, 1e-4);
   EXPECT_NEAR(extentsBaseFootprint[1], 0.001, 1e-4);
   EXPECT_NEAR(extentsBaseFootprint[2], 0.001, 1e-4);
 
-  const Eigen::Vector3d &offsetBaseFootprint = pr2_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset();
+  const Eigen::Vector3d& offsetBaseFootprint = pr2_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset();
   EXPECT_NEAR(offsetBaseFootprint[0], 0.0, 1e-4);
   EXPECT_NEAR(offsetBaseFootprint[1], 0.0, 1e-4);
   EXPECT_NEAR(offsetBaseFootprint[2], 0.071, 1e-4);
 
-  const Eigen::Vector3d &extentsBaseLink = pr2_state.getLinkModel("base_link")->getShapeExtentsAtOrigin();
+  const Eigen::Vector3d& extentsBaseLink = pr2_state.getLinkModel("base_link")->getShapeExtentsAtOrigin();
   // values computed from moveit_resources/pr2_description/urdf/meshes/base_v0/base_L.stl in e.g. Meshlab
   EXPECT_NEAR(extentsBaseLink[0], 0.668242, 1e-4);
   EXPECT_NEAR(extentsBaseLink[1], 0.668242, 1e-4);
   EXPECT_NEAR(extentsBaseLink[2], 0.656175, 1e-4);
 
-  const Eigen::Vector3d &offsetBaseLink = pr2_state.getLinkModel("base_link")->getCenteredBoundingBoxOffset();
+  const Eigen::Vector3d& offsetBaseLink = pr2_state.getLinkModel("base_link")->getCenteredBoundingBoxOffset();
   EXPECT_NEAR(offsetBaseLink[0], 0.0, 1e-4);
   EXPECT_NEAR(offsetBaseLink[1], 0.0, 1e-4);
-  EXPECT_NEAR(offsetBaseLink[2], 0.656175 / 2, 1e-4); // The 3D mesh isn't centered, but is whole above z axis
+  EXPECT_NEAR(offsetBaseLink[2], 0.656175 / 2, 1e-4);  // The 3D mesh isn't centered, but is whole above z axis
 
   std::vector<double> pr2_aabb;
   pr2_state.computeAABB(pr2_aabb);
@@ -143,13 +140,14 @@ TEST_F(TestAABB, TestPR2) {
     std::cout << dim << ", " << (pr2_aabb[2*i+1] - center) << std::endl;
   }
   // */
-
 }
 
-TEST_F(TestAABB, TestSimple) {
+TEST_F(TestAABB, TestSimple)
+{
   // Contains a link with simple geometry and an offset in the collision link
 
-  const std::string SIMPLE_URDF = "<?xml version='1.0' ?>"
+  const std::string SIMPLE_URDF =
+      "<?xml version='1.0' ?>"
       "<robot name='simple'>"
       "  <link name='base_link'>"
       "    <collision>"
@@ -174,7 +172,8 @@ TEST_F(TestAABB, TestSimple) {
       "  </joint>"
       "</robot>";
 
-  const std::string SIMPLE_SRDF = "<?xml version='1.0'?>"
+  const std::string SIMPLE_SRDF =
+      "<?xml version='1.0'?>"
       "<robot name='simple'>  "
       "  <virtual_joint name='world_joint' type='planar' parent_frame='odom_combined' child_link='base_footprint'/>   "
       "  <group name='base'>"
@@ -194,7 +193,6 @@ TEST_F(TestAABB, TestSimple) {
   EXPECT_NEAR(simple_aabb[3], 0.6682 / 2, 1e-4);
   EXPECT_NEAR(simple_aabb[4], 0.0510, 1e-4);
   EXPECT_NEAR(simple_aabb[5], 0.7071, 1e-4);
-
 }
 
 TEST_F(TestAABB, TestComplex)
@@ -202,37 +200,38 @@ TEST_F(TestAABB, TestComplex)
   // Contains a link with simple geometry and an offset and rotation in the collision link
 
   const std::string COMPLEX_URDF = "<?xml version='1.0' ?>"
-      "<robot name='complex'>"
-      "  <link name='base_link'>"
-      "    <collision>"
-      "      <origin rpy='0 0 1.5708' xyz='5.0 0 1.0'/>"
-      "      <geometry>"
-      "        <box size='1.0 0.1 0.1' />"
-      "      </geometry>"
-      "    </collision>"
-      "    <collision>"
-      "      <origin rpy='0 0 1.5708' xyz='4.0 0 1.0'/>"
-      "      <geometry>"
-      "        <box size='1.0 0.1 0.1' />"
-      "      </geometry>"
-      "    </collision>"
-      "  </link>"
-      "  <link name='base_footprint'>"
-      "    <collision>"
-      "      <origin rpy='0 1.5708 0' xyz='-5.0 0 -1.0'/>"
-      "      <geometry>"
-      "        <box size='0.1 1.0 0.1' />"
-      "      </geometry>"
-      "    </collision>"
-      "  </link>"
-      "  <joint name='base_footprint_joint' type='fixed'>"
-      "    <origin rpy='0 0 1.5708' xyz='0 0 1'/>"
-      "    <child link='base_link'/>"
-      "    <parent link='base_footprint'/>"
-      "  </joint>"
-      "</robot>";
+                                   "<robot name='complex'>"
+                                   "  <link name='base_link'>"
+                                   "    <collision>"
+                                   "      <origin rpy='0 0 1.5708' xyz='5.0 0 1.0'/>"
+                                   "      <geometry>"
+                                   "        <box size='1.0 0.1 0.1' />"
+                                   "      </geometry>"
+                                   "    </collision>"
+                                   "    <collision>"
+                                   "      <origin rpy='0 0 1.5708' xyz='4.0 0 1.0'/>"
+                                   "      <geometry>"
+                                   "        <box size='1.0 0.1 0.1' />"
+                                   "      </geometry>"
+                                   "    </collision>"
+                                   "  </link>"
+                                   "  <link name='base_footprint'>"
+                                   "    <collision>"
+                                   "      <origin rpy='0 1.5708 0' xyz='-5.0 0 -1.0'/>"
+                                   "      <geometry>"
+                                   "        <box size='0.1 1.0 0.1' />"
+                                   "      </geometry>"
+                                   "    </collision>"
+                                   "  </link>"
+                                   "  <joint name='base_footprint_joint' type='fixed'>"
+                                   "    <origin rpy='0 0 1.5708' xyz='0 0 1'/>"
+                                   "    <child link='base_link'/>"
+                                   "    <parent link='base_footprint'/>"
+                                   "  </joint>"
+                                   "</robot>";
 
-  const std::string COMPLEX_SRDF = "<?xml version='1.0'?>"
+  const std::string COMPLEX_SRDF =
+      "<?xml version='1.0'?>"
       "<robot name='complex'>  "
       "  <virtual_joint name='world_joint' type='planar' parent_frame='odom_combined' child_link='base_footprint'/>   "
       "  <group name='base'>"
@@ -246,7 +245,7 @@ TEST_F(TestAABB, TestComplex)
   EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[1], 1.0, 1e-4);
   EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[2], 0.1, 1e-4);
   EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[0], -5.0, 1e-4);
-  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[1],  0.0, 1e-4);
+  EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[1], 0.0, 1e-4);
   EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getCenteredBoundingBoxOffset()[2], -1.0, 1e-4);
 
   EXPECT_NEAR(complex_state.getLinkModel("base_link")->getShapeExtentsAtOrigin()[0], 1.1, 1e-4);
@@ -261,11 +260,11 @@ TEST_F(TestAABB, TestComplex)
 
   ASSERT_EQ(complex_aabb.size(), 6);
   EXPECT_NEAR(complex_aabb[0], -5.05, 1e-4);
-  EXPECT_NEAR(complex_aabb[1],  0.5, 1e-4);
+  EXPECT_NEAR(complex_aabb[1], 0.5, 1e-4);
   EXPECT_NEAR(complex_aabb[2], -0.5, 1e-4);
-  EXPECT_NEAR(complex_aabb[3],  5.05, 1e-4);
-  EXPECT_NEAR(complex_aabb[4],  -1.05, 1e-4);
-  EXPECT_NEAR(complex_aabb[5],  2.05, 1e-4);
+  EXPECT_NEAR(complex_aabb[3], 5.05, 1e-4);
+  EXPECT_NEAR(complex_aabb[4], -1.05, 1e-4);
+  EXPECT_NEAR(complex_aabb[5], 2.05, 1e-4);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Fixed bugs in computation of AABB in LinkModel and RobotState.

Discussion started here: https://github.com/ros-planning/moveit/pull/516#issuecomment-309784558

If you visualize the bounding box computed for the PR2 robot, it is plainly wrong:
![snimek obrazovky porizeny 2017-11-22 18 24 50](https://user-images.githubusercontent.com/182533/33387056-9bc24580-d52c-11e7-8a89-23bd51c8f359.png)

This is the result with my fix: 
![snimek obrazovky porizeny 2017-11-28 14 07 06](https://user-images.githubusercontent.com/182533/33387092-b273a198-d52c-11e7-8261-c21f04b38f6e.png)

I added tests that should check for most of the fail cases I've found. Here's a visualization of the "Complex" test:
![snimek obrazovky porizeny 2017-11-29 16 07 42](https://user-images.githubusercontent.com/182533/33387137-caf9ea56-d52c-11e7-8e06-e4fdbc833713.png)

There were 2 sources of wrong computations:

-  Assuming that when I take the 2 extremal points of a bbox and then apply an affine transform, these points remain extremal even in the new frame
- Computing just the extents and ignoring any transformation of the collision elements inside a link

I'm almost sure the code is breaking ABI. Now the question is if there is a way (and will) to make it ABI compatible, or if this should just get cherry-picked to upstream. However, I think the consequences of these bugs can be pretty severe and it might be nice to have them fixed in all releases.

The code also might be optimized for performance, which I'm not good at.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
