### PR TITLE
Add support for the Arctic gamepad

### DIFF
--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -320,6 +320,82 @@ class PS3WiredStatus(JoyStatus):
         self.right_analog_y = msg.axes[3]
         self.orig_msg = msg
 
+
+class ArcticStatus(JoyStatus):
+    def __init__(self, msg):
+        JoyStatus.__init__(self)
+        if msg.buttons[8] == 1:
+            # Button 9 on the gamepad.
+            self.select = True
+        else:
+            self.select = False
+        if msg.buttons[9] == 1:
+            # Button 10 on the gamepad.
+            self.start = True
+        else:
+            self.start = False
+        if msg.buttons[3] == 1:
+            # Button 4 on the gamepad.
+            self.square = True
+        else:
+            self.square = False
+        if msg.buttons[1] == 1:
+            # Button 2 on the gamepad.
+            self.circle = True
+        else:
+            self.circle = False
+        if msg.axes[5] > 0.1:
+            # Digital control on the gamepad.
+            self.up = True
+        else:
+            self.up = False
+        if msg.axes[5] < -0.1:
+            # Digital control on the gamepad.
+            self.down = True
+        else:
+            self.down = False
+        if msg.axes[4] < -0.1:
+            # Digital control on the gamepad.
+            self.left = True
+        else:
+            self.left = False
+        if msg.axes[4] > 0.1:
+            # Digital control on the gamepad.
+            self.right = True
+        else:
+            self.right = False
+        if msg.buttons[0] == 1:
+            # Button 1 on the gamepad.
+            self.triangle = True
+        else:
+            self.triangle = False
+        if msg.buttons[2] == 1:
+            # Button 3 on the gamepad.
+            self.cross = True
+        else:
+            self.cross = False
+        if msg.buttons[4] == 1:
+            self.L1 = True
+        else:
+            self.L1 = False
+        if msg.buttons[5] == 1:
+            self.R1 = True
+        else:
+            self.R1 = False
+        if msg.buttons[6] == 1:
+            self.L2 = True
+        else:
+            self.L2 = False
+        if msg.buttons[7] == 1:
+            self.R2 = True
+        else:
+            self.R2 = False
+        self.left_analog_x = msg.axes[0]
+        self.left_analog_y = msg.axes[1]
+        self.right_analog_x = msg.axes[2]
+        self.right_analog_y = msg.axes[3]
+        self.orig_msg = msg
+
 class StatusHistory():
   def __init__(self, max_length=10):
     self.max_length = max_length
@@ -469,6 +545,8 @@ class MoveitJoy:
             status = XBoxStatus(msg)
         elif len(msg.axes) == 20 and len(msg.buttons) == 17:
             status = PS3Status(msg)
+        elif len(msg.axes) == 7 and len(msg.buttons) == 12:
+            status = ArcticStatus(msg)
         else:
             raise Exception("Unknown joystick")
         self.run(status)


### PR DESCRIPTION
### Description

Add support for the arctic gamepad in `moveitjoy_module.py`, and, indirectly in `moveit_ros_visualization::moveit_joy.py`.

Arctic gamepad: https://www.arctic.ac/eu_en/usb-wireless-gamepad.html.

I'm ready to add the support for this gamepad somewhere if someone can point me where.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code), **didn't touch much**
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI, **no change in any GUI**
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html), **not necessary**
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic), **can be cherry picked, very local changes**

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
