### PR TITLE
Adds parameter lookup function for kinematics plugins

### DIFF
--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -615,15 +615,15 @@ protected:
     }
 
     ros::NodeHandle nh;
-    if (nh.hasParam("robot_description_kinematics/" + param))
-    {
-      val = nh.param("robot_description_kinematics/" + param, default_val);
-      return true;
-    }
-
     if (nh.hasParam("robot_description_kinematics/" + group_name_ + "/" + param))
     {
       val = nh.param("robot_description_kinematics/" + group_name_ + "/" + param, default_val);
+      return true;
+    }
+
+    if (nh.hasParam("robot_description_kinematics/" + param))
+    {
+      val = nh.param("robot_description_kinematics/" + param, default_val);
       return true;
     }
 

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -603,6 +603,11 @@ protected:
   /**
    * @brief Enables kinematics plugins access to parameters that are defined
    * for the 'robot_description_kinematics' namespace.
+   * Parameters are queried in order of the specified group hierarchy.
+   * That is parameters are first searched in the private namespace
+   * then in the subroup namespace and finally in the group namespace.
+   * This order maintains default behavior by keeping the private namespace
+   * as the predominant configuration but also allows groupwise specifications.
    */
   template <typename T>
   inline bool lookupParam(const std::string& param, T& val, const T& default_val) const

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -46,7 +46,6 @@
 #include <boost/function.hpp>
 #include <string>
 
-
 namespace moveit
 {
 namespace core
@@ -609,20 +608,20 @@ protected:
   inline bool lookupParam(const std::string& param, T& val, const T& default_val) const
   {
     ros::NodeHandle pnh("~");
-    if(pnh.hasParam(param))
+    if (pnh.hasParam(param))
     {
       val = pnh.param(param, default_val);
       return true;
     }
 
     ros::NodeHandle nh;
-    if(nh.hasParam("robot_description_kinematics/" + param))
+    if (nh.hasParam("robot_description_kinematics/" + param))
     {
       val = nh.param("robot_description_kinematics/" + param, default_val);
       return true;
     }
 
-    if(nh.hasParam("robot_description_kinematics/" + group_name_ + "/" + param))
+    if (nh.hasParam("robot_description_kinematics/" + group_name_ + "/" + param))
     {
       val = nh.param("robot_description_kinematics/" + group_name_ + "/" + param, default_val);
       return true;


### PR DESCRIPTION
Some kinematics plugins access parameters that are defined in the private namespace of their node.
With multiple nodes, each node needs to be initialized with the same parameters which can be
very inconvenient in some setups.
This commit resolves the issue by enabling plugins to query parameters from the
namespace 'robot_description_kinematics' so that they can be defined in the kinematics.yaml either under the corresponding group or directly.

This PR helps to resolve issues [with multiple arms](https://github.com/ros-industrial/universal_robot/issues/247) and when launching the plugin with [rviz and the moveit commander simultaneously](https://github.com/ros-industrial/universal_robot/issues/256) (also see [here](https://github.com/ros-planning/moveit/issues/545) and [here](https://bitbucket.org/traclabs/trac_ik/issues/25/unable-to-set-solver_type-in-launch-file)), although the plugins will actually have to make use of the new method.

Example:
In our UR5 setup we add a prefix 'ur5_' to each joint name in the robot description.
When using the UR5KinematicsPlugin from ur_kinematics we have to define the parameter 'arm_prefix' at every launch within the private namespace of each node using the kinematics plugin.
With this PR and [this minor change](https://github.com/TAMS-Group/universal_robot/commit/e384a27cd6ae149826f5bb474f462d15d3f9330e) in ur_kinematics we just need to set the parameter once inside the kinematics.yaml under the group arm.

@v4hn 