### PR TITLE
removing redundant capabilities from capability names and adding swp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ qtcreator-*
 # Emacs
 .#*
 
+# Vim
+*.swp
+
 # Catkin custom files
 CATKIN_IGNORE
 

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -46,9 +46,7 @@ namespace move_group
 static const char* DEFAULT_CAPABILITIES[] = {
    "move_group/MoveGroupCartesianPathService",
    "move_group/MoveGroupKinematicsService",
-   "move_group/MoveGroupCartesianPathService",
    "move_group/MoveGroupExecuteTrajectoryAction",
-   "move_group/MoveGroupKinematicsService",
    "move_group/MoveGroupMoveAction",
    "move_group/MoveGroupPickPlaceAction",
    "move_group/MoveGroupPlanService",


### PR DESCRIPTION
### Description
Minor fixes

- The .gitignore regex for swaps doesn't work on my machine so I added a regex that does.
- Removing redundant capability names from the default capabilities list. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
