### PR TITLE
use waitForCurrentState(ros::Time::now(), instead of waitForCurrentSt…

### DIFF
--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time program_options signals thread)
+find_package(Boost REQUIRED system filesystem date_time program_options signals thread chrono)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_perception

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time program_options signals thread chrono)
+find_package(Boost REQUIRED system filesystem date_time program_options signals thread)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_perception

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -44,6 +44,7 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/condition_variable.hpp>
 
 namespace planning_scene_monitor
 {
@@ -134,6 +135,11 @@ public:
    *  @return Returns the map from joint names to joint state values*/
   std::map<std::string, double> getCurrentStateValues() const;
 
+  /** @brief Wait for at most \e wait_time seconds (default 1s) for a robot state more recent than t
+   *  @return true on success, false if up-to-date robot state wasn't received within \e wait_time
+   */
+  bool waitForCurrentState(const ros::Time t = ros::Time::now(), double wait_time = 1.0) const;
+
   /** @brief Wait for at most \e wait_time seconds until the complete current state is known. Return true if the full
    * state is known */
   bool waitForCurrentState(double wait_time) const;
@@ -189,6 +195,7 @@ private:
   ros::Time last_tf_update_;
 
   mutable boost::mutex state_update_lock_;
+  mutable boost::condition_variable state_update_condition_;
   std::vector<JointStateUpdateCallback> update_callbacks_;
 };
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -44,7 +44,6 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/thread/condition_variable.hpp>
 
 namespace planning_scene_monitor
 {
@@ -195,7 +194,6 @@ private:
   ros::Time last_tf_update_;
 
   mutable boost::mutex state_update_lock_;
-  mutable boost::condition_variable state_update_condition_;
   std::vector<JointStateUpdateCallback> update_callbacks_;
 };
 

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -263,17 +263,17 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::D
 
 bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros::Time t, double wait_time) const
 {
-  ros::WallTime start = ros::WallTime::now();
-  ros::WallDuration elapsed(0, 0);
-  ros::WallDuration timeout(wait_time);
+  ros::WallTime timeout = ros::WallTime::now() + ros::WallDuration(wait_time);
+  ros::WallDuration busywait(0.1);
 
   boost::mutex::scoped_lock lock(state_update_lock_);
   while (current_state_time_ < t)
   {
-    state_update_condition_.wait_for(lock, boost::chrono::nanoseconds((timeout - elapsed).toNSec()));
-    elapsed = ros::WallTime::now() - start;
-    if (elapsed > timeout)
+    lock.unlock();
+    busywait.sleep();
+    if (ros::WallTime::now() < timeout)
       return false;
+    lock.lock();
   }
   return true;
 }
@@ -411,8 +411,4 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
   if (update)
     for (std::size_t i = 0; i < update_callbacks_.size(); ++i)
       update_callbacks_[i](joint_state);
-
-
-  // notify waitForCurrentState() *after* potential update callbacks
-  state_update_condition_.notify_all();
 }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -271,7 +271,7 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros:
   {
     lock.unlock();
     busywait.sleep();
-    if (ros::WallTime::now() < timeout)
+    if (ros::WallTime::now() >= timeout)
       return false;
     lock.lock();
   }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -932,7 +932,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
   ROS_DEBUG_NAMED("traj_execution", "Validating trajectory with allowed_start_tolerance %g", allowed_start_tolerance_);
 
   robot_state::RobotStatePtr current_state;
-  if (!csm_->waitForCurrentState(1.0) || !(current_state = csm_->getCurrentState()))
+  if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
   {
     ROS_WARN_NAMED("traj_execution", "Failed to validate trajectory: couldn't receive full current joint state within "
                                      "1s");


### PR DESCRIPTION
…ate(1.0) in TrajectoryExecutionManager::validate, cherry pick part of #350

### Description

Current indigo moveit has regression compare to hydro, which you could find very easily  at [answers.ros.org](https://www.google.co.jp/search?ei=QUYtWvOXOYfI0gTXvIiYBw&q=%2Bsite%3Aanswers.ros.org+Failed+to+validate+trajectory%3A+couldn%27t+receive+full+current+joint+state+within+1s&oq=%2Bsite%3Aanswers.ros.org+Failed+to+validate+trajectory%3A+couldn%27t+receive+full+current+joint+state+within+1s&gs_l=psy-ab.3...3450.3450.0.3725.1.1.0.0.0.0.0.0..0.0....0...1c.1.64.psy-ab..1.0.0....0.LiRDd4s9FU0), such as

- https://answers.ros.org/question/252114/failed-to-validate-trajectory-couldnt-receive-full-current-joint-state-within-1s-error/
- https://answers.ros.org/question/254927/failed-to-validate-trajectory-after-updating-moveit-feb-2017/
- https://answers.ros.org/question/257874/moveit-cannot-update-robots-state/
- https://answers.ros.org/question/273444/cannot-use-moveit-with-dual_ur5-platform/

and interestingly this problem was fixed in Kinetic

that is because indigo moveit requires update of entire joints from `/joint_states` by using [`haveCompleteState()` function](https://github.com/ros-planning/moveit/blob/0.9.9/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp#L282-L293), whereas kinetic moveit uses `state_update_condition_.wait_for(lock, boost::chrono::nanoseconds((timeout - elapsed).toNSec()));` in https://github.com/ros-planning/moveit/pull/63 which uses https://github.com/ros-planning/moveit/blob/0.9.9/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp#L265-L280 with basicall wait for 

This change has been introduced in https://github.com/ros-planning/moveit/pull/350

To summarize, if `/joint_states` is not complite, 

- Hydro : The robot can move trajectory
- Indigo (before this PR), It shows `Failed to validate trajectory: couldn't receive full current joint state within 1s` and do not move
- Indigo (after this PR), it shows `The complete state of the robot is not yet known.  Missing RHAND_JOINT0, JOINT1, JOINT2, ...` and robot can move
- Kinetic, as same as Indigo (after this PR)


### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
