### PR TITLE
cleanup #663

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -696,7 +696,7 @@ public:
 
   /** \brief Construct a vector of messages (\e collision_objects) with the collision object data for all objects in
    * planning_scene */
-  bool getCollisionObjectMsgs(std::vector<moveit_msgs::CollisionObject>& collision_objs) const;
+  void getCollisionObjectMsgs(std::vector<moveit_msgs::CollisionObject>& collision_objs) const;
 
   /** \brief Construct a message (\e attached_collision_object) with the attached collision object data from the
    * planning_scene for the requested object*/
@@ -705,13 +705,13 @@ public:
 
   /** \brief Construct a vector of messages (\e attached_collision_objects) with the attached collision object data for
    * all objects in planning_scene */
-  bool getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
+  void getAttachedCollisionObjectMsgs(std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const;
 
   /** \brief Construct a message (\e octomap) with the octomap data from the planning_scene */
   bool getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const;
 
   /** \brief Construct a vector of messages (\e object_colors) with the colors of the objects from the planning_scene */
-  bool getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const;
+  void getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const;
 
   /** \brief Apply changes to this planning scene as diffs, even if the message itself is not marked as being a diff
      (is_diff

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -848,7 +848,7 @@ bool planning_scene::PlanningScene::getCollisionObjectMsg(moveit_msgs::Collision
   return true;
 }
 
-bool planning_scene::PlanningScene::getCollisionObjectMsgs(
+void planning_scene::PlanningScene::getCollisionObjectMsgs(
     std::vector<moveit_msgs::CollisionObject>& collision_objs) const
 {
   collision_objs.clear();
@@ -860,11 +860,6 @@ bool planning_scene::PlanningScene::getCollisionObjectMsgs(
       getCollisionObjectMsg(co, ns[i]);
       collision_objs.push_back(co);
     }
-
-  if (collision_objs.size() < 1)
-    return false;
-  else
-    return true;
 }
 
 bool planning_scene::PlanningScene::getAttachedCollisionObjectMsg(
@@ -883,16 +878,12 @@ bool planning_scene::PlanningScene::getAttachedCollisionObjectMsg(
   return false;
 }
 
-bool planning_scene::PlanningScene::getAttachedCollisionObjectMsgs(
+void planning_scene::PlanningScene::getAttachedCollisionObjectMsgs(
     std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs) const
 {
   std::vector<const moveit::core::AttachedBody*> attached_bodies;
   getCurrentState().getAttachedBodies(attached_bodies);
   attachedBodiesToAttachedCollisionObjectMsgs(attached_bodies, attached_collision_objs);
-  if (attached_collision_objs.size() < 1)
-    return false;
-  else
-    return true;
 }
 
 bool planning_scene::PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const
@@ -910,14 +901,12 @@ bool planning_scene::PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose&
       tf::poseEigenToMsg(map->shape_poses_[0], octomap.origin);
       return true;
     }
-    else
-      logError("Unexpected number of shapes in octomap collision object. Not including '%s' object",
-               OCTOMAP_NS.c_str());
-    return false;
+    logError("Unexpected number of shapes in octomap collision object. Not including '%s' object", OCTOMAP_NS.c_str());
   }
+  return false;
 }
 
-bool planning_scene::PlanningScene::getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const
+void planning_scene::PlanningScene::getObjectColorMsgs(std::vector<moveit_msgs::ObjectColor>& object_colors) const
 {
   object_colors.clear();
 
@@ -930,10 +919,6 @@ bool planning_scene::PlanningScene::getObjectColorMsgs(std::vector<moveit_msgs::
     object_colors[i].id = it->first;
     object_colors[i].color = it->second;
   }
-  if (object_colors.size() < 1)
-    return false;
-  else
-    return true;
 }
 
 void planning_scene::PlanningScene::getPlanningSceneMsg(moveit_msgs::PlanningScene& scene_msg) const

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -766,9 +766,8 @@ void planning_scene::PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::Plannin
       }
       else
       {
-        moveit_msgs::CollisionObject co;
-        getCollisionObjectMsg(co, it->first);
-        scene_msg.world.collision_objects.push_back(co);
+        scene_msg.world.collision_objects.emplace_back();
+        getCollisionObjectMsg(scene_msg.world.collision_objects.back(), it->first);
       }
     }
     if (do_omap)
@@ -856,9 +855,8 @@ void planning_scene::PlanningScene::getCollisionObjectMsgs(
   for (std::size_t i = 0; i < ns.size(); ++i)
     if (ns[i] != OCTOMAP_NS)
     {
-      moveit_msgs::CollisionObject co;
-      getCollisionObjectMsg(co, ns[i]);
-      collision_objs.push_back(co);
+      collision_objs.emplace_back();
+      getCollisionObjectMsg(collision_objs.back(), ns[i]);
     }
 }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/conversions.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/conversions.h
@@ -91,7 +91,7 @@ void robotStateToRobotStateMsg(const RobotState& state, moveit_msgs::RobotState&
  */
 void attachedBodiesToAttachedCollisionObjectMsgs(
     const std::vector<const AttachedBody*>& attached_bodies,
-    std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs);
+    std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs);
 /**
  * @brief Convert a MoveIt! robot state to a joint state message
  * @param state The input MoveIt! robot state object

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -401,7 +401,7 @@ void moveit::core::robotStateToRobotStateMsg(const RobotState& state, moveit_msg
 
 void moveit::core::attachedBodiesToAttachedCollisionObjectMsgs(
     const std::vector<const AttachedBody*>& attached_bodies,
-    std::vector<moveit_msgs::AttachedCollisionObject> attached_collision_objs)
+    std::vector<moveit_msgs::AttachedCollisionObject>& attached_collision_objs)
 {
   attached_collision_objs.resize(attached_bodies.size());
   for (std::size_t i = 0; i < attached_bodies.size(); ++i)


### PR DESCRIPTION
This PR provides some cleanup to the previously merged PR #663.
As a major regression, after #663, displaying of attached collision objects didn't work anymore (#723).
Besides fixing this, the present PR provides some other minor improvements.
