### PR TITLE
continous joint limits are always satisfied

### DIFF
--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -169,11 +169,9 @@ double RevoluteJointModel::distance(const double* values1, const double* values2
 bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   if (continuous_)
-  {
     return true;
-  } else {
+  else
     return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
-  }
 }
 
 bool RevoluteJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const

--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -168,7 +168,11 @@ double RevoluteJointModel::distance(const double* values1, const double* values2
 
 bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
-  return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+  if (!continuous_)
+  {
+    return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+  }
+  return true;
 }
 
 bool RevoluteJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const

--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -168,11 +168,12 @@ double RevoluteJointModel::distance(const double* values1, const double* values2
 
 bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
-  if (!continuous_)
+  if (continuous_)
   {
+    return true;
+  } else {
     return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
   }
-  return true;
 }
 
 bool RevoluteJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -524,7 +524,7 @@ TEST_F(OneRobot, FK)
 
   upd_a["joint_a"] = 3.2;
   state.setVariablePositions(upd_a);
-  EXPECT_FALSE(state.satisfiesBounds(model->getJointModel("joint_a")));
+  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a")));
   EXPECT_NEAR(state.getVariablePosition("joint_a"), 3.2, 1e-3);
   state.enforceBounds();
   EXPECT_NEAR(state.getVariablePosition("joint_a"), -3.083185, 1e-3);


### PR DESCRIPTION
### Description

Some continuous joints (e.g. joint1 on my Kinova Mico robot arm) will show as violating joint limits in some situations.   

This change returns true that continuous joints always satisfiesPositionBounds()

Originally, the urdf limits were set to -2PI to +2PI.  According to the Urdf Joint documentation, the limits should not be set for continuous joints; however, removing the limits gave the same joint violations in the moveit RViz window  for some continuous joints.

One could argue to set the limits to MIN_FLOAT and MAX_FLOAT, but that will not be defined with the "+/-margin" calculation in this file.

Thus, always returning true seems to me to be the safest for continuous joints.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
