### PR TITLE
Feature/waypoint check

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -43,8 +43,6 @@
 #include <moveit/profiler/profiler.h>
 #include <boost/bind.hpp>
 
-#include <stdio.h>
-
 moveit::core::RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)
   , has_velocity_(false)
@@ -1951,23 +1949,17 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
     last_valid_percentage = percentage;
   }
 
-//    logWarn("Traj size: %u", (unsigned int) traj.size());
-    logWarn("Checking traj 0 and 1. in plan!?!?!?!");
-//    std::cout << traj.at(0) << '\n';
-//    std::cout << traj.at(1) << '\n';
-//    std::cout << ((*(traj[0])).hasVelocities() == 0) << '\n';
-    std::cout <<"Traj1: " << (*(traj[1])).acceleration_ << '\n';
-//    std::cout << "equal nums? " << (1 == 1) << '\n';
-    std::cout << "equal values? " << ((*(traj[0])).acceleration_ == (*(traj[1])).acceleration_ ) << '\n';
-    if (traj.size() > 1 && (*(traj.at(0))).has_acceleration_ == (*(traj.at(1))).has_acceleration_ == 0)
-    {
-        logWarn("There are two identical waypoints in this path.");
-    }
+  // Check to see if the two first points in the trajectory are identical.
+  if (traj.size() > 1 && (*(*(traj[0])).position_) == (*(*(traj[1])).position_))
+  {
+    logWarn("There is a duplicate waypoint in the path. Check that the starting point is not a waypoint.");
+  }
 
   if (test_joint_space_jump)
   {
     last_valid_percentage *= testJointSpaceJump(group, traj, jump_threshold);
   }
+
   return last_valid_percentage;
 }
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1942,18 +1942,35 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
 
     if (setFromIK(group, pose, link->getName(), 1, 0.0, validCallback, options))
     {
+      logWarn("Loop number i: %u", (unsigned int) i);
       traj.push_back(RobotStatePtr(new RobotState(*this)));
+      logWarn("Now checking points in trajectory");
+      if (traj.at(0) == traj.back())
+      {
+          logWarn("There are two identical waypoints in this path.");
+      }
     }
+
     else
       break;
     last_valid_percentage = percentage;
   }
 
+    logWarn("Traj size: %u", (unsigned int) traj.size());
+//    logWarn("Looping to check trajectory");
+//    for (int j=1; j < traj.size(); j++)
+//    {
+//        logWarn("Checking traj point %u", j);
+//        if (traj[0] == traj[j])
+//        {
+//            logWarn("There are two identical waypoints in this path.");
+//        }
+//    }
+
   if (test_joint_space_jump)
   {
     last_valid_percentage *= testJointSpaceJump(group, traj, jump_threshold);
   }
-
   return last_valid_percentage;
 }
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -43,6 +43,8 @@
 #include <moveit/profiler/profiler.h>
 #include <boost/bind.hpp>
 
+#include <stdio.h>
+
 moveit::core::RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)
   , has_velocity_(false)
@@ -1942,22 +1944,22 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
 
     if (setFromIK(group, pose, link->getName(), 1, 0.0, validCallback, options))
     {
-      logWarn("Loop number i: %u", (unsigned int) i);
       traj.push_back(RobotStatePtr(new RobotState(*this)));
-      logWarn("Now checking points in trajectory");
-      if (traj.at(0) == traj.back())
-      {
-          logWarn("There are two identical waypoints in this path.");
-      }
     }
     else
       break;
     last_valid_percentage = percentage;
   }
 
-    logWarn("Traj size: %u", (unsigned int) traj.size());
-    logWarn("Checking traj 0 and 1. in plan");
-    if (traj.size() >=2 && traj.at(0) == traj.at(1))
+//    logWarn("Traj size: %u", (unsigned int) traj.size());
+    logWarn("Checking traj 0 and 1. in plan!?!?!?!");
+//    std::cout << traj.at(0) << '\n';
+//    std::cout << traj.at(1) << '\n';
+//    std::cout << ((*(traj[0])).hasVelocities() == 0) << '\n';
+    std::cout <<"Traj1: " << (*(traj[1])).acceleration_ << '\n';
+//    std::cout << "equal nums? " << (1 == 1) << '\n';
+    std::cout << "equal values? " << ((*(traj[0])).acceleration_ == (*(traj[1])).acceleration_ ) << '\n';
+    if (traj.size() > 1 && (*(traj.at(0))).has_acceleration_ == (*(traj.at(1))).has_acceleration_ == 0)
     {
         logWarn("There are two identical waypoints in this path.");
     }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1950,22 +1950,17 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
           logWarn("There are two identical waypoints in this path.");
       }
     }
-
     else
       break;
     last_valid_percentage = percentage;
   }
 
     logWarn("Traj size: %u", (unsigned int) traj.size());
-//    logWarn("Looping to check trajectory");
-//    for (int j=1; j < traj.size(); j++)
-//    {
-//        logWarn("Checking traj point %u", j);
-//        if (traj[0] == traj[j])
-//        {
-//            logWarn("There are two identical waypoints in this path.");
-//        }
-//    }
+    logWarn("Checking traj 0 and 1. in plan");
+    if (traj.size() >=2 && traj.at(0) == traj.at(1))
+    {
+        logWarn("There are two identical waypoints in this path.");
+    }
 
   if (test_joint_space_jump)
   {


### PR DESCRIPTION
### Description

Added warning when the first two points of a cartesian trajectory are identical.
    
This change came about while trying to run the Moveit Tutorials on the moveit website using the Python API. The website appends the starting point to the waypoints[] list, which results in errors because the path planner will try and append a waypoint to the path that does not monotonically increase with time.
    
I have since added this warning to alert the user of the plausible cause of an error as well as updated the tutorial to reflect a less error-prone example.

See the accompanying PR with the Moveit Tutorials for further information: 

https://github.com/ros-planning/moveit_tutorials/pull/146


### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

  