### PR TITLE
moveit_ros_visualisation: rviz TrajectoryDisplay timing calculation fix

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -405,7 +405,9 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       if (trajectory_slider_panel_)
         trajectory_slider_panel_->setSliderPosition(0);
     }
-  } else {
+  }
+  else
+  {
     current_state_time_ += wall_dt;
   }
 
@@ -438,7 +440,7 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
         if (!loop_display_property_->getBool() && trajectory_slider_panel_)
           trajectory_slider_panel_->pauseButton(true);
       }
-      current_state_time_ = current_state_time_ -  tm;
+      current_state_time_ = current_state_time_ - tm;
     }
   }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -399,12 +399,14 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
     if (animating_path_)
     {
       current_state_ = -1;
-      current_state_time_ = std::numeric_limits<float>::infinity();
+      current_state_time_ = 0;
       display_path_robot_->update(displaying_trajectory_message_->getFirstWayPointPtr());
       display_path_robot_->setVisible(display_->isEnabled());
       if (trajectory_slider_panel_)
         trajectory_slider_panel_->setSliderPosition(0);
     }
+  } else {
+    current_state_time_ += wall_dt;
   }
 
   if (animating_path_)
@@ -436,9 +438,8 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
         if (!loop_display_property_->getBool() && trajectory_slider_panel_)
           trajectory_slider_panel_->pauseButton(true);
       }
-      current_state_time_ = 0.0f;
+      current_state_time_ = current_state_time_ -  tm;
     }
-    current_state_time_ += wall_dt;
   }
 }
 


### PR DESCRIPTION
### Description
This PR fixes the timing calculation used for displaying the next RobotState. Previously, the time variable was set to zero after displaying a new state. This led to a time offset building up with each state update and the trajectory getting out-of-sync when using REALTIME.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
