### PR TITLE
Floating Joint Support in CurrentStateMonitor

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -55,6 +55,10 @@ typedef boost::function<void(const sensor_msgs::JointStateConstPtr& joint_state)
     @brief Monitors the joint_states topic and tf to maintain the current state of the robot. */
 class CurrentStateMonitor
 {
+  /* tf changed their interface between indigo and kinetic
+     from boost::signals::connection to boost::signals2::connection */
+  typedef decltype(tf::Transformer().addTransformsChangedListener(boost::function<void(void)>())) TFConnection;
+
 public:
   /**
    * @brief Constructor.
@@ -193,6 +197,7 @@ public:
 
 private:
   void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
+  void tfCallback();
   bool isPassiveOrMimicDOF(const std::string& dof) const;
 
   ros::NodeHandle nh_;
@@ -206,11 +211,12 @@ private:
   double error_;
   ros::Subscriber joint_state_subscriber_;
   ros::Time current_state_time_;
-  ros::Time last_tf_update_;
 
   mutable boost::mutex state_update_lock_;
   mutable boost::condition_variable state_update_condition_;
   std::vector<JointStateUpdateCallback> update_callbacks_;
+
+  std::shared_ptr<TFConnection> tf_connection_;
 };
 
 MOVEIT_CLASS_FORWARD(CurrentStateMonitor);

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -198,13 +198,12 @@ public:
 private:
   void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
   void tfCallback();
-  bool isPassiveOrMimicDOF(const std::string& dof) const;
 
   ros::NodeHandle nh_;
   boost::shared_ptr<tf::Transformer> tf_;
   robot_model::RobotModelConstPtr robot_model_;
   robot_state::RobotState robot_state_;
-  std::map<std::string, ros::Time> joint_time_;
+  std::map<const moveit::core::JointModel*, ros::Time> joint_time_;
   bool state_monitor_started_;
   bool copy_dynamics_;  // Copy velocity and effort from joint_state
   ros::Time monitor_start_time_;

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -148,7 +148,7 @@ void planning_scene_monitor::CurrentStateMonitor::stopStateMonitor()
     if (tf_ && tf_connection_)
     {
       tf_->removeTransformsChangedListener(*tf_connection_);
-      tf_connection_ = nullptr;
+      tf_connection_.reset();
     }
     ROS_DEBUG("No longer listening for joint states");
     state_monitor_started_ = false;

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -35,7 +35,9 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
+
 #include <tf_conversions/tf_eigen.h>
+
 #include <limits>
 
 planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
@@ -122,6 +124,11 @@ void planning_scene_monitor::CurrentStateMonitor::startStateMonitor(const std::s
       ROS_ERROR("The joint states topic cannot be an empty string");
     else
       joint_state_subscriber_ = nh_.subscribe(joint_states_topic, 25, &CurrentStateMonitor::jointStateCallback, this);
+    if (tf_ && robot_model_->getMultiDOFJointModels().size() > 0)
+    {
+      tf_connection_.reset(
+          new TFConnection(tf_->addTransformsChangedListener(boost::bind(&CurrentStateMonitor::tfCallback, this))));
+    }
     state_monitor_started_ = true;
     monitor_start_time_ = ros::Time::now();
     ROS_DEBUG("Listening to joint states on topic '%s'", nh_.resolveName(joint_states_topic).c_str());
@@ -138,7 +145,12 @@ void planning_scene_monitor::CurrentStateMonitor::stopStateMonitor()
   if (state_monitor_started_)
   {
     joint_state_subscriber_.shutdown();
-    ROS_DEBUG("No longer listening o joint states");
+    if (tf_ && tf_connection_)
+    {
+      tf_->removeTransformsChangedListener(*tf_connection_);
+      tf_connection_ = nullptr;
+    }
+    ROS_DEBUG("No longer listening for joint states");
     state_monitor_started_ = false;
   }
 }
@@ -306,7 +318,7 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(const std
   std::vector<std::string> missing_joints;
   if (!haveCompleteState(missing_joints))
   {
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (jmg)
     {
       std::set<std::string> mj;
@@ -345,7 +357,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
     current_state_time_ = joint_state->header.stamp;
     for (std::size_t i = 0; i < n; ++i)
     {
-      const robot_model::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
+      const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
       if (!jm)
         continue;
       // ignore fixed joints, multi-dof joints (they should not even be in the message)
@@ -376,8 +388,8 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
         }
 
         // continuous joints wrap, so we don't modify them (even if they are outside bounds!)
-        if (jm->getType() == robot_model::JointModel::REVOLUTE)
-          if (static_cast<const robot_model::RevoluteJointModel*>(jm)->isContinuous())
+        if (jm->getType() == moveit::core::JointModel::REVOLUTE)
+          if (static_cast<const moveit::core::RevoluteJointModel*>(jm)->isContinuous())
             continue;
 
         const robot_model::VariableBounds& b =
@@ -391,46 +403,6 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
           robot_state_.setJointPositions(jm, &b.max_position_);
       }
     }
-
-    // read root transform, if needed
-    if (tf_ && (robot_model_->getRootJoint()->getType() == robot_model::JointModel::PLANAR ||
-                robot_model_->getRootJoint()->getType() == robot_model::JointModel::FLOATING))
-    {
-      const std::string& child_frame = robot_model_->getRootLink()->getName();
-      const std::string& parent_frame = robot_model_->getModelFrame();
-
-      std::string err;
-      ros::Time tm;
-      tf::StampedTransform transf;
-      bool ok = false;
-      if (tf_->getLatestCommonTime(parent_frame, child_frame, tm, &err) == tf::NO_ERROR)
-      {
-        try
-        {
-          tf_->lookupTransform(parent_frame, child_frame, tm, transf);
-          ok = true;
-        }
-        catch (tf::TransformException& ex)
-        {
-          ROS_ERROR_THROTTLE(1, "Unable to lookup transform from %s to %s.  Exception: %s", parent_frame.c_str(),
-                             child_frame.c_str(), ex.what());
-        }
-      }
-      else
-        ROS_DEBUG_THROTTLE(1, "Unable to lookup transform from %s to %s: no common time.", parent_frame.c_str(),
-                           child_frame.c_str());
-      if (ok && last_tf_update_ != tm)
-      {
-        update = true;
-        last_tf_update_ = tm;
-        const std::vector<std::string>& vars = robot_model_->getRootJoint()->getVariableNames();
-        for (std::size_t j = 0; j < vars.size(); ++j)
-          joint_time_[vars[j]] = tm;
-        Eigen::Affine3d eigen_transf;
-        tf::transformTFToEigen(transf, eigen_transf);
-        robot_state_.setJointPositions(robot_model_->getRootJoint(), eigen_transf);
-      }
-    }
   }
 
   // callbacks, if needed
@@ -440,4 +412,82 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
 
   // notify waitForCurrentState() *after* potential update callbacks
   state_update_condition_.notify_all();
+}
+
+void planning_scene_monitor::CurrentStateMonitor::tfCallback()
+{
+  bool update = false;
+  bool changes = false;
+
+  // read multi-dof joint states from TF, if needed
+  const std::vector<const moveit::core::JointModel*>& multi_dof_joints = robot_model_->getMultiDOFJointModels();
+
+  {
+    for (const moveit::core::JointModel* joint : multi_dof_joints)
+    {
+      const std::string& child_frame = joint->getChildLinkModel()->getName();
+      const std::string& parent_frame =
+          joint->getParentLinkModel() ? joint->getParentLinkModel()->getName() : robot_model_->getModelFrame();
+
+      std::string err;
+      ros::Time tm;
+      if (!tf_->getLatestCommonTime(parent_frame, child_frame, tm, &err) == tf::NO_ERROR)
+      {
+        ROS_DEBUG_STREAM_THROTTLE(1, "Unable to update multi-dof joint '"
+                                         << joint->getName() << "': tf has no common time between '"
+                                         << parent_frame.c_str() << "' and '" << child_frame.c_str() << "': " << err);
+        continue;
+      }
+
+      const std::vector<std::string>& joint_vars = joint->getVariableNames();
+      assert(joint_vars.size() > 0);
+      if (joint_time_[joint_vars[0]] != tm)
+      {
+        // only lock if we actually update something
+        boost::mutex::scoped_lock _(state_update_lock_);
+        tf::StampedTransform transf;
+        try
+        {
+          tf_->lookupTransform(parent_frame, child_frame, tm, transf);
+        }
+        catch (tf::TransformException& ex)
+        {
+          ROS_ERROR_STREAM_THROTTLE(1, "Unable to update multi-dof joint '" << joint->getName()
+                                                                            << "'. TF exception: " << ex.what());
+          continue;
+        }
+        for (const std::string& var : joint_vars)
+          joint_time_[var] = tm;
+        Eigen::Affine3d eigen_transf;
+        tf::transformTFToEigen(transf, eigen_transf);
+
+        double new_values[joint->getStateSpaceDimension()];
+        joint->computeVariablePositions(eigen_transf, new_values);
+
+        if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
+        {
+          changes = true;
+        }
+
+        robot_state_.setJointPositions(joint, new_values);
+        update = true;
+      }
+    }
+  }
+
+  // callbacks, if needed
+  if (changes)
+  {
+    // stub joint state: multi-dof joints are not modelled in the message,
+    // but we should still trigger the update callbacks
+    sensor_msgs::JointStatePtr joint_state(new sensor_msgs::JointState);
+    for (std::size_t i = 0; i < update_callbacks_.size(); ++i)
+      update_callbacks_[i](joint_state);
+  }
+
+  if (update)
+  {
+    // notify waitForCurrentState() *after* potential update callbacks
+    state_update_condition_.notify_all();
+  }
 }


### PR DESCRIPTION
MoveIt supports Floating and Planar joints throughout the pipeline... almost throughout the pipeline.
Whenever someone actually tried to use it, they encountered problems with how to get the current state information into the MoveIt system. For over at least 4(!!!) years.

See among others [here](https://groups.google.com/forum/#!topic/moveit-users/C07EZmTgSBQ) and [here](https://github.com/ros-planning/moveit_ros/issues/620).

This works (rather hacked) for floating joints as root joint of the robot, but they are also important for online calibration procedures and mobile objects that are inherent to the setup and should be part of the urdf.

Turns out most things that are required to get this to work in general have been done a long time ago.
I simply implement a proposal by @hersh and add a tf callback that reads the state of all multi-dof joints from TF. This still does not allow to get velocities/effort readings into moveit, but it covers most everyday use-cases for multi-dof joints.
Also because it uses TF updates, it "just works" in practice and you don't have to explain the difference between transforms and joint states of floating joints to users. There simply isn't any.

This is mostly a generalization of the previous code. The only behavior that is supposed to change is that joint states for multi-dof joints are updated even if no `JointState` messages are received and are updated whenever a transform is published instead.

Please note that the class already subscribes to TF anyway (it is passed a tf-listener) and that I only lock the state if an actual update happens, so that most TF callbacks don't block the RobotState.

This breaks ABI, so it will not be back-ported to indigo.

Lastly please note the proposed code intentionally supports compiling on indigo.