### PR TITLE
cherry pick #350

### DIFF
--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -335,6 +335,8 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback(const moveit_ms
 {
   setPickupState(PLANNING);
 
+  // before we start planning, ensure that we have the latest robot state received...
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::PickupGoalConstPtr goal;
@@ -380,6 +382,8 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback(const moveit_msg
 {
   setPlaceState(PLANNING);
 
+  // before we start planning, ensure that we have the latest robot state received...
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::PlaceResult action_res;

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -59,6 +59,8 @@ void move_group::MoveGroupMoveAction::initialize()
 void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
 {
   setMoveState(PLANNING);
+  // before we start planning, ensure that we have the latest robot state received...
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::MoveGroupResult action_res;

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -52,6 +52,8 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
                                                           moveit_msgs::GetMotionPlan::Response& res)
 {
   ROS_INFO("Received new planning service request...");
+  // before we start planning, ensure that we have the latest robot state received...
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   bool solved = false;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -355,6 +355,13 @@ public:
   /** @brief This function is called every time there is a change to the planning scene */
   void triggerSceneUpdateEvent(SceneUpdateType update_type);
 
+  /** \brief Wait for robot state to become more recent than time t.
+   *
+   * If there is no state monitor active, there will be no scene updates.
+   * Hence, you can specify a timeout to wait for those updates. Default is 1s.
+   */
+  bool waitForCurrentRobotState(const ros::Time& t, double wait_time = 1.);
+
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
   void lockSceneRead();
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -293,6 +293,7 @@ private:
   void executeThread(const ExecutionCompleteCallback& callback, const PathSegmentCompleteCallback& part_callback,
                      bool auto_clear);
   bool executePart(std::size_t part_index);
+  bool waitForRobotToStop(const TrajectoryExecutionContext& context, double wait_time = 1.0);
   void continuousExecutionThread();
 
   void stopExecutionInternal();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group.cpp
@@ -588,9 +588,11 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    if (!current_state_monitor_->waitForCurrentState(opt_.group_name_, wait_seconds))
-      ROS_WARN_NAMED("move_group_interface", "Joint values for monitored state are requested but the full state is not "
-                                             "known");
+    if (!current_state_monitor_->waitForCurrentState(ros::Time::now(), wait_seconds))
+    {
+      ROS_ERROR_NAMED("move_group_interface", "Failed to fetch current robot state");
+      return false;
+    }
 
     current_state = current_state_monitor_->getCurrentState();
     return true;

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -7,6 +7,7 @@ if (CATKIN_ENABLE_TESTING)
   #target_link_libraries(test_cleanup moveit_move_group_interface)
 
   add_rostest(python_move_group.test)
+  add_rostest(robot_state_update.test)
 endif()
 
 install(PROGRAMS python_move_group.py DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)

--- a/moveit_ros/planning_interface/test/robot_state_update.py
+++ b/moveit_ros/planning_interface/test/robot_state_update.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import unittest
+import numpy as np
+import rospy
+import rostest
+import os
+
+from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroup
+
+
+class RobotStateUpdateTest(unittest.TestCase):
+    PLANNING_GROUP = "manipulator"
+
+    @classmethod
+    def setUpClass(self):
+        self.group = MoveGroup(self.PLANNING_GROUP, "robot_description")
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def plan(self, target):
+        self.group.set_joint_value_target(target)
+        return self.group.compute_plan()
+
+    def test(self):
+        current = np.asarray(self.group.get_current_joint_values())
+        for i in range(30):
+            target = current + np.random.uniform(-0.5, 0.5, size = current.shape)
+            # if plan was successfully executed, current state should be reported at target
+            if self.group.execute(self.plan(target)):
+                 actual = np.asarray(self.group.get_current_joint_values())
+                 self.assertTrue(np.allclose(target, actual, atol=1e-4, rtol=0.0))
+            # otherwise current state should be still the same
+            else:
+               actual = np.asarray(self.group.get_current_joint_values())
+               self.assertTrue(np.allclose(current, actual, atol=1e-4, rtol=0.0))
+
+
+if __name__ == '__main__':
+    PKGNAME = 'moveit_ros_planning_interface'
+    NODENAME = 'moveit_test_robot_state_update'
+    rospy.init_node(NODENAME)
+    rostest.rosrun(PKGNAME, NODENAME, RobotStateUpdateTest)
+
+    # suppress cleanup segfault in ROS < Kinetic
+    os._exit(0)

--- a/moveit_ros/planning_interface/test/robot_state_update.test
+++ b/moveit_ros/planning_interface/test/robot_state_update.test
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <test pkg="moveit_ros_planning_interface" type="robot_state_update.py" test-name="robot_state_update"
+        time-limit="300" args=""/>
+</launch>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -226,6 +226,8 @@ private:
   void configureWorkspace();
   void updateQueryStateHelper(robot_state::RobotState& state, const std::string& v);
   void fillStateSelectionOptions();
+  void useStartStateButtonExec();
+  void useGoalStateButtonExec();
 
   // Scene objects tab
   void addObject(const collision_detection::WorldPtr& world, const std::string& id, const shapes::ShapeConstPtr& shape,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -242,6 +242,7 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState& state,
 
   if (v == "<current>")
   {
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
     if (ps)
       state = ps->getCurrentState();
@@ -407,11 +408,11 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyCo
 {
   if (move_group_ && planning_display_)
   {
-    robot_state::RobotState state = *planning_display_->getQueryStartState();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
-      state = ps->getCurrentState();
+      robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryStartState(state);
     }
   }
@@ -421,11 +422,11 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
 {
   if (move_group_ && planning_display_)
   {
-    robot_state::RobotState state = *planning_display_->getQueryStartState();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
-      state = ps->getCurrentState();
+      robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryGoalState(state);
     }
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -175,13 +175,17 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
 
   // update query start state to current if neccessary
   if (ui_->start_state_selection->currentText() == "<current>")
-  {
-    ros::Duration(1).sleep();
     useStartStateButtonClicked();
-  }
 }
 
 void MotionPlanningFrame::useStartStateButtonClicked()
+{
+  // use background job: fetching the current state might take up to a second
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::useStartStateButtonExec, this),  //
+                                      "update start state");
+}
+
+void MotionPlanningFrame::useStartStateButtonExec()
 {
   robot_state::RobotState start = *planning_display_->getQueryStartState();
   updateQueryStateHelper(start, ui_->start_state_selection->currentText().toStdString());
@@ -189,6 +193,13 @@ void MotionPlanningFrame::useStartStateButtonClicked()
 }
 
 void MotionPlanningFrame::useGoalStateButtonClicked()
+{
+  // use background job: fetching the current state might take up to a second
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::useGoalStateButtonExec, this),  //
+                                      "update goal state");
+}
+
+void MotionPlanningFrame::useGoalStateButtonExec()
 {
   robot_state::RobotState goal = *planning_display_->getQueryGoalState();
   updateQueryStateHelper(goal, ui_->goal_state_selection->currentText().toStdString());

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -104,7 +104,12 @@ public:
 
   const std::string getMoveGroupNS() const;
   const robot_model::RobotModelConstPtr& getRobotModel() const;
+
+  /// wait for robot state more recent than t
+  bool waitForCurrentRobotState(const ros::Time& t = ros::Time::now());
+  /// get read-only access to planning scene
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
+  /// get write access to planning scene
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -282,6 +282,13 @@ const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() con
   }
 }
 
+bool PlanningSceneDisplay::waitForCurrentRobotState(const ros::Time& t)
+{
+  if (planning_scene_monitor_)
+    return planning_scene_monitor_->waitForCurrentRobotState(t);
+  return false;
+}
+
 planning_scene_monitor::LockedPlanningSceneRO PlanningSceneDisplay::getPlanningSceneRO() const
 {
   return planning_scene_monitor::LockedPlanningSceneRO(planning_scene_monitor_);


### PR DESCRIPTION
This is another attempt to migrate changes of #350 from Kinetic to Indigo maintaining ABI compatibility.
A recent attempt () only considered a small fraction of the original PR, still leading to errors (#749).

Now I ported most of the other stuff, including the unit test.
@rkeatin3 However, as I don't have a running Indigo system anymore, I appreciate real-world testing. Particularly, check whether fetching the current state from the rviz MotionPlanning plugin works without issues.

