### PR TITLE
skip non-actuated joints for trajectory execution

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1025,7 +1025,8 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
   std::set<std::string> actuated_joints;
 
   std::vector<std::string>::const_iterator it;
-  for (it = trajectory.multi_dof_joint_trajectory.joint_names.begin(); it !=  trajectory.multi_dof_joint_trajectory.joint_names.end(); ++it)
+  for (it = trajectory.multi_dof_joint_trajectory.joint_names.begin();
+       it != trajectory.multi_dof_joint_trajectory.joint_names.end(); ++it)
   {
     const std::string& joint_name = *it;
     const robot_model::JointModel* jm = robot_model_->getJointModel(joint_name);
@@ -1039,7 +1040,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
     }
   }
 
-  for (it = trajectory.joint_trajectory.joint_names.begin(); it !=  trajectory.joint_trajectory.joint_names.end(); ++it)
+  for (it = trajectory.joint_trajectory.joint_names.begin(); it != trajectory.joint_trajectory.joint_names.end(); ++it)
   {
     const std::string& joint_name = *it;
     const robot_model::JointModel* jm = robot_model_->getJointModel(joint_name);
@@ -1052,7 +1053,6 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
       actuated_joints.insert(joint_name);
     }
   }
-
 
   if (actuated_joints.empty())
   {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1023,10 +1023,37 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
     return false;
   }
   std::set<std::string> actuated_joints;
-  actuated_joints.insert(trajectory.multi_dof_joint_trajectory.joint_names.begin(),
-                         trajectory.multi_dof_joint_trajectory.joint_names.end());
-  actuated_joints.insert(trajectory.joint_trajectory.joint_names.begin(),
-                         trajectory.joint_trajectory.joint_names.end());
+
+  std::vector<std::string>::const_iterator it;
+  for (it = trajectory.multi_dof_joint_trajectory.joint_names.begin(); it !=  trajectory.multi_dof_joint_trajectory.joint_names.end(); ++it)
+  {
+    const std::string& joint_name = *it;
+    const robot_model::JointModel* jm = robot_model_->getJointModel(joint_name);
+    if (jm)
+    {
+      if (jm->isPassive() || jm->getMimic() != NULL || jm->getType() == robot_model::JointModel::FIXED)
+      {
+        continue;
+      }
+      actuated_joints.insert(joint_name);
+    }
+  }
+
+  for (it = trajectory.joint_trajectory.joint_names.begin(); it !=  trajectory.joint_trajectory.joint_names.end(); ++it)
+  {
+    const std::string& joint_name = *it;
+    const robot_model::JointModel* jm = robot_model_->getJointModel(joint_name);
+    if (jm)
+    {
+      if (jm->isPassive() || jm->getMimic() != NULL || jm->getType() == robot_model::JointModel::FIXED)
+      {
+        continue;
+      }
+      actuated_joints.insert(joint_name);
+    }
+  }
+
+
   if (actuated_joints.empty())
   {
     ROS_WARN_NAMED("traj_execution", "The trajectory to execute specifies no joints");

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -524,6 +524,10 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     for (std::vector<const robot_model::JointModel*>::const_iterator joint_it = joint_models.begin();
          joint_it != joint_models.end(); ++joint_it)
     {
+      if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != NULL || (*joint_it)->getType() == robot_model::JointModel::FIXED)
+      {
+        continue;
+      }
       emitter << (*joint_it)->getName();
     }
     emitter << YAML::EndSeq;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -524,7 +524,8 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     for (std::vector<const robot_model::JointModel*>::const_iterator joint_it = joint_models.begin();
          joint_it != joint_models.end(); ++joint_it)
     {
-      if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != NULL || (*joint_it)->getType() == robot_model::JointModel::FIXED)
+      if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != NULL ||
+          (*joint_it)->getType() == robot_model::JointModel::FIXED)
       {
         continue;
       }


### PR DESCRIPTION
### Description
I have made two modifications for treatment of passive joints:

1. They are no longer output as part of a trajectory for whichever group they belong to.
2. They are no longer included in the joint list for the group's fake controller. 

See [Issue 640](https://github.com/ros-planning/moveit/issues/640) for more information. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
