### PR TITLE
MoveAction capability can drop cancel request if it is sent shortly after goal is sent

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -83,9 +83,6 @@ install(FILES
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-
   find_package(rostest REQUIRED)
-
   add_rostest(test/test_cancel_before_plan_execution.test)
-
 endif()

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -81,3 +81,11 @@ install(PROGRAMS
 install(FILES
   default_capabilities_plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+
+  find_package(rostest REQUIRED)
+
+  add_rostest(test/test_cancel_before_plan_execution.test)
+
+endif()

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -33,7 +33,6 @@
   <run_depend>std_srvs</run_depend>
 
   <test_depend>rostest</test_depend>
-  <test_depend>rosunit</test_depend>
   <test_depend>moveit_resources</test_depend>
 
   <export>

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -32,6 +32,10 @@
   <run_depend>pluginlib</run_depend>
   <run_depend>std_srvs</run_depend>
 
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
+  <test_depend>moveit_resources</test_depend>
+
   <export>
     <moveit_ros_move_group plugin="${prefix}/default_capabilities_plugin_description.xml"/>
   </export>

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -68,6 +68,7 @@ private:
   moveit_msgs::MoveGroupFeedback move_feedback_;
 
   MoveGroupState move_state_;
+  bool preempt_requested_;
 };
 }
 

--- a/moveit_ros/move_group/test/test_cancel_before_plan_execution.py
+++ b/moveit_ros/move_group/test/test_cancel_before_plan_execution.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+import sys
+import rospy
+import unittest
+from actionlib import SimpleActionClient
+import moveit_commander
+from moveit_msgs.msg import MoveItErrorCodes, MoveGroupGoal, Constraints, JointConstraint, MoveGroupAction
+
+
+class TestMoveActionCancelDrop(unittest.TestCase):
+
+    def setUp(self):
+        # create a action client of move group
+        self._move_client = SimpleActionClient('move_group', MoveGroupAction)
+        self._move_client.wait_for_server()
+
+        moveit_commander.roscpp_initialize(sys.argv)
+        group_name = moveit_commander.RobotCommander().get_group_names()[0]
+        group = moveit_commander.MoveGroupCommander(group_name)
+
+        # prepare a joint goal
+        self._goal = MoveGroupGoal()
+        self._goal.request.group_name = group_name
+        self._goal.request.max_velocity_scaling_factor = 0.1
+        self._goal.request.max_acceleration_scaling_factor = 0.1
+        self._goal.request.start_state.is_diff = True
+
+        goal_constraint = Constraints()
+        joint_values = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+        joint_names = group.get_active_joints()
+        for i in range(len(joint_names)):
+            joint_constraint = JointConstraint()
+            joint_constraint.joint_name = joint_names[i]
+            joint_constraint.position = joint_values[i]
+            joint_constraint.weight = 1.0
+            goal_constraint.joint_constraints.append(joint_constraint)
+
+        self._goal.request.goal_constraints.append(goal_constraint)
+        self._goal.planning_options.planning_scene_diff.robot_state.is_diff = True
+
+    def test_cancel_drop_plan_execution(self):
+        # send the goal
+        self._move_client.send_goal(self._goal)
+
+        # cancel the goal
+        self._move_client.cancel_goal()
+
+        # wait for result
+        self._move_client.wait_for_result()
+
+        # polling the result, since result can come after the state is Done
+        result = None
+        while result is None:
+            result = self._move_client.get_result()
+            rospy.sleep(0.1)
+
+        # check the error code in result
+        # error code is 0 if the server ends with RECALLED status
+        self.assertTrue(result.error_code.val == MoveItErrorCodes.PREEMPTED or result.error_code.val == 0)
+
+    def test_cancel_drop_plan_only(self):
+        # set the plan only flag
+        self._goal.planning_options.plan_only = True
+
+        # send the goal
+        self._move_client.send_goal(self._goal)
+
+        # cancel the goal
+        self._move_client.cancel_goal()
+
+        # wait for result
+        self._move_client.wait_for_result()
+
+        # polling the result, since result can come after the state is Done
+        result = None
+        while result is None:
+            result = self._move_client.get_result()
+            rospy.sleep(0.1)
+
+        # check the error code in result
+        # error code is 0 if the server ends with RECALLED status
+        self.assertTrue(result.error_code.val == MoveItErrorCodes.PREEMPTED or result.error_code.val == 0)
+
+    def test_cancel_resend(self):
+        # send the goal
+        self._move_client.send_goal(self._goal)
+
+        # cancel the goal
+        self._move_client.cancel_goal()
+
+        # send the goal again
+        self._move_client.send_goal(self._goal)
+
+        # wait for result
+        self._move_client.wait_for_result()
+
+        # polling the result, since result can come after the state is Done
+        result = None
+        while result is None:
+            result = self._move_client.get_result()
+            rospy.sleep(0.1)
+
+        # check the error code in result
+        self.assertEqual(result.error_code.val, MoveItErrorCodes.SUCCESS)
+
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node('cancel_before_plan_execution')
+    rostest.rosrun('moveit_ros_move_group', 'test_cancel_before_plan_execution', TestMoveActionCancelDrop)

--- a/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
+++ b/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
@@ -1,31 +1,24 @@
 <launch>
+	<!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+		<arg name="load_robot_description" value="true"/>
+	</include>
 
+	<!-- We do not have a robot connected, so publish fake joint states -->
+	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+		<param name="/use_gui" value="false"/>
+		<rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+	</node>
 
-<!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
-   <arg name="load_robot_description" value="true"/>
-</include>
+	<!-- Given the published joint states, publish tf for the robot links -->
+	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
-<!-- If needed, broadcast static tf for robot root -->
+	<!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
+	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/move_group.launch">
+		<arg name="allow_trajectory_execution" value="true"/>
+		<arg name="fake_execution" value="true"/>
+		<arg name="info" value="true"/>
+	</include>
 
-
-<!-- We do not have a robot connected, so publish fake joint states -->
-<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-   <param name="/use_gui" value="false"/>
-   <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
-</node>
-
-<!-- Given the published joint states, publish tf for the robot links -->
-<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
-
-<!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-<include file="$(find moveit_resources)/fanuc_moveit_config/launch/move_group.launch">
-   <arg name="allow_trajectory_execution" value="true"/>
-   <arg name="fake_execution" value="true"/>
-   <arg name="info" value="true"/>
-</include>
-
-
-<test test-name="cancel_before_plan_execution" pkg="moveit_ros_move_group" type="test_cancel_before_plan_execution.py"/>
-
+	<test test-name="cancel_before_plan_execution" pkg="moveit_ros_move_group" type="test_cancel_before_plan_execution.py"/>
 </launch>

--- a/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
+++ b/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
@@ -1,0 +1,31 @@
+<launch>
+
+
+<!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+   <arg name="load_robot_description" value="true"/>
+</include>
+
+<!-- If needed, broadcast static tf for robot root -->
+
+
+<!-- We do not have a robot connected, so publish fake joint states -->
+<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+   <param name="/use_gui" value="false"/>
+   <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+</node>
+
+<!-- Given the published joint states, publish tf for the robot links -->
+<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+<!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
+<include file="$(find moveit_resources)/fanuc_moveit_config/launch/move_group.launch">
+   <arg name="allow_trajectory_execution" value="true"/>
+   <arg name="fake_execution" value="true"/>
+   <arg name="info" value="true"/>
+</include>
+
+
+<test test-name="cancel_before_plan_execution" pkg="moveit_ros_move_group" type="test_cancel_before_plan_execution.py"/>
+
+</launch>


### PR DESCRIPTION
### Description

Preempt request could be dropped in `MoveGroupMoveAction` capability if it is sent shortly after goal is sent. 

The problem is that the `preemptMoveCallback` sets the `PlanExecution::preempt_requested_` as `true` but `executeMoveCallback_PlanAndExecute` resets the `PlanExecution::preempt_requested_` as `false`. If `preemptMoveCallback` is called before `plan_execution_->planAndExecute`, the preempt request is  lost. In this case the goal status is set to `PREEMPTING` but the goal is planned and executed. In the end a result with error code `SUCCESS` is received. A test is provided to reproduce the problem.

An easy fix is provided by adding a similar `preempt_requested_` flag in  `MoveGroupMoveAction` and checking this flag before `plan_execution_->planAndExecute` is called. At the end of `executeMoveCallback` the flag is reset to `false`. 

I am not sure if this is the right place to fix since there could be also similar problems in other action capabilities. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
