### PR TITLE
show/hide panel if display is enabled/disabled

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1240,6 +1240,9 @@ void MotionPlanningDisplay::onEnable()
 
   int_marker_display_->setEnabled(true);
   int_marker_display_->setFixedFrame(fixed_frame_);
+
+  if (frame_)
+    frame_->parentWidget()->show();
 }
 
 // ******************************************************************************************
@@ -1259,6 +1262,9 @@ void MotionPlanningDisplay::onDisable()
 
   // Planned Path Display
   trajectory_visual_->onDisable();
+
+  if (frame_)
+    frame_->parentWidget()->hide();
 }
 
 // ******************************************************************************************

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -450,14 +450,12 @@ void MotionPlanningFrame::enable()
 
   // activate the frame
   parentWidget()->show();
-  show();
 }
 
 void MotionPlanningFrame::disable()
 {
   move_group_.reset();
   parentWidget()->hide();
-  hide();
 }
 
 void MotionPlanningFrame::tabChanged(int index)


### PR DESCRIPTION
Fixes an issue mentioned in https://github.com/ros-planning/moveit/pull/653#issuecomment-346681760: Since, #452 / #466, enabling/disabling the rviz display, didn't show/hide the panel anymore. The original issue #633 doesn't pose an issue anymore.

Now, the following behavior is implemented:
1. Disabling the display also disables the panel, but not vice versa.
2. Enabling the display enables the panel and vice versa.
3. The saved state in .rviz config is restored (both for display and panel state).