### PR TITLE
MSA: fix setting of group states

### DIFF
--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -291,7 +291,7 @@ void RobotPosesWidget::showNewScreen()
   // Switch to screen - do this before clearEditText()
   stacked_layout_->setCurrentIndex(1);
 
-  // No pose edited
+  // Remember that this is a new pose
   current_edit_pose_ = nullptr;
 
   // Manually send the load joint sliders signal

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -526,12 +526,11 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
     // Decide what this joint's initial value is
     if (joint_state_map_.find(joint_model->getName()) == joint_state_map_.end())
     {
-      // the joint state map does not yet have an entry for this joint
-
-      // get the first joint value in its vector
+      // The joint state map does not yet have an entry for this joint
+      // Get the first joint value in its vector
       joint_model->getVariableDefaultPositions(&init_value);
     }
-    else  // there is already a value in the map
+    else  // There is already a value in the map
     {
       init_value = joint_state_map_[joint_model->getName()];
     }

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.h
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.h
@@ -150,8 +150,8 @@ private:
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;
 
-  /// Orignal name of pose currently being edited. This is used to find the element in the vector
-  std::string current_edit_pose_;
+  /// Pointer to currently edited group state
+  srdf::Model::GroupState* current_edit_pose_;
 
   /// All the joint slider values that have thus far been seen. May contain more than just the current joints' values
   std::map<std::string, double> joint_state_map_;
@@ -177,7 +177,7 @@ private:
    * @param name - name of data to find in datastructure
    * @return pointer to data in datastructure
    */
-  srdf::Model::GroupState* findPoseByName(const std::string& name);
+  srdf::Model::GroupState* findPoseByName(const std::string& name, const std::string& group);
 
   /**
    * Create the main list view of poses for robot
@@ -210,7 +210,7 @@ private:
    *
    * @param name name of pose
    */
-  void edit(const std::string& name);
+  void edit(int row);
 
   /**
    * Show the robot in the current pose


### PR DESCRIPTION
MSA restricted names of group states to be unique globally, although they only need to be unique within planning groups. This rendered the definition of hand poses "open" for both hands of a bimanual robot impossible. This is fixed.
Additionally, only _active joints_ are considered for the definition of named group states.