### PR TITLE
improve RobotState::updateStateWithLinkAt()

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -239,6 +239,9 @@ public:
   /** \brief Get a link by its name. Output error and return NULL when the link is missing. */
   LinkModel* getLinkModel(const std::string& link);
 
+  /** \brief Get earliest link model that is rigidly connected to the given link */
+  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link);
+
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const
   {

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1137,6 +1137,22 @@ moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::strin
   return NULL;
 }
 
+const moveit::core::LinkModel* moveit::core::RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link)
+{
+  if (!link)
+    return link;
+  const robot_model::LinkModel* parent_link = link->getParentLinkModel();
+  const robot_model::JointModel* joint = link->getParentJointModel();
+
+  while (parent_link && joint->getType() == robot_model::JointModel::FIXED)
+  {
+    link = parent_link;
+    joint = link->getParentJointModel();
+    parent_link = joint->getParentLinkModel();
+  }
+  return link;
+}
+
 void moveit::core::RobotModel::updateMimicJoints(double* values) const
 {
   for (std::size_t i = 0; i < mimic_joints_.size(); ++i)

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1110,11 +1110,7 @@ moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const std::str
 
 const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::string& name) const
 {
-  LinkModelMap::const_iterator it = link_model_map_.find(name);
-  if (it != link_model_map_.end())
-    return it->second;
-  logError("Link '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
-  return NULL;
+  return const_cast<RobotModel*>(this)->getLinkModel(name);
 }
 
 const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(int index) const

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1730,6 +1730,7 @@ private:
   }
 
   void updateLinkTransformsInternal(const JointModel* start);
+  void updateCollisionBodyTransformsInternal(const JointModel* start);
 
   void getMissingKeys(const std::map<std::string, double>& variable_map,
                       std::vector<std::string>& missing_variables) const;


### PR DESCRIPTION
The method `RobotState::updateStateWithLinkAt()` is used to warp a link (together with its descendants) to an arbitrary position. This is used in moveit_ros_manipulation's pick-place pipeline to (i) check collisions of the end-effector in target pose and (ii) to visualize the end-effector in that pose.

However, so far only the link transforms were updated, not the collision transforms. Consequently, MoveIt complains about dirty collision transforms when trying to access them.

This PR now updates both kind of transforms. However, to suppress MoveIt's warnings about invalid transforms, it's important to not mark the state as dirty (although the state's transforms don't resemble the joint variables)!