### PR TITLE
improve RobotState::updateStateWithLinkAt()

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -239,6 +239,9 @@ public:
   /** \brief Get a link by its name. Output error and return NULL when the link is missing. */
   LinkModel* getLinkModel(const std::string& link);
 
+  /** \brief Get earliest link model that is rigidly connected to the given link */
+  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link);
+
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const
   {

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -239,7 +239,17 @@ public:
   /** \brief Get a link by its name. Output error and return NULL when the link is missing. */
   LinkModel* getLinkModel(const std::string& link);
 
-  /** \brief Get earliest link model that is rigidly connected to the given link */
+  /** \brief Get the latest link upwards the kinematic tree, which is only connected via fixed joints
+   *
+   * This is useful, if the link should be warped to a specific pose using updateStateWithLinkAt().
+   * As updateStateWithLinkAt() warps only the specified link and its descendants, you might not
+   * achieve what you expect, if link is an abstract frame name. Considering the following example:
+   * root -> arm0 -> ... -> armN -> wrist -- grasp_frame
+   *                                      -- palm -> end effector ...
+   * Calling updateStateWithLinkAt(grasp_frame), will not warp the end effector, which is probably
+   * what you went for. Instead, updateStateWithLinkAt(getRigidlyConnectedParentLinkModel(grasp_frame), ...)
+   * will actually warp wrist (and all its descendants).
+   */
   static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link);
 
   /** \brief Get the array of links  */

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1137,6 +1137,22 @@ moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::strin
   return NULL;
 }
 
+const moveit::core::LinkModel* moveit::core::RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link)
+{
+  if (!link)
+    return link;
+  const robot_model::LinkModel* parent_link = link->getParentLinkModel();
+  const robot_model::JointModel* joint = link->getParentJointModel();
+
+  while (parent_link && joint->getType() == robot_model::JointModel::FIXED)
+  {
+    link = parent_link;
+    joint = link->getParentJointModel();
+    parent_link = joint->getParentLinkModel();
+  }
+  return link;
+}
+
 void moveit::core::RobotModel::updateMimicJoints(double* values) const
 {
   for (std::size_t i = 0; i < mimic_joints_.size(); ++i)

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1110,11 +1110,7 @@ moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const std::str
 
 const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::string& name) const
 {
-  LinkModelMap::const_iterator it = link_model_map_.find(name);
-  if (it != link_model_map_.end())
-    return it->second;
-  logError("Link '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
-  return NULL;
+  return const_cast<RobotModel*>(this)->getLinkModel(name);
 }
 
 const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(int index) const

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1296,7 +1296,14 @@ as the new values that correspond to the group */
   /** \brief Update all transforms. */
   void update(bool force = false);
 
-  /** \brief Update the state after setting a particular link to the input global transform pose.*/
+  /** \brief Update the state after setting a particular link to the input global transform pose.
+
+      This "warps" the given link to the given pose, neglecting the joint values of its parent joint.
+      The link transforms of link and all its descendants are updated, but not marked as dirty,
+      although they do not match the joint values anymore!
+      Collision body transforms are not yet updated, but marked dirty only.
+      Use update(false) or updateCollisionBodyTransforms() to update them as well.
+   */
   void updateStateWithLinkAt(const std::string& link_name, const Eigen::Affine3d& transform, bool backward = false)
   {
     updateStateWithLinkAt(robot_model_->getLinkModel(link_name), transform, backward);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -688,12 +688,8 @@ void moveit::core::RobotState::updateStateWithLinkAt(const LinkModel* link, cons
         if (cj[i] != child_link->getParentJointModel())
           updateLinkTransformsInternal(cj[i]);
     }
-    // update the root joint of the model to match (as best as possible given #DOF) the transform we wish to obtain for
-    // the root link.
-    // but I am disabling this code, since I do not think this function should modify variable values.
-    //    parent_link->getParentJointModel()->computeVariableValues(global_link_transforms_[parent_link->getLinkIndex()],
-    //                                                              position_ +
-    //                                                              parent_link->getParentJointModel()->getFirstVariableIndex());
+    // all collision body transforms are invalid now
+    dirty_collision_body_transforms_ = parent_link->getParentJointModel();
   }
 
   // update attached bodies tf; these are usually very few, so we update them all


### PR DESCRIPTION
Improve documentation for `RobotState::updateStateWithLinkAt()`. For me it was unclear, which transforms were updated and which were marked dirty.

If argument `backward = true` is passed, mark all collision body transforms as dirty.

Provide utility function `RobotModel::getRigidlyConnectedParentLinkModel()` to find the top-most parent link that is ridigly linked to the given link. Usually, when placing a link with `RobotState::updateStateWithLinkAt()`, this parent link should be used.
