### PR TITLE
fix computation of shape_extents_ of links w/o shapes

### DIFF
--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -105,7 +105,10 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
   }
 
   centered_bounding_box_offset_ = aabb.center();
-  shape_extents_ = aabb.sizes();
+  if (shapes_.empty())
+    shape_extents_.setZero();
+  else
+    shape_extents_ = aabb.sizes();
 }
 
 void moveit::core::LinkModel::setVisualMesh(const std::string& visual_mesh, const Eigen::Affine3d& origin,


### PR DESCRIPTION
This fixes a newly introduced bug in #703.
If a link doesn't have any associated shapes, the bounding box stays maximal. However, we should return zero extents in this case.