### PR TITLE
fix interaction with planar joints

### DIFF
--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -338,35 +338,13 @@ void InteractionHandler::updateStateEndEffector(robot_state::RobotState* state, 
 void InteractionHandler::updateStateJoint(robot_state::RobotState* state, const JointInteraction* vj,
                                           const geometry_msgs::Pose* feedback_pose, StateChangeCallbackFn* callback)
 {
-  geometry_msgs::Pose rel_pose = *feedback_pose;
-  if (!vj->parent_frame.empty() && !robot_state::Transforms::sameFrame(vj->parent_frame, planning_frame_))
-  {
-    Eigen::Affine3d p;
-    tf::poseMsgToEigen(rel_pose, p);
-    tf::poseEigenToMsg(state->getGlobalLinkTransform(vj->parent_frame).inverse() * p, rel_pose);
-  }
+  Eigen::Affine3d pose;
+  tf::poseMsgToEigen(*feedback_pose, pose);
 
-  Eigen::Quaterniond q;
-  tf::quaternionMsgToEigen(rel_pose.orientation, q);
-  std::map<std::string, double> vals;
-  if (vj->dof == 3)
-  {
-    vals[vj->joint_name + "/x"] = rel_pose.position.x;
-    vals[vj->joint_name + "/y"] = rel_pose.position.y;
-    Eigen::Vector3d xyz = q.matrix().eulerAngles(0, 1, 2);
-    vals[vj->joint_name + "/theta"] = xyz[2];
-  }
-  else if (vj->dof == 6)
-  {
-    vals[vj->joint_name + "/trans_x"] = rel_pose.position.x;
-    vals[vj->joint_name + "/trans_y"] = rel_pose.position.y;
-    vals[vj->joint_name + "/trans_z"] = rel_pose.position.z;
-    vals[vj->joint_name + "/rot_x"] = q.x();
-    vals[vj->joint_name + "/rot_y"] = q.y();
-    vals[vj->joint_name + "/rot_z"] = q.z();
-    vals[vj->joint_name + "/rot_w"] = q.w();
-  }
-  state->setVariablePositions(vals);
+  if (!vj->parent_frame.empty() && !robot_state::Transforms::sameFrame(vj->parent_frame, planning_frame_))
+      pose = state->getGlobalLinkTransform(vj->parent_frame).inverse() * pose;
+
+  state->setJointPositions(vj->joint_name, pose);
   state->update();
 
   if (update_callback_)

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -342,7 +342,7 @@ void InteractionHandler::updateStateJoint(robot_state::RobotState* state, const 
   tf::poseMsgToEigen(*feedback_pose, pose);
 
   if (!vj->parent_frame.empty() && !robot_state::Transforms::sameFrame(vj->parent_frame, planning_frame_))
-      pose = state->getGlobalLinkTransform(vj->parent_frame).inverse() * pose;
+    pose = state->getGlobalLinkTransform(vj->parent_frame).inverse() * pose;
 
   state->setJointPositions(vj->joint_name, pose);
   state->update();


### PR DESCRIPTION
Rotation angle for planar joint was computed based on Euler angles which exhibits discontinuities.
Better use dedicated method setJointPositions(joint_name, pose).