### PR TITLE
fix updateMimicJoint()

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1741,6 +1741,7 @@ private:
     {
       const int fvi = jm->getFirstVariableIndex();
       position_[fvi] = jm->getMimicFactor() * position_[jm->getMimic()->getFirstVariableIndex()] + jm->getMimicOffset();
+      markDirtyJointTransforms(jm);
     }
     markDirtyJointTransforms(group);
   }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -40,6 +40,7 @@
 
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/attached_body.h>
+#include <moveit/macros/deprecation.h>
 #include <sensor_msgs/JointState.h>
 #include <visualization_msgs/MarkerArray.h>
 #include <std_msgs/ColorRGBA.h>
@@ -1718,7 +1719,8 @@ private:
   }
 
   /** \brief Update a set of joints that are certain to be mimicking other joints */
-  void updateMimicJoint(const std::vector<const JointModel*>& mim)
+  /* use updateMimicJoints() instead, which also marks joints dirty */
+  MOVEIT_DEPRECATED void updateMimicJoint(const std::vector<const JointModel*>& mim)
   {
     for (std::size_t i = 0; i < mim.size(); ++i)
     {
@@ -1730,6 +1732,17 @@ private:
       // updateMimicJoint(group->getMimicJointModels()) + markDirtyJointTransforms(group);
       dirty_joint_transforms_[mim[i]->getJointIndex()] = 1;
     }
+  }
+
+  /** \brief Update all mimic joints within group */
+  void updateMimicJoints(const JointModelGroup* group)
+  {
+    for (const JointModel* jm : group->getMimicJointModels())
+    {
+      const int fvi = jm->getFirstVariableIndex();
+      position_[fvi] = jm->getMimicFactor() * position_[jm->getMimic()->getFirstVariableIndex()] + jm->getMimicOffset();
+    }
+    markDirtyJointTransforms(group);
   }
 
   void updateLinkTransformsInternal(const JointModel* start);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1713,7 +1713,7 @@ private:
     for (std::size_t i = 0; i < mim.size(); ++i)
     {
       position_[mim[i]->getFirstVariableIndex()] = mim[i]->getMimicFactor() * v + mim[i]->getMimicOffset();
-      dirty_joint_transforms_[mim[i]->getJointIndex()] = 1;
+      markDirtyJointTransforms(mim[i]);
     }
   }
 
@@ -1725,6 +1725,9 @@ private:
       const int fvi = mim[i]->getFirstVariableIndex();
       position_[fvi] =
           mim[i]->getMimicFactor() * position_[mim[i]->getMimic()->getFirstVariableIndex()] + mim[i]->getMimicOffset();
+      // Only mark joint transform dirty, but not the associated link transform
+      // as this function is always used in combination of
+      // updateMimicJoint(group->getMimicJointModels()) + markDirtyJointTransforms(group);
       dirty_joint_transforms_[mim[i]->getJointIndex()] = 1;
     }
   }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -231,8 +231,7 @@ void moveit::core::RobotState::setToRandomPositions(const JointModelGroup* group
   const std::vector<const JointModel*>& joints = group->getActiveJointModels();
   for (std::size_t i = 0; i < joints.size(); ++i)
     joints[i]->getVariableRandomPositions(rng, position_ + joints[i]->getFirstVariableIndex());
-  updateMimicJoint(group->getMimicJointModels());
-  markDirtyJointTransforms(group);
+  updateMimicJoints(group);
 }
 
 void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
@@ -249,8 +248,7 @@ void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup*
     joints[i]->getVariableRandomPositionsNearBy(rng, position_ + joints[i]->getFirstVariableIndex(),
                                                 near.position_ + idx, distances[i]);
   }
-  updateMimicJoint(group->getMimicJointModels());
-  markDirtyJointTransforms(group);
+  updateMimicJoints(group);
 }
 
 void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
@@ -266,8 +264,7 @@ void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup*
     joints[i]->getVariableRandomPositionsNearBy(rng, position_ + joints[i]->getFirstVariableIndex(),
                                                 near.position_ + idx, distance);
   }
-  updateMimicJoint(group->getMimicJointModels());
-  markDirtyJointTransforms(group);
+  updateMimicJoints(group);
 }
 
 bool moveit::core::RobotState::setToDefaultValues(const JointModelGroup* group, const std::string& name)
@@ -425,8 +422,7 @@ void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* gro
     for (std::size_t i = 0; i < il.size(); ++i)
       position_[il[i]] = gstate[i];
   }
-  updateMimicJoint(group->getMimicJointModels());
-  markDirtyJointTransforms(group);
+  updateMimicJoints(group);
 }
 
 void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* group, const Eigen::VectorXd& values)
@@ -434,8 +430,7 @@ void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* gro
   const std::vector<int>& il = group->getVariableIndexList();
   for (std::size_t i = 0; i < il.size(); ++i)
     position_[il[i]] = values(i);
-  updateMimicJoint(group->getMimicJointModels());
-  markDirtyJointTransforms(group);
+  updateMimicJoints(group);
 }
 
 void moveit::core::RobotState::copyJointGroupPositions(const JointModelGroup* group, double* gstate) const
@@ -833,8 +828,7 @@ void moveit::core::RobotState::interpolate(const RobotState& to, double t, Robot
     const int idx = jm[i]->getFirstVariableIndex();
     jm[i]->interpolate(position_ + idx, to.position_ + idx, t, state.position_ + idx);
   }
-  state.markDirtyJointTransforms(joint_group);
-  state.updateMimicJoint(joint_group->getMimicJointModels());
+  state.updateMimicJoints(joint_group);
 }
 
 void moveit::core::RobotState::setAttachedBodyUpdateCallback(const AttachedBodyCallback& callback)


### PR DESCRIPTION
Mimic joints were not correctly updated.
Although the joint transform was marked dirty, the corresponding link transform was not!
