### PR TITLE
improve association of IK solvers to groups

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -184,6 +184,8 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(
     std::stringstream ss;
     std::copy(groups.begin(), groups.end(), std::ostream_iterator<std::string>(ss, " "));
     ROS_DEBUG_STREAM("Loaded information about the following groups: '" << ss.str() << "'");
+    if (groups.empty() && !model_->getJointModelGroups().empty())
+      ROS_WARN("No kinematics plugins defined. Fill and load kinematics.yaml!");
 
     std::map<std::string, robot_model::SolverAllocatorFn> imap;
     for (std::size_t i = 0; i < groups.size(); ++i)

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -93,8 +93,7 @@ void RobotInteraction::decideActiveComponents(const std::string& group, Interact
   decideActiveJoints(group);
   if (!group.empty() && active_eef_.empty() && active_vj_.empty() && active_generic_.empty())
     ROS_INFO_NAMED("robot_interaction", "No active joints or end effectors found for group '%s'. "
-                                        "Make sure you have defined an end effector in your SRDF file and that "
-                                        "kinematics.yaml is loaded in this node's namespace.",
+                                        "Make sure that kinematics.yaml is loaded in this node's namespace.",
                    group.c_str());
 }
 

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -91,7 +91,7 @@ void RobotInteraction::decideActiveComponents(const std::string& group, Interact
 {
   decideActiveEndEffectors(group, style);
   decideActiveJoints(group);
-  if (active_eef_.empty() && active_vj_.empty() && active_generic_.empty())
+  if (!group.empty() && active_eef_.empty() && active_vj_.empty() && active_generic_.empty())
     ROS_INFO_NAMED("robot_interaction", "No active joints or end effectors found for group '%s'. "
                                         "Make sure you have defined an end effector in your SRDF file and that "
                                         "kinematics.yaml is loaded in this node's namespace.",
@@ -185,10 +185,10 @@ void RobotInteraction::decideActiveJoints(const std::string& group)
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
   active_vj_.clear();
 
-  ROS_DEBUG_NAMED("robot_interaction", "Deciding active joints for group '%s'", group.c_str());
-
   if (group.empty())
     return;
+
+  ROS_DEBUG_NAMED("robot_interaction", "Deciding active joints for group '%s'", group.c_str());
 
   const srdf::ModelConstSharedPtr& srdf = robot_model_->getSRDF();
   const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
@@ -261,10 +261,10 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
   active_eef_.clear();
 
-  ROS_DEBUG_NAMED("robot_interaction", "Deciding active end-effectors for group '%s'", group.c_str());
-
   if (group.empty())
     return;
+
+  ROS_DEBUG_NAMED("robot_interaction", "Deciding active end-effectors for group '%s'", group.c_str());
 
   const srdf::ModelConstSharedPtr& srdf = robot_model_->getSRDF();
   const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -282,30 +282,28 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   // if we have an IK solver for the selected group, we check if there are any end effectors attached to this group
   if (smap.first)
   {
-    if (eef.empty() && !jmg->getLinkModelNames().empty())
+    for (std::size_t i = 0; i < eef.size(); ++i)
+      if ((jmg->hasLinkModel(eef[i].parent_link_) || jmg->getName() == eef[i].parent_group_) &&
+          jmg->canSetStateFromIK(eef[i].parent_link_))
+      {
+        // We found an end-effector whose parent is the group.
+        EndEffectorInteraction ee;
+        ee.parent_group = group;
+        ee.parent_link = eef[i].parent_link_;
+        ee.eef_group = eef[i].component_group_;
+        ee.interaction = style;
+        active_eef_.push_back(ee);
+      }
+
+    // No end effectors found.  Use last link in group as the "end effector".
+    if (active_eef_.empty() && !jmg->getLinkModelNames().empty())
     {
-      // No end effectors.  Use last link in group as the "end effector".
       EndEffectorInteraction ee;
       ee.parent_group = group;
       ee.parent_link = jmg->getLinkModelNames().back();
       ee.eef_group = group;
       ee.interaction = style;
       active_eef_.push_back(ee);
-    }
-    else
-    {
-      for (std::size_t i = 0; i < eef.size(); ++i)
-        if ((jmg->hasLinkModel(eef[i].parent_link_) || jmg->getName() == eef[i].parent_group_) &&
-            jmg->canSetStateFromIK(eef[i].parent_link_))
-        {
-          // We found an end-effector whose parent is the group.
-          EndEffectorInteraction ee;
-          ee.parent_group = group;
-          ee.parent_link = eef[i].parent_link_;
-          ee.eef_group = eef[i].component_group_;
-          ee.interaction = style;
-          active_eef_.push_back(ee);
-        }
     }
   }
   else if (!smap.second.empty())

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -55,7 +55,11 @@ EndEffectorsWidget::EndEffectorsWidget(QWidget* parent, moveit_setup_assistant::
   // Top Header Area ------------------------------------------------
 
   HeaderWidget* header =
-      new HeaderWidget("End Effectors", "Setup grippers and other end effectors for your robot", this);
+      new HeaderWidget("End Effectors", "Setup your robot's end effectors. These are planning groups "
+                                        "corresponding to grippers or tools, attached to a parent "
+                                        "planning group (an arm).\n"
+                                        "The specified parent link is used as the reference frame for IK attempts.",
+                       this);
   layout->addWidget(header);
 
   // Create contents screens ---------------------------------------

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -104,8 +104,8 @@ PlanningGroupsWidget::PlanningGroupsWidget(QWidget* parent, moveit_setup_assista
   // Top Label Area ------------------------------------------------
   HeaderWidget* header = new HeaderWidget(
       "Planning Groups", "Create and edit planning groups for your robot based on joint collections, "
-                         "link collections, kinematic chains and subgroups.\n"
-                         "A planning group defines the set of (joint, link) pairs considered for planning. "
+                         "link collections, kinematic chains or subgroups.\n"
+                         "A planning group defines the set of (joint, link) pairs considered for planning.\n"
                          "Define individual groups for each subset of the robot you want to plan for.",
       this);
   layout->addWidget(header);

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -104,8 +104,9 @@ PlanningGroupsWidget::PlanningGroupsWidget(QWidget* parent, moveit_setup_assista
   // Top Label Area ------------------------------------------------
   HeaderWidget* header = new HeaderWidget(
       "Planning Groups", "Create and edit planning groups for your robot based on joint collections, "
-                         "link collections, kinematic chains or subgroups.\n"
-                         "A planning group defines the set of (joint, link) pairs considered for planning.\n"
+                         "link collections, kinematic chains or subgroups. "
+                         "A planning group defines the set of (joint, link) pairs considered for planning. "
+                         "Note: when adding a link to the group, its parent joint is added too and vice versa.\n"
                          "Define individual groups for each subset of the robot you want to plan for.",
       this);
   layout->addWidget(header);

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -102,10 +102,12 @@ PlanningGroupsWidget::PlanningGroupsWidget(QWidget* parent, moveit_setup_assista
   QVBoxLayout* layout = new QVBoxLayout();
 
   // Top Label Area ------------------------------------------------
-  HeaderWidget* header =
-      new HeaderWidget("Planning Groups", "Create and edit planning groups for your robot based on joint collections, "
-                                          "link collections, kinematic chains and subgroups.",
-                       this);
+  HeaderWidget* header = new HeaderWidget(
+      "Planning Groups", "Create and edit planning groups for your robot based on joint collections, "
+                         "link collections, kinematic chains and subgroups.\n"
+                         "A planning group defines the set of (joint, link) pairs considered for planning. "
+                         "Define individual groups for each subset of the robot you want to plan for.",
+      this);
   layout->addWidget(header);
 
   // Left Side ---------------------------------------------

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -105,7 +105,8 @@ PlanningGroupsWidget::PlanningGroupsWidget(QWidget* parent, moveit_setup_assista
   HeaderWidget* header = new HeaderWidget(
       "Planning Groups", "Create and edit planning groups for your robot based on joint collections, "
                          "link collections, kinematic chains or subgroups. "
-                         "A planning group defines the set of (joint, link) pairs considered for planning. "
+                         "A planning group defines the set of (joint, link) pairs considered for planning "
+                         "and collision checking. "
                          "Note: when adding a link to the group, its parent joint is added too and vice versa.\n"
                          "Define individual groups for each subset of the robot you want to plan for.",
       this);


### PR DESCRIPTION
This is an attempt to slightly improve the association of IK solvers to joint model groups, which is essential to have interactive end-effector markers in rviz.

There are frequently issues reported related to this, e.g. #616.
This PR aims to 
* improve both code and user documentation
* improve on issued warnings
