### PR TITLE
disable flaky unittest

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -84,5 +84,6 @@ install(FILES
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  add_rostest(test/test_cancel_before_plan_execution.test)
+  # this test is flaky
+  # add_rostest(test/test_cancel_before_plan_execution.test)
 endif()


### PR DESCRIPTION
For now disable the new unittest introduced in #756 as it fails 50% of the time.
@khupilz As you proposed the original PR #756, please can you have a look and fix this.
