### PR TITLE
Fix dependencies for chomp interface test

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -56,9 +56,10 @@ install(TARGETS ${PROJECT_NAME} chomp_planner_plugin
 
 if(CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS rostest roscpp moveit_ros_planning_interface)
-
+  include_directories(${catkin_INCLUDE_DIRS})
   add_rostest_gtest(chomp_moveit_test
     test/chomp_moveit.test
     test/chomp_moveit_test.cpp)
   target_link_libraries(chomp_moveit_test ${catkin_LIBRARIES})
+  add_dependencies(chomp_moveit_test chomp_planner_plugin move_group moveit_move_group_default_capabilities moveit_move_group_pick_place_capability)
 endif()

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -20,7 +20,10 @@
   <build_depend>chomp_motion_planner</build_depend>
   <build_depend>moveit_experimental</build_depend>
 
+  <test_depend>moveit_ros_manipulation</test_depend>
   <test_depend>moveit_ros_planning_interface</test_depend>
+  <test_depend>roscpp</test_depend>
+  <test_depend>rostest</test_depend>
 
   <export>
     <moveit_core plugin="${prefix}/chomp_interface_plugin_description.xml"/>

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -22,7 +22,6 @@
 
   <test_depend>moveit_ros_manipulation</test_depend>
   <test_depend>moveit_ros_planning_interface</test_depend>
-  <test_depend>roscpp</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>


### PR DESCRIPTION
### Description
Fixes #755.

Trivial change: added missing include and dependencies in `CMakeLists.txt` and `package.xml` of chomp_interface.

Without this, `catkin_make run_tests_moveit_planners_chomp` fails with:
```
[100%] Built target moveit_move_group_interface
Scanning dependencies of target chomp_moveit_test
[100%] Building CXX object moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/chomp_moveit_test.dir/test/chomp_moveit_test.cpp.o
/tmp/moveit_ws/src/moveit/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp:40:62: fatal error: moveit/move_group_interface/move_group_interface.h: No such file or directory
compilation terminated.
moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/chomp_moveit_test.dir/build.make:62: recipe for target 'moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/chomp_moveit_test.dir/test/chomp_moveit_test.cpp.o' failed
make[3]: *** [moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/chomp_moveit_test.dir/test/chomp_moveit_test.cpp.o] Error 1
CMakeFiles/Makefile2:15547: recipe for target 'moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/chomp_moveit_test.dir/all' failed
make[2]: *** [moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/chomp_moveit_test.dir/all] Error 2
CMakeFiles/Makefile2:15483: recipe for target 'moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/run_tests_moveit_planners_chomp.dir/rule' failed
make[1]: *** [moveit/moveit_planners/chomp/chomp_interface/CMakeFiles/run_tests_moveit_planners_chomp.dir/rule] Error 2
Makefile:3930: recipe for target 'run_tests_moveit_planners_chomp' failed
make: *** [run_tests_moveit_planners_chomp] Error 2
Invoking "make run_tests_moveit_planners_chomp -j4 -l4" failed
```

With this change, running `catkin_make run_tests_moveit_planners_chomp` on a clean workspace containing just moveit runs through the test.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
