### PR TITLE
Move group with namespace

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -46,9 +46,9 @@ class MoveGroupCommander(object):
     Execution of simple commands for a particular group
     """
 
-    def __init__(self, name, robot_description="robot_description"):
+    def __init__(self, name, robot_description="robot_description", ns=""):
         """ Specify the group name for which to construct this commander instance. Throws an exception if there is an initialization error. """
-        self._g = _moveit_move_group_interface.MoveGroupInterface(name, robot_description)
+        self._g = _moveit_move_group_interface.MoveGroupInterface(name, robot_description, ns)
 
     def get_name(self):
         """ Get the name of the group this instance was initialized for """

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -56,7 +56,8 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
   @param tf
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const std::string& robot_description,
+                                                                     const robot_model::RobotModelConstPtr& kmodel,
                                                                      const boost::shared_ptr<tf::Transformer>& tf);
 
 /**
@@ -67,7 +68,8 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot
   @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const std::string& robot_description,
+                                                                     const robot_model::RobotModelConstPtr& kmodel,
                                                                      const boost::shared_ptr<tf::Transformer>& tf,
                                                                      ros::NodeHandle nh);
 

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -102,25 +102,27 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
   }
 }
 
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const std::string& robot_description,
+                                                                     const robot_model::RobotModelConstPtr& kmodel,
                                                                      const boost::shared_ptr<tf::Transformer>& tf)
 {
-  return getSharedStateMonitor(kmodel, tf, ros::NodeHandle());
+  return getSharedStateMonitor(robot_description, kmodel, tf, ros::NodeHandle());
 }
 
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const std::string& robot_description,
+                                                                     const robot_model::RobotModelConstPtr& kmodel,
                                                                      const boost::shared_ptr<tf::Transformer>& tf,
                                                                      ros::NodeHandle nh)
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);
-  if (s.state_monitors_.find(kmodel->getName()) != s.state_monitors_.end())
-    return s.state_monitors_[kmodel->getName()];
+  if (s.state_monitors_.find(robot_description) != s.state_monitors_.end())
+    return s.state_monitors_[robot_description];
   else
   {
     planning_scene_monitor::CurrentStateMonitorPtr monitor(
         new planning_scene_monitor::CurrentStateMonitor(kmodel, tf, nh));
-    s.state_monitors_[kmodel->getName()] = monitor;
+    s.state_monitors_[robot_description] = monitor;
     return monitor;
   }
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -139,7 +139,7 @@ public:
     attached_object_publisher_ = node_handle_.advertise<moveit_msgs::AttachedCollisionObject>(
         planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC, 1, false);
 
-    current_state_monitor_ = getSharedStateMonitor(robot_model_, tf_, node_handle_);
+    current_state_monitor_ = getSharedStateMonitor(opt_.robot_description_, robot_model_, tf_, node_handle_);
 
     ros::WallTime timeout_for_servers = ros::WallTime::now() + wait_for_servers;
     if (wait_for_servers == ros::WallDuration())

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -61,10 +61,11 @@ class MoveGroupInterfaceWrapper : protected py_bindings_tools::ROScppInitializer
 public:
   // ROSInitializer is constructed first, and ensures ros::init() was called, if
   // needed
-  MoveGroupInterfaceWrapper(const std::string& group_name, const std::string& robot_description)
+  MoveGroupInterfaceWrapper(const std::string& group_name, const std::string& robot_description,
+                            const std::string& ns = "")
     : py_bindings_tools::ROScppInitializer()
-    , MoveGroupInterface(Options(group_name, robot_description), boost::shared_ptr<tf::Transformer>(),
-                         ros::WallDuration(5, 0))
+    , MoveGroupInterface(Options(group_name, robot_description, ros::NodeHandle(ns)),
+                         boost::shared_ptr<tf::Transformer>(), ros::WallDuration(5, 0))
   {
   }
 
@@ -472,8 +473,8 @@ public:
 class MoveGroupWrapper : public MoveGroupInterfaceWrapper
 {
 public:
-  MoveGroupWrapper(const std::string& group_name, const std::string& robot_description)
-    : MoveGroupInterfaceWrapper(group_name, robot_description)
+  MoveGroupWrapper(const std::string& group_name, const std::string& robot_description, const std::string& ns = "")
+    : MoveGroupInterfaceWrapper(group_name, robot_description, ns)
   {
     ROS_WARN("The MoveGroup class is deprecated and will be removed in ROS lunar. Please use MoveGroupInterface "
              "instead.");
@@ -483,8 +484,9 @@ public:
 static void wrap_move_group_interface()
 {
   bp::class_<MoveGroupInterfaceWrapper, boost::noncopyable> MoveGroupInterfaceClass(
-      "MoveGroupInterface", bp::init<std::string, std::string>());
+      "MoveGroupInterface", bp::init<std::string, std::string, std::string>());
 
+  MoveGroupInterfaceClass.def(bp::init<std::string, std::string>());
   MoveGroupInterfaceClass.def("async_move", &MoveGroupInterfaceWrapper::asyncMovePython);
   MoveGroupInterfaceClass.def("move", &MoveGroupInterfaceWrapper::movePython);
   MoveGroupInterfaceClass.def("execute", &MoveGroupInterfaceWrapper::executePython);
@@ -609,7 +611,8 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("get_current_state_bounded", &MoveGroupInterfaceWrapper::getCurrentStateBoundedPython);
 
   bp::class_<MoveGroupWrapper, bp::bases<MoveGroupInterfaceWrapper>, boost::noncopyable> MoveGroupClass(
-      "MoveGroup", bp::init<std::string, std::string>());
+      "MoveGroup", bp::init<std::string, std::string, std::string>());
+  MoveGroupClass.def(bp::init<std::string, std::string>());
 }
 }
 }

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -59,7 +59,8 @@ public:
     robot_model_ = planning_interface::getSharedRobotModel(robot_description);
     if (!robot_model_)
       throw std::runtime_error("RobotInterfacePython: invalid robot model");
-    current_state_monitor_ = planning_interface::getSharedStateMonitor(robot_model_, planning_interface::getSharedTF());
+    current_state_monitor_ =
+        planning_interface::getSharedStateMonitor(robot_description, robot_model_, planning_interface::getSharedTF());
   }
 
   const char* getRobotName() const

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -56,12 +56,17 @@ class PythonMoveGroupTest(unittest.TestCase):
         plan3 = self.plan(current)
         self.assertTrue(self.group.execute(plan3))
 
+class PythonMoveGroupWithNamespaceTest(PythonMoveGroupTest):
+    @classmethod
+    def setUpClass(self):
+        self.group = MoveGroupInterface(self.PLANNING_GROUP, "test/robot_description", "test")
 
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'
     NODENAME = 'moveit_test_python_move_group'
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonMoveGroupTest)
+    rostest.rosrun(PKGNAME, NODENAME, PythonMoveGroupWithNamespaceTest)
 
     # suppress cleanup segfault
     os._exit(0)

--- a/moveit_ros/planning_interface/test/python_move_group.test
+++ b/moveit_ros/planning_interface/test/python_move_group.test
@@ -1,5 +1,27 @@
 <launch>
   <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <group ns="test">
+    <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+    <include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+      <arg name="load_robot_description" value="true"/>
+    </include>
+
+    <!-- We do not have a robot connected, so publish fake joint states -->
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+      <param name="/use_gui" value="false"/>
+      <rosparam param="/test/source_list">[/test/move_group/fake_controller_joint_states]</rosparam>
+    </node>
+
+    <!-- Given the published joint states, publish tf for the robot links -->
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+    <!-- Run the main MoveIt executable -->
+    <include file="$(find moveit_resources)/fanuc_moveit_config/launch/move_group.launch">
+      <arg name="allow_trajectory_execution" value="true"/>
+      <arg name="fake_execution" value="true"/>
+      <arg name="info" value="true"/>
+    </include>
+  </group>
   <test pkg="moveit_ros_planning_interface" type="python_move_group.py" test-name="python_move_group"
         time-limit="300" args=""/>
 </launch>


### PR DESCRIPTION
### Description
When using MoveGroupCommander in rospy, I made it possible to give namespace arguments to MoveGroupCommander so that we can connect to move_group actions even if namespace is set in move_group.
Related to #757.