### PR TITLE
cleanup minimum steps for jump threshold test in computeCartesianPath [fix issue #783]

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1773,10 +1773,6 @@ private:
   bool has_acceleration_;
   bool has_effort_;
 
-  /** \brief We at least 5 steps per trajectory for testing jump thresholds with computeCartesianPath. Otherwise
-   * testJointSpaceJump doens't work well. */
-  static const unsigned int min_steps_for_jump_thresh = 5;
-
   const JointModel* dirty_link_transforms_;
   const JointModel* dirty_collision_body_transforms_;
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1773,6 +1773,10 @@ private:
   bool has_acceleration_;
   bool has_effort_;
 
+  /** \brief We at least 5 steps per trajectory for testing jump thresholds with computeCartesianPath. Otherwise
+   * testJointSpaceJump doens't work well. */
+  static const unsigned int min_steps_for_jump_thresh = 5;
+
   const JointModel* dirty_link_transforms_;
   const JointModel* dirty_collision_body_transforms_;
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -524,7 +524,7 @@ public:
   {
     if (has_acceleration_)
     {
-      logError("Unable to set joint efforts because array is being used for accelerations");
+      CONSOLE_BRIDGE_logError("Unable to set joint efforts because array is being used for accelerations");
       return;
     }
     has_effort_ = true;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -166,7 +166,7 @@ bool moveit::core::RobotState::checkJointTransforms(const JointModel* joint) con
 {
   if (dirtyJointTransform(joint))
   {
-    logWarn("Returning dirty joint transforms for joint '%s'", joint->getName().c_str());
+    CONSOLE_BRIDGE_logWarn("Returning dirty joint transforms for joint '%s'", joint->getName().c_str());
     return false;
   }
   return true;
@@ -176,7 +176,7 @@ bool moveit::core::RobotState::checkLinkTransforms() const
 {
   if (dirtyLinkTransforms())
   {
-    logWarn("Returning dirty link transforms");
+    CONSOLE_BRIDGE_logWarn("Returning dirty link transforms");
     return false;
   }
   return true;
@@ -186,7 +186,7 @@ bool moveit::core::RobotState::checkCollisionTransforms() const
 {
   if (dirtyCollisionBodyTransforms())
   {
-    logWarn("Returning dirty collision body transforms");
+    CONSOLE_BRIDGE_logWarn("Returning dirty collision body transforms");
     return false;
   }
   return true;
@@ -860,7 +860,7 @@ const moveit::core::AttachedBody* moveit::core::RobotState::getAttachedBody(cons
   std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
   {
-    logError("Attached body '%s' not found", id.c_str());
+    CONSOLE_BRIDGE_logError("Attached body '%s' not found", id.c_str());
     return NULL;
   }
   else
@@ -1003,7 +1003,7 @@ const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::st
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    logError("Transform from frame '%s' to frame '%s' is not known ('%s' should be a link name or an attached body "
+    CONSOLE_BRIDGE_logError("Transform from frame '%s' to frame '%s' is not known ('%s' should be a link name or an attached body "
              "id).",
              id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
@@ -1011,11 +1011,11 @@ const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::st
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   if (tf.empty())
   {
-    logError("Attached body '%s' has no geometry associated to it. No transform to return.", id.c_str());
+    CONSOLE_BRIDGE_logError("Attached body '%s' has no geometry associated to it. No transform to return.", id.c_str());
     return identity_transform;
   }
   if (tf.size() > 1)
-    logDebug("There are multiple geometries associated to attached body '%s'. Returning the transform for the first "
+    CONSOLE_BRIDGE_logDebug("There are multiple geometries associated to attached body '%s'. Returning the transform for the first "
              "one.",
              id.c_str());
   return tf[0];
@@ -1054,7 +1054,7 @@ void moveit::core::RobotState::getRobotMarkers(visualization_msgs::MarkerArray& 
   ros::Time tm = ros::Time::now();
   for (std::size_t i = 0; i < link_names.size(); ++i)
   {
-    logDebug("Trying to get marker for link '%s'", link_names[i].c_str());
+    CONSOLE_BRIDGE_logDebug("Trying to get marker for link '%s'", link_names[i].c_str());
     const LinkModel* lm = robot_model_->getLinkModel(link_names[i]);
     if (!lm)
       continue;
@@ -1134,13 +1134,13 @@ bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const L
 
   if (!group->isChain())
   {
-    logError("The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
+    CONSOLE_BRIDGE_logError("The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
     return false;
   }
 
   if (!group->isLinkUpdated(link->getName()))
   {
-    logError("Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
+    CONSOLE_BRIDGE_logError("Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
              link->getName().c_str(), group->getName().c_str());
     return false;
   }
@@ -1157,7 +1157,7 @@ bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const L
   Eigen::Vector3d point_transform = link_transform * reference_point_position;
 
   /*
-  logDebug("Point from reference origin expressed in world coordinates: %f %f %f",
+  CONSOLE_BRIDGE_logDebug("Point from reference origin expressed in world coordinates: %f %f %f",
            point_transform.x(),
            point_transform.y(),
            point_transform.z());
@@ -1169,11 +1169,11 @@ bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const L
   while (link)
   {
     /*
-    logDebug("Link: %s, %f %f %f",link_state->getName().c_str(),
+    CONSOLE_BRIDGE_logDebug("Link: %s, %f %f %f",link_state->getName().c_str(),
              link_state->getGlobalLinkTransform().translation().x(),
              link_state->getGlobalLinkTransform().translation().y(),
              link_state->getGlobalLinkTransform().translation().z());
-    logDebug("Joint: %s",link_state->getParentJointState()->getName().c_str());
+    CONSOLE_BRIDGE_logDebug("Joint: %s",link_state->getParentJointState()->getName().c_str());
     */
     const JointModel* pjm = link->getParentJointModel();
     if (pjm->getVariableCount() > 0)
@@ -1206,7 +1206,7 @@ bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const L
         jacobian.block<3, 1>(3, joint_index + 2) = jacobian.block<3, 1>(3, joint_index + 2) + joint_axis;
       }
       else
-        logError("Unknown type of joint in Jacobian computation");
+        CONSOLE_BRIDGE_logError("Unknown type of joint in Jacobian computation");
     }
     if (pjm == root_joint_model)
       break;
@@ -1314,7 +1314,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const geome
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
   {
-    logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+    CONSOLE_BRIDGE_logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
   return setFromIK(jmg, pose, solver->getTipFrame(), attempts, timeout, constraint, options);
@@ -1338,7 +1338,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
   {
-    logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+    CONSOLE_BRIDGE_logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
   static std::vector<double> consistency_limits;
@@ -1435,7 +1435,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   // Error check
   if (poses_in.size() != tips_in.size())
   {
-    logError("moveit.robot_state: Number of poses must be the same as number of tips");
+    CONSOLE_BRIDGE_logError("moveit.robot_state: Number of poses must be the same as number of tips");
     return false;
   }
 
@@ -1454,7 +1454,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     std::string error_msg;
     if (!solver->supportsGroup(jmg, &error_msg))
     {
-      logError("moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
+      CONSOLE_BRIDGE_logError("moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
                typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
       valid_solver = false;
     }
@@ -1470,7 +1470,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     }
     else
     {
-      logError("moveit.robot_state: No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+      CONSOLE_BRIDGE_logError("moveit.robot_state: No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
       return false;
     }
   }
@@ -1479,7 +1479,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    logError("moveit.robot_state: Invalid number (%d) of sets of consistency limits for a setFromIK request that is "
+    CONSOLE_BRIDGE_logError("moveit.robot_state: Invalid number (%d) of sets of consistency limits for a setFromIK request that is "
              "being solved by a single IK solver",
              consistency_limit_sets.size());
     return false;
@@ -1536,7 +1536,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
           const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
-            logError("moveit.robot_state: Cannot use an attached body with multiple geometries as a reference frame.");
+            CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot use an attached body with multiple geometries as a reference frame.");
             return false;
           }
           pose_frame = ab->getAttachedLinkName();
@@ -1571,12 +1571,12 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     // Make sure one of the tip frames worked
     if (!found_valid_frame)
     {
-      logError("moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i, pose_frame.c_str());
+      CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i, pose_frame.c_str());
       // Debug available tip frames
       std::stringstream ss;
       for (solver_tip_id = 0; solver_tip_id < solver_tip_frames.size(); ++solver_tip_id)
         ss << solver_tip_frames[solver_tip_id] << ", ";
-      logError("Available tip frames: [%s]", ss.str().c_str());
+      CONSOLE_BRIDGE_logError("Available tip frames: [%s]", ss.str().c_str());
       return false;
     }
 
@@ -1655,7 +1655,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     }
     else
     {
-      logDebug("moveit.robot_state: Rerunning IK solver with random joint positions");
+      CONSOLE_BRIDGE_logDebug("moveit.robot_state: Rerunning IK solver with random joint positions");
 
       // sample a random seed
       random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
@@ -1707,19 +1707,19 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
   // Error check
   if (poses_in.size() != sub_groups.size())
   {
-    logError("Number of poses (%u) must be the same as number of sub-groups (%u)", poses_in.size(), sub_groups.size());
+    CONSOLE_BRIDGE_logError("Number of poses (%u) must be the same as number of sub-groups (%u)", poses_in.size(), sub_groups.size());
     return false;
   }
 
   if (tips_in.size() != sub_groups.size())
   {
-    logError("Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(), sub_groups.size());
+    CONSOLE_BRIDGE_logError("Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(), sub_groups.size());
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != sub_groups.size())
   {
-    logError("Number of consistency limit vectors must be the same as number of sub-groups");
+    CONSOLE_BRIDGE_logError("Number of consistency limit vectors must be the same as number of sub-groups");
     return false;
   }
 
@@ -1727,7 +1727,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      logError("Number of joints in consistency_limits is %u but it should be should be %u", (unsigned int)i,
+      CONSOLE_BRIDGE_logError("Number of joints in consistency_limits is %u but it should be should be %u", (unsigned int)i,
                sub_groups[i]->getVariableCount());
       return false;
     }
@@ -1740,7 +1740,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
     kinematics::KinematicsBaseConstPtr solver = sub_groups[i]->getSolverInstance();
     if (!solver)
     {
-      logError("Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
+      CONSOLE_BRIDGE_logError("Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
       return false;
     }
     solvers.push_back(solver);
@@ -1776,7 +1776,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
         const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
         if (ab_trans.size() != 1)
         {
-          logError("Cannot use an attached body with multiple geometries as a reference frame.");
+          CONSOLE_BRIDGE_logError("Cannot use an attached body with multiple geometries as a reference frame.");
           return false;
         }
         pose_frame = ab->getAttachedLinkName();
@@ -1800,7 +1800,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
 
     if (pose_frame != solver_tip_frame)
     {
-      logError("Cannot compute IK for query pose reference frame '%s', desired: '%s'", pose_frame.c_str(),
+      CONSOLE_BRIDGE_logError("Cannot compute IK for query pose reference frame '%s', desired: '%s'", pose_frame.c_str(),
                solver_tip_frame.c_str());
       return false;
     }
@@ -1874,7 +1874,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
         found_solution = false;
         break;
       }
-      logDebug("IK attempt: %d of %d", st, attempts);
+      CONSOLE_BRIDGE_logDebug("IK attempt: %d of %d", st, attempts);
     }
     if (found_solution)
     {
@@ -1882,7 +1882,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
       copyJointGroupPositions(jmg, full_solution);
       if (constraint ? constraint(this, jmg, &full_solution[0]) : true)
       {
-        logDebug("Found IK solution");
+        CONSOLE_BRIDGE_logDebug("Found IK solution");
         return true;
       }
     }
@@ -1975,7 +1975,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
-    logWarn("The computed trajectory is too short to detect jumps in joint-space "
+    CONSOLE_BRIDGE_logWarn("The computed trajectory is too short to detect jumps in joint-space "
             "Need at least %zu steps, only got %zu. Try a lower max_step.",
             MIN_STEPS_FOR_JUMP_THRESH, traj.size());
   }
@@ -1995,7 +1995,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
   for (std::size_t i = 0; i < dist_vector.size(); ++i)
     if (dist_vector[i] > thres)
     {
-      logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+      CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
       percentage = (double)i / (double)dist_vector.size();
       traj.resize(i);
       break;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1936,7 +1936,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   double distance = (rotated_target.translation() - start_pose.translation()).norm();
 
   // If we are testing using the jump threshold, we always want at least MIN_STEPS_FOR_JUMP_THRESH steps
-  unsigned int steps = static_cast<unsigned int>(floor(distance / max_step) + 1);
+  unsigned int steps = floor(distance / max_step) + 1;
   if (test_joint_space_jump && steps < MIN_STEPS_FOR_JUMP_THRESH)
     steps = MIN_STEPS_FOR_JUMP_THRESH;
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -48,8 +48,10 @@ namespace moveit
 {
 namespace core
 {
-/** \brief At least 10 steps per trajectory for testing jump thresholds with computeCartesianPath. Otherwise
- * testJointSpaceJump doesn't work well. */
+/** \brief It is recommended that there are at least 10 steps per trajectory
+ * for testing jump thresholds with computeCartesianPath. With less than 10 steps
+ * it is difficult to choose a jump_threshold parameter that effectively separates
+ * valid paths from paths with large joint space jumps. */
 static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
 }
 }
@@ -1934,8 +1936,8 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   double distance = (rotated_target.translation() - start_pose.translation()).norm();
 
   // If we are testing using the jump threshold, we always want at least MIN_STEPS_FOR_JUMP_THRESH steps
-  unsigned int steps = (unsigned int)floor(distance / max_step) + 1;
-  if (test_joint_space_jump && steps<MIN_STEPS_FOR_JUMP_THRESH)
+  unsigned int steps = static_cast<unsigned int>(floor(distance / max_step) + 1);
+  if (test_joint_space_jump && steps < MIN_STEPS_FOR_JUMP_THRESH)
     steps = MIN_STEPS_FOR_JUMP_THRESH;
 
   traj.clear();

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -43,15 +43,14 @@
 #include <moveit/profiler/profiler.h>
 #include <boost/bind.hpp>
 #include <moveit/robot_model/aabb.h>
-#include <algorithm>
 
 namespace moveit
 {
 namespace core
 {
-/** \brief At least 5 steps per trajectory for testing jump thresholds with computeCartesianPath. Otherwise
- * testJointSpaceJump doens't work well. */
-static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 5;
+/** \brief At least 10 steps per trajectory for testing jump thresholds with computeCartesianPath. Otherwise
+ * testJointSpaceJump doesn't work well. */
+static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
 }
 }
 
@@ -1935,11 +1934,9 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   double distance = (rotated_target.translation() - start_pose.translation()).norm();
 
   // If we are testing using the jump threshold, we always want at least MIN_STEPS_FOR_JUMP_THRESH steps
-  unsigned int steps;
-  if (test_joint_space_jump)
-    steps = std::max(MIN_STEPS_FOR_JUMP_THRESH, (std::size_t)floor(distance / max_step) + 1);
-  else
-    steps = (unsigned int)floor(distance / max_step) + 1;
+  unsigned int steps = (unsigned int)floor(distance / max_step) + 1;
+  if (test_joint_space_jump && steps<MIN_STEPS_FOR_JUMP_THRESH)
+    steps = MIN_STEPS_FOR_JUMP_THRESH;
 
   traj.clear();
   traj.push_back(RobotStatePtr(new RobotState(*this)));

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1003,9 +1003,10 @@ const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::st
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    CONSOLE_BRIDGE_logError("Transform from frame '%s' to frame '%s' is not known ('%s' should be a link name or an attached body "
-             "id).",
-             id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
+    CONSOLE_BRIDGE_logError("Transform from frame '%s' to frame '%s' is not known ('%s' should be a link name or an "
+                            "attached body "
+                            "id).",
+                            id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
   }
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
@@ -1015,9 +1016,10 @@ const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::st
     return identity_transform;
   }
   if (tf.size() > 1)
-    CONSOLE_BRIDGE_logDebug("There are multiple geometries associated to attached body '%s'. Returning the transform for the first "
-             "one.",
-             id.c_str());
+    CONSOLE_BRIDGE_logDebug("There are multiple geometries associated to attached body '%s'. Returning the transform "
+                            "for the first "
+                            "one.",
+                            id.c_str());
   return tf[0];
 }
 
@@ -1141,7 +1143,7 @@ bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const L
   if (!group->isLinkUpdated(link->getName()))
   {
     CONSOLE_BRIDGE_logError("Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
-             link->getName().c_str(), group->getName().c_str());
+                            link->getName().c_str(), group->getName().c_str());
     return false;
   }
 
@@ -1455,7 +1457,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     if (!solver->supportsGroup(jmg, &error_msg))
     {
       CONSOLE_BRIDGE_logError("moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
-               typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
+                              typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
       valid_solver = false;
     }
   }
@@ -1470,7 +1472,8 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     }
     else
     {
-      CONSOLE_BRIDGE_logError("moveit.robot_state: No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+      CONSOLE_BRIDGE_logError("moveit.robot_state: No kinematics solver instantiated for group '%s'",
+                              jmg->getName().c_str());
       return false;
     }
   }
@@ -1479,9 +1482,10 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    CONSOLE_BRIDGE_logError("moveit.robot_state: Invalid number (%d) of sets of consistency limits for a setFromIK request that is "
-             "being solved by a single IK solver",
-             consistency_limit_sets.size());
+    CONSOLE_BRIDGE_logError("moveit.robot_state: Invalid number (%d) of sets of consistency limits for a setFromIK "
+                            "request that is "
+                            "being solved by a single IK solver",
+                            consistency_limit_sets.size());
     return false;
   }
   else if (consistency_limit_sets.size() == 1)
@@ -1536,7 +1540,8 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
           const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
-            CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot use an attached body with multiple geometries as a reference frame.");
+            CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot use an attached body with multiple geometries as a "
+                                    "reference frame.");
             return false;
           }
           pose_frame = ab->getAttachedLinkName();
@@ -1571,7 +1576,8 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
     // Make sure one of the tip frames worked
     if (!found_valid_frame)
     {
-      CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i, pose_frame.c_str());
+      CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i,
+                              pose_frame.c_str());
       // Debug available tip frames
       std::stringstream ss;
       for (solver_tip_id = 0; solver_tip_id < solver_tip_frames.size(); ++solver_tip_id)
@@ -1707,13 +1713,15 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
   // Error check
   if (poses_in.size() != sub_groups.size())
   {
-    CONSOLE_BRIDGE_logError("Number of poses (%u) must be the same as number of sub-groups (%u)", poses_in.size(), sub_groups.size());
+    CONSOLE_BRIDGE_logError("Number of poses (%u) must be the same as number of sub-groups (%u)", poses_in.size(),
+                            sub_groups.size());
     return false;
   }
 
   if (tips_in.size() != sub_groups.size())
   {
-    CONSOLE_BRIDGE_logError("Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(), sub_groups.size());
+    CONSOLE_BRIDGE_logError("Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(),
+                            sub_groups.size());
     return false;
   }
 
@@ -1727,8 +1735,8 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      CONSOLE_BRIDGE_logError("Number of joints in consistency_limits is %u but it should be should be %u", (unsigned int)i,
-               sub_groups[i]->getVariableCount());
+      CONSOLE_BRIDGE_logError("Number of joints in consistency_limits is %u but it should be should be %u",
+                              (unsigned int)i, sub_groups[i]->getVariableCount());
       return false;
     }
   }
@@ -1800,8 +1808,8 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
 
     if (pose_frame != solver_tip_frame)
     {
-      CONSOLE_BRIDGE_logError("Cannot compute IK for query pose reference frame '%s', desired: '%s'", pose_frame.c_str(),
-               solver_tip_frame.c_str());
+      CONSOLE_BRIDGE_logError("Cannot compute IK for query pose reference frame '%s', desired: '%s'",
+                              pose_frame.c_str(), solver_tip_frame.c_str());
       return false;
     }
   }
@@ -1976,8 +1984,8 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
     CONSOLE_BRIDGE_logWarn("The computed trajectory is too short to detect jumps in joint-space "
-            "Need at least %zu steps, only got %zu. Try a lower max_step.",
-            MIN_STEPS_FOR_JUMP_THRESH, traj.size());
+                           "Need at least %zu steps, only got %zu. Try a lower max_step.",
+                           MIN_STEPS_FOR_JUMP_THRESH, traj.size());
   }
   std::vector<double> dist_vector;
   dist_vector.reserve(traj.size() - 1);


### PR DESCRIPTION
### Description
issue #783 

With the current implementation, if you use computeCartesianPath with Eigen::Affine3d you can get different results than if you pass in a vector with a single waypoint to computeCartesianPath with EigenSTL::vector_Affine3d.  This fixes that bug. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
