### PR TITLE
Add API to get planner_id

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -405,6 +405,10 @@ class MoveGroupCommander(object):
         """ Specify which planner to use when motion planning """
         self._g.set_planner_id(planner_id)
 
+    def get_planner_id(self):
+        """ Get the current planner_id """
+        self._g.get_planner_id()
+
     def set_num_planning_attempts(self, num_planning_attempts):
         """ Set the number of times the motion plan is to be computed from scratch before the shortest solution is returned. The default value is 1. """
         self._g.set_num_planning_attempts(num_planning_attempts)

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -226,6 +226,9 @@ public:
   /** \brief Specify a planner to be used for further planning */
   void setPlannerId(const std::string& planner_id);
 
+  /** \brief Get the current planner_id */
+  const std::string& getPlannerId() const;
+
   /** \brief Specify the maximum amount of time to use when planning */
   void setPlanningTime(double seconds);
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -393,6 +393,11 @@ public:
     planner_id_ = planner_id;
   }
 
+  const std::string& getPlannerId() const
+  {
+    return planner_id_;
+  }
+
   void setNumPlanningAttempts(unsigned int num_planning_attempts)
   {
     num_planning_attempts_ = num_planning_attempts;
@@ -1446,6 +1451,11 @@ std::string moveit::planning_interface::MoveGroupInterface::getDefaultPlannerId(
 void moveit::planning_interface::MoveGroupInterface::setPlannerId(const std::string& planner_id)
 {
   impl_->setPlannerId(planner_id);
+}
+
+const std::string& moveit::planning_interface::MoveGroupInterface::getPlannerId() const
+{
+  return impl_->getPlannerId();
 }
 
 void moveit::planning_interface::MoveGroupInterface::setNumPlanningAttempts(unsigned int num_planning_attempts)

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -388,6 +388,11 @@ public:
     return asyncExecute(plan) == MoveItErrorCode::SUCCESS;
   }
 
+  const char* getPlannerIdCStr() const
+  {
+    return getPlannerId().c_str();
+  }
+
   std::string getPlanPython()
   {
     MoveGroupInterface::Plan plan;
@@ -597,6 +602,7 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("set_max_acceleration_scaling_factor",
                               &MoveGroupWrapper::setMaxAccelerationScalingFactor);
   MoveGroupInterfaceClass.def("set_planner_id", &MoveGroupInterfaceWrapper::setPlannerId);
+  MoveGroupInterfaceClass.def("get_planner_id", &MoveGroupInterfaceWrapper::getPlannerIdCStr);
   MoveGroupInterfaceClass.def("set_num_planning_attempts", &MoveGroupInterfaceWrapper::setNumPlanningAttempts);
   MoveGroupInterfaceClass.def("compute_plan", &MoveGroupInterfaceWrapper::getPlanPython);
   MoveGroupInterfaceClass.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathPython);


### PR DESCRIPTION
This PR adds a API to `MoveGroupInterface`  that get the current planner_id.
I need this to:
1. Call underlying `move_group` actions using an existing `MoveGroupInterface`'s settings
2. Use for visualization/debug
