### PR TITLE
MoveitCommander support for TrajectoryConstraints

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -34,6 +34,7 @@
 
 from geometry_msgs.msg import Pose, PoseStamped
 from moveit_msgs.msg import RobotTrajectory, Grasp, PlaceLocation, Constraints
+from moveit_msgs.msg import MoveItErrorCodes, TrajectoryConstraints
 from sensor_msgs.msg import JointState
 import rospy
 import tf
@@ -388,6 +389,27 @@ class MoveGroupCommander(object):
     def clear_path_constraints(self):
         """ Specify that no path constraints are to be used during motion planning """
         self._g.clear_path_constraints()
+
+    def get_trajectory_constraints(self):
+        """ Get the actual trajectory constraints in form of a moveit_msgs.msgs.Constraints """
+        c = Constraints()
+        c_str = self._g.get_trajectory_constraints()
+        conversions.msg_from_string(c, c_str)
+        return c
+
+    def set_trajectory_constraints(self, value):
+        """ Specify the trajectory constraints to be used (as read from the database) """
+        if value == None:
+            self.clear_path_constraints()
+        else:
+            if type(value) is TrajectoryConstraints:
+                self._g.set_trajectory_constraints_from_msg(conversions.msg_to_string(value))
+            elif not self._g.set_trajectory_constraints(value):
+                raise MoveItCommanderException("Unable to set path constraints " + value)
+
+    def clear_trajectory_constraints(self):
+        """ Specify that no trajectory constraints are to be used during motion planning """
+        self._g.clear_trajectory_constraints()
 
     def set_constraints_database(self, host, port):
         """ Specify which database to connect to for loading possible path constraints """

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -398,14 +398,14 @@ class MoveGroupCommander(object):
         return c
 
     def set_trajectory_constraints(self, value):
-        """ Specify the trajectory constraints to be used (as read from the database) """
+        """ Specify the trajectory constraints to be used """
         if value == None:
-            self.clear_path_constraints()
+            self.clear_trajectory_constraints()
         else:
             if type(value) is TrajectoryConstraints:
                 self._g.set_trajectory_constraints_from_msg(conversions.msg_to_string(value))
             elif not self._g.set_trajectory_constraints(value):
-                raise MoveItCommanderException("Unable to set path constraints " + value)
+                raise MoveItCommanderException("Unable to set trajectory constraints " + value)
 
     def clear_trajectory_constraints(self):
         """ Specify that no trajectory constraints are to be used during motion planning """

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -906,6 +906,11 @@ public:
       This removes any path constraints set in previous calls to setPathConstraints(). */
   void clearPathConstraints();
 
+  moveit_msgs::TrajectoryConstraints getTrajectoryConstraints() const;
+  bool setTrajectoryConstraints(const std::string& constraints);
+  void setTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints& constraint);
+  void clearTrajectoryConstraints();
+
   /**@}*/
 
 private:

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -907,7 +907,6 @@ public:
   void clearPathConstraints();
 
   moveit_msgs::TrajectoryConstraints getTrajectoryConstraints() const;
-  bool setTrajectoryConstraints(const std::string& constraints);
   void setTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints& constraint);
   void clearTrajectoryConstraints();
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -2206,7 +2206,8 @@ moveit_msgs::TrajectoryConstraints moveit::planning_interface::MoveGroupInterfac
   return impl_->getTrajectoryConstraints();
 }
 
-void moveit::planning_interface::MoveGroupInterface::setTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints& constraint)
+void moveit::planning_interface::MoveGroupInterface::setTrajectoryConstraints(
+    const moveit_msgs::TrajectoryConstraints& constraint)
 {
   impl_->setTrajectoryConstraints(constraint);
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1144,6 +1144,8 @@ public:
 
     if (path_constraints_)
       request.path_constraints = *path_constraints_;
+    if (trajectory_constraints_)
+      request.trajectory_constraints = *trajectory_constraints_;
   }
 
   void constructGoal(moveit_msgs::MoveGroupGoal& goal)
@@ -1213,6 +1215,16 @@ public:
     path_constraints_.reset();
   }
 
+  void setTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints& constraint)
+  {
+    trajectory_constraints_.reset(new moveit_msgs::TrajectoryConstraints(constraint));
+  }
+
+  void clearTrajectoryConstraints()
+  {
+    trajectory_constraints_.reset();
+  }
+
   std::vector<std::string> getKnownConstraints() const
   {
     while (initializing_constraints_)
@@ -1234,6 +1246,14 @@ public:
       return *path_constraints_;
     else
       return moveit_msgs::Constraints();
+  }
+
+  moveit_msgs::TrajectoryConstraints getTrajectoryConstraints() const
+  {
+    if (trajectory_constraints_)
+      return *trajectory_constraints_;
+    else
+      return moveit_msgs::TrajectoryConstraints();
   }
 
   void initializeConstraintsStorage(const std::string& host, unsigned int port)
@@ -1313,6 +1333,7 @@ private:
   // common properties for goals
   ActiveTargetType active_target_;
   std::unique_ptr<moveit_msgs::Constraints> path_constraints_;
+  std::unique_ptr<moveit_msgs::TrajectoryConstraints> trajectory_constraints_;
   std::string end_effector_link_;
   std::string pose_reference_frame_;
   std::string support_surface_;
@@ -2178,6 +2199,21 @@ void moveit::planning_interface::MoveGroupInterface::setPathConstraints(const mo
 void moveit::planning_interface::MoveGroupInterface::clearPathConstraints()
 {
   impl_->clearPathConstraints();
+}
+
+moveit_msgs::TrajectoryConstraints moveit::planning_interface::MoveGroupInterface::getTrajectoryConstraints() const
+{
+  return impl_->getTrajectoryConstraints();
+}
+
+void moveit::planning_interface::MoveGroupInterface::setTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints& constraint)
+{
+  impl_->setTrajectoryConstraints(constraint);
+}
+
+void moveit::planning_interface::MoveGroupInterface::clearTrajectoryConstraints()
+{
+  impl_->clearTrajectoryConstraints();
 }
 
 void moveit::planning_interface::MoveGroupInterface::setConstraintsDatabase(const std::string& host, unsigned int port)

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -602,7 +602,8 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("get_path_constraints", &MoveGroupInterfaceWrapper::getPathConstraintsPython);
   MoveGroupInterfaceClass.def("clear_path_constraints", &MoveGroupInterfaceWrapper::clearPathConstraints);
 
-  MoveGroupInterfaceClass.def("set_trajectory_constraints_from_msg", &MoveGroupInterfaceWrapper::setTrajectoryConstraintsFromMsg);
+  MoveGroupInterfaceClass.def("set_trajectory_constraints_from_msg",
+                              &MoveGroupInterfaceWrapper::setTrajectoryConstraintsFromMsg);
   MoveGroupInterfaceClass.def("get_trajectory_constraints", &MoveGroupInterfaceWrapper::getTrajectoryConstraintsPython);
   MoveGroupInterfaceClass.def("clear_trajectory_constraints", &MoveGroupInterfaceWrapper::clearTrajectoryConstraints);
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -435,6 +435,20 @@ public:
     return constraints_str;
   }
 
+  void setTrajectoryConstraintsFromMsg(const std::string& constraints_str)
+  {
+    moveit_msgs::TrajectoryConstraints constraints_msg;
+    py_bindings_tools::deserializeMsg(constraints_str, constraints_msg);
+    setTrajectoryConstraints(constraints_msg);
+  }
+
+  std::string getTrajectoryConstraintsPython()
+  {
+    moveit_msgs::TrajectoryConstraints constraints_msg(getTrajectoryConstraints());
+    std::string constraints_str = py_bindings_tools::serializeMsg(constraints_msg);
+    return constraints_str;
+  }
+
   std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
                                double velocity_scaling_factor)
   {
@@ -587,6 +601,11 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("set_path_constraints_from_msg", &MoveGroupInterfaceWrapper::setPathConstraintsFromMsg);
   MoveGroupInterfaceClass.def("get_path_constraints", &MoveGroupInterfaceWrapper::getPathConstraintsPython);
   MoveGroupInterfaceClass.def("clear_path_constraints", &MoveGroupInterfaceWrapper::clearPathConstraints);
+
+  MoveGroupInterfaceClass.def("set_trajectory_constraints_from_msg", &MoveGroupInterfaceWrapper::setTrajectoryConstraintsFromMsg);
+  MoveGroupInterfaceClass.def("get_trajectory_constraints", &MoveGroupInterfaceWrapper::getTrajectoryConstraintsPython);
+  MoveGroupInterfaceClass.def("clear_trajectory_constraints", &MoveGroupInterfaceWrapper::clearTrajectoryConstraints);
+
   MoveGroupInterfaceClass.def("get_known_constraints", &MoveGroupInterfaceWrapper::getKnownConstraintsList);
   MoveGroupInterfaceClass.def("set_constraints_database", &MoveGroupInterfaceWrapper::setConstraintsDatabase);
   MoveGroupInterfaceClass.def("set_workspace", &MoveGroupInterfaceWrapper::setWorkspace);


### PR DESCRIPTION
### Description

TLDR: 
* `trajectory_constraints` is a member of [`MotionPlanRequest`](http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/MotionPlanRequest.html) yet the MoveGroupInterface doesn't allow for specifying it.
* `trajectory_constraints` can carry entire trajectories while `path_constraints` can't (in a clean way). 

----

The [`MotionPlanRequest`](http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/MotionPlanRequest.html) message has a field `trajectory_constraints` but  `class MoveGroupInterface (C++)` doesn't allow for setting them. I've added support for this both to the C++ class and the Python wrapper. 
What's the motivation for this? Passing in _initial trajectories_, _initial guesses_ or _seed trajectories_ to optimization-based planners such as the case of [STOMP](https://github.com/ros-industrial/industrial_moveit/blob/kinetic-devel/stomp_moveit/src/stomp_planner.cpp#L505).

This was on #790 , now separated.

We should probably add some tests.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
