### PR TITLE
msa: cleanup yaml parsing

### DIFF
--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -42,14 +42,9 @@ add_definitions(-DQT_NO_KEYWORDS)
 
 # Support new yaml-cpp API.
 find_package(PkgConfig)
-pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
-if(NEW_YAMLCPP_FOUND)
-  add_definitions(-DHAVE_NEW_YAMLCPP)
-  include_directories(${NEW_YAMLCPP_INCLUDE_DIRS})
-  link_directories(${NEW_YAMLCPP_LIBRARY_DIRS})
-endif(NEW_YAMLCPP_FOUND)
-
-find_library(YAML yaml-cpp REQUIRED)
+pkg_check_modules(YAMLCPP REQUIRED yaml-cpp>=0.5)
+include_directories(${YAMLCPP_INCLUDE_DIRS})
+link_directories(${YAMLCPP_LIBRARY_DIRS})
 
 catkin_package(
   INCLUDE_DIRS
@@ -91,7 +86,7 @@ add_library(${PROJECT_NAME}_tools
 )
 set_target_properties(${PROJECT_NAME}_tools PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_tools
-  ${YAML}
+  ${YAMLCPP_LIBRARIES}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
   ${QT_LIBRARIES}

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -45,6 +45,8 @@ find_package(PkgConfig)
 pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
 if(NEW_YAMLCPP_FOUND)
   add_definitions(-DHAVE_NEW_YAMLCPP)
+  include_directories(${NEW_YAMLCPP_INCLUDE_DIRS})
+  link_directories(${NEW_YAMLCPP_LIBRARY_DIRS})
 endif(NEW_YAMLCPP_FOUND)
 
 find_library(YAML yaml-cpp REQUIRED)

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -109,12 +109,10 @@ namespace fs = boost::filesystem;
 typedef boost::optional<YAML::Node> yaml_node_t;
 
 // Helper function to find a value (yaml-cpp 0.5)
-template <typename T>
-yaml_node_t findValue(const YAML::Node& node, const T& key)
+yaml_node_t findValue(const YAML::Node& node, const std::string& key)
 {
-  if (node[key])
-    return node[key];
-  return yaml_node_t();
+  YAML::Node value = node[key];
+  return yaml_node_t(bool(value), value);
 }
 
 // The >> operator disappeared in yaml-cpp 0.5, so this function is
@@ -129,8 +127,7 @@ void operator>>(const YAML::Node& node, T& i)
 typedef const YAML::Node* yaml_node_t;
 
 // Helper function to find a value (yaml-cpp 0.3)
-template <typename T>
-yaml_node_t findValue(const YAML::Node& node, const T& key)
+yaml_node_t findValue(const YAML::Node& node, const std::string& key)
 {
   return node.FindValue(key);
 }


### PR DESCRIPTION
While tracking down a bug in yaml parsing, which finally turned out to be a bug in yamp-cpp itself (https://github.com/jbeder/yaml-cpp/pull/568), I cleaned the code a little bit.
