### PR TITLE
msa: added support for xacro args

### DIFF
--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -193,7 +193,7 @@ bool rdf_loader::RDFLoader::loadXacroFileToString(std::string& buffer, const std
     return false;
   }
 
-  std::string cmd = "rosrun xacro xacro --inorder ";
+  std::string cmd = "rosrun xacro xacro ";
   for (std::vector<std::string>::const_iterator it = xacro_args.begin(); it != xacro_args.end(); ++it)
     cmd += *it + " ";
   cmd += path;

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -170,6 +170,8 @@ public:
 
   /// Flag indicating whether the URDF was loaded from .xacro format
   bool urdf_from_xacro_;
+  /// xacro arguments
+  std::string xacro_args_;
 
   /// URDF robot model
   urdf::ModelSharedPtr urdf_model_;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -258,6 +258,7 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
   emitter << YAML::Value << YAML::BeginMap;
   emitter << YAML::Key << "package" << YAML::Value << urdf_pkg_name_;
   emitter << YAML::Key << "relative_path" << YAML::Value << urdf_pkg_relative_path_;
+  emitter << YAML::Key << "xacro_args" << YAML::Value << xacro_args_;
   emitter << YAML::EndMap;
 
   /// SRDF Path Location
@@ -1041,7 +1042,7 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
       // URDF Properties
       if (urdf_node = findValue(*title_node, "URDF"))
       {
-        // Load first property
+        // Load package
         if (package_node = findValue(*urdf_node, "package"))
         {
           *package_node >> urdf_pkg_name_;
@@ -1051,7 +1052,7 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
           return false;  // if we do not find this value we cannot continue
         }
 
-        // Load second property
+        // Load relative_path
         if (relative_node = findValue(*urdf_node, "relative_path"))
         {
           *relative_node >> urdf_pkg_relative_path_;
@@ -1059,6 +1060,16 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
         else
         {
           return false;  // if we do not find this value we cannot continue
+        }
+
+        // Load xacro_args
+        if (relative_node = findValue(*urdf_node, "xacro_args"))
+        {
+          *relative_node >> xacro_args_;
+        }
+        else
+        {
+          xacro_args_.clear();  // xacro args are optional
         }
       }
       // SRDF Properties

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1002,7 +1002,8 @@ void ConfigurationFilesWidget::loadTemplateStrings()
 
   // Pair 3
   if (config_data_->urdf_from_xacro_)
-    addTemplateString("[URDF_LOAD_ATTRIBUTE]", "command=\"$(find xacro)/xacro --inorder '" + urdf_location + "'\"");
+    addTemplateString("[URDF_LOAD_ATTRIBUTE]",
+                      "command=\"xacro " + config_data_->xacro_args_ + " '" + urdf_location + "'\"");
   else
     addTemplateString("[URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -86,7 +86,7 @@ ConfigurationFilesWidget::ConfigurationFilesWidget(QWidget* parent,
                                    "Specify the desired directory for the MoveIt configuration package to be "
                                    "generated. Overwriting an existing configuration package directory is acceptable. "
                                    "Example: <i>/u/robot/ros/pr2_moveit_config</i>",
-                                   true, this);  // is directory
+                                   this, true);  // is directory
   layout->addWidget(stack_path_);
 
   // Pass the package path from start screen to configuration files screen

--- a/moveit_setup_assistant/src/widgets/header_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/header_widget.cpp
@@ -88,8 +88,8 @@ HeaderWidget::HeaderWidget(const std::string& title, const std::string& instruct
 // ******************************************************************************************
 // Create the widget
 // ******************************************************************************************
-LoadPathWidget::LoadPathWidget(const std::string& title, const std::string& instructions, const bool dir_only,
-                               const bool load_only, QWidget* parent)
+LoadPathWidget::LoadPathWidget(const QString& title, const QString& instructions, QWidget* parent,
+                               const bool dir_only, const bool load_only)
   : QFrame(parent), dir_only_(dir_only), load_only_(load_only)
 {
   // Set frame graphics
@@ -106,7 +106,7 @@ LoadPathWidget::LoadPathWidget(const std::string& title, const std::string& inst
 
   // Widget Title
   QLabel* widget_title = new QLabel(this);
-  widget_title->setText(title.c_str());
+  widget_title->setText(title);
   QFont widget_title_font(QFont().defaultFamily(), 12, QFont::Bold);
   widget_title->setFont(widget_title_font);
   layout->addWidget(widget_title);
@@ -114,13 +114,13 @@ LoadPathWidget::LoadPathWidget(const std::string& title, const std::string& inst
 
   // Widget Instructions
   QLabel* widget_instructions = new QLabel(this);
-  widget_instructions->setText(instructions.c_str());
+  widget_instructions->setText(instructions);
   widget_instructions->setWordWrap(true);
   widget_instructions->setTextFormat(Qt::RichText);
   layout->addWidget(widget_instructions);
   layout->setAlignment(widget_instructions, Qt::AlignTop);
 
-  // Line Edit
+  // Line Edit for path
   path_box_ = new QLineEdit(this);
   hlayout->addWidget(path_box_);
 
@@ -171,7 +171,7 @@ void LoadPathWidget::btn_file_dialog()
 // ******************************************************************************************
 // Get the QString path
 // ******************************************************************************************
-const QString LoadPathWidget::getQPath()
+QString LoadPathWidget::getQPath() const
 {
   return path_box_->text();
 }
@@ -179,7 +179,7 @@ const QString LoadPathWidget::getQPath()
 // ******************************************************************************************
 // Get Std String path
 // ******************************************************************************************
-const std::string LoadPathWidget::getPath()
+std::string LoadPathWidget::getPath() const
 {
   return getQPath().toStdString();
 }

--- a/moveit_setup_assistant/src/widgets/header_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/header_widget.cpp
@@ -88,8 +88,8 @@ HeaderWidget::HeaderWidget(const std::string& title, const std::string& instruct
 // ******************************************************************************************
 // Create the widget
 // ******************************************************************************************
-LoadPathWidget::LoadPathWidget(const QString& title, const QString& instructions, QWidget* parent,
-                               const bool dir_only, const bool load_only)
+LoadPathWidget::LoadPathWidget(const QString& title, const QString& instructions, QWidget* parent, const bool dir_only,
+                               const bool load_only)
   : QFrame(parent), dir_only_(dir_only), load_only_(load_only)
 {
   // Set frame graphics
@@ -122,6 +122,8 @@ LoadPathWidget::LoadPathWidget(const QString& title, const QString& instructions
 
   // Line Edit for path
   path_box_ = new QLineEdit(this);
+  connect(path_box_, SIGNAL(textChanged(QString)), this, SIGNAL(pathChanged(QString)));
+  connect(path_box_, SIGNAL(editingFinished()), this, SIGNAL(pathEditingFinished()));
   hlayout->addWidget(path_box_);
 
   // Button
@@ -198,5 +200,33 @@ void LoadPathWidget::setPath(const QString& path)
 void LoadPathWidget::setPath(const std::string& path)
 {
   path_box_->setText(QString(path.c_str()));
+}
+
+LoadPathArgsWidget::LoadPathArgsWidget(const QString& title, const QString& instructions,
+                                       const QString& arg_instructions, QWidget* parent, const bool dir_only,
+                                       const bool load_only)
+  : LoadPathWidget(title, instructions, parent, dir_only, load_only)
+{
+  // Line Edit for xacro args
+  args_instructions_ = new QLabel(arg_instructions, this);
+  args_ = new QLineEdit(this);
+
+  layout()->addWidget(args_instructions_);
+  layout()->addWidget(args_);
+}
+
+QString LoadPathArgsWidget::getArgs() const
+{
+  return args_->text();
+}
+
+void LoadPathArgsWidget::setArgs(const QString& args)
+{
+  args_->setText(args);
+}
+
+void LoadPathArgsWidget::setArgsEnabled(bool enabled)
+{
+  args_->setEnabled(enabled);
 }
 }

--- a/moveit_setup_assistant/src/widgets/header_widget.h
+++ b/moveit_setup_assistant/src/widgets/header_widget.h
@@ -74,14 +74,18 @@ private:
   // Stores the path qstring
   QLineEdit* path_box_;
 
+Q_SIGNALS:
+  void pathChanged(const QString& path);
+  void pathEditingFinished();
+
 private Q_SLOTS:
   /// Load the file dialog
   void btn_file_dialog();
 
 public:
   /// Constructor
-  LoadPathWidget(const QString &title, const QString &instructions, QWidget* parent,
-                 const bool dir_only = false, const bool load_only = false);
+  LoadPathWidget(const QString& title, const QString& instructions, QWidget* parent, const bool dir_only = false,
+                 const bool load_only = false);
 
   /// Returns the file path in QString format
   QString getQPath() const;
@@ -94,6 +98,25 @@ public:
 
   /// Set the path with std string
   void setPath(const std::string& path);
+};
+
+/// Extend LoadPathWidget with additional line edit for arguments
+class LoadPathArgsWidget : public LoadPathWidget
+{
+  Q_OBJECT
+
+private:
+  QLineEdit* args_;
+  QLabel* args_instructions_;
+
+public:
+  /// Constructor
+  LoadPathArgsWidget(const QString& title, const QString& instructions, const QString& arg_instructions,
+                     QWidget* parent, const bool dir_only = false, const bool load_only = false);
+
+  QString getArgs() const;
+  void setArgs(const QString& args);
+  void setArgsEnabled(bool enabled = true);
 };
 }
 

--- a/moveit_setup_assistant/src/widgets/header_widget.h
+++ b/moveit_setup_assistant/src/widgets/header_widget.h
@@ -80,14 +80,14 @@ private Q_SLOTS:
 
 public:
   /// Constructor
-  LoadPathWidget(const std::string& title, const std::string& instructions, const bool dir_only = false,
-                 const bool load_only = false, QWidget* parent = 0);
+  LoadPathWidget(const QString &title, const QString &instructions, QWidget* parent,
+                 const bool dir_only = false, const bool load_only = false);
 
   /// Returns the file path in QString format
-  const QString getQPath();
+  QString getQPath() const;
 
   /// Returns the file path in std::string format
-  const std::string getPath();
+  std::string getPath() const;
 
   /// Set the path with QString
   void setPath(const QString& path);

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -504,6 +504,11 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path)
     return false;
   }
 
+  if (urdf_string.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_file_path)) {
+    QMessageBox::warning(this, "Error Loading Files", "Running xacro failed.\nPlease check console for errors.");
+    return false;
+  }
+
   // Verify that file is in correct format / not an XACRO by loading into robot model
   if (!config_data_->urdf_model_->initString(urdf_string))
   {

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -141,7 +141,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   stack_path_ = new LoadPathWidget("Load MoveIt Configuration Package Path",
                                    "Specify the package name or path of an existing MoveIt configuration package to be "
                                    "edited for your robot. Example package name: <i>pr2_moveit_config</i>",
-                                   true, this);  // is directory
+                                   this, true);  // is directory
   stack_path_->hide();                           // user needs to select option before this is shown
   left_layout->addWidget(stack_path_);
 
@@ -150,7 +150,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
       new LoadPathWidget("Load a URDF or COLLADA Robot Model",
                          "Specify the location of an existing Universal Robot Description Format or COLLADA file for "
                          "your robot. The robot model will be loaded to the parameter server for you.",
-                         false, true, this);  // no directory, load only
+                         this, false, true);  // no directory, load only
   urdf_file_->hide();                         // user needs to select option before this is shown
   left_layout->addWidget(urdf_file_);
 
@@ -193,7 +193,6 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
 
   // Stretch
   left_layout->setSpacing(30);
-  // hlayout->setContentsMargins( 0, 20, 0, 0);
 
   // Attach Layouts
   hlayout->addLayout(left_layout);

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -116,6 +116,11 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
     ROS_ERROR_STREAM("FAILED TO LOAD " << image_path);
   }
 
+  right_layout->addWidget(logo_image_label_);
+  right_layout->setAlignment(logo_image_label_, Qt::AlignLeft | Qt::AlignTop);
+  right_layout->addWidget(right_image_label_);
+  right_layout->setAlignment(right_image_label_, Qt::AlignRight | Qt::AlignTop);
+
   // Top Label Area ---------------------------------------------------
   HeaderWidget* header = new HeaderWidget(
       "MoveIt Setup Assistant", "Welcome to the MoveIt Setup Assistant! These tools will assist you in creating a "
@@ -126,9 +131,6 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
       this);
   layout->addWidget(header);
 
-  left_layout->addWidget(logo_image_label_);
-  left_layout->setAlignment(logo_image_label_, Qt::AlignLeft | Qt::AlignTop);
-
   // Select Mode Area -------------------------------------------------
   select_mode_ = new SelectModeWidget(this);
   connect(select_mode_->btn_new_, SIGNAL(clicked()), this, SLOT(showNewOptions()));
@@ -138,20 +140,25 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   // Path Box Area ----------------------------------------------------
 
   // Stack Path Dialog
-  stack_path_ = new LoadPathWidget("Load MoveIt Configuration Package Path",
-                                   "Specify the package name or path of an existing MoveIt configuration package to be "
-                                   "edited for your robot. Example package name: <i>pr2_moveit_config</i>",
-                                   this, true);  // is directory
-  stack_path_->hide();                           // user needs to select option before this is shown
+  stack_path_ =
+      new LoadPathArgsWidget("Load MoveIt Configuration Package Path",
+                             "Specify the package name or path of an existing MoveIt configuration package to be "
+                             "edited for your robot. Example package name: <i>pr2_moveit_config</i>",
+                             "xacro arguments", this, true);  // directory
+  stack_path_->hide();                                        // user needs to select option before this is shown
+  stack_path_->setArgs("--inorder ");
+  connect(stack_path_, SIGNAL(pathChanged(QString)), this, SLOT(onPackagePathChanged(QString)));
   left_layout->addWidget(stack_path_);
 
   // URDF File Dialog
-  urdf_file_ =
-      new LoadPathWidget("Load a URDF or COLLADA Robot Model",
-                         "Specify the location of an existing Universal Robot Description Format or COLLADA file for "
-                         "your robot. The robot model will be loaded to the parameter server for you.",
-                         this, false, true);  // no directory, load only
-  urdf_file_->hide();                         // user needs to select option before this is shown
+  urdf_file_ = new LoadPathArgsWidget("Load a URDF or COLLADA Robot Model",
+                                      "Specify the location of an existing Universal Robot Description Format or "
+                                      "COLLADA file for "
+                                      "your robot. The robot model will be loaded to the parameter server for you.",
+                                      "xacro arguments", this, false, true);  // no directory, load only
+  urdf_file_->hide();  // user needs to select option before this is shown
+  urdf_file_->setArgs("--inorder ");
+  connect(urdf_file_, SIGNAL(pathChanged(QString)), this, SLOT(onUrdfPathChanged(QString)));
   left_layout->addWidget(urdf_file_);
 
   // Load settings box ---------------------------------------------
@@ -162,7 +169,6 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   progress_bar_->setMinimum(0);
   progress_bar_->hide();
   load_files_layout->addWidget(progress_bar_);
-  // load_files_layout->setContentsMargins( 20, 30, 20, 30 );
 
   btn_load_ = new QPushButton("&Load Files", this);
   btn_load_->setMinimumWidth(180);
@@ -181,9 +187,6 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   //  next_label_->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Preferred );
   next_label_->hide();  // only show once the files have been loaded.
 
-  right_layout->addWidget(right_image_label_);
-  right_layout->setAlignment(right_image_label_, Qt::AlignRight | Qt::AlignTop);
-
   // Final Layout Setup ---------------------------------------------
   // Alignment
   layout->setAlignment(Qt::AlignTop);
@@ -192,7 +195,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
   right_layout->setAlignment(Qt::AlignTop);
 
   // Stretch
-  left_layout->setSpacing(30);
+  left_layout->setSpacing(10);
 
   // Attach Layouts
   hlayout->addLayout(left_layout);
@@ -305,7 +308,67 @@ void StartScreenWidget::loadFilesClick()
   {
     // Hide the logo image so that other screens can resize the rviz thing properly
     right_image_label_->hide();
+    logo_image_label_->hide();
   }
+}
+
+void StartScreenWidget::onPackagePathChanged(const QString& path)
+{
+  if (!loadPackageSettings(false))
+    return;
+  // set xacro args from loaded settings
+  stack_path_->setArgs(QString::fromStdString(config_data_->xacro_args_));
+}
+
+void StartScreenWidget::onUrdfPathChanged(const QString& path)
+{
+  urdf_file_->setArgsEnabled(rdf_loader::RDFLoader::isXacroFile(path.toStdString()));
+}
+
+bool StartScreenWidget::loadPackageSettings(bool show_warnings)
+{
+  // Get the package path
+  std::string package_path_input = stack_path_->getPath();
+  // Check that input is provided
+  if (package_path_input.empty())
+  {
+    if (show_warnings)
+      QMessageBox::warning(this, "Error Loading Files", "Please specify a configuration package path to load.");
+    return false;
+  }
+
+  // check that the folder exists
+  if (!config_data_->setPackagePath(package_path_input))
+  {
+    if (show_warnings)
+      QMessageBox::critical(this, "Error Loading Files", "The specified path is not a directory or is not accessable");
+    return false;
+  }
+
+  std::string setup_assistant_path;
+
+  // Check if the old package is a setup assistant package. If it is not, quit
+  if (!config_data_->getSetupAssistantYAMLPath(setup_assistant_path))
+  {
+    if (show_warnings)
+      QMessageBox::warning(
+          this, "Incorrect Directory/Package",
+          QString("The chosen package location exists but was not created using MoveIt Setup Assistant. "
+                  "If this is a mistake, provide the missing file: ")
+              .append(setup_assistant_path.c_str()));
+    return false;
+  }
+
+  // Get setup assistant data
+  if (!config_data_->inputSetupAssistantYAML(setup_assistant_path))
+  {
+    if (show_warnings)
+      QMessageBox::warning(this, "Setup Assistant File Error",
+                           QString("Unable to correctly parse the setup assistant configuration file: ")
+                               .append(setup_assistant_path.c_str()));
+    return false;
+  }
+  return true;
 }
 
 // ******************************************************************************************
@@ -317,31 +380,8 @@ bool StartScreenWidget::loadExistingFiles()
   progress_bar_->setValue(10);
   QApplication::processEvents();
 
-  // Get the package path
-  if (!createFullPackagePath())
-    return false;  // error occured
-
-  std::string setup_assistant_path;
-
-  // Check if the old package is a setup assistant package. If it is not, quit
-  if (!config_data_->getSetupAssistantYAMLPath(setup_assistant_path))
-  {
-    QMessageBox::warning(
-        this, "Incorrect Directory/Package",
-        QString("The chosen package location exists but was not previously created using this MoveIt Setup Assistant. "
-                "If this is a mistake, replace the missing file: ")
-            .append(setup_assistant_path.c_str()));
+  if (!loadPackageSettings(true))
     return false;
-  }
-
-  // Get setup assistant data
-  if (!config_data_->inputSetupAssistantYAML(setup_assistant_path))
-  {
-    QMessageBox::warning(this, "Setup Assistant File Error",
-                         QString("Unable to correctly parse the setup assistant configuration file: ")
-                             .append(setup_assistant_path.c_str()));
-    return false;
-  }
 
   // Progress Indicator
   progress_bar_->setValue(30);
@@ -351,8 +391,11 @@ bool StartScreenWidget::loadExistingFiles()
   if (!createFullURDFPath())
     return false;  // error occured
 
+  // use xacro args from GUI
+  config_data_->xacro_args_ = stack_path_->getArgs().toStdString();
+
   // Load the URDF
-  if (!loadURDFFile(config_data_->urdf_path_))
+  if (!loadURDFFile(config_data_->urdf_path_, config_data_->xacro_args_))
     return false;  // error occured
 
   // Get the SRDF path using the loaded .setup_assistant data and check it
@@ -443,8 +486,11 @@ bool StartScreenWidget::loadNewFiles()
   progress_bar_->setValue(20);
   QApplication::processEvents();
 
+  // use xacro args from GUI
+  config_data_->xacro_args_ = urdf_file_->getArgs().toStdString();
+
   // Load the URDF to the parameter server and check that it is correct format
-  if (!loadURDFFile(config_data_->urdf_path_))
+  if (!loadURDFFile(config_data_->urdf_path_, config_data_->xacro_args_))
     return false;  // error occurred
 
   // Progress Indicator
@@ -491,19 +537,20 @@ bool StartScreenWidget::loadNewFiles()
 // ******************************************************************************************
 // Load URDF File to Parameter Server
 // ******************************************************************************************
-bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path)
+bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const std::string& xacro_args)
 {
-  const std::vector<std::string> xacro_args;  // TODO: somehow allow arguments to be passed in when parsing xacro URDFs
+  const std::vector<std::string> xacro_args_ = { xacro_args };
 
   std::string urdf_string;
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string, urdf_file_path, xacro_args))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string, urdf_file_path, xacro_args_))
   {
     QMessageBox::warning(this, "Error Loading Files",
                          QString("URDF/COLLADA file not found: ").append(urdf_file_path.c_str()));
     return false;
   }
 
-  if (urdf_string.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_file_path)) {
+  if (urdf_string.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_file_path))
+  {
     QMessageBox::warning(this, "Error Loading Files", "Running xacro failed.\nPlease check console for errors.");
     return false;
   }
@@ -699,13 +746,12 @@ bool StartScreenWidget::createFullURDFPath()
     }
     else
     {
-      QMessageBox::warning(
-          this, "Error Loading Files",
-          QString("Unable to locate the URDF file in package. File: ").append(config_data_->urdf_path_.c_str()));
+      QMessageBox::warning(this, "Error Loading Files",
+                           QString("Unable to locate the URDF file in package. Expected File: \n")
+                               .append(config_data_->urdf_path_.c_str()));
     }
     return false;
   }
-  fs::path urdf_path;
 
   // Check if a package name was provided
   if (config_data_->urdf_pkg_name_.empty())
@@ -729,29 +775,6 @@ bool StartScreenWidget::createFullSRDFPath(const std::string& package_path)
   }
 
   return true;  // success
-}
-
-// ******************************************************************************************
-// Get the full package path for editing an existing package
-// ******************************************************************************************
-bool StartScreenWidget::createFullPackagePath()
-{
-  // Get package path
-  std::string package_path_input = stack_path_->getPath();
-  // check that input is provided
-  if (package_path_input.empty())
-  {
-    QMessageBox::warning(this, "Error Loading Files", "Please specify a configuration package path to load.");
-    return false;
-  }
-
-  // check that the folder exists
-  if (!config_data_->setPackagePath(package_path_input))
-  {
-    QMessageBox::critical(this, "Error Loading Files", "The specified path is not a directory or is not accessable");
-    return false;
-  }
-  return true;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -55,7 +55,7 @@ namespace moveit_setup_assistant
 {
 // Class Prototypes
 class SelectModeWidget;
-class LoadPathWidget;
+class LoadPathArgsWidget;
 
 /**
  * \brief Start screen user interface for MoveIt Configuration Assistant
@@ -80,8 +80,8 @@ public:
   // Qt Components
   // ******************************************************************************************
   SelectModeWidget* select_mode_;
-  LoadPathWidget* stack_path_;
-  LoadPathWidget* urdf_file_;
+  LoadPathArgsWidget* stack_path_;
+  LoadPathArgsWidget* urdf_file_;
   QPushButton* btn_load_;
   QLabel* next_label_;
   QProgressBar* progress_bar_;
@@ -108,6 +108,12 @@ private Q_SLOTS:
   /// Button event for loading user chosen files
   void loadFilesClick();
 
+  /// load package settings
+  void onPackagePathChanged(const QString& path);
+
+  /// enable xacro arguments
+  void onUrdfPathChanged(const QString& path);
+
 Q_SIGNALS:
 
   // ******************************************************************************************
@@ -132,6 +138,9 @@ private:
   // Private Functions
   // ******************************************************************************************
 
+  /// load package settings from .setup_assistant file
+  bool loadPackageSettings(bool show_warnings);
+
   /// Load chosen files for creating new package
   bool loadNewFiles();
 
@@ -139,7 +148,7 @@ private:
   bool loadExistingFiles();
 
   /// Load URDF File to Parameter Server
-  bool loadURDFFile(const std::string& urdf_file_path);
+  bool loadURDFFile(const std::string& urdf_file_path, const std::string& xacro_args);
 
   /// Load SRDF File
   bool loadSRDFFile(const std::string& srdf_file_path);
@@ -155,9 +164,6 @@ private:
 
   /// Make the full SRDF path using the loaded .setup_assistant data
   bool createFullSRDFPath(const std::string& package_path);
-
-  /// Get the full package path for editing an existing package
-  bool createFullPackagePath();
 };
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -56,7 +56,6 @@ namespace moveit_setup_assistant
 // Class Prototypes
 class SelectModeWidget;
 class LoadPathWidget;
-// class LoadURDFWidget;
 
 /**
  * \brief Start screen user interface for MoveIt Configuration Assistant
@@ -83,7 +82,6 @@ public:
   SelectModeWidget* select_mode_;
   LoadPathWidget* stack_path_;
   LoadPathWidget* urdf_file_;
-  // LoadPathWidget *srdf_file_;
   QPushButton* btn_load_;
   QLabel* next_label_;
   QProgressBar* progress_bar_;


### PR DESCRIPTION
I stumbled about a robot urdf that required xacro cmdline arguments. This wasn't supported in MSA yet (although there was a TODO as reminder). I added support for specifying xacro arguments, both for the `urdf file` and `package` gui. The xacro args are remembered in `.setup_assistant` file and added to `planning_context.launch`.
Removed hard-coded `--inorder` option, but set `inorder` as default for new projects.