### PR TITLE
Adding absolute jump threshold in parallel with existing jump threshold factor for computeCartesianPath

### DIFF
--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   include_directories(${moveit_resources_INCLUDE_DIRS})
 
-  catkin_add_gtest(test_robot_state test/test_kinematic.cpp)
+  catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
   target_link_libraries(test_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1043,6 +1043,7 @@ as the new values that correspond to the group */
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn());
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
+
       The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
      of a robot
       link (\e link). The direction is assumed to be either in a global reference frame or in the local reference frame
@@ -1082,6 +1083,7 @@ as the new values that correspond to the group */
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
+
       The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
      robot
       link (\e link). The target frame is assumed to be either in a global reference frame or in the local reference
@@ -1120,6 +1122,7 @@ as the new values that correspond to the group */
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
+
       The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
      of a robot
       link (\e link). The waypoints are transforms given either in a global reference frame or in the local reference
@@ -1230,19 +1233,6 @@ as the new values that correspond to the group */
                               double revolute_jump_threshold, double prismatic_jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
-
-  /**
-   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
-   * computed. If two adjacent trajectory points have distance > \e prismatic_jump_threshold or revolute_jump_threshold,
-   * the trajectory is cut off at this point.
-   * @param group The joint model group of the robot state.
-   * @param traj The trajectory that should be tested.
-   * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .
-   * @param revolute_jump_threshold The threshold to determine if a joint space jump has occurred .
-   * @return The fraction of the trajectory that passed.
-   */
-  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                            double revolute_jump_threshold, double prismatic_jump_threshold);
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for
@@ -1853,6 +1843,19 @@ private:
    * @return The fraction of the trajectory that passed.
    */
   double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
+
+  /**
+   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
+   * computed. If two adjacent trajectory points have distance > \e prismatic_jump_threshold or revolute_jump_threshold,
+   * the trajectory is cut off at this point.
+   * @param group The joint model group of the robot state.
+   * @param traj The trajectory that should be tested.
+   * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @param revolute_jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @return The fraction of the trajectory that passed.
+   */
+  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                            double revolute_jump_threshold, double prismatic_jump_threshold);
 
   /** \brief This function is only called in debug mode */
   bool checkJointTransforms(const JointModel* joint) const;

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1089,12 +1089,6 @@ as the new values that correspond to the group */
 
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
-                              double max_step, double revolute_jump_threshold, double prismatic_jump_threshold,
-                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
-
-  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
-                              const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                               double max_step, double jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
@@ -1133,12 +1127,6 @@ as the new values that correspond to the group */
 
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
-                              double revolute_jump_threshold, double prismatic_jump_threshold,
-                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
-
-  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
-                              const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
                               double jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
@@ -1171,12 +1159,6 @@ as the new values that correspond to the group */
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
                               const JumpThreshold& jump_threshold,
-                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
-
-  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
-                              const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
-                              double revolute_jump_threshold, double prismatic_jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1159,7 +1159,23 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
 
-      The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+      The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
+     of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local
+     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
+     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
+     computation of the path stops and the value returned corresponds to the distance that was computed and for which
+     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
+     to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if
+     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
+     corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e
+     prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are
+     computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values
+     is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these
+     limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
+     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                               double max_step, double revolute_jump_threshold, double prismatic_jump_threshold,
@@ -1168,7 +1184,23 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
-       The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+       The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
+     robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local
+     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
+     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
+     computation of the path stops and the value returned corresponds to the distance that was computed and for which
+     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
+     to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if
+     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
+     corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e
+     prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are
+     computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values
+     is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these
+     limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
+     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
                               double revolute_jump_threshold, double prismatic_jump_threshold,
@@ -1177,7 +1209,22 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
-      The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+      The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
+     of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local
+     reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line,
+     following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector
+     \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is
+     specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK().
+     In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that
+     was computed and for which corresponding states were added to the path.  At the end of the function call, the state
+     of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is
+     sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the
+     Cartesian distance between the corresponding points is as expected. To account for this, the \e
+     revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding
+     to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the
+     sequence of joint values is computed, the absolute difference in joint space between sequential points is computed
+     and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can
+     be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
                               double revolute_jump_threshold, double prismatic_jump_threshold,
@@ -1186,16 +1233,16 @@ as the new values that correspond to the group */
 
   /**
    * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
-   * computed. If two adjacent trajectory points have distance > \e prismatic_jump_threshold or revolute_jump_threshold, the trajectory is cut of
-   * at this point.
+   * computed. If two adjacent trajectory points have distance > \e prismatic_jump_threshold or revolute_jump_threshold,
+   * the trajectory is cut off at this point.
    * @param group The joint model group of the robot state.
    * @param traj The trajectory that should be tested.
    * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .
    * @param revolute_jump_threshold The threshold to determine if a joint space jump has occurred .
    * @return The fraction of the trajectory that passed.
    */
-  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double revolute_jump_threshold, double prismatic_jump_threshold);
-
+  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                            double revolute_jump_threshold, double prismatic_jump_threshold);
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for
@@ -1806,7 +1853,6 @@ private:
    * @return The fraction of the trajectory that passed.
    */
   double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
-
 
   /** \brief This function is only called in debug mode */
   bool checkJointTransforms(const JointModel* joint) const;

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1200,7 +1200,7 @@ as the new values that correspond to the group */
    * @return The fraction of the trajectory that passed.
    */
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                            const JumpThreshold& jump_threshold);
+                                   const JumpThreshold& jump_threshold);
 
   /**
    * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
@@ -1211,7 +1211,8 @@ as the new values that correspond to the group */
    * @param jump_threshold The threshold to determine if a joint space jump has occurred .
    * @return The fraction of the trajectory that passed.
    */
-  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
+  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                   double jump_threshold);
 
   /**
    * \brief Tests for absolute joint space jumps of a trajectory. The absolute difference in joint space between
@@ -1224,7 +1225,7 @@ as the new values that correspond to the group */
    * @return The fraction of the trajectory that passed.
    */
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                            double revolute_jump_threshold, double prismatic_jump_threshold);
+                                   double revolute_jump_threshold, double prismatic_jump_threshold);
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -65,9 +65,12 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
 
 /** \brief Struct for containing jump_threshold.
 
-    For the purposes of maintaining API, we support both \e jump_threshold_factor which provides a scaling factor for detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute thresholds for detecting joint space jumps. */
+    For the purposes of maintaining API, we support both \e jump_threshold_factor which provides a scaling factor for
+   detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute
+   thresholds for detecting joint space jumps. */
 
-struct jump_threshold_t {
+struct jump_threshold_t
+{
   double jump_threshold_factor;
   double prismatic_jump_threshold;
   double revolute_jump_threshold;
@@ -1054,7 +1057,30 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
 
-     The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose. During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump, distances in joint space between consecutive points are computed. Once the sequence of joint values is computed, the average distance between consecutive points (in joint space) is also computed. It is then verified that none of the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump. Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+     The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
+     of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local
+     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
+     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
+     computation of the path stops and the value returned corresponds to the distance that was computed and for which
+     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
+     to the last attempted Cartesian pose. During the computation of the trajectory, it is sometimes preferred if
+     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
+     corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e
+     jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e
+     revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for
+     absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump,
+     distances in joint space between consecutive points are computed. Once the sequence of joint values is computed,
+     the average distance between consecutive points (in joint space) is also computed. It is then verified that none of
+     the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point
+     in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e
+     jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump.
+     Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the
+     absolute difference in joint space between sequential points is computed and if it exceededs these limits the
+     returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
+     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                               double max_step, const jump_threshold_t& jump_threshold,
@@ -1075,7 +1101,30 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
-     The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump, distances in joint space between consecutive points are computed. Once the sequence of joint values is computed, the average distance between consecutive points (in joint space) is also computed. It is then verified that none of the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump. Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+     The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
+     robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local
+     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
+     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
+     computation of the path stops and the value returned corresponds to the distance that was computed and for which
+     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
+     to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if
+     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
+     corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e
+     jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e
+     revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for
+     absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump,
+     distances in joint space between consecutive points are computed. Once the sequence of joint values is computed,
+     the average distance between consecutive points (in joint space) is also computed. It is then verified that none of
+     the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point
+     in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e
+     jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump.
+     Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the
+     absolute difference in joint space between sequential points is computed and if it exceededs these limits the
+     returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
+     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
                               const jump_threshold_t& jump_threshold,
@@ -1094,10 +1143,31 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
-
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
-     The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump, distances in joint space between consecutive points are computed. Once the sequence of joint values is computed, the average distance between consecutive points (in joint space) is also computed. It is then verified that none of the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump. Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+     The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
+     of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local
+     reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line,
+     following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector
+     \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is
+     specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK().
+     In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that
+     was computed and for which corresponding states were added to the path.  At the end of the function call, the state
+     of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is
+     sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the
+     Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold
+     parameter is provided. \e jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold
+     and \e revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we
+     test for absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative
+     jump, distances in joint space between consecutive points are computed. Once the sequence of joint values is
+     computed, the average distance between consecutive points (in joint space) is also computed. It is then verified
+     that none of the computed distances is above the average distance by a factor larger than \e jump_threshold_factor.
+     If a point in joint is found such that it is further away than the previous one by more than
+     average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is truncated
+     up to just before the jump. Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For
+     absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it
+     exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be
+     disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
                               const jump_threshold_t& jump_threshold,
@@ -1715,15 +1785,21 @@ private:
                       std::vector<std::string>& missing_variables) const;
   void getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0, bool last) const;
 
-
   /**
-   * \brief Tests joint space jumps of a trajectory. If \e jump_threshold.jump_threshold_factor is set, we check for relative jumps and if \e jump_threshold.prismatic_jump_threshold or \e jump_threshold.revolute_jump_threshold are greater than 0 then we check for absolute joint space jumps. For relative jumps the average distance between adjacent trajectory points is computed and if two adjacent trajectory points have distance > \e jump_threshold_factor * average, the trajectory is cut of at this point. For absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump.
+   * \brief Tests joint space jumps of a trajectory. If \e jump_threshold.jump_threshold_factor is set, we check for
+   * relative jumps and if \e jump_threshold.prismatic_jump_threshold or \e jump_threshold.revolute_jump_threshold are
+   * greater than 0 then we check for absolute joint space jumps. For relative jumps the average distance between
+   * adjacent trajectory points is computed and if two adjacent trajectory points have distance > \e
+   * jump_threshold_factor * average, the trajectory is cut of at this point. For absolute jump thresholds, the absolute
+   * difference in joint space between sequential points is computed and if it exceededs these limits the returned path
+   * is truncated up to just before the jump.
    * @param group The joint model group of the robot state.
    * @param traj The trajectory that should be tested.
    * @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
    * @return The fraction of the trajectory that passed.
    */
-  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const jump_threshold_t& jump_threshold);
+  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                            const jump_threshold_t& jump_threshold);
 
   /**
    * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
@@ -1737,7 +1813,9 @@ private:
   double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
 
   /**
-   * \brief Tests for absolute joint space jumps of a trajectory. The absolute difference in joint space between sequential points for each active joint is computed and if it exceededs \e prismatic_jump_threshold for prismatic joints or revolute_jump_threshold for revolute joints, the returned path is truncated up to just before the jump.
+   * \brief Tests for absolute joint space jumps of a trajectory. The absolute difference in joint space between
+   * sequential points for each active joint is computed and if it exceededs \e prismatic_jump_threshold for prismatic
+   * joints or revolute_jump_threshold for revolute joints, the returned path is truncated up to just before the jump.
    * @param group The joint model group of the robot state.
    * @param traj The trajectory that should be tested.
    * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1043,7 +1043,6 @@ as the new values that correspond to the group */
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn());
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
-
       The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
      of a robot
       link (\e link). The direction is assumed to be either in a global reference frame or in the local reference frame
@@ -1083,7 +1082,6 @@ as the new values that correspond to the group */
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
-
       The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
      robot
       link (\e link). The target frame is assumed to be either in a global reference frame or in the local reference
@@ -1122,7 +1120,6 @@ as the new values that correspond to the group */
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
-
       The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
      of a robot
       link (\e link). The waypoints are transforms given either in a global reference frame or in the local reference
@@ -1159,6 +1156,46 @@ as the new values that correspond to the group */
                               double jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
+  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
+
+      The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+                              const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
+                              double max_step, double revolute_jump_threshold, double prismatic_jump_threshold,
+                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
+  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
+
+       The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+                              const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
+                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
+  /** \brief Compute the sequence of joint values that perform a general Cartesian path.
+
+      The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line, following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that was computed and for which corresponding states were added to the path.  At the end of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the corresponding points is as expected. To account for this, the \e revolute_jump_threshold and \e prismatic_jump_threshold parameters are provided. As the joint values corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also computed. Once the sequence of joint values is computed, the absolute difference in joint space between sequential points is computed and if it exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+                              const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
+                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
+  /**
+   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
+   * computed. If two adjacent trajectory points have distance > \e prismatic_jump_threshold or revolute_jump_threshold, the trajectory is cut of
+   * at this point.
+   * @param group The joint model group of the robot state.
+   * @param traj The trajectory that should be tested.
+   * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @param revolute_jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @return The fraction of the trajectory that passed.
+   */
+  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double revolute_jump_threshold, double prismatic_jump_threshold);
+
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for
@@ -1769,6 +1806,7 @@ private:
    * @return The fraction of the trajectory that passed.
    */
   double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
+
 
   /** \brief This function is only called in debug mode */
   bool checkJointTransforms(const JointModel* joint) const;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2163,27 +2163,31 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
   double percentage = 1.0;
   bool still_valid = true;
   const std::vector<const JointModel*>& joints = group->getActiveJointModels();
-  for (std::size_t traj_ix=0; traj_ix < traj.size() - 1; ++traj_ix)
+  for (std::size_t traj_ix = 0; traj_ix < traj.size() - 1; ++traj_ix)
   {
-    for (auto &joint : joints)
+    for (auto& joint : joints)
     {
-      if(!joint->getType() == JointModel::PRISMATIC && !joint->getType() == JointModel::REVOLUTE)
+      if (!joint->getType() == JointModel::PRISMATIC && !joint->getType() == JointModel::REVOLUTE)
       {
-        CONSOLE_BRIDGE_logError("Unsupported joint type %zu in JointModelGroup %s testJointSpaceJump can only support prismatic and revolute joints.", joint->getType(), group->getName().c_str());
+        CONSOLE_BRIDGE_logError("Unsupported joint type %zu in JointModelGroup %s testJointSpaceJump can only support "
+                                "prismatic and revolute joints.",
+                                joint->getType(), group->getName().c_str());
         throw Exception("Unsupported joint type");
       }
 
       double distance = traj[traj_ix]->distance(*traj[traj_ix + 1], joint);
-      if (joint->getType() == JointModel::PRISMATIC && prismatic_jump_threshold > 0.0 && distance > prismatic_jump_threshold)
+      if (joint->getType() == JointModel::PRISMATIC && prismatic_jump_threshold > 0.0 &&
+          distance > prismatic_jump_threshold)
       {
-        CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint-space distance", distance,
-                                prismatic_jump_threshold);
+        CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint-space distance",
+                                distance, prismatic_jump_threshold);
         still_valid = false;
       }
-      else if (joint->getType() == JointModel::REVOLUTE && revolute_jump_threshold > 0.0 && distance > revolute_jump_threshold)
+      else if (joint->getType() == JointModel::REVOLUTE && revolute_jump_threshold > 0.0 &&
+               distance > revolute_jump_threshold)
       {
-        CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint-space distance", distance,
-                                revolute_jump_threshold);
+        CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint-space distance",
+                                distance, revolute_jump_threshold);
         still_valid = false;
       }
     }
@@ -2196,7 +2200,6 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
   }
   return percentage;
 }
-
 
 void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
 {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2134,7 +2134,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
           still_valid = false;
         }
       }
-      else
+      else if (joints[i]->getType() != JointModel::FIXED)
       {
         CONSOLE_BRIDGE_logError("Unsupported joint type in JointModelGroup %s at index %zu, As of now "
                                 "testJointSpaceJump only supports prismatic and revolute joints.",

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1927,21 +1927,6 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
 }
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Vector3d& direction,
-                                                      bool global_reference_frame, double distance, double max_step,
-                                                      double revolute_jump_threshold, double prismatic_jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
-{
-  JumpThreshold jt;
-  jt.jump_threshold_factor = 0.0;
-  jt.prismatic_jump_threshold = prismatic_jump_threshold;
-  jt.revolute_jump_threshold = revolute_jump_threshold;
-  return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step, jt,
-                              validCallback, options);
-}
-
-double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const Eigen::Affine3d& target,
                                                       bool global_reference_frame, double max_step,
                                                       const JumpThreshold& jump_threshold,
@@ -2027,20 +2012,6 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
 }
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Affine3d& target,
-                                                      bool global_reference_frame, double max_step,
-                                                      double revolute_jump_threshold, double prismatic_jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
-{
-  JumpThreshold jt;
-  jt.jump_threshold_factor = 0.0;
-  jt.prismatic_jump_threshold = prismatic_jump_threshold;
-  jt.revolute_jump_threshold = revolute_jump_threshold;
-  return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step, jt, validCallback, options);
-}
-
-double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
                                                       bool global_reference_frame, double max_step,
                                                       const JumpThreshold& jump_threshold,
@@ -2094,21 +2065,6 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   jt.jump_threshold_factor = jump_threshold;
   jt.prismatic_jump_threshold = 0.0;
   jt.revolute_jump_threshold = 0.0;
-  return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback,
-                              options);
-}
-
-double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
-                                                      bool global_reference_frame, double max_step,
-                                                      double revolute_jump_threshold, double prismatic_jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
-{
-  JumpThreshold jt;
-  jt.jump_threshold_factor = 0.0;
-  jt.prismatic_jump_threshold = prismatic_jump_threshold;
-  jt.revolute_jump_threshold = revolute_jump_threshold;
   return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback,
                               options);
 }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2048,11 +2048,9 @@ double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<
   if (jump_threshold.jump_threshold_factor > 0.0)
     percentage *= testJointSpaceJump(group, traj, jump_threshold.jump_threshold_factor);
 
-  else if (jump_threshold.prismatic_jump_threshold > 0.0 || jump_threshold.revolute_jump_threshold > 0.0)
+  if (jump_threshold.prismatic_jump_threshold > 0.0 || jump_threshold.revolute_jump_threshold > 0.0)
     percentage *= testJointSpaceJump(group, traj, jump_threshold.revolute_jump_threshold,
                                      jump_threshold.prismatic_jump_threshold);
-  else
-    throw Exception("testJointSpaceJump called without all jump threshold values <= 0");
 
   return percentage;
 }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2125,7 +2125,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
         // This is a revolute joint
         if (revolute_jump_threshold > 0.0 && dist > revolute_jump_threshold)
         {
-          CONSOLE_BRIDGE_logError("Truncating Cartesian path due to detected jump of %.3f/%.3f in joint-space distance",
+          CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.3f/%.3f in joint-space distance",
                                   dist, revolute_jump_threshold);
           still_valid = false;
         }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2104,21 +2104,18 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
 {
   double percentage = 1.0;
   bool still_valid = true;
-  const std::vector<const JointModel*>& jm = group->getActiveJointModels();
+  const std::vector<const JointModel*>& joints = group->getActiveJointModels();
   for (std::size_t i; i < traj.size() - 1 && still_valid; ++i)
   {
-    for (std::size_t j = 0; j < jm.size() && still_valid; ++j)
+    for (std::size_t j = 0; j < joints.size() && still_valid; ++j)
     {
-      const int idx = jm[j]->getFirstVariableIndex();
-      double dist =
-          jm[j]->getDistanceFactor() * jm[j]->distance(traj[i]->position_ + idx, traj[i + 1]->position_ + idx);
+      const int idx = joints[j]->getFirstVariableIndex();
+      double dist = joints[j]->distance(traj[i]->position_ + idx, traj[i + 1]->position_ + idx);
 
-      const PrismaticJointModel* pjm = dynamic_cast<const PrismaticJointModel*>(jm[j]);
-      const RevoluteJointModel* rjm = dynamic_cast<const RevoluteJointModel*>(jm[j]);
-      if (pjm)
+      if (joints[i]->getType() == JointModel::PRISMATIC)
       {
         // This is a prismatic joint
-        if (dist > prismatic_jump_threshold && prismatic_jump_threshold > 0.0)
+        if (prismatic_jump_threshold > 0.0 && dist > prismatic_jump_threshold)
         {
           CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
           percentage = (double)i / (double)(traj.size() - 1);
@@ -2126,10 +2123,10 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
           still_valid = false;
         }
       }
-      else if (rjm)
+      else if (joints[i]->getType() == JointModel::REVOLUTE)
       {
         // This is a revolute joint
-        if (dist > revolute_jump_threshold && revolute_jump_threshold > 0.0)
+        if (revolute_jump_threshold > 0.0 && dist > revolute_jump_threshold)
         {
           CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
           percentage = (double)i / (double)(traj.size() - 1);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1877,7 +1877,6 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
   return false;
 }
 
-
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const Eigen::Vector3d& direction,
                                                       bool global_reference_frame, double distance, double max_step,
@@ -1911,7 +1910,8 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   jt.jump_threshold_factor = jump_threshold;
   jt.prismatic_jump_threshold = 0.0;
   jt.revolute_jump_threshold = 0.0;
-  return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step, jt, validCallback, options);
+  return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step, jt,
+                              validCallback, options);
 }
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
@@ -1925,9 +1925,9 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   jt.jump_threshold_factor = 0.0;
   jt.prismatic_jump_threshold = prismatic_jump_threshold;
   jt.revolute_jump_threshold = revolute_jump_threshold;
-  return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step, jt, validCallback, options);
+  return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step, jt,
+                              validCallback, options);
 }
-
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const Eigen::Affine3d& target,
@@ -1947,7 +1947,9 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   // the target can be in the local reference frame (in which case we rotate it)
   Eigen::Affine3d rotated_target = global_reference_frame ? target : start_pose * target;
 
-  bool test_joint_space_jump = jump_threshold.prismatic_jump_threshold > 0.0 || jump_threshold.revolute_jump_threshold > 0.0 ||jump_threshold.jump_threshold_factor > 0.0;
+  bool test_joint_space_jump = jump_threshold.prismatic_jump_threshold > 0.0 ||
+                               jump_threshold.revolute_jump_threshold > 0.0 ||
+                               jump_threshold.jump_threshold_factor > 0.0;
 
   // decide how many steps we will need for this trajectory
   double distance = (rotated_target.translation() - start_pose.translation()).norm();
@@ -2019,11 +2021,11 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
     percentage *= testJointSpaceJump(group, traj, jump_threshold.jump_threshold_factor);
 
   if (jump_threshold.prismatic_jump_threshold > 0.0 || jump_threshold.revolute_jump_threshold > 0.0)
-    percentage *= testJointSpaceJump(group, traj, jump_threshold.revolute_jump_threshold, jump_threshold.prismatic_jump_threshold);
+    percentage *= testJointSpaceJump(group, traj, jump_threshold.revolute_jump_threshold,
+                                     jump_threshold.prismatic_jump_threshold);
 
   return percentage;
 }
-
 
 double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                     double jump_threshold)
@@ -2079,8 +2081,8 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
         // This is a revolute joint
         if (revolute_jump_threshold > 0.0 && dist > revolute_jump_threshold)
         {
-          CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance",
-                                  dist, revolute_jump_threshold);
+          CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance", dist,
+                                  revolute_jump_threshold);
           still_valid = false;
         }
       }
@@ -2135,7 +2137,8 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
     }
   }
 
-  if (jump_threshold.jump_threshold_factor > 0.0 || jump_threshold.prismatic_jump_threshold > 0.0 || jump_threshold.revolute_jump_threshold > 0.0)
+  if (jump_threshold.jump_threshold_factor > 0.0 || jump_threshold.prismatic_jump_threshold > 0.0 ||
+      jump_threshold.revolute_jump_threshold > 0.0)
   {
     percentage_solved *= testJointSpaceJump(group, traj, jump_threshold);
   }
@@ -2154,9 +2157,9 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   jt.jump_threshold_factor = jump_threshold;
   jt.prismatic_jump_threshold = 0.0;
   jt.revolute_jump_threshold = 0.0;
-  return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback, options);
+  return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback,
+                              options);
 }
-
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
@@ -2169,7 +2172,8 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   jt.jump_threshold_factor = 0.0;
   jt.prismatic_jump_threshold = prismatic_jump_threshold;
   jt.revolute_jump_threshold = revolute_jump_threshold;
-  return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback, options);
+  return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback,
+                              options);
 }
 
 void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2041,8 +2041,8 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   target_pose.translation() += rotated_direction * distance;
 
   // call computeCartesianPath for the computed target pose in the global reference frame
-  return (distance *
-          computeCartesianPath(group, traj, link, target_pose, true, max_step, revolute_jump_threshold, prismatic_jump_threshold, validCallback, options));
+  return (distance * computeCartesianPath(group, traj, link, target_pose, true, max_step, revolute_jump_threshold,
+                                          prismatic_jump_threshold, validCallback, options));
 }
 
 double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
@@ -2110,7 +2110,8 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
     for (std::size_t j = 0; j < jm.size() && still_valid; ++j)
     {
       const int idx = jm[j]->getFirstVariableIndex();
-      double dist = jm[j]->getDistanceFactor() * jm[j]->distance(traj[i]->position_ + idx, traj[i + 1]->position_ + idx);
+      double dist =
+          jm[j]->getDistanceFactor() * jm[j]->distance(traj[i]->position_ + idx, traj[i + 1]->position_ + idx);
 
       const PrismaticJointModel* pjm = dynamic_cast<const PrismaticJointModel*>(jm[j]);
       const RevoluteJointModel* rjm = dynamic_cast<const RevoluteJointModel*>(jm[j]);
@@ -2119,7 +2120,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
         // This is a prismatic joint
         if (dist > prismatic_jump_threshold && prismatic_jump_threshold > 0.0)
         {
-          logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+          CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
           percentage = (double)i / (double)(traj.size() - 1);
           traj.resize(i);
           still_valid = false;
@@ -2130,7 +2131,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
         // This is a revolute joint
         if (dist > revolute_jump_threshold && revolute_jump_threshold > 0.0)
         {
-          logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+          CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
           percentage = (double)i / (double)(traj.size() - 1);
           traj.resize(i);
           still_valid = false;
@@ -2138,7 +2139,9 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
       }
       else
       {
-        logError("Unsupported joint type in JointModelGroup %s at index %zu, As of now testJointSpaceJump only supports prismatic and revolute joints.", group->getName(), j);
+        CONSOLE_BRIDGE_logError("Unsupported joint type in JointModelGroup %s at index %zu, As of now "
+                                "testJointSpaceJump only supports prismatic and revolute joints.",
+                                group->getName(), j);
       }
     }
   }
@@ -2158,8 +2161,9 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
     // Don't test joint space jumps for every waypoint, test them later on the whole trajectory.
     static const double no_joint_space_jump_test = 0.0;
     std::vector<RobotStatePtr> waypoint_traj;
-    double wp_percentage_solved = computeCartesianPath(group, waypoint_traj, link, waypoints[i], global_reference_frame,
-                                                       max_step, no_joint_space_jump_test, no_joint_space_jump_test, validCallback, options);
+    double wp_percentage_solved =
+        computeCartesianPath(group, waypoint_traj, link, waypoints[i], global_reference_frame, max_step,
+                             no_joint_space_jump_test, no_joint_space_jump_test, validCallback, options);
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
       percentage_solved = (double)(i + 1) / (double)waypoints.size();

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1865,11 +1865,11 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Vector3d& direction,
-                                                      bool global_reference_frame, double distance, double max_step,
-                                                      const JumpThreshold& jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const Eigen::Vector3d& direction,
+                                        bool global_reference_frame, double distance, double max_step,
+                                        const JumpThreshold& jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   // this is the Cartesian pose we start from, and have to move in the direction indicated
   const Eigen::Affine3d& start_pose = getGlobalLinkTransform(link);
@@ -1887,11 +1887,10 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Vector3d& direction,
-                                                      bool global_reference_frame, double distance, double max_step,
-                                                      double jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const Eigen::Vector3d& direction,
+                                        bool global_reference_frame, double distance, double max_step,
+                                        double jump_threshold, const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   JumpThreshold jt;
   jt.jump_threshold_factor = jump_threshold;
@@ -1902,11 +1901,11 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Affine3d& target,
-                                                      bool global_reference_frame, double max_step,
-                                                      const JumpThreshold& jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const Eigen::Affine3d& target,
+                                        bool global_reference_frame, double max_step,
+                                        const JumpThreshold& jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   const std::vector<const JointModel*>& cjnt = group->getContinuousJointModels();
   // make sure that continuous joints wrap
@@ -1973,11 +1972,10 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Affine3d& target,
-                                                      bool global_reference_frame, double max_step,
-                                                      double jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const Eigen::Affine3d& target,
+                                        bool global_reference_frame, double max_step, double jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   JumpThreshold jt;
   jt.jump_threshold_factor = jump_threshold;
@@ -1987,11 +1985,11 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
-                                                      bool global_reference_frame, double max_step,
-                                                      const JumpThreshold& jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
+                                        bool global_reference_frame, double max_step,
+                                        const JumpThreshold& jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   double percentage_solved = 0.0;
   for (std::size_t i = 0; i < waypoints.size(); ++i)
@@ -2030,11 +2028,10 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
-                                                      bool global_reference_frame, double max_step,
-                                                      double jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
+                                        bool global_reference_frame, double max_step, double jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   JumpThreshold jt;
   jt.jump_threshold_factor = jump_threshold;
@@ -2045,7 +2042,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                    const JumpThreshold& jump_threshold)
+                                      const JumpThreshold& jump_threshold)
 {
   double percentage = 1.0;
   if (jump_threshold.jump_threshold_factor > 0.0)
@@ -2061,7 +2058,7 @@ double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<
 }
 
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                    double jump_threshold)
+                                      double jump_threshold)
 {
   std::vector<double> dist_vector;
   dist_vector.reserve(traj.size() - 1);
@@ -2089,7 +2086,7 @@ double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<
 }
 
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                    double revolute_jump_threshold, double prismatic_jump_threshold)
+                                      double revolute_jump_threshold, double prismatic_jump_threshold)
 {
   double percentage = 1.0;
   bool still_valid = true;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2023,6 +2023,170 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   return percentage_solved;
 }
 
+double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                                      const LinkModel* link, const Eigen::Vector3d& direction,
+                                                      bool global_reference_frame, double distance, double max_step,
+                                                      double revolute_jump_threshold, double prismatic_jump_threshold,
+                                                      const GroupStateValidityCallbackFn& validCallback,
+                                                      const kinematics::KinematicsQueryOptions& options)
+{
+  // this is the Cartesian pose we start from, and have to move in the direction indicated
+  const Eigen::Affine3d& start_pose = getGlobalLinkTransform(link);
+
+  // the direction can be in the local reference frame (in which case we rotate it)
+  const Eigen::Vector3d rotated_direction = global_reference_frame ? direction : start_pose.rotation() * direction;
+
+  // The target pose is built by applying a translation to the start pose for the desired direction and distance
+  Eigen::Affine3d target_pose = start_pose;
+  target_pose.translation() += rotated_direction * distance;
+
+  // call computeCartesianPath for the computed target pose in the global reference frame
+  return (distance *
+          computeCartesianPath(group, traj, link, target_pose, true, max_step, revolute_jump_threshold, prismatic_jump_threshold, validCallback, options));
+}
+
+double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                                      const LinkModel* link, const Eigen::Affine3d& target,
+                                                      bool global_reference_frame, double max_step,
+                                                      double revolute_jump_threshold, double prismatic_jump_threshold,
+                                                      const GroupStateValidityCallbackFn& validCallback,
+                                                      const kinematics::KinematicsQueryOptions& options)
+{
+  const std::vector<const JointModel*>& cjnt = group->getContinuousJointModels();
+  // make sure that continuous joints wrap
+  for (std::size_t i = 0; i < cjnt.size(); ++i)
+    enforceBounds(cjnt[i]);
+
+  // this is the Cartesian pose we start from, and we move in the direction indicated
+  Eigen::Affine3d start_pose = getGlobalLinkTransform(link);
+
+  // the target can be in the local reference frame (in which case we rotate it)
+  Eigen::Affine3d rotated_target = global_reference_frame ? target : start_pose * target;
+
+  bool test_joint_space_jump = revolute_jump_threshold > 0.0 || prismatic_jump_threshold > 0.0;
+
+  // decide how many steps we will need for this trajectory
+  double distance = (rotated_target.translation() - start_pose.translation()).norm();
+  unsigned int steps = (test_joint_space_jump ? 5 : 1) + (unsigned int)floor(distance / max_step);
+
+  traj.clear();
+  traj.push_back(RobotStatePtr(new RobotState(*this)));
+
+  double last_valid_percentage = 0.0;
+  Eigen::Quaterniond start_quaternion(start_pose.rotation());
+  Eigen::Quaterniond target_quaternion(rotated_target.rotation());
+  for (unsigned int i = 1; i <= steps; ++i)
+  {
+    double percentage = (double)i / (double)steps;
+
+    Eigen::Affine3d pose(start_quaternion.slerp(percentage, target_quaternion));
+    pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
+
+    if (setFromIK(group, pose, link->getName(), 1, 0.0, validCallback, options))
+    {
+      traj.push_back(RobotStatePtr(new RobotState(*this)));
+    }
+    else
+      break;
+    last_valid_percentage = percentage;
+  }
+
+  if (test_joint_space_jump)
+  {
+    last_valid_percentage *= testJointSpaceJump(group, traj, revolute_jump_threshold, prismatic_jump_threshold);
+  }
+
+  return last_valid_percentage;
+}
+
+double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                                    double revolute_jump_threshold, double prismatic_jump_threshold)
+{
+  double percentage = 1.0;
+  bool still_valid = true;
+  const std::vector<const JointModel*>& jm = group->getActiveJointModels();
+  for (std::size_t i; i < traj.size() - 1 && still_valid; ++i)
+  {
+    for (std::size_t j = 0; j < jm.size() && still_valid; ++j)
+    {
+      const int idx = jm[j]->getFirstVariableIndex();
+      double dist = jm[j]->getDistanceFactor() * jm[j]->distance(traj[i]->position_ + idx, traj[i + 1]->position_ + idx);
+
+      const PrismaticJointModel* pjm = dynamic_cast<const PrismaticJointModel*>(jm[j]);
+      const RevoluteJointModel* rjm = dynamic_cast<const RevoluteJointModel*>(jm[j]);
+      if (pjm)
+      {
+        // This is a prismatic joint
+        if (dist > prismatic_jump_threshold && prismatic_jump_threshold > 0.0)
+        {
+          logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+          percentage = (double)i / (double)(traj.size() - 1);
+          traj.resize(i);
+          still_valid = false;
+        }
+      }
+      else if (rjm)
+      {
+        // This is a revolute joint
+        if (dist > revolute_jump_threshold && revolute_jump_threshold > 0.0)
+        {
+          logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+          percentage = (double)i / (double)(traj.size() - 1);
+          traj.resize(i);
+          still_valid = false;
+        }
+      }
+      else
+      {
+        logError("Unsupported joint type in JointModelGroup %s at index %zu, As of now testJointSpaceJump only supports prismatic and revolute joints.", group->getName(), j);
+      }
+    }
+  }
+  return percentage;
+}
+
+double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                                      const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
+                                                      bool global_reference_frame, double max_step,
+                                                      double revolute_jump_threshold, double prismatic_jump_threshold,
+                                                      const GroupStateValidityCallbackFn& validCallback,
+                                                      const kinematics::KinematicsQueryOptions& options)
+{
+  double percentage_solved = 0.0;
+  for (std::size_t i = 0; i < waypoints.size(); ++i)
+  {
+    // Don't test joint space jumps for every waypoint, test them later on the whole trajectory.
+    static const double no_joint_space_jump_test = 0.0;
+    std::vector<RobotStatePtr> waypoint_traj;
+    double wp_percentage_solved = computeCartesianPath(group, waypoint_traj, link, waypoints[i], global_reference_frame,
+                                                       max_step, no_joint_space_jump_test, no_joint_space_jump_test, validCallback, options);
+    if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
+    {
+      percentage_solved = (double)(i + 1) / (double)waypoints.size();
+      std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
+      if (i > 0 && !waypoint_traj.empty())
+        std::advance(start, 1);
+      traj.insert(traj.end(), start, waypoint_traj.end());
+    }
+    else
+    {
+      percentage_solved += wp_percentage_solved / (double)waypoints.size();
+      std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
+      if (i > 0 && !waypoint_traj.empty())
+        std::advance(start, 1);
+      traj.insert(traj.end(), start, waypoint_traj.end());
+      break;
+    }
+  }
+
+  if (revolute_jump_threshold > 0.0 || prismatic_jump_threshold > 0.0)
+  {
+    percentage_solved *= testJointSpaceJump(group, traj, revolute_jump_threshold, prismatic_jump_threshold);
+  }
+
+  return percentage_solved;
+}
+
 void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
 {
   BOOST_VERIFY(checkLinkTransforms());

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -592,9 +592,11 @@ protected:
   moveit::core::RobotModelConstPtr robot_model;
 };
 
-void generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& traj, const moveit::core::RobotModelConstPtr& robot_model, const robot_model::JointModelGroup* joint_model_group)
+void generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& traj,
+                      const moveit::core::RobotModelConstPtr& robot_model,
+                      const robot_model::JointModelGroup* joint_model_group)
 {
-  std::size_t n_joints = joint_model_group->getJointModelNames().size(); 
+  std::size_t n_joints = joint_model_group->getJointModelNames().size();
   std::vector<double> joint_positions;
   joint_positions.resize(n_joints, 0.0);
   for (std::size_t traj_ix = 0; traj_ix < 3; ++traj_ix)
@@ -613,14 +615,13 @@ void generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& tra
 
 TEST_F(LoadPR2, testJointSpaceJumpCutoff)
 {
-  const robot_model::JointModelGroup* joint_model_group =
-      robot_model->getJointModelGroup("right_arm");
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("right_arm");
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
-  
+
   generateTestTraj(traj, robot_model, joint_model_group);
   // Test the absolute joint space jump test function
   // Traj has 4 points in the trajectory with a joint space jump of 1.01 at the last waypoint.
-  // testJointSpaceJump should identify the jump at the 4th waypoint and trim that off returning 
+  // testJointSpaceJump should identify the jump at the 4th waypoint and trim that off returning
   // .75 and a trajectory of length 3
   double result = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, 1.0, 1.0);
   EXPECT_NEAR(result, 0.75, 0.01);
@@ -629,8 +630,7 @@ TEST_F(LoadPR2, testJointSpaceJumpCutoff)
 
 TEST_F(LoadPR2, testJointSpaceJumpCutoffOldMethod)
 {
-  const robot_model::JointModelGroup* joint_model_group =
-      robot_model->getJointModelGroup("right_arm");
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("right_arm");
 
   std::size_t n_joints = joint_model_group->getJointModelNames().size();
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
@@ -638,12 +638,12 @@ TEST_F(LoadPR2, testJointSpaceJumpCutoffOldMethod)
   // generate a test trajectory of len 4 with all zeros except one large jump at the last waypoint
   generateTestTraj(traj, robot_model, joint_model_group);
 
-  // Test testJointSpaceJump with a jump_threshold factor 
+  // Test testJointSpaceJump with a jump_threshold factor
   // Traj has 4 points in the trajectory with a large jump at the last waypoint.
   // testJointSpaceJump should identify the jump at the 4th waypoint and trim it
   // Returning a trajectory of length 3 wich is 3/4 of the original traj length
   double result = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, 1.0);
-  EXPECT_NEAR(result, 3./4., 0.01);
+  EXPECT_NEAR(result, 3. / 4., 0.01);
   EXPECT_NEAR(traj.size(), 3, 0.01);
 }
 

--- a/moveit_core/robot_state/test/test_kinematic.cpp
+++ b/moveit_core/robot_state/test/test_kinematic.cpp
@@ -595,9 +595,9 @@ protected:
 
 TEST_F(LoadPR2, testJointSpaceJumpCutoff)
 {
-  robot_model::RobotModelPtr robot_model;
-  robot_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  robot_model::JointModelGroup* joint_model_group =
+  // robot_model::RobotModelPtr robot_model;
+  // robot_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
+  const robot_model::JointModelGroup* joint_model_group =
       robot_model->getJointModelGroup("right_arm");
   // std::vector<std::string> joint_names = joint_model_group->getJointModelNames().size();
   std::size_t n_joints = joint_model_group->getJointModelNames().size(); //= joint_names.size();
@@ -619,6 +619,34 @@ TEST_F(LoadPR2, testJointSpaceJumpCutoff)
   traj.push_back(rs);
 
   double result = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, 1.0, 1.0);
+  EXPECT_NEAR(result, 0.75, 0.01);
+  EXPECT_NEAR(traj.size(), 3, 0.01);
+}
+
+TEST_F(LoadPR2, testJointSpaceJumpCutoffOldMethod)
+{
+  const robot_model::JointModelGroup* joint_model_group =
+      robot_model->getJointModelGroup("right_arm");
+
+  std::size_t n_joints = joint_model_group->getJointModelNames().size(); //= joint_names.size();
+  std::vector<std::shared_ptr<robot_state::RobotState>> traj;
+
+  for (std::size_t i = 0; i<3; ++i)
+  {
+    std::shared_ptr<robot_state::RobotState> rs(new robot_state::RobotState(robot_model));
+    std::vector<double> joint_positions;
+    joint_positions.resize(n_joints, 0.0);
+    rs->setJointGroupPositions(joint_model_group, joint_positions);
+    traj.push_back(rs);
+  }
+  std::vector<double> joint_positions2;
+  joint_positions2.resize(n_joints, 0.0);
+  joint_positions2[0] = 1.01;
+  std::shared_ptr<robot_state::RobotState> rs(new robot_state::RobotState(robot_model));
+  rs->setJointGroupPositions(joint_model_group, joint_positions2);
+  traj.push_back(rs);
+
+  double result = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, 1.0);
   EXPECT_NEAR(result, 0.75, 0.01);
   EXPECT_NEAR(traj.size(), 3, 0.01);
 }


### PR DESCRIPTION
### Description

I took a stab at implementing a absolute jump threshold for the computeCartesianPath functionality. (#773) This implementation required separate jump thresholds for prismatic and revolute joints and does not support planar, floating, fixed or multi-DOF joints. This implementation does not affect or replace the old computeCartesianPath method which is used by the move_group computeCartesianPath capability since that would involve changing messages and would have a much larger scope.

The goal of this PR is to address the issue where using the existing jump_threshold method, paths with few waypoints can have huge jumps in joint space. To demonstrate this problem, I generated hundreds of thousands of trajectories with varying goals, eef_steps and jump_thresholds, filtered out anything with less than 100% completion, sorted them by the number of interpolated waypoints in the returned trajectory, and then searched through for the largest absolute jump.

![image](https://user-images.githubusercontent.com/3253549/37381665-00658a46-2704-11e8-9151-17861cd4a332.png)

eef_steps = [0.01, 0.05, 0.1]
jump_thresholds = [1.1, 1.5, 1.75, 2.0]

After testing this new implementation and comparing it to the existing computeCartesianPath, I was able to filter out jumps from 100,000 trajectories with minimal parameter tuning. For what it's worth, IMHO it is a lot easier to tune the absolute jump thresholds than the jump threshold factor. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
