### PR TITLE
Support static TFs for multi DOF joints in CurrentStateMonitor

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -443,15 +443,15 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       Eigen::Affine3d eigen_transf;
       tf::transformTFToEigen(transf, eigen_transf);
 
-      double new_values[joint->getStateSpaceDimension()]
+      double new_values[joint->getStateSpaceDimension()];
       joint->computeVariablePositions(eigen_transf, new_values);
 
-      if (joint->distance(&new_values[0], robot_state_.getJointPositions(joint)) > 1e-5)
+      if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
       {
         changes = true;
       }
 
-      robot_state_.setJointPositions(joint, &new_values[0]);
+      robot_state_.setJointPositions(joint, new_values);
       update = true;
     }
   }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -424,6 +424,7 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
         continue;
       }
 
+      // allow update if time is more recent or if it is a static transform (time = 0)
       if (latest_common_time <= joint_time_[joint] && latest_common_time > ros::Time(0))
         continue;
 

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -443,8 +443,8 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       Eigen::Affine3d eigen_transf;
       tf::transformTFToEigen(transf, eigen_transf);
 
-      std::vector<double> new_values(joint->getStateSpaceDimension());
-      joint->computeVariablePositions(eigen_transf, &new_values[0]);
+      double new_values[joint->getStateSpaceDimension()]
+      joint->computeVariablePositions(eigen_transf, new_values);
 
       if (joint->distance(&new_values[0], robot_state_.getJointPositions(joint)) > 1e-5)
       {

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -411,15 +411,16 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
     {
       const moveit::core::JointModel* joint = multi_dof_joints[i];
       const std::string& child_frame = joint->getChildLinkModel()->getName();
-      const std::string& parent_frame = joint->getParentLinkModel() ? joint->getParentLinkModel()->getName() : robot_model_->getModelFrame();
+      const std::string& parent_frame =
+          joint->getParentLinkModel() ? joint->getParentLinkModel()->getName() : robot_model_->getModelFrame();
 
       ros::Time latest_common_time;
       std::string err;
       if (tf_->getLatestCommonTime(parent_frame, child_frame, latest_common_time, &err) != tf::NO_ERROR)
       {
         ROS_WARN_STREAM_THROTTLE(1, "Unable to update multi-DOF joint '"
-                                    << joint->getName() << "': TF has no common time between '"
-                                    << parent_frame.c_str() << "' and '" << child_frame.c_str() << "': " << err);
+                                        << joint->getName() << "': TF has no common time between '"
+                                        << parent_frame.c_str() << "' and '" << child_frame.c_str() << "': " << err);
         continue;
       }
 
@@ -471,4 +472,3 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
     state_update_condition_.notify_all();
   }
 }
-


### PR DESCRIPTION
### Description
The tfCallback method in CurrentStateMonitor disregards any TF lookups with a common time of zero. This makes it impossible to update a floating joint with a static TF because static TFs are published at time zero.

This fix adds support for static TF updates to floating joints in CurrentStateMonitor by also considering TFs with a common time of zero.