### PR TITLE
MotionPlanningDisplay: check for parent widget

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1241,7 +1241,7 @@ void MotionPlanningDisplay::onEnable()
   int_marker_display_->setEnabled(true);
   int_marker_display_->setFixedFrame(fixed_frame_);
 
-  if (frame_)
+  if (frame_ && frame_->parentWidget())
     frame_->parentWidget()->show();
 }
 
@@ -1263,7 +1263,7 @@ void MotionPlanningDisplay::onDisable()
   // Planned Path Display
   trajectory_visual_->onDisable();
 
-  if (frame_)
+  if (frame_ && frame_->parentWidget())
     frame_->parentWidget()->hide();
 }
 


### PR DESCRIPTION
### Description

The MotionPlanningDisplay does not check if a parent widget exists. This causes the using application to crash if no parent widget was created. This issue happens when building a custom application using the rviz library.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format]
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
