### PR TITLE
API to get pick place plan result

### DIFF
--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -117,6 +117,7 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback_PlanOnly(const 
       if (result->id_ < goal->possible_grasps.size())
         action_res.grasp = goal->possible_grasps[result->id_];
       action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+      action_res.planning_time = plan->getLastPlanTime();
     }
   }
   else
@@ -156,6 +157,7 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback_PlanOnly(const m
       if (result->id_ < goal->place_locations.size())
         action_res.place_location = goal->place_locations[result->id_];
       action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+      action_res.planning_time = plan->getLastPlanTime();
     }
   }
   else
@@ -196,6 +198,7 @@ bool move_group::MoveGroupPickPlaceAction::planUsingPickPlace_Pickup(const movei
       if (result->id_ < goal.possible_grasps.size())
         action_res->grasp = goal.possible_grasps[result->id_];
       plan.error_code_.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+      action_res->planning_time = pick_plan->getLastPlanTime();
     }
   }
   else
@@ -238,6 +241,7 @@ bool move_group::MoveGroupPickPlaceAction::planUsingPickPlace_Place(const moveit
       if (result->id_ < goal.place_locations.size())
         action_res->place_location = goal.place_locations[result->id_];
       plan.error_code_.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+      action_res->planning_time = place_plan->getLastPlanTime();
     }
   }
   else

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
@@ -71,6 +71,10 @@ public:
     return error_code_;
   }
 
+  double getLastPlanTime() const
+  {
+    return last_plan_time_;
+  }
 protected:
   void initialize();
   void waitForPipeline(const ros::WallTime& endtime);

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
@@ -75,6 +75,7 @@ public:
   {
     return last_plan_time_;
   }
+
 protected:
   void initialize();
   void waitForPipeline(const ros::WallTime& endtime);

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -135,6 +135,33 @@ public:
     double planning_time_;
   };
 
+  struct ManipulationPlan
+  {
+    /// The full starting state of the robot at the start of the trajectory
+    moveit_msgs::RobotState start_state_;
+
+    /// The trajectory that moved group produced for execution
+    std::vector<moveit_msgs::RobotTrajectory> trajectory_stages_;
+
+    /// Descriptions for the trajectory stages
+    std::vector<std::string> trajectory_descriptions_;
+
+    /// The amount of time it took to generate the plan
+    double planning_time_;
+  };
+
+  struct PickPlan : public ManipulationPlan
+  {
+    /// The performed grasp, if attempt was successful
+    moveit_msgs::Grasp grasp_;
+  };
+
+  struct PlacePlan : public ManipulationPlan
+  {
+    /// The successful place location, if any
+    moveit_msgs::PlaceLocation place_location_;
+  };
+
   /**
       \brief Construct a MoveGroupInterface instance call using a specified set of options \e opt.
 
@@ -758,35 +785,63 @@ public:
       This applies a number of hard-coded default grasps */
   MoveItErrorCode pick(const std::string& object);
 
+  MoveItErrorCode pick(const std::string& object, PickPlan& plan);
+
   /** \brief Pick up an object given a grasp pose */
   MoveItErrorCode pick(const std::string& object, const moveit_msgs::Grasp& grasp);
+
+  MoveItErrorCode pick(const std::string& object, const moveit_msgs::Grasp& grasp, PickPlan& plan);
 
   /** \brief Pick up an object given possible grasp poses
 
       if the vector is left empty this behaves like pick(const std::string &object) */
   MoveItErrorCode pick(const std::string& object, const std::vector<moveit_msgs::Grasp>& grasps);
 
+  /** \brief Pick up an object given possible grasp poses
+
+      This overload returns a result of planning */
+  MoveItErrorCode pick(const std::string& object, const std::vector<moveit_msgs::Grasp>& grasps, PickPlan& plan);
+
   /** \brief Pick up an object
 
       calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
-  MoveItErrorCode planGraspsAndPick(const std::string& object = "");
+  MoveItErrorCode planGraspsAndPick();
+
+  MoveItErrorCode planGraspsAndPick(PickPlan& plan);
+
+  /** \brief Pick up an object
+
+      calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
+  MoveItErrorCode planGraspsAndPick(const std::string& object);
+
+  MoveItErrorCode planGraspsAndPick(const std::string& object, PickPlan& plan);
 
   /** \brief Pick up an object
 
       calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject& object);
 
+  MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject& object, PickPlan& plan);
+
   /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
   MoveItErrorCode place(const std::string& object);
+
+  MoveItErrorCode place(const std::string& object, PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible locations */
   MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations);
 
+  MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations, PlacePlan& plan);
+
   /** \brief Place an object at one of the specified possible locations */
   MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses);
 
+  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses, PlacePlan& plan);
+
   /** \brief Place an object at one of the specified possible location */
   MoveItErrorCode place(const std::string& object, const geometry_msgs::PoseStamped& pose);
+
+  MoveItErrorCode place(const std::string& object, const geometry_msgs::PoseStamped& pose, PlacePlan& plan);
 
   /** \brief Given the name of an object in the planning scene, make
       the object attached to a link of the robot.  If no link name is

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -785,11 +785,15 @@ public:
       This applies a number of hard-coded default grasps */
   MoveItErrorCode pick(const std::string& object);
 
+  /** \brief Pick up an object (with returning planning result)
+
+      This applies a number of hard-coded default grasps */
   MoveItErrorCode pick(const std::string& object, PickPlan& plan);
 
   /** \brief Pick up an object given a grasp pose */
   MoveItErrorCode pick(const std::string& object, const moveit_msgs::Grasp& grasp);
 
+  /** \brief Pick up an object given a grasp pose  (with returning planning result) */
   MoveItErrorCode pick(const std::string& object, const moveit_msgs::Grasp& grasp, PickPlan& plan);
 
   /** \brief Pick up an object given possible grasp poses
@@ -797,9 +801,9 @@ public:
       if the vector is left empty this behaves like pick(const std::string &object) */
   MoveItErrorCode pick(const std::string& object, const std::vector<moveit_msgs::Grasp>& grasps);
 
-  /** \brief Pick up an object given possible grasp poses
+  /** \brief Pick up an object given possible grasp poses (with returning planning result)
 
-      This overload returns a result of planning */
+      if the vector is left empty this behaves like pick(const std::string &object) */
   MoveItErrorCode pick(const std::string& object, const std::vector<moveit_msgs::Grasp>& grasps, PickPlan& plan);
 
   /** \brief Pick up an object
@@ -807,6 +811,9 @@ public:
       calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick();
 
+  /** \brief Pick up an object (with returning planning result)
+
+      calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick(PickPlan& plan);
 
   /** \brief Pick up an object
@@ -814,6 +821,9 @@ public:
       calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick(const std::string& object);
 
+  /** \brief Pick up an object (with returning planning result)
+
+      calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick(const std::string& object, PickPlan& plan);
 
   /** \brief Pick up an object
@@ -821,26 +831,33 @@ public:
       calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject& object);
 
+  /** \brief Pick up an object (with returning planning result)
+
+      calls the external moveit_msgs::GraspPlanning service "plan_grasps" to compute possible grasps */
   MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject& object, PickPlan& plan);
 
   /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
   MoveItErrorCode place(const std::string& object);
 
+  /** \brief Place an object somewhere safe in the world (a safe location will be detected) (with returning planning result) */
   MoveItErrorCode place(const std::string& object, PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible locations */
   MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations);
 
+  /** \brief Place an object at one of the specified possible locations (with returning planning result) */
   MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations, PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible locations */
   MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses);
 
+  /** \brief Place an object at one of the specified possible locations (with returning planning result) */
   MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses, PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible location */
   MoveItErrorCode place(const std::string& object, const geometry_msgs::PoseStamped& pose);
 
+  /** \brief Place an object at one of the specified possible location (with returning planning result) */
   MoveItErrorCode place(const std::string& object, const geometry_msgs::PoseStamped& pose, PlacePlan& plan);
 
   /** \brief Given the name of an object in the planning scene, make

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -839,20 +839,23 @@ public:
   /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
   MoveItErrorCode place(const std::string& object);
 
-  /** \brief Place an object somewhere safe in the world (a safe location will be detected) (with returning planning result) */
+  /** \brief Place an object somewhere safe in the world (a safe location will be detected) (with returning planning
+   * result) */
   MoveItErrorCode place(const std::string& object, PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible locations */
   MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations);
 
   /** \brief Place an object at one of the specified possible locations (with returning planning result) */
-  MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations, PlacePlan& plan);
+  MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations,
+                        PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible locations */
   MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses);
 
   /** \brief Place an object at one of the specified possible locations (with returning planning result) */
-  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses, PlacePlan& plan);
+  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses,
+                        PlacePlan& plan);
 
   /** \brief Place an object at one of the specified possible location */
   MoveItErrorCode place(const std::string& object, const geometry_msgs::PoseStamped& pose);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -629,7 +629,8 @@ public:
   }
 
   /** \brief Place an object at one of the specified possible locations */
-  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses, PlacePlan& plan)
+  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::PoseStamped>& poses,
+                        PlacePlan& plan)
   {
     std::vector<moveit_msgs::PlaceLocation> locations;
     for (std::size_t i = 0; i < poses.size(); ++i)
@@ -654,7 +655,8 @@ public:
     return place(object, locations, plan);
   }
 
-  MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations, PlacePlan& plan)
+  MoveItErrorCode place(const std::string& object, const std::vector<moveit_msgs::PlaceLocation>& locations,
+                        PlacePlan& plan)
   {
     if (!place_action_client_)
     {
@@ -1519,8 +1521,8 @@ moveit::planning_interface::MoveGroupInterface::pick(const std::string& object, 
   return impl_->pick(object, std::vector<moveit_msgs::Grasp>(1, grasp), unused);
 }
 
-moveit::planning_interface::MoveItErrorCode
-moveit::planning_interface::MoveGroupInterface::pick(const std::string& object, const moveit_msgs::Grasp& grasp, PickPlan& plan)
+moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::pick(
+    const std::string& object, const moveit_msgs::Grasp& grasp, PickPlan& plan)
 {
   return impl_->pick(object, std::vector<moveit_msgs::Grasp>(1, grasp), plan);
 }
@@ -1538,8 +1540,7 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
   return impl_->pick(object, grasps, plan);
 }
 
-moveit::planning_interface::MoveItErrorCode
-moveit::planning_interface::MoveGroupInterface::planGraspsAndPick()
+moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::planGraspsAndPick()
 {
   PickPlan unused;
   return impl_->planGraspsAndPick("", unused);
@@ -1571,8 +1572,8 @@ moveit::planning_interface::MoveGroupInterface::planGraspsAndPick(const moveit_m
   return impl_->planGraspsAndPick(object, unused);
 }
 
-moveit::planning_interface::MoveItErrorCode
-moveit::planning_interface::MoveGroupInterface::planGraspsAndPick(const moveit_msgs::CollisionObject& object, PickPlan& plan)
+moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::planGraspsAndPick(
+    const moveit_msgs::CollisionObject& object, PickPlan& plan)
 {
   return impl_->planGraspsAndPick(object, plan);
 }
@@ -1623,8 +1624,8 @@ moveit::planning_interface::MoveGroupInterface::place(const std::string& object,
   return impl_->place(object, std::vector<geometry_msgs::PoseStamped>(1, pose), unused);
 }
 
-moveit::planning_interface::MoveItErrorCode
-moveit::planning_interface::MoveGroupInterface::place(const std::string& object, const geometry_msgs::PoseStamped& pose, PlacePlan& plan)
+moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::place(
+    const std::string& object, const geometry_msgs::PoseStamped& pose, PlacePlan& plan)
 {
   return impl_->place(object, std::vector<geometry_msgs::PoseStamped>(1, pose), plan);
 }


### PR DESCRIPTION
### Description

Add series of APIs to get a planning result from pick-and-place capability to `MoveGroupInerface`.
To keep consistency of the existing interfaces, this PR adds lots of member overloadings to the class.
It is really helpful for me to your opinion about API design.

This PR depends on GH-791.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
