### PR TITLE
consider shape transform for OcTree

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -53,6 +53,8 @@ namespace Ogre
 class SceneManager;
 class SceneNode;
 class AxisAlignedBox;
+class Vector3;
+class Quaternion;
 }
 
 namespace moveit_rviz_plugin
@@ -76,6 +78,9 @@ public:
                OctreeVoxelColorMode octree_color_mode, std::size_t max_octree_depth, Ogre::SceneManager* scene_manager,
                Ogre::SceneNode* parent_node);
   virtual ~OcTreeRender();
+
+  void setPosition(const Ogre::Vector3& position);
+  void setOrientation(const Ogre::Quaternion& orientation);
 
 private:
   void setColor(double z_pos, double min_z, double max_z, double color_factor, rviz::PointCloud::Point* point);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -96,6 +96,16 @@ OcTreeRender::~OcTreeRender()
   }
 }
 
+void OcTreeRender::setPosition(const Ogre::Vector3& position)
+{
+  scene_node_->setPosition(position);
+}
+
+void moveit_rviz_plugin::OcTreeRender::setOrientation(const Ogre::Quaternion& orientation)
+{
+  scene_node_->setOrientation(orientation);
+}
+
 // method taken from octomap_server package
 void OcTreeRender::setColor(double z_pos, double min_z, double max_z, double color_factor,
                             rviz::PointCloud::Point* point)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -76,6 +76,10 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
                                const rviz::Color& color, float alpha)
 {
   rviz::Shape* ogre_shape = NULL;
+  Eigen::Vector3d translation = p.translation();
+  Ogre::Vector3 position(translation.x(), translation.y(), translation.z());
+  Eigen::Quaterniond q(p.rotation());
+  Ogre::Quaternion orientation(q.w(), q.x(), q.y(), q.z());
 
   // we don't know how to render cones directly, but we can convert them to a mesh
   if (s->type == shapes::CONE)
@@ -154,7 +158,8 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
     {
       OcTreeRenderPtr octree(new OcTreeRender(static_cast<const shapes::OcTree*>(s)->octree, octree_voxel_rendering,
                                               octree_color_mode, 0u, context_->getSceneManager(), node));
-
+      octree->setPosition(position);
+      octree->setOrientation(orientation);
       octree_voxel_grids_.push_back(octree);
     }
     break;
@@ -166,13 +171,10 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
   if (ogre_shape)
   {
     ogre_shape->setColor(color.r_, color.g_, color.b_, alpha);
-    Ogre::Vector3 position(p.translation().x(), p.translation().y(), p.translation().z());
-    Eigen::Quaterniond q(p.rotation());
-    Ogre::Quaternion orientation(q.w(), q.x(), q.y(), q.z());
 
     if (s->type == shapes::CYLINDER)
     {
-      // in geometric shapes, the z axis of the cylinder is it height;
+      // in geometric shapes, the z axis of the cylinder is its height;
       // for the rviz shape, the y axis is the height; we add a transform to fix this
       static Ogre::Quaternion fix(Ogre::Radian(boost::math::constants::pi<double>() / 2.0),
                                   Ogre::Vector3(1.0, 0.0, 0.0));


### PR DESCRIPTION
Fix for #728: The provided shape transform was not considered at all for octree visualization.