### PR TITLE
Constrained Cartesian planning using moveit commander

### DIFF
--- a/moveit_commander/demos/plan_with_constraints.py
+++ b/moveit_commander/demos/plan_with_constraints.py
@@ -2,7 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2013, Willow Garage, Inc.
+# Copyright (c) 2018, Houston Mechatronics, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -48,11 +48,10 @@ if __name__=='__main__':
     robot = RobotCommander()
     rospy.sleep(1)
 
-    # Plan to a random location
     a = robot.right_arm
     a.set_start_state(RobotState())
 
-    print "cutternt pose:"
+    print "current pose:"
     print a.get_current_pose()
     c = Constraints()
 
@@ -73,4 +72,4 @@ if __name__=='__main__':
     waypoints.append(wpose)
 
     plan, fraction = a.compute_cartesian_path(waypoints, 0.01, 0.0, path_constraints=c)
-    print 'Plan success rate: ', fraction
+    print 'Plan success percent: ', fraction

--- a/moveit_commander/demos/plan_with_constraints.py
+++ b/moveit_commander/demos/plan_with_constraints.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Siddharth Srivatsa
+
+import sys
+import rospy
+from moveit_commander import RobotCommander, roscpp_initialize, roscpp_shutdown
+from moveit_msgs.msg import RobotState, Constraints
+from geometry_msgs.msg import Pose
+
+if __name__=='__main__':
+
+    roscpp_initialize(sys.argv)
+    rospy.init_node('moveit_py_demo', anonymous=True)
+
+    robot = RobotCommander()
+    rospy.sleep(1)
+
+    # Plan to a random location
+    a = robot.right_arm
+    a.set_start_state(RobotState())
+
+    print "cutternt pose:"
+    print a.get_current_pose()
+    c = Constraints()
+
+    waypoints = []
+    waypoints.append(a.get_current_pose().pose)
+
+    # Move forward
+    wpose = Pose()
+    wpose.position.x = wpose.position.x + 0.1
+    waypoints.append(wpose)
+
+    # Move down
+    wpose.position.z -= 0.10
+    waypoints.append(wpose)
+
+    # Move to the side
+    wpose.position.y += 0.05
+    waypoints.append(wpose)
+
+    plan, fraction = a.compute_cartesian_path(waypoints, 0.01, 0.0, path_constraints=c)
+    print 'Plan success rate: ', fraction

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -475,9 +475,17 @@ class MoveGroupCommander(object):
         plan.deserialize(self._g.compute_plan())
         return plan
 
-    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, avoid_collisions = True):
+    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, avoid_collisions = True, path_constraints=None):
         """ Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. Configurations are computed for every eef_step meters; The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath. The return value is a tuple: a fraction of how much of the path was followed, the actual RobotTrajectory. """
-        (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions)
+        if path_constraints:
+            if type(path_constraints) is Constraints:
+                constraints_str = conversions.msg_to_string(path_constraints)
+            else:
+                raise MoveItCommanderException("Unable to set path constraints, unknown constraint type " + type(path_constraints))
+            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions, constraints_str)
+        else:
+            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions)
+
         path = RobotTrajectory()
         path.deserialize(ser_path)
         return (path, fraction)

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -90,7 +90,7 @@ class MoveGroupCommander(object):
     def set_pose_reference_frame(self, reference_frame):
         """ Set the reference frame to assume for poses of end-effectors """
         self._g.set_pose_reference_frame(reference_frame)
-    
+
     def get_planning_frame(self):
         """ Get the name of the frame where all planning is performed """
         return self._g.get_planning_frame()
@@ -156,14 +156,14 @@ class MoveGroupCommander(object):
         Specify a target joint configuration for the group.
         - if the type of arg1 is one of the following: dict, list, JointState message, then no other arguments should be provided.
         The dict should specify pairs of joint variable names and their target values, the list should specify all the variable values
-        for the group. The JointState message specifies the positions of some single-dof joints. 
+        for the group. The JointState message specifies the positions of some single-dof joints.
         - if the type of arg1 is string, then arg2 is expected to be defined and be either a real value or a list of real values. This is
         interpreted as setting a particular joint to a particular value.
         - if the type of arg1 is Pose or PoseStamped, both arg2 and arg3 could be defined. If arg2 or arg3 are defined, their types must
         be either string or bool. The string type argument is interpreted as the end-effector the pose is specified for (default is to use
         the default end-effector), and the bool is used to decide whether the pose specified is approximate (default is false). This situation
         allows setting the joint target of the group by calling IK. This does not send a pose to the planner and the planner will do no IK.
-        Instead, one IK solution will be computed first, and that will be sent to the planner. 
+        Instead, one IK solution will be computed first, and that will be sent to the planner.
         """
         if type(arg1) is JointState:
             if (arg2 != None or arg3 != None):
@@ -296,7 +296,7 @@ class MoveGroupCommander(object):
     def clear_pose_target(self, end_effector_link):
         """ Clear the pose target for a particular end-effector """
         self._g.clear_pose_target(end_effector_link)
-        
+
     def clear_pose_targets(self):
         """ Clear all known pose targets """
         self._g.clear_pose_targets()
@@ -319,7 +319,7 @@ class MoveGroupCommander(object):
     def get_remembered_joint_values(self):
         """ Get a dictionary that maps names to joint configurations for the group """
         return self._g.get_remembered_joint_values()
-    
+
     def forget_joint_values(self, name):
         """ Forget a stored joint configuration """
         self._g.forget_joint_values(name)
@@ -363,7 +363,7 @@ class MoveGroupCommander(object):
     def allow_replanning(self, value):
         """ Enable/disable replanning """
         self._g.allow_replanning(value)
-        
+
     def get_known_constraints(self):
         """ Get a list of names for the constraints specific for this group, as read from the warehouse """
         return self._g.get_known_constraints()
@@ -423,7 +423,7 @@ class MoveGroupCommander(object):
                     raise MoveItCommanderException("Expected 0, 4 or 6 values in list specifying workspace")
 
     def set_max_velocity_scaling_factor(self, value):
-        """ Set a scaling factor for optionally reducing the maximum joint velocity. Allowed values are in (0,1]. """        
+        """ Set a scaling factor for optionally reducing the maximum joint velocity. Allowed values are in (0,1]. """
         if value > 0 and value <= 1:
             self._g.set_max_velocity_scaling_factor(value)
         else:
@@ -475,8 +475,8 @@ class MoveGroupCommander(object):
         plan.deserialize(self._g.compute_plan())
         return plan
 
-    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, avoid_collisions = True, path_constraints=None):
-        """ Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. Configurations are computed for every eef_step meters; The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath. The return value is a tuple: a fraction of how much of the path was followed, the actual RobotTrajectory. """
+    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, avoid_collisions = True, path_constraints = None):
+        """ Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. Configurations are computed for every eef_step meters; The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned. The return value is a tuple: a fraction of how much of the path was followed, the actual RobotTrajectory. """
         if path_constraints:
             if type(path_constraints) is Constraints:
                 constraints_str = conversions.msg_to_string(path_constraints)

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -403,7 +403,7 @@ public:
   }
 
   bp::tuple computeCartesianPathConstrainedPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                     bool avoid_collisions, const std::string& path_constraints_str)
+                                                  bool avoid_collisions, const std::string& path_constraints_str)
   {
     moveit_msgs::Constraints path_constraints;
     py_bindings_tools::deserializeMsg(path_constraints_str, path_constraints);
@@ -411,12 +411,13 @@ public:
   }
 
   bp::tuple doComputeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                     bool avoid_collisions, const moveit_msgs::Constraints& path_constraints)
+                                         bool avoid_collisions, const moveit_msgs::Constraints& path_constraints)
   {
     std::vector<geometry_msgs::Pose> poses;
     convertListToArrayOfPoses(waypoints, poses);
     moveit_msgs::RobotTrajectory trajectory;
-    double fraction = computeCartesianPath(poses, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
+    double fraction =
+        computeCartesianPath(poses, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
     return bp::make_tuple(py_bindings_tools::serializeMsg(trajectory), fraction);
   }
 
@@ -615,7 +616,8 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("set_num_planning_attempts", &MoveGroupInterfaceWrapper::setNumPlanningAttempts);
   MoveGroupInterfaceClass.def("compute_plan", &MoveGroupInterfaceWrapper::getPlanPython);
   MoveGroupInterfaceClass.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathPython);
-  MoveGroupInterfaceClass.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathConstrainedPython);
+  MoveGroupInterfaceClass.def("compute_cartesian_path",
+                              &MoveGroupInterfaceWrapper::computeCartesianPathConstrainedPython);
   MoveGroupInterfaceClass.def("set_support_surface_name", &MoveGroupInterfaceWrapper::setSupportSurfaceName);
   MoveGroupInterfaceClass.def("attach_object", &MoveGroupInterfaceWrapper::attachObjectPython);
   MoveGroupInterfaceClass.def("detach_object", &MoveGroupInterfaceWrapper::detachObject);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -398,10 +398,25 @@ public:
   bp::tuple computeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
                                        bool avoid_collisions)
   {
+    moveit_msgs::Constraints path_constraints_tmp;
+    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, avoid_collisions, path_constraints_tmp);
+  }
+
+  bp::tuple computeCartesianPathConstrainedPython(const bp::list& waypoints, double eef_step, double jump_threshold,
+                                     bool avoid_collisions, const std::string& path_constraints_str)
+  {
+    moveit_msgs::Constraints path_constraints;
+    py_bindings_tools::deserializeMsg(path_constraints_str, path_constraints);
+    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, avoid_collisions, path_constraints);
+  }
+
+  bp::tuple doComputeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
+                                     bool avoid_collisions, const moveit_msgs::Constraints& path_constraints)
+  {
     std::vector<geometry_msgs::Pose> poses;
     convertListToArrayOfPoses(waypoints, poses);
     moveit_msgs::RobotTrajectory trajectory;
-    double fraction = computeCartesianPath(poses, eef_step, jump_threshold, trajectory, avoid_collisions);
+    double fraction = computeCartesianPath(poses, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
     return bp::make_tuple(py_bindings_tools::serializeMsg(trajectory), fraction);
   }
 
@@ -600,6 +615,7 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("set_num_planning_attempts", &MoveGroupInterfaceWrapper::setNumPlanningAttempts);
   MoveGroupInterfaceClass.def("compute_plan", &MoveGroupInterfaceWrapper::getPlanPython);
   MoveGroupInterfaceClass.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathPython);
+  MoveGroupInterfaceClass.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathConstrainedPython);
   MoveGroupInterfaceClass.def("set_support_surface_name", &MoveGroupInterfaceWrapper::setSupportSurfaceName);
   MoveGroupInterfaceClass.def("attach_object", &MoveGroupInterfaceWrapper::attachObjectPython);
   MoveGroupInterfaceClass.def("detach_object", &MoveGroupInterfaceWrapper::detachObject);


### PR DESCRIPTION
### Description
The `moveit::planning_interface::MoveGroup::computeCartesianPath` takes in an optional argument for path constraints, but the wrapper for using `move_group` in python using `moveit_commander` does not have the same option. 
This PR adds that feature to allow for constrained cartesian planning using `moveit_commander`.

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
