### PR TITLE
Improve ikfast kinematics plugin

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -158,7 +158,7 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   std::vector<double> joint_max_vector_;
   std::vector<bool> joint_has_limits_vector_;
   std::vector<std::string> link_names_;
-  size_t num_joints_;
+  const size_t num_joints_;
   std::vector<int> free_params_;
   bool active_;  // Internal variable that indicates whether solvers are configured and ready
 
@@ -175,7 +175,7 @@ public:
   /** @class
    *  @brief Interface for an IKFast kinematics plugin
    */
-  IKFastKinematicsPlugin() : active_(false)
+  IKFastKinematicsPlugin() : num_joints_(GetNumJoints()), active_(false)
   {
     srand(time(NULL));
     supported_methods_.push_back(kinematics::DiscretizationMethods::NO_DISCRETIZATION);
@@ -348,7 +348,6 @@ bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, co
 
   // IKFast56/61
   fillFreeParams(GetNumFreeParameters(), GetFreeParameters());
-  num_joints_ = GetNumJoints();
 
   if (free_params_.size() > 1)
   {

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -783,7 +783,7 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_
   }
 
   IkReal angles[num_joints_];
-  for (unsigned char i = 0; i < angles.size(); i++)
+  for (unsigned char i = 0; i < num_joints_; i++)
     angles[i] = joint_angles[i];
 
   // IKFast56/61

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -775,8 +775,15 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_
   bool valid = true;
 
   IkReal eerot[9], eetrans[3];
-  IkReal angles[joint_angles.size()];
-  for (unsigned char i = 0; i < joint_angles.size(); i++)
+
+  if (joint_angles.size() != num_joints_)
+  {
+    ROS_ERROR_NAMED("ik_fast", "Unexpected number of joint angles");
+    return false;
+  }
+
+  IkReal angles[num_joints_];
+  for (unsigned char i = 0; i < angles.size(); i++)
     angles[i] = joint_angles[i];
 
   // IKFast56/61


### PR DESCRIPTION
### Description

This PR represents minor improvements concerning the num_joints_ variable in IKFastKinematicsPlugin. I propose to declare num_joints_ as a constant and initialize it in the constructor. Also in getPositionFK() the size of input array joint_angles is compared against the value of num_joints_.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
