### PR TITLE
Add time-optimal trajectory parameterization plugin

### DIFF
--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MOVEIT_LIB_NAME moveit_trajectory_processing)
 add_library(${MOVEIT_LIB_NAME}
   src/iterative_time_parameterization.cpp
   src/trajectory_tools.cpp
+  src/time_optimal_trajectory_generation.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)
 
@@ -14,3 +15,8 @@ install(TARGETS ${MOVEIT_LIB_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_time_optimal_trajectory_generation test/test_time_optimal_trajectory_generation.cpp)
+  target_link_libraries(test_time_optimal_trajectory_generation ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${MOVEIT_LIB_NAME})
+endif()

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2011-2012, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author: Tobias Kunz <tobias@gatech.edu>
+ * Date: 05/2012
+ *
+ * Humanoid Robotics Lab      Georgia Institute of Technology
+ * Director: Mike Stilman     http://www.golems.org
+ *
+ * Algorithm details and publications:
+ * http://www.golems.org/node/1570
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <Eigen/Core>
+ 
+/*
+ * Copyright (c) 2011, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author: Tobias Kunz <tobias@gatech.edu>
+ * Date: 05/2012
+ *
+ * Humanoid Robotics Lab      Georgia Institute of Technology
+ * Director: Mike Stilman     http://www.golems.org
+ *
+ * Algorithm details and publications:
+ * http://www.golems.org/node/1570
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <list>
+#include <Eigen/Core>
+
+class PathSegment
+{
+public:
+  PathSegment(double length = 0.0) :
+    length(length)
+  {
+  }
+  
+  virtual ~PathSegment() {}
+
+  double getLength() const {
+    return length;
+  }
+  virtual Eigen::VectorXd getConfig(double s) const = 0;
+  virtual Eigen::VectorXd getTangent(double s) const = 0;
+  virtual Eigen::VectorXd getCurvature(double s) const = 0;
+  virtual std::list<double> getSwitchingPoints() const = 0;
+  virtual PathSegment* clone() const = 0;
+
+  double position;
+protected:
+  double length;
+};
+
+
+
+class Path
+{
+public:
+  Path(const std::list<Eigen::VectorXd> &path, double maxDeviation = 0.0);
+  Path(const Path &path);
+  ~Path();
+  double getLength() const;
+  Eigen::VectorXd getConfig(double s) const;
+  Eigen::VectorXd getTangent(double s) const;
+  Eigen::VectorXd getCurvature(double s) const;
+  double getNextSwitchingPoint(double s, bool &discontinuity) const;
+  std::list<std::pair<double, bool> > getSwitchingPoints() const;
+private:
+  PathSegment* getPathSegment(double &s) const;
+  double length;
+  std::list<std::pair<double, bool> > switchingPoints;
+  std::list<PathSegment*> pathSegments;
+};
+
+class Trajectory
+{
+public:
+  // Generates a time-optimal trajectory
+  Trajectory(const Path &path, const Eigen::VectorXd &maxVelocity, const Eigen::VectorXd &maxAcceleration, double timeStep = 0.001);
+  
+  ~Trajectory(void);
+
+  // Call this method after constructing the object to make sure the trajectory generation succeeded without errors.
+  // If this method returns false, all other methods have undefined behavior.
+  bool isValid() const;
+
+  // Returns the optimal duration of the trajectory
+  double getDuration() const;
+
+  // Return the position/configuration or velocity vector of the robot for a given point in time within the trajectory.
+  Eigen::VectorXd getPosition(double time) const;
+  Eigen::VectorXd getVelocity(double time) const;
+
+  // Outputs the phase trajectory and the velocity limit curve in 2 files for debugging purposes.
+  void outputPhasePlaneTrajectory() const;
+
+private:
+  struct TrajectoryStep {
+    TrajectoryStep() {}
+    TrajectoryStep(double pathPos, double pathVel) :
+      pathPos(pathPos),
+      pathVel(pathVel)
+    {}
+    double pathPos;
+    double pathVel;
+    double time;
+  };
+
+  bool getNextSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration);
+  bool getNextAccelerationSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration);
+  bool getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration);
+  bool integrateForward(std::list<TrajectoryStep> &trajectory, double acceleration);
+  void integrateBackward(std::list<TrajectoryStep> &startTrajectory, double pathPos, double pathVel, double acceleration);
+  double getMinMaxPathAcceleration(double pathPosition, double pathVelocity, bool max);
+  double getMinMaxPhaseSlope(double pathPosition, double pathVelocity, bool max);
+  double getAccelerationMaxPathVelocity(double pathPos) const;
+  double getVelocityMaxPathVelocity(double pathPos) const;
+  double getAccelerationMaxPathVelocityDeriv(double pathPos);
+  double getVelocityMaxPathVelocityDeriv(double pathPos);
+  
+  std::list<TrajectoryStep>::const_iterator getTrajectorySegment(double time) const;
+  
+  Path path;
+  Eigen::VectorXd maxVelocity;
+  Eigen::VectorXd maxAcceleration;
+  unsigned int n;
+  bool valid;
+  std::list<TrajectoryStep> trajectory;
+  std::list<TrajectoryStep> endTrajectory; // non-empty only if the trajectory generation failed.
+
+  static const double eps;
+  const double timeStep;
+
+  mutable double cachedTime;
+  mutable std::list<TrajectoryStep>::const_iterator cachedTrajectorySegment;
+};

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -41,6 +41,7 @@
 
 #include <Eigen/Core>
 #include <list>
+#include <moveit/robot_trajectory/robot_trajectory.h>
 
 namespace trajectory_processing
 {
@@ -164,6 +165,15 @@ private:
   mutable double cachedTime;
   mutable std::list<TrajectoryStep>::const_iterator cachedTrajectorySegment;
 };
+
+namespace time_optimal_trajectory_generation
+{
+
+bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
+                       const double max_velocity_scaling_factor,
+                       const double max_acceleration_scaling_factor);
+
+}  // namespace time_optimal_trajectory_generation
 
 }  // namespace trajectory_processing
 

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -36,64 +36,27 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef MOVEIT_TRAJECTORY_PROCESSING_TIME_OPTIMAL_TRAJECTORY_GENERATION_H
+#define MOVEIT_TRAJECTORY_PROCESSING_TIME_OPTIMAL_TRAJECTORY_GENERATION_H
 
 #include <Eigen/Core>
- 
-/*
- * Copyright (c) 2011, Georgia Tech Research Corporation
- * All rights reserved.
- *
- * Author: Tobias Kunz <tobias@gatech.edu>
- * Date: 05/2012
- *
- * Humanoid Robotics Lab      Georgia Institute of Technology
- * Director: Mike Stilman     http://www.golems.org
- *
- * Algorithm details and publications:
- * http://www.golems.org/node/1570
- *
- * This file is provided under the following "BSD-style" License:
- *   Redistribution and use in source and binary forms, with or
- *   without modification, are permitted provided that the following
- *   conditions are met:
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
- *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *   POSSIBILITY OF SUCH DAMAGE.
- */
-
-#pragma once
-
 #include <list>
-#include <Eigen/Core>
 
+namespace trajectory_processing
+{
 class PathSegment
 {
 public:
-  PathSegment(double length = 0.0) :
-    length(length)
+  PathSegment(double length = 0.0) : length(length)
   {
   }
-  
-  virtual ~PathSegment() {}
 
-  double getLength() const {
+  virtual ~PathSegment()
+  {
+  }
+
+  double getLength() const
+  {
     return length;
   }
   virtual Eigen::VectorXd getConfig(double s) const = 0;
@@ -103,26 +66,26 @@ public:
   virtual PathSegment* clone() const = 0;
 
   double position;
+
 protected:
   double length;
 };
 
-
-
 class Path
 {
 public:
-  Path(const std::list<Eigen::VectorXd> &path, double maxDeviation = 0.0);
-  Path(const Path &path);
+  Path(const std::list<Eigen::VectorXd>& path, double maxDeviation = 0.0);
+  Path(const Path& path);
   ~Path();
   double getLength() const;
   Eigen::VectorXd getConfig(double s) const;
   Eigen::VectorXd getTangent(double s) const;
   Eigen::VectorXd getCurvature(double s) const;
-  double getNextSwitchingPoint(double s, bool &discontinuity) const;
+  double getNextSwitchingPoint(double s, bool& discontinuity) const;
   std::list<std::pair<double, bool> > getSwitchingPoints() const;
+
 private:
-  PathSegment* getPathSegment(double &s) const;
+  PathSegment* getPathSegment(double& s) const;
   double length;
   std::list<std::pair<double, bool> > switchingPoints;
   std::list<PathSegment*> pathSegments;
@@ -131,58 +94,69 @@ private:
 class Trajectory
 {
 public:
-  // Generates a time-optimal trajectory
-  Trajectory(const Path &path, const Eigen::VectorXd &maxVelocity, const Eigen::VectorXd &maxAcceleration, double timeStep = 0.001);
-  
+  /// @brief Generates a time-optimal trajectory
+  Trajectory(const Path& path, const Eigen::VectorXd& maxVelocity, const Eigen::VectorXd& maxAcceleration,
+             double timeStep = 0.001);
+
   ~Trajectory(void);
 
-  // Call this method after constructing the object to make sure the trajectory generation succeeded without errors.
-  // If this method returns false, all other methods have undefined behavior.
+  /** @brief Call this method after constructing the object to make sure the
+     trajectory generation succeeded without errors. If this method returns
+     false, all other methods have undefined behavior. **/
   bool isValid() const;
 
-  // Returns the optimal duration of the trajectory
+  /// @brief Returns the optimal duration of the trajectory
   double getDuration() const;
 
-  // Return the position/configuration or velocity vector of the robot for a given point in time within the trajectory.
+  /** @brief Return the position/configuration vector for a given point in time
+   */
   Eigen::VectorXd getPosition(double time) const;
+  /** @brief Return the velocity vector for a given point in time */
   Eigen::VectorXd getVelocity(double time) const;
 
-  // Outputs the phase trajectory and the velocity limit curve in 2 files for debugging purposes.
-  void outputPhasePlaneTrajectory() const;
+  // Outputs the phase trajectory and the velocity limit curve in 2 files for
+  // debugging purposes.
+  // void outputPhasePlaneTrajectory() const;
 
 private:
-  struct TrajectoryStep {
-    TrajectoryStep() {}
-    TrajectoryStep(double pathPos, double pathVel) :
-      pathPos(pathPos),
-      pathVel(pathVel)
-    {}
+  struct TrajectoryStep
+  {
+    TrajectoryStep()
+    {
+    }
+    TrajectoryStep(double pathPos, double pathVel) : pathPos(pathPos), pathVel(pathVel)
+    {
+    }
     double pathPos;
     double pathVel;
     double time;
   };
 
-  bool getNextSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration);
-  bool getNextAccelerationSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration);
-  bool getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration);
-  bool integrateForward(std::list<TrajectoryStep> &trajectory, double acceleration);
-  void integrateBackward(std::list<TrajectoryStep> &startTrajectory, double pathPos, double pathVel, double acceleration);
+  bool getNextSwitchingPoint(double pathPos, TrajectoryStep& nextSwitchingPoint, double& beforeAcceleration,
+                             double& afterAcceleration);
+  bool getNextAccelerationSwitchingPoint(double pathPos, TrajectoryStep& nextSwitchingPoint, double& beforeAcceleration,
+                                         double& afterAcceleration);
+  bool getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep& nextSwitchingPoint, double& beforeAcceleration,
+                                     double& afterAcceleration);
+  bool integrateForward(std::list<TrajectoryStep>& trajectory, double acceleration);
+  void integrateBackward(std::list<TrajectoryStep>& startTrajectory, double pathPos, double pathVel,
+                         double acceleration);
   double getMinMaxPathAcceleration(double pathPosition, double pathVelocity, bool max);
   double getMinMaxPhaseSlope(double pathPosition, double pathVelocity, bool max);
   double getAccelerationMaxPathVelocity(double pathPos) const;
   double getVelocityMaxPathVelocity(double pathPos) const;
   double getAccelerationMaxPathVelocityDeriv(double pathPos);
   double getVelocityMaxPathVelocityDeriv(double pathPos);
-  
+
   std::list<TrajectoryStep>::const_iterator getTrajectorySegment(double time) const;
-  
+
   Path path;
   Eigen::VectorXd maxVelocity;
   Eigen::VectorXd maxAcceleration;
   unsigned int n;
   bool valid;
   std::list<TrajectoryStep> trajectory;
-  std::list<TrajectoryStep> endTrajectory; // non-empty only if the trajectory generation failed.
+  std::list<TrajectoryStep> endTrajectory;  // non-empty only if the trajectory generation failed.
 
   static const double eps;
   const double timeStep;
@@ -190,3 +164,7 @@ private:
   mutable double cachedTime;
   mutable std::list<TrajectoryStep>::const_iterator cachedTrajectorySegment;
 };
+
+}  // namespace trajectory_processing
+
+#endif  // MOVEIT_TRAJECTORY_PROCESSING_TIME_OPTIMAL_TRAJECTORY_GENERATION_H

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1,0 +1,778 @@
+/*
+ * Copyright (c) 2011, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author: Tobias Kunz <tobias@gatech.edu>
+ * Date: 05/2012
+ *
+ * Humanoid Robotics Lab      Georgia Institute of Technology
+ * Director: Mike Stilman     http://www.golems.org
+ *
+ * Algorithm details and publications:
+ * http://www.golems.org/node/1570
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Path.h"
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <Eigen/Geometry>
+
+using namespace std;
+using namespace Eigen;
+
+
+class LinearPathSegment : public PathSegment
+{
+public:
+  LinearPathSegment(const Eigen::VectorXd &start, const Eigen::VectorXd &end) :
+    start(start),
+    end(end),
+    PathSegment((end-start).norm())
+  {
+  }
+
+  Eigen::VectorXd getConfig(double s) const {
+    s /= length;
+    s = std::max(0.0, std::min(1.0, s));
+    return (1.0 - s) * start + s * end;
+  }
+
+  Eigen::VectorXd getTangent(double /* s */) const {
+    return (end - start) / length;
+  }
+
+  Eigen::VectorXd getCurvature(double /* s */) const {
+    return Eigen::VectorXd::Zero(start.size());
+  }
+
+  list<double> getSwitchingPoints() const {
+    return list<double>();
+  }
+
+  LinearPathSegment* clone() const {
+    return new LinearPathSegment(*this);
+  }
+
+private:
+  Eigen::VectorXd start;
+  Eigen::VectorXd end;
+};
+
+
+class CircularPathSegment : public PathSegment
+{
+public:
+  CircularPathSegment(const Eigen::VectorXd &start, const Eigen::VectorXd &intersection, const Eigen::VectorXd &end, double maxDeviation) {
+    if((intersection - start).norm() < 0.000001 || (end - intersection).norm() < 0.000001) {
+      length = 0.0;
+      radius = 1.0;
+      center = intersection;
+      x = Eigen::VectorXd::Zero(start.size());
+      y = Eigen::VectorXd::Zero(start.size());
+      return;
+    }
+
+    const Eigen::VectorXd startDirection = (intersection - start).normalized();
+    const Eigen::VectorXd endDirection = (end - intersection).normalized();
+
+    if((startDirection - endDirection).norm() < 0.000001) {
+      length = 0.0;
+      radius = 1.0;
+      center = intersection;
+      x = Eigen::VectorXd::Zero(start.size());
+      y = Eigen::VectorXd::Zero(start.size());
+      return;
+    }
+
+    const double startDistance = (start - intersection).norm();
+    const double endDistance = (end - intersection).norm();
+
+    double distance = std::min((start - intersection).norm(), (end - intersection).norm());
+    const double angle = acos(startDirection.dot(endDirection));
+
+    distance = std::min(distance, maxDeviation * sin(0.5 * angle) / (1.0 - cos(0.5 * angle)));  // enforce max deviation
+
+    radius = distance / tan(0.5 * angle);
+    length = angle * radius;
+
+    center = intersection + (endDirection - startDirection).normalized() * radius / cos(0.5 * angle);
+    x = (intersection - distance * startDirection - center).normalized();
+    y = startDirection;
+  }
+
+  Eigen::VectorXd getConfig(double s) const {
+    const double angle = s / radius;
+    return center + radius * (x * cos(angle) + y * sin(angle));
+  }
+
+  Eigen::VectorXd getTangent(double s) const {
+    const double angle = s / radius;
+    return - x * sin(angle) + y * cos(angle);
+  }
+
+  Eigen::VectorXd getCurvature(double s) const {
+    const double angle = s / radius;
+    return - 1.0 / radius * (x * cos(angle) + y * sin(angle));
+  }
+
+  list<double> getSwitchingPoints() const {
+    list<double> switchingPoints;
+    const double dim = x.size();
+    for(unsigned int i = 0; i < dim; i++) {
+      double switchingAngle = atan2(y[i], x[i]);
+      if(switchingAngle < 0.0) {
+        switchingAngle += M_PI;
+      }
+      const double switchingPoint = switchingAngle * radius;
+      if(switchingPoint < length) {
+        switchingPoints.push_back(switchingPoint);
+      }
+    }
+    switchingPoints.sort();
+    return switchingPoints;
+  }
+
+  CircularPathSegment* clone() const {
+    return new CircularPathSegment(*this);
+  }
+
+private:
+  double radius;
+  Eigen::VectorXd center;
+  Eigen::VectorXd x;
+  Eigen::VectorXd y;
+};
+
+
+
+Path::Path(const list<VectorXd> &path, double maxDeviation) :
+  length(0.0)
+{
+  if(path.size() < 2)
+    return;
+  list<VectorXd>::const_iterator config1 = path.begin();
+  list<VectorXd>::const_iterator config2 = config1;
+  config2++;
+  list<VectorXd>::const_iterator config3;
+  VectorXd startConfig = *config1;
+  while(config2 != path.end()) {
+    config3 = config2;
+    config3++;
+    if(maxDeviation > 0.0 && config3 != path.end()) {
+      CircularPathSegment* blendSegment = new CircularPathSegment(0.5 * (*config1 + *config2), *config2, 0.5 * (*config2 + *config3), maxDeviation);
+      VectorXd endConfig = blendSegment->getConfig(0.0);
+      if((endConfig - startConfig).norm() > 0.000001) {
+        pathSegments.push_back(new LinearPathSegment(startConfig, endConfig));
+      }
+      pathSegments.push_back(blendSegment);
+      
+      startConfig = blendSegment->getConfig(blendSegment->getLength());
+    }
+    else {
+      pathSegments.push_back(new LinearPathSegment(startConfig, *config2));
+      startConfig = *config2;
+    }
+    config1 = config2;
+    config2++;
+  }
+
+  // create list of switching point candidates, calculate total path length and absolute positions of path segments
+  for(list<PathSegment*>::iterator segment = pathSegments.begin(); segment != pathSegments.end(); segment++) {
+    (*segment)->position = length;
+    list<double> localSwitchingPoints = (*segment)->getSwitchingPoints();
+    for(list<double>::const_iterator point = localSwitchingPoints.begin(); point != localSwitchingPoints.end(); point++) {
+      switchingPoints.push_back(make_pair(length + *point, false));
+    }
+    length += (*segment)->getLength();
+    while(!switchingPoints.empty() && switchingPoints.back().first >= length)
+      switchingPoints.pop_back();
+    switchingPoints.push_back(make_pair(length, true));
+  }
+  switchingPoints.pop_back();
+}
+
+Path::Path(const Path &path) :
+  length(path.length),
+  switchingPoints(path.switchingPoints)
+{
+  for(list<PathSegment*>::const_iterator it = path.pathSegments.begin(); it != path.pathSegments.end(); it++) {
+    pathSegments.push_back((*it)->clone());
+  }
+}
+
+Path::~Path() {
+  for(list<PathSegment*>::iterator it = pathSegments.begin(); it != pathSegments.end(); it++) {
+    delete *it;
+  }
+}
+
+double Path::getLength() const {
+  return length;
+}
+
+PathSegment* Path::getPathSegment(double &s) const {
+  list<PathSegment*>::const_iterator it = pathSegments.begin();
+  list<PathSegment*>::const_iterator next = it;
+  next++;
+  while(next != pathSegments.end() && s >= (*next)->position) {
+    it = next;
+    next++;
+  }
+  s -= (*it)->position;
+  return *it;
+}
+
+VectorXd Path::getConfig(double s) const {
+  const PathSegment* pathSegment = getPathSegment(s);
+  return pathSegment->getConfig(s);
+}
+
+VectorXd Path::getTangent(double s) const {
+  const PathSegment* pathSegment = getPathSegment(s);
+  return pathSegment->getTangent(s);
+}
+
+VectorXd Path::getCurvature(double s) const {
+  const PathSegment* pathSegment = getPathSegment(s);
+  return pathSegment->getCurvature(s);
+}
+
+double Path::getNextSwitchingPoint(double s, bool &discontinuity) const {
+  list<pair<double, bool> >::const_iterator it = switchingPoints.begin();
+  while(it != switchingPoints.end() && it->first <= s) {
+    it++;
+  }
+  if(it == switchingPoints.end()) {
+    discontinuity = true;
+    return length;
+  }
+  else {
+    discontinuity = it->second;
+    return it->first;
+  }
+}
+
+list<pair<double, bool> > Path::getSwitchingPoints() const {
+  return switchingPoints;
+}
+
+/*
+ * Copyright (c) 2011, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author: Tobias Kunz <tobias@gatech.edu>
+ * Date: 05/2012
+ *
+ * Humanoid Robotics Lab      Georgia Institute of Technology
+ * Director: Mike Stilman     http://www.golems.org
+ *
+ * Algorithm details and publications:
+ * http://www.golems.org/node/1570
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Trajectory.h"
+#include <limits>
+#include <iostream>
+#include <fstream>
+
+using namespace Eigen;
+using namespace std;
+
+const double Trajectory::eps = 0.000001;
+
+static double squared(double d) {
+  return d * d;
+}
+
+Trajectory::Trajectory(const Path &path, const VectorXd &maxVelocity, const VectorXd &maxAcceleration, double timeStep) :
+  path(path),
+  maxVelocity(maxVelocity),
+  maxAcceleration(maxAcceleration),
+  n(maxVelocity.size()),
+  valid(true),
+  timeStep(timeStep),
+  cachedTime(numeric_limits<double>::max())
+{
+  trajectory.push_back(TrajectoryStep(0.0, 0.0));
+  double afterAcceleration = getMinMaxPathAcceleration(0.0, 0.0, true);
+  while(valid && !integrateForward(trajectory, afterAcceleration) && valid) {
+    double beforeAcceleration;
+    TrajectoryStep switchingPoint;
+    if(getNextSwitchingPoint(trajectory.back().pathPos, switchingPoint, beforeAcceleration, afterAcceleration)) {
+      break;
+    }
+    integrateBackward(trajectory, switchingPoint.pathPos, switchingPoint.pathVel, beforeAcceleration);
+  }
+
+  if(valid) {
+    double beforeAcceleration = getMinMaxPathAcceleration(path.getLength(), 0.0, false);
+    integrateBackward(trajectory, path.getLength(), 0.0, beforeAcceleration);
+  }
+
+  if(valid) {
+    // calculate timing
+    list<TrajectoryStep>::iterator previous = trajectory.begin();
+    list<TrajectoryStep>::iterator it = previous;
+    it->time = 0.0;
+    it++;
+    while(it != trajectory.end()) {
+      it->time = previous->time + (it->pathPos - previous->pathPos) / ((it->pathVel + previous->pathVel) / 2.0);
+      previous = it;
+      it++;
+    }
+  }
+}
+
+Trajectory::~Trajectory(void) {
+}
+
+void Trajectory::outputPhasePlaneTrajectory() const {
+  ofstream file1("maxVelocity.txt");
+  const double stepSize = path.getLength() / 100000.0;
+  for(double s = 0.0; s < path.getLength(); s += stepSize) {
+    double maxVelocity = getAccelerationMaxPathVelocity(s);
+    if(maxVelocity == numeric_limits<double>::infinity())
+      maxVelocity = 10.0;
+    file1 << s << "  " << maxVelocity << "  " << getVelocityMaxPathVelocity(s) << endl;
+  }
+  file1.close();
+
+  ofstream file2("trajectory.txt");
+  for(list<TrajectoryStep>::const_iterator it = trajectory.begin(); it != trajectory.end(); it++) {
+    file2 << it->pathPos << "  " << it->pathVel << endl;
+  }
+  for(list<TrajectoryStep>::const_iterator it = endTrajectory.begin(); it != endTrajectory.end(); it++) {
+    file2 << it->pathPos << "  " << it->pathVel << endl;
+  }
+  file2.close();
+}
+
+// returns true if end of path is reached.
+bool Trajectory::getNextSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration) {
+  TrajectoryStep accelerationSwitchingPoint(pathPos, 0.0);
+  double accelerationBeforeAcceleration, accelerationAfterAcceleration;
+  bool accelerationReachedEnd;
+  do {
+    accelerationReachedEnd = getNextAccelerationSwitchingPoint(accelerationSwitchingPoint.pathPos, accelerationSwitchingPoint, accelerationBeforeAcceleration, accelerationAfterAcceleration);
+    double test = getVelocityMaxPathVelocity(accelerationSwitchingPoint.pathPos);
+  } while(!accelerationReachedEnd && accelerationSwitchingPoint.pathVel > getVelocityMaxPathVelocity(accelerationSwitchingPoint.pathPos));
+  
+  TrajectoryStep velocitySwitchingPoint(pathPos, 0.0);
+  double velocityBeforeAcceleration, velocityAfterAcceleration;
+  bool velocityReachedEnd;
+  do {
+    velocityReachedEnd = getNextVelocitySwitchingPoint(velocitySwitchingPoint.pathPos, velocitySwitchingPoint, velocityBeforeAcceleration, velocityAfterAcceleration);
+  } while(!velocityReachedEnd && velocitySwitchingPoint.pathPos <= accelerationSwitchingPoint.pathPos
+    && (velocitySwitchingPoint.pathVel > getAccelerationMaxPathVelocity(velocitySwitchingPoint.pathPos - eps)
+    || velocitySwitchingPoint.pathVel > getAccelerationMaxPathVelocity(velocitySwitchingPoint.pathPos + eps)));
+
+  if(accelerationReachedEnd && velocityReachedEnd) {
+    return true;
+  }
+  else if(!accelerationReachedEnd && (velocityReachedEnd || accelerationSwitchingPoint.pathPos <= velocitySwitchingPoint.pathPos)) {
+    nextSwitchingPoint = accelerationSwitchingPoint;
+    beforeAcceleration = accelerationBeforeAcceleration;
+    afterAcceleration = accelerationAfterAcceleration;
+    return false;
+  }
+  else {
+    nextSwitchingPoint = velocitySwitchingPoint;
+    beforeAcceleration = velocityBeforeAcceleration;
+    afterAcceleration = velocityAfterAcceleration;
+    return false;
+  }
+}
+
+bool Trajectory::getNextAccelerationSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration) {
+  double switchingPathPos = pathPos;
+  double switchingPathVel;
+  while(true) {
+    bool discontinuity;
+    switchingPathPos = path.getNextSwitchingPoint(switchingPathPos, discontinuity);
+
+    if(switchingPathPos > path.getLength() - eps) {
+      return true;
+    }
+    
+    if(discontinuity) {
+      const double beforePathVel = getAccelerationMaxPathVelocity(switchingPathPos - eps);
+      const double afterPathVel = getAccelerationMaxPathVelocity(switchingPathPos + eps);
+      switchingPathVel = min(beforePathVel, afterPathVel);
+      beforeAcceleration = getMinMaxPathAcceleration(switchingPathPos - eps, switchingPathVel, false);
+      afterAcceleration = getMinMaxPathAcceleration(switchingPathPos + eps, switchingPathVel, true);
+      
+      if((beforePathVel > afterPathVel
+        || getMinMaxPhaseSlope(switchingPathPos - eps, switchingPathVel, false) > getAccelerationMaxPathVelocityDeriv(switchingPathPos - 2.0*eps))
+        && (beforePathVel < afterPathVel
+        || getMinMaxPhaseSlope(switchingPathPos + eps, switchingPathVel, true) < getAccelerationMaxPathVelocityDeriv(switchingPathPos + 2.0*eps)))
+      {
+        break;
+      }
+    }
+    else {
+      switchingPathVel = getAccelerationMaxPathVelocity(switchingPathPos);
+      beforeAcceleration = 0.0;
+      afterAcceleration = 0.0;
+
+      if(getAccelerationMaxPathVelocityDeriv(switchingPathPos - eps) < 0.0 && getAccelerationMaxPathVelocityDeriv(switchingPathPos + eps) > 0.0) {
+        break;
+      }
+    }
+  }
+  
+  nextSwitchingPoint = TrajectoryStep(switchingPathPos, switchingPathVel);
+  return false;
+}
+
+bool Trajectory::getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration) {
+  const double stepSize = 0.001;
+  const double accuracy = 0.000001;
+
+  bool start = false;
+  pathPos -= stepSize;
+  do {
+    pathPos += stepSize;
+
+
+    if(getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) >= getVelocityMaxPathVelocityDeriv(pathPos)) {
+      start = true;
+    }
+  } while((!start || getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) > getVelocityMaxPathVelocityDeriv(pathPos))
+    && pathPos < path.getLength());
+
+  if(pathPos >= path.getLength()) {
+    return true; // end of trajectory reached
+  }
+
+  double beforePathPos = pathPos - stepSize;
+  double afterPathPos = pathPos;
+  while(afterPathPos - beforePathPos > accuracy) {
+    pathPos = (beforePathPos + afterPathPos) / 2.0;
+    if(getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) > getVelocityMaxPathVelocityDeriv(pathPos)) {
+      beforePathPos = pathPos;
+    }
+    else {
+      afterPathPos = pathPos;
+    }
+  }
+
+  beforeAcceleration = getMinMaxPathAcceleration(beforePathPos, getVelocityMaxPathVelocity(beforePathPos), false);
+  afterAcceleration = getMinMaxPathAcceleration(afterPathPos, getVelocityMaxPathVelocity(afterPathPos), true);
+  nextSwitchingPoint = TrajectoryStep(afterPathPos, getVelocityMaxPathVelocity(afterPathPos));
+  return false;
+}
+
+// returns true if end of path is reached
+bool Trajectory::integrateForward(list<TrajectoryStep> &trajectory, double acceleration) {
+  
+  double pathPos = trajectory.back().pathPos;
+  double pathVel = trajectory.back().pathVel;
+  
+  list<pair<double, bool> > switchingPoints = path.getSwitchingPoints();
+  list<pair<double, bool> >::iterator nextDiscontinuity = switchingPoints.begin();
+
+  while(true)
+  {
+    while(nextDiscontinuity != switchingPoints.end() && (nextDiscontinuity->first <= pathPos || !nextDiscontinuity->second)) {
+      nextDiscontinuity++;
+    }
+
+    double oldPathPos = pathPos;
+    double oldPathVel = pathVel;
+    
+    pathVel += timeStep * acceleration;
+    pathPos += timeStep * 0.5 * (oldPathVel + pathVel);
+
+    if(nextDiscontinuity != switchingPoints.end() && pathPos > nextDiscontinuity->first) {
+      pathVel = oldPathVel + (nextDiscontinuity->first - oldPathPos) * (pathVel - oldPathVel) / (pathPos - oldPathPos);
+      pathPos = nextDiscontinuity->first;
+    }
+
+    if(pathPos > path.getLength()) {
+      trajectory.push_back(TrajectoryStep(pathPos, pathVel));
+      return true;
+    }
+    else if(pathVel < 0.0) {
+      valid = false;
+      cout << "error" << endl;
+      return true;
+    }
+
+    if(pathVel > getVelocityMaxPathVelocity(pathPos)
+      && getMinMaxPhaseSlope(oldPathPos, getVelocityMaxPathVelocity(oldPathPos), false) <= getVelocityMaxPathVelocityDeriv(oldPathPos))
+    {
+      pathVel = getVelocityMaxPathVelocity(pathPos);
+    }
+
+    trajectory.push_back(TrajectoryStep(pathPos, pathVel));
+    acceleration = getMinMaxPathAcceleration(pathPos, pathVel, true);
+
+    if(pathVel > getAccelerationMaxPathVelocity(pathPos) || pathVel > getVelocityMaxPathVelocity(pathPos)) {
+      // find more accurate intersection with max-velocity curve using bisection
+      TrajectoryStep overshoot = trajectory.back();
+      trajectory.pop_back();
+      double before = trajectory.back().pathPos;
+      double beforePathVel = trajectory.back().pathVel;
+      double after = overshoot.pathPos;
+      double afterPathVel = overshoot.pathVel;
+      while(after - before > eps) {
+        const double midpoint = 0.5 * (before + after);
+        double midpointPathVel = 0.5 * (beforePathVel + afterPathVel);
+
+        if(midpointPathVel > getVelocityMaxPathVelocity(midpoint)
+          && getMinMaxPhaseSlope(before, getVelocityMaxPathVelocity(before), false) <= getVelocityMaxPathVelocityDeriv(before))
+        {
+          midpointPathVel = getVelocityMaxPathVelocity(midpoint);
+        }
+
+        if(midpointPathVel > getAccelerationMaxPathVelocity(midpoint) || midpointPathVel > getVelocityMaxPathVelocity(midpoint)) {
+          after = midpoint;
+          afterPathVel = midpointPathVel;
+        }
+        else {
+          before = midpoint;
+          beforePathVel = midpointPathVel;
+        }
+      }
+      trajectory.push_back(TrajectoryStep(before, beforePathVel));
+    
+      if(getAccelerationMaxPathVelocity(after) < getVelocityMaxPathVelocity(after)) {
+        if(after > nextDiscontinuity->first) {
+          return false;
+        }
+        else if(getMinMaxPhaseSlope(trajectory.back().pathPos, trajectory.back().pathVel, true) > getAccelerationMaxPathVelocityDeriv(trajectory.back().pathPos)) {
+          return false;
+        }
+      }
+      else {
+        if(getMinMaxPhaseSlope(trajectory.back().pathPos, trajectory.back().pathVel, false) > getVelocityMaxPathVelocityDeriv(trajectory.back().pathPos)) {
+          return false;
+        }
+      }
+    }
+  }
+}
+
+void Trajectory::integrateBackward(list<TrajectoryStep> &startTrajectory, double pathPos, double pathVel, double acceleration) {
+  list<TrajectoryStep>::iterator start2 = startTrajectory.end();
+  start2--;
+  list<TrajectoryStep>::iterator start1 = start2;
+  start1--;
+  list<TrajectoryStep> trajectory;
+  double slope;
+  assert(start1->pathPos <= pathPos);
+
+  while(start1 != startTrajectory.begin() || pathPos >= 0.0)
+  {
+    if(start1->pathPos <= pathPos) {
+      trajectory.push_front(TrajectoryStep(pathPos, pathVel));
+      pathVel -= timeStep * acceleration;
+      pathPos -= timeStep * 0.5 * (pathVel + trajectory.front().pathVel);
+      acceleration = getMinMaxPathAcceleration(pathPos, pathVel, false);
+      slope = (trajectory.front().pathVel - pathVel) / (trajectory.front().pathPos - pathPos);
+      
+      if(pathVel < 0.0) {
+        valid = false;
+        cout << "Error while integrating backward: Negative path velocity" << endl;
+        endTrajectory = trajectory;
+        return;
+      }
+    }
+    else {
+      start1--;
+      start2--;
+    }
+
+    // check for intersection between current start trajectory and backward trajectory segments
+    const double startSlope = (start2->pathVel - start1->pathVel) / (start2->pathPos - start1->pathPos);
+    const double intersectionPathPos = (start1->pathVel - pathVel + slope * pathPos - startSlope * start1->pathPos) / (slope - startSlope);
+    if(max(start1->pathPos, pathPos) - eps <= intersectionPathPos && intersectionPathPos <= eps + min(start2->pathPos, trajectory.front().pathPos)) {
+      const double intersectionPathVel = start1->pathVel + startSlope * (intersectionPathPos - start1->pathPos);
+      startTrajectory.erase(start2, startTrajectory.end());
+      startTrajectory.push_back(TrajectoryStep(intersectionPathPos, intersectionPathVel));
+      startTrajectory.splice(startTrajectory.end(), trajectory);
+      return;
+    }
+  }
+
+  valid = false;
+  cout << "Error while integrating backward: Did not hit start trajectory" << endl;
+  endTrajectory = trajectory;
+}
+
+double Trajectory::getMinMaxPathAcceleration(double pathPos, double pathVel, bool max) {
+  VectorXd configDeriv = path.getTangent(pathPos);
+  VectorXd configDeriv2 = path.getCurvature(pathPos);
+  double factor = max ? 1.0 : -1.0;
+  double maxPathAcceleration = numeric_limits<double>::max();
+  for(unsigned int i = 0; i < n; i++) {
+    if(configDeriv[i] != 0.0) {
+      maxPathAcceleration = min(maxPathAcceleration,
+        maxAcceleration[i]/abs(configDeriv[i]) - factor * configDeriv2[i] * pathVel*pathVel / configDeriv[i]);
+    }
+  }
+  return factor * maxPathAcceleration;
+}
+
+double Trajectory::getMinMaxPhaseSlope(double pathPos, double pathVel, bool max) {
+  return getMinMaxPathAcceleration(pathPos, pathVel, max) / pathVel;
+}
+
+double Trajectory::getAccelerationMaxPathVelocity(double pathPos) const {
+  double maxPathVelocity = numeric_limits<double>::infinity();
+  const VectorXd configDeriv = path.getTangent(pathPos);
+  const VectorXd configDeriv2 = path.getCurvature(pathPos);
+  for(unsigned int i = 0; i < n; i++) {
+    if(configDeriv[i] != 0.0) {
+      for(unsigned int j = i + 1; j < n; j++) {
+        if(configDeriv[j] != 0.0) {
+          double A_ij = configDeriv2[i] / configDeriv[i] - configDeriv2[j] / configDeriv[j];
+          if(A_ij != 0.0) {
+            maxPathVelocity = min(maxPathVelocity,
+              sqrt((maxAcceleration[i] / abs(configDeriv[i]) + maxAcceleration[j] / abs(configDeriv[j]))
+              / abs(A_ij)));
+          }
+        }
+      }
+    }
+    else if(configDeriv2[i] != 0.0) {
+      maxPathVelocity = min(maxPathVelocity, sqrt(maxAcceleration[i] / abs(configDeriv2[i])));
+    }
+  }
+  return maxPathVelocity;
+}
+
+
+double Trajectory::getVelocityMaxPathVelocity(double pathPos) const {
+  const VectorXd tangent = path.getTangent(pathPos);
+  double maxPathVelocity = numeric_limits<double>::max();
+  for(unsigned int i = 0; i < n; i++) {
+    maxPathVelocity = min(maxPathVelocity, maxVelocity[i] / abs(tangent[i]));
+  }
+  return maxPathVelocity;
+}
+
+double Trajectory::getAccelerationMaxPathVelocityDeriv(double pathPos) {
+  return (getAccelerationMaxPathVelocity(pathPos + eps) - getAccelerationMaxPathVelocity(pathPos - eps)) / (2.0 * eps);
+}
+
+double Trajectory::getVelocityMaxPathVelocityDeriv(double pathPos) {
+  const VectorXd tangent = path.getTangent(pathPos);
+  double maxPathVelocity = numeric_limits<double>::max();
+  unsigned int activeConstraint;
+  for(unsigned int i = 0; i < n; i++) {
+    const double thisMaxPathVelocity = maxVelocity[i] / abs(tangent[i]);
+    if(thisMaxPathVelocity < maxPathVelocity) {
+      maxPathVelocity = thisMaxPathVelocity;
+      activeConstraint = i;
+    }
+  }
+  return - (maxVelocity[activeConstraint] * path.getCurvature(pathPos)[activeConstraint])
+    / (tangent[activeConstraint] * abs(tangent[activeConstraint]));
+}
+
+bool Trajectory::isValid() const {
+  return valid;
+}
+
+double Trajectory::getDuration() const {
+  return trajectory.back().time;
+}
+
+list<Trajectory::TrajectoryStep>::const_iterator Trajectory::getTrajectorySegment(double time) const {
+  if(time >= trajectory.back().time) {
+    list<TrajectoryStep>::const_iterator last = trajectory.end();
+    last--;
+    return last;
+  }
+  else {
+    if(time < cachedTime) {
+      cachedTrajectorySegment = trajectory.begin();
+    }
+    while(time >= cachedTrajectorySegment->time) {
+      cachedTrajectorySegment++;
+    }
+    cachedTime = time;
+    return cachedTrajectorySegment;
+  }
+}
+
+VectorXd Trajectory::getPosition(double time) const {
+  list<TrajectoryStep>::const_iterator it = getTrajectorySegment(time);
+  list<TrajectoryStep>::const_iterator previous = it;
+  previous--;
+  
+  double timeStep = it->time - previous->time;
+  const double acceleration = 2.0 * (it->pathPos - previous->pathPos - timeStep * previous->pathVel) / (timeStep * timeStep);
+
+  timeStep = time - previous->time;
+  const double pathPos = previous->pathPos + timeStep * previous->pathVel + 0.5 * timeStep * timeStep * acceleration; 
+  
+  return path.getConfig(pathPos);
+}
+
+VectorXd Trajectory::getVelocity(double time) const {
+  list<TrajectoryStep>::const_iterator it = getTrajectorySegment(time);
+  list<TrajectoryStep>::const_iterator previous = it;
+  previous--;
+    
+  double timeStep = it->time - previous->time;
+  const double acceleration = 2.0 * (it->pathPos - previous->pathPos - timeStep * previous->pathVel) / (timeStep * timeStep);
+
+  timeStep = time - previous->time;
+  const double pathPos = previous->pathPos + timeStep * previous->pathVel + 0.5 * timeStep * timeStep * acceleration; 
+  const double pathVel = previous->pathVel + timeStep * acceleration;
+  
+  return path.getTangent(pathPos) * pathVel;
+}

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -36,47 +36,51 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "Path.h"
-#include <fstream>
-#include <iostream>
-#include <vector>
-#include <algorithm>
-#include <cmath>
+#include <limits>
+//#include <fstream>
+//#include <iostream>
 #include <Eigen/Geometry>
+#include <algorithm>
+#include <angles/angles.h>
+#include <cmath>
+#include <console_bridge/console.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <vector>
 
-using namespace std;
-using namespace Eigen;
-
-
+namespace trajectory_processing
+{
 class LinearPathSegment : public PathSegment
 {
 public:
-  LinearPathSegment(const Eigen::VectorXd &start, const Eigen::VectorXd &end) :
-    start(start),
-    end(end),
-    PathSegment((end-start).norm())
+  LinearPathSegment(const Eigen::VectorXd& start, const Eigen::VectorXd& end)
+    : start(start), end(end), PathSegment((end - start).norm())
   {
   }
 
-  Eigen::VectorXd getConfig(double s) const {
+  Eigen::VectorXd getConfig(double s) const
+  {
     s /= length;
     s = std::max(0.0, std::min(1.0, s));
     return (1.0 - s) * start + s * end;
   }
 
-  Eigen::VectorXd getTangent(double /* s */) const {
+  Eigen::VectorXd getTangent(double /* s */) const
+  {
     return (end - start) / length;
   }
 
-  Eigen::VectorXd getCurvature(double /* s */) const {
+  Eigen::VectorXd getCurvature(double /* s */) const
+  {
     return Eigen::VectorXd::Zero(start.size());
   }
 
-  list<double> getSwitchingPoints() const {
-    return list<double>();
+  std::list<double> getSwitchingPoints() const
+  {
+    return std::list<double>();
   }
 
-  LinearPathSegment* clone() const {
+  LinearPathSegment* clone() const
+  {
     return new LinearPathSegment(*this);
   }
 
@@ -85,12 +89,14 @@ private:
   Eigen::VectorXd end;
 };
 
-
 class CircularPathSegment : public PathSegment
 {
 public:
-  CircularPathSegment(const Eigen::VectorXd &start, const Eigen::VectorXd &intersection, const Eigen::VectorXd &end, double maxDeviation) {
-    if((intersection - start).norm() < 0.000001 || (end - intersection).norm() < 0.000001) {
+  CircularPathSegment(const Eigen::VectorXd& start, const Eigen::VectorXd& intersection, const Eigen::VectorXd& end,
+                      double maxDeviation)
+  {
+    if ((intersection - start).norm() < 0.000001 || (end - intersection).norm() < 0.000001)
+    {
       length = 0.0;
       radius = 1.0;
       center = intersection;
@@ -102,7 +108,8 @@ public:
     const Eigen::VectorXd startDirection = (intersection - start).normalized();
     const Eigen::VectorXd endDirection = (end - intersection).normalized();
 
-    if((startDirection - endDirection).norm() < 0.000001) {
+    if ((startDirection - endDirection).norm() < 0.000001)
+    {
       length = 0.0;
       radius = 1.0;
       center = intersection;
@@ -127,31 +134,38 @@ public:
     y = startDirection;
   }
 
-  Eigen::VectorXd getConfig(double s) const {
+  Eigen::VectorXd getConfig(double s) const
+  {
     const double angle = s / radius;
     return center + radius * (x * cos(angle) + y * sin(angle));
   }
 
-  Eigen::VectorXd getTangent(double s) const {
+  Eigen::VectorXd getTangent(double s) const
+  {
     const double angle = s / radius;
-    return - x * sin(angle) + y * cos(angle);
+    return -x * sin(angle) + y * cos(angle);
   }
 
-  Eigen::VectorXd getCurvature(double s) const {
+  Eigen::VectorXd getCurvature(double s) const
+  {
     const double angle = s / radius;
-    return - 1.0 / radius * (x * cos(angle) + y * sin(angle));
+    return -1.0 / radius * (x * cos(angle) + y * sin(angle));
   }
 
-  list<double> getSwitchingPoints() const {
-    list<double> switchingPoints;
+  std::list<double> getSwitchingPoints() const
+  {
+    std::list<double> switchingPoints;
     const double dim = x.size();
-    for(unsigned int i = 0; i < dim; i++) {
+    for (unsigned int i = 0; i < dim; i++)
+    {
       double switchingAngle = atan2(y[i], x[i]);
-      if(switchingAngle < 0.0) {
+      if (switchingAngle < 0.0)
+      {
         switchingAngle += M_PI;
       }
       const double switchingPoint = switchingAngle * radius;
-      if(switchingPoint < length) {
+      if (switchingPoint < length)
+      {
         switchingPoints.push_back(switchingPoint);
       }
     }
@@ -159,7 +173,8 @@ public:
     return switchingPoints;
   }
 
-  CircularPathSegment* clone() const {
+  CircularPathSegment* clone() const
+  {
     return new CircularPathSegment(*this);
   }
 
@@ -170,32 +185,34 @@ private:
   Eigen::VectorXd y;
 };
 
-
-
-Path::Path(const list<VectorXd> &path, double maxDeviation) :
-  length(0.0)
+Path::Path(const std::list<Eigen::VectorXd>& path, double maxDeviation) : length(0.0)
 {
-  if(path.size() < 2)
+  if (path.size() < 2)
     return;
-  list<VectorXd>::const_iterator config1 = path.begin();
-  list<VectorXd>::const_iterator config2 = config1;
+  std::list<Eigen::VectorXd>::const_iterator config1 = path.begin();
+  std::list<Eigen::VectorXd>::const_iterator config2 = config1;
   config2++;
-  list<VectorXd>::const_iterator config3;
-  VectorXd startConfig = *config1;
-  while(config2 != path.end()) {
+  std::list<Eigen::VectorXd>::const_iterator config3;
+  Eigen::VectorXd startConfig = *config1;
+  while (config2 != path.end())
+  {
     config3 = config2;
     config3++;
-    if(maxDeviation > 0.0 && config3 != path.end()) {
-      CircularPathSegment* blendSegment = new CircularPathSegment(0.5 * (*config1 + *config2), *config2, 0.5 * (*config2 + *config3), maxDeviation);
-      VectorXd endConfig = blendSegment->getConfig(0.0);
-      if((endConfig - startConfig).norm() > 0.000001) {
+    if (maxDeviation > 0.0 && config3 != path.end())
+    {
+      CircularPathSegment* blendSegment =
+          new CircularPathSegment(0.5 * (*config1 + *config2), *config2, 0.5 * (*config2 + *config3), maxDeviation);
+      Eigen::VectorXd endConfig = blendSegment->getConfig(0.0);
+      if ((endConfig - startConfig).norm() > 0.000001)
+      {
         pathSegments.push_back(new LinearPathSegment(startConfig, endConfig));
       }
       pathSegments.push_back(blendSegment);
-      
+
       startConfig = blendSegment->getConfig(blendSegment->getLength());
     }
-    else {
+    else
+    {
       pathSegments.push_back(new LinearPathSegment(startConfig, *config2));
       startConfig = *config2;
     }
@@ -203,45 +220,53 @@ Path::Path(const list<VectorXd> &path, double maxDeviation) :
     config2++;
   }
 
-  // create list of switching point candidates, calculate total path length and absolute positions of path segments
-  for(list<PathSegment*>::iterator segment = pathSegments.begin(); segment != pathSegments.end(); segment++) {
+  // Create list of switching point candidates, calculate total path length and
+  // absolute positions of path segments
+  for (std::list<PathSegment*>::iterator segment = pathSegments.begin(); segment != pathSegments.end(); segment++)
+  {
     (*segment)->position = length;
-    list<double> localSwitchingPoints = (*segment)->getSwitchingPoints();
-    for(list<double>::const_iterator point = localSwitchingPoints.begin(); point != localSwitchingPoints.end(); point++) {
-      switchingPoints.push_back(make_pair(length + *point, false));
+    std::list<double> localSwitchingPoints = (*segment)->getSwitchingPoints();
+    for (std::list<double>::const_iterator point = localSwitchingPoints.begin(); point != localSwitchingPoints.end();
+         point++)
+    {
+      switchingPoints.push_back(std::make_pair(length + *point, false));
     }
     length += (*segment)->getLength();
-    while(!switchingPoints.empty() && switchingPoints.back().first >= length)
+    while (!switchingPoints.empty() && switchingPoints.back().first >= length)
       switchingPoints.pop_back();
-    switchingPoints.push_back(make_pair(length, true));
+    switchingPoints.push_back(std::make_pair(length, true));
   }
   switchingPoints.pop_back();
 }
 
-Path::Path(const Path &path) :
-  length(path.length),
-  switchingPoints(path.switchingPoints)
+Path::Path(const Path& path) : length(path.length), switchingPoints(path.switchingPoints)
 {
-  for(list<PathSegment*>::const_iterator it = path.pathSegments.begin(); it != path.pathSegments.end(); it++) {
+  for (std::list<PathSegment*>::const_iterator it = path.pathSegments.begin(); it != path.pathSegments.end(); it++)
+  {
     pathSegments.push_back((*it)->clone());
   }
 }
 
-Path::~Path() {
-  for(list<PathSegment*>::iterator it = pathSegments.begin(); it != pathSegments.end(); it++) {
+Path::~Path()
+{
+  for (std::list<PathSegment*>::iterator it = pathSegments.begin(); it != pathSegments.end(); it++)
+  {
     delete *it;
   }
 }
 
-double Path::getLength() const {
+double Path::getLength() const
+{
   return length;
 }
 
-PathSegment* Path::getPathSegment(double &s) const {
-  list<PathSegment*>::const_iterator it = pathSegments.begin();
-  list<PathSegment*>::const_iterator next = it;
+PathSegment* Path::getPathSegment(double& s) const
+{
+  std::list<PathSegment*>::const_iterator it = pathSegments.begin();
+  std::list<PathSegment*>::const_iterator next = it;
   next++;
-  while(next != pathSegments.end() && s >= (*next)->position) {
+  while (next != pathSegments.end() && s >= (*next)->position)
+  {
     it = next;
     next++;
   }
@@ -249,124 +274,93 @@ PathSegment* Path::getPathSegment(double &s) const {
   return *it;
 }
 
-VectorXd Path::getConfig(double s) const {
+Eigen::VectorXd Path::getConfig(double s) const
+{
   const PathSegment* pathSegment = getPathSegment(s);
   return pathSegment->getConfig(s);
 }
 
-VectorXd Path::getTangent(double s) const {
+Eigen::VectorXd Path::getTangent(double s) const
+{
   const PathSegment* pathSegment = getPathSegment(s);
   return pathSegment->getTangent(s);
 }
 
-VectorXd Path::getCurvature(double s) const {
+Eigen::VectorXd Path::getCurvature(double s) const
+{
   const PathSegment* pathSegment = getPathSegment(s);
   return pathSegment->getCurvature(s);
 }
 
-double Path::getNextSwitchingPoint(double s, bool &discontinuity) const {
-  list<pair<double, bool> >::const_iterator it = switchingPoints.begin();
-  while(it != switchingPoints.end() && it->first <= s) {
+double Path::getNextSwitchingPoint(double s, bool& discontinuity) const
+{
+  std::list<std::pair<double, bool> >::const_iterator it = switchingPoints.begin();
+  while (it != switchingPoints.end() && it->first <= s)
+  {
     it++;
   }
-  if(it == switchingPoints.end()) {
+  if (it == switchingPoints.end())
+  {
     discontinuity = true;
     return length;
   }
-  else {
+  else
+  {
     discontinuity = it->second;
     return it->first;
   }
 }
 
-list<pair<double, bool> > Path::getSwitchingPoints() const {
+std::list<std::pair<double, bool> > Path::getSwitchingPoints() const
+{
   return switchingPoints;
 }
 
-/*
- * Copyright (c) 2011, Georgia Tech Research Corporation
- * All rights reserved.
- *
- * Author: Tobias Kunz <tobias@gatech.edu>
- * Date: 05/2012
- *
- * Humanoid Robotics Lab      Georgia Institute of Technology
- * Director: Mike Stilman     http://www.golems.org
- *
- * Algorithm details and publications:
- * http://www.golems.org/node/1570
- *
- * This file is provided under the following "BSD-style" License:
- *   Redistribution and use in source and binary forms, with or
- *   without modification, are permitted provided that the following
- *   conditions are met:
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
- *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *   POSSIBILITY OF SUCH DAMAGE.
- */
-
-#include "Trajectory.h"
-#include <limits>
-#include <iostream>
-#include <fstream>
-
-using namespace Eigen;
-using namespace std;
-
 const double Trajectory::eps = 0.000001;
 
-static double squared(double d) {
+static double squared(double d)
+{
   return d * d;
 }
 
-Trajectory::Trajectory(const Path &path, const VectorXd &maxVelocity, const VectorXd &maxAcceleration, double timeStep) :
-  path(path),
-  maxVelocity(maxVelocity),
-  maxAcceleration(maxAcceleration),
-  n(maxVelocity.size()),
-  valid(true),
-  timeStep(timeStep),
-  cachedTime(numeric_limits<double>::max())
+Trajectory::Trajectory(const Path& path, const Eigen::VectorXd& maxVelocity, const Eigen::VectorXd& maxAcceleration,
+                       double timeStep)
+  : path(path)
+  , maxVelocity(maxVelocity)
+  , maxAcceleration(maxAcceleration)
+  , n(maxVelocity.size())
+  , valid(true)
+  , timeStep(timeStep)
+  , cachedTime(std::numeric_limits<double>::max())
 {
   trajectory.push_back(TrajectoryStep(0.0, 0.0));
   double afterAcceleration = getMinMaxPathAcceleration(0.0, 0.0, true);
-  while(valid && !integrateForward(trajectory, afterAcceleration) && valid) {
+  while (valid && !integrateForward(trajectory, afterAcceleration) && valid)
+  {
     double beforeAcceleration;
     TrajectoryStep switchingPoint;
-    if(getNextSwitchingPoint(trajectory.back().pathPos, switchingPoint, beforeAcceleration, afterAcceleration)) {
+    if (getNextSwitchingPoint(trajectory.back().pathPos, switchingPoint, beforeAcceleration, afterAcceleration))
+    {
       break;
     }
     integrateBackward(trajectory, switchingPoint.pathPos, switchingPoint.pathVel, beforeAcceleration);
   }
 
-  if(valid) {
+  if (valid)
+  {
     double beforeAcceleration = getMinMaxPathAcceleration(path.getLength(), 0.0, false);
     integrateBackward(trajectory, path.getLength(), 0.0, beforeAcceleration);
   }
 
-  if(valid) {
-    // calculate timing
-    list<TrajectoryStep>::iterator previous = trajectory.begin();
-    list<TrajectoryStep>::iterator it = previous;
+  if (valid)
+  {
+    // Calculate timing
+    std::list<TrajectoryStep>::iterator previous = trajectory.begin();
+    std::list<TrajectoryStep>::iterator it = previous;
     it->time = 0.0;
     it++;
-    while(it != trajectory.end()) {
+    while (it != trajectory.end())
+    {
       it->time = previous->time + (it->pathPos - previous->pathPos) / ((it->pathVel + previous->pathVel) / 2.0);
       previous = it;
       it++;
@@ -374,59 +368,79 @@ Trajectory::Trajectory(const Path &path, const VectorXd &maxVelocity, const Vect
   }
 }
 
-Trajectory::~Trajectory(void) {
+Trajectory::~Trajectory(void)
+{
 }
 
-void Trajectory::outputPhasePlaneTrajectory() const {
+/*void Trajectory::outputPhasePlaneTrajectory() const
+{
   ofstream file1("maxVelocity.txt");
   const double stepSize = path.getLength() / 100000.0;
-  for(double s = 0.0; s < path.getLength(); s += stepSize) {
+  for (double s = 0.0; s < path.getLength(); s += stepSize)
+  {
     double maxVelocity = getAccelerationMaxPathVelocity(s);
-    if(maxVelocity == numeric_limits<double>::infinity())
+    if (maxVelocity == std::numeric_limits<double>::infinity())
       maxVelocity = 10.0;
-    file1 << s << "  " << maxVelocity << "  " << getVelocityMaxPathVelocity(s) << endl;
+    file1 << s << "  " << maxVelocity << "  " << getVelocityMaxPathVelocity(s)
+<< endl;
   }
   file1.close();
 
   ofstream file2("trajectory.txt");
-  for(list<TrajectoryStep>::const_iterator it = trajectory.begin(); it != trajectory.end(); it++) {
+  for (std::list<TrajectoryStep>::const_iterator it = trajectory.begin(); it !=
+trajectory.end(); it++)
+  {
     file2 << it->pathPos << "  " << it->pathVel << endl;
   }
-  for(list<TrajectoryStep>::const_iterator it = endTrajectory.begin(); it != endTrajectory.end(); it++) {
+  for (std::list<TrajectoryStep>::const_iterator it = endTrajectory.begin(); it
+!= endTrajectory.end(); it++)
+  {
     file2 << it->pathPos << "  " << it->pathVel << endl;
   }
   file2.close();
-}
+}*/
 
-// returns true if end of path is reached.
-bool Trajectory::getNextSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration) {
+// Returns true if end of path is reached.
+bool Trajectory::getNextSwitchingPoint(double pathPos, TrajectoryStep& nextSwitchingPoint, double& beforeAcceleration,
+                                       double& afterAcceleration)
+{
   TrajectoryStep accelerationSwitchingPoint(pathPos, 0.0);
   double accelerationBeforeAcceleration, accelerationAfterAcceleration;
   bool accelerationReachedEnd;
-  do {
-    accelerationReachedEnd = getNextAccelerationSwitchingPoint(accelerationSwitchingPoint.pathPos, accelerationSwitchingPoint, accelerationBeforeAcceleration, accelerationAfterAcceleration);
+  do
+  {
+    accelerationReachedEnd =
+        getNextAccelerationSwitchingPoint(accelerationSwitchingPoint.pathPos, accelerationSwitchingPoint,
+                                          accelerationBeforeAcceleration, accelerationAfterAcceleration);
     double test = getVelocityMaxPathVelocity(accelerationSwitchingPoint.pathPos);
-  } while(!accelerationReachedEnd && accelerationSwitchingPoint.pathVel > getVelocityMaxPathVelocity(accelerationSwitchingPoint.pathPos));
-  
+  } while (!accelerationReachedEnd &&
+           accelerationSwitchingPoint.pathVel > getVelocityMaxPathVelocity(accelerationSwitchingPoint.pathPos));
+
   TrajectoryStep velocitySwitchingPoint(pathPos, 0.0);
   double velocityBeforeAcceleration, velocityAfterAcceleration;
   bool velocityReachedEnd;
-  do {
-    velocityReachedEnd = getNextVelocitySwitchingPoint(velocitySwitchingPoint.pathPos, velocitySwitchingPoint, velocityBeforeAcceleration, velocityAfterAcceleration);
-  } while(!velocityReachedEnd && velocitySwitchingPoint.pathPos <= accelerationSwitchingPoint.pathPos
-    && (velocitySwitchingPoint.pathVel > getAccelerationMaxPathVelocity(velocitySwitchingPoint.pathPos - eps)
-    || velocitySwitchingPoint.pathVel > getAccelerationMaxPathVelocity(velocitySwitchingPoint.pathPos + eps)));
+  do
+  {
+    velocityReachedEnd = getNextVelocitySwitchingPoint(velocitySwitchingPoint.pathPos, velocitySwitchingPoint,
+                                                       velocityBeforeAcceleration, velocityAfterAcceleration);
+  } while (!velocityReachedEnd && velocitySwitchingPoint.pathPos <= accelerationSwitchingPoint.pathPos &&
+           (velocitySwitchingPoint.pathVel > getAccelerationMaxPathVelocity(velocitySwitchingPoint.pathPos - eps) ||
+            velocitySwitchingPoint.pathVel > getAccelerationMaxPathVelocity(velocitySwitchingPoint.pathPos + eps)));
 
-  if(accelerationReachedEnd && velocityReachedEnd) {
+  if (accelerationReachedEnd && velocityReachedEnd)
+  {
     return true;
   }
-  else if(!accelerationReachedEnd && (velocityReachedEnd || accelerationSwitchingPoint.pathPos <= velocitySwitchingPoint.pathPos)) {
+  else if (!accelerationReachedEnd &&
+           (velocityReachedEnd || accelerationSwitchingPoint.pathPos <= velocitySwitchingPoint.pathPos))
+  {
     nextSwitchingPoint = accelerationSwitchingPoint;
     beforeAcceleration = accelerationBeforeAcceleration;
     afterAcceleration = accelerationAfterAcceleration;
     return false;
   }
-  else {
+  else
+  {
     nextSwitchingPoint = velocitySwitchingPoint;
     beforeAcceleration = velocityBeforeAcceleration;
     afterAcceleration = velocityAfterAcceleration;
@@ -434,75 +448,96 @@ bool Trajectory::getNextSwitchingPoint(double pathPos, TrajectoryStep &nextSwitc
   }
 }
 
-bool Trajectory::getNextAccelerationSwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration) {
+bool Trajectory::getNextAccelerationSwitchingPoint(double pathPos, TrajectoryStep& nextSwitchingPoint,
+                                                   double& beforeAcceleration, double& afterAcceleration)
+{
   double switchingPathPos = pathPos;
   double switchingPathVel;
-  while(true) {
+  while (true)
+  {
     bool discontinuity;
     switchingPathPos = path.getNextSwitchingPoint(switchingPathPos, discontinuity);
 
-    if(switchingPathPos > path.getLength() - eps) {
+    if (switchingPathPos > path.getLength() - eps)
+    {
       return true;
     }
-    
-    if(discontinuity) {
+
+    if (discontinuity)
+    {
       const double beforePathVel = getAccelerationMaxPathVelocity(switchingPathPos - eps);
       const double afterPathVel = getAccelerationMaxPathVelocity(switchingPathPos + eps);
-      switchingPathVel = min(beforePathVel, afterPathVel);
+      switchingPathVel = std::min(beforePathVel, afterPathVel);
       beforeAcceleration = getMinMaxPathAcceleration(switchingPathPos - eps, switchingPathVel, false);
       afterAcceleration = getMinMaxPathAcceleration(switchingPathPos + eps, switchingPathVel, true);
-      
-      if((beforePathVel > afterPathVel
-        || getMinMaxPhaseSlope(switchingPathPos - eps, switchingPathVel, false) > getAccelerationMaxPathVelocityDeriv(switchingPathPos - 2.0*eps))
-        && (beforePathVel < afterPathVel
-        || getMinMaxPhaseSlope(switchingPathPos + eps, switchingPathVel, true) < getAccelerationMaxPathVelocityDeriv(switchingPathPos + 2.0*eps)))
+
+      if ((beforePathVel > afterPathVel ||
+           getMinMaxPhaseSlope(switchingPathPos - eps, switchingPathVel, false) >
+               getAccelerationMaxPathVelocityDeriv(switchingPathPos - 2.0 * eps)) &&
+          (beforePathVel < afterPathVel ||
+           getMinMaxPhaseSlope(switchingPathPos + eps, switchingPathVel, true) <
+               getAccelerationMaxPathVelocityDeriv(switchingPathPos + 2.0 * eps)))
       {
         break;
       }
     }
-    else {
+    else
+    {
       switchingPathVel = getAccelerationMaxPathVelocity(switchingPathPos);
       beforeAcceleration = 0.0;
       afterAcceleration = 0.0;
 
-      if(getAccelerationMaxPathVelocityDeriv(switchingPathPos - eps) < 0.0 && getAccelerationMaxPathVelocityDeriv(switchingPathPos + eps) > 0.0) {
+      if (getAccelerationMaxPathVelocityDeriv(switchingPathPos - eps) < 0.0 &&
+          getAccelerationMaxPathVelocityDeriv(switchingPathPos + eps) > 0.0)
+      {
         break;
       }
     }
   }
-  
+
   nextSwitchingPoint = TrajectoryStep(switchingPathPos, switchingPathVel);
   return false;
 }
 
-bool Trajectory::getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep &nextSwitchingPoint, double &beforeAcceleration, double &afterAcceleration) {
+bool Trajectory::getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep& nextSwitchingPoint,
+                                               double& beforeAcceleration, double& afterAcceleration)
+{
   const double stepSize = 0.001;
   const double accuracy = 0.000001;
 
   bool start = false;
   pathPos -= stepSize;
-  do {
+  do
+  {
     pathPos += stepSize;
 
-
-    if(getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) >= getVelocityMaxPathVelocityDeriv(pathPos)) {
+    if (getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) >=
+        getVelocityMaxPathVelocityDeriv(pathPos))
+    {
       start = true;
     }
-  } while((!start || getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) > getVelocityMaxPathVelocityDeriv(pathPos))
-    && pathPos < path.getLength());
+  } while ((!start ||
+            getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) >
+                getVelocityMaxPathVelocityDeriv(pathPos)) &&
+           pathPos < path.getLength());
 
-  if(pathPos >= path.getLength()) {
-    return true; // end of trajectory reached
+  if (pathPos >= path.getLength())
+  {
+    return true;  // end of trajectory reached
   }
 
   double beforePathPos = pathPos - stepSize;
   double afterPathPos = pathPos;
-  while(afterPathPos - beforePathPos > accuracy) {
+  while (afterPathPos - beforePathPos > accuracy)
+  {
     pathPos = (beforePathPos + afterPathPos) / 2.0;
-    if(getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) > getVelocityMaxPathVelocityDeriv(pathPos)) {
+    if (getMinMaxPhaseSlope(pathPos, getVelocityMaxPathVelocity(pathPos), false) >
+        getVelocityMaxPathVelocityDeriv(pathPos))
+    {
       beforePathPos = pathPos;
     }
-    else {
+    else
+    {
       afterPathPos = pathPos;
     }
   }
@@ -513,44 +548,50 @@ bool Trajectory::getNextVelocitySwitchingPoint(double pathPos, TrajectoryStep &n
   return false;
 }
 
-// returns true if end of path is reached
-bool Trajectory::integrateForward(list<TrajectoryStep> &trajectory, double acceleration) {
-  
+// Returns true if end of path is reached
+bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double acceleration)
+{
   double pathPos = trajectory.back().pathPos;
   double pathVel = trajectory.back().pathVel;
-  
-  list<pair<double, bool> > switchingPoints = path.getSwitchingPoints();
-  list<pair<double, bool> >::iterator nextDiscontinuity = switchingPoints.begin();
 
-  while(true)
+  std::list<std::pair<double, bool> > switchingPoints = path.getSwitchingPoints();
+  std::list<std::pair<double, bool> >::iterator nextDiscontinuity = switchingPoints.begin();
+
+  while (true)
   {
-    while(nextDiscontinuity != switchingPoints.end() && (nextDiscontinuity->first <= pathPos || !nextDiscontinuity->second)) {
+    while ((nextDiscontinuity != switchingPoints.end()) &&
+           (nextDiscontinuity->first <= pathPos || !nextDiscontinuity->second))
+    {
       nextDiscontinuity++;
     }
 
     double oldPathPos = pathPos;
     double oldPathVel = pathVel;
-    
+
     pathVel += timeStep * acceleration;
     pathPos += timeStep * 0.5 * (oldPathVel + pathVel);
 
-    if(nextDiscontinuity != switchingPoints.end() && pathPos > nextDiscontinuity->first) {
+    if (nextDiscontinuity != switchingPoints.end() && pathPos > nextDiscontinuity->first)
+    {
       pathVel = oldPathVel + (nextDiscontinuity->first - oldPathPos) * (pathVel - oldPathVel) / (pathPos - oldPathPos);
       pathPos = nextDiscontinuity->first;
     }
 
-    if(pathPos > path.getLength()) {
+    if (pathPos > path.getLength())
+    {
       trajectory.push_back(TrajectoryStep(pathPos, pathVel));
       return true;
     }
-    else if(pathVel < 0.0) {
+    else if (pathVel < 0.0)
+    {
       valid = false;
-      cout << "error" << endl;
+      logError("error");
       return true;
     }
 
-    if(pathVel > getVelocityMaxPathVelocity(pathPos)
-      && getMinMaxPhaseSlope(oldPathPos, getVelocityMaxPathVelocity(oldPathPos), false) <= getVelocityMaxPathVelocityDeriv(oldPathPos))
+    if (pathVel > getVelocityMaxPathVelocity(pathPos) &&
+        getMinMaxPhaseSlope(oldPathPos, getVelocityMaxPathVelocity(oldPathPos), false) <=
+            getVelocityMaxPathVelocityDeriv(oldPathPos))
     {
       pathVel = getVelocityMaxPathVelocity(pathPos);
     }
@@ -558,45 +599,58 @@ bool Trajectory::integrateForward(list<TrajectoryStep> &trajectory, double accel
     trajectory.push_back(TrajectoryStep(pathPos, pathVel));
     acceleration = getMinMaxPathAcceleration(pathPos, pathVel, true);
 
-    if(pathVel > getAccelerationMaxPathVelocity(pathPos) || pathVel > getVelocityMaxPathVelocity(pathPos)) {
-      // find more accurate intersection with max-velocity curve using bisection
+    if (pathVel > getAccelerationMaxPathVelocity(pathPos) || pathVel > getVelocityMaxPathVelocity(pathPos))
+    {
+      // Find more accurate intersection with max-velocity curve using bisection
       TrajectoryStep overshoot = trajectory.back();
       trajectory.pop_back();
       double before = trajectory.back().pathPos;
       double beforePathVel = trajectory.back().pathVel;
       double after = overshoot.pathPos;
       double afterPathVel = overshoot.pathVel;
-      while(after - before > eps) {
+      while (after - before > eps)
+      {
         const double midpoint = 0.5 * (before + after);
         double midpointPathVel = 0.5 * (beforePathVel + afterPathVel);
 
-        if(midpointPathVel > getVelocityMaxPathVelocity(midpoint)
-          && getMinMaxPhaseSlope(before, getVelocityMaxPathVelocity(before), false) <= getVelocityMaxPathVelocityDeriv(before))
+        if (midpointPathVel > getVelocityMaxPathVelocity(midpoint) &&
+            getMinMaxPhaseSlope(before, getVelocityMaxPathVelocity(before), false) <=
+                getVelocityMaxPathVelocityDeriv(before))
         {
           midpointPathVel = getVelocityMaxPathVelocity(midpoint);
         }
 
-        if(midpointPathVel > getAccelerationMaxPathVelocity(midpoint) || midpointPathVel > getVelocityMaxPathVelocity(midpoint)) {
+        if (midpointPathVel > getAccelerationMaxPathVelocity(midpoint) ||
+            midpointPathVel > getVelocityMaxPathVelocity(midpoint))
+        {
           after = midpoint;
           afterPathVel = midpointPathVel;
         }
-        else {
+        else
+        {
           before = midpoint;
           beforePathVel = midpointPathVel;
         }
       }
       trajectory.push_back(TrajectoryStep(before, beforePathVel));
-    
-      if(getAccelerationMaxPathVelocity(after) < getVelocityMaxPathVelocity(after)) {
-        if(after > nextDiscontinuity->first) {
+
+      if (getAccelerationMaxPathVelocity(after) < getVelocityMaxPathVelocity(after))
+      {
+        if (after > nextDiscontinuity->first)
+        {
           return false;
         }
-        else if(getMinMaxPhaseSlope(trajectory.back().pathPos, trajectory.back().pathVel, true) > getAccelerationMaxPathVelocityDeriv(trajectory.back().pathPos)) {
+        else if (getMinMaxPhaseSlope(trajectory.back().pathPos, trajectory.back().pathVel, true) >
+                 getAccelerationMaxPathVelocityDeriv(trajectory.back().pathPos))
+        {
           return false;
         }
       }
-      else {
-        if(getMinMaxPhaseSlope(trajectory.back().pathPos, trajectory.back().pathVel, false) > getVelocityMaxPathVelocityDeriv(trajectory.back().pathPos)) {
+      else
+      {
+        if (getMinMaxPhaseSlope(trajectory.back().pathPos, trajectory.back().pathVel, false) >
+            getVelocityMaxPathVelocityDeriv(trajectory.back().pathPos))
+        {
           return false;
         }
       }
@@ -604,40 +658,49 @@ bool Trajectory::integrateForward(list<TrajectoryStep> &trajectory, double accel
   }
 }
 
-void Trajectory::integrateBackward(list<TrajectoryStep> &startTrajectory, double pathPos, double pathVel, double acceleration) {
-  list<TrajectoryStep>::iterator start2 = startTrajectory.end();
+void Trajectory::integrateBackward(std::list<TrajectoryStep>& startTrajectory, double pathPos, double pathVel,
+                                   double acceleration)
+{
+  std::list<TrajectoryStep>::iterator start2 = startTrajectory.end();
   start2--;
-  list<TrajectoryStep>::iterator start1 = start2;
+  std::list<TrajectoryStep>::iterator start1 = start2;
   start1--;
-  list<TrajectoryStep> trajectory;
+  std::list<TrajectoryStep> trajectory;
   double slope;
   assert(start1->pathPos <= pathPos);
 
-  while(start1 != startTrajectory.begin() || pathPos >= 0.0)
+  while (start1 != startTrajectory.begin() || pathPos >= 0.0)
   {
-    if(start1->pathPos <= pathPos) {
+    if (start1->pathPos <= pathPos)
+    {
       trajectory.push_front(TrajectoryStep(pathPos, pathVel));
       pathVel -= timeStep * acceleration;
       pathPos -= timeStep * 0.5 * (pathVel + trajectory.front().pathVel);
       acceleration = getMinMaxPathAcceleration(pathPos, pathVel, false);
       slope = (trajectory.front().pathVel - pathVel) / (trajectory.front().pathPos - pathPos);
-      
-      if(pathVel < 0.0) {
+
+      if (pathVel < 0.0)
+      {
         valid = false;
-        cout << "Error while integrating backward: Negative path velocity" << endl;
+        logError("Error while integrating backward: Negative path velocity");
         endTrajectory = trajectory;
         return;
       }
     }
-    else {
+    else
+    {
       start1--;
       start2--;
     }
 
-    // check for intersection between current start trajectory and backward trajectory segments
+    // Check for intersection between current start trajectory and backward
+    // trajectory segments
     const double startSlope = (start2->pathVel - start1->pathVel) / (start2->pathPos - start1->pathPos);
-    const double intersectionPathPos = (start1->pathVel - pathVel + slope * pathPos - startSlope * start1->pathPos) / (slope - startSlope);
-    if(max(start1->pathPos, pathPos) - eps <= intersectionPathPos && intersectionPathPos <= eps + min(start2->pathPos, trajectory.front().pathPos)) {
+    const double intersectionPathPos =
+        (start1->pathVel - pathVel + slope * pathPos - startSlope * start1->pathPos) / (slope - startSlope);
+    if (std::max(start1->pathPos, pathPos) - eps <= intersectionPathPos &&
+        intersectionPathPos <= eps + std::min(start2->pathPos, trajectory.front().pathPos))
+    {
       const double intersectionPathVel = start1->pathVel + startSlope * (intersectionPathPos - start1->pathPos);
       startTrajectory.erase(start2, startTrajectory.end());
       startTrajectory.push_back(TrajectoryStep(intersectionPathPos, intersectionPathVel));
@@ -647,100 +710,124 @@ void Trajectory::integrateBackward(list<TrajectoryStep> &startTrajectory, double
   }
 
   valid = false;
-  cout << "Error while integrating backward: Did not hit start trajectory" << endl;
+  logError("Error while integrating backward: Did not hit start trajectory");
   endTrajectory = trajectory;
 }
 
-double Trajectory::getMinMaxPathAcceleration(double pathPos, double pathVel, bool max) {
-  VectorXd configDeriv = path.getTangent(pathPos);
-  VectorXd configDeriv2 = path.getCurvature(pathPos);
+double Trajectory::getMinMaxPathAcceleration(double pathPos, double pathVel, bool max)
+{
+  Eigen::VectorXd configDeriv = path.getTangent(pathPos);
+  Eigen::VectorXd configDeriv2 = path.getCurvature(pathPos);
   double factor = max ? 1.0 : -1.0;
-  double maxPathAcceleration = numeric_limits<double>::max();
-  for(unsigned int i = 0; i < n; i++) {
-    if(configDeriv[i] != 0.0) {
-      maxPathAcceleration = min(maxPathAcceleration,
-        maxAcceleration[i]/abs(configDeriv[i]) - factor * configDeriv2[i] * pathVel*pathVel / configDeriv[i]);
+  double maxPathAcceleration = std::numeric_limits<double>::max();
+  for (unsigned int i = 0; i < n; i++)
+  {
+    if (configDeriv[i] != 0.0)
+    {
+      maxPathAcceleration =
+          std::min(maxPathAcceleration, maxAcceleration[i] / std::abs(configDeriv[i]) -
+                                            factor * configDeriv2[i] * pathVel * pathVel / configDeriv[i]);
     }
   }
   return factor * maxPathAcceleration;
 }
 
-double Trajectory::getMinMaxPhaseSlope(double pathPos, double pathVel, bool max) {
+double Trajectory::getMinMaxPhaseSlope(double pathPos, double pathVel, bool max)
+{
   return getMinMaxPathAcceleration(pathPos, pathVel, max) / pathVel;
 }
 
-double Trajectory::getAccelerationMaxPathVelocity(double pathPos) const {
-  double maxPathVelocity = numeric_limits<double>::infinity();
-  const VectorXd configDeriv = path.getTangent(pathPos);
-  const VectorXd configDeriv2 = path.getCurvature(pathPos);
-  for(unsigned int i = 0; i < n; i++) {
-    if(configDeriv[i] != 0.0) {
-      for(unsigned int j = i + 1; j < n; j++) {
-        if(configDeriv[j] != 0.0) {
+double Trajectory::getAccelerationMaxPathVelocity(double pathPos) const
+{
+  double maxPathVelocity = std::numeric_limits<double>::infinity();
+  const Eigen::VectorXd configDeriv = path.getTangent(pathPos);
+  const Eigen::VectorXd configDeriv2 = path.getCurvature(pathPos);
+  for (unsigned int i = 0; i < n; i++)
+  {
+    if (configDeriv[i] != 0.0)
+    {
+      for (unsigned int j = i + 1; j < n; j++)
+      {
+        if (configDeriv[j] != 0.0)
+        {
           double A_ij = configDeriv2[i] / configDeriv[i] - configDeriv2[j] / configDeriv[j];
-          if(A_ij != 0.0) {
-            maxPathVelocity = min(maxPathVelocity,
-              sqrt((maxAcceleration[i] / abs(configDeriv[i]) + maxAcceleration[j] / abs(configDeriv[j]))
-              / abs(A_ij)));
+          if (A_ij != 0.0)
+          {
+            maxPathVelocity = std::min(maxPathVelocity, sqrt((maxAcceleration[i] / std::abs(configDeriv[i]) +
+                                                              maxAcceleration[j] / std::abs(configDeriv[j])) /
+                                                             std::abs(A_ij)));
           }
         }
       }
     }
-    else if(configDeriv2[i] != 0.0) {
-      maxPathVelocity = min(maxPathVelocity, sqrt(maxAcceleration[i] / abs(configDeriv2[i])));
+    else if (configDeriv2[i] != 0.0)
+    {
+      maxPathVelocity = std::min(maxPathVelocity, sqrt(maxAcceleration[i] / std::abs(configDeriv2[i])));
     }
   }
   return maxPathVelocity;
 }
 
-
-double Trajectory::getVelocityMaxPathVelocity(double pathPos) const {
-  const VectorXd tangent = path.getTangent(pathPos);
-  double maxPathVelocity = numeric_limits<double>::max();
-  for(unsigned int i = 0; i < n; i++) {
-    maxPathVelocity = min(maxPathVelocity, maxVelocity[i] / abs(tangent[i]));
+double Trajectory::getVelocityMaxPathVelocity(double pathPos) const
+{
+  const Eigen::VectorXd tangent = path.getTangent(pathPos);
+  double maxPathVelocity = std::numeric_limits<double>::max();
+  for (unsigned int i = 0; i < n; i++)
+  {
+    maxPathVelocity = std::min(maxPathVelocity, maxVelocity[i] / std::abs(tangent[i]));
   }
   return maxPathVelocity;
 }
 
-double Trajectory::getAccelerationMaxPathVelocityDeriv(double pathPos) {
+double Trajectory::getAccelerationMaxPathVelocityDeriv(double pathPos)
+{
   return (getAccelerationMaxPathVelocity(pathPos + eps) - getAccelerationMaxPathVelocity(pathPos - eps)) / (2.0 * eps);
 }
 
-double Trajectory::getVelocityMaxPathVelocityDeriv(double pathPos) {
-  const VectorXd tangent = path.getTangent(pathPos);
-  double maxPathVelocity = numeric_limits<double>::max();
+double Trajectory::getVelocityMaxPathVelocityDeriv(double pathPos)
+{
+  const Eigen::VectorXd tangent = path.getTangent(pathPos);
+  double maxPathVelocity = std::numeric_limits<double>::max();
   unsigned int activeConstraint;
-  for(unsigned int i = 0; i < n; i++) {
-    const double thisMaxPathVelocity = maxVelocity[i] / abs(tangent[i]);
-    if(thisMaxPathVelocity < maxPathVelocity) {
+  for (unsigned int i = 0; i < n; i++)
+  {
+    const double thisMaxPathVelocity = maxVelocity[i] / std::abs(tangent[i]);
+    if (thisMaxPathVelocity < maxPathVelocity)
+    {
       maxPathVelocity = thisMaxPathVelocity;
       activeConstraint = i;
     }
   }
-  return - (maxVelocity[activeConstraint] * path.getCurvature(pathPos)[activeConstraint])
-    / (tangent[activeConstraint] * abs(tangent[activeConstraint]));
+  return -(maxVelocity[activeConstraint] * path.getCurvature(pathPos)[activeConstraint]) /
+         (tangent[activeConstraint] * std::abs(tangent[activeConstraint]));
 }
 
-bool Trajectory::isValid() const {
+bool Trajectory::isValid() const
+{
   return valid;
 }
 
-double Trajectory::getDuration() const {
+double Trajectory::getDuration() const
+{
   return trajectory.back().time;
 }
 
-list<Trajectory::TrajectoryStep>::const_iterator Trajectory::getTrajectorySegment(double time) const {
-  if(time >= trajectory.back().time) {
-    list<TrajectoryStep>::const_iterator last = trajectory.end();
+std::list<Trajectory::TrajectoryStep>::const_iterator Trajectory::getTrajectorySegment(double time) const
+{
+  if (time >= trajectory.back().time)
+  {
+    std::list<TrajectoryStep>::const_iterator last = trajectory.end();
     last--;
     return last;
   }
-  else {
-    if(time < cachedTime) {
+  else
+  {
+    if (time < cachedTime)
+    {
       cachedTrajectorySegment = trajectory.begin();
     }
-    while(time >= cachedTrajectorySegment->time) {
+    while (time >= cachedTrajectorySegment->time)
+    {
       cachedTrajectorySegment++;
     }
     cachedTime = time;
@@ -748,31 +835,37 @@ list<Trajectory::TrajectoryStep>::const_iterator Trajectory::getTrajectorySegmen
   }
 }
 
-VectorXd Trajectory::getPosition(double time) const {
-  list<TrajectoryStep>::const_iterator it = getTrajectorySegment(time);
-  list<TrajectoryStep>::const_iterator previous = it;
+Eigen::VectorXd Trajectory::getPosition(double time) const
+{
+  std::list<TrajectoryStep>::const_iterator it = getTrajectorySegment(time);
+  std::list<TrajectoryStep>::const_iterator previous = it;
   previous--;
-  
+
   double timeStep = it->time - previous->time;
-  const double acceleration = 2.0 * (it->pathPos - previous->pathPos - timeStep * previous->pathVel) / (timeStep * timeStep);
+  const double acceleration =
+      2.0 * (it->pathPos - previous->pathPos - timeStep * previous->pathVel) / (timeStep * timeStep);
 
   timeStep = time - previous->time;
-  const double pathPos = previous->pathPos + timeStep * previous->pathVel + 0.5 * timeStep * timeStep * acceleration; 
-  
+  const double pathPos = previous->pathPos + timeStep * previous->pathVel + 0.5 * timeStep * timeStep * acceleration;
+
   return path.getConfig(pathPos);
 }
 
-VectorXd Trajectory::getVelocity(double time) const {
-  list<TrajectoryStep>::const_iterator it = getTrajectorySegment(time);
-  list<TrajectoryStep>::const_iterator previous = it;
+Eigen::VectorXd Trajectory::getVelocity(double time) const
+{
+  std::list<TrajectoryStep>::const_iterator it = getTrajectorySegment(time);
+  std::list<TrajectoryStep>::const_iterator previous = it;
   previous--;
-    
+
   double timeStep = it->time - previous->time;
-  const double acceleration = 2.0 * (it->pathPos - previous->pathPos - timeStep * previous->pathVel) / (timeStep * timeStep);
+  const double acceleration =
+      2.0 * (it->pathPos - previous->pathPos - timeStep * previous->pathVel) / (timeStep * timeStep);
 
   timeStep = time - previous->time;
-  const double pathPos = previous->pathPos + timeStep * previous->pathVel + 0.5 * timeStep * timeStep * acceleration; 
+  const double pathPos = previous->pathPos + timeStep * previous->pathVel + 0.5 * timeStep * timeStep * acceleration;
   const double pathVel = previous->pathVel + timeStep * acceleration;
-  
+
   return path.getTangent(pathPos) * pathVel;
 }
+
+}  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -1,0 +1,100 @@
+#include <cstdlib>
+#include <list>
+#include <Eigen/Core>
+#include "Trajectory.h"
+
+int numTests = 0;
+int numTestsFailed = 0;
+
+void test(std::string name, std::list<Eigen::VectorXd> waypoints, double maxDeviation, const Eigen::VectorXd& maxVelocities, const Eigen::VectorXd& maxAccelerations, double timeStep) {
+  Trajectory trajectory(Path(waypoints, maxDeviation), maxVelocities, maxAccelerations, timeStep);
+  numTests++;
+  if(!trajectory.isValid()) {
+    numTestsFailed++;
+    std::cout << name << " with time step " << timeStep << " failed." << std::endl;
+    trajectory.outputPhasePlaneTrajectory();
+  }
+}
+
+void test1() {
+  Eigen::VectorXd waypoint(4);
+  std::list<Eigen::VectorXd> waypoints;
+
+  waypoint << 1424.0, 984.999694824219, 2126.0, 0.0;
+  waypoints.push_back(waypoint);
+  waypoint << 1423.0, 985.000244140625, 2126.0, 0.0;
+  waypoints.push_back(waypoint);
+
+  Eigen::VectorXd maxVelocities(4);
+  maxVelocities << 1.3, 0.67, 0.67, 0.5;
+  Eigen::VectorXd maxAccelerations(4);
+  maxAccelerations << 0.00249, 0.00249, 0.00249, 0.00249;
+
+  test("Test 1", waypoints, 100.0, maxVelocities, maxAccelerations, 10.0);
+}
+
+void test2() {
+  Eigen::VectorXd waypoint(4);
+  std::list<Eigen::VectorXd> waypoints;
+
+  waypoint << 1427.0, 368.0, 690.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 1427.0, 368.0, 790.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 452.5, 533.0, 1051.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 452.5, 533.0, 951.0, 90.0;
+  waypoints.push_back(waypoint);
+
+  Eigen::VectorXd maxVelocities(4);
+  maxVelocities << 1.3, 0.67, 0.67, 0.5;
+  Eigen::VectorXd maxAccelerations(4);
+  maxAccelerations << 0.002, 0.002, 0.002, 0.002;
+
+  test("Test 2", waypoints, 100.0, maxVelocities, maxAccelerations, 10.0);
+}
+
+static inline double randomInRange(double min, double max) {
+  return min + (max-min) * ((double)rand() / (double)RAND_MAX);
+}
+
+Eigen::VectorXd sampleConfig() {
+  Eigen::VectorXd maxPositions(7);
+  maxPositions << 115.0, 105.0, 90.0, 70.0, 130.0, 90.0, 55.0;
+  maxPositions *= 3.14159 / 180.0;
+  Eigen::VectorXd config(7);
+  for(unsigned int i = 0; i < 7; i++) {
+    config[i] = randomInRange(-maxPositions[i], maxPositions[i]);
+  }
+  return config;
+}
+
+void randomTests() {
+  const int numIterations = 10000;
+
+  Eigen::VectorXd maxVelocities(7);
+  maxVelocities << 1.309, 1.6406, 3.2812, 2.618, 5.236, 3.4907, 3.4907;
+  Eigen::VectorXd maxAccelerations = maxVelocities;
+
+  for(int iteration = 0; iteration < numIterations; iteration++) {
+    std::list<Eigen::VectorXd> waypoints;
+    for(int numWaypoints = 0; numWaypoints < 10; numWaypoints++) {
+      waypoints.push_back(sampleConfig());
+    }
+    std::stringstream name;
+    name << "Random test " << iteration;
+    test(name.str(), waypoints, 0.5, maxVelocities, maxAccelerations, 0.001);
+    test(name.str(), waypoints, 0.5, maxVelocities, maxAccelerations, 0.01);
+  }
+}
+
+int main() {
+  test1();
+  test2();
+  randomTests();
+
+  std::cout << numTestsFailed << " out of " << numTests << " tests failed." << std::endl;
+  return 0;
+}

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCE_FILES
   src/fix_start_state_collision.cpp
   src/fix_start_state_path_constraints.cpp
   src/fix_workspace_bounds.cpp
-  src/add_time_parameterization.cpp)
+  src/add_time_parameterization.cpp
+  src/add_time_optimal_parameterization.cpp)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION 0.7.3)

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -1,0 +1,81 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan, Michael Ferguson */
+
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <class_loader/class_loader.h>
+#include <ros/console.h>
+
+namespace default_planner_request_adapters
+{
+
+using trajectory_processing::time_optimal_trajectory_generation::computeTimeStamps;
+
+/** @brief This adapter uses the ... */
+class AddTimeOptimalParameterization : public planning_request_adapter::PlanningRequestAdapter
+{
+public:
+  AddTimeOptimalParameterization() : planning_request_adapter::PlanningRequestAdapter()
+  {
+  }
+
+  virtual std::string getDescription() const
+  {
+    return "Add Time Optimal Parameterization";
+  }
+
+  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                            const planning_interface::MotionPlanRequest& req,
+                            planning_interface::MotionPlanResponse& res,
+                            std::vector<std::size_t>& added_path_index) const
+  {
+    bool result = planner(planning_scene, req, res);
+    if (result && res.trajectory_)
+    {
+      ROS_DEBUG("Running '%s'", getDescription().c_str());
+      if (!computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
+                             req.max_acceleration_scaling_factor))
+        ROS_WARN("Time parametrization for the solution path failed.");
+    }
+
+    return result;
+  }
+};
+
+}  // namespace default_planners_request_adapters
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddTimeOptimalParameterization,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -30,4 +30,10 @@
     </description>
   </class>
 
+  <class name="default_planner_request_adapters/AddTimeOptimalParameterization" type="default_planner_request_adapters::AddTimeOptimalParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+      This is an improved time parameterization using Time-Optimal Trajectory Generation for Path Following With Bounded Acceleration and Velocity (Kunz and Stilman, RSS 2008) 
+    </description>
+  </class>
+
 </library>


### PR DESCRIPTION
### Description

This is a long-overdue request, implementing #160. This wraps/modifies the TOTG code from https://github.com/tobiaskunz/trajectories to work within MoveIt. Compared to the current Iterative Time Parameterization, this one actually does a pretty job enforcing the velocity/acceleration limits (although, based on some plotting, in some cases it probably produces a larger jerk).

There are two remaining "magic numbers" (the "tolerance" and the "resample" time) that need to be parameterized somewhere, but I'm not sure where. Before I went and implemented something, I figured I would see if anyone has a strong opinion about how similar we want these parameterization things to be (for instance, do we want to insist that they all have same function signature in computeTimeStamps?).

I produced this PR to Indigo, once we've OK'd that, I'll create a Kinetic version as well (it will be slightly different since it looks like we have TOPP in Kinetic, so some of the CMake changes will likely conflict).

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
