### PR TITLE
Simplify adding CollisionObjects with colors

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1937,7 +1937,7 @@ void planning_scene::PlanningScene::setObjectColor(const std::string& id, const 
 {
   if (id.empty())
   {
-    ROS_ERROR("Cannot set color of object with empty id.");
+    CONSOLE_BRIDGE_logError("Cannot set color of object with empty id.");
     return;
   }
   if (!object_colors_)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1935,6 +1935,11 @@ void planning_scene::PlanningScene::getKnownObjectColors(ObjectColorMap& kc) con
 
 void planning_scene::PlanningScene::setObjectColor(const std::string& id, const std_msgs::ColorRGBA& color)
 {
+  if (id.empty())
+  {
+    ROS_ERROR("Cannot set color of object with empty id.");
+    return;
+  }
   if (!object_colors_)
     object_colors_.reset(new ObjectColorMap());
   (*object_colors_)[id] = color;

--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -105,8 +105,7 @@ public:
 
   /** \brief Apply collision objects to the planning scene of the move_group node synchronously.
       Other PlanningSceneMonitors will NOT receive the update unless they subscribe to move_group's monitored scene.
-      If the first entries in object_colors have an empty id the id of the corresponding object in collision_objects is
-     filled in. */
+      If object_colors do not specify an id, the corresponding object id from collision_objects is used. */
   bool applyCollisionObjects(
       const std::vector<moveit_msgs::CollisionObject>& collision_objects,
       const std::vector<moveit_msgs::ObjectColor>& object_colors = std::vector<moveit_msgs::ObjectColor>());

--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -104,7 +104,9 @@ public:
                             const std_msgs::ColorRGBA& object_color);
 
   /** \brief Apply collision objects to the planning scene of the move_group node synchronously.
-      Other PlanningSceneMonitors will NOT receive the update unless they subscribe to move_group's monitored scene */
+      Other PlanningSceneMonitors will NOT receive the update unless they subscribe to move_group's monitored scene.
+      If the first entries in object_colors have an empty id the id of the corresponding object in collision_objects is
+     filled in. */
   bool applyCollisionObjects(
       const std::vector<moveit_msgs::CollisionObject>& collision_objects,
       const std::vector<moveit_msgs::ObjectColor>& object_colors = std::vector<moveit_msgs::ObjectColor>());

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -234,7 +234,7 @@ public:
     planning_scene.world.collision_objects = collision_objects;
     planning_scene.object_colors = object_colors;
 
-    for (size_t i = 0; i < planning_scene.object_colors.size(); i++)
+    for (size_t i = 0; i < planning_scene.object_colors.size(); ++i)
     {
       if (planning_scene.object_colors[i].id.empty() && i < collision_objects.size())
         planning_scene.object_colors[i].id = collision_objects[i].id;
@@ -343,7 +343,7 @@ bool PlanningSceneInterface::applyCollisionObjects(const std::vector<moveit_msgs
   ps.world.collision_objects = collision_objects;
   ps.object_colors = object_colors;
 
-  for (size_t i = 0; i < ps.object_colors.size(); i++)
+  for (size_t i = 0; i < ps.object_colors.size(); ++i)
   {
     if (ps.object_colors[i].id.empty() && i < collision_objects.size())
       ps.object_colors[i].id = collision_objects[i].id;

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -233,6 +233,15 @@ public:
     moveit_msgs::PlanningScene planning_scene;
     planning_scene.world.collision_objects = collision_objects;
     planning_scene.object_colors = object_colors;
+
+    for (size_t i = 0; i < planning_scene.object_colors.size(); i++)
+    {
+      if (planning_scene.object_colors[i].id.empty() && i < collision_objects.size())
+        planning_scene.object_colors[i].id = collision_objects[i].id;
+      else
+        break;
+    }
+
     planning_scene.is_diff = true;
     planning_scene_diff_publisher_.publish(planning_scene);
   }
@@ -333,6 +342,15 @@ bool PlanningSceneInterface::applyCollisionObjects(const std::vector<moveit_msgs
   ps.is_diff = true;
   ps.world.collision_objects = collision_objects;
   ps.object_colors = object_colors;
+
+  for (size_t i = 0; i < ps.object_colors.size(); i++)
+  {
+    if (ps.object_colors[i].id.empty() && i < collision_objects.size())
+      ps.object_colors[i].id = collision_objects[i].id;
+    else
+      break;
+  }
+
   return applyPlanningScene(ps);
 }
 


### PR DESCRIPTION
When calling `addCollisionObjects` or `applyCollisionObjects` with colors for the objects, each `ObjectColor` id had to be set to the corresponding object id.
This can lead to confusion as each method is already given a vector of `CollisionObjects`, so that one might think each `ObjectColor` is applied to the CollisionObject with the corresponding index.

Now, in case the `ObjectColor` id field is left empty, the id of the `CollisionObject` with the corresponding index is used instead.
This is done until one of the `ObjectColors` in the vector contains an id.

If there are still empty `ObjectColor` ids left after an `ObjectColor` already contained a non-empty id an error message is printed later in the `PlanningScene` class.

@v4hn
