### PR TITLE
Add method to monitor collisions while executing previously created plan

### DIFF
--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -130,13 +130,18 @@ public:
   void planAndExecute(ExecutableMotionPlan& plan, const Options& opt);
   void planAndExecute(ExecutableMotionPlan& plan, const moveit_msgs::PlanningScene& scene_diff, const Options& opt);
 
+  /** \brief Execute and monitor a previously created \e plan.
+
+      In case there is no \e planning_scene or \e planning_scene_monitor set in the \e plan they will be set at the
+      start of the method. They are then used to monitor the execution. */
+  moveit_msgs::MoveItErrorCodes executeAndMonitor(ExecutableMotionPlan& plan);
+
   void stop();
 
   std::string getErrorCodeString(const moveit_msgs::MoveItErrorCodes& error_code);
 
 private:
   void planAndExecuteHelper(ExecutableMotionPlan& plan, const Options& opt);
-  moveit_msgs::MoveItErrorCodes executeAndMonitor(const ExecutableMotionPlan& plan);
   bool isRemainingPathValid(const ExecutableMotionPlan& plan);
   bool isRemainingPathValid(const ExecutableMotionPlan& plan, const std::pair<int, int>& path_segment);
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -314,8 +314,13 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
   return true;
 }
 
-moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(const ExecutableMotionPlan& plan)
+moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan)
 {
+  if (!plan.planning_scene_monitor_)
+    plan.planning_scene_monitor_ = planning_scene_monitor_;
+  if (!plan.planning_scene_)
+    plan.planning_scene_ = planning_scene_monitor_->getPlanningScene();
+
   moveit_msgs::MoveItErrorCodes result;
 
   // try to execute the trajectory


### PR DESCRIPTION
At the moment only `planAndExecute` is public API in `PlanExecution`, so previously created plans cannot be executed there . The proposed method can be used to do just that.

While this is nice to have standalone already, this pull request is in preparation to solve a problem mentioned in issue #468:
When using `plan()` and `execute()` with a `MoveGroupInterface` there is no check for collisions with newly added objects while executing the plan. 
In the `execute_trajectory_action_capability` the ` trajectory_execution_manager_` is used directly to execute the plan, but collision monitoring is only implemented in `PlanExecution`.

This problem can be solved by using the new method in `PlanExecution` instead.
A shortcoming here is that the capability receives a `RobotTrajectory` msg goal, which does not specify which `JointModelGroup` (if any) the trajectory belongs to. As a result collision checking would have to consider *all* links or there would have to be additional logic to detect relevant checks..
This is slightly inefficient.

Another option would be to create a new `move_group` capability, that already receives the group name and a list of trajectories that define the plan.

Which solution do you prefer in MoveIt?

@v4hn