### PR TITLE
Prevent C++11 style enforcement in indigo-devel

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ PenaltyExcessCharacter: 1000
 PenaltyReturnTypeOnItsOwnLine: 90
 SpacesBeforeTrailingComments: 2
 Cpp11BracedListStyle: false
-Standard:        Auto
+Standard:        Cpp03
 IndentWidth:     2
 TabWidth:        2
 UseTab:          Never

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -161,7 +161,7 @@ struct DistanceFieldCacheEntry
    * to check for collisions between this link and that object.  Size of inner
    * and outer lists are the same and equal the sum of the size of link_names_
    * and attached_body_names_ */
-  std::vector<std::vector<bool>> intra_group_collision_enabled_;
+  std::vector<std::vector<bool> > intra_group_collision_enabled_;
 };
 
 BodyDecompositionConstPtr getBodyDecompositionCacheEntry(const shapes::ShapeConstPtr& shape, double resolution);

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
@@ -67,7 +67,7 @@ public:
                               double collision_tolerance, double max_propogation_distance, double padding);
 
   CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& kmodel,
-                              const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
+                              const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions,
                               double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
                               double size_z = DEFAULT_SIZE_Z,
                               bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
@@ -78,7 +78,7 @@ public:
 
   CollisionRobotDistanceField(const CollisionRobotDistanceField& other);
 
-  void initialize(const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
+  void initialize(const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions,
                   const Eigen::Vector3d& size, const Eigen::Vector3d& origin, bool use_signed_distance_field,
                   double resolution, double collision_tolerance, double max_propogation_distance);
 
@@ -219,7 +219,7 @@ protected:
   void addLinkBodyDecompositions(double resolution);
 
   void addLinkBodyDecompositions(double resolution,
-                                 const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions);
+                                 const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions);
 
   PosedBodySphereDecompositionPtr getPosedLinkBodySphereDecomposition(const moveit::core::LinkModel* ls,
                                                                       unsigned int ind) const;
@@ -250,8 +250,8 @@ protected:
 
   mutable boost::mutex update_cache_lock_;
   boost::shared_ptr<DistanceFieldCacheEntry> distance_field_cache_entry_;
-  std::map<std::string, std::map<std::string, bool>> in_group_update_map_;
-  std::map<std::string, boost::shared_ptr<GroupStateRepresentation>> pregenerated_group_state_representation_map_;
+  std::map<std::string, std::map<std::string, bool> > in_group_update_map_;
+  std::map<std::string, boost::shared_ptr<GroupStateRepresentation> > pregenerated_group_state_representation_map_;
 
   planning_scene::PlanningScenePtr planning_scene_;
 };

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_hybrid.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_hybrid.h
@@ -54,7 +54,7 @@ public:
   CollisionRobotHybrid(const robot_model::RobotModelConstPtr& kmodel);
 
   CollisionRobotHybrid(const robot_model::RobotModelConstPtr& kmodel,
-                       const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
+                       const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions,
                        double size_x = 3.0, double size_y = 3.0, double size_z = 4.0,
                        bool use_signed_distance_field = false, double resolution = .02,
                        double collision_tolerance = 0.0, double max_propogation_distance = .25, double padding = 0.0,
@@ -62,9 +62,10 @@ public:
 
   CollisionRobotHybrid(const CollisionRobotHybrid& other);
 
-  void initializeRobotDistanceField(const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
-                                    double size_x, double size_y, double size_z, bool use_signed_distance_field,
-                                    double resolution, double collision_tolerance, double max_propogation_distance)
+  void
+  initializeRobotDistanceField(const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions,
+                               double size_x, double size_y, double size_z, bool use_signed_distance_field,
+                               double resolution, double collision_tolerance, double max_propogation_distance)
   {
     crobot_distance_->initialize(link_body_decompositions, Eigen::Vector3d(size_x, size_y, size_z),
                                  Eigen::Vector3d(0, 0, 0), use_signed_distance_field, resolution, collision_tolerance,

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
@@ -49,7 +49,7 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   struct DistanceFieldCacheEntry
   {
-    std::map<std::string, std::vector<PosedBodyPointDecompositionPtr>> posed_body_point_decompositions_;
+    std::map<std::string, std::vector<PosedBodyPointDecompositionPtr> > posed_body_point_decompositions_;
     boost::shared_ptr<distance_field::DistanceField> distance_field_;
   };
 

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -51,7 +51,7 @@ CollisionRobotDistanceField::CollisionRobotDistanceField(const robot_model::Robo
 {
   // planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
 
-  std::map<std::string, std::vector<CollisionSphere>> link_body_decompositions;
+  std::map<std::string, std::vector<CollisionSphere> > link_body_decompositions;
   Eigen::Vector3d size(DEFAULT_SIZE_X, DEFAULT_SIZE_Y, DEFAULT_SIZE_Z);
   initialize(link_body_decompositions, size, Eigen::Vector3d(0, 0, 0), DEFAULT_USE_SIGNED_DISTANCE_FIELD,
              DEFAULT_RESOLUTION, DEFAULT_COLLISION_TOLERANCE, DEFAULT_MAX_PROPOGATION_DISTANCE);
@@ -60,7 +60,7 @@ CollisionRobotDistanceField::CollisionRobotDistanceField(const robot_model::Robo
 
 CollisionRobotDistanceField::CollisionRobotDistanceField(
     const robot_model::RobotModelConstPtr& kmodel,
-    const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
+    const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions, double size_x, double size_y,
     double size_z, bool use_signed_distance_field, double resolution, double collision_tolerance,
     double max_propogation_distance, double padding, double scale)
   : CollisionRobot(kmodel, padding, scale)
@@ -75,7 +75,7 @@ CollisionRobotDistanceField::CollisionRobotDistanceField(const CollisionRobot& c
                                                          double max_propogation_distance, double padding)
   : CollisionRobot(col_robot)
 {
-  std::map<std::string, std::vector<CollisionSphere>> link_body_decompositions;
+  std::map<std::string, std::vector<CollisionSphere> > link_body_decompositions;
   initialize(link_body_decompositions, size, origin, use_signed_distance_field, resolution, collision_tolerance,
              max_propogation_distance);
   setPadding(padding);
@@ -99,7 +99,7 @@ CollisionRobotDistanceField::CollisionRobotDistanceField(const CollisionRobotDis
 }
 
 void CollisionRobotDistanceField::initialize(
-    const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, const Eigen::Vector3d& size,
+    const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions, const Eigen::Vector3d& size,
     const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution, double collision_tolerance,
     double max_propogation_distance)
 {
@@ -859,7 +859,7 @@ boost::shared_ptr<DistanceFieldCacheEntry> CollisionRobotDistanceField::generate
     }
   }
 
-  std::map<std::string, boost::shared_ptr<GroupStateRepresentation>>::const_iterator it =
+  std::map<std::string, boost::shared_ptr<GroupStateRepresentation> >::const_iterator it =
       pregenerated_group_state_representation_map_.find(dfce->group_name_);
   if (it != pregenerated_group_state_representation_map_.end())
   {
@@ -1043,7 +1043,7 @@ void CollisionRobotDistanceField::createCollisionModelMarker(const moveit::core:
 }
 
 void CollisionRobotDistanceField::addLinkBodyDecompositions(
-    double resolution, const std::map<std::string, std::vector<CollisionSphere>>& link_spheres)
+    double resolution, const std::map<std::string, std::vector<CollisionSphere> >& link_spheres)
 {
   ROS_ASSERT_MSG(robot_model_, "RobotModelPtr is invalid");
   const std::vector<const moveit::core::LinkModel*>& link_models = robot_model_->getLinkModelsWithCollisionGeometry();

--- a/moveit_experimental/collision_distance_field/src/collision_robot_hybrid.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_hybrid.cpp
@@ -45,7 +45,7 @@ CollisionRobotHybrid::CollisionRobotHybrid(const robot_model::RobotModelConstPtr
 
 CollisionRobotHybrid::CollisionRobotHybrid(
     const robot_model::RobotModelConstPtr& kmodel,
-    const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
+    const std::map<std::string, std::vector<CollisionSphere> >& link_body_decompositions, double size_x, double size_y,
     double size_z, bool use_signed_distance_field, double resolution, double collision_tolerance,
     double max_propogation_distance, double padding, double scale)
   : CollisionRobotFCL(kmodel)

--- a/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
@@ -504,7 +504,7 @@ void CollisionWorldDistanceField::updateDistanceObject(
     const std::string& id, boost::shared_ptr<CollisionWorldDistanceField::DistanceFieldCacheEntry>& dfce,
     EigenSTL::vector_Vector3d& add_points, EigenSTL::vector_Vector3d& subtract_points)
 {
-  std::map<std::string, std::vector<PosedBodyPointDecompositionPtr>>::iterator cur_it =
+  std::map<std::string, std::vector<PosedBodyPointDecompositionPtr> >::iterator cur_it =
       dfce->posed_body_point_decompositions_.find(id);
   if (cur_it != dfce->posed_body_point_decompositions_.end())
   {

--- a/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
@@ -83,7 +83,7 @@ protected:
 
     acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-    std::map<std::string, std::vector<collision_detection::CollisionSphere>> link_body_decompositions;
+    std::map<std::string, std::vector<collision_detection::CollisionSphere> > link_body_decompositions;
     crobot_.reset(new DefaultCRobotType(robot_model_, link_body_decompositions));
     cworld_.reset(new DefaultCWorldType());
   }


### PR DESCRIPTION
Fix pre request of @v4hn to allow https://github.com/ros-planning/moveit/pull/718 to be merged in

See documentation of [Standard](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)