### PR TITLE
code clean up of robot_model

### DIFF
--- a/moveit_core/robot_model/src/fixed_joint_model.cpp
+++ b/moveit_core/robot_model/src/fixed_joint_model.cpp
@@ -36,63 +36,67 @@
 
 #include <moveit/robot_model/fixed_joint_model.h>
 
-moveit::core::FixedJointModel::FixedJointModel(const std::string& name) : JointModel(name)
+namespace moveit
+{
+namespace core
+{
+FixedJointModel::FixedJointModel(const std::string& name) : JointModel(name)
 {
   type_ = FIXED;
 }
 
-unsigned int moveit::core::FixedJointModel::getStateSpaceDimension() const
+unsigned int FixedJointModel::getStateSpaceDimension() const
 {
   return 0;
 }
 
-void moveit::core::FixedJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
+void FixedJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
 {
 }
 
-void moveit::core::FixedJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                               double* values, const Bounds& bounds) const
+void FixedJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                 const Bounds& bounds) const
 {
 }
 
-void moveit::core::FixedJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                     double* values, const Bounds& bounds,
-                                                                     const double* near, const double distance) const
+void FixedJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                       const Bounds& bounds, const double* near,
+                                                       const double distance) const
 {
 }
 
-bool moveit::core::FixedJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
+bool FixedJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
 {
   return false;
 }
 
-bool moveit::core::FixedJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds,
-                                                            double margin) const
+bool FixedJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   return true;
 }
 
-double moveit::core::FixedJointModel::distance(const double* values1, const double* values2) const
+double FixedJointModel::distance(const double* values1, const double* values2) const
 {
   return 0.0;
 }
 
-double moveit::core::FixedJointModel::getMaximumExtent(const Bounds& other_bounds) const
+double FixedJointModel::getMaximumExtent(const Bounds& other_bounds) const
 {
   return 0.0;
 }
 
-void moveit::core::FixedJointModel::interpolate(const double* from, const double* to, const double t,
-                                                double* state) const
+void FixedJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
 {
 }
 
-void moveit::core::FixedJointModel::computeTransform(const double* /* joint_values */, Eigen::Affine3d& transf) const
+void FixedJointModel::computeTransform(const double* /* joint_values */, Eigen::Affine3d& transf) const
 {
   transf.setIdentity();
 }
 
-void moveit::core::FixedJointModel::computeVariablePositions(const Eigen::Affine3d& /* transform */,
-                                                             double* /* joint_values */) const
+void FixedJointModel::computeVariablePositions(const Eigen::Affine3d& /* transform */, double* /* joint_values */) const
 {
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -41,8 +41,11 @@
 #include <limits>
 #include <cmath>
 
-moveit::core::FloatingJointModel::FloatingJointModel(const std::string& name)
-  : JointModel(name), angular_distance_weight_(1.0)
+namespace moveit
+{
+namespace core
+{
+FloatingJointModel::FloatingJointModel(const std::string& name) : JointModel(name), angular_distance_weight_(1.0)
 {
   type_ = FLOATING;
   local_variable_names_.push_back("trans_x");
@@ -86,7 +89,7 @@ moveit::core::FloatingJointModel::FloatingJointModel(const std::string& name)
   computeVariableBoundsMsg();
 }
 
-double moveit::core::FloatingJointModel::getMaximumExtent(const Bounds& other_bounds) const
+double FloatingJointModel::getMaximumExtent(const Bounds& other_bounds) const
 {
   double dx = other_bounds[0].max_position_ - other_bounds[0].min_position_;
   double dy = other_bounds[1].max_position_ - other_bounds[1].min_position_;
@@ -94,12 +97,12 @@ double moveit::core::FloatingJointModel::getMaximumExtent(const Bounds& other_bo
   return sqrt(dx * dx + dy * dy + dz * dz) + boost::math::constants::pi<double>() * 0.5 * angular_distance_weight_;
 }
 
-double moveit::core::FloatingJointModel::distance(const double* values1, const double* values2) const
+double FloatingJointModel::distance(const double* values1, const double* values2) const
 {
   return distanceTranslation(values1, values2) + angular_distance_weight_ * distanceRotation(values1, values2);
 }
 
-double moveit::core::FloatingJointModel::distanceTranslation(const double* values1, const double* values2) const
+double FloatingJointModel::distanceTranslation(const double* values1, const double* values2) const
 {
   double dx = values1[0] - values2[0];
   double dy = values1[1] - values2[1];
@@ -107,7 +110,7 @@ double moveit::core::FloatingJointModel::distanceTranslation(const double* value
   return sqrt(dx * dx + dy * dy + dz * dz);
 }
 
-double moveit::core::FloatingJointModel::distanceRotation(const double* values1, const double* values2) const
+double FloatingJointModel::distanceRotation(const double* values1, const double* values2) const
 {
   double dq =
       fabs(values1[3] * values2[3] + values1[4] * values2[4] + values1[5] * values2[5] + values1[6] * values2[6]);
@@ -117,8 +120,7 @@ double moveit::core::FloatingJointModel::distanceRotation(const double* values1,
     return acos(dq);
 }
 
-void moveit::core::FloatingJointModel::interpolate(const double* from, const double* to, const double t,
-                                                   double* state) const
+void FloatingJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
 {
   // interpolate position
   state[0] = from[0] + (to[0] - from[0]) * t;
@@ -148,8 +150,7 @@ void moveit::core::FloatingJointModel::interpolate(const double* from, const dou
   }
 }
 
-bool moveit::core::FloatingJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds,
-                                                               double margin) const
+bool FloatingJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
     return false;
@@ -163,7 +164,7 @@ bool moveit::core::FloatingJointModel::satisfiesPositionBounds(const double* val
   return true;
 }
 
-bool moveit::core::FloatingJointModel::normalizeRotation(double* values) const
+bool FloatingJointModel::normalizeRotation(double* values) const
 {
   // normalize the quaternion if we need to
   double normSqr = values[3] * values[3] + values[4] * values[4] + values[5] * values[5] + values[6] * values[6];
@@ -191,12 +192,12 @@ bool moveit::core::FloatingJointModel::normalizeRotation(double* values) const
     return false;
 }
 
-unsigned int moveit::core::FloatingJointModel::getStateSpaceDimension() const
+unsigned int FloatingJointModel::getStateSpaceDimension() const
 {
   return 6;
 }
 
-bool moveit::core::FloatingJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
+bool FloatingJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
 {
   bool result = normalizeRotation(values);
   for (unsigned int i = 0; i < 3; ++i)
@@ -215,15 +216,14 @@ bool moveit::core::FloatingJointModel::enforcePositionBounds(double* values, con
   return result;
 }
 
-void moveit::core::FloatingJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
+void FloatingJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
 {
   transf = Eigen::Affine3d(
       Eigen::Translation3d(joint_values[0], joint_values[1], joint_values[2]) *
       Eigen::Quaterniond(joint_values[6], joint_values[3], joint_values[4], joint_values[5]).toRotationMatrix());
 }
 
-void moveit::core::FloatingJointModel::computeVariablePositions(const Eigen::Affine3d& transf,
-                                                                double* joint_values) const
+void FloatingJointModel::computeVariablePositions(const Eigen::Affine3d& transf, double* joint_values) const
 {
   joint_values[0] = transf.translation().x();
   joint_values[1] = transf.translation().y();
@@ -235,7 +235,7 @@ void moveit::core::FloatingJointModel::computeVariablePositions(const Eigen::Aff
   joint_values[6] = q.w();
 }
 
-void moveit::core::FloatingJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
+void FloatingJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
 {
   for (unsigned int i = 0; i < 3; ++i)
   {
@@ -252,8 +252,8 @@ void moveit::core::FloatingJointModel::getVariableDefaultPositions(double* value
   values[6] = 1.0;
 }
 
-void moveit::core::FloatingJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                                  double* values, const Bounds& bounds) const
+void FloatingJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                    const Bounds& bounds) const
 {
   if (bounds[0].max_position_ >= std::numeric_limits<double>::infinity() ||
       bounds[0].min_position_ <= -std::numeric_limits<double>::infinity())
@@ -279,9 +279,9 @@ void moveit::core::FloatingJointModel::getVariableRandomPositions(random_numbers
   values[6] = q[3];
 }
 
-void moveit::core::FloatingJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                        double* values, const Bounds& bounds,
-                                                                        const double* near, const double distance) const
+void FloatingJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                          const Bounds& bounds, const double* near,
+                                                          const double distance) const
 {
   if (bounds[0].max_position_ >= std::numeric_limits<double>::infinity() ||
       bounds[0].min_position_ <= -std::numeric_limits<double>::infinity())
@@ -343,3 +343,6 @@ void moveit::core::FloatingJointModel::getVariableRandomPositionsNearBy(random_n
     values[6] = near[6] * q[3] - near[3] * q[0] - near[4] * q[1] - near[5] * q[2];
   }
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -40,7 +40,11 @@
 #include <moveit/robot_model/link_model.h>
 #include <algorithm>
 
-moveit::core::JointModel::JointModel(const std::string& name)
+namespace moveit
+{
+namespace core
+{
+JointModel::JointModel(const std::string& name)
   : name_(name)
   , type_(UNKNOWN)
   , parent_link_model_(NULL)
@@ -55,11 +59,11 @@ moveit::core::JointModel::JointModel(const std::string& name)
 {
 }
 
-moveit::core::JointModel::~JointModel()
+JointModel::~JointModel()
 {
 }
 
-std::string moveit::core::JointModel::getTypeName() const
+std::string JointModel::getTypeName() const
 {
   switch (type_)
   {
@@ -80,7 +84,7 @@ std::string moveit::core::JointModel::getTypeName() const
   }
 }
 
-int moveit::core::JointModel::getLocalVariableIndex(const std::string& variable) const
+int JointModel::getLocalVariableIndex(const std::string& variable) const
 {
   VariableIndexMap::const_iterator it = variable_index_map_.find(variable);
   if (it == variable_index_map_.end())
@@ -88,7 +92,7 @@ int moveit::core::JointModel::getLocalVariableIndex(const std::string& variable)
   return it->second;
 }
 
-bool moveit::core::JointModel::enforceVelocityBounds(double* values, const Bounds& other_bounds) const
+bool JointModel::enforceVelocityBounds(double* values, const Bounds& other_bounds) const
 {
   bool change = false;
   for (std::size_t i = 0; i < other_bounds.size(); ++i)
@@ -105,8 +109,7 @@ bool moveit::core::JointModel::enforceVelocityBounds(double* values, const Bound
   return change;
 }
 
-bool moveit::core::JointModel::satisfiesVelocityBounds(const double* values, const Bounds& other_bounds,
-                                                       double margin) const
+bool JointModel::satisfiesVelocityBounds(const double* values, const Bounds& other_bounds, double margin) const
 {
   for (std::size_t i = 0; i < other_bounds.size(); ++i)
     if (other_bounds[i].max_velocity_ + margin < values[i])
@@ -116,18 +119,18 @@ bool moveit::core::JointModel::satisfiesVelocityBounds(const double* values, con
   return true;
 }
 
-const moveit::core::VariableBounds& moveit::core::JointModel::getVariableBounds(const std::string& variable) const
+const VariableBounds& JointModel::getVariableBounds(const std::string& variable) const
 {
   return variable_bounds_[getLocalVariableIndex(variable)];
 }
 
-void moveit::core::JointModel::setVariableBounds(const std::string& variable, const VariableBounds& bounds)
+void JointModel::setVariableBounds(const std::string& variable, const VariableBounds& bounds)
 {
   variable_bounds_[getLocalVariableIndex(variable)] = bounds;
   computeVariableBoundsMsg();
 }
 
-void moveit::core::JointModel::setVariableBounds(const std::vector<moveit_msgs::JointLimits>& jlim)
+void JointModel::setVariableBounds(const std::vector<moveit_msgs::JointLimits>& jlim)
 {
   for (std::size_t j = 0; j < variable_names_.size(); ++j)
     for (std::size_t i = 0; i < jlim.size(); ++i)
@@ -156,7 +159,7 @@ void moveit::core::JointModel::setVariableBounds(const std::vector<moveit_msgs::
   computeVariableBoundsMsg();
 }
 
-void moveit::core::JointModel::computeVariableBoundsMsg()
+void JointModel::computeVariableBoundsMsg()
 {
   variable_bounds_msg_.clear();
   for (std::size_t i = 0; i < variable_bounds_.size(); ++i)
@@ -175,26 +178,26 @@ void moveit::core::JointModel::computeVariableBoundsMsg()
   }
 }
 
-void moveit::core::JointModel::setMimic(const JointModel* mimic, double factor, double offset)
+void JointModel::setMimic(const JointModel* mimic, double factor, double offset)
 {
   mimic_ = mimic;
   mimic_factor_ = factor;
   mimic_offset_ = offset;
 }
 
-void moveit::core::JointModel::addMimicRequest(const JointModel* joint)
+void JointModel::addMimicRequest(const JointModel* joint)
 {
   mimic_requests_.push_back(joint);
 }
 
-void moveit::core::JointModel::addDescendantJointModel(const JointModel* joint)
+void JointModel::addDescendantJointModel(const JointModel* joint)
 {
   descendant_joint_models_.push_back(joint);
   if (joint->getType() != FIXED)
     non_fixed_descendant_joint_models_.push_back(joint);
 }
 
-void moveit::core::JointModel::addDescendantLinkModel(const LinkModel* link)
+void JointModel::addDescendantLinkModel(const LinkModel* link)
 {
   descendant_link_models_.push_back(link);
 }
@@ -212,7 +215,7 @@ inline void printBoundHelper(std::ostream& out, double v)
 }
 }
 
-std::ostream& moveit::core::operator<<(std::ostream& out, const VariableBounds& b)
+std::ostream& operator<<(std::ostream& out, const VariableBounds& b)
 {
   out << "P." << (b.position_bounded_ ? "bounded" : "unbounded") << " [";
   printBoundHelper(out, b.min_position_);
@@ -231,3 +234,6 @@ std::ostream& moveit::core::operator<<(std::ostream& out, const VariableBounds& 
   out << "];";
   return out;
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -96,12 +96,10 @@ bool jointPrecedes(const JointModel* a, const JointModel* b)
   return false;
 }
 }
-}
-}
 
-moveit::core::JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Model::Group& config,
-                                               const std::vector<const JointModel*>& unsorted_group_joints,
-                                               const RobotModel* parent_model)
+JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Model::Group& config,
+                                 const std::vector<const JointModel*>& unsorted_group_joints,
+                                 const RobotModel* parent_model)
   : parent_model_(parent_model)
   , name_(group_name)
   , common_root_(NULL)
@@ -263,11 +261,11 @@ moveit::core::JointModelGroup::JointModelGroup(const std::string& group_name, co
   }
 }
 
-moveit::core::JointModelGroup::~JointModelGroup()
+JointModelGroup::~JointModelGroup()
 {
 }
 
-void moveit::core::JointModelGroup::setSubgroupNames(const std::vector<std::string>& subgroups)
+void JointModelGroup::setSubgroupNames(const std::vector<std::string>& subgroups)
 {
   subgroup_names_ = subgroups;
   subgroup_names_set_.clear();
@@ -275,24 +273,24 @@ void moveit::core::JointModelGroup::setSubgroupNames(const std::vector<std::stri
     subgroup_names_set_.insert(subgroup_names_[i]);
 }
 
-void moveit::core::JointModelGroup::getSubgroups(std::vector<const JointModelGroup*>& sub_groups) const
+void JointModelGroup::getSubgroups(std::vector<const JointModelGroup*>& sub_groups) const
 {
   sub_groups.resize(subgroup_names_.size());
   for (std::size_t i = 0; i < subgroup_names_.size(); ++i)
     sub_groups[i] = parent_model_->getJointModelGroup(subgroup_names_[i]);
 }
 
-bool moveit::core::JointModelGroup::hasJointModel(const std::string& joint) const
+bool JointModelGroup::hasJointModel(const std::string& joint) const
 {
   return joint_model_map_.find(joint) != joint_model_map_.end();
 }
 
-bool moveit::core::JointModelGroup::hasLinkModel(const std::string& link) const
+bool JointModelGroup::hasLinkModel(const std::string& link) const
 {
   return link_model_map_.find(link) != link_model_map_.end();
 }
 
-const moveit::core::LinkModel* moveit::core::JointModelGroup::getLinkModel(const std::string& name) const
+const LinkModel* JointModelGroup::getLinkModel(const std::string& name) const
 {
   LinkModelMapConst::const_iterator it = link_model_map_.find(name);
   if (it == link_model_map_.end())
@@ -303,7 +301,7 @@ const moveit::core::LinkModel* moveit::core::JointModelGroup::getLinkModel(const
   return it->second;
 }
 
-const moveit::core::JointModel* moveit::core::JointModelGroup::getJointModel(const std::string& name) const
+const JointModel* JointModelGroup::getJointModel(const std::string& name) const
 {
   JointModelMapConst::const_iterator it = joint_model_map_.find(name);
   if (it == joint_model_map_.end())
@@ -314,9 +312,8 @@ const moveit::core::JointModel* moveit::core::JointModelGroup::getJointModel(con
   return it->second;
 }
 
-void moveit::core::JointModelGroup::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                               double* values,
-                                                               const JointBoundsVector& active_joint_bounds) const
+void JointModelGroup::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                 const JointBoundsVector& active_joint_bounds) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -326,10 +323,9 @@ void moveit::core::JointModelGroup::getVariableRandomPositions(random_numbers::R
   updateMimicJoints(values);
 }
 
-void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                     double* values,
-                                                                     const JointBoundsVector& active_joint_bounds,
-                                                                     const double* near, double distance) const
+void JointModelGroup::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                       const JointBoundsVector& active_joint_bounds, const double* near,
+                                                       double distance) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -339,7 +335,7 @@ void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(random_numb
   updateMimicJoints(values);
 }
 
-void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(
+void JointModelGroup::getVariableRandomPositionsNearBy(
     random_numbers::RandomNumberGenerator& rng, double* values, const JointBoundsVector& active_joint_bounds,
     const double* near, const std::map<JointModel::JointType, double>& distance_map) const
 {
@@ -347,7 +343,7 @@ void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
   {
     double distance = 0.0;
-    std::map<moveit::core::JointModel::JointType, double>::const_iterator iter =
+    std::map<JointModel::JointType, double>::const_iterator iter =
         distance_map.find(active_joint_model_vector_[i]->getType());
     if (iter != distance_map.end())
       distance = iter->second;
@@ -360,11 +356,9 @@ void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(
   updateMimicJoints(values);
 }
 
-void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                     double* values,
-                                                                     const JointBoundsVector& active_joint_bounds,
-                                                                     const double* near,
-                                                                     const std::vector<double>& distances) const
+void JointModelGroup::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                       const JointBoundsVector& active_joint_bounds, const double* near,
+                                                       const std::vector<double>& distances) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   if (distances.size() != active_joint_model_vector_.size())
@@ -379,9 +373,8 @@ void moveit::core::JointModelGroup::getVariableRandomPositionsNearBy(random_numb
   updateMimicJoints(values);
 }
 
-bool moveit::core::JointModelGroup::satisfiesPositionBounds(const double* state,
-                                                            const JointBoundsVector& active_joint_bounds,
-                                                            double margin) const
+bool JointModelGroup::satisfiesPositionBounds(const double* state, const JointBoundsVector& active_joint_bounds,
+                                              double margin) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -391,8 +384,7 @@ bool moveit::core::JointModelGroup::satisfiesPositionBounds(const double* state,
   return true;
 }
 
-bool moveit::core::JointModelGroup::enforcePositionBounds(double* state,
-                                                          const JointBoundsVector& active_joint_bounds) const
+bool JointModelGroup::enforcePositionBounds(double* state, const JointBoundsVector& active_joint_bounds) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   bool change = false;
@@ -405,7 +397,7 @@ bool moveit::core::JointModelGroup::enforcePositionBounds(double* state,
   return change;
 }
 
-double moveit::core::JointModelGroup::getMaximumExtent(const JointBoundsVector& active_joint_bounds) const
+double JointModelGroup::getMaximumExtent(const JointBoundsVector& active_joint_bounds) const
 {
   double max_distance = 0.0;
   for (std::size_t j = 0; j < active_joint_model_vector_.size(); ++j)
@@ -414,7 +406,7 @@ double moveit::core::JointModelGroup::getMaximumExtent(const JointBoundsVector& 
   return max_distance;
 }
 
-double moveit::core::JointModelGroup::distance(const double* state1, const double* state2) const
+double JointModelGroup::distance(const double* state1, const double* state2) const
 {
   double d = 0.0;
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -424,7 +416,7 @@ double moveit::core::JointModelGroup::distance(const double* state1, const doubl
   return d;
 }
 
-void moveit::core::JointModelGroup::interpolate(const double* from, const double* to, double t, double* state) const
+void JointModelGroup::interpolate(const double* from, const double* to, double t, double* state) const
 {
   // we interpolate values only for active joint models (non-mimic)
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -436,7 +428,7 @@ void moveit::core::JointModelGroup::interpolate(const double* from, const double
   updateMimicJoints(state);
 }
 
-void moveit::core::JointModelGroup::updateMimicJoints(double* values) const
+void JointModelGroup::updateMimicJoints(double* values) const
 {
   // update mimic (only local joints as we are dealing with a local group state)
   for (std::size_t i = 0; i < group_mimic_update_.size(); ++i)
@@ -444,15 +436,13 @@ void moveit::core::JointModelGroup::updateMimicJoints(double* values) const
         values[group_mimic_update_[i].src] * group_mimic_update_[i].factor + group_mimic_update_[i].offset;
 }
 
-void moveit::core::JointModelGroup::addDefaultState(const std::string& name,
-                                                    const std::map<std::string, double>& default_state)
+void JointModelGroup::addDefaultState(const std::string& name, const std::map<std::string, double>& default_state)
 {
   default_states_[name] = default_state;
   default_states_names_.push_back(name);
 }
 
-bool moveit::core::JointModelGroup::getVariableDefaultPositions(const std::string& name,
-                                                                std::map<std::string, double>& values) const
+bool JointModelGroup::getVariableDefaultPositions(const std::string& name, std::map<std::string, double>& values) const
 {
   std::map<std::string, std::map<std::string, double> >::const_iterator it = default_states_.find(name);
   if (it == default_states_.end())
@@ -461,14 +451,14 @@ bool moveit::core::JointModelGroup::getVariableDefaultPositions(const std::strin
   return true;
 }
 
-void moveit::core::JointModelGroup::getVariableDefaultPositions(double* values) const
+void JointModelGroup::getVariableDefaultPositions(double* values) const
 {
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
     active_joint_model_vector_[i]->getVariableDefaultPositions(values + active_joint_model_start_index_[i]);
   updateMimicJoints(values);
 }
 
-void moveit::core::JointModelGroup::getVariableDefaultPositions(std::map<std::string, double>& values) const
+void JointModelGroup::getVariableDefaultPositions(std::map<std::string, double>& values) const
 {
   std::vector<double> tmp(variable_count_);
   getVariableDefaultPositions(&tmp[0]);
@@ -476,23 +466,23 @@ void moveit::core::JointModelGroup::getVariableDefaultPositions(std::map<std::st
     values[variable_names_[i]] = tmp[i];
 }
 
-void moveit::core::JointModelGroup::setEndEffectorName(const std::string& name)
+void JointModelGroup::setEndEffectorName(const std::string& name)
 {
   end_effector_name_ = name;
 }
 
-void moveit::core::JointModelGroup::setEndEffectorParent(const std::string& group, const std::string& link)
+void JointModelGroup::setEndEffectorParent(const std::string& group, const std::string& link)
 {
   end_effector_parent_.first = group;
   end_effector_parent_.second = link;
 }
 
-void moveit::core::JointModelGroup::attachEndEffector(const std::string& eef_name)
+void JointModelGroup::attachEndEffector(const std::string& eef_name)
 {
   attached_end_effector_names_.push_back(eef_name);
 }
 
-bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<std::string>& tips) const
+bool JointModelGroup::getEndEffectorTips(std::vector<std::string>& tips) const
 {
   // Get a vector of tip links
   std::vector<const LinkModel*> tip_links;
@@ -508,7 +498,7 @@ bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<std::string>&
   return true;
 }
 
-bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) const
+bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) const
 {
   for (std::size_t i = 0; i < getAttachedEndEffectorNames().size(); ++i)
   {
@@ -532,9 +522,9 @@ bool moveit::core::JointModelGroup::getEndEffectorTips(std::vector<const LinkMod
   return true;
 }
 
-const moveit::core::LinkModel* moveit::core::JointModelGroup::getOnlyOneEndEffectorTip() const
+const LinkModel* JointModelGroup::getOnlyOneEndEffectorTip() const
 {
-  std::vector<const moveit::core::LinkModel*> tips;
+  std::vector<const LinkModel*> tips;
   getEndEffectorTips(tips);
   if (tips.size() == 1)
     return tips.front();
@@ -545,7 +535,7 @@ const moveit::core::LinkModel* moveit::core::JointModelGroup::getOnlyOneEndEffec
   return NULL;
 }
 
-int moveit::core::JointModelGroup::getVariableGroupIndex(const std::string& variable) const
+int JointModelGroup::getVariableGroupIndex(const std::string& variable) const
 {
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);
   if (it == joint_variables_index_map_.end())
@@ -556,7 +546,7 @@ int moveit::core::JointModelGroup::getVariableGroupIndex(const std::string& vari
   return it->second;
 }
 
-void moveit::core::JointModelGroup::setDefaultIKTimeout(double ik_timeout)
+void JointModelGroup::setDefaultIKTimeout(double ik_timeout)
 {
   group_kinematics_.first.default_ik_timeout_ = ik_timeout;
   if (group_kinematics_.first.solver_instance_)
@@ -565,15 +555,15 @@ void moveit::core::JointModelGroup::setDefaultIKTimeout(double ik_timeout)
     it->second.default_ik_timeout_ = ik_timeout;
 }
 
-void moveit::core::JointModelGroup::setDefaultIKAttempts(unsigned int ik_attempts)
+void JointModelGroup::setDefaultIKAttempts(unsigned int ik_attempts)
 {
   group_kinematics_.first.default_ik_attempts_ = ik_attempts;
   for (KinematicsSolverMap::iterator it = group_kinematics_.second.begin(); it != group_kinematics_.second.end(); ++it)
     it->second.default_ik_attempts_ = ik_attempts;
 }
 
-bool moveit::core::JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik_jnames,
-                                                            std::vector<unsigned int>& joint_bijection) const
+bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik_jnames,
+                                              std::vector<unsigned int>& joint_bijection) const
 {
   joint_bijection.clear();
   for (std::size_t i = 0; i < ik_jnames.size(); ++i)
@@ -596,8 +586,7 @@ bool moveit::core::JointModelGroup::computeIKIndexBijection(const std::vector<st
   return true;
 }
 
-void moveit::core::JointModelGroup::setSolverAllocators(
-    const std::pair<SolverAllocatorFn, SolverAllocatorMapFn>& solvers)
+void JointModelGroup::setSolverAllocators(const std::pair<SolverAllocatorFn, SolverAllocatorMapFn>& solvers)
 {
   if (solvers.first)
   {
@@ -631,7 +620,7 @@ void moveit::core::JointModelGroup::setSolverAllocators(
       }
 }
 
-bool moveit::core::JointModelGroup::canSetStateFromIK(const std::string& tip) const
+bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
 {
   const kinematics::KinematicsBaseConstPtr& solver = getSolverInstance();
   if (!solver || tip.empty())
@@ -678,7 +667,7 @@ bool moveit::core::JointModelGroup::canSetStateFromIK(const std::string& tip) co
   return false;
 }
 
-void moveit::core::JointModelGroup::printGroupInfo(std::ostream& out) const
+void JointModelGroup::printGroupInfo(std::ostream& out) const
 {
   out << "Group '" << name_ << "' using " << variable_count_ << " variables" << std::endl;
   out << "  * Joints:" << std::endl;
@@ -737,3 +726,6 @@ void moveit::core::JointModelGroup::printGroupInfo(std::ostream& out) const
   }
   out << std::endl;
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -39,7 +39,11 @@
 #include <geometric_shapes/shape_operations.h>
 #include <moveit/robot_model/aabb.h>
 
-moveit::core::LinkModel::LinkModel(const std::string& name)
+namespace moveit
+{
+namespace core
+{
+LinkModel::LinkModel(const std::string& name)
   : name_(name)
   , parent_joint_model_(NULL)
   , parent_link_model_(NULL)
@@ -51,11 +55,11 @@ moveit::core::LinkModel::LinkModel(const std::string& name)
   joint_origin_transform_.setIdentity();
 }
 
-moveit::core::LinkModel::~LinkModel()
+LinkModel::~LinkModel()
 {
 }
 
-void moveit::core::LinkModel::setJointOriginTransform(const Eigen::Affine3d& transform)
+void LinkModel::setJointOriginTransform(const Eigen::Affine3d& transform)
 {
   joint_origin_transform_ = transform;
   joint_origin_transform_is_identity_ =
@@ -63,14 +67,13 @@ void moveit::core::LinkModel::setJointOriginTransform(const Eigen::Affine3d& tra
       joint_origin_transform_.translation().norm() < std::numeric_limits<double>::epsilon();
 }
 
-void moveit::core::LinkModel::setParentJointModel(const JointModel* joint)
+void LinkModel::setParentJointModel(const JointModel* joint)
 {
   parent_joint_model_ = joint;
   is_parent_joint_fixed_ = joint->getType() == JointModel::FIXED;
 }
 
-void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPtr>& shapes,
-                                          const EigenSTL::vector_Affine3d& origins)
+void LinkModel::setGeometry(const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Affine3d& origins)
 {
   shapes_ = shapes;
   collision_origin_transform_ = origins;
@@ -111,10 +114,13 @@ void moveit::core::LinkModel::setGeometry(const std::vector<shapes::ShapeConstPt
     shape_extents_ = aabb.sizes();
 }
 
-void moveit::core::LinkModel::setVisualMesh(const std::string& visual_mesh, const Eigen::Affine3d& origin,
-                                            const Eigen::Vector3d& scale)
+void LinkModel::setVisualMesh(const std::string& visual_mesh, const Eigen::Affine3d& origin,
+                              const Eigen::Vector3d& scale)
 {
   visual_mesh_filename_ = visual_mesh;
   visual_mesh_origin_ = origin;
   visual_mesh_scale_ = scale;
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -40,8 +40,11 @@
 #include <limits>
 #include <cmath>
 
-moveit::core::PlanarJointModel::PlanarJointModel(const std::string& name)
-  : JointModel(name), angular_distance_weight_(1.0)
+namespace moveit
+{
+namespace core
+{
+PlanarJointModel::PlanarJointModel(const std::string& name) : JointModel(name), angular_distance_weight_(1.0)
 {
   type_ = PLANAR;
 
@@ -69,19 +72,19 @@ moveit::core::PlanarJointModel::PlanarJointModel(const std::string& name)
   computeVariableBoundsMsg();
 }
 
-unsigned int moveit::core::PlanarJointModel::getStateSpaceDimension() const
+unsigned int PlanarJointModel::getStateSpaceDimension() const
 {
   return 3;
 }
 
-double moveit::core::PlanarJointModel::getMaximumExtent(const Bounds& other_bounds) const
+double PlanarJointModel::getMaximumExtent(const Bounds& other_bounds) const
 {
   double dx = other_bounds[0].max_position_ - other_bounds[0].min_position_;
   double dy = other_bounds[1].max_position_ - other_bounds[1].min_position_;
   return sqrt(dx * dx + dy * dy) + boost::math::constants::pi<double>() * angular_distance_weight_;
 }
 
-void moveit::core::PlanarJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
+void PlanarJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
 {
   for (unsigned int i = 0; i < 2; ++i)
   {
@@ -94,8 +97,8 @@ void moveit::core::PlanarJointModel::getVariableDefaultPositions(double* values,
   values[2] = 0.0;
 }
 
-void moveit::core::PlanarJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                                double* values, const Bounds& bounds) const
+void PlanarJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                  const Bounds& bounds) const
 {
   if (bounds[0].max_position_ >= std::numeric_limits<double>::infinity() ||
       bounds[0].min_position_ <= -std::numeric_limits<double>::infinity())
@@ -110,9 +113,9 @@ void moveit::core::PlanarJointModel::getVariableRandomPositions(random_numbers::
   values[2] = rng.uniformReal(bounds[2].min_position_, bounds[2].max_position_);
 }
 
-void moveit::core::PlanarJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                      double* values, const Bounds& bounds,
-                                                                      const double* near, const double distance) const
+void PlanarJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                        const Bounds& bounds, const double* near,
+                                                        const double distance) const
 {
   if (bounds[0].max_position_ >= std::numeric_limits<double>::infinity() ||
       bounds[0].min_position_ <= -std::numeric_limits<double>::infinity())
@@ -135,8 +138,7 @@ void moveit::core::PlanarJointModel::getVariableRandomPositionsNearBy(random_num
   normalizeRotation(values);
 }
 
-void moveit::core::PlanarJointModel::interpolate(const double* from, const double* to, const double t,
-                                                 double* state) const
+void PlanarJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
 {
   // interpolate position
   state[0] = from[0] + (to[0] - from[0]) * t;
@@ -161,7 +163,7 @@ void moveit::core::PlanarJointModel::interpolate(const double* from, const doubl
   }
 }
 
-double moveit::core::PlanarJointModel::distance(const double* values1, const double* values2) const
+double PlanarJointModel::distance(const double* values1, const double* values2) const
 {
   double dx = values1[0] - values2[0];
   double dy = values1[1] - values2[1];
@@ -171,8 +173,7 @@ double moveit::core::PlanarJointModel::distance(const double* values1, const dou
   return sqrt(dx * dx + dy * dy) + angular_distance_weight_ * d;
 }
 
-bool moveit::core::PlanarJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds,
-                                                             double margin) const
+bool PlanarJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   for (unsigned int i = 0; i < 3; ++i)
     if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
@@ -180,7 +181,7 @@ bool moveit::core::PlanarJointModel::satisfiesPositionBounds(const double* value
   return true;
 }
 
-bool moveit::core::PlanarJointModel::normalizeRotation(double* values) const
+bool PlanarJointModel::normalizeRotation(double* values) const
 {
   double& v = values[2];
   if (v >= -boost::math::constants::pi<double>() && v <= boost::math::constants::pi<double>())
@@ -193,7 +194,7 @@ bool moveit::core::PlanarJointModel::normalizeRotation(double* values) const
   return true;
 }
 
-bool moveit::core::PlanarJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
+bool PlanarJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
 {
   bool result = normalizeRotation(values);
   for (unsigned int i = 0; i < 2; ++i)
@@ -212,13 +213,13 @@ bool moveit::core::PlanarJointModel::enforcePositionBounds(double* values, const
   return result;
 }
 
-void moveit::core::PlanarJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
+void PlanarJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
 {
   transf = Eigen::Affine3d(Eigen::Translation3d(joint_values[0], joint_values[1], 0.0) *
                            Eigen::AngleAxisd(joint_values[2], Eigen::Vector3d::UnitZ()));
 }
 
-void moveit::core::PlanarJointModel::computeVariablePositions(const Eigen::Affine3d& transf, double* joint_values) const
+void PlanarJointModel::computeVariablePositions(const Eigen::Affine3d& transf, double* joint_values) const
 {
   joint_values[0] = transf.translation().x();
   joint_values[1] = transf.translation().y();
@@ -234,3 +235,6 @@ void moveit::core::PlanarJointModel::computeVariablePositions(const Eigen::Affin
     joint_values[2] = (acos(q.w()) * 2.0f) * (q.z() * s);
   }
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/prismatic_joint_model.cpp
+++ b/moveit_core/robot_model/src/prismatic_joint_model.cpp
@@ -37,7 +37,11 @@
 #include <moveit/robot_model/prismatic_joint_model.h>
 #include <limits>
 
-moveit::core::PrismaticJointModel::PrismaticJointModel(const std::string& name) : JointModel(name), axis_(0.0, 0.0, 0.0)
+namespace moveit
+{
+namespace core
+{
+PrismaticJointModel::PrismaticJointModel(const std::string& name) : JointModel(name), axis_(0.0, 0.0, 0.0)
 {
   type_ = PRISMATIC;
   variable_names_.push_back(name_);
@@ -49,17 +53,17 @@ moveit::core::PrismaticJointModel::PrismaticJointModel(const std::string& name) 
   computeVariableBoundsMsg();
 }
 
-unsigned int moveit::core::PrismaticJointModel::getStateSpaceDimension() const
+unsigned int PrismaticJointModel::getStateSpaceDimension() const
 {
   return 1;
 }
 
-double moveit::core::PrismaticJointModel::getMaximumExtent(const Bounds& other_bounds) const
+double PrismaticJointModel::getMaximumExtent(const Bounds& other_bounds) const
 {
   return variable_bounds_[0].max_position_ - other_bounds[0].min_position_;
 }
 
-void moveit::core::PrismaticJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
+void PrismaticJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
 {
   // if zero is a valid value
   if (bounds[0].min_position_ <= 0.0 && bounds[0].max_position_ >= 0.0)
@@ -68,30 +72,28 @@ void moveit::core::PrismaticJointModel::getVariableDefaultPositions(double* valu
     values[0] = (bounds[0].min_position_ + bounds[0].max_position_) / 2.0;
 }
 
-bool moveit::core::PrismaticJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds,
-                                                                double margin) const
+bool PrismaticJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
     return false;
   return true;
 }
 
-void moveit::core::PrismaticJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                                   double* values, const Bounds& bounds) const
+void PrismaticJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                     const Bounds& bounds) const
 {
   values[0] = rng.uniformReal(bounds[0].min_position_, bounds[0].max_position_);
 }
 
-void moveit::core::PrismaticJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                         double* values, const Bounds& bounds,
-                                                                         const double* near,
-                                                                         const double distance) const
+void PrismaticJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                           const Bounds& bounds, const double* near,
+                                                           const double distance) const
 {
   values[0] = rng.uniformReal(std::max(bounds[0].min_position_, near[0] - distance),
                               std::min(bounds[0].max_position_, near[0] + distance));
 }
 
-bool moveit::core::PrismaticJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
+bool PrismaticJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
 {
   if (values[0] < bounds[0].min_position_)
   {
@@ -106,18 +108,17 @@ bool moveit::core::PrismaticJointModel::enforcePositionBounds(double* values, co
   return false;
 }
 
-double moveit::core::PrismaticJointModel::distance(const double* values1, const double* values2) const
+double PrismaticJointModel::distance(const double* values1, const double* values2) const
 {
   return fabs(values1[0] - values2[0]);
 }
 
-void moveit::core::PrismaticJointModel::interpolate(const double* from, const double* to, const double t,
-                                                    double* state) const
+void PrismaticJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
 {
   state[0] = from[0] + (to[0] - from[0]) * t;
 }
 
-void moveit::core::PrismaticJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
+void PrismaticJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
 {
   double* d = transf.data();
   d[0] = 1.0;
@@ -144,8 +145,10 @@ void moveit::core::PrismaticJointModel::computeTransform(const double* joint_val
   //  transf.translation() = Eigen::Vector3d(axis_ * joint_values[0]);
 }
 
-void moveit::core::PrismaticJointModel::computeVariablePositions(const Eigen::Affine3d& transf,
-                                                                 double* joint_values) const
+void PrismaticJointModel::computeVariablePositions(const Eigen::Affine3d& transf, double* joint_values) const
 {
   joint_values[0] = transf.translation().dot(axis_);
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -41,7 +41,11 @@
 #include <limits>
 #include <cmath>
 
-moveit::core::RevoluteJointModel::RevoluteJointModel(const std::string& name)
+namespace moveit
+{
+namespace core
+{
+RevoluteJointModel::RevoluteJointModel(const std::string& name)
   : JointModel(name)
   , axis_(0.0, 0.0, 0.0)
   , continuous_(false)
@@ -62,12 +66,12 @@ moveit::core::RevoluteJointModel::RevoluteJointModel(const std::string& name)
   computeVariableBoundsMsg();
 }
 
-unsigned int moveit::core::RevoluteJointModel::getStateSpaceDimension() const
+unsigned int RevoluteJointModel::getStateSpaceDimension() const
 {
   return 1;
 }
 
-void moveit::core::RevoluteJointModel::setAxis(const Eigen::Vector3d& axis)
+void RevoluteJointModel::setAxis(const Eigen::Vector3d& axis)
 {
   axis_ = axis.normalized();
   x2_ = axis_.x() * axis_.x();
@@ -78,7 +82,7 @@ void moveit::core::RevoluteJointModel::setAxis(const Eigen::Vector3d& axis)
   yz_ = axis_.y() * axis_.z();
 }
 
-void moveit::core::RevoluteJointModel::setContinuous(bool flag)
+void RevoluteJointModel::setContinuous(bool flag)
 {
   continuous_ = flag;
   if (flag)
@@ -92,12 +96,12 @@ void moveit::core::RevoluteJointModel::setContinuous(bool flag)
   computeVariableBoundsMsg();
 }
 
-double moveit::core::RevoluteJointModel::getMaximumExtent(const Bounds& other_bounds) const
+double RevoluteJointModel::getMaximumExtent(const Bounds& other_bounds) const
 {
   return variable_bounds_[0].max_position_ - variable_bounds_[0].min_position_;
 }
 
-void moveit::core::RevoluteJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
+void RevoluteJointModel::getVariableDefaultPositions(double* values, const Bounds& bounds) const
 {
   // if zero is a valid value
   if (bounds[0].min_position_ <= 0.0 && bounds[0].max_position_ >= 0.0)
@@ -106,15 +110,15 @@ void moveit::core::RevoluteJointModel::getVariableDefaultPositions(double* value
     values[0] = (bounds[0].min_position_ + bounds[0].max_position_) / 2.0;
 }
 
-void moveit::core::RevoluteJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                                  double* values, const Bounds& bounds) const
+void RevoluteJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                    const Bounds& bounds) const
 {
   values[0] = rng.uniformReal(bounds[0].min_position_, bounds[0].max_position_);
 }
 
-void moveit::core::RevoluteJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng,
-                                                                        double* values, const Bounds& bounds,
-                                                                        const double* near, const double distance) const
+void RevoluteJointModel::getVariableRandomPositionsNearBy(random_numbers::RandomNumberGenerator& rng, double* values,
+                                                          const Bounds& bounds, const double* near,
+                                                          const double distance) const
 {
   if (continuous_)
   {
@@ -126,8 +130,7 @@ void moveit::core::RevoluteJointModel::getVariableRandomPositionsNearBy(random_n
                                 std::min(bounds[0].max_position_, near[0] + distance));
 }
 
-void moveit::core::RevoluteJointModel::interpolate(const double* from, const double* to, const double t,
-                                                   double* state) const
+void RevoluteJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
 {
   if (continuous_)
   {
@@ -152,7 +155,7 @@ void moveit::core::RevoluteJointModel::interpolate(const double* from, const dou
     state[0] = from[0] + (to[0] - from[0]) * t;
 }
 
-double moveit::core::RevoluteJointModel::distance(const double* values1, const double* values2) const
+double RevoluteJointModel::distance(const double* values1, const double* values2) const
 {
   if (continuous_)
   {
@@ -163,15 +166,14 @@ double moveit::core::RevoluteJointModel::distance(const double* values1, const d
     return fabs(values1[0] - values2[0]);
 }
 
-bool moveit::core::RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds,
-                                                               double margin) const
+bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
     return false;
   return true;
 }
 
-bool moveit::core::RevoluteJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
+bool RevoluteJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const
 {
   if (continuous_)
   {
@@ -202,7 +204,7 @@ bool moveit::core::RevoluteJointModel::enforcePositionBounds(double* values, con
   return false;
 }
 
-void moveit::core::RevoluteJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
+void RevoluteJointModel::computeTransform(const double* joint_values, Eigen::Affine3d& transf) const
 {
   const double c = cos(joint_values[0]);
   const double s = sin(joint_values[0]);
@@ -241,8 +243,7 @@ void moveit::core::RevoluteJointModel::computeTransform(const double* joint_valu
   //  transf = Eigen::Affine3d(Eigen::AngleAxisd(joint_values[0], axis_));
 }
 
-void moveit::core::RevoluteJointModel::computeVariablePositions(const Eigen::Affine3d& transf,
-                                                                double* joint_values) const
+void RevoluteJointModel::computeVariablePositions(const Eigen::Affine3d& transf, double* joint_values) const
 {
   Eigen::Quaterniond q(transf.rotation());
   q.normalize();
@@ -250,3 +251,6 @@ void moveit::core::RevoluteJointModel::computeVariablePositions(const Eigen::Aff
   axis_.array().abs().maxCoeff(&maxIdx);
   joint_values[0] = 2. * atan2(q.vec()[maxIdx] / axis_[maxIdx], q.w());
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -46,7 +46,6 @@
 #include <memory>
 #include "order_robot_model_items.inc"
 
-/* ------------------------ RobotModel ------------------------ */
 namespace moveit
 {
 namespace core

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -47,9 +47,11 @@
 #include "order_robot_model_items.inc"
 
 /* ------------------------ RobotModel ------------------------ */
-
-moveit::core::RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
-                                     const srdf::ModelConstSharedPtr& srdf_model)
+namespace moveit
+{
+namespace core
+{
+RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model, const srdf::ModelConstSharedPtr& srdf_model)
 {
   root_joint_ = NULL;
   urdf_ = urdf_model;
@@ -57,7 +59,7 @@ moveit::core::RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_m
   buildModel(*urdf_model, *srdf_model);
 }
 
-moveit::core::RobotModel::~RobotModel()
+RobotModel::~RobotModel()
 {
   for (JointModelGroupMap::iterator it = joint_model_group_map_.begin(); it != joint_model_group_map_.end(); ++it)
     delete it->second;
@@ -67,17 +69,17 @@ moveit::core::RobotModel::~RobotModel()
     delete link_model_vector_[i];
 }
 
-const moveit::core::JointModel* moveit::core::RobotModel::getRootJoint() const
+const JointModel* RobotModel::getRootJoint() const
 {
   return root_joint_;
 }
 
-const moveit::core::LinkModel* moveit::core::RobotModel::getRootLink() const
+const LinkModel* RobotModel::getRootLink() const
 {
   return root_link_;
 }
 
-void moveit::core::RobotModel::buildModel(const urdf::ModelInterface& urdf_model, const srdf::Model& srdf_model)
+void RobotModel::buildModel(const urdf::ModelInterface& urdf_model, const srdf::Model& srdf_model)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("RobotModel::buildModel");
@@ -123,10 +125,6 @@ void moveit::core::RobotModel::buildModel(const urdf::ModelInterface& urdf_model
     CONSOLE_BRIDGE_logWarn("No root link found");
 }
 
-namespace moveit
-{
-namespace core
-{
 namespace
 {
 typedef std::map<const JointModel*, std::pair<std::set<const LinkModel*, OrderLinksByIndex>,
@@ -194,10 +192,8 @@ void computeCommonRootsHelper(const JointModel* joint, std::vector<int>& common_
   }
 }
 }
-}
-}
 
-void moveit::core::RobotModel::computeCommonRoots()
+void RobotModel::computeCommonRoots()
 {
   // compute common roots for all pairs of joints;
   // there are 3 cases of pairs (X, Y):
@@ -230,7 +226,7 @@ void moveit::core::RobotModel::computeCommonRoots()
   }
 }
 
-void moveit::core::RobotModel::computeDescendants()
+void RobotModel::computeDescendants()
 {
   // compute the list of descendants for all joints
   std::vector<const JointModel*> parents;
@@ -249,7 +245,7 @@ void moveit::core::RobotModel::computeDescendants()
   }
 }
 
-void moveit::core::RobotModel::buildJointInfo()
+void RobotModel::buildJointInfo()
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("RobotModel::buildJointInfo");
@@ -319,7 +315,7 @@ void moveit::core::RobotModel::buildJointInfo()
   computeCommonRoots();  // must be called _after_ list of descendants was computed
 }
 
-void moveit::core::RobotModel::buildGroupStates(const srdf::Model& srdf_model)
+void RobotModel::buildGroupStates(const srdf::Model& srdf_model)
 {
   // copy the default states to the groups
   const std::vector<srdf::Model::GroupState>& ds = srdf_model.getGroupStates();
@@ -359,7 +355,7 @@ void moveit::core::RobotModel::buildGroupStates(const srdf::Model& srdf_model)
   }
 }
 
-void moveit::core::RobotModel::buildMimic(const urdf::ModelInterface& urdf_model)
+void RobotModel::buildMimic(const urdf::ModelInterface& urdf_model)
 {
   // compute mimic joints
   for (std::size_t i = 0; i < joint_model_vector_.size(); ++i)
@@ -419,12 +415,12 @@ void moveit::core::RobotModel::buildMimic(const urdf::ModelInterface& urdf_model
     }
 }
 
-bool moveit::core::RobotModel::hasEndEffector(const std::string& eef) const
+bool RobotModel::hasEndEffector(const std::string& eef) const
 {
   return end_effectors_map_.find(eef) != end_effectors_map_.end();
 }
 
-const moveit::core::JointModelGroup* moveit::core::RobotModel::getEndEffector(const std::string& name) const
+const JointModelGroup* RobotModel::getEndEffector(const std::string& name) const
 {
   JointModelGroupMap::const_iterator it = end_effectors_map_.find(name);
   if (it == end_effectors_map_.end())
@@ -438,7 +434,7 @@ const moveit::core::JointModelGroup* moveit::core::RobotModel::getEndEffector(co
   return it->second;
 }
 
-moveit::core::JointModelGroup* moveit::core::RobotModel::getEndEffector(const std::string& name)
+JointModelGroup* RobotModel::getEndEffector(const std::string& name)
 {
   JointModelGroupMap::const_iterator it = end_effectors_map_.find(name);
   if (it == end_effectors_map_.end())
@@ -452,12 +448,12 @@ moveit::core::JointModelGroup* moveit::core::RobotModel::getEndEffector(const st
   return it->second;
 }
 
-bool moveit::core::RobotModel::hasJointModelGroup(const std::string& name) const
+bool RobotModel::hasJointModelGroup(const std::string& name) const
 {
   return joint_model_group_map_.find(name) != joint_model_group_map_.end();
 }
 
-const moveit::core::JointModelGroup* moveit::core::RobotModel::getJointModelGroup(const std::string& name) const
+const JointModelGroup* RobotModel::getJointModelGroup(const std::string& name) const
 {
   JointModelGroupMap::const_iterator it = joint_model_group_map_.find(name);
   if (it == joint_model_group_map_.end())
@@ -468,7 +464,7 @@ const moveit::core::JointModelGroup* moveit::core::RobotModel::getJointModelGrou
   return it->second;
 }
 
-moveit::core::JointModelGroup* moveit::core::RobotModel::getJointModelGroup(const std::string& name)
+JointModelGroup* RobotModel::getJointModelGroup(const std::string& name)
 {
   JointModelGroupMap::const_iterator it = joint_model_group_map_.find(name);
   if (it == joint_model_group_map_.end())
@@ -479,7 +475,7 @@ moveit::core::JointModelGroup* moveit::core::RobotModel::getJointModelGroup(cons
   return it->second;
 }
 
-void moveit::core::RobotModel::buildGroups(const srdf::Model& srdf_model)
+void RobotModel::buildGroups(const srdf::Model& srdf_model)
 {
   const std::vector<srdf::Model::Group>& group_configs = srdf_model.getGroups();
 
@@ -531,7 +527,7 @@ void moveit::core::RobotModel::buildGroups(const srdf::Model& srdf_model)
   buildGroupsInfo_EndEffectors(srdf_model);
 }
 
-void moveit::core::RobotModel::buildGroupsInfo_Subgroups(const srdf::Model& srdf_model)
+void RobotModel::buildGroupsInfo_Subgroups(const srdf::Model& srdf_model)
 {
   // compute subgroups
   for (JointModelGroupMap::const_iterator it = joint_model_group_map_.begin(); it != joint_model_group_map_.end(); ++it)
@@ -560,7 +556,7 @@ void moveit::core::RobotModel::buildGroupsInfo_Subgroups(const srdf::Model& srdf
   }
 }
 
-void moveit::core::RobotModel::buildGroupsInfo_EndEffectors(const srdf::Model& srdf_model)
+void RobotModel::buildGroupsInfo_EndEffectors(const srdf::Model& srdf_model)
 {
   // set the end-effector flags
   const std::vector<srdf::Model::EndEffector>& eefs = srdf_model.getEndEffectors();
@@ -644,7 +640,7 @@ void moveit::core::RobotModel::buildGroupsInfo_EndEffectors(const srdf::Model& s
   std::sort(end_effectors_.begin(), end_effectors_.end(), OrderGroupsByName());
 }
 
-bool moveit::core::RobotModel::addJointModelGroup(const srdf::Model::Group& gc)
+bool RobotModel::addJointModelGroup(const srdf::Model::Group& gc)
 {
   if (joint_model_group_map_.find(gc.name_) != joint_model_group_map_.end())
   {
@@ -759,8 +755,7 @@ bool moveit::core::RobotModel::addJointModelGroup(const srdf::Model::Group& gc)
   return true;
 }
 
-moveit::core::JointModel* moveit::core::RobotModel::buildRecursive(LinkModel* parent, const urdf::Link* urdf_link,
-                                                                   const srdf::Model& srdf_model)
+JointModel* RobotModel::buildRecursive(LinkModel* parent, const urdf::Link* urdf_link, const srdf::Model& srdf_model)
 {
   // construct the joint
   JointModel* joint = urdf_link->parent_joint ?
@@ -810,9 +805,9 @@ moveit::core::JointModel* moveit::core::RobotModel::buildRecursive(LinkModel* pa
 namespace
 {
 // construct bounds for 1DOF joint
-static inline moveit::core::VariableBounds jointBoundsFromURDF(const urdf::Joint* urdf_joint)
+static inline VariableBounds jointBoundsFromURDF(const urdf::Joint* urdf_joint)
 {
-  moveit::core::VariableBounds b;
+  VariableBounds b;
   if (urdf_joint->safety)
   {
     b.position_bounded_ = true;
@@ -845,9 +840,8 @@ static inline moveit::core::VariableBounds jointBoundsFromURDF(const urdf::Joint
 }
 }
 
-moveit::core::JointModel* moveit::core::RobotModel::constructJointModel(const urdf::Joint* urdf_joint,
-                                                                        const urdf::Link* child_link,
-                                                                        const srdf::Model& srdf_model)
+JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const urdf::Link* child_link,
+                                            const srdf::Model& srdf_model)
 {
   JointModel* result = NULL;
 
@@ -967,7 +961,7 @@ static inline Eigen::Affine3d urdfPose2Affine3d(const urdf::Pose& pose)
 }
 }
 
-moveit::core::LinkModel* moveit::core::RobotModel::constructLinkModel(const urdf::Link* urdf_link)
+LinkModel* RobotModel::constructLinkModel(const urdf::Link* urdf_link)
 {
   LinkModel* result = new LinkModel(urdf_link->name);
 
@@ -1035,7 +1029,7 @@ moveit::core::LinkModel* moveit::core::RobotModel::constructLinkModel(const urdf
   return result;
 }
 
-shapes::ShapePtr moveit::core::RobotModel::constructShape(const urdf::Geometry* geom)
+shapes::ShapePtr RobotModel::constructShape(const urdf::Geometry* geom)
 {
   moveit::tools::Profiler::ScopedBlock prof_block("RobotModel::constructShape");
 
@@ -1074,17 +1068,17 @@ shapes::ShapePtr moveit::core::RobotModel::constructShape(const urdf::Geometry* 
   return shapes::ShapePtr(result);
 }
 
-bool moveit::core::RobotModel::hasJointModel(const std::string& name) const
+bool RobotModel::hasJointModel(const std::string& name) const
 {
   return joint_model_map_.find(name) != joint_model_map_.end();
 }
 
-bool moveit::core::RobotModel::hasLinkModel(const std::string& name) const
+bool RobotModel::hasLinkModel(const std::string& name) const
 {
   return link_model_map_.find(name) != link_model_map_.end();
 }
 
-const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const std::string& name) const
+const JointModel* RobotModel::getJointModel(const std::string& name) const
 {
   JointModelMap::const_iterator it = joint_model_map_.find(name);
   if (it != joint_model_map_.end())
@@ -1093,7 +1087,7 @@ const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const st
   return NULL;
 }
 
-const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(int index) const
+const JointModel* RobotModel::getJointModel(int index) const
 {
   if (index < 0 || index >= static_cast<int>(joint_model_vector_.size()))
   {
@@ -1104,7 +1098,7 @@ const moveit::core::JointModel* moveit::core::RobotModel::getJointModel(int inde
   return joint_model_vector_[index];
 }
 
-moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const std::string& name)
+JointModel* RobotModel::getJointModel(const std::string& name)
 {
   JointModelMap::const_iterator it = joint_model_map_.find(name);
   if (it != joint_model_map_.end())
@@ -1113,12 +1107,12 @@ moveit::core::JointModel* moveit::core::RobotModel::getJointModel(const std::str
   return NULL;
 }
 
-const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::string& name) const
+const LinkModel* RobotModel::getLinkModel(const std::string& name) const
 {
   return const_cast<RobotModel*>(this)->getLinkModel(name);
 }
 
-const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(int index) const
+const LinkModel* RobotModel::getLinkModel(int index) const
 {
   if (index < 0 || index >= static_cast<int>(link_model_vector_.size()))
   {
@@ -1129,7 +1123,7 @@ const moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(int index)
   return link_model_vector_[index];
 }
 
-moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::string& name)
+LinkModel* RobotModel::getLinkModel(const std::string& name)
 {
   LinkModelMap::const_iterator it = link_model_map_.find(name);
   if (it != link_model_map_.end())
@@ -1138,7 +1132,7 @@ moveit::core::LinkModel* moveit::core::RobotModel::getLinkModel(const std::strin
   return NULL;
 }
 
-const moveit::core::LinkModel* moveit::core::RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link)
+const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link)
 {
   if (!link)
     return link;
@@ -1154,7 +1148,7 @@ const moveit::core::LinkModel* moveit::core::RobotModel::getRigidlyConnectedPare
   return link;
 }
 
-void moveit::core::RobotModel::updateMimicJoints(double* values) const
+void RobotModel::updateMimicJoints(double* values) const
 {
   for (std::size_t i = 0; i < mimic_joints_.size(); ++i)
   {
@@ -1164,16 +1158,15 @@ void moveit::core::RobotModel::updateMimicJoints(double* values) const
   }
 }
 
-void moveit::core::RobotModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                          double* values) const
+void RobotModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values) const
 {
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
     active_joint_model_vector_[i]->getVariableRandomPositions(rng, values + active_joint_model_start_index_[i]);
   updateMimicJoints(values);
 }
 
-void moveit::core::RobotModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
-                                                          std::map<std::string, double>& values) const
+void RobotModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng,
+                                            std::map<std::string, double>& values) const
 {
   std::vector<double> tmp(variable_count_);
   getVariableRandomPositions(rng, &tmp[0]);
@@ -1182,14 +1175,14 @@ void moveit::core::RobotModel::getVariableRandomPositions(random_numbers::Random
     values[variable_names_[i]] = tmp[i];
 }
 
-void moveit::core::RobotModel::getVariableDefaultPositions(double* values) const
+void RobotModel::getVariableDefaultPositions(double* values) const
 {
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
     active_joint_model_vector_[i]->getVariableDefaultPositions(values + active_joint_model_start_index_[i]);
   updateMimicJoints(values);
 }
 
-void moveit::core::RobotModel::getVariableDefaultPositions(std::map<std::string, double>& values) const
+void RobotModel::getVariableDefaultPositions(std::map<std::string, double>& values) const
 {
   std::vector<double> tmp(variable_count_);
   getVariableDefaultPositions(&tmp[0]);
@@ -1198,8 +1191,8 @@ void moveit::core::RobotModel::getVariableDefaultPositions(std::map<std::string,
     values[variable_names_[i]] = tmp[i];
 }
 
-void moveit::core::RobotModel::getMissingVariableNames(const std::vector<std::string>& variables,
-                                                       std::vector<std::string>& missing_variables) const
+void RobotModel::getMissingVariableNames(const std::vector<std::string>& variables,
+                                         std::vector<std::string>& missing_variables) const
 {
   missing_variables.clear();
   std::set<std::string> keys(variables.begin(), variables.end());
@@ -1209,7 +1202,7 @@ void moveit::core::RobotModel::getMissingVariableNames(const std::vector<std::st
         missing_variables.push_back(variable_names_[i]);
 }
 
-int moveit::core::RobotModel::getVariableIndex(const std::string& variable) const
+int RobotModel::getVariableIndex(const std::string& variable) const
 {
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);
   if (it == joint_variables_index_map_.end())
@@ -1217,7 +1210,7 @@ int moveit::core::RobotModel::getVariableIndex(const std::string& variable) cons
   return it->second;
 }
 
-double moveit::core::RobotModel::getMaximumExtent(const JointBoundsVector& active_joint_bounds) const
+double RobotModel::getMaximumExtent(const JointBoundsVector& active_joint_bounds) const
 {
   double max_distance = 0.0;
   for (std::size_t j = 0; j < active_joint_model_vector_.size(); ++j)
@@ -1226,9 +1219,8 @@ double moveit::core::RobotModel::getMaximumExtent(const JointBoundsVector& activ
   return max_distance;
 }
 
-bool moveit::core::RobotModel::satisfiesPositionBounds(const double* state,
-                                                       const JointBoundsVector& active_joint_bounds,
-                                                       double margin) const
+bool RobotModel::satisfiesPositionBounds(const double* state, const JointBoundsVector& active_joint_bounds,
+                                         double margin) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -1238,7 +1230,7 @@ bool moveit::core::RobotModel::satisfiesPositionBounds(const double* state,
   return true;
 }
 
-bool moveit::core::RobotModel::enforcePositionBounds(double* state, const JointBoundsVector& active_joint_bounds) const
+bool RobotModel::enforcePositionBounds(double* state, const JointBoundsVector& active_joint_bounds) const
 {
   assert(active_joint_bounds.size() == active_joint_model_vector_.size());
   bool change = false;
@@ -1251,7 +1243,7 @@ bool moveit::core::RobotModel::enforcePositionBounds(double* state, const JointB
   return change;
 }
 
-double moveit::core::RobotModel::distance(const double* state1, const double* state2) const
+double RobotModel::distance(const double* state1, const double* state2) const
 {
   double d = 0.0;
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -1261,7 +1253,7 @@ double moveit::core::RobotModel::distance(const double* state1, const double* st
   return d;
 }
 
-void moveit::core::RobotModel::interpolate(const double* from, const double* to, double t, double* state) const
+void RobotModel::interpolate(const double* from, const double* to, double t, double* state) const
 {
   // we interpolate values only for active joint models (non-mimic)
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
@@ -1272,7 +1264,7 @@ void moveit::core::RobotModel::interpolate(const double* from, const double* to,
   updateMimicJoints(state);
 }
 
-void moveit::core::RobotModel::setKinematicsAllocators(const std::map<std::string, SolverAllocatorFn>& allocators)
+void RobotModel::setKinematicsAllocators(const std::map<std::string, SolverAllocatorFn>& allocators)
 {
   // we first set all the "simple" allocators -- where a group has one IK solver
   for (JointModelGroup* jmg : joint_model_groups_)
@@ -1345,7 +1337,7 @@ void moveit::core::RobotModel::setKinematicsAllocators(const std::map<std::strin
   }
 }
 
-void moveit::core::RobotModel::printModelInfo(std::ostream& out) const
+void RobotModel::printModelInfo(std::ostream& out) const
 {
   out << "Model " << model_name_ << " in frame " << model_frame_ << ", using " << getVariableCount() << " variables"
       << std::endl;
@@ -1396,8 +1388,8 @@ void moveit::core::RobotModel::printModelInfo(std::ostream& out) const
     joint_model_groups_[i]->printGroupInfo(out);
 }
 
-void moveit::core::RobotModel::computeFixedTransforms(const LinkModel* link, const Eigen::Affine3d& transform,
-                                                      LinkTransformMap& associated_transforms)
+void RobotModel::computeFixedTransforms(const LinkModel* link, const Eigen::Affine3d& transform,
+                                        LinkTransformMap& associated_transforms)
 {
   associated_transforms[link] = transform * link->getJointOriginTransform();
   for (std::size_t i = 0; i < link->getChildJointModels().size(); ++i)
@@ -1405,3 +1397,6 @@ void moveit::core::RobotModel::computeFixedTransforms(const LinkModel* link, con
       computeFixedTransforms(link->getChildJointModels()[i]->getChildLinkModel(),
                              transform * link->getJointOriginTransform(), associated_transforms);
 }
+
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -235,8 +235,7 @@ void RobotState::setToRandomPositions(const JointModelGroup* group)
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
   setToRandomPositions(group, rng);
 }
-void RobotState::setToRandomPositions(const JointModelGroup* group,
-                                                    random_numbers::RandomNumberGenerator& rng)
+void RobotState::setToRandomPositions(const JointModelGroup* group, random_numbers::RandomNumberGenerator& rng)
 {
   const std::vector<const JointModel*>& joints = group->getActiveJointModels();
   for (std::size_t i = 0; i < joints.size(); ++i)
@@ -245,7 +244,7 @@ void RobotState::setToRandomPositions(const JointModelGroup* group,
 }
 
 void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
-                                                          const std::vector<double>& distances)
+                                            const std::vector<double>& distances)
 {
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
@@ -261,8 +260,7 @@ void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const 
   updateMimicJoints(group);
 }
 
-void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
-                                                          double distance)
+void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near, double distance)
 {
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
@@ -320,7 +318,7 @@ void RobotState::setVariablePositions(const std::map<std::string, double>& varia
 }
 
 void RobotState::getMissingKeys(const std::map<std::string, double>& variable_map,
-                                              std::vector<std::string>& missing_variables) const
+                                std::vector<std::string>& missing_variables) const
 {
   missing_variables.clear();
   const std::vector<std::string>& nm = robot_model_->getVariableNames();
@@ -331,14 +329,14 @@ void RobotState::getMissingKeys(const std::map<std::string, double>& variable_ma
 }
 
 void RobotState::setVariablePositions(const std::map<std::string, double>& variable_map,
-                                                    std::vector<std::string>& missing_variables)
+                                      std::vector<std::string>& missing_variables)
 {
   setVariablePositions(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
 void RobotState::setVariablePositions(const std::vector<std::string>& variable_names,
-                                                    const std::vector<double>& variable_position)
+                                      const std::vector<double>& variable_position)
 {
   for (std::size_t i = 0; i < variable_names.size(); ++i)
   {
@@ -359,14 +357,14 @@ void RobotState::setVariableVelocities(const std::map<std::string, double>& vari
 }
 
 void RobotState::setVariableVelocities(const std::map<std::string, double>& variable_map,
-                                                     std::vector<std::string>& missing_variables)
+                                       std::vector<std::string>& missing_variables)
 {
   setVariableVelocities(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
 void RobotState::setVariableVelocities(const std::vector<std::string>& variable_names,
-                                                     const std::vector<double>& variable_velocity)
+                                       const std::vector<double>& variable_velocity)
 {
   markVelocity();
   assert(variable_names.size() == variable_velocity.size());
@@ -383,14 +381,14 @@ void RobotState::setVariableAccelerations(const std::map<std::string, double>& v
 }
 
 void RobotState::setVariableAccelerations(const std::map<std::string, double>& variable_map,
-                                                        std::vector<std::string>& missing_variables)
+                                          std::vector<std::string>& missing_variables)
 {
   setVariableAccelerations(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
 void RobotState::setVariableAccelerations(const std::vector<std::string>& variable_names,
-                                                        const std::vector<double>& variable_acceleration)
+                                          const std::vector<double>& variable_acceleration)
 {
   markAcceleration();
   assert(variable_names.size() == variable_acceleration.size());
@@ -407,14 +405,14 @@ void RobotState::setVariableEffort(const std::map<std::string, double>& variable
 }
 
 void RobotState::setVariableEffort(const std::map<std::string, double>& variable_map,
-                                                 std::vector<std::string>& missing_variables)
+                                   std::vector<std::string>& missing_variables)
 {
   setVariableEffort(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
 void RobotState::setVariableEffort(const std::vector<std::string>& variable_names,
-                                                 const std::vector<double>& variable_effort)
+                                   const std::vector<double>& variable_effort)
 {
   markEffort();
   assert(variable_names.size() == variable_effort.size());
@@ -650,8 +648,7 @@ void RobotState::updateLinkTransformsInternal(const JointModel* start)
     it->second->computeTransform(global_link_transforms_[it->second->getAttachedLink()->getLinkIndex()]);
 }
 
-void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Affine3d& transform,
-                                                     bool backward)
+void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Affine3d& transform, bool backward)
 {
   updateLinkTransforms();  // no link transforms must be dirty, otherwise the transform we set will be overwritten
 
@@ -740,8 +737,7 @@ std::pair<double, const JointModel*> RobotState::getMinDistanceToPositionBounds(
   return getMinDistanceToPositionBounds(robot_model_->getActiveJointModels());
 }
 
-std::pair<double, const JointModel*>
-RobotState::getMinDistanceToPositionBounds(const JointModelGroup* group) const
+std::pair<double, const JointModel*> RobotState::getMinDistanceToPositionBounds(const JointModelGroup* group) const
 {
   return getMinDistanceToPositionBounds(group->getActiveJointModels());
 }
@@ -783,8 +779,7 @@ RobotState::getMinDistanceToPositionBounds(const std::vector<const JointModel*>&
   return std::make_pair(distance, index);
 }
 
-bool RobotState::isValidVelocityMove(const RobotState& other, const JointModelGroup* group,
-                                                   double dt) const
+bool RobotState::isValidVelocityMove(const RobotState& other, const JointModelGroup* group, double dt) const
 {
   const std::vector<const JointModel*>& jm = group->getActiveJointModels();
   for (std::size_t joint_id = 0; joint_id < jm.size(); ++joint_id)
@@ -826,7 +821,7 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state) 
 }
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state,
-                                           const JointModelGroup* joint_group) const
+                             const JointModelGroup* joint_group) const
 {
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
   for (std::size_t i = 0; i < jm.size(); ++i)
@@ -868,9 +863,8 @@ void RobotState::attachBody(AttachedBody* attached_body)
 }
 
 void RobotState::attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                                          const EigenSTL::vector_Affine3d& attach_trans,
-                                          const std::set<std::string>& touch_links, const std::string& link,
-                                          const trajectory_msgs::JointTrajectory& detach_posture)
+                            const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
+                            const std::string& link, const trajectory_msgs::JointTrajectory& detach_posture)
 {
   const LinkModel* l = robot_model_->getLinkModel(link);
   AttachedBody* ab = new AttachedBody(l, id, shapes, attach_trans, touch_links, detach_posture);
@@ -890,7 +884,7 @@ void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bo
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies,
-                                                 const JointModelGroup* group) const
+                                   const JointModelGroup* group) const
 {
   attached_bodies.clear();
   for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
@@ -899,8 +893,7 @@ void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bo
       attached_bodies.push_back(it->second);
 }
 
-void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies,
-                                                 const LinkModel* lm) const
+void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies, const LinkModel* lm) const
 {
   attached_bodies.clear();
   for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
@@ -1023,10 +1016,9 @@ bool RobotState::knowsFrameTransform(const std::string& id) const
   return it != attached_body_map_.end() && it->second->getGlobalCollisionBodyTransforms().size() >= 1;
 }
 
-void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
-                                               const std::vector<std::string>& link_names,
-                                               const std_msgs::ColorRGBA& color, const std::string& ns,
-                                               const ros::Duration& dur, bool include_attached) const
+void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std::vector<std::string>& link_names,
+                                 const std_msgs::ColorRGBA& color, const std::string& ns, const ros::Duration& dur,
+                                 bool include_attached) const
 {
   std::size_t cur_num = arr.markers.size();
   getRobotMarkers(arr, link_names, include_attached);
@@ -1040,8 +1032,8 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
   }
 }
 
-void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
-                                               const std::vector<std::string>& link_names, bool include_attached) const
+void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std::vector<std::string>& link_names,
+                                 bool include_attached) const
 {
   ros::Time tm = ros::Time::now();
   for (std::size_t i = 0; i < link_names.size(); ++i)
@@ -1110,7 +1102,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
 }
 
 Eigen::MatrixXd RobotState::getJacobian(const JointModelGroup* group,
-                                                      const Eigen::Vector3d& reference_point_position) const
+                                        const Eigen::Vector3d& reference_point_position) const
 {
   Eigen::MatrixXd result;
   if (!getJacobian(group, group->getLinkModels().back(), reference_point_position, result, false))
@@ -1119,8 +1111,8 @@ Eigen::MatrixXd RobotState::getJacobian(const JointModelGroup* group,
 }
 
 bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link,
-                                           const Eigen::Vector3d& reference_point_position, Eigen::MatrixXd& jacobian,
-                                           bool use_quaternion_representation) const
+                             const Eigen::Vector3d& reference_point_position, Eigen::MatrixXd& jacobian,
+                             bool use_quaternion_representation) const
 {
   BOOST_VERIFY(checkLinkTransforms());
 
@@ -1220,18 +1212,16 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   return true;
 }
 
-bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const Eigen::VectorXd& twist,
-                                             const std::string& tip, double dt,
-                                             const GroupStateValidityCallbackFn& constraint)
+bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const Eigen::VectorXd& twist, const std::string& tip,
+                               double dt, const GroupStateValidityCallbackFn& constraint)
 {
   Eigen::VectorXd qdot;
   computeVariableVelocity(jmg, qdot, twist, getLinkModel(tip));
   return integrateVariableVelocity(jmg, qdot, dt, constraint);
 }
 
-bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const geometry_msgs::Twist& twist,
-                                             const std::string& tip, double dt,
-                                             const GroupStateValidityCallbackFn& constraint)
+bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const geometry_msgs::Twist& twist, const std::string& tip,
+                               double dt, const GroupStateValidityCallbackFn& constraint)
 {
   Eigen::Matrix<double, 6, 1> t;
   tf::twistMsgToEigen(twist, t);
@@ -1239,7 +1229,7 @@ bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const geometry_msgs::
 }
 
 void RobotState::computeVariableVelocity(const JointModelGroup* jmg, Eigen::VectorXd& qdot,
-                                                       const Eigen::VectorXd& twist, const LinkModel* tip) const
+                                         const Eigen::VectorXd& twist, const LinkModel* tip) const
 {
   // Get the Jacobian of the group at the current configuration
   Eigen::MatrixXd J(6, jmg->getVariableCount());
@@ -1279,8 +1269,8 @@ void RobotState::computeVariableVelocity(const JointModelGroup* jmg, Eigen::Vect
   qdot = Jinv * twist;
 }
 
-bool RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eigen::VectorXd& qdot,
-                                                         double dt, const GroupStateValidityCallbackFn& constraint)
+bool RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eigen::VectorXd& qdot, double dt,
+                                           const GroupStateValidityCallbackFn& constraint)
 {
   Eigen::VectorXd q(jmg->getVariableCount());
   copyJointGroupPositions(jmg, q);
@@ -1298,10 +1288,9 @@ bool RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eig
     return true;
 }
 
-bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
-                                         unsigned int attempts, double timeout,
-                                         const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose, unsigned int attempts,
+                           double timeout, const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
@@ -1312,10 +1301,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose
   return setFromIK(jmg, pose, solver->getTipFrame(), attempts, timeout, constraint, options);
 }
 
-bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
-                                         const std::string& tip, unsigned int attempts, double timeout,
-                                         const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose, const std::string& tip,
+                           unsigned int attempts, double timeout, const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   Eigen::Affine3d mat;
   tf::poseMsgToEigen(pose, mat);
@@ -1324,8 +1312,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose, unsigned int attempts,
-                                         double timeout, const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+                           double timeout, const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
@@ -1337,15 +1325,16 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& po
   return setFromIK(jmg, pose, solver->getTipFrame(), consistency_limits, attempts, timeout, constraint, options);
 }
 
-bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in,
-                                         const std::string& tip_in, unsigned int attempts, double timeout,
-                                         const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in, const std::string& tip_in,
+                           unsigned int attempts, double timeout, const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   static std::vector<double> consistency_limits;
   return setFromIK(jmg, pose_in, tip_in, consistency_limits, attempts, timeout, constraint, options);
 }
 
+namespace
+{
 bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
                          const GroupStateValidityCallbackFn& constraint, const geometry_msgs::Pose&,
                          const std::vector<double>& ik_sol, moveit_msgs::MoveItErrorCodes& error_code)
@@ -1360,9 +1349,9 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return true;
 }
+}
 
-bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose,
-                                                  const kinematics::KinematicsBaseConstPtr& solver)
+bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const kinematics::KinematicsBaseConstPtr& solver)
 {
   return setToIKSolverFrame(pose, solver->getBaseFrame());
 }
@@ -1380,11 +1369,10 @@ bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const std::string& ik
   return true;
 }
 
-bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in,
-                                         const std::string& tip_in, const std::vector<double>& consistency_limits_in,
-                                         unsigned int attempts, double timeout,
-                                         const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in, const std::string& tip_in,
+                           const std::vector<double>& consistency_limits_in, unsigned int attempts, double timeout,
+                           const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   // Convert from single pose and tip to vectors
   EigenSTL::vector_Affine3d poses;
@@ -1400,20 +1388,19 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& po
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
-                                         const std::vector<std::string>& tips_in, unsigned int attempts, double timeout,
-                                         const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+                           const std::vector<std::string>& tips_in, unsigned int attempts, double timeout,
+                           const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   static const std::vector<std::vector<double> > consistency_limits;
   return setFromIK(jmg, poses_in, tips_in, consistency_limits, attempts, timeout, constraint, options);
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
-                                         const std::vector<std::string>& tips_in,
-                                         const std::vector<std::vector<double> >& consistency_limit_sets,
-                                         unsigned int attempts, double timeout,
-                                         const GroupStateValidityCallbackFn& constraint,
-                                         const kinematics::KinematicsQueryOptions& options)
+                           const std::vector<std::string>& tips_in,
+                           const std::vector<std::vector<double> >& consistency_limit_sets, unsigned int attempts,
+                           double timeout, const GroupStateValidityCallbackFn& constraint,
+                           const kinematics::KinematicsQueryOptions& options)
 {
   // Error check
   if (poses_in.size() != tips_in.size())
@@ -1678,11 +1665,10 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
 }
 
 bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
-                                                  const std::vector<std::string>& tips_in,
-                                                  const std::vector<std::vector<double> >& consistency_limits,
-                                                  unsigned int attempts, double timeout,
-                                                  const GroupStateValidityCallbackFn& constraint,
-                                                  const kinematics::KinematicsQueryOptions& options)
+                                    const std::vector<std::string>& tips_in,
+                                    const std::vector<std::vector<double> >& consistency_limits, unsigned int attempts,
+                                    double timeout, const GroupStateValidityCallbackFn& constraint,
+                                    const kinematics::KinematicsQueryOptions& options)
 {
   // Assume we have already ran setFromIK() and those checks
 
@@ -1879,11 +1865,10 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Vector3d& direction,
-                                                      bool global_reference_frame, double distance, double max_step,
-                                                      double jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const Eigen::Vector3d& direction,
+                                        bool global_reference_frame, double distance, double max_step,
+                                        double jump_threshold, const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   // this is the Cartesian pose we start from, and have to move in the direction indicated
   const Eigen::Affine3d& start_pose = getGlobalLinkTransform(link);
@@ -1901,11 +1886,10 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const Eigen::Affine3d& target,
-                                                      bool global_reference_frame, double max_step,
-                                                      double jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const Eigen::Affine3d& target,
+                                        bool global_reference_frame, double max_step, double jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   const std::vector<const JointModel*>& cjnt = group->getContinuousJointModels();
   // make sure that continuous joints wrap
@@ -1970,7 +1954,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                    double jump_threshold)
+                                      double jump_threshold)
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
@@ -2004,11 +1988,10 @@ double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                                      const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
-                                                      bool global_reference_frame, double max_step,
-                                                      double jump_threshold,
-                                                      const GroupStateValidityCallbackFn& validCallback,
-                                                      const kinematics::KinematicsQueryOptions& options)
+                                        const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
+                                        bool global_reference_frame, double max_step, double jump_threshold,
+                                        const GroupStateValidityCallbackFn& validCallback,
+                                        const kinematics::KinematicsQueryOptions& options)
 {
   double percentage_solved = 0.0;
   for (std::size_t i = 0; i < waypoints.size(); ++i)
@@ -2207,7 +2190,7 @@ void getPoseString(std::ostream& ss, const Eigen::Affine3d& pose, const std::str
 }
 
 void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0,
-                                                       bool last) const
+                                         bool last) const
 {
   std::string pfx = pfx0 + "+--";
 
@@ -2242,5 +2225,5 @@ std::ostream& operator<<(std::ostream& out, const RobotState& s)
   return out;
 }
 
-}// end of namespace core
-}// end of namespace moveit
+}  // end of namespace core
+}  // end of namespace moveit

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -53,10 +53,8 @@ namespace core
  * it is difficult to choose a jump_threshold parameter that effectively separates
  * valid paths from paths with large joint space jumps. */
 static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
-}
-}
 
-moveit::core::RobotState::RobotState(const RobotModelConstPtr& robot_model)
+RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)
   , has_velocity_(false)
   , has_acceleration_(false)
@@ -73,14 +71,14 @@ moveit::core::RobotState::RobotState(const RobotModelConstPtr& robot_model)
   memset(dirty_joint_transforms_, 1, sizeof(double) * nr_doubles_for_dirty_joint_transforms);
 }
 
-moveit::core::RobotState::RobotState(const RobotState& other) : rng_(NULL)
+RobotState::RobotState(const RobotState& other) : rng_(NULL)
 {
   robot_model_ = other.robot_model_;
   allocMemory();
   copyFrom(other);
 }
 
-moveit::core::RobotState::~RobotState()
+RobotState::~RobotState()
 {
   clearAttachedBodies();
   free(memory_);
@@ -88,7 +86,7 @@ moveit::core::RobotState::~RobotState()
     delete rng_;
 }
 
-void moveit::core::RobotState::allocMemory(void)
+void RobotState::allocMemory(void)
 {
   // memory for the dirty joint transforms
   const int nr_doubles_for_dirty_joint_transforms =
@@ -111,14 +109,14 @@ void moveit::core::RobotState::allocMemory(void)
   effort_ = acceleration_ = velocity_ + robot_model_->getVariableCount();
 }
 
-moveit::core::RobotState& moveit::core::RobotState::operator=(const RobotState& other)
+RobotState& RobotState::operator=(const RobotState& other)
 {
   if (this != &other)
     copyFrom(other);
   return *this;
 }
 
-void moveit::core::RobotState::copyFrom(const RobotState& other)
+void RobotState::copyFrom(const RobotState& other)
 {
   has_velocity_ = other.has_velocity_;
   has_acceleration_ = other.has_acceleration_;
@@ -162,7 +160,7 @@ void moveit::core::RobotState::copyFrom(const RobotState& other)
                it->second->getTouchLinks(), it->second->getAttachedLinkName(), it->second->getDetachPosture());
 }
 
-bool moveit::core::RobotState::checkJointTransforms(const JointModel* joint) const
+bool RobotState::checkJointTransforms(const JointModel* joint) const
 {
   if (dirtyJointTransform(joint))
   {
@@ -172,7 +170,7 @@ bool moveit::core::RobotState::checkJointTransforms(const JointModel* joint) con
   return true;
 }
 
-bool moveit::core::RobotState::checkLinkTransforms() const
+bool RobotState::checkLinkTransforms() const
 {
   if (dirtyLinkTransforms())
   {
@@ -182,7 +180,7 @@ bool moveit::core::RobotState::checkLinkTransforms() const
   return true;
 }
 
-bool moveit::core::RobotState::checkCollisionTransforms() const
+bool RobotState::checkCollisionTransforms() const
 {
   if (dirtyCollisionBodyTransforms())
   {
@@ -192,7 +190,7 @@ bool moveit::core::RobotState::checkCollisionTransforms() const
   return true;
 }
 
-void moveit::core::RobotState::markVelocity()
+void RobotState::markVelocity()
 {
   if (!has_velocity_)
   {
@@ -201,7 +199,7 @@ void moveit::core::RobotState::markVelocity()
   }
 }
 
-void moveit::core::RobotState::markAcceleration()
+void RobotState::markAcceleration()
 {
   if (!has_acceleration_)
   {
@@ -211,7 +209,7 @@ void moveit::core::RobotState::markAcceleration()
   }
 }
 
-void moveit::core::RobotState::markEffort()
+void RobotState::markEffort()
 {
   if (!has_effort_)
   {
@@ -221,7 +219,7 @@ void moveit::core::RobotState::markEffort()
   }
 }
 
-void moveit::core::RobotState::setToRandomPositions()
+void RobotState::setToRandomPositions()
 {
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
   robot_model_->getVariableRandomPositions(rng, position_);
@@ -230,14 +228,14 @@ void moveit::core::RobotState::setToRandomPositions()
   // mimic values are correctly set in RobotModel
 }
 
-void moveit::core::RobotState::setToRandomPositions(const JointModelGroup* group)
+void RobotState::setToRandomPositions(const JointModelGroup* group)
 {
   // we do not make calls to RobotModel for random number generation because mimic joints
   // could trigger updates outside the state of the group itself
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
   setToRandomPositions(group, rng);
 }
-void moveit::core::RobotState::setToRandomPositions(const JointModelGroup* group,
+void RobotState::setToRandomPositions(const JointModelGroup* group,
                                                     random_numbers::RandomNumberGenerator& rng)
 {
   const std::vector<const JointModel*>& joints = group->getActiveJointModels();
@@ -246,7 +244,7 @@ void moveit::core::RobotState::setToRandomPositions(const JointModelGroup* group
   updateMimicJoints(group);
 }
 
-void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
+void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
                                                           const std::vector<double>& distances)
 {
   // we do not make calls to RobotModel for random number generation because mimic joints
@@ -263,7 +261,7 @@ void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup*
   updateMimicJoints(group);
 }
 
-void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
+void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& near,
                                                           double distance)
 {
   // we do not make calls to RobotModel for random number generation because mimic joints
@@ -279,7 +277,7 @@ void moveit::core::RobotState::setToRandomPositionsNearBy(const JointModelGroup*
   updateMimicJoints(group);
 }
 
-bool moveit::core::RobotState::setToDefaultValues(const JointModelGroup* group, const std::string& name)
+bool RobotState::setToDefaultValues(const JointModelGroup* group, const std::string& name)
 {
   std::map<std::string, double> m;
   bool r = group->getVariableDefaultPositions(name, m);  // mimic values are updated
@@ -287,7 +285,7 @@ bool moveit::core::RobotState::setToDefaultValues(const JointModelGroup* group, 
   return r;
 }
 
-void moveit::core::RobotState::setToDefaultValues()
+void RobotState::setToDefaultValues()
 {
   robot_model_->getVariableDefaultPositions(position_);  // mimic values are updated
   // set velocity & acceleration to 0
@@ -296,7 +294,7 @@ void moveit::core::RobotState::setToDefaultValues()
   dirty_link_transforms_ = robot_model_->getRootJoint();
 }
 
-void moveit::core::RobotState::setVariablePositions(const double* position)
+void RobotState::setVariablePositions(const double* position)
 {
   // assume everything is in order in terms of array lengths (for efficiency reasons)
   memcpy(position_, position, robot_model_->getVariableCount() * sizeof(double));
@@ -308,7 +306,7 @@ void moveit::core::RobotState::setVariablePositions(const double* position)
   dirty_link_transforms_ = robot_model_->getRootJoint();
 }
 
-void moveit::core::RobotState::setVariablePositions(const std::map<std::string, double>& variable_map)
+void RobotState::setVariablePositions(const std::map<std::string, double>& variable_map)
 {
   for (std::map<std::string, double>::const_iterator it = variable_map.begin(), end = variable_map.end(); it != end;
        ++it)
@@ -321,7 +319,7 @@ void moveit::core::RobotState::setVariablePositions(const std::map<std::string, 
   }
 }
 
-void moveit::core::RobotState::getMissingKeys(const std::map<std::string, double>& variable_map,
+void RobotState::getMissingKeys(const std::map<std::string, double>& variable_map,
                                               std::vector<std::string>& missing_variables) const
 {
   missing_variables.clear();
@@ -332,14 +330,14 @@ void moveit::core::RobotState::getMissingKeys(const std::map<std::string, double
         missing_variables.push_back(nm[i]);
 }
 
-void moveit::core::RobotState::setVariablePositions(const std::map<std::string, double>& variable_map,
+void RobotState::setVariablePositions(const std::map<std::string, double>& variable_map,
                                                     std::vector<std::string>& missing_variables)
 {
   setVariablePositions(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
-void moveit::core::RobotState::setVariablePositions(const std::vector<std::string>& variable_names,
+void RobotState::setVariablePositions(const std::vector<std::string>& variable_names,
                                                     const std::vector<double>& variable_position)
 {
   for (std::size_t i = 0; i < variable_names.size(); ++i)
@@ -352,7 +350,7 @@ void moveit::core::RobotState::setVariablePositions(const std::vector<std::strin
   }
 }
 
-void moveit::core::RobotState::setVariableVelocities(const std::map<std::string, double>& variable_map)
+void RobotState::setVariableVelocities(const std::map<std::string, double>& variable_map)
 {
   markVelocity();
   for (std::map<std::string, double>::const_iterator it = variable_map.begin(), end = variable_map.end(); it != end;
@@ -360,14 +358,14 @@ void moveit::core::RobotState::setVariableVelocities(const std::map<std::string,
     velocity_[robot_model_->getVariableIndex(it->first)] = it->second;
 }
 
-void moveit::core::RobotState::setVariableVelocities(const std::map<std::string, double>& variable_map,
+void RobotState::setVariableVelocities(const std::map<std::string, double>& variable_map,
                                                      std::vector<std::string>& missing_variables)
 {
   setVariableVelocities(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
-void moveit::core::RobotState::setVariableVelocities(const std::vector<std::string>& variable_names,
+void RobotState::setVariableVelocities(const std::vector<std::string>& variable_names,
                                                      const std::vector<double>& variable_velocity)
 {
   markVelocity();
@@ -376,7 +374,7 @@ void moveit::core::RobotState::setVariableVelocities(const std::vector<std::stri
     velocity_[robot_model_->getVariableIndex(variable_names[i])] = variable_velocity[i];
 }
 
-void moveit::core::RobotState::setVariableAccelerations(const std::map<std::string, double>& variable_map)
+void RobotState::setVariableAccelerations(const std::map<std::string, double>& variable_map)
 {
   markAcceleration();
   for (std::map<std::string, double>::const_iterator it = variable_map.begin(), end = variable_map.end(); it != end;
@@ -384,14 +382,14 @@ void moveit::core::RobotState::setVariableAccelerations(const std::map<std::stri
     acceleration_[robot_model_->getVariableIndex(it->first)] = it->second;
 }
 
-void moveit::core::RobotState::setVariableAccelerations(const std::map<std::string, double>& variable_map,
+void RobotState::setVariableAccelerations(const std::map<std::string, double>& variable_map,
                                                         std::vector<std::string>& missing_variables)
 {
   setVariableAccelerations(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
-void moveit::core::RobotState::setVariableAccelerations(const std::vector<std::string>& variable_names,
+void RobotState::setVariableAccelerations(const std::vector<std::string>& variable_names,
                                                         const std::vector<double>& variable_acceleration)
 {
   markAcceleration();
@@ -400,7 +398,7 @@ void moveit::core::RobotState::setVariableAccelerations(const std::vector<std::s
     acceleration_[robot_model_->getVariableIndex(variable_names[i])] = variable_acceleration[i];
 }
 
-void moveit::core::RobotState::setVariableEffort(const std::map<std::string, double>& variable_map)
+void RobotState::setVariableEffort(const std::map<std::string, double>& variable_map)
 {
   markEffort();
   for (std::map<std::string, double>::const_iterator it = variable_map.begin(), end = variable_map.end(); it != end;
@@ -408,14 +406,14 @@ void moveit::core::RobotState::setVariableEffort(const std::map<std::string, dou
     acceleration_[robot_model_->getVariableIndex(it->first)] = it->second;
 }
 
-void moveit::core::RobotState::setVariableEffort(const std::map<std::string, double>& variable_map,
+void RobotState::setVariableEffort(const std::map<std::string, double>& variable_map,
                                                  std::vector<std::string>& missing_variables)
 {
   setVariableEffort(variable_map);
   getMissingKeys(variable_map, missing_variables);
 }
 
-void moveit::core::RobotState::setVariableEffort(const std::vector<std::string>& variable_names,
+void RobotState::setVariableEffort(const std::vector<std::string>& variable_names,
                                                  const std::vector<double>& variable_effort)
 {
   markEffort();
@@ -424,7 +422,7 @@ void moveit::core::RobotState::setVariableEffort(const std::vector<std::string>&
     effort_[robot_model_->getVariableIndex(variable_names[i])] = variable_effort[i];
 }
 
-void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* group, const double* gstate)
+void RobotState::setJointGroupPositions(const JointModelGroup* group, const double* gstate)
 {
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
@@ -437,7 +435,7 @@ void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* gro
   updateMimicJoints(group);
 }
 
-void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* group, const Eigen::VectorXd& values)
+void RobotState::setJointGroupPositions(const JointModelGroup* group, const Eigen::VectorXd& values)
 {
   const std::vector<int>& il = group->getVariableIndexList();
   for (std::size_t i = 0; i < il.size(); ++i)
@@ -445,7 +443,7 @@ void moveit::core::RobotState::setJointGroupPositions(const JointModelGroup* gro
   updateMimicJoints(group);
 }
 
-void moveit::core::RobotState::copyJointGroupPositions(const JointModelGroup* group, double* gstate) const
+void RobotState::copyJointGroupPositions(const JointModelGroup* group, double* gstate) const
 {
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
@@ -455,7 +453,7 @@ void moveit::core::RobotState::copyJointGroupPositions(const JointModelGroup* gr
       gstate[i] = position_[il[i]];
 }
 
-void moveit::core::RobotState::copyJointGroupPositions(const JointModelGroup* group, Eigen::VectorXd& values) const
+void RobotState::copyJointGroupPositions(const JointModelGroup* group, Eigen::VectorXd& values) const
 {
   const std::vector<int>& il = group->getVariableIndexList();
   values.resize(il.size());
@@ -463,7 +461,7 @@ void moveit::core::RobotState::copyJointGroupPositions(const JointModelGroup* gr
     values(i) = position_[il[i]];
 }
 
-void moveit::core::RobotState::setJointGroupVelocities(const JointModelGroup* group, const double* gstate)
+void RobotState::setJointGroupVelocities(const JointModelGroup* group, const double* gstate)
 {
   markVelocity();
   const std::vector<int>& il = group->getVariableIndexList();
@@ -476,7 +474,7 @@ void moveit::core::RobotState::setJointGroupVelocities(const JointModelGroup* gr
   }
 }
 
-void moveit::core::RobotState::setJointGroupVelocities(const JointModelGroup* group, const Eigen::VectorXd& values)
+void RobotState::setJointGroupVelocities(const JointModelGroup* group, const Eigen::VectorXd& values)
 {
   markVelocity();
   const std::vector<int>& il = group->getVariableIndexList();
@@ -484,7 +482,7 @@ void moveit::core::RobotState::setJointGroupVelocities(const JointModelGroup* gr
     velocity_[il[i]] = values(i);
 }
 
-void moveit::core::RobotState::copyJointGroupVelocities(const JointModelGroup* group, double* gstate) const
+void RobotState::copyJointGroupVelocities(const JointModelGroup* group, double* gstate) const
 {
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
@@ -494,7 +492,7 @@ void moveit::core::RobotState::copyJointGroupVelocities(const JointModelGroup* g
       gstate[i] = velocity_[il[i]];
 }
 
-void moveit::core::RobotState::copyJointGroupVelocities(const JointModelGroup* group, Eigen::VectorXd& values) const
+void RobotState::copyJointGroupVelocities(const JointModelGroup* group, Eigen::VectorXd& values) const
 {
   const std::vector<int>& il = group->getVariableIndexList();
   values.resize(il.size());
@@ -502,7 +500,7 @@ void moveit::core::RobotState::copyJointGroupVelocities(const JointModelGroup* g
     values(i) = velocity_[il[i]];
 }
 
-void moveit::core::RobotState::setJointGroupAccelerations(const JointModelGroup* group, const double* gstate)
+void RobotState::setJointGroupAccelerations(const JointModelGroup* group, const double* gstate)
 {
   markAcceleration();
   const std::vector<int>& il = group->getVariableIndexList();
@@ -515,7 +513,7 @@ void moveit::core::RobotState::setJointGroupAccelerations(const JointModelGroup*
   }
 }
 
-void moveit::core::RobotState::setJointGroupAccelerations(const JointModelGroup* group, const Eigen::VectorXd& values)
+void RobotState::setJointGroupAccelerations(const JointModelGroup* group, const Eigen::VectorXd& values)
 {
   markAcceleration();
   const std::vector<int>& il = group->getVariableIndexList();
@@ -523,7 +521,7 @@ void moveit::core::RobotState::setJointGroupAccelerations(const JointModelGroup*
     acceleration_[il[i]] = values(i);
 }
 
-void moveit::core::RobotState::copyJointGroupAccelerations(const JointModelGroup* group, double* gstate) const
+void RobotState::copyJointGroupAccelerations(const JointModelGroup* group, double* gstate) const
 {
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
@@ -533,7 +531,7 @@ void moveit::core::RobotState::copyJointGroupAccelerations(const JointModelGroup
       gstate[i] = acceleration_[il[i]];
 }
 
-void moveit::core::RobotState::copyJointGroupAccelerations(const JointModelGroup* group, Eigen::VectorXd& values) const
+void RobotState::copyJointGroupAccelerations(const JointModelGroup* group, Eigen::VectorXd& values) const
 {
   const std::vector<int>& il = group->getVariableIndexList();
   values.resize(il.size());
@@ -541,7 +539,7 @@ void moveit::core::RobotState::copyJointGroupAccelerations(const JointModelGroup
     values(i) = acceleration_[il[i]];
 }
 
-void moveit::core::RobotState::update(bool force)
+void RobotState::update(bool force)
 {
   // make sure we do everything from scratch if needed
   if (force)
@@ -554,7 +552,7 @@ void moveit::core::RobotState::update(bool force)
   updateCollisionBodyTransforms();
 }
 
-void moveit::core::RobotState::updateCollisionBodyTransforms()
+void RobotState::updateCollisionBodyTransforms()
 {
   if (dirty_link_transforms_ != NULL)
     updateLinkTransforms();
@@ -578,7 +576,7 @@ void moveit::core::RobotState::updateCollisionBodyTransforms()
   }
 }
 
-void moveit::core::RobotState::updateLinkTransforms()
+void RobotState::updateLinkTransforms()
 {
   if (dirty_link_transforms_ != NULL)
   {
@@ -592,7 +590,7 @@ void moveit::core::RobotState::updateLinkTransforms()
   }
 }
 
-void moveit::core::RobotState::updateLinkTransformsInternal(const JointModel* start)
+void RobotState::updateLinkTransformsInternal(const JointModel* start)
 {
   const std::vector<const LinkModel*>& links = start->getDescendantLinkModels();
   if (!links.empty())
@@ -652,7 +650,7 @@ void moveit::core::RobotState::updateLinkTransformsInternal(const JointModel* st
     it->second->computeTransform(global_link_transforms_[it->second->getAttachedLink()->getLinkIndex()]);
 }
 
-void moveit::core::RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Affine3d& transform,
+void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Affine3d& transform,
                                                      bool backward)
 {
   updateLinkTransforms();  // no link transforms must be dirty, otherwise the transform we set will be overwritten
@@ -705,7 +703,7 @@ void moveit::core::RobotState::updateStateWithLinkAt(const LinkModel* link, cons
     it->second->computeTransform(global_link_transforms_[it->second->getAttachedLink()->getLinkIndex()]);
 }
 
-bool moveit::core::RobotState::satisfiesBounds(double margin) const
+bool RobotState::satisfiesBounds(double margin) const
 {
   const std::vector<const JointModel*>& jm = robot_model_->getActiveJointModels();
   for (std::size_t i = 0; i < jm.size(); ++i)
@@ -714,7 +712,7 @@ bool moveit::core::RobotState::satisfiesBounds(double margin) const
   return true;
 }
 
-bool moveit::core::RobotState::satisfiesBounds(const JointModelGroup* group, double margin) const
+bool RobotState::satisfiesBounds(const JointModelGroup* group, double margin) const
 {
   const std::vector<const JointModel*>& jm = group->getActiveJointModels();
   for (std::size_t i = 0; i < jm.size(); ++i)
@@ -723,33 +721,33 @@ bool moveit::core::RobotState::satisfiesBounds(const JointModelGroup* group, dou
   return true;
 }
 
-void moveit::core::RobotState::enforceBounds()
+void RobotState::enforceBounds()
 {
   const std::vector<const JointModel*>& jm = robot_model_->getActiveJointModels();
   for (std::size_t i = 0; i < jm.size(); ++i)
     enforceBounds(jm[i]);
 }
 
-void moveit::core::RobotState::enforceBounds(const JointModelGroup* joint_group)
+void RobotState::enforceBounds(const JointModelGroup* joint_group)
 {
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
   for (std::size_t i = 0; i < jm.size(); ++i)
     enforceBounds(jm[i]);
 }
 
-std::pair<double, const moveit::core::JointModel*> moveit::core::RobotState::getMinDistanceToPositionBounds() const
+std::pair<double, const JointModel*> RobotState::getMinDistanceToPositionBounds() const
 {
   return getMinDistanceToPositionBounds(robot_model_->getActiveJointModels());
 }
 
-std::pair<double, const moveit::core::JointModel*>
-moveit::core::RobotState::getMinDistanceToPositionBounds(const JointModelGroup* group) const
+std::pair<double, const JointModel*>
+RobotState::getMinDistanceToPositionBounds(const JointModelGroup* group) const
 {
   return getMinDistanceToPositionBounds(group->getActiveJointModels());
 }
 
-std::pair<double, const moveit::core::JointModel*>
-moveit::core::RobotState::getMinDistanceToPositionBounds(const std::vector<const JointModel*>& joints) const
+std::pair<double, const JointModel*>
+RobotState::getMinDistanceToPositionBounds(const std::vector<const JointModel*>& joints) const
 {
   double distance = std::numeric_limits<double>::max();
   const JointModel* index = NULL;
@@ -785,14 +783,14 @@ moveit::core::RobotState::getMinDistanceToPositionBounds(const std::vector<const
   return std::make_pair(distance, index);
 }
 
-bool moveit::core::RobotState::isValidVelocityMove(const RobotState& other, const JointModelGroup* group,
+bool RobotState::isValidVelocityMove(const RobotState& other, const JointModelGroup* group,
                                                    double dt) const
 {
   const std::vector<const JointModel*>& jm = group->getActiveJointModels();
   for (std::size_t joint_id = 0; joint_id < jm.size(); ++joint_id)
   {
     const int idx = jm[joint_id]->getFirstVariableIndex();
-    const std::vector<moveit::core::VariableBounds>& bounds = jm[joint_id]->getVariableBounds();
+    const std::vector<VariableBounds>& bounds = jm[joint_id]->getVariableBounds();
 
     // Check velocity for each joint variable
     for (std::size_t var_id = 0; var_id < jm[joint_id]->getVariableCount(); ++var_id)
@@ -807,7 +805,7 @@ bool moveit::core::RobotState::isValidVelocityMove(const RobotState& other, cons
   return true;
 }
 
-double moveit::core::RobotState::distance(const RobotState& other, const JointModelGroup* joint_group) const
+double RobotState::distance(const RobotState& other, const JointModelGroup* joint_group) const
 {
   double d = 0.0;
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
@@ -819,7 +817,7 @@ double moveit::core::RobotState::distance(const RobotState& other, const JointMo
   return d;
 }
 
-void moveit::core::RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
+void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
   robot_model_->interpolate(getVariablePositions(), to.getVariablePositions(), t, state.getVariablePositions());
 
@@ -827,7 +825,7 @@ void moveit::core::RobotState::interpolate(const RobotState& to, double t, Robot
   state.dirty_link_transforms_ = state.robot_model_->getRootJoint();
 }
 
-void moveit::core::RobotState::interpolate(const RobotState& to, double t, RobotState& state,
+void RobotState::interpolate(const RobotState& to, double t, RobotState& state,
                                            const JointModelGroup* joint_group) const
 {
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
@@ -839,17 +837,17 @@ void moveit::core::RobotState::interpolate(const RobotState& to, double t, Robot
   state.updateMimicJoints(joint_group);
 }
 
-void moveit::core::RobotState::setAttachedBodyUpdateCallback(const AttachedBodyCallback& callback)
+void RobotState::setAttachedBodyUpdateCallback(const AttachedBodyCallback& callback)
 {
   attached_body_update_callback_ = callback;
 }
 
-bool moveit::core::RobotState::hasAttachedBody(const std::string& id) const
+bool RobotState::hasAttachedBody(const std::string& id) const
 {
   return attached_body_map_.find(id) != attached_body_map_.end();
 }
 
-const moveit::core::AttachedBody* moveit::core::RobotState::getAttachedBody(const std::string& id) const
+const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 {
   std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
@@ -861,7 +859,7 @@ const moveit::core::AttachedBody* moveit::core::RobotState::getAttachedBody(cons
     return it->second;
 }
 
-void moveit::core::RobotState::attachBody(AttachedBody* attached_body)
+void RobotState::attachBody(AttachedBody* attached_body)
 {
   attached_body_map_[attached_body->getName()] = attached_body;
   attached_body->computeTransform(getGlobalLinkTransform(attached_body->getAttachedLink()));
@@ -869,7 +867,7 @@ void moveit::core::RobotState::attachBody(AttachedBody* attached_body)
     attached_body_update_callback_(attached_body, true);
 }
 
-void moveit::core::RobotState::attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+void RobotState::attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
                                           const EigenSTL::vector_Affine3d& attach_trans,
                                           const std::set<std::string>& touch_links, const std::string& link,
                                           const trajectory_msgs::JointTrajectory& detach_posture)
@@ -882,7 +880,7 @@ void moveit::core::RobotState::attachBody(const std::string& id, const std::vect
     attached_body_update_callback_(ab, true);
 }
 
-void moveit::core::RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies) const
+void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies) const
 {
   attached_bodies.clear();
   attached_bodies.reserve(attached_body_map_.size());
@@ -891,7 +889,7 @@ void moveit::core::RobotState::getAttachedBodies(std::vector<const AttachedBody*
     attached_bodies.push_back(it->second);
 }
 
-void moveit::core::RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies,
+void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies,
                                                  const JointModelGroup* group) const
 {
   attached_bodies.clear();
@@ -901,7 +899,7 @@ void moveit::core::RobotState::getAttachedBodies(std::vector<const AttachedBody*
       attached_bodies.push_back(it->second);
 }
 
-void moveit::core::RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies,
+void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies,
                                                  const LinkModel* lm) const
 {
   attached_bodies.clear();
@@ -911,7 +909,7 @@ void moveit::core::RobotState::getAttachedBodies(std::vector<const AttachedBody*
       attached_bodies.push_back(it->second);
 }
 
-void moveit::core::RobotState::clearAttachedBodies()
+void RobotState::clearAttachedBodies()
 {
   for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
        it != attached_body_map_.end(); ++it)
@@ -923,7 +921,7 @@ void moveit::core::RobotState::clearAttachedBodies()
   attached_body_map_.clear();
 }
 
-void moveit::core::RobotState::clearAttachedBodies(const LinkModel* link)
+void RobotState::clearAttachedBodies(const LinkModel* link)
 {
   std::map<std::string, AttachedBody*>::iterator it = attached_body_map_.begin();
   while (it != attached_body_map_.end())
@@ -941,7 +939,7 @@ void moveit::core::RobotState::clearAttachedBodies(const LinkModel* link)
   }
 }
 
-void moveit::core::RobotState::clearAttachedBodies(const JointModelGroup* group)
+void RobotState::clearAttachedBodies(const JointModelGroup* group)
 {
   std::map<std::string, AttachedBody*>::iterator it = attached_body_map_.begin();
   while (it != attached_body_map_.end())
@@ -959,7 +957,7 @@ void moveit::core::RobotState::clearAttachedBodies(const JointModelGroup* group)
   }
 }
 
-bool moveit::core::RobotState::clearAttachedBody(const std::string& id)
+bool RobotState::clearAttachedBody(const std::string& id)
 {
   std::map<std::string, AttachedBody*>::iterator it = attached_body_map_.find(id);
   if (it != attached_body_map_.end())
@@ -974,13 +972,13 @@ bool moveit::core::RobotState::clearAttachedBody(const std::string& id)
     return false;
 }
 
-const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::string& id)
+const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id)
 {
   updateLinkTransforms();
   return static_cast<const RobotState*>(this)->getFrameTransform(id);
 }
 
-const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::string& id) const
+const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) const
 {
   if (!id.empty() && id[0] == '/')
     return getFrameTransform(id.substr(1));
@@ -1015,7 +1013,7 @@ const Eigen::Affine3d& moveit::core::RobotState::getFrameTransform(const std::st
   return tf[0];
 }
 
-bool moveit::core::RobotState::knowsFrameTransform(const std::string& id) const
+bool RobotState::knowsFrameTransform(const std::string& id) const
 {
   if (!id.empty() && id[0] == '/')
     return knowsFrameTransform(id.substr(1));
@@ -1025,7 +1023,7 @@ bool moveit::core::RobotState::knowsFrameTransform(const std::string& id) const
   return it != attached_body_map_.end() && it->second->getGlobalCollisionBodyTransforms().size() >= 1;
 }
 
-void moveit::core::RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
+void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
                                                const std::vector<std::string>& link_names,
                                                const std_msgs::ColorRGBA& color, const std::string& ns,
                                                const ros::Duration& dur, bool include_attached) const
@@ -1042,7 +1040,7 @@ void moveit::core::RobotState::getRobotMarkers(visualization_msgs::MarkerArray& 
   }
 }
 
-void moveit::core::RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
+void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr,
                                                const std::vector<std::string>& link_names, bool include_attached) const
 {
   ros::Time tm = ros::Time::now();
@@ -1111,7 +1109,7 @@ void moveit::core::RobotState::getRobotMarkers(visualization_msgs::MarkerArray& 
   }
 }
 
-Eigen::MatrixXd moveit::core::RobotState::getJacobian(const JointModelGroup* group,
+Eigen::MatrixXd RobotState::getJacobian(const JointModelGroup* group,
                                                       const Eigen::Vector3d& reference_point_position) const
 {
   Eigen::MatrixXd result;
@@ -1120,7 +1118,7 @@ Eigen::MatrixXd moveit::core::RobotState::getJacobian(const JointModelGroup* gro
   return result;
 }
 
-bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link,
+bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link,
                                            const Eigen::Vector3d& reference_point_position, Eigen::MatrixXd& jacobian,
                                            bool use_quaternion_representation) const
 {
@@ -1222,7 +1220,7 @@ bool moveit::core::RobotState::getJacobian(const JointModelGroup* group, const L
   return true;
 }
 
-bool moveit::core::RobotState::setFromDiffIK(const JointModelGroup* jmg, const Eigen::VectorXd& twist,
+bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const Eigen::VectorXd& twist,
                                              const std::string& tip, double dt,
                                              const GroupStateValidityCallbackFn& constraint)
 {
@@ -1231,7 +1229,7 @@ bool moveit::core::RobotState::setFromDiffIK(const JointModelGroup* jmg, const E
   return integrateVariableVelocity(jmg, qdot, dt, constraint);
 }
 
-bool moveit::core::RobotState::setFromDiffIK(const JointModelGroup* jmg, const geometry_msgs::Twist& twist,
+bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const geometry_msgs::Twist& twist,
                                              const std::string& tip, double dt,
                                              const GroupStateValidityCallbackFn& constraint)
 {
@@ -1240,7 +1238,7 @@ bool moveit::core::RobotState::setFromDiffIK(const JointModelGroup* jmg, const g
   return setFromDiffIK(jmg, t, tip, dt, constraint);
 }
 
-void moveit::core::RobotState::computeVariableVelocity(const JointModelGroup* jmg, Eigen::VectorXd& qdot,
+void RobotState::computeVariableVelocity(const JointModelGroup* jmg, Eigen::VectorXd& qdot,
                                                        const Eigen::VectorXd& twist, const LinkModel* tip) const
 {
   // Get the Jacobian of the group at the current configuration
@@ -1281,7 +1279,7 @@ void moveit::core::RobotState::computeVariableVelocity(const JointModelGroup* jm
   qdot = Jinv * twist;
 }
 
-bool moveit::core::RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eigen::VectorXd& qdot,
+bool RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eigen::VectorXd& qdot,
                                                          double dt, const GroupStateValidityCallbackFn& constraint)
 {
   Eigen::VectorXd q(jmg->getVariableCount());
@@ -1300,7 +1298,7 @@ bool moveit::core::RobotState::integrateVariableVelocity(const JointModelGroup* 
     return true;
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
                                          unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn& constraint,
                                          const kinematics::KinematicsQueryOptions& options)
@@ -1314,7 +1312,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const geome
   return setFromIK(jmg, pose, solver->getTipFrame(), attempts, timeout, constraint, options);
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
                                          const std::string& tip, unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn& constraint,
                                          const kinematics::KinematicsQueryOptions& options)
@@ -1325,7 +1323,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const geome
   return setFromIK(jmg, mat, tip, consistency_limits, attempts, timeout, constraint, options);
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose, unsigned int attempts,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose, unsigned int attempts,
                                          double timeout, const GroupStateValidityCallbackFn& constraint,
                                          const kinematics::KinematicsQueryOptions& options)
 {
@@ -1339,7 +1337,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   return setFromIK(jmg, pose, solver->getTipFrame(), consistency_limits, attempts, timeout, constraint, options);
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in,
                                          const std::string& tip_in, unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn& constraint,
                                          const kinematics::KinematicsQueryOptions& options)
@@ -1348,12 +1346,6 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   return setFromIK(jmg, pose_in, tip_in, consistency_limits, attempts, timeout, constraint, options);
 }
 
-namespace moveit
-{
-namespace core
-{
-namespace
-{
 bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
                          const GroupStateValidityCallbackFn& constraint, const geometry_msgs::Pose&,
                          const std::vector<double>& ik_sol, moveit_msgs::MoveItErrorCodes& error_code)
@@ -1368,17 +1360,14 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return true;
 }
-}
-}
-}
 
-bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d& pose,
+bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose,
                                                   const kinematics::KinematicsBaseConstPtr& solver)
 {
   return setToIKSolverFrame(pose, solver->getBaseFrame());
 }
 
-bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const std::string& ik_frame)
+bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const std::string& ik_frame)
 {
   // Bring the pose to the frame of the IK solver
   if (!Transforms::sameFrame(ik_frame, robot_model_->getModelFrame()))
@@ -1391,7 +1380,7 @@ bool moveit::core::RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const s
   return true;
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& pose_in,
                                          const std::string& tip_in, const std::vector<double>& consistency_limits_in,
                                          unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn& constraint,
@@ -1410,7 +1399,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   return setFromIK(jmg, poses, tips, consistency_limits, attempts, timeout, constraint, options);
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
                                          const std::vector<std::string>& tips_in, unsigned int attempts, double timeout,
                                          const GroupStateValidityCallbackFn& constraint,
                                          const kinematics::KinematicsQueryOptions& options)
@@ -1419,7 +1408,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   return setFromIK(jmg, poses_in, tips_in, consistency_limits, attempts, timeout, constraint, options);
 }
 
-bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
                                          const std::vector<std::string>& tips_in,
                                          const std::vector<std::vector<double> >& consistency_limit_sets,
                                          unsigned int attempts, double timeout,
@@ -1688,7 +1677,7 @@ bool moveit::core::RobotState::setFromIK(const JointModelGroup* jmg, const Eigen
   return false;
 }
 
-bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
+bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::vector_Affine3d& poses_in,
                                                   const std::vector<std::string>& tips_in,
                                                   const std::vector<std::vector<double> >& consistency_limits,
                                                   unsigned int attempts, double timeout,
@@ -1889,7 +1878,7 @@ bool moveit::core::RobotState::setFromIKSubgroups(const JointModelGroup* jmg, co
   return false;
 }
 
-double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const Eigen::Vector3d& direction,
                                                       bool global_reference_frame, double distance, double max_step,
                                                       double jump_threshold,
@@ -1911,7 +1900,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
           computeCartesianPath(group, traj, link, target_pose, true, max_step, jump_threshold, validCallback, options));
 }
 
-double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const Eigen::Affine3d& target,
                                                       bool global_reference_frame, double max_step,
                                                       double jump_threshold,
@@ -1980,7 +1969,7 @@ double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* gro
   return last_valid_percentage;
 }
 
-double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                     double jump_threshold)
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
@@ -2014,7 +2003,7 @@ double moveit::core::RobotState::testJointSpaceJump(const JointModelGroup* group
   return percentage;
 }
 
-double moveit::core::RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                                       const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
                                                       bool global_reference_frame, double max_step,
                                                       double jump_threshold,
@@ -2092,14 +2081,14 @@ void robot_state::RobotState::computeAABB(std::vector<double>& aabb) const
   }
 }
 
-void moveit::core::RobotState::printStatePositions(std::ostream& out) const
+void RobotState::printStatePositions(std::ostream& out) const
 {
   const std::vector<std::string>& nm = robot_model_->getVariableNames();
   for (std::size_t i = 0; i < nm.size(); ++i)
     out << nm[i] << "=" << position_[i] << std::endl;
 }
 
-void moveit::core::RobotState::printDirtyInfo(std::ostream& out) const
+void RobotState::printDirtyInfo(std::ostream& out) const
 {
   out << "  * Dirty Joint Transforms: " << std::endl;
   const std::vector<const JointModel*>& jm = robot_model_->getJointModels();
@@ -2112,7 +2101,7 @@ void moveit::core::RobotState::printDirtyInfo(std::ostream& out) const
       << (dirty_collision_body_transforms_ ? dirty_collision_body_transforms_->getName() : "NULL") << std::endl;
 }
 
-void moveit::core::RobotState::printStateInfo(std::ostream& out) const
+void RobotState::printStateInfo(std::ostream& out) const
 {
   out << "Robot State @" << this << std::endl;
 
@@ -2155,7 +2144,7 @@ void moveit::core::RobotState::printStateInfo(std::ostream& out) const
   printTransforms(out);
 }
 
-void moveit::core::RobotState::printTransform(const Eigen::Affine3d& transform, std::ostream& out) const
+void RobotState::printTransform(const Eigen::Affine3d& transform, std::ostream& out) const
 {
   Eigen::Quaterniond q(transform.rotation());
   out << "T.xyz = [" << transform.translation().x() << ", " << transform.translation().y() << ", "
@@ -2163,7 +2152,7 @@ void moveit::core::RobotState::printTransform(const Eigen::Affine3d& transform, 
       << "]" << std::endl;
 }
 
-void moveit::core::RobotState::printTransforms(std::ostream& out) const
+void RobotState::printTransforms(std::ostream& out) const
 {
   if (!variable_joint_transforms_)
   {
@@ -2192,7 +2181,7 @@ void moveit::core::RobotState::printTransforms(std::ostream& out) const
   }
 }
 
-std::string moveit::core::RobotState::getStateTreeString(const std::string& prefix) const
+std::string RobotState::getStateTreeString(const std::string& prefix) const
 {
   std::stringstream ss;
   ss << "ROBOT: " << robot_model_->getName() << std::endl;
@@ -2217,7 +2206,7 @@ void getPoseString(std::ostream& ss, const Eigen::Affine3d& pose, const std::str
 }
 }
 
-void moveit::core::RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0,
+void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0,
                                                        bool last) const
 {
   std::string pfx = pfx0 + "+--";
@@ -2247,8 +2236,11 @@ void moveit::core::RobotState::getStateTreeJointString(std::ostream& ss, const J
     getStateTreeJointString(ss, *it, pfx, it + 1 == lm->getChildJointModels().end());
 }
 
-std::ostream& moveit::core::operator<<(std::ostream& out, const RobotState& s)
+std::ostream& operator<<(std::ostream& out, const RobotState& s)
 {
   s.printStateInfo(out);
   return out;
 }
+
+}// end of namespace core
+}// end of namespace moveit


### PR DESCRIPTION
### Description

The repetitive namespace declaration of "moveit::core" has been removed from all the spaces. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
