### PR TITLE
adding absolute jump threshold capability in parallel

### DIFF
--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   include_directories(${moveit_resources_INCLUDE_DIRS})
 
-  catkin_add_gtest(test_robot_state test/test_kinematic.cpp)
+  catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
   target_link_libraries(test_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -63,6 +63,19 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
                              const double* joint_group_variable_values)>
     GroupStateValidityCallbackFn;
 
+/** \brief Struct for containing jump_threshold.
+
+    For the purposes of maintaining API, we support both \e jump_threshold_factor which provides a scaling factor for
+   detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute
+   thresholds for detecting joint space jumps. */
+
+struct JumpThreshold
+{
+  double jump_threshold_factor;
+  double prismatic_jump_threshold;
+  double revolute_jump_threshold;
+};
+
 /** \brief Representation of a robot's state. This includes position,
     velocity, acceleration and effort.
 
@@ -1044,38 +1057,36 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
 
-      The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
-     of a robot
-      link (\e link). The direction is assumed to be either in a global reference frame or in the local reference frame
-     of the
-      link. In the latter case (\e global_reference_frame is false) the \e direction is rotated accordingly. The link
-     needs to move in a
-      straight line, following the specified direction, for the desired \e distance. The resulting joint values are
-     stored in
-      the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the
-     resulting path
-      is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to
-      setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the
-     distance that
-      was computed and for which corresponding states were added to the path.  At the end of the function call, the
-     state of the
-      group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes
-     preferred if
-      consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between
-     the
-      corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided.  As the
-     joint values
-      corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also
-     computed. Once
-      the sequence of joint values is computed, the average distance between consecutive points (in joint space) is also
-     computed. It
-      is then verified that none of the computed distances is above the average distance by a factor larger than \e
-     jump_threshold. If
-      a point in joint is found such that it is further away than the previous one by more than
-     average_consecutive_distance * \e jump_threshold,
-      that is considered a failure and the returned path is truncated up to just before the jump. The jump detection can
-     be disabled
-      by setting \e jump_threshold to 0.0*/
+     The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
+     of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local
+     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
+     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
+     computation of the path stops and the value returned corresponds to the distance that was computed and for which
+     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
+     to the last attempted Cartesian pose. During the computation of the trajectory, it is sometimes preferred if
+     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
+     corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e
+     jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e
+     revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for
+     absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump,
+     distances in joint space between consecutive points are computed. Once the sequence of joint values is computed,
+     the average distance between consecutive points (in joint space) is also computed. It is then verified that none of
+     the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point
+     in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e
+     jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump.
+     Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the
+     absolute difference in joint space between sequential points is computed and if it exceededs these limits the
+     returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
+     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+                              const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
+                              double max_step, const JumpThreshold& jump_threshold,
+                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                               double max_step, double jump_threshold,
@@ -1084,37 +1095,36 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
-      The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
-     robot
-      link (\e link). The target frame is assumed to be either in a global reference frame or in the local reference
-     frame of the
-      link. In the latter case (\e global_reference_frame is false) the \e target is rotated accordingly. The link needs
-     to move in a
-      straight line towards the target. The resulting joint values are stored in
-      the vector \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the
-     resulting path
-      is specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to
-      setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to the
-     percentage of the
-      path (between 0 and 1) that was completed and for which corresponding states were added to the path.  At the end
-     of the function call,
-      the state of the group corresponds to the last attempted Cartesian pose.  During the computation of the
-     trajectory, it is sometimes preferred if
-      consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between
-     the
-      corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided.  As the
-     joint values
-      corresponding to the Cartesian path are computed, distances in joint space between consecutive points are also
-     computed. Once
-      the sequence of joint values is computed, the average distance between consecutive points (in joint space) is also
-     computed. It
-      is then verified that none of the computed distances is above the average distance by a factor larger than \e
-     jump_threshold. If
-      a point in joint is found such that it is further away than the previous one by more than
-     average_consecutive_distance * \e jump_threshold,
-      that is considered a failure and the returned path is truncated up to just before the jump. The jump detection can
-     be disabled
-      by setting \e jump_threshold to 0.0*/
+     The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
+     robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local
+     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
+     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
+     computation of the path stops and the value returned corresponds to the distance that was computed and for which
+     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
+     to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if
+     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
+     corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e
+     jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e
+     revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for
+     absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump,
+     distances in joint space between consecutive points are computed. Once the sequence of joint values is computed,
+     the average distance between consecutive points (in joint space) is also computed. It is then verified that none of
+     the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point
+     in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e
+     jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump.
+     Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the
+     absolute difference in joint space between sequential points is computed and if it exceededs these limits the
+     returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
+     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+                              const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
+                              const JumpThreshold& jump_threshold,
+                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
                               double jump_threshold,
@@ -1123,42 +1133,81 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
-      The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
-     of a robot
-      link (\e link). The waypoints are transforms given either in a global reference frame or in the local reference
-     frame of the
-      link at the immediately preceeding waypoint. The link needs to move in a straight line between two consecutive
-     waypoints.
-      The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in Cartesian space
-     between
-      consecutive points on the resulting path is specified by \e max_step.  If a \e validCallback is specified, this is
-     passed to the
-      internal call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned
-     corresponds to the
-      percentage of the path (between 0 and 1) that was completed and for which corresponding states were added to the
-     path.  At the end
-      of the function call, the state of the group corresponds to the last attempted Cartesian pose.  During the
-     computation of the
-      trajectory, it is sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space,
-     even if the
-      Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold
-     parameter is
-      provided.  As the joint values corresponding to the Cartesian path are computed, distances in joint space between
-     consecutive
-      points are also computed. Once the sequence of joint values is computed, the average distance between consecutive
-     points (in
-      joint space) is also computed. It is then verified that none of the computed distances is above the average
-     distance by a
-      factor larger than \e jump_threshold. If a point in joint is found such that it is further away than the previous
-     one by more
-      than average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is
-     truncated up to
-      just before the jump. The jump detection can be disabled by setting \e jump_threshold to 0.0*/
+     The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
+     of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local
+     reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line,
+     following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector
+     \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is
+     specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK().
+     In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that
+     was computed and for which corresponding states were added to the path.  At the end of the function call, the state
+     of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is
+     sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the
+     Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold
+     parameter is provided. \e jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold
+     and \e revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we
+     test for absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative
+     jump, distances in joint space between consecutive points are computed. Once the sequence of joint values is
+     computed, the average distance between consecutive points (in joint space) is also computed. It is then verified
+     that none of the computed distances is above the average distance by a factor larger than \e jump_threshold_factor.
+     If a point in joint is found such that it is further away than the previous one by more than
+     average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is truncated
+     up to just before the jump. Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For
+     absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it
+     exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be
+     disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+  double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+                              const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
+                              const JumpThreshold& jump_threshold,
+                              const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
                               double jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
+  /**
+   * \brief Tests joint space jumps of a trajectory. If \e jump_threshold.jump_threshold_factor is set, we check for
+   * relative jumps and if \e jump_threshold.prismatic_jump_threshold or \e jump_threshold.revolute_jump_threshold are
+   * greater than 0 then we check for absolute joint space jumps. For relative jumps the average distance between
+   * adjacent trajectory points is computed and if two adjacent trajectory points have distance > \e
+   * jump_threshold_factor * average, the trajectory is cut of at this point. For absolute jump thresholds, the absolute
+   * difference in joint space between sequential points is computed and if it exceededs these limits the returned path
+   * is truncated up to just before the jump.
+   * @param group The joint model group of the robot state.
+   * @param traj The trajectory that should be tested.
+   * @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
+   * @return The fraction of the trajectory that passed.
+   */
+  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                   const JumpThreshold& jump_threshold);
+
+  /**
+   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
+   * computed. If two adjacent trajectory points have distance > \e jump_threshold * average, the trajectory is cut of
+   * at this point.
+   * @param group The joint model group of the robot state.
+   * @param traj The trajectory that should be tested.
+   * @param jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @return The fraction of the trajectory that passed.
+   */
+  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                   double jump_threshold);
+
+  /**
+   * \brief Tests for absolute joint space jumps of a trajectory. The absolute difference in joint space between
+   * sequential points for each active joint is computed and if it exceededs \e prismatic_jump_threshold for prismatic
+   * joints or revolute_jump_threshold for revolute joints, the returned path is truncated up to just before the jump.
+   * @param group The joint model group of the robot state.
+   * @param traj The trajectory that should be tested.
+   * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @param revolute_jump_threshold The threshold to determine if a joint space jump has occurred .
+   * @return The fraction of the trajectory that passed.
+   */
+  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                   double revolute_jump_threshold, double prismatic_jump_threshold);
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for
@@ -1758,17 +1807,6 @@ private:
   void getMissingKeys(const std::map<std::string, double>& variable_map,
                       std::vector<std::string>& missing_variables) const;
   void getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0, bool last) const;
-
-  /**
-   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
-   * computed. If two adjacent trajectory points have distance > \e jump_threshold * average, the trajectory is cut of
-   * at this point.
-   * @param group The joint model group of the robot state.
-   * @param traj The trajectory that should be tested.
-   * @param jump_threshold The threshold to determine if a joint space jump has occurred .
-   * @return The fraction of the trajectory that passed.
-   */
-  double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, double jump_threshold);
 
   /** \brief This function is only called in debug mode */
   bool checkJointTransforms(const JointModel* joint) const;

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -70,7 +70,6 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
     thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
-
   // Test for large joint space jumps using a cutoff factor
   bool test_for_relative_jump;
   double factor;
@@ -80,7 +79,8 @@ struct JumpThreshold
   double prismatic;
   double revolute;
 
-  explicit JumpThreshold() : test_for_relative_jump(false), factor(0.0), test_for_absolute_jump(false), prismatic(0.0), revolute(0.0)
+  explicit JumpThreshold()
+    : test_for_relative_jump(false), factor(0.0), test_for_absolute_jump(false), prismatic(0.0), revolute(0.0)
   {
   }
 
@@ -1120,7 +1120,6 @@ as the new values that correspond to the group */
     else
       return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step,
                                   JumpThreshold(), validCallback, options);
-
   }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
@@ -1146,9 +1145,8 @@ as the new values that correspond to the group */
       return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
                                   JumpThreshold(jump_threshold_factor), validCallback, options);
     else
-      return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
-                                  JumpThreshold(), validCallback, options);
-
+      return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step, JumpThreshold(),
+                                  validCallback, options);
   }
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
@@ -1173,9 +1171,8 @@ as the new values that correspond to the group */
       return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
                                   JumpThreshold(jump_threshold_factor), validCallback, options);
     else
-      return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
-                                  JumpThreshold(), validCallback, options);
-
+      return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, JumpThreshold(),
+                                  validCallback, options);
   }
 
   /** \brief Tests joint space jumps of a trajectory.

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -70,23 +70,23 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
     thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
-  double jump_threshold_factor;
-  double prismatic_jump_threshold;
-  double revolute_jump_threshold;
+  double factor;
+  double prismatic;
+  double revolute;
 
-  explicit JumpThreshold() : jump_threshold_factor(0.0), prismatic_jump_threshold(0.0), revolute_jump_threshold(0.0)
+  explicit JumpThreshold() : factor(0.0), prismatic(0.0), revolute(0.0)
   {
   }
 
-  explicit JumpThreshold(double factor) : JumpThreshold()
+  explicit JumpThreshold(double jt_factor) : JumpThreshold()
   {
-    jump_threshold_factor = factor;
+    factor = jt_factor;
   }
 
-  explicit JumpThreshold(double revolute, double prismatic) : JumpThreshold()
+  explicit JumpThreshold(double jt_revolute, double jt_prismatic) : JumpThreshold()
   {
-    prismatic_jump_threshold = prismatic;
-    revolute_jump_threshold = revolute;
+    prismatic = jt_prismatic;
+    revolute = jt_revolute;
   }
 };
 
@@ -1181,8 +1181,8 @@ as the new values that correspond to the group */
      @param jump_threshold_factor The threshold to determine if a joint space jump has occurred .
      @return The fraction of the trajectory that passed.
   */
-  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                   double jump_threshold);
+  static double testRelativeJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                           double jump_threshold_factor);
 
   /** \brief Tests for absolute joint space jumps of the trajectory \e traj.
 
@@ -1195,8 +1195,8 @@ as the new values that correspond to the group */
      @param prismatic_jump_threshold Absolute joint-space threshold for prismatic joints.
      @return The fraction of the trajectory that passed.
   */
-  static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                   double revolute_jump_threshold, double prismatic_jump_threshold);
+  static double testAbsoluteJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
+                                           double revolute_jump_threshold, double prismatic_jump_threshold);
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -66,9 +66,8 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
 /** \brief Struct for containing jump_threshold.
 
     For the purposes of maintaining API, we support both \e jump_threshold_factor which provides a scaling factor for
-   detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute
-   thresholds for detecting joint space jumps. */
-
+    detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute
+    thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
   double jump_threshold_factor;
@@ -1058,29 +1057,28 @@ as the new values that correspond to the group */
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
 
      The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
+     The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
      of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local
      reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated
-     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
-     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
-     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
-     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
-     computation of the path stops and the value returned corresponds to the distance that was computed and for which
-     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
-     to the last attempted Cartesian pose. During the computation of the trajectory, it is sometimes preferred if
-     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
-     corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e
-     jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e
-     revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for
-     absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump,
-     distances in joint space between consecutive points are computed. Once the sequence of joint values is computed,
-     the average distance between consecutive points (in joint space) is also computed. It is then verified that none of
-     the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point
-     in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e
-     jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump.
-     Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the
-     absolute difference in joint space between sequential points is computed and if it exceededs these limits the
-     returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
-     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired
+     \e distance. The resulting joint values are stored in the vector \e traj, one by one.
+     The maximum distance in Cartesian space between consecutive points on the resulting path is specified by
+     \e max_step.
+     If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure,
+     the computation of the path stops and the value returned corresponds to the distance that was computed and for
+     which corresponding states were added to the path.  At the end of the function call, the state of the group
+     corresponds to the last attempted Cartesian pose.
+     During the computation of the trajectory, it is usually preferred if consecutive joint values do not 'jump' by a
+     large amount in joint space, even if the Cartesian distance between the corresponding points is small as expected.
+     To account for this, the \e jump_threshold struct is provided, which comprises three fields:
+     \e jump_threshold_factor, \e prismatic_jump_threshold and \e revolute_jump_threshold.
+     If \e prismatic_jump_threshold or \e revolute_jump_threshold are non-zero, we test for absolute jumps.
+     If \e jump_threshold_factor is non-zero, we test for relative jumps. Otherwise (all params are zero), jump
+     detection is disabled.
+     For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
+     computed. If any individual joint-space motion delta is larger then this average distance by a factor of
+     \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
+     before the jump. */
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                               double max_step, const JumpThreshold& jump_threshold,
@@ -1095,30 +1093,11 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
-     The Cartesian path to be followed is specified as a target frame to be reached (\e target) for the origin of a
-     robot link (\e link). The target frame is assumed to be either in a global reference frame or in the local
-     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is rotated
-     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
-     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
-     Cartesian space between consecutive points on the resulting path is specified by \e max_step.  If a \e
-     validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure, the
-     computation of the path stops and the value returned corresponds to the distance that was computed and for which
-     corresponding states were added to the path.  At the end of the function call, the state of the group corresponds
-     to the last attempted Cartesian pose.  During the computation of the trajectory, it is sometimes preferred if
-     consecutive joint values do not 'jump' by a large amount in joint space, even if the Cartesian distance between the
-     corresponding points is as expected. To account for this, the \e jump_threshold parameter is provided. \e
-     jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold and \e
-     revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we test for
-     absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative jump,
-     distances in joint space between consecutive points are computed. Once the sequence of joint values is computed,
-     the average distance between consecutive points (in joint space) is also computed. It is then verified that none of
-     the computed distances is above the average distance by a factor larger than \e jump_threshold_factor. If a point
-     in joint is found such that it is further away than the previous one by more than average_consecutive_distance * \e
-     jump_threshold, that is considered a failure and the returned path is truncated up to just before the jump.
-     Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For absolute jump thresholds, the
-     absolute difference in joint space between sequential points is computed and if it exceededs these limits the
-     returned path is truncated up to just before the jump. The jump detection can be disabled by setting \e
-     prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+     In contrast to the previous function, the Cartesian path is specified as a target frame to be reached (\e target)
+     for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or
+     in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is
+     rotated accordingly.
+     All other comments from the previous function apply. */
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
                               const JumpThreshold& jump_threshold,
@@ -1133,29 +1112,10 @@ as the new values that correspond to the group */
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
-     The Cartesian path to be followed is specified as a set of \e waypoints to be sequentially reached for the origin
-     of a robotlink (\e link). The waypoints are transforms given either in a global reference frame or in the local
-     reference frame of the link at the immediately preceeding waypoint. The link needs to move in a straight line,
-     following the specified direction, for the desired \e distance. The resulting joint values are stored in the vector
-     \e traj, one by one. The maximum distance in Cartesian space between consecutive points on the resulting path is
-     specified by \e max_step.  If a \e validCallback is specified, this is passed to the internal call to setFromIK().
-     In case of IK failure, the computation of the path stops and the value returned corresponds to the distance that
-     was computed and for which corresponding states were added to the path.  At the end of the function call, the state
-     of the group corresponds to the last attempted Cartesian pose.  During the computation of the trajectory, it is
-     sometimes preferred if consecutive joint values do not 'jump' by a large amount in joint space, even if the
-     Cartesian distance between the corresponding points is as expected. To account for this, the \e jump_threshold
-     parameter is provided. \e jump_threshold has three fields, \e jump_threshold_factor, \e prismatic_jump_threshold
-     and \e revolute_jump_threshold. If either \e prismatic_jump_threshold or \e revolute_jump_threshold !=0, then we
-     test for absolute jump thresholds and if \e jump_threshold_factor is set, we test for relative jumps. For relative
-     jump, distances in joint space between consecutive points are computed. Once the sequence of joint values is
-     computed, the average distance between consecutive points (in joint space) is also computed. It is then verified
-     that none of the computed distances is above the average distance by a factor larger than \e jump_threshold_factor.
-     If a point in joint is found such that it is further away than the previous one by more than
-     average_consecutive_distance * \e jump_threshold, that is considered a failure and the returned path is truncated
-     up to just before the jump. Relative jump tests can be disabled by setting \e jump_threshold_factor = 0. For
-     absolute jump thresholds, the absolute difference in joint space between sequential points is computed and if it
-     exceededs these limits the returned path is truncated up to just before the jump. The jump detection can be
-     disabled by setting \e prismatic_jump_threshold and \e revolute_jump_threshold to 0.0*/
+     In contrast to the previous functions, the Cartesian path is specified as a set of \e waypoints to be sequentially
+     reached for the origin of a robot link (\e link). The waypoints are transforms given either in a global reference
+     frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move
+     in a straight line between two consecutive waypoints. All other comments apply. */
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
                               const JumpThreshold& jump_threshold,
@@ -1168,44 +1128,46 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
-  /**
-   * \brief Tests joint space jumps of a trajectory. If \e jump_threshold.jump_threshold_factor is set, we check for
-   * relative jumps and if \e jump_threshold.prismatic_jump_threshold or \e jump_threshold.revolute_jump_threshold are
-   * greater than 0 then we check for absolute joint space jumps. For relative jumps the average distance between
-   * adjacent trajectory points is computed and if two adjacent trajectory points have distance > \e
-   * jump_threshold_factor * average, the trajectory is cut of at this point. For absolute jump thresholds, the absolute
-   * difference in joint space between sequential points is computed and if it exceededs these limits the returned path
-   * is truncated up to just before the jump.
-   * @param group The joint model group of the robot state.
-   * @param traj The trajectory that should be tested.
-   * @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
-   * @return The fraction of the trajectory that passed.
-   */
+  /** \brief Tests joint space jumps of a trajectory.
+
+     If \e jump_threshold_factor is non-zero, we test for relative jumps.
+     If \e prismatic_jump_threshold or \e revolute_jump_threshold are non-zero, we test for absolute jumps.
+     Otherwise (all params are zero), jump detection is skipped.
+     For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
+     computed. If any individual joint-space motion delta is larger then this average distance by a factor of
+     \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
+     before the jump.
+     @param group The joint model group of the robot state.
+     @param traj The trajectory that should be tested.
+     @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
+     @return The fraction of the trajectory that passed.
+  */
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                    const JumpThreshold& jump_threshold);
 
-  /**
-   * \brief Tests joint space jumps of a trajectory. First, the average distance between adjacent trajectory points is
-   * computed. If two adjacent trajectory points have distance > \e jump_threshold * average, the trajectory is cut of
-   * at this point.
-   * @param group The joint model group of the robot state.
-   * @param traj The trajectory that should be tested.
-   * @param jump_threshold The threshold to determine if a joint space jump has occurred .
-   * @return The fraction of the trajectory that passed.
-   */
+  /** \brief Tests for relative joint space jumps of the trajectory \e traj.
+
+     First, the average distance between adjacent trajectory points is computed. If two adjacent trajectory points
+     have distance > \e jump_threshold_factor * average, the trajectory is truncated at this point.
+     @param group The joint model group of the robot state.
+     @param traj The trajectory that should be tested.
+     @param jump_threshold_factor The threshold to determine if a joint space jump has occurred .
+     @return The fraction of the trajectory that passed.
+  */
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                    double jump_threshold);
 
-  /**
-   * \brief Tests for absolute joint space jumps of a trajectory. The absolute difference in joint space between
-   * sequential points for each active joint is computed and if it exceededs \e prismatic_jump_threshold for prismatic
-   * joints or revolute_jump_threshold for revolute joints, the returned path is truncated up to just before the jump.
-   * @param group The joint model group of the robot state.
-   * @param traj The trajectory that should be tested.
-   * @param prismatic_jump_threshold The threshold to determine if a joint space jump has occurred .
-   * @param revolute_jump_threshold The threshold to determine if a joint space jump has occurred .
-   * @return The fraction of the trajectory that passed.
-   */
+  /** \brief Tests for absolute joint space jumps of the trajectory \e traj.
+
+     The joint-space difference between consecutive waypoints is computed for each active joint and compared to
+     the absolute thresholds \e prismatic_jump_threshold for prismatic joints or \e revolute_jump_threshold for
+     revolute joints. If these thresholds are exceeded, the trajectory is truncated.
+     @param group The joint model group of the robot state.
+     @param traj The trajectory that should be tested.
+     @param revolute_jump_threshold Absolute joint-space threshold for revolute joints.
+     @param prismatic_jump_threshold Absolute joint-space threshold for prismatic joints.
+     @return The fraction of the trajectory that passed.
+  */
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                    double revolute_jump_threshold, double prismatic_jump_threshold);
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -70,21 +70,29 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
     thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
+
+  // Test for large joint space jumps using a cutoff factor
+  bool test_for_relative_jump;
   double factor;
+
+  // Test for joint space jumps that exceed some cutoff value
+  bool test_for_absolute_jump;
   double prismatic;
   double revolute;
 
-  explicit JumpThreshold() : factor(0.0), prismatic(0.0), revolute(0.0)
+  explicit JumpThreshold() : test_for_relative_jump(false), factor(0.0), test_for_absolute_jump(false), prismatic(0.0), revolute(0.0)
   {
   }
 
   explicit JumpThreshold(double jt_factor) : JumpThreshold()
   {
+    test_for_relative_jump = true;
     factor = jt_factor;
   }
 
   explicit JumpThreshold(double jt_revolute, double jt_prismatic) : JumpThreshold()
   {
+    test_for_absolute_jump = true;
     prismatic = jt_prismatic;
     revolute = jt_revolute;
   }
@@ -1106,8 +1114,13 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step,
-                                JumpThreshold(jump_threshold_factor), validCallback, options);
+    if (jump_threshold_factor)
+      return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step,
+                                  JumpThreshold(jump_threshold_factor), validCallback, options);
+    else
+      return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step,
+                                  JumpThreshold(), validCallback, options);
+
   }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
@@ -1129,8 +1142,13 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
-                                JumpThreshold(jump_threshold_factor), validCallback, options);
+    if (jump_threshold_factor)
+      return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
+                                  JumpThreshold(jump_threshold_factor), validCallback, options);
+    else
+      return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
+                                  JumpThreshold(), validCallback, options);
+
   }
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
@@ -1151,8 +1169,13 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
-                                JumpThreshold(jump_threshold_factor), validCallback, options);
+    if (jump_threshold_factor)
+      return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
+                                  JumpThreshold(jump_threshold_factor), validCallback, options);
+    else
+      return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
+                                  JumpThreshold(), validCallback, options);
+
   }
 
   /** \brief Tests joint space jumps of a trajectory.

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -73,6 +73,21 @@ struct JumpThreshold
   double jump_threshold_factor;
   double prismatic_jump_threshold;
   double revolute_jump_threshold;
+
+  explicit JumpThreshold() : jump_threshold_factor(0.0), prismatic_jump_threshold(0.0), revolute_jump_threshold(0.0)
+  {
+  }
+
+  explicit JumpThreshold(double factor) : JumpThreshold()
+  {
+    jump_threshold_factor = factor;
+  }
+
+  explicit JumpThreshold(double revolute, double prismatic) : JumpThreshold()
+  {
+    prismatic_jump_threshold = prismatic;
+    revolute_jump_threshold = revolute;
+  }
 };
 
 /** \brief Representation of a robot's state. This includes position,
@@ -1087,9 +1102,13 @@ as the new values that correspond to the group */
 
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
-                              double max_step, double jump_threshold,
+                              double max_step, double jump_threshold_factor,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step,
+                                JumpThreshold(jump_threshold_factor), validCallback, options);
+  }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
@@ -1106,9 +1125,13 @@ as the new values that correspond to the group */
 
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
-                              double jump_threshold,
+                              double jump_threshold_factor,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
+                                JumpThreshold(jump_threshold_factor), validCallback, options);
+  }
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
@@ -1124,9 +1147,13 @@ as the new values that correspond to the group */
 
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
-                              double jump_threshold,
+                              double jump_threshold_factor,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                              const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
+                                JumpThreshold(jump_threshold_factor), validCallback, options);
+  }
 
   /** \brief Tests joint space jumps of a trajectory.
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1922,7 +1922,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
   // If we are testing for relative jumps, we always want at least MIN_STEPS_FOR_JUMP_THRESH steps
   unsigned int steps = floor(distance / max_step) + 1;
-  if (jump_threshold.factor > 0 && steps < MIN_STEPS_FOR_JUMP_THRESH)
+  if (jump_threshold.test_for_relative_jump && steps < MIN_STEPS_FOR_JUMP_THRESH)
     steps = MIN_STEPS_FOR_JUMP_THRESH;
 
   traj.clear();
@@ -1992,14 +1992,11 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                       const JumpThreshold& jump_threshold)
 {
-  if (jump_threshold.factor > 0.0)
+  if (jump_threshold.test_for_relative_jump)
     return testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
 
-  else if (jump_threshold.prismatic > 0.0 && jump_threshold.revolute > 0.0)
+  if (jump_threshold.test_for_absolute_jump)
     return testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
-
-  else if (jump_threshold.prismatic > 0.0 || jump_threshold.revolute > 0.0)
-    CONSOLE_BRIDGE_logWarn("Attempting to test for absolute joint-space jumps, but zero threshold was provided");
 
   return 1.0;
 }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1887,20 +1887,6 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                        const LinkModel* link, const Eigen::Vector3d& direction,
-                                        bool global_reference_frame, double distance, double max_step,
-                                        double jump_threshold, const GroupStateValidityCallbackFn& validCallback,
-                                        const kinematics::KinematicsQueryOptions& options)
-{
-  JumpThreshold jt;
-  jt.jump_threshold_factor = jump_threshold;
-  jt.prismatic_jump_threshold = 0.0;
-  jt.revolute_jump_threshold = 0.0;
-  return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step, jt,
-                              validCallback, options);
-}
-
-double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                         const LinkModel* link, const Eigen::Affine3d& target,
                                         bool global_reference_frame, double max_step,
                                         const JumpThreshold& jump_threshold,
@@ -1972,19 +1958,6 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                        const LinkModel* link, const Eigen::Affine3d& target,
-                                        bool global_reference_frame, double max_step, double jump_threshold,
-                                        const GroupStateValidityCallbackFn& validCallback,
-                                        const kinematics::KinematicsQueryOptions& options)
-{
-  JumpThreshold jt;
-  jt.jump_threshold_factor = jump_threshold;
-  jt.prismatic_jump_threshold = 0.0;
-  jt.revolute_jump_threshold = 0.0;
-  return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step, jt, validCallback, options);
-}
-
-double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                         const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
                                         bool global_reference_frame, double max_step,
                                         const JumpThreshold& jump_threshold,
@@ -2025,20 +1998,6 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
   }
 
   return percentage_solved;
-}
-
-double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
-                                        const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
-                                        bool global_reference_frame, double max_step, double jump_threshold,
-                                        const GroupStateValidityCallbackFn& validCallback,
-                                        const kinematics::KinematicsQueryOptions& options)
-{
-  JumpThreshold jt;
-  jt.jump_threshold_factor = jump_threshold;
-  jt.prismatic_jump_threshold = 0.0;
-  jt.revolute_jump_threshold = 0.0;
-  return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step, jt, validCallback,
-                              options);
 }
 
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2047,18 +2047,18 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
     {
       if (!joint->getType() == JointModel::PRISMATIC && !joint->getType() == JointModel::REVOLUTE)
       {
-        CONSOLE_BRIDGE_logWarn("Unsupported joint type %s in JointModelGroup %s testAbsoluteJointSpaceJump can only "
-                               "support prismatic and revolute joints.",
-                               joint->getTypeName().c_str(), group->getName().c_str());
+        CONSOLE_BRIDGE_logWarn("Joint %s is of unsupported type %s. \n"
+                               "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
+                               joint->getName().c_str(), joint->getTypeName().c_str());
       }
 
       double distance = traj[traj_ix]->distance(*traj[traj_ix + 1], joint);
       if ((joint->getType() == JointModel::PRISMATIC && distance > prismatic_jump_threshold) ||
           (joint->getType() == JointModel::REVOLUTE && distance > revolute_jump_threshold))
       {
-        CONSOLE_BRIDGE_logError("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint-space distance",
-                                distance, joint->getType() == JointModel::PRISMATIC ? prismatic_jump_threshold :
-                                                                                      revolute_jump_threshold);
+        double limit = joint->getType() == JointModel::PRISMATIC ? prismatic_jump_threshold : revolute_jump_threshold;
+        CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint %s", distance,
+                                limit, joint->getName().c_str());
         still_valid = false;
         break;
       }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2007,6 +2007,13 @@ double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                       double jump_threshold_factor)
 {
+  if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
+  {
+    CONSOLE_BRIDGE_logWarn("The computed trajectory is too short to detect jumps in joint-space "
+                           "Need at least %zu steps, only got %zu. Try a lower max_step.",
+                           MIN_STEPS_FOR_JUMP_THRESH, traj.size());
+  }
+
   std::vector<double> dist_vector;
   dist_vector.reserve(traj.size() - 1);
   double total_dist = 0.0;

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -33,14 +33,18 @@
 *********************************************************************/
 
 /* Author: Ioan Sucan */
-
+#include <boost/filesystem/path.hpp>
+#include <moveit/rdf_loader/rdf_loader.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <urdf_parser/urdf_parser.h>
 #include <gtest/gtest.h>
+#include <fstream>
 #include <sstream>
 #include <algorithm>
 #include <ctype.h>
+#include <moveit_resources/config.h>
+#include <gtest/gtest.h>
 
 static bool sameStringIgnoringWS(const std::string& s1, const std::string& s2)
 {
@@ -551,6 +555,96 @@ TEST(FK, OneRobot)
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_c").translation(), Eigen::Vector3d(0.0, 0.4, 0));
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_d").translation(), Eigen::Vector3d(1.7, 0.5, 0));
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_e").translation(), Eigen::Vector3d(2.8, 0.6, 0));
+}
+
+class LoadPR2 : public testing::Test
+{
+protected:
+  virtual void SetUp()
+  {
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+
+    srdf_model.reset(new srdf::Model());
+    std::string xml_string;
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
+    if (xml_file.is_open())
+    {
+      while (xml_file.good())
+      {
+        std::string line;
+        std::getline(xml_file, line);
+        xml_string += (line + "\n");
+      }
+      xml_file.close();
+      urdf_model = urdf::parseURDF(xml_string);
+    }
+    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
+    robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
+  };
+
+  virtual void TearDown()
+  {
+  }
+
+protected:
+  urdf::ModelInterfaceSharedPtr urdf_model;
+  srdf::ModelSharedPtr srdf_model;
+  moveit::core::RobotModelConstPtr robot_model;
+};
+
+void generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& traj,
+                      const moveit::core::RobotModelConstPtr& robot_model,
+                      const robot_model::JointModelGroup* joint_model_group)
+{
+  std::size_t n_joints = joint_model_group->getJointModelNames().size();
+  std::vector<double> joint_positions;
+  joint_positions.resize(n_joints, 0.0);
+  for (std::size_t traj_ix = 0; traj_ix < 3; ++traj_ix)
+  {
+    std::shared_ptr<robot_state::RobotState> robot_state(new robot_state::RobotState(robot_model));
+    robot_state->setJointGroupPositions(joint_model_group, joint_positions);
+    traj.push_back(robot_state);
+  }
+  std::vector<double> joint_positions2;
+  joint_positions2.resize(n_joints, 0.0);
+  joint_positions2[0] = 1.01;
+  std::shared_ptr<robot_state::RobotState> robot_state(new robot_state::RobotState(robot_model));
+  robot_state->setJointGroupPositions(joint_model_group, joint_positions2);
+  traj.push_back(robot_state);
+}
+
+TEST_F(LoadPR2, testJointSpaceJumpCutoff)
+{
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("right_arm");
+  std::vector<std::shared_ptr<robot_state::RobotState>> traj;
+
+  generateTestTraj(traj, robot_model, joint_model_group);
+  // Test the absolute joint space jump test function
+  // Traj has 4 points in the trajectory with a joint space jump of 1.01 at the last waypoint.
+  // testJointSpaceJump should identify the jump at the 4th waypoint and trim that off returning
+  // .75 and a trajectory of length 3
+  double result = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, 1.0, 1.0);
+  EXPECT_NEAR(result, 0.75, 0.01);
+  EXPECT_NEAR(traj.size(), 3, 0.01);
+}
+
+TEST_F(LoadPR2, testJointSpaceJumpCutoffOldMethod)
+{
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("right_arm");
+
+  std::size_t n_joints = joint_model_group->getJointModelNames().size();
+  std::vector<std::shared_ptr<robot_state::RobotState>> traj;
+
+  // generate a test trajectory of len 4 with all zeros except one large jump at the last waypoint
+  generateTestTraj(traj, robot_model, joint_model_group);
+
+  // Test testJointSpaceJump with a jump_threshold factor
+  // Traj has 4 points in the trajectory with a large jump at the last waypoint.
+  // testJointSpaceJump should identify the jump at the 4th waypoint and trim it
+  // Returning a trajectory of length 3 wich is 3/4 of the original traj length
+  double result = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, 1.0);
+  EXPECT_NEAR(result, 3. / 4., 0.01);
+  EXPECT_NEAR(traj.size(), 3, 0.01);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -569,7 +569,8 @@ protected:
 
   virtual void TearDown()
   {
-  }
+  }  std::vector<double> joint_positions;
+
 
 protected:
   urdf::ModelInterfaceSharedPtr urdf_model;
@@ -583,15 +584,6 @@ std::size_t generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState
 {
   traj.clear();
 
-  std::vector<double> joint_positions;
-
-  std::shared_ptr<robot_state::RobotState> robot_state0(new robot_state::RobotState(robot_model));
-  robot_state0->setToDefaultValues();
-  robot_state0->copyJointGroupPositions(joint_model_group, joint_positions);
-  joint_positions[6] = .01;
-  robot_state0->setJointGroupPositions(joint_model_group, joint_positions);
-  traj.push_back(robot_state0);
-
   std::size_t n_joints = joint_model_group->getJointModelNames().size();
   for (std::size_t traj_ix = 0; traj_ix < 3; ++traj_ix)
   {
@@ -600,35 +592,15 @@ std::size_t generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState
     traj.push_back(robot_state1);
   }
 
-  // This should trip the jump_threshold_factor = 1 check.
+  // This is a jump
   std::shared_ptr<robot_state::RobotState> robot_state2(new robot_state::RobotState(robot_model));
   robot_state2->setToDefaultValues();
+  std::vector<double> joint_positions;
   robot_state2->copyJointGroupPositions(joint_model_group, joint_positions);
-  joint_positions[0] -= 1.0;
+  joint_positions[0] -= 1.01;
   robot_state2->setJointGroupPositions(joint_model_group, joint_positions);
   traj.push_back(robot_state2);
 
-  std::shared_ptr<robot_state::RobotState> robot_state3(new robot_state::RobotState(robot_model));
-  robot_state3->setToDefaultValues();
-  robot_state3->copyJointGroupPositions(joint_model_group, joint_positions);
-  joint_positions[1] -= 0.1;
-  robot_state3->setJointGroupPositions(joint_model_group, joint_positions);
-  traj.push_back(robot_state3);
-
-  // This should trip the revolute_jump_threshold = 1 check
-  std::shared_ptr<robot_state::RobotState> robot_state4(new robot_state::RobotState(robot_model));
-  robot_state4->setToDefaultValues();
-  robot_state4->copyJointGroupPositions(joint_model_group, joint_positions);
-  joint_positions[0] -= 1.01;
-  robot_state4->setJointGroupPositions(joint_model_group, joint_positions);
-  traj.push_back(robot_state4);
-
-  std::shared_ptr<robot_state::RobotState> robot_state5(new robot_state::RobotState(robot_model));
-  robot_state5->setToDefaultValues();
-  robot_state5->copyJointGroupPositions(joint_model_group, joint_positions);
-  joint_positions[1] -= 0.1;
-  robot_state5->setJointGroupPositions(joint_model_group, joint_positions);
-  traj.push_back(robot_state3);
   return traj.size();
 }
 
@@ -641,8 +613,8 @@ TEST_F(LoadPR2, testJointSpaceJumpAbsolute)
   robot_state::JumpThreshold jt_abs(1.0, 1.0);
   double fraction = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, jt_abs);
 
-  EXPECT_NEAR(traj.size(), 6, 0.01);
-  EXPECT_NEAR(fraction, 6. / (double)traj_len, 0.01);
+  EXPECT_NEAR(traj.size(), 3, 0.01);
+  EXPECT_NEAR(fraction, 3. / (double)traj_len, 0.01);
 }
 
 TEST_F(LoadPR2, testJointSpaceJumpRelative)
@@ -654,8 +626,8 @@ TEST_F(LoadPR2, testJointSpaceJumpRelative)
   robot_state::JumpThreshold jt_rel(1.0);
   double fraction = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, jt_rel);
 
-  EXPECT_NEAR(traj.size(), 4, 0.01);
-  EXPECT_NEAR(fraction, 4. / (double)traj_len, 0.01);
+  EXPECT_NEAR(traj.size(), 3, 0.01);
+  EXPECT_NEAR(fraction, 3. / (double)traj_len, 0.01);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

The git history in my pr [#798](https://github.com/ros-planning/moveit/pull/798) got very messy with multiple upstream merges followed by local commits. I cleaned up the git history so I could re-open the PR. I'm not sure if that was the best way and am open to feedback on better ways to cleanup my PR's in the future.  

I took a stab at implementing a absolute jump threshold for the computeCartesianPath functionality. (#773) This implementation required separate jump thresholds for prismatic and revolute joints and does not support planar, floating, fixed or multi-DOF joints. This implementation does not affect or replace the old computeCartesianPath method which is used by the move_group computeCartesianPath capability since that would involve changing messages and would have a much larger scope.

The goal of this PR is to address the issue where using the existing jump_threshold method, paths with few waypoints can have huge jumps in joint space. To demonstrate this problem, I generated hundreds of thousands of trajectories with varying goals, eef_steps and jump_thresholds, filtered out anything with less than 100% completion, sorted them by the number of interpolated waypoints in the returned trajectory, and then searched through for the largest absolute jump.

![image](https://user-images.githubusercontent.com/3253549/37381665-00658a46-2704-11e8-9151-17861cd4a332.png)

eef_steps = [0.01, 0.05, 0.1]
jump_thresholds = [1.1, 1.5, 1.75, 2.0]

After testing this new implementation and comparing it to the existing computeCartesianPath, I was able to filter out jumps from 100,000 trajectories with minimal parameter tuning. For what it's worth, IMHO it is a lot easier to tune the absolute jump thresholds than the jump threshold factor. 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
