### PR TITLE
MotionPlanningRvizPlugin: Enhanced External ROS Topic API

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -285,6 +285,7 @@ private:
 
   ros::Subscriber plan_subscriber_;
   ros::Subscriber execute_subscriber_;
+  ros::Subscriber stop_subscriber_;
   ros::Subscriber update_start_state_subscriber_;
   ros::Subscriber update_goal_state_subscriber_;
   ros::Subscriber update_start_state_RobotState_subscriber_;
@@ -296,6 +297,7 @@ private:
 
   void remotePlanCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteExecuteCallback(const std_msgs::EmptyConstPtr& msg);
+  void remoteStopCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateGoalStateCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateStartStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -300,8 +300,8 @@ private:
   void remoteStopCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateGoalStateCallback(const std_msgs::EmptyConstPtr& msg);
-  void remoteUpdateStartStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
-  void remoteUpdateGoalStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
+  void remoteUpdateCustomStartStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
+  void remoteUpdateCustomGoalStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
 
   /* Selects or unselects a item in a list by the item name */
   void setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -288,8 +288,8 @@ private:
   ros::Subscriber stop_subscriber_;
   ros::Subscriber update_start_state_subscriber_;
   ros::Subscriber update_goal_state_subscriber_;
-  ros::Subscriber update_start_state_RobotState_subscriber_;
-  ros::Subscriber update_goal_state_RobotState_subscriber_;
+  ros::Subscriber update_custom_start_state_subscriber_;
+  ros::Subscriber update_custom_goal_state_subscriber_;
   // General
   void changePlanningGroupHelper();
   void importResource(const std::string& path);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -287,6 +287,8 @@ private:
   ros::Subscriber execute_subscriber_;
   ros::Subscriber update_start_state_subscriber_;
   ros::Subscriber update_goal_state_subscriber_;
+  ros::Subscriber update_start_state_RobotState_subscriber_;
+  ros::Subscriber update_goal_state_RobotState_subscriber_;
   // General
   void changePlanningGroupHelper();
   void importResource(const std::string& path);
@@ -296,6 +298,8 @@ private:
   void remoteExecuteCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr& msg);
   void remoteUpdateGoalStateCallback(const std_msgs::EmptyConstPtr& msg);
+  void remoteUpdateStartStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
+  void remoteUpdateGoalStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
 
   /* Selects or unselects a item in a list by the item name */
   void setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1319,6 +1319,8 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     bool b;
     if (config.mapGetBool("MoveIt_Use_Constraint_Aware_IK", &b))
       frame_->ui_->collision_aware_ik->setChecked(b);
+    if (config.mapGetBool("MoveIt_Allow_External_Program", &b))
+      frame_->ui_->allow_external_program->setChecked(b);
 
     rviz::Config workspace = config.mapGetChild("MoveIt_Workspace");
     rviz::Config ws_center = workspace.mapGetChild("Center");
@@ -1366,6 +1368,7 @@ void MotionPlanningDisplay::save(rviz::Config config) const
     config.mapSetValue("MoveIt_Planning_Attempts", frame_->ui_->planning_attempts->value());
     config.mapSetValue("MoveIt_Goal_Tolerance", frame_->ui_->goal_tolerance->value());
     config.mapSetValue("MoveIt_Use_Constraint_Aware_IK", frame_->ui_->collision_aware_ik->isChecked());
+    config.mapSetValue("MoveIt_Allow_External_Program", frame_->ui_->allow_external_program->isChecked());
 
     rviz::Config workspace = config.mapMakeChild("MoveIt_Workspace");
     rviz::Config ws_center = workspace.mapMakeChild("Center");

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -222,6 +222,10 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
         nh.subscribe("/rviz/moveit/update_start_state", 1, &MotionPlanningFrame::remoteUpdateStartStateCallback, this);
     update_goal_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_goal_state", 1, &MotionPlanningFrame::remoteUpdateGoalStateCallback, this);
+    update_start_state_RobotState_subscriber_ =
+        nh.subscribe("/rviz/moveit/update_start_state_RobotState", 1, &MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback, this);
+    update_goal_state_RobotState_subscriber_ =
+        nh.subscribe("/rviz/moveit/update_goal_state_RobotState", 1, &MotionPlanningFrame::remoteUpdateGoalStateRobotStateCallback, this);
   }
   else
   {  // disable
@@ -229,6 +233,8 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
     execute_subscriber_.shutdown();
     update_start_state_subscriber_.shutdown();
     update_goal_state_subscriber_.shutdown();
+    update_start_state_RobotState_subscriber_.shutdown();
+    update_goal_state_RobotState_subscriber_.shutdown();
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -224,7 +224,7 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
     ros::NodeHandle nh;
     plan_subscriber_ = nh.subscribe("/rviz/moveit/plan", 1, &MotionPlanningFrame::remotePlanCallback, this);
     execute_subscriber_ = nh.subscribe("/rviz/moveit/execute", 1, &MotionPlanningFrame::remoteExecuteCallback, this);
-    stop_subscriber_ = nh.subscribe("/rviz/moveit/stop", 1, &MotionPlanningFrame::remoteExecuteCallback, this);
+    stop_subscriber_ = nh.subscribe("/rviz/moveit/stop", 1, &MotionPlanningFrame::remoteStopCallback, this);
     update_start_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_start_state", 1, &MotionPlanningFrame::remoteUpdateStartStateCallback, this);
     update_goal_state_subscriber_ =

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -222,6 +222,7 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
     ros::NodeHandle nh;
     plan_subscriber_ = nh.subscribe("/rviz/moveit/plan", 1, &MotionPlanningFrame::remotePlanCallback, this);
     execute_subscriber_ = nh.subscribe("/rviz/moveit/execute", 1, &MotionPlanningFrame::remoteExecuteCallback, this);
+    stop_subscriber_ = nh.subscribe("/rviz/moveit/stop", 1, &MotionPlanningFrame::remoteExecuteCallback, this);
     update_start_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_start_state", 1, &MotionPlanningFrame::remoteUpdateStartStateCallback, this);
     update_goal_state_subscriber_ =
@@ -235,6 +236,7 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
   {  // disable
     plan_subscriber_.shutdown();
     execute_subscriber_.shutdown();
+    stop_subscriber_.shutdown();
     update_start_state_subscriber_.shutdown();
     update_goal_state_subscriber_.shutdown();
     update_start_state_RobotState_subscriber_.shutdown();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -228,10 +228,10 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
     update_goal_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_goal_state", 1, &MotionPlanningFrame::remoteUpdateGoalStateCallback, this);
     update_custom_start_state_subscriber_ =
-        nh.subscribe("/rviz/moveit/update_start_state_RobotState", 1,
+        nh.subscribe("/rviz/moveit/update_custom_start_state", 1,
                      &MotionPlanningFrame::remoteUpdateCustomStartStateCallback, this);
     update_custom_goal_state_subscriber_ =
-        nh.subscribe("/rviz/moveit/update_goal_state_RobotState", 1,
+        nh.subscribe("/rviz/moveit/update_custom_goal_state", 1,
                      &MotionPlanningFrame::remoteUpdateCustomGoalStateCallback, this);
   }
   else

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -146,7 +146,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
   planning_scene_world_publisher_ = nh_.advertise<moveit_msgs::PlanningSceneWorld>("planning_scene_world", 1);
 
-  //  object_recognition_trigger_publisher_ = nh_.advertise<std_msgs::Bool>("recognize_objects_switch", 1);
+  // object_recognition_trigger_publisher_ = nh_.advertise<std_msgs::Bool>("recognize_objects_switch", 1);
   object_recognition_client_.reset(new actionlib::SimpleActionClient<object_recognition_msgs::ObjectRecognitionAction>(
       OBJECT_RECOGNITION_ACTION, false));
   object_recognition_subscriber_ =
@@ -160,7 +160,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
     }
     catch (std::exception& ex)
     {
-      //      ROS_ERROR("Object recognition action: %s", ex.what());
+      // ROS_ERROR("Object recognition action: %s", ex.what());
       object_recognition_client_.reset();
     }
   }
@@ -211,6 +211,8 @@ void MotionPlanningFrame::setItemSelectionInList(const std::string& item_name, b
 
 void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
 {
+  // This is needed to prevent UI event (resuming the options) triggered
+  // before getRobotInteraction() is loaded and ready
   if (first_time_)
   {
     return;
@@ -227,12 +229,10 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
         nh.subscribe("/rviz/moveit/update_start_state", 1, &MotionPlanningFrame::remoteUpdateStartStateCallback, this);
     update_goal_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_goal_state", 1, &MotionPlanningFrame::remoteUpdateGoalStateCallback, this);
-    update_custom_start_state_subscriber_ =
-        nh.subscribe("/rviz/moveit/update_custom_start_state", 1,
-                     &MotionPlanningFrame::remoteUpdateCustomStartStateCallback, this);
-    update_custom_goal_state_subscriber_ =
-        nh.subscribe("/rviz/moveit/update_custom_goal_state", 1,
-                     &MotionPlanningFrame::remoteUpdateCustomGoalStateCallback, this);
+    update_custom_start_state_subscriber_ = nh.subscribe(
+        "/rviz/moveit/update_custom_start_state", 1, &MotionPlanningFrame::remoteUpdateCustomStartStateCallback, this);
+    update_custom_goal_state_subscriber_ = nh.subscribe(
+        "/rviz/moveit/update_custom_goal_state", 1, &MotionPlanningFrame::remoteUpdateCustomGoalStateCallback, this);
   }
   else
   {  // disable
@@ -343,6 +343,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
           planning_display_->setQueryStartState(ps->getCurrentState());
           planning_display_->setQueryGoalState(ps->getCurrentState());
         }
+        // This ensures subscribers enabled after getRobotInteraction() is loaded and ready
         if (ui_->allow_external_program->isChecked())
         {
           planning_display_->addMainLoopJob(

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -227,10 +227,12 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
         nh.subscribe("/rviz/moveit/update_start_state", 1, &MotionPlanningFrame::remoteUpdateStartStateCallback, this);
     update_goal_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_goal_state", 1, &MotionPlanningFrame::remoteUpdateGoalStateCallback, this);
-    update_start_state_RobotState_subscriber_ =
-        nh.subscribe("/rviz/moveit/update_start_state_RobotState", 1, &MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback, this);
-    update_goal_state_RobotState_subscriber_ =
-        nh.subscribe("/rviz/moveit/update_goal_state_RobotState", 1, &MotionPlanningFrame::remoteUpdateGoalStateRobotStateCallback, this);
+    update_custom_start_state_subscriber_ =
+        nh.subscribe("/rviz/moveit/update_start_state_RobotState", 1,
+                     &MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback, this);
+    update_custom_goal_state_subscriber_ =
+        nh.subscribe("/rviz/moveit/update_goal_state_RobotState", 1,
+                     &MotionPlanningFrame::remoteUpdateGoalStateRobotStateCallback, this);
   }
   else
   {  // disable
@@ -239,8 +241,8 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
     stop_subscriber_.shutdown();
     update_start_state_subscriber_.shutdown();
     update_goal_state_subscriber_.shutdown();
-    update_start_state_RobotState_subscriber_.shutdown();
-    update_goal_state_RobotState_subscriber_.shutdown();
+    update_custom_start_state_subscriber_.shutdown();
+    update_custom_goal_state_subscriber_.shutdown();
   }
 }
 
@@ -341,9 +343,10 @@ void MotionPlanningFrame::changePlanningGroupHelper()
           planning_display_->setQueryStartState(ps->getCurrentState());
           planning_display_->setQueryGoalState(ps->getCurrentState());
         }
-        if(ui_->allow_external_program->isChecked())
+        if (ui_->allow_external_program->isChecked())
         {
-          planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::allowExternalProgramCommunication, this, true));
+          planning_display_->addMainLoopJob(
+              boost::bind(&MotionPlanningFrame::allowExternalProgramCommunication, this, true));
         }
       }
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -211,6 +211,10 @@ void MotionPlanningFrame::setItemSelectionInList(const std::string& item_name, b
 
 void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
 {
+  if (first_time_)
+  {
+    return;
+  }
   planning_display_->getRobotInteraction()->toggleMoveInteractiveMarkerTopic(enable);
   planning_display_->toggleSelectPlanningGroupSubscription(enable);
   if (enable)
@@ -334,6 +338,10 @@ void MotionPlanningFrame::changePlanningGroupHelper()
         {
           planning_display_->setQueryStartState(ps->getCurrentState());
           planning_display_->setQueryGoalState(ps->getCurrentState());
+        }
+        if(ui_->allow_external_program->isChecked())
+        {
+          planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::allowExternalProgramCommunication, this, true));
         }
       }
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -229,10 +229,10 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
         nh.subscribe("/rviz/moveit/update_goal_state", 1, &MotionPlanningFrame::remoteUpdateGoalStateCallback, this);
     update_custom_start_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_start_state_RobotState", 1,
-                     &MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback, this);
+                     &MotionPlanningFrame::remoteUpdateCustomStartStateCallback, this);
     update_custom_goal_state_subscriber_ =
         nh.subscribe("/rviz/moveit/update_goal_state_RobotState", 1,
-                     &MotionPlanningFrame::remoteUpdateGoalStateRobotStateCallback, this);
+                     &MotionPlanningFrame::remoteUpdateCustomGoalStateCallback, this);
   }
   else
   {  // disable

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -36,11 +36,13 @@
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
+#include <moveit/robot_state/robot_state.h>
 
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/robot_state/conversions.h>
 
 #include <std_srvs/Empty.h>
+#include <moveit_msgs/RobotState.h>
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
@@ -439,6 +441,38 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
     {
       robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryGoalState(state);
+    }
+  }
+}
+
+void MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg)
+{
+  moveit_msgs::RobotState msg_no_attached(*msg);
+  if (move_group_ && planning_display_)
+  {
+    planning_display_->waitForCurrentRobotState();
+    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+    if (ps)
+    {
+      robot_state::RobotStatePtr state(new robot_state::RobotState(ps->getCurrentState()));
+      robot_state::robotStateMsgToRobotState(ps->getTransforms(), msg_no_attached, *state);
+      planning_display_->setQueryStartState(*state);
+    }
+  }
+}
+
+void MotionPlanningFrame::remoteUpdateGoalStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg)
+{
+  moveit_msgs::RobotState msg_no_attached(*msg);
+  if (move_group_ && planning_display_)
+  {
+    planning_display_->waitForCurrentRobotState();
+    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+    if (ps)
+    {
+      robot_state::RobotStatePtr state(new robot_state::RobotState(ps->getCurrentState()));
+      robot_state::robotStateMsgToRobotState(ps->getTransforms(), msg_no_attached, *state);
+      planning_display_->setQueryGoalState(*state);
     }
   }
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -450,9 +450,11 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
   }
 }
 
-void MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg)
+void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs::RobotStateConstPtr& msg)
 {
   moveit_msgs::RobotState msg_no_attached(*msg);
+  msg_no_attached.attached_collision_objects.clear();
+  msg_no_attached.is_diff = true;
   if (move_group_ && planning_display_)
   {
     planning_display_->waitForCurrentRobotState();
@@ -466,9 +468,11 @@ void MotionPlanningFrame::remoteUpdateStartStateRobotStateCallback(const moveit_
   }
 }
 
-void MotionPlanningFrame::remoteUpdateGoalStateRobotStateCallback(const moveit_msgs::RobotStateConstPtr& msg)
+void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs::RobotStateConstPtr& msg)
 {
   moveit_msgs::RobotState msg_no_attached(*msg);
+  msg_no_attached.attached_collision_objects.clear();
+  msg_no_attached.is_diff = true;
   if (move_group_ && planning_display_)
   {
     planning_display_->waitForCurrentRobotState();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -417,6 +417,11 @@ void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::EmptyConstPtr& m
   executeButtonClicked();
 }
 
+void MotionPlanningFrame::remoteStopCallback(const std_msgs::EmptyConstPtr& msg)
+{
+  stopButtonClicked();
+}
+
 void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr& msg)
 {
   if (move_group_ && planning_display_)


### PR DESCRIPTION
### Description

This PR derived from the idea in [a ROS Answer question](http://answers.ros.org/question/257394/how-to-change-moveit-goal-state-through-code/): Provide external topics setting the start state and the goal state in the MotionPlanningRvizPlugin with a RobotState object. This improves the current API in which the state can only be set with the current robot position.

To achieve this, two new topics are subscribed:

  - `/rviz/moveit/update_custom_start_state`
  - `/rviz/moveit/update_custom_goal_state`

What's more, for the completeness of the external API, stopping command is exposed too:

  - `/rviz/moveit/stop`

Finally, the state of allow_external_program UI checkbox can be kept across sessions now, in order to ease the usage. The slot function adds a init check, to prevent uninitialized error.

As I am new to MoveIt! and C++, any feedback is welcome. The feature has been tested locally, and I will complete the following checklist in a week, sorry about that.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/) - **Nothing in the docs for now except [the joystick](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/ros_visualization/joystick.html); I will not add more docs**
- [x] Include a screenshot if changing a GUI - **N/A**
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)