### PR TITLE
fix race condition

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -447,7 +447,6 @@ protected:
   boost::shared_mutex scene_update_mutex_;         /// mutex for stored scene
   ros::Time last_update_time_;                     /// Last time the state was updated
   ros::Time last_robot_motion_time_;               /// Last time the robot has moved
-  bool enforce_next_state_update_;                 /// flag to enforce immediate state update in onStateUpdate()
 
   ros::NodeHandle nh_;
   ros::NodeHandle root_nh_;


### PR DESCRIPTION
As pointed out in https://github.com/ros-planning/moveit/pull/350#issuecomment-378265191, the race condition in `waitForCurrentState()` was not fully resolved yet.
The reason was that only the first incoming `joint_state` update triggered a `PlanningScene` update, while later updates were throttled. To overcome this issue, we should explicitly trigger a scene update in `waitForCurrentState()`, if there were (further) updates.
As verified by @mmoerdijk, this PR finally resolves the issue. 
The unittest so far only involved fake controllers that didn't revealed the timing issue.