### PR TITLE
update include statements to use new pluginlib and class_loader headers

### DIFF
--- a/moveit_experimental/collision_distance_field/src/collision_detector_hybrid_plugin_loader.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_detector_hybrid_plugin_loader.cpp
@@ -1,5 +1,5 @@
 #include <moveit/collision_distance_field/collision_detector_hybrid_plugin_loader.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace collision_detection
 {

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/include/kinematics_cache_ros/kinematics_cache_ros.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/include/kinematics_cache_ros/kinematics_cache_ros.h
@@ -40,7 +40,7 @@
 
 #include <kinematics_cache/kinematics_cache.h>
 #include <planning_models/robot_model.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 namespace kinematics_cache_ros
 {

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ik_kinematics_plugin.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ik_kinematics_plugin.cpp
@@ -40,7 +40,7 @@
 //#include <moveit/lma_kinematics_plugin/lma_kinematics_plugin.h>
 #include <moveit/srv_kinematics_plugin/srv_kinematics_plugin.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 // register CachedIKKinematicsPlugin<KDLKinematicsPlugin> as a KinematicsBase implementation
 PLUGINLIB_EXPORT_CLASS(
     cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>,

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ur_kinematics_plugin.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/cached_ur_kinematics_plugin.cpp
@@ -37,7 +37,7 @@
 #include <moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h>
 #include <ur_kinematics/ur_moveit_plugin.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 // register CachedIKKinematicsPlugin<URKinematicsPlugin> as a KinematicsBase implementation
 PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<ur_kinematics::URKinematicsPlugin>,
                        kinematics::KinematicsBase);

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -1373,5 +1373,5 @@ bool IKFastKinematicsPlugin::sampleRedundantJoint(kinematics::DiscretizationMeth
 }  // end namespace
 
 // register IKFastKinematicsPlugin as a KinematicsBase implementation
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(ikfast_kinematics_plugin::IKFastKinematicsPlugin, kinematics::KinematicsBase);

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -35,7 +35,7 @@
 /* Author: Sachin Chitta, David Lu!!, Ugo Cupcic */
 
 #include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 //#include <tf/transform_datatypes.h>
 #include <tf_conversions/tf_kdl.h>

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -35,7 +35,7 @@
 /* Author: Francisco Suarez-Ruiz */
 
 #include <moveit/lma_kinematics_plugin/lma_kinematics_plugin.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 #include <tf_conversions/tf_kdl.h>
 #include <kdl_parser/kdl_parser.hpp>

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -35,7 +35,7 @@
 /* Author: Dave Coleman, Masaki Murooka */
 
 #include <moveit/srv_kinematics_plugin/srv_kinematics_plugin.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 // URDF, SRDF
 #include <urdf_model/model.h>

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -40,7 +40,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace chomp_interface
 {

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -39,7 +39,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/profiler/profiler.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 #include <dynamic_reconfigure/server.h>
 #include "moveit_planners_ompl/OMPLDynamicReconfigureConfig.h"

--- a/moveit_planners/sbpl/ros/sbpl_interface_ros/src/sbpl_meta_plugin.cpp
+++ b/moveit_planners/sbpl/ros/sbpl_interface_ros/src/sbpl_meta_plugin.cpp
@@ -40,7 +40,7 @@
 #include <moveit_msgs/GetMotionPlan.h>
 #include <sbpl_interface/sbpl_meta_interface.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace sbpl_interface_ros
 {

--- a/moveit_planners/sbpl/ros/sbpl_interface_ros/src/sbpl_plugin.cpp
+++ b/moveit_planners/sbpl/ros/sbpl_interface_ros/src/sbpl_plugin.cpp
@@ -40,7 +40,7 @@
 #include <moveit_msgs/GetMotionPlan.h>
 #include <sbpl_interface/sbpl_interface.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace sbpl_interface_ros
 {

--- a/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
+++ b/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
@@ -37,7 +37,7 @@
 #include <ros/ros.h>
 #include <moveit/controller_manager/controller_manager.h>
 #include <sensor_msgs/JointState.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <map>
 
 namespace moveit_controller_manager_example

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -39,7 +39,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <sensor_msgs/JointState.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <map>
 #include <iterator>
 

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -45,8 +45,8 @@
 #include <controller_manager_msgs/ListControllers.h>
 #include <controller_manager_msgs/SwitchController.h>
 
-#include <pluginlib/class_list_macros.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_list_macros.hpp>
+#include <pluginlib/class_loader.hpp>
 
 #include <boost/bimap.hpp>
 

--- a/moveit_plugins/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
@@ -36,7 +36,7 @@
 
 #include <ros/ros.h>
 #include <moveit_ros_control_interface/ControllerHandle.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
 #include <memory>
 

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -39,7 +39,7 @@
 #include <moveit_simple_controller_manager/action_based_controller_handle.h>
 #include <moveit_simple_controller_manager/gripper_controller_handle.h>
 #include <moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <algorithm>
 #include <map>
 

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -48,7 +48,7 @@
 #include <moveit/warehouse/trajectory_constraints_storage.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <warehouse_ros/database_loader.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <map>
 #include <vector>

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -460,5 +460,5 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
   goal.possible_grasps.push_back(g);
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupPickPlaceAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -60,5 +60,5 @@ bool move_group::ApplyPlanningSceneService::applyScene(moveit_msgs::ApplyPlannin
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::ApplyPlanningSceneService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -181,5 +181,5 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupCartesianPathService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
@@ -60,5 +60,5 @@ bool move_group::ClearOctomapService::clearOctomap(std_srvs::Empty::Request& req
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::ClearOctomapService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -137,5 +137,5 @@ void MoveGroupExecuteTrajectoryAction::setExecuteTrajectoryState(MoveGroupState 
 
 }  // namespace move_group
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupExecuteTrajectoryAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
@@ -108,5 +108,5 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupExecuteService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.cpp
@@ -58,5 +58,5 @@ bool move_group::MoveGroupGetPlanningSceneService::getPlanningSceneService(movei
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupGetPlanningSceneService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -211,5 +211,5 @@ bool move_group::MoveGroupKinematicsService::computeFKService(moveit_msgs::GetPo
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupKinematicsService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -244,5 +244,5 @@ void move_group::MoveGroupMoveAction::setMoveState(MoveGroupState state)
   move_action_server_->publishFeedback(move_feedback_);
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupMoveAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -73,5 +73,5 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupPlanService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
@@ -125,5 +125,5 @@ bool move_group::MoveGroupQueryPlannersService::setParams(moveit_msgs::SetPlanne
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupQueryPlannersService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -122,5 +122,5 @@ bool move_group::MoveGroupStateValidationService::computeService(moveit_msgs::Ge
   return true;
 }
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupStateValidationService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/list_capabilities.cpp
+++ b/moveit_ros/move_group/src/list_capabilities.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/move_group/move_group_capability.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 int main(int argc, char** argv)

--- a/moveit_ros/perception/depth_image_octomap_updater/src/updater_plugin.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/updater_plugin.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan */
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/depth_image_octomap_updater/depth_image_octomap_updater.h>
 
 CLASS_LOADER_REGISTER_CLASS(occupancy_map_monitor::DepthImageOctomapUpdater,

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -213,5 +213,5 @@ void mesh_filter::DepthSelfFiltering::depthCb(const sensor_msgs::ImageConstPtr& 
   filter(depth_msg, info_msg);
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(mesh_filter::DepthSelfFiltering, nodelet::Nodelet)

--- a/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -41,7 +41,7 @@
 #include <string>
 #include <ros/ros.h>
 #include <tf/tf.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <moveit_msgs/SaveMap.h>
 #include <moveit_msgs/LoadMap.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/plugin_init.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/plugin_init.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan */
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h>
 
 CLASS_LOADER_REGISTER_CLASS(occupancy_map_monitor::PointCloudOctomapUpdater, occupancy_map_monitor::OccupancyMapUpdater)

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -33,7 +33,7 @@
  *********************************************************************/
 
 #include <moveit/collision_plugin_loader/collision_plugin_loader.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <memory>
 
 namespace collision_detection

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <ros/ros.h>
 #include <boost/tokenizer.hpp>
 #include <memory>

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/kinematics_plugin_loader/kinematics_plugin_loader.h>
 #include <moveit/rdf_loader/rdf_loader.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <boost/thread/mutex.hpp>
 #include <sstream>
 #include <vector>

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -43,7 +43,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_scene_monitor/trajectory_monitor.h>
 #include <moveit/sensor_manager/sensor_manager.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 /** \brief This namespace includes functionality specific to the execution and monitoring of motion plans */
 namespace plan_execution

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
@@ -43,7 +43,7 @@
 
 #include <moveit/planning_scene_monitor/trajectory_monitor.h>
 #include <moveit/sensor_manager/sensor_manager.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <memory>
 

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -39,7 +39,7 @@
 
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <ros/ros.h>
 
 #include <memory>

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -37,7 +37,7 @@
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <ros/console.h>
 
 namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <ros/console.h>
 
 namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 namespace default_planner_request_adapters
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -38,7 +38,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <moveit/robot_state/conversions.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <ros/ros.h>
 
 namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -37,7 +37,7 @@
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <ros/ros.h>
 
 namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -37,7 +37,7 @@
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/robot_state/conversions.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <ros/ros.h>
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <ros/ros.h>
 
 namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan */
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <ros/ros.h>
 #include <memory>

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -46,7 +46,7 @@
 #include <ros/ros.h>
 #include <moveit/controller_manager/controller_manager.h>
 #include <boost/thread.hpp>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <memory>
 

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_moveit_controller_manager_plugin.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_moveit_controller_manager_plugin.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include "test_moveit_controller_manager.h"
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(test_moveit_controller_manager::TestMoveItControllerManager,
                        moveit_controller_manager::MoveItControllerManager);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/plugin_init.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan */
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
 
 CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::MotionPlanningDisplay, rviz::Display)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/plugin_init.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan */
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/planning_scene_rviz_plugin/planning_scene_display.h>
 
 CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::PlanningSceneDisplay, rviz::Display)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/plugin_init.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan */
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/robot_state_rviz_plugin/robot_state_display.h>
 
 CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::RobotStateDisplay, rviz::Display)

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/plugin_init.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Dave Coleman */
 
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 #include <moveit/trajectory_rviz_plugin/trajectory_display.h>
 
 CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::TrajectoryDisplay, rviz::Display)

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -40,7 +40,7 @@
 #include <QFormLayout>
 #include <QString>
 #include "group_edit_widget.h"
-#include <pluginlib/class_loader.h>  // for loading all avail kinematic planners
+#include <pluginlib/class_loader.hpp>  // for loading all avail kinematic planners
 
 namespace moveit_setup_assistant
 {

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -48,7 +48,7 @@
 #include <QCloseEvent>
 #include <QMessageBox>
 #include <QString>
-#include <pluginlib/class_loader.h>  // for loading all avail kinematic planners
+#include <pluginlib/class_loader.hpp>  // for loading all avail kinematic planners
 // Rviz
 #include <rviz/render_panel.h>
 #include <rviz/visualization_manager.h>


### PR DESCRIPTION
Disclaimer: This in an automated PR, if it is not relevant on this branch, apologies for the inconveniance, feel free close it.

----

`pluginlib` and `class_loader` headers have been refactored and renamed. The previous headers `.h` have been deprecated in favor of their `.hpp` equivalent. The new headers are available on all active ROS distributions and the deprecated ones will be removed in a future version of ROS (likely ROS-N).

This PR migrates the include statements to use the non-deprecated ones and should compile for any active ROS distribution starting with Indigo
The migration was done by running the scripts [pluginlib_headers_migration.py](https://github.com/ros/pluginlib/blob/6ada92c4665a392339c683682de1d1503658c209/scripts/pluginlib_headers_migration.py) and [class_loader_headers_update.py](https://github.com/ros/class_loader/blob/1515546103de4d987daa8f5519ca43fe6cffbca6/scripts/class_loader_headers_update.py) on this repository.
Note: this will not work for Jade