### PR TITLE
Provide more informative error message if shape transform cannot be found

### DIFF
--- a/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
+++ b/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
@@ -128,7 +128,16 @@ void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::Poi
     std::size_t j = 0;
     for (std::set<SeeShape>::const_iterator it = bodies_.begin(); it != bodies_.end(); ++it)
     {
-      if (transform_callback_(it->handle, tmp))
+      if (!transform_callback_(it->handle, tmp))
+      {
+        if (!it->body)
+          ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape with handle " << it->handle << " without a "
+                                                                                                           "body");
+        else
+          ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape " << it->body->getType() << " with handle "
+                                                                              << it->handle);
+      }
+      else
       {
         it->body->setPose(tmp);
         it->body->computeBoundingSphere(bspheres_[j++]);

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -151,7 +151,6 @@ bool PointCloudOctomapUpdater::getShapeTransform(ShapeHandle h, Eigen::Affine3d&
   ShapeTransformCache::const_iterator it = transform_cache_.find(h);
   if (it == transform_cache_.end())
   {
-    ROS_ERROR("Internal error. Shape filter handle %u not found", h);
     return false;
   }
   transform = it->second;


### PR DESCRIPTION
Moved error msg from callee (`getShapeTransform`) to caller (`maskContainment`).

Also I don't think it belongs in this lookup function in the first place.
The signature defines a bool return value for success/failure.

This builds on a change in geometric_shapes 0.5.4.
So I think this request can wait until the new version is rolled out.