### PR TITLE
MoveIt! tf2 migration

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -32,7 +32,8 @@ find_package(urdfdom_headers REQUIRED)
 
 find_package(catkin REQUIRED
 COMPONENTS
-  eigen_conversions
+  tf2_eigen
+  tf2_kdl
   eigen_stl_containers
   geometric_shapes
   geometry_msgs
@@ -111,7 +112,7 @@ catkin_package(
     moveit_dynamics_solver
     ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
-    eigen_conversions
+    tf2_eigen
     eigen_stl_containers
     geometric_shapes
     geometry_msgs

--- a/moveit_core/collision_detection/src/collision_tools.cpp
+++ b/moveit_core/collision_detection/src/collision_tools.cpp
@@ -37,7 +37,6 @@
 #include <moveit/collision_detection/collision_tools.h>
 #include <tf2_eigen/tf2_eigen.h>
 
-
 namespace collision_detection
 {
 void getCostMarkers(visualization_msgs::MarkerArray& arr, const std::string& frame_id,

--- a/moveit_core/collision_detection/src/collision_tools.cpp
+++ b/moveit_core/collision_detection/src/collision_tools.cpp
@@ -35,7 +35,8 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/collision_detection/collision_tools.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
+
 
 namespace collision_detection
 {
@@ -272,8 +273,8 @@ void costSourceToMsg(const CostSource& cost_source, moveit_msgs::CostSource& msg
 
 void contactToMsg(const Contact& contact, moveit_msgs::ContactInformation& msg)
 {
-  tf::pointEigenToMsg(contact.pos, msg.position);
-  tf::vectorEigenToMsg(contact.normal, msg.normal);
+  msg.position = tf2::toMsg(contact.pos);
+  tf2::toMsg(contact.normal, msg.normal);
   msg.depth = contact.depth;
   msg.contact_body_1 = contact.body_name_1;
   msg.contact_body_2 = contact.body_name_2;

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -26,10 +26,10 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl REQUIRED)
   find_package(angles REQUIRED)
-  find_package(tf_conversions REQUIRED)
+  find_package(tf2_kdl REQUIRED)
   find_package(moveit_resources REQUIRED)
 
-  include_directories(${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf_conversions_INCLUDE_DIRS} ${moveit_resources_INCLUDE_DIRS})
+  include_directories(${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS} ${moveit_resources_INCLUDE_DIRS})
 
   catkin_add_gtest(test_constraint_samplers
     test/test_constraint_samplers.cpp
@@ -41,7 +41,6 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
     ${angles_LIBRARIES}
     ${orocos_kdl_LIBRARIES}
-    ${tf_conversions_LIBRARIES}
     ${urdfdom_LIBRARIES}
     ${urdfdom_headers_LIBRARIES}
   )

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -37,7 +37,6 @@
 #include <moveit/constraint_samplers/default_constraint_samplers.h>
 #include <set>
 #include <cassert>
-#include <eigen_conversions/eigen_msg.h>
 #include <boost/bind.hpp>
 
 namespace constraint_samplers

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -36,8 +36,7 @@
 
 #include <geometry_msgs/PoseStamped.h>
 #include <kdl_parser/kdl_parser.hpp>
-#include <eigen_conversions/eigen_msg.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_kdl/tf2_kdl.h>
 #include <algorithm>
 #include <numeric>
 
@@ -340,9 +339,7 @@ bool PR2ArmKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose
     return false;
   }
   KDL::Frame pose_desired;
-  Eigen::Affine3d tp;
-  tf::poseMsgToEigen(ik_pose, tp);
-  tf::transformEigenToKDL(tp, pose_desired);
+  tf2::fromMsg(ik_pose, pose_desired);
 
   // Do the IK
   KDL::JntArray jnt_pos_in;

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -43,7 +43,6 @@
 #include <kdl_parser/kdl_parser.hpp>
 
 #include <angles/angles.h>
-#include <tf_conversions/tf_kdl.h>
 
 #include <moveit/macros/class_forward.h>
 #include <moveit_msgs/GetPositionFK.h>

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -37,7 +37,7 @@
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/find_internal_points.h>
 #include <geometric_shapes/body_operations.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <ros/console.h>
 #include <octomap/octomap.h>
 #include <octomap/OcTree.h>
@@ -229,7 +229,7 @@ void DistanceField::addShapeToField(const shapes::Shape* shape, const Eigen::Aff
 void DistanceField::addShapeToField(const shapes::Shape* shape, const geometry_msgs::Pose& pose)
 {
   Eigen::Affine3d pose_e;
-  tf::poseMsgToEigen(pose, pose_e);
+  tf2::fromMsg(pose, pose_e);
   addShapeToField(shape, pose_e);
 }
 
@@ -310,8 +310,8 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const geometry_
                                      const geometry_msgs::Pose& new_pose)
 {
   Eigen::Affine3d old_pose_e, new_pose_e;
-  tf::poseMsgToEigen(old_pose, old_pose_e);
-  tf::poseMsgToEigen(new_pose, new_pose_e);
+  tf2::fromMsg(old_pose, old_pose_e);
+  tf2::fromMsg(new_pose, new_pose_e);
   moveShapeInField(shape, old_pose_e, new_pose_e);
 }
 
@@ -329,7 +329,7 @@ void DistanceField::removeShapeFromField(const shapes::Shape* shape, const Eigen
 void DistanceField::removeShapeFromField(const shapes::Shape* shape, const geometry_msgs::Pose& pose)
 {
   Eigen::Affine3d pose_e;
-  tf::poseMsgToEigen(pose, pose_e);
+  tf2::fromMsg(pose, pose_e);
   removeShapeFromField(shape, pose_e);
 }
 

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -40,7 +40,7 @@
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <moveit/distance_field/find_internal_points.h>
 #include <geometric_shapes/body_operations.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <octomap/octomap.h>
 #include <ros/console.h>
 
@@ -511,7 +511,7 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
   p.position.z = .5;
 
   Eigen::Affine3d p_eigen;
-  tf::poseMsgToEigen(p, p_eigen);
+  tf2::fromMsg(p, p_eigen);
 
   gradient_df.addShapeToField(&sphere, p_eigen);
   // printBoth(gradient_df, numX, numY, numZ);

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -41,7 +41,7 @@
 #include <moveit/collision_detection_fcl/collision_robot_fcl.h>
 #include <moveit/collision_detection_fcl/collision_world_fcl.h>
 #include <boost/math/constants/constants.hpp>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <boost/bind.hpp>
 #include <limits>
 #include <memory>
@@ -319,7 +319,7 @@ bool PositionConstraint::configure(const moveit_msgs::PositionConstraint& pc, co
       }
       constraint_region_.push_back(bodies::BodyPtr(bodies::createBodyFromShape(shape.get())));
       Eigen::Affine3d t;
-      tf::poseMsgToEigen(pc.constraint_region.primitive_poses[i], t);
+      tf2::fromMsg(pc.constraint_region.primitive_poses[i], t);
       constraint_region_pose_.push_back(t);
       if (mobile_frame_)
         constraint_region_.back()->setPose(constraint_region_pose_.back());
@@ -346,7 +346,7 @@ bool PositionConstraint::configure(const moveit_msgs::PositionConstraint& pc, co
       }
       constraint_region_.push_back(bodies::BodyPtr(bodies::createBodyFromShape(shape.get())));
       Eigen::Affine3d t;
-      tf::poseMsgToEigen(pc.constraint_region.mesh_poses[i], t);
+      tf2::fromMsg(pc.constraint_region.mesh_poses[i], t);
       constraint_region_pose_.push_back(t);
       if (mobile_frame_)
         constraint_region_.back()->setPose(constraint_region_pose_.back());
@@ -504,7 +504,7 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
     return false;
   }
   Eigen::Quaterniond q;
-  tf::quaternionMsgToEigen(oc.orientation, q);
+  tf2::fromMsg(oc.orientation, q);
   if (fabs(q.norm() - 1.0) > 1e-3)
   {
     ROS_WARN_NAMED("kinematic_constraints", "Orientation constraint for link '%s' is probably incorrect: %f, %f, %f, "
@@ -698,7 +698,7 @@ bool VisibilityConstraint::configure(const moveit_msgs::VisibilityConstraint& vc
     points_.push_back(Eigen::Vector3d(x, y, 0.0));
   }
 
-  tf::poseMsgToEigen(vc.target_pose.pose, target_pose_);
+  tf2::fromMsg(vc.target_pose.pose, target_pose_);
 
   if (tf.isFixedFrame(vc.target_pose.header.frame_id))
   {
@@ -715,7 +715,7 @@ bool VisibilityConstraint::configure(const moveit_msgs::VisibilityConstraint& vc
     mobile_target_frame_ = true;
   }
 
-  tf::poseMsgToEigen(vc.sensor_pose.pose, sensor_pose_);
+  tf2::fromMsg(vc.sensor_pose.pose, sensor_pose_);
 
   if (tf.isFixedFrame(vc.sensor_pose.header.frame_id))
   {

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -36,7 +36,6 @@
 
 #include <moveit/kinematic_constraints/utils.h>
 #include <geometric_shapes/solid_primitive_dims.h>
-#include <eigen_conversions/eigen_msg.h>
 
 moveit_msgs::Constraints kinematic_constraints::mergeConstraints(const moveit_msgs::Constraints& first,
                                                                  const moveit_msgs::Constraints& second)

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -38,7 +38,7 @@
 #include <gtest/gtest.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <boost/filesystem/path.hpp>
 #include <moveit_resources/config.h>
 
@@ -659,9 +659,7 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
 
   ASSERT_TRUE(oc.getLinkModel());
 
-  geometry_msgs::Pose p;
-
-  tf::poseEigenToMsg(ks.getGlobalLinkTransform(oc.getLinkModel()->getName()), p);
+  geometry_msgs::Pose p = tf2::toMsg(ks.getGlobalLinkTransform(oc.getLinkModel()->getName()));
 
   ocm.orientation = p.orientation;
   ocm.header.frame_id = kmodel->getModelFrame();

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -22,7 +22,6 @@
   <build_depend>assimp</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>eigen_conversions</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
   <build_depend>libfcl-dev</build_depend>
   <build_depend version_gte="0.5.2">geometric_shapes</build_depend>
@@ -43,13 +42,14 @@
   <build_depend>shape_msgs</build_depend>
   <build_depend>srdfdom</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_kdl</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
 
   <run_depend>assimp</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>eigen</run_depend>
-  <run_depend>eigen_conversions</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
   <run_depend>libfcl-dev</run_depend>
   <run_depend version_gte="0.5.2">geometric_shapes</run_depend>
@@ -68,6 +68,8 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>srdfdom</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_kdl</run_depend>
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
 
@@ -75,5 +77,4 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>orocos_kdl</test_depend>
   <test_depend>rosunit</test_depend>
-  <test_depend>tf_conversions</test_depend>
 </package>

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -44,7 +44,7 @@
 #include <moveit/exceptions/exceptions.h>
 #include <moveit/robot_state/attached_body.h>
 #include <octomap_msgs/conversions.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <memory>
 #include <set>
 
@@ -821,9 +821,7 @@ bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collisio
     shapes::ShapeMsg sm;
     if (constructMsgFromShape(obj->shapes_[j].get(), sm))
     {
-      geometry_msgs::Pose p;
-      tf::poseEigenToMsg(obj->shape_poses_[j], p);
-
+      geometry_msgs::Pose p = tf2::toMsg(obj->shape_poses_[j]);
       sv.setPoseMessage(&p);
       boost::apply_visitor(sv, sm);
     }
@@ -885,7 +883,7 @@ bool PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const
     {
       const shapes::OcTree* o = static_cast<const shapes::OcTree*>(map->shapes_[0].get());
       octomap_msgs::fullMapToMsg(*o->octree, octomap.octomap);
-      tf::poseEigenToMsg(map->shape_poses_[0], octomap.origin);
+      octomap.origin = tf2::toMsg(map->shape_poses_[0]);
       return true;
     }
     ROS_ERROR_NAMED("planning_scene",
@@ -1359,7 +1357,7 @@ void PlanningScene::processOctomapMsg(const octomap_msgs::OctomapWithPose& map)
   std::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map.octomap)));
   const Eigen::Affine3d& t = getTransforms().getTransform(map.header.frame_id);
   Eigen::Affine3d p;
-  tf::poseMsgToEigen(map.origin, p);
+  tf2::fromMsg(map.origin, p);
   p = t * p;
   world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), p);
 }
@@ -1500,7 +1498,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           if (s)
           {
             Eigen::Affine3d p;
-            tf::poseMsgToEigen(object.object.primitive_poses[i], p);
+            tf2::fromMsg(object.object.primitive_poses[i], p);
             shapes.push_back(shapes::ShapeConstPtr(s));
             poses.push_back(p);
           }
@@ -1511,7 +1509,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           if (s)
           {
             Eigen::Affine3d p;
-            tf::poseMsgToEigen(object.object.mesh_poses[i], p);
+            tf2::fromMsg(object.object.mesh_poses[i], p);
             shapes.push_back(shapes::ShapeConstPtr(s));
             poses.push_back(p);
           }
@@ -1522,7 +1520,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           if (s)
           {
             Eigen::Affine3d p;
-            tf::poseMsgToEigen(object.object.plane_poses[i], p);
+            tf2::fromMsg(object.object.plane_poses[i], p);
             shapes.push_back(shapes::ShapeConstPtr(s));
             poses.push_back(p);
           }
@@ -1698,7 +1696,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
       if (s)
       {
         Eigen::Affine3d p;
-        tf::poseMsgToEigen(object.primitive_poses[i], p);
+        tf2::fromMsg(object.primitive_poses[i], p);
         world_->addToObject(object.id, shapes::ShapeConstPtr(s), t * p);
       }
     }
@@ -1708,7 +1706,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
       if (s)
       {
         Eigen::Affine3d p;
-        tf::poseMsgToEigen(object.mesh_poses[i], p);
+        tf2::fromMsg(object.mesh_poses[i], p);
         world_->addToObject(object.id, shapes::ShapeConstPtr(s), t * p);
       }
     }
@@ -1718,7 +1716,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
       if (s)
       {
         Eigen::Affine3d p;
-        tf::poseMsgToEigen(object.plane_poses[i], p);
+        tf2::fromMsg(object.plane_poses[i], p);
         world_->addToObject(object.id, shapes::ShapeConstPtr(s), t * p);
       }
     }
@@ -1754,19 +1752,19 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
       for (std::size_t i = 0; i < object.primitive_poses.size(); ++i)
       {
         Eigen::Affine3d p;
-        tf::poseMsgToEigen(object.primitive_poses[i], p);
+        tf2::fromMsg(object.primitive_poses[i], p);
         new_poses.push_back(t * p);
       }
       for (std::size_t i = 0; i < object.mesh_poses.size(); ++i)
       {
         Eigen::Affine3d p;
-        tf::poseMsgToEigen(object.mesh_poses[i], p);
+        tf2::fromMsg(object.mesh_poses[i], p);
         new_poses.push_back(t * p);
       }
       for (std::size_t i = 0; i < object.plane_poses.size(); ++i)
       {
         Eigen::Affine3d p;
-        tf::poseMsgToEigen(object.plane_poses[i], p);
+        tf2::fromMsg(object.plane_poses[i], p);
         new_poses.push_back(t * p);
       }
 

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -93,7 +93,7 @@ void RobotModel::buildModel(const urdf::ModelInterface& urdf_model, const srdf::
   if (urdf_model.getRoot())
   {
     const urdf::Link* root_link_ptr = urdf_model.getRoot().get();
-    model_frame_ = '/' + root_link_ptr->name;
+    model_frame_ = root_link_ptr->name;
 
     ROS_DEBUG_NAMED("robot_model", "... building kinematic chain");
     root_joint_ = buildRecursive(NULL, root_link_ptr, srdf_model);
@@ -920,8 +920,6 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
           if (vjoints[i].type_ != "fixed")
           {
             model_frame_ = vjoints[i].parent_frame_;
-            if (model_frame_[0] != '/')
-              model_frame_ = '/' + model_frame_;
           }
           break;
         }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -38,7 +38,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/transforms/transforms.h>
 #include <geometric_shapes/shape_operations.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <moveit/backtrace/backtrace.h>
 #include <moveit/profiler/profiler.h>
 #include <boost/bind.hpp>
@@ -978,7 +978,7 @@ const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) cons
   BOOST_VERIFY(checkLinkTransforms());
 
   static const Eigen::Affine3d identity_transform = Eigen::Affine3d::Identity();
-  if (id.size() + 1 == robot_model_->getModelFrame().size() && '/' + id == robot_model_->getModelFrame())
+  if (id == robot_model_->getModelFrame())
     return identity_transform;
   if (robot_model_->hasLinkModel(id))
   {
@@ -1058,7 +1058,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std
               // if the object is invisible (0 volume) we skip it
               if (fabs(att_mark.scale.x * att_mark.scale.y * att_mark.scale.z) < std::numeric_limits<float>::epsilon())
                 continue;
-              tf::poseEigenToMsg(it->second->getGlobalCollisionBodyTransforms()[j], att_mark.pose);
+              att_mark.pose = tf2::toMsg(it->second->getGlobalCollisionBodyTransforms()[j]);
               arr.markers.push_back(att_mark);
             }
           }
@@ -1082,7 +1082,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std
         // if the object is invisible (0 volume) we skip it
         if (fabs(mark.scale.x * mark.scale.y * mark.scale.z) < std::numeric_limits<float>::epsilon())
           continue;
-        tf::poseEigenToMsg(global_collision_body_transforms_[lm->getFirstCollisionBodyTransformIndex() + j], mark.pose);
+        mark.pose = tf2::toMsg(global_collision_body_transforms_[lm->getFirstCollisionBodyTransformIndex() + j]);
       }
       else
       {
@@ -1094,7 +1094,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std
         mark.scale.x = mesh_scale[0];
         mark.scale.y = mesh_scale[1];
         mark.scale.z = mesh_scale[2];
-        tf::poseEigenToMsg(global_link_transforms_[lm->getLinkIndex()] * lm->getVisualMeshOrigin(), mark.pose);
+        mark.pose = tf2::toMsg(global_link_transforms_[lm->getLinkIndex()] * lm->getVisualMeshOrigin());
       }
 
       arr.markers.push_back(mark);
@@ -1225,7 +1225,7 @@ bool RobotState::setFromDiffIK(const JointModelGroup* jmg, const geometry_msgs::
                                double dt, const GroupStateValidityCallbackFn& constraint)
 {
   Eigen::Matrix<double, 6, 1> t;
-  tf::twistMsgToEigen(twist, t);
+  tf2::fromMsg(twist, t);
   return setFromDiffIK(jmg, t, tip, dt, constraint);
 }
 
@@ -1307,7 +1307,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose
                            const kinematics::KinematicsQueryOptions& options)
 {
   Eigen::Affine3d mat;
-  tf::poseMsgToEigen(pose, mat);
+  tf2::fromMsg(pose, mat);
   static std::vector<double> consistency_limits;
   return setFromIK(jmg, mat, tip, consistency_limits, attempts, timeout, constraint, options);
 }
@@ -1558,7 +1558,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
 
     // Convert Eigen pose to geometry_msgs pose
     geometry_msgs::Pose ik_query;
-    tf::poseEigenToMsg(pose, ik_query);
+    ik_query = tf2::toMsg(pose);
 
     // Save into vectors
     ik_queries[solver_tip_id] = ik_query;
@@ -1588,7 +1588,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
 
     // Convert Eigen pose to geometry_msgs pose
     geometry_msgs::Pose ik_query;
-    tf::poseEigenToMsg(current_pose, ik_query);
+    ik_query = tf2::toMsg(current_pose);
 
     // Save into vectors - but this needs to be ordered in the same order as the IK solver expects its tip frames
     ik_queries[solver_tip_id] = ik_query;

--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -16,7 +16,7 @@ COMPONENTS
   kdl_parser
   geometric_shapes
   eigen_stl_containers
-  eigen_conversions
+  tf2_eigen
   random_numbers
   visualization_msgs
   roslib
@@ -57,7 +57,6 @@ catkin_package(
     moveit_core
     geometric_shapes
     eigen_stl_containers
-    eigen_conversions
     moveit_msgs
     kdl_parser
     pluginlib

--- a/moveit_experimental/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_common_distance_field.cpp
@@ -37,7 +37,7 @@
 #include <moveit/collision_distance_field/collision_common_distance_field.h>
 #include <ros/console.h>
 #include <boost/thread/mutex.hpp>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <memory>
 
 namespace collision_detection
@@ -176,7 +176,7 @@ void getBodySphereVisualizationMarkers(GroupStateRepresentationConstPtr& gsr, st
           gsr->link_body_decompositions_[i];
       for (unsigned int j = 0; j < sphere_representation->getCollisionSpheres().size(); j++)
       {
-        tf::pointEigenToMsg(sphere_representation->getSphereCenters()[j], sphere_marker.pose.position);
+        sphere_marker.pose.position = tf2::toMsg(sphere_representation->getSphereCenters()[j]);
         sphere_marker.scale.x = sphere_marker.scale.y = sphere_marker.scale.z =
             sphere_representation->getCollisionSpheres()[j].radius_;
         sphere_marker.id = id;
@@ -212,7 +212,7 @@ void getBodySphereVisualizationMarkers(GroupStateRepresentationConstPtr& gsr, st
       PosedBodySphereDecompositionVectorPtr sphere_decp = gsr->attached_body_decompositions_[i];
       sphere_decp->updatePose(j, att->getGlobalCollisionBodyTransforms()[j]);
 
-      tf::pointEigenToMsg(sphere_decp->getSphereCenters()[j], sphere_marker.pose.position);
+      sphere_marker.pose.position = tf2::toMsg(sphere_decp->getSphereCenters()[j]);
       sphere_marker.scale.x = sphere_marker.scale.y = sphere_marker.scale.z =
           sphere_decp->getCollisionSpheres()[j].radius_;
       sphere_marker.id = id;

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -40,7 +40,7 @@
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <ros/console.h>
 #include <ros/assert.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 namespace collision_detection
 {
@@ -1030,7 +1030,7 @@ void CollisionRobotDistanceField::createCollisionModelMarker(const moveit::core:
     sphere_representation->updatePose(state.getGlobalLinkTransform(link_name));
     for (unsigned int j = 0; j < sphere_representation->getCollisionSpheres().size(); j++)
     {
-      tf::pointEigenToMsg(sphere_representation->getSphereCenters()[j], sphere_marker.pose.position);
+      sphere_marker.pose.position = tf2::toMsg(sphere_representation->getSphereCenters()[j]);
       sphere_marker.scale.x = sphere_marker.scale.y = sphere_marker.scale.z =
           2 * sphere_representation->getCollisionSpheres()[j].radius_;
       sphere_marker.id = id;

--- a/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
+++ b/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
@@ -40,7 +40,7 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <Eigen/Geometry.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <boost/bind.hpp>
 
 namespace kinematics_constraint_aware
@@ -345,7 +345,7 @@ EigenSTL::vector_Affine3d KinematicsConstraintAware::transformPoses(
   for (std::size_t i = 0; i < poses.size(); ++i)
   {
     geometry_msgs::Pose pose = poses[i].pose;
-    tf::poseMsgToEigen(pose, eigen_pose_2);
+    tf2::fromMsg(pose, eigen_pose_2);
     planning_scene->getTransforms()->transformPose(kinematic_state, poses[i].header.frame_id, eigen_pose_2, eigen_pose);
     if (!target_frame_is_root_frame)
     {
@@ -365,11 +365,11 @@ geometry_msgs::Pose KinematicsConstraintAware::getTipFramePose(
   Eigen::Affine3d eigen_pose_in, eigen_pose_link, eigen_pose_tip;
   std::string tip_name =
       kinematic_model_->getJointModelGroup(sub_groups_names_[sub_group_index])->getSolverInstance()->getTipFrame();
-  tf::poseMsgToEigen(pose, eigen_pose_in);
+  tf2::fromMsg(pose, eigen_pose_in);
   eigen_pose_link = planning_scene->getTransforms()->getTransform(kinematic_state, link_name);
   eigen_pose_tip = planning_scene->getTransforms()->getTransform(kinematic_state, tip_name);
   eigen_pose_in = eigen_pose_in * (eigen_pose_link.inverse() * eigen_pose_tip);
-  tf::poseEigenToMsg(eigen_pose_in, result);
+  result = tf2::toMsg(eigen_pose_in, result);
   return result;
 }
 }

--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -35,7 +35,7 @@
   <build_depend>boost</build_depend>
   <build_depend>assimp</build_depend>
   <build_depend>eigen_stl_containers</build_depend>
-  <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rostime</build_depend>
@@ -53,7 +53,7 @@
   <run_depend>boost</run_depend>
   <run_depend>assimp</run_depend>
   <run_depend>eigen_stl_containers</run_depend>
-  <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf2_eigen</run_depend>
   <run_depend version_gte="0.3.4">geometric_shapes</run_depend>
   <run_depend>rostime</run_depend>
   <run_depend>rosconsole</run_depend>
@@ -71,7 +71,6 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>orocos_kdl</test_depend>
   <test_depend>angles</test_depend>
-  <test_depend>tf_conversions</test_depend>
 
   <export>
     <moveit_core plugin="${prefix}/collision_detector_hybrid_description.xml" />

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -17,8 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
   rosconsole
   srdfdom
   urdf
-  tf
-  tf_conversions
+  tf2
+  tf2_kdl
 )
 
 find_package(PkgConfig REQUIRED)

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -278,8 +278,8 @@ if __name__ == '__main__':
    package_xml = etree.parse(package_file_name, parser)
 
    # Make sure at least all required dependencies are in the depends lists
-   build_deps = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions"]
-   run_deps   = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions"]
+   build_deps = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf2_kdl"]
+   run_deps   = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf2_kdl"]
 
    def update_deps(reqd_deps, req_type, e_parent):
       curr_deps = [e.text for e in e_parent.findall(req_type)]

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib
   roscpp
-  tf_conversions
+  tf2_kdl
 )
 
 include_directories(${catkin_INCLUDE_DIRS})
@@ -18,7 +18,7 @@ catkin_package(
     moveit_core
     pluginlib
     roscpp
-    tf_conversions
+    tf2_kdl
 )
 
 include_directories(include)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -49,7 +49,7 @@
 #include <ros/ros.h>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <urdf/model.h>
-#include <tf_conversions/tf_kdl.h>
+#include <tf2_kdl/tf2_kdl.h>
 
 // Need a floating point tolerance when checking joint limits, in case the joint starts at limit
 const double LIMIT_TOLERANCE = .0000001;
@@ -797,7 +797,7 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_
     p_out.M.data[i] = eerot[i];
 
   poses.resize(1);
-  tf::poseKDLToMsg(p_out, poses[0]);
+  poses[0] = tf2::toMsg(p_out);
 
   return valid;
 }
@@ -932,7 +932,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose
   // Initialize
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_pose, frame);
+  tf2::fromMsg(ik_pose, frame);
 
   std::vector<double> vfree(free_params_.size());
 
@@ -1113,7 +1113,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, c
   }
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_pose, frame);
+  tf2::fromMsg(ik_pose, frame);
 
   IkSolutionList<IkReal> solutions;
   int numsol = solve(frame, vfree, solutions);
@@ -1215,7 +1215,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
   }
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_poses[0], frame);
+  tf2::fromMsg(ik_poses[0], frame);
 
   // solving ik
   std::vector<IkSolutionList<IkReal>> solution_set;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -37,8 +37,9 @@
 #include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
 #include <class_loader/class_loader.hpp>
 
-//#include <tf/transform_datatypes.h>
-#include <tf_conversions/tf_kdl.h>
+#include <tf2_kdl/tf2_kdl.h>
+#include <tf2/transform_datatypes.h>
+
 #include <kdl_parser/kdl_parser.hpp>
 
 // URDF, SRDF
@@ -485,7 +486,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   solution.resize(dimension_);
 
   KDL::Frame pose_desired;
-  tf::poseMsgToKDL(ik_pose, pose_desired);
+  tf2::fromMsg(ik_pose, pose_desired);
 
   ROS_DEBUG_STREAM_NAMED("kdl", "searchPositionIK2: Position request pose is "
                                     << ik_pose.position.x << " " << ik_pose.position.y << " " << ik_pose.position.z
@@ -573,9 +574,6 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   }
 
   KDL::Frame p_out;
-  geometry_msgs::PoseStamped pose;
-  tf::Stamped<tf::Pose> tf_pose;
-
   KDL::JntArray jnt_pos_in(dimension_);
   for (unsigned int i = 0; i < dimension_; i++)
   {
@@ -590,7 +588,7 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
     ROS_DEBUG_NAMED("kdl", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
     if (fk_solver.JntToCart(jnt_pos_in, p_out, getKDLSegmentIndex(link_names[i])) >= 0)
     {
-      tf::poseKDLToMsg(p_out, poses[i]);
+      poses[i] = tf2::toMsg(p_out);
     }
     else
     {

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -37,7 +37,7 @@
 #include <moveit/lma_kinematics_plugin/lma_kinematics_plugin.h>
 #include <class_loader/class_loader.hpp>
 
-#include <tf_conversions/tf_kdl.h>
+#include <tf2_kdl/tf2_kdl.h>
 #include <kdl_parser/kdl_parser.hpp>
 
 // URDF, SRDF
@@ -495,7 +495,7 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   solution.resize(dimension_);
 
   KDL::Frame pose_desired;
-  tf::poseMsgToKDL(ik_pose, pose_desired);
+  tf2::fromMsg(ik_pose, pose_desired);
 
   ROS_DEBUG_STREAM_NAMED("lma", "searchPositionIK2: Position request pose is "
                                     << ik_pose.position.x << " " << ik_pose.position.y << " " << ik_pose.position.z
@@ -583,9 +583,6 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   }
 
   KDL::Frame p_out;
-  geometry_msgs::PoseStamped pose;
-  tf::Stamped<tf::Pose> tf_pose;
-
   KDL::JntArray jnt_pos_in(dimension_);
   for (unsigned int i = 0; i < dimension_; i++)
   {
@@ -600,7 +597,7 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
     ROS_DEBUG_NAMED("lma", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
     if (fk_solver.JntToCart(jnt_pos_in, p_out, getKDLSegmentIndex(link_names[i])) >= 0)
     {
-      tf::poseKDLToMsg(p_out, poses[i]);
+      poses[i] = tf2::toMsg(p_out);
     }
     else
     {

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -26,11 +26,14 @@
   <build_depend>actionlib</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
+  <build_depend>tf2_kdl</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_kdl</run_depend>
 
 
   <export>

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -43,8 +43,6 @@
 #include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
-#include <tf/transform_listener.h>
-
 #include <moveit/robot_state/conversions.h>
 
 namespace chomp_interface
@@ -69,8 +67,6 @@ public:
 private:
   CHOMPInterfacePtr chomp_interface_;
   moveit::core::RobotModelConstPtr robot_model_;
-
-  boost::shared_ptr<tf::TransformListener> tf_;
 };
 
 } /* namespace chomp_interface */

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -38,8 +38,6 @@
 #include <moveit_msgs/GetMotionPlan.h>
 #include <chomp_interface/chomp_planning_context.h>
 
-#include <boost/shared_ptr.hpp>
-
 #include <pluginlib/class_list_macros.hpp>
 
 namespace chomp_interface

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -791,7 +791,6 @@ double ChompOptimizer::getCollisionCost()
 
 void ChompOptimizer::computeJointProperties(int trajectory_point)
 {
-  // tf::Transform inverseWorldTransform = collision_space_->getInverseWorldTransform(*state_);
   for (int j = 0; j < num_joints_; j++)
   {
     const moveit::core::JointModel* joint_model = state_.getJointModel(joint_names_[j]);

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -15,9 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosconsole
   pluginlib
-  tf
+  tf2_ros
   dynamic_reconfigure
-  eigen_conversions
   )
 
 find_package(OMPL REQUIRED)

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -45,7 +45,6 @@
 #include <moveit/ompl_interface/constraints_library.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/profiler/profiler.h>
-#include <eigen_conversions/eigen_msg.h>
 
 #include <ompl/base/samplers/UniformValidStateSampler.h>
 #include <ompl/base/goals/GoalLazySamples.h>

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner.cpp
@@ -133,7 +133,8 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener =
+      std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
   planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf_buffer);
   if (psm.getPlanningScene())
   {

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner.cpp
@@ -37,10 +37,11 @@
 #include <moveit/ompl_interface/ompl_interface.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/ompl_interface/model_based_planning_context.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit/profiler/profiler.h>
 #include <moveit_msgs/GetMotionPlan.h>
+#include <memory>
 
 static const std::string PLANNER_NODE_NAME = "ompl_planning";  // name of node
 static const std::string PLANNER_SERVICE_NAME =
@@ -129,9 +130,11 @@ int main(int argc, char** argv)
 
   ros::AsyncSpinner spinner(1);
   spinner.start();
+  ros::NodeHandle nh;
 
-  boost::shared_ptr<tf::TransformListener> tf(new tf::TransformListener());
-  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf);
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf_buffer);
   if (psm.getPlanningScene())
   {
     psm.startWorldGeometryMonitor();

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -18,20 +18,18 @@
 
   <build_depend>moveit_core</build_depend>
   <build_depend>ompl</build_depend>
-  <build_depend>eigen_conversions</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>pluginlib</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>ompl</run_depend>
-  <run_depend>eigen_conversions</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>tf</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>pluginlib</run_depend>
 
   <test_depend>moveit_resources</test_depend>

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 find_package(Boost REQUIRED filesystem)
 
 find_package(catkin REQUIRED COMPONENTS
+  tf2_eigen
   moveit_ros_planning
   moveit_ros_warehouse
   roscpp
@@ -20,6 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   LIBRARIES ${MOVEIT_LIB_NAME}
   CATKIN_DEPENDS
+    tf2_eigen
     moveit_ros_planning
     moveit_ros_warehouse
     roscpp

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -51,7 +51,7 @@
 #include <boost/progress.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
@@ -374,7 +374,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
             wMc_msg.position = constr->position_constraints[0].constraint_region.primitive_poses[0].position;
             wMc_msg.orientation = constr->orientation_constraints[0].orientation;
             Eigen::Affine3d wMc;
-            tf::poseMsgToEigen(wMc_msg, wMc);
+            tf2::fromMsg(wMc_msg, wMc);
 
             Eigen::Affine3d offset_tf(Eigen::AngleAxis<double>(options_.offsets[3], Eigen::Vector3d::UnitX()) *
                                       Eigen::AngleAxis<double>(options_.offsets[4], Eigen::Vector3d::UnitY()) *
@@ -383,7 +383,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
 
             Eigen::Affine3d wMnc = wMc * offset_tf;
             geometry_msgs::Pose wMnc_msg;
-            tf::poseEigenToMsg(wMnc, wMnc_msg);
+            wMnc_msg = tf2::toMsg(wMnc);
 
             req.motion_plan_request.goal_constraints[0]
                 .position_constraints[0]
@@ -465,11 +465,10 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
               wMc_msg.orientation =
                   req.motion_plan_request.trajectory_constraints.constraints[tc].orientation_constraints[0].orientation;
               Eigen::Affine3d wMc;
-              tf::poseMsgToEigen(wMc_msg, wMc);
+              tf2::fromMsg(wMc_msg, wMc);
 
               Eigen::Affine3d wMnc = wMc * offset_tf;
-              geometry_msgs::Pose wMnc_msg;
-              tf::poseEigenToMsg(wMnc, wMnc_msg);
+              geometry_msgs::Pose wMnc_msg = tf2::toMsg(wMnc);
 
               req.motion_plan_request.trajectory_constraints.constraints[tc]
                   .position_constraints[0]

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -20,11 +20,13 @@
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_ros_warehouse</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_depend version_gte="1.10.4">pluginlib</build_depend>
 
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>moveit_ros_warehouse</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>tf2_eigen</run_depend>
   <run_depend version_gte="1.10.4">pluginlib</run_depend>
 
 </package>

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/benchmarks/BenchmarkExecutor.h>
 #include <moveit/version.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 #include <boost/regex.hpp>
 #include <boost/progress.hpp>
@@ -449,11 +449,11 @@ void BenchmarkExecutor::shiftConstraintsByOffset(moveit_msgs::Constraints& const
   constraint_pose_msg.position = constraints.position_constraints[0].constraint_region.primitive_poses[0].position;
   constraint_pose_msg.orientation = constraints.orientation_constraints[0].orientation;
   Eigen::Affine3d constraint_pose;
-  tf::poseMsgToEigen(constraint_pose_msg, constraint_pose);
+  tf2::fromMsg(constraint_pose_msg, constraint_pose);
 
   Eigen::Affine3d new_pose = constraint_pose * offset_tf;
   geometry_msgs::Pose new_pose_msg;
-  tf::poseEigenToMsg(new_pose, new_pose_msg);
+  new_pose_msg = tf2::toMsg(new_pose);
 
   constraints.position_constraints[0].constraint_region.primitive_poses[0].position = new_pose_msg.position;
   constraints.orientation_constraints[0].orientation = new_pose_msg.orientation;

--- a/moveit_ros/manipulation/CMakeLists.txt
+++ b/moveit_ros/manipulation/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   roscpp
   rosconsole
-  tf
+  tf2_eigen
   pluginlib
   actionlib
 )

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -39,8 +39,6 @@
 #include <moveit/plan_execution/plan_with_sensing.h>
 #include <moveit/move_group_pick_place_capability/capability_names.h>
 
-#include <eigen_conversions/eigen_msg.h>
-
 move_group::MoveGroupPickPlaceAction::MoveGroupPickPlaceAction()
   : MoveGroupCapability("PickPlaceAction"), pickup_state_(IDLE)
 {

--- a/moveit_ros/manipulation/package.xml
+++ b/moveit_ros/manipulation/package.xml
@@ -26,7 +26,7 @@
   <build_depend>moveit_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>eigen</build_depend>
 
@@ -38,7 +38,7 @@
   <run_depend>moveit_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
-  <run_depend>tf</run_depend>
+  <run_depend>tf2_eigen</run_depend>
   <run_depend>pluginlib</run_depend>
 
   <export>

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_pipeline.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_pipeline.h
@@ -39,7 +39,6 @@
 
 #include <moveit/pick_place/manipulation_stage.h>
 #include <boost/thread.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <vector>
 #include <deque>

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -37,7 +37,7 @@
 #include <moveit/pick_place/pick_place.h>
 #include <moveit/pick_place/approach_and_translate_stage.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <ros/console.h>
 
 namespace pick_place
@@ -199,8 +199,8 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 
   // convert approach direction and retreat direction to Eigen structures
   Eigen::Vector3d approach_direction, retreat_direction;
-  tf::vectorMsgToEigen(plan->approach_.direction.vector, approach_direction);
-  tf::vectorMsgToEigen(plan->retreat_.direction.vector, retreat_direction);
+  tf2::fromMsg(plan->approach_.direction.vector, approach_direction);
+  tf2::fromMsg(plan->retreat_.direction.vector, retreat_direction);
 
   // if translation vectors are specified in the frame of the ik link name, then we assume the frame is local;
   // otherwise, the frame is global

--- a/moveit_ros/manipulation/pick_place/src/pick_place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place.cpp
@@ -38,7 +38,6 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <eigen_conversions/eigen_msg.h>
 #include <ros/console.h>
 
 namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -39,7 +39,7 @@
 #include <moveit/pick_place/approach_and_translate_stage.h>
 #include <moveit/pick_place/plan_stage.h>
 #include <moveit/robot_state/conversions.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <ros/console.h>
 
 namespace pick_place
@@ -58,10 +58,10 @@ bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
     return false;
 
   Eigen::Affine3d end_effector_transform;
-  tf::poseMsgToEigen(goal_pose.pose, end_effector_transform);
+  tf2::fromMsg(goal_pose.pose, end_effector_transform);
   end_effector_transform = end_effector_transform * fixed_transforms[0].inverse();
   place_pose.header = goal_pose.header;
-  tf::poseEigenToMsg(end_effector_transform, place_pose.pose);
+  place_pose.pose = tf2::toMsg(end_effector_transform);
   return true;
 }
 }

--- a/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
+++ b/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/pick_place/reachable_valid_pose_filter.h>
 #include <moveit/kinematic_constraints/utils.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <boost/bind.hpp>
 #include <ros/console.h>
 
@@ -92,7 +92,7 @@ bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
 bool pick_place::ReachableAndValidPoseFilter::isEndEffectorFree(const ManipulationPlanPtr& plan,
                                                                 robot_state::RobotState& token_state) const
 {
-  tf::poseMsgToEigen(plan->goal_pose_.pose, plan->transformed_goal_pose_);
+  tf2::fromMsg(plan->goal_pose_.pose, plan->transformed_goal_pose_);
   plan->transformed_goal_pose_ =
       planning_scene_->getFrameTransform(token_state, plan->goal_pose_.header.frame_id) * plan->transformed_goal_pose_;
   token_state.updateStateWithLinkAt(plan->shared_data_->ik_link_, plan->transformed_goal_pose_);
@@ -116,7 +116,7 @@ bool pick_place::ReachableAndValidPoseFilter::evaluate(const ManipulationPlanPtr
     // so we convert to a frame that is certainly known
     if (!robot_state::Transforms::sameFrame(planning_scene_->getPlanningFrame(), plan->goal_pose_.header.frame_id))
     {
-      tf::poseEigenToMsg(plan->transformed_goal_pose_, plan->goal_pose_.pose);
+      plan->goal_pose_.pose = tf2::toMsg(plan->transformed_goal_pose_);
       plan->goal_pose_.header.frame_id = planning_scene_->getPlanningFrame();
     }
 

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -15,7 +15,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   pluginlib
   std_srvs
-  tf
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
 )
 
 catkin_package(

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -20,7 +20,9 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>actionlib</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>std_srvs</build_depend>
 
@@ -28,7 +30,9 @@
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>actionlib</run_depend>
-  <run_depend>tf</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>std_srvs</run_depend>
 

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -38,7 +38,7 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/collision_detection/collision_tools.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <moveit/move_group/capability_names.h>
 #include <moveit/planning_pipeline/planning_pipeline.h>
 #include <moveit_msgs/DisplayTrajectory.h>
@@ -95,14 +95,14 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
     for (std::size_t i = 0; i < req.waypoints.size(); ++i)
     {
       if (no_transform)
-        tf::poseMsgToEigen(req.waypoints[i], waypoints[i]);
+        tf2::fromMsg(req.waypoints[i], waypoints[i]);
       else
       {
         geometry_msgs::PoseStamped p;
         p.header = req.header;
         p.pose = req.waypoints[i];
         if (performTransform(p, default_frame))
-          tf::poseMsgToEigen(p.pose, waypoints[i]);
+          tf2::fromMsg(p.pose, waypoints[i]);
         else
         {
           ROS_ERROR("Error encountered transforming waypoints to frame '%s'", default_frame.c_str());

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.h
@@ -39,6 +39,7 @@
 
 #include <moveit/move_group/move_group_capability.h>
 #include <moveit_msgs/ExecuteKnownTrajectory.h>
+#include <ros/callback_queue.h>
 
 namespace move_group
 {

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -37,7 +37,7 @@
 #include "kinematics_service_capability.h"
 #include <moveit/robot_state/conversions.h>
 #include <moveit/kinematic_constraints/utils.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <moveit/move_group/capability_names.h>
 
 move_group::MoveGroupKinematicsService::MoveGroupKinematicsService() : MoveGroupCapability("KinematicsService")
@@ -115,7 +115,7 @@ void move_group::MoveGroupKinematicsService::computeIK(
         {
           geometry_msgs::PoseStamped msg = req.pose_stamped_vector[k];
           if (performTransform(msg, default_frame))
-            tf::poseMsgToEigen(msg.pose, req_poses[k]);
+            tf2::fromMsg(msg.pose, req_poses[k]);
           else
           {
             error_code.val = moveit_msgs::MoveItErrorCodes::FRAME_TRANSFORM_FAILURE;
@@ -194,7 +194,7 @@ bool move_group::MoveGroupKinematicsService::computeFKService(moveit_msgs::GetPo
     if (rs.getRobotModel()->hasLinkModel(req.fk_link_names[i]))
     {
       res.pose_stamped.resize(res.pose_stamped.size() + 1);
-      tf::poseEigenToMsg(rs.getGlobalLinkTransform(req.fk_link_names[i]), res.pose_stamped.back().pose);
+      res.pose_stamped.back().pose = tf2::toMsg(rs.getGlobalLinkTransform(req.fk_link_names[i]));
       res.pose_stamped.back().header.frame_id = default_frame;
       res.pose_stamped.back().header.stamp = ros::Time::now();
       if (do_transform)

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -38,7 +38,6 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/collision_detection/collision_tools.h>
-#include <eigen_conversions/eigen_msg.h>
 #include <moveit/move_group/capability_names.h>
 
 move_group::MoveGroupStateValidationService::MoveGroupStateValidationService()

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
 #include <moveit/move_group/capability_names.h>
 #include <moveit/move_group/move_group_capability.h>
 #include <boost/algorithm/string/join.hpp>
@@ -172,11 +172,13 @@ int main(int argc, char** argv)
 
   ros::AsyncSpinner spinner(1);
   spinner.start();
+  ros::NodeHandle nh;
 
-  boost::shared_ptr<tf::TransformListener> tf(new tf::TransformListener(ros::Duration(10.0)));
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>(ros::Duration(10.0));
+  std::shared_ptr<tf2_ros::TransformListener> tfl = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
 
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor(
-      new planning_scene_monitor::PlanningSceneMonitor(ROBOT_DESCRIPTION, tf));
+      new planning_scene_monitor::PlanningSceneMonitor(ROBOT_DESCRIPTION, tf_buffer));
 
   if (planning_scene_monitor->getPlanningScene())
   {

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -185,17 +185,10 @@ bool move_group::MoveGroupCapability::performTransform(geometry_msgs::PoseStampe
 
   try
   {
-    std::string error;
-    ros::Time common_time;
-    context_->planning_scene_monitor_->getTFClient()->_getLatestCommonTime(
-        context_->planning_scene_monitor_->getTFClient()->_lookupFrameNumber(pose_msg.header.frame_id),
-        context_->planning_scene_monitor_->getTFClient()->_lookupFrameNumber(target_frame),
-        common_time, &error);
-    if (!error.empty())
-      ROS_ERROR("TF Problem: %s", error.c_str());
-
+    geometry_msgs::TransformStamped common_tf = context_->planning_scene_monitor_->getTFClient()->lookupTransform(
+                                                            pose_msg.header.frame_id, target_frame, ros::Time(0.0));
     geometry_msgs::PoseStamped pose_msg_in(pose_msg);
-    pose_msg_in.header.stamp = common_time;
+    pose_msg_in.header.stamp = common_tf.header.stamp;
     context_->planning_scene_monitor_->getTFClient()->transform(pose_msg_in, pose_msg, target_frame);
   }
   catch (tf2::TransformException& ex)

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/move_group/move_group_capability.h>
 #include <moveit/robot_state/conversions.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 void move_group::MoveGroupCapability::setContext(const MoveGroupContextPtr& context)
 {
@@ -186,18 +187,18 @@ bool move_group::MoveGroupCapability::performTransform(geometry_msgs::PoseStampe
   {
     std::string error;
     ros::Time common_time;
-    context_->planning_scene_monitor_->getTFClient()->getLatestCommonTime(pose_msg.header.frame_id, target_frame,
-                                                                          common_time, &error);
+    context_->planning_scene_monitor_->getTFClient()->_getLatestCommonTime(
+        context_->planning_scene_monitor_->getTFClient()->_lookupFrameNumber(pose_msg.header.frame_id),
+        context_->planning_scene_monitor_->getTFClient()->_lookupFrameNumber(target_frame),
+        common_time, &error);
     if (!error.empty())
       ROS_ERROR("TF Problem: %s", error.c_str());
 
-    tf::Stamped<tf::Pose> pose_tf, pose_tf_out;
-    tf::poseStampedMsgToTF(pose_msg, pose_tf);
-    pose_tf.stamp_ = common_time;
-    context_->planning_scene_monitor_->getTFClient()->transformPose(target_frame, pose_tf, pose_tf_out);
-    tf::poseStampedTFToMsg(pose_tf_out, pose_msg);
+    geometry_msgs::PoseStamped pose_msg_in(pose_msg);
+    pose_msg_in.header.stamp = common_time;
+    context_->planning_scene_monitor_->getTFClient()->transform(pose_msg_in, pose_msg, target_frame);
   }
-  catch (tf::TransformException& ex)
+  catch (tf2::TransformException& ex)
   {
     ROS_ERROR("TF Problem: %s", ex.what());
     return false;

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -186,7 +186,7 @@ bool move_group::MoveGroupCapability::performTransform(geometry_msgs::PoseStampe
   try
   {
     geometry_msgs::TransformStamped common_tf = context_->planning_scene_monitor_->getTFClient()->lookupTransform(
-                                                            pose_msg.header.frame_id, target_frame, ros::Time(0.0));
+        pose_msg.header.frame_id, target_frame, ros::Time(0.0));
     geometry_msgs::PoseStamped pose_msg_in(pose_msg);
     pose_msg_in.header.stamp = common_tf.header.stamp;
     context_->planning_scene_monitor_->getTFClient()->transform(pose_msg_in, pose_msg, target_frame);

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -32,8 +32,9 @@ find_package(catkin REQUIRED COMPONENTS
   rosconsole
   urdf
   message_filters
-  tf
-  tf_conversions
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
   pluginlib
   image_transport
   object_recognition_msgs

--- a/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -38,7 +38,7 @@
 #define MOVEIT_OCCUPANCY_MAP_DEPTH_IMAGE_OCCUPANCY_MAP_UPDATER_
 
 #include <ros/ros.h>
-#include <tf/tf.h>
+#include <tf2_ros/buffer.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
 #include <moveit/mesh_filter/mesh_filter.h>
 #include <moveit/mesh_filter/stereo_camera_model.h>
@@ -67,7 +67,7 @@ private:
   void stopHelper();
 
   ros::NodeHandle nh_;
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   image_transport::ImageTransport input_depth_transport_;
   image_transport::ImageTransport model_depth_transport_;
   image_transport::ImageTransport filtered_depth_transport_;

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -46,9 +46,10 @@
 #include <moveit/mesh_filter/mesh_filter_base.h>
 #include <map>
 
-namespace tf
+namespace tf2_ros
 {
 class TransformListener;
+class Buffer;
 }
 
 /**
@@ -148,7 +149,8 @@ private:
   std::map<mesh_filter::MeshHandle, TransformContextPtr> handle2context_;
 
   /** \brief TransformListener used to listen and update transformations*/
-  boost::shared_ptr<tf::TransformListener> tf_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 
   /** \brief SceneMonitor used to get current states*/
   planning_scene_monitor::PlanningSceneMonitorPtr psm_;

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -35,8 +35,9 @@
 /* Author: Suat Gedikli */
 
 #include <moveit/mesh_filter/transform_provider.h>
-#include <tf/transform_listener.h>
-#include <tf_conversions/tf_eigen.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 using namespace std;
 using namespace boost;
@@ -46,8 +47,9 @@ using namespace mesh_filter;
 
 TransformProvider::TransformProvider(unsigned long interval_us) : stop_(true), interval_us_(interval_us)
 {
-  tf_.reset(new TransformListener);
-  psm_.reset(new planning_scene_monitor::PlanningSceneMonitor("robot_description", tf_));
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
+  tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
+  psm_.reset(new planning_scene_monitor::PlanningSceneMonitor("robot_description", tf_buffer_));
   psm_->startStateMonitor();
 }
 
@@ -126,25 +128,26 @@ void TransformProvider::setUpdateInterval(unsigned long usecs)
 
 void TransformProvider::updateTransforms()
 {
-  static Affine3d transformation;
+  static tf2::Stamped<Affine3d> input_transform, output_transform;
   static robot_state::RobotStatePtr robot_state;
   robot_state = psm_->getStateMonitor()->getCurrentState();
 
   static string error;
-  static Stamped<Pose> input_pose, out_pose;
-  tf_->getLatestCommonTime(frame_id_, psm_->getPlanningScene()->getPlanningFrame(), input_pose.stamp_, &error);
-  input_pose.frame_id_ = psm_->getPlanningScene()->getPlanningFrame();
+  tf_buffer_->_getLatestCommonTime( tf_buffer_->_lookupFrameNumber(frame_id_),
+                tf_buffer_->_lookupFrameNumber(psm_->getPlanningScene()->getPlanningFrame()),
+                input_transform.stamp_, &error);
+  input_transform.frame_id_ = psm_->getPlanningScene()->getPlanningFrame();
 
   for (map<MeshHandle, shared_ptr<TransformContext> >::const_iterator contextIt = handle2context_.begin();
        contextIt != handle2context_.end(); ++contextIt)
   {
-    transformation = robot_state->getLinkState(contextIt->second->frame_id_)->getGlobalCollisionBodyTransform();
-    poseEigenToTF(transformation, input_pose);
     try
     {
-      tf_->transformPose(frame_id_, input_pose, out_pose);
+      // TODO: check logic here - which global collision body's transform should be used?
+      input_transform.setData(robot_state->getAttachedBody(contextIt->second->frame_id_)->getGlobalCollisionBodyTransforms()[0]);
+      tf_buffer_->transform(input_transform, output_transform, frame_id_);
     }
-    catch (const tf::TransformException& ex)
+    catch (const tf2::TransformException& ex)
     {
       handle2context_[contextIt->first]->mutex_.lock();
       handle2context_[contextIt->first]->transformation_.matrix().setZero();
@@ -155,9 +158,8 @@ void TransformProvider::updateTransforms()
     {
       ROS_ERROR("Caught %s while updating transforms", ex.what());
     }
-    poseTFToEigen(out_pose, transformation);
     handle2context_[contextIt->first]->mutex_.lock();
-    handle2context_[contextIt->first]->transformation_ = transformation;
+    handle2context_[contextIt->first]->transformation_ = static_cast<Affine3d>(output_transform);
     handle2context_[contextIt->first]->mutex_.unlock();
   }
 }

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -133,9 +133,8 @@ void TransformProvider::updateTransforms()
   robot_state = psm_->getStateMonitor()->getCurrentState();
   try
   {
-    geometry_msgs::TransformStamped common_tf = tf_buffer_->lookupTransform(frame_id_,
-                                                            psm_->getPlanningScene()->getPlanningFrame(),
-                                                            ros::Time(0.0));
+    geometry_msgs::TransformStamped common_tf =
+        tf_buffer_->lookupTransform(frame_id_, psm_->getPlanningScene()->getPlanningFrame(), ros::Time(0.0));
   }
   catch (tf2::TransformException& ex)
   {
@@ -151,7 +150,8 @@ void TransformProvider::updateTransforms()
     try
     {
       // TODO: check logic here - which global collision body's transform should be used?
-      input_transform.setData(robot_state->getAttachedBody(contextIt->second->frame_id_)->getGlobalCollisionBodyTransforms()[0]);
+      input_transform.setData(
+          robot_state->getAttachedBody(contextIt->second->frame_id_)->getGlobalCollisionBodyTransforms()[0]);
       tf_buffer_->transform(input_transform, output_transform, frame_id_);
     }
     catch (const tf2::TransformException& ex)

--- a/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -40,8 +40,8 @@
 #include <vector>
 #include <string>
 #include <ros/ros.h>
-#include <tf/tf.h>
-#include <pluginlib/class_loader.hpp>
+#include <tf2_ros/buffer.h>
+#include <pluginlib/class_loader.h>
 
 #include <moveit_msgs/SaveMap.h>
 #include <moveit_msgs/LoadMap.h>
@@ -57,10 +57,10 @@ namespace occupancy_map_monitor
 class OccupancyMapMonitor
 {
 public:
-  OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer>& tf, const std::string& map_frame = "",
+  OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& map_frame = "",
                       double map_resolution = 0.0);
   OccupancyMapMonitor(double map_resolution = 0.0);
-  OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer>& tf, ros::NodeHandle& nh,
+  OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, ros::NodeHandle& nh,
                       const std::string& map_frame = "", double map_resolution = 0.0);
 
   ~OccupancyMapMonitor();
@@ -96,9 +96,9 @@ public:
     return map_resolution_;
   }
 
-  const boost::shared_ptr<tf::Transformer>& getTFClient() const
+  const std::shared_ptr<tf2_ros::Buffer>& getTFClient() const
   {
-    return tf_;
+    return tf_buffer_;
   }
 
   void addUpdater(const OccupancyMapUpdaterPtr& updater);
@@ -136,7 +136,7 @@ private:
   bool getShapeTransformCache(std::size_t index, const std::string& target_frame, const ros::Time& target_time,
                               ShapeTransformCache& cache) const;
 
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::string map_frame_;
   double map_resolution_;
   boost::mutex parameters_lock_;

--- a/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -41,7 +41,7 @@
 #include <string>
 #include <ros/ros.h>
 #include <tf2_ros/buffer.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <moveit_msgs/SaveMap.h>
 #include <moveit_msgs/LoadMap.h>

--- a/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -40,7 +40,6 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit/occupancy_map_monitor/occupancy_map.h>
 #include <geometric_shapes/shapes.h>
-#include <boost/shared_ptr.hpp>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -49,16 +49,26 @@ OccupancyMapMonitor::OccupancyMapMonitor(double map_resolution)
   initialize();
 }
 
-OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& map_frame,
-                                         double map_resolution)
-  : tf_buffer_(tf_buffer), map_frame_(map_frame), map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_("~")
+OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
+                                         const std::string& map_frame, double map_resolution)
+  : tf_buffer_(tf_buffer)
+  , map_frame_(map_frame)
+  , map_resolution_(map_resolution)
+  , debug_info_(false)
+  , mesh_handle_count_(0)
+  , nh_("~")
 {
   initialize();
 }
 
 OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, ros::NodeHandle& nh,
                                          const std::string& map_frame, double map_resolution)
-  : tf_buffer_(tf_buffer), map_frame_(map_frame), map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_(nh)
+  : tf_buffer_(tf_buffer)
+  , map_frame_(map_frame)
+  , map_resolution_(map_resolution)
+  , debug_info_(false)
+  , mesh_handle_count_(0)
+  , nh_(nh)
 {
   initialize();
 }

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -49,16 +49,16 @@ OccupancyMapMonitor::OccupancyMapMonitor(double map_resolution)
   initialize();
 }
 
-OccupancyMapMonitor::OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer>& tf, const std::string& map_frame,
+OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& map_frame,
                                          double map_resolution)
-  : tf_(tf), map_frame_(map_frame), map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_("~")
+  : tf_buffer_(tf_buffer), map_frame_(map_frame), map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_("~")
 {
   initialize();
 }
 
-OccupancyMapMonitor::OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer>& tf, ros::NodeHandle& nh,
+OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, ros::NodeHandle& nh,
                                          const std::string& map_frame, double map_resolution)
-  : tf_(tf), map_frame_(map_frame), map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_(nh)
+  : tf_buffer_(tf_buffer), map_frame_(map_frame), map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_(nh)
 {
   initialize();
 }
@@ -76,10 +76,10 @@ void OccupancyMapMonitor::initialize()
 
   if (map_frame_.empty())
     if (!nh_.getParam("octomap_frame", map_frame_))
-      if (tf_)
+      if (tf_buffer_)
         ROS_WARN("No target frame specified for Octomap. No transforms will be applied to received data.");
 
-  if (!tf_ && !map_frame_.empty())
+  if (!tf_buffer_ && !map_frame_.empty())
     ROS_WARN("Target frame specified but no TF instance specified. No transforms will be applied to received data.");
 
   tree_.reset(new OccMapTree(map_resolution_));

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -34,10 +34,9 @@
 
 /* Author: Jon Binney, Ioan Sucan */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <ros/ros.h>
-#include <tf/tf.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <octomap_msgs/conversions.h>
 
@@ -68,8 +67,9 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "occupancy_map_server");
   ros::NodeHandle nh;
   ros::Publisher octree_binary_pub = nh.advertise<octomap_msgs::Octomap>("octomap_binary", 1);
-  boost::shared_ptr<tf::Transformer> listener = boost::make_shared<tf::TransformListener>(ros::Duration(5.0));
-  occupancy_map_monitor::OccupancyMapMonitor server(listener);
+  std::shared_ptr<tf2_ros::Buffer> buffer = std::make_shared<tf2_ros::Buffer>(ros::Duration(5.0));
+  std::shared_ptr<tf2_ros::TransformListener> listener = std::make_shared<tf2_ros::TransformListener>(*buffer, nh);
+  occupancy_map_monitor::OccupancyMapMonitor server(buffer);
   server.setUpdateCallback(boost::bind(&publishOctomap, &octree_binary_pub, &server));
   server.startMonitor();
 

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -22,8 +22,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf_conversions</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>pluginlib</build_depend>
@@ -35,13 +33,15 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>urdf</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf_conversions</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>pluginlib</run_depend>
@@ -52,6 +52,10 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>moveit_msgs</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_ros</run_depend>
 
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -38,8 +38,8 @@
 #define MOVEIT_PERCEPTION_POINTCLOUD_OCTOMAP_UPDATER_
 
 #include <ros/ros.h>
-#include <tf/tf.h>
-#include <tf/message_filter.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/message_filter.h>
 #include <message_filters/subscriber.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
@@ -74,7 +74,9 @@ private:
 
   ros::NodeHandle root_nh_;
   ros::NodeHandle private_nh_;
-  boost::shared_ptr<tf::Transformer> tf_;
+
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   /* params */
   std::string point_cloud_topic_;
@@ -86,7 +88,7 @@ private:
   ros::Publisher filtered_cloud_publisher_;
 
   message_filters::Subscriber<sensor_msgs::PointCloud2>* point_cloud_subscriber_;
-  tf::MessageFilter<sensor_msgs::PointCloud2>* point_cloud_filter_;
+  tf2_ros::MessageFilter<sensor_msgs::PointCloud2>* point_cloud_filter_;
 
   /* used to store all cells in the map which a given ray passes through during raycasting.
      we cache this here because it dynamically pre-allocates a lot of memory in its contsructor */

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -47,7 +47,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 // Eigen
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <Eigen/Geometry>
 
 namespace moveit
@@ -368,7 +368,7 @@ std::vector<geometry_msgs::PoseStamped> SemanticWorld::generatePlacePoses(const 
           Eigen::Vector3d point((double)(point_x) / scale_factor + x_min, (double)(point_y) / scale_factor + y_min,
                                 height_above_table + mm * delta_height);
           Eigen::Affine3d pose;
-          tf::poseMsgToEigen(table.pose, pose);
+          tf2::fromMsg(table.pose, pose);
           point = pose * point;
           geometry_msgs::PoseStamped place_pose;
           place_pose.pose.orientation.w = 1.0;
@@ -428,7 +428,7 @@ bool SemanticWorld::isInsideTableContour(const geometry_msgs::Pose& pose, const 
 
   Eigen::Vector3d point(pose.position.x, pose.position.y, pose.position.z);
   Eigen::Affine3d pose_table;
-  tf::poseMsgToEigen(table.pose, pose_table);
+  tf2::fromMsg(table.pose, pose_table);
 
   // Point in table frame
   point = pose_table.inverse() * point;
@@ -490,9 +490,9 @@ void SemanticWorld::transformTableArray(object_recognition_msgs::TableArray& tab
     std::string error_text;
     const Eigen::Affine3d& original_transform = planning_scene_->getTransforms().getTransform(original_frame);
     Eigen::Affine3d original_pose;
-    tf::poseMsgToEigen(table_array.tables[i].pose, original_pose);
+    tf2::fromMsg(table_array.tables[i].pose, original_pose);
     original_pose = original_transform * original_pose;
-    tf::poseEigenToMsg(original_pose, table_array.tables[i].pose);
+    table_array.tables[i].pose = tf2::toMsg(original_pose);
     table_array.tables[i].header.frame_id = planning_scene_->getTransforms().getTargetFrame();
     ROS_INFO_STREAM("Successfully transformed table array from " << original_frame << "to "
                                                                  << table_array.tables[i].header.frame_id);

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -19,9 +19,11 @@ find_package(catkin REQUIRED COMPONENTS
   message_filters
   srdfdom
   urdf
-  tf
-  tf_conversions
-  eigen_conversions
+  tf2
+  tf2_geometry_msgs
+  tf2_eigen
+  tf2_msgs
+  tf2_ros
 )
 
 find_package(Eigen3 REQUIRED)

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -25,7 +25,11 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>angles</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_perception</run_depend>
@@ -33,7 +37,11 @@
   <run_depend>actionlib</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>angles</run_depend>
-  <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_msgs</run_depend>
+  <run_depend>tf2_ros</run_depend>
 
   <export>
     <moveit_core plugin="${prefix}/planning_request_adapters_plugin_description.xml"/>

--- a/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
@@ -53,7 +53,8 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener =
+      std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
   planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf_buffer);
   if (psm.getPlanningScene())
   {

--- a/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
@@ -36,6 +36,8 @@
 
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <cstdlib>
+#include <tf2_ros/transform_listener.h>
+#include <memory>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
@@ -48,15 +50,16 @@ int main(int argc, char** argv)
 
   double radius = 0.02;
   double lifetime = 600.0;
+  ros::NodeHandle nh;
 
-  boost::shared_ptr<tf::TransformListener> tr(new tf::TransformListener());
-  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tr);
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf_buffer);
   if (psm.getPlanningScene())
   {
     psm.startWorldGeometryMonitor();
     psm.startSceneMonitor();
     psm.startStateMonitor();
-    ros::NodeHandle nh;
     ros::Publisher pub_markers = nh.advertise<visualization_msgs::MarkerArray>("visualization_marker_array", 10);
     std::cout << "\nListening for planning scene...\nType the number of spheres to generate and press Enter: "
               << std::endl;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -64,15 +64,16 @@ public:
    * @param robot_model The current kinematic model to build on
    * @param tf_buffer A pointer to the tf2_ros Buffer to use
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
   /** @brief Constructor.
    *  @param robot_model The current kinematic model to build on
    *  @param tf_buffer A pointer to the tf2_ros Buffer to use
    *  @param nh A ros::NodeHandle to pass node specific options
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                      ros::NodeHandle nh);
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, ros::NodeHandle nh);
 
   ~CurrentStateMonitor();
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -38,11 +38,10 @@
 #define MOVEIT_PLANNING_SCENE_MONITOR_CURRENT_STATE_MONITOR_
 
 #include <ros/ros.h>
-#include <tf/tf.h>
+#include <tf2_ros/buffer.h>
 #include <moveit/robot_state/robot_state.h>
 #include <sensor_msgs/JointState.h>
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <moveit/macros/deprecation.h>
 #include <boost/thread/condition_variable.hpp>
@@ -57,22 +56,22 @@ class CurrentStateMonitor
 {
   /* tf changed their interface between indigo and kinetic
      from boost::signals::connection to boost::signals2::connection */
-  typedef decltype(tf::Transformer().addTransformsChangedListener(boost::function<void(void)>())) TFConnection;
+  typedef decltype(tf2_ros::Buffer()._addTransformsChangedListener(boost::function<void(void)>())) TFConnection;
 
 public:
   /**
    * @brief Constructor.
    * @param robot_model The current kinematic model to build on
-   * @param tf A pointer to the tf transformer to use
+   * @param tf_buffer A pointer to the tf2_ros Buffer to use
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model, const boost::shared_ptr<tf::Transformer>& tf);
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
   /** @brief Constructor.
    *  @param robot_model The current kinematic model to build on
-   *  @param tf A pointer to the tf transformer to use
+   *  @param tf_buffer A pointer to the tf2_ros Buffer to use
    *  @param nh A ros::NodeHandle to pass node specific options
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model, const boost::shared_ptr<tf::Transformer>& tf,
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                       ros::NodeHandle nh);
 
   ~CurrentStateMonitor();
@@ -200,7 +199,7 @@ private:
   void tfCallback();
 
   ros::NodeHandle nh_;
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   robot_model::RobotModelConstPtr robot_model_;
   robot_state::RobotState robot_state_;
   std::map<const moveit::core::JointModel*, ros::Time> joint_time_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -38,8 +38,8 @@
 #define MOVEIT_PLANNING_SCENE_MONITOR_PLANNING_SCENE_MONITOR_
 
 #include <ros/ros.h>
-#include <tf/tf.h>
-#include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
+#include <tf2_ros/buffer.h>
 #include <message_filters/subscriber.h>
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_scene/planning_scene.h>
@@ -106,41 +106,41 @@ public:
 
   /** @brief Constructor
    *  @param robot_description The name of the ROS parameter that contains the URDF (in string format)
-   *  @param tf A pointer to a tf::Transformer
+   *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
   PlanningSceneMonitor(const std::string& robot_description,
-                       const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>(),
+                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
   /** @brief Constructor
    *  @param rml A pointer to a kinematic model loader
-   *  @param tf A pointer to a tf::Transformer
+   *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
   PlanningSceneMonitor(const robot_model_loader::RobotModelLoaderPtr& rml,
-                       const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>(),
+                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
   /** @brief Constructor
    *  @param scene The scene instance to maintain up to date with monitored information
    *  @param robot_description The name of the ROS parameter that contains the URDF (in string format)
-   *  @param tf A pointer to a tf::Transformer
+   *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
   PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene, const std::string& robot_description,
-                       const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>(),
+                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
   /** @brief Constructor
    *  @param scene The scene instance to maintain up to date with monitored information
    *  @param rml A pointer to a kinematic model loader
-   *  @param tf A pointer to a tf::Transformer
+   *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
   PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
                        const robot_model_loader::RobotModelLoaderPtr& rml,
-                       const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>(),
+                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
   ~PlanningSceneMonitor();
@@ -233,9 +233,9 @@ public:
   }
 
   /** @brief Get the instance of the TF client that was passed to the constructor of this class. */
-  const boost::shared_ptr<tf::Transformer>& getTFClient() const
+  const std::shared_ptr<tf2_ros::Buffer>& getTFClient() const
   {
-    return tf_;
+    return tf_buffer_;
   }
 
   /** \brief By default, the maintained planning scene does not reason about diffs. When the flag passed in is true, the
@@ -404,7 +404,7 @@ protected:
 
   /** @brief Callback for a new collision object msg that failed to pass the TF filter */
   void collisionObjectFailTFCallback(const moveit_msgs::CollisionObjectConstPtr& obj,
-                                     tf::filter_failure_reasons::FilterFailureReason reason);
+                                     tf2_ros::filter_failure_reasons::FilterFailureReason reason);
 
   /** @brief Callback for a new planning scene world*/
   void newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr& world);
@@ -450,7 +450,8 @@ protected:
 
   ros::NodeHandle nh_;
   ros::NodeHandle root_nh_;
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+
   std::string robot_description_;
 
   /// default robot padding
@@ -481,7 +482,7 @@ protected:
   ros::Subscriber attached_collision_object_subscriber_;
 
   std::unique_ptr<message_filters::Subscriber<moveit_msgs::CollisionObject> > collision_object_subscriber_;
-  std::unique_ptr<tf::MessageFilter<moveit_msgs::CollisionObject> > collision_object_filter_;
+  std::unique_ptr<tf2_ros::MessageFilter<moveit_msgs::CollisionObject> > collision_object_filter_;
 
   // include a octomap monitor
   std::unique_ptr<occupancy_map_monitor::OccupancyMapMonitor> octomap_monitor_;

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -425,9 +425,9 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       catch (tf2::TransformException& ex)
       {
         ROS_WARN_STREAM_THROTTLE(1, "Unable to update multi-DOF joint '"
-                                    << joint->getName() << "': Failure to lookup transform between '"
-                                    << parent_frame.c_str() << "' and '"
-                                    << child_frame.c_str() << "' with TF exception: " << ex.what());
+                                        << joint->getName() << "': Failure to lookup transform between '"
+                                        << parent_frame.c_str() << "' and '" << child_frame.c_str()
+                                        << "' with TF exception: " << ex.what());
         continue;
       }
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -45,7 +45,6 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2_msgs/TF2Error.h>
 #include <moveit/profiler/profiler.h>
 
 #include <memory>
@@ -1303,22 +1302,10 @@ void planning_scene_monitor::PlanningSceneMonitor::getUpdatedFrameTransforms(
     if (all_frame_names[i] == target || getRobotModel()->hasLinkModel(all_frame_names[i]))
       continue;
 
-    ros::Time stamp(0);
-    std::string err_string;
-    if (tf_buffer_->_getLatestCommonTime(tf_buffer_->_lookupFrameNumber(target),
-                                         tf_buffer_->_lookupFrameNumber(all_frame_names[i]), stamp,
-                                         &err_string) != tf2_msgs::TF2Error::NO_ERROR)
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "No transform available between frame '"
-                                         << all_frame_names[i] << "' and planning frame '" << target << "' ("
-                                         << err_string << ")");
-      continue;
-    }
-
     geometry_msgs::TransformStamped f;
     try
     {
-      f = tf_buffer_->lookupTransform(target, all_frame_names[i], stamp);
+      f = tf_buffer_->lookupTransform(target, all_frame_names[i], ros::Time(0));
     }
     catch (tf2::TransformException& ex)
     {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -38,7 +38,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_ros_planning/TrajectoryExecutionDynamicReconfigureConfig.h>
 #include <dynamic_reconfigure/server.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 namespace trajectory_execution_manager
 {
@@ -1010,7 +1010,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         // and start transform in trajectory
         Eigen::Affine3d cur_transform, start_transform;
         jm->computeTransform(current_state->getJointPositions(jm), cur_transform);
-        tf::transformMsgToEigen(transforms[i], start_transform);
+        start_transform = tf2::transformToEigen(transforms[i]);
         Eigen::Vector3d offset = cur_transform.translation() - start_transform.translation();
         Eigen::AngleAxisd rotation;
         rotation.fromRotationMatrix(cur_transform.rotation().inverse() * start_transform.rotation());

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -22,9 +22,11 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_warehouse
   moveit_ros_manipulation
   moveit_ros_move_group
-  eigen_conversions
-  tf_conversions
-  tf
+  geometry_msgs
+  tf2
+  tf2_eigen
+  tf2_geometry_msgs
+  tf2_ros
   roscpp
   actionlib
   rospy

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -43,32 +43,32 @@ namespace moveit
 {
 namespace planning_interface
 {
-boost::shared_ptr<tf::Transformer> getSharedTF();
+std::shared_ptr<tf2_ros::Buffer> getSharedTF();
 
 robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_description);
 
 /**
   @brief getSharedStateMonitor is a simpler version of getSharedStateMonitor(const robot_model::RobotModelConstPtr
-  &kmodel, const boost::shared_ptr<tf::Transformer> &tf,
+  &kmodel, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
     ros::NodeHandle nh = ros::NodeHandle() ). It calls this function using the default constructed ros::NodeHandle
 
   @param kmodel
-  @param tf
+  @param tf_buffer
   @return
  */
 planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
-                                                                     const boost::shared_ptr<tf::Transformer>& tf);
+                                                                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
 /**
   @brief getSharedStateMonitor
 
   @param kmodel
-  @param tf
+  @param tf_buffer
   @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
   @return
  */
 planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
-                                                                     const boost::shared_ptr<tf::Transformer>& tf,
+                                                                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                      ros::NodeHandle nh);
 
 }  // namespace planning interface

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
 
 namespace
 {
@@ -48,13 +48,15 @@ struct SharedStorage
 
   ~SharedStorage()
   {
-    tf_.reset();
+    tf_buffer_.reset();
+    tf_listener_.reset();
     state_monitors_.clear();
     model_loaders_.clear();
   }
 
   boost::mutex lock_;
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::map<std::string, robot_model_loader::RobotModelLoaderPtr> model_loaders_;
   std::map<std::string, planning_scene_monitor::CurrentStateMonitorPtr> state_monitors_;
 };
@@ -77,13 +79,22 @@ namespace moveit
 {
 namespace planning_interface
 {
-boost::shared_ptr<tf::Transformer> getSharedTF()
+std::shared_ptr<tf2_ros::Buffer> getSharedTF()
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);
-  if (!s.tf_)
-    s.tf_.reset(new tf::TransformListener());
-  return s.tf_;
+  if (!s.tf_buffer_ || !s.tf_listener_)
+  {
+    if(s.tf_listener_)
+    {
+      // First release the current TF Listener to ensure
+      // the deleted Buffer is not accessed
+      s.tf_listener_.reset();
+    }
+    s.tf_buffer_.reset(new tf2_ros::Buffer());
+    s.tf_listener_.reset(new tf2_ros::TransformListener(*s.tf_buffer_));
+  }
+  return s.tf_buffer_;
 }
 
 robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_description)
@@ -103,13 +114,13 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
 }
 
 planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
-                                                                     const boost::shared_ptr<tf::Transformer>& tf)
+                                                                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
 {
-  return getSharedStateMonitor(kmodel, tf, ros::NodeHandle());
+  return getSharedStateMonitor(kmodel, tf_buffer, ros::NodeHandle());
 }
 
 planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
-                                                                     const boost::shared_ptr<tf::Transformer>& tf,
+                                                                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                      ros::NodeHandle nh)
 {
   SharedStorage& s = getSharedStorage();
@@ -119,7 +130,7 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot
   else
   {
     planning_scene_monitor::CurrentStateMonitorPtr monitor(
-        new planning_scene_monitor::CurrentStateMonitor(kmodel, tf, nh));
+        new planning_scene_monitor::CurrentStateMonitor(kmodel, tf_buffer, nh));
     s.state_monitors_[kmodel->getName()] = monitor;
     return monitor;
   }

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -83,14 +83,8 @@ std::shared_ptr<tf2_ros::Buffer> getSharedTF()
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);
-  if (!s.tf_buffer_ || !s.tf_listener_)
+  if (!s.tf_listener_)
   {
-    if(s.tf_listener_)
-    {
-      // First release the current TF Listener to ensure
-      // the deleted Buffer is not accessed
-      s.tf_listener_.reset();
-    }
     s.tf_buffer_.reset(new tf2_ros::Buffer());
     s.tf_listener_.reset(new tf2_ros::TransformListener(*s.tf_buffer_));
   }

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -49,8 +49,8 @@
 #include <moveit_msgs/PlaceLocation.h>
 #include <moveit_msgs/MotionPlanRequest.h>
 #include <geometry_msgs/PoseStamped.h>
-#include <boost/shared_ptr.hpp>
-#include <tf/tf.h>
+#include <memory>
+#include <tf2_ros/buffer.h>
 
 namespace moveit
 {
@@ -141,25 +141,27 @@ public:
       \param opt. A MoveGroupInterface::Options structure, if you pass a ros::NodeHandle with a specific callback queue,
      it has to be of type ros::CallbackQueue
         (which is the default type of callback queues used in ROS)
-      \param tf. Specify a TF instance to use. If not specified, one will be constructed internally.
+      \param tf_buffer. Specify a TF2_ROS Buffer instance to use. If not specified,
+                        one will be constructed internally along with an internal TF2_ROS TransformListener
       \param wait_for_servers. Timeout for connecting to action servers. Zero time means unlimited waiting.
     */
   MoveGroupInterface(const Options& opt,
-                     const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>(),
+                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                      const ros::WallDuration& wait_for_servers = ros::WallDuration());
-  MOVEIT_DEPRECATED MoveGroupInterface(const Options& opt, const boost::shared_ptr<tf::Transformer>& tf,
+  MOVEIT_DEPRECATED MoveGroupInterface(const Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                        const ros::Duration& wait_for_servers);
 
   /**
       \brief Construct a client for the MoveGroup action for a particular \e group.
 
-      \param tf. Specify a TF instance to use. If not specified, one will be constructed internally.
+      \param tf_buffer. Specify a TF2_ROS Buffer instance to use. If not specified,
+                        one will be constructed internally along with an internal TF2_ROS TransformListener
       \param wait_for_servers. Timeout for connecting to action servers. Zero time means unlimited waiting.
     */
   MoveGroupInterface(const std::string& group,
-                     const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>(),
+                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                      const ros::WallDuration& wait_for_servers = ros::WallDuration());
-  MOVEIT_DEPRECATED MoveGroupInterface(const std::string& group, const boost::shared_ptr<tf::Transformer>& tf,
+  MOVEIT_DEPRECATED MoveGroupInterface(const std::string& group, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                        const ros::Duration& wait_for_servers);
 
   ~MoveGroupInterface();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1383,8 +1383,8 @@ moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const Options
 }
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(
-    const moveit::planning_interface::MoveGroupInterface::Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-    const ros::Duration& wait_for_servers)
+    const moveit::planning_interface::MoveGroupInterface::Options& opt,
+    const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::Duration& wait_for_servers)
   : MoveGroupInterface(opt, tf_buffer, ros::WallDuration(wait_for_servers.toSec()))
 {
 }
@@ -1905,7 +1905,7 @@ inline void transformPose(const tf2_ros::Buffer& tf_buffer, const std::string& d
     geometry_msgs::PoseStamped target_in(target);
     tf_buffer.transform(target_in, target, desired_frame);
     // we leave the stamp to ros::Time(0) on purpose
-    target.header.stamp =  ros::Time(0);
+    target.header.stamp = ros::Time(0);
   }
 }
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -62,11 +62,11 @@
 #include <moveit_msgs/SetPlannerParams.h>
 
 #include <actionlib/client/simple_action_client.h>
-#include <eigen_conversions/eigen_msg.h>
 #include <std_msgs/String.h>
-#include <tf/transform_listener.h>
-#include <tf/transform_datatypes.h>
-#include <tf_conversions/tf_eigen.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tf2/utils.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_ros/transform_listener.h>
 #include <ros/console.h>
 #include <ros/ros.h>
 
@@ -93,9 +93,9 @@ enum ActiveTargetType
 class MoveGroupInterface::MoveGroupInterfaceImpl
 {
 public:
-  MoveGroupInterfaceImpl(const Options& opt, const boost::shared_ptr<tf::Transformer>& tf,
+  MoveGroupInterfaceImpl(const Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                          const ros::WallDuration& wait_for_servers)
-    : opt_(opt), node_handle_(opt.node_handle_), tf_(tf)
+    : opt_(opt), node_handle_(opt.node_handle_), tf_buffer_(tf_buffer)
   {
     robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(opt.robot_description_);
     if (!getRobotModel())
@@ -139,7 +139,7 @@ public:
     attached_object_publisher_ = node_handle_.advertise<moveit_msgs::AttachedCollisionObject>(
         planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC, 1, false);
 
-    current_state_monitor_ = getSharedStateMonitor(robot_model_, tf_, node_handle_);
+    current_state_monitor_ = getSharedStateMonitor(robot_model_, tf_buffer_, node_handle_);
 
     ros::WallTime timeout_for_servers = ros::WallTime::now() + wait_for_servers;
     if (wait_for_servers == ros::WallDuration())
@@ -311,9 +311,9 @@ public:
       constraints_init_thread_->join();
   }
 
-  const boost::shared_ptr<tf::Transformer>& getTF() const
+  const std::shared_ptr<tf2_ros::Buffer>& getTF() const
   {
-    return tf_;
+    return tf_buffer_;
   }
 
   const Options& getOptions() const
@@ -475,7 +475,7 @@ public:
           // transform the pose first if possible, then do IK
           const Eigen::Affine3d& t = getJointStateTarget().getFrameTransform(frame);
           Eigen::Affine3d p;
-          tf::poseMsgToEigen(eef_pose, p);
+          tf2::fromMsg(eef_pose, p);
           return getJointStateTarget().setFromIK(getJointModelGroup(), t * p, eef, 0, 0.0,
                                                  moveit::core::GroupStateValidityCallbackFn(), o);
         }
@@ -1304,7 +1304,7 @@ private:
 
   Options opt_;
   ros::NodeHandle node_handle_;
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   robot_model::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
@@ -1360,32 +1360,32 @@ private:
 }
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const std::string& group_name,
-                                                                   const boost::shared_ptr<tf::Transformer>& tf,
+                                                                   const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                    const ros::WallDuration& wait_for_servers)
 {
   if (!ros::ok())
     throw std::runtime_error("ROS does not seem to be running");
-  impl_ = new MoveGroupInterfaceImpl(Options(group_name), tf ? tf : getSharedTF(), wait_for_servers);
+  impl_ = new MoveGroupInterfaceImpl(Options(group_name), tf_buffer ? tf_buffer : getSharedTF(), wait_for_servers);
 }
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const std::string& group,
-                                                                   const boost::shared_ptr<tf::Transformer>& tf,
+                                                                   const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                    const ros::Duration& wait_for_servers)
-  : MoveGroupInterface(group, tf, ros::WallDuration(wait_for_servers.toSec()))
+  : MoveGroupInterface(group, tf_buffer, ros::WallDuration(wait_for_servers.toSec()))
 {
 }
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const Options& opt,
-                                                                   const boost::shared_ptr<tf::Transformer>& tf,
+                                                                   const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                    const ros::WallDuration& wait_for_servers)
 {
-  impl_ = new MoveGroupInterfaceImpl(opt, tf ? tf : getSharedTF(), wait_for_servers);
+  impl_ = new MoveGroupInterfaceImpl(opt, tf_buffer ? tf_buffer : getSharedTF(), wait_for_servers);
 }
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(
-    const moveit::planning_interface::MoveGroupInterface::Options& opt, const boost::shared_ptr<tf::Transformer>& tf,
+    const moveit::planning_interface::MoveGroupInterface::Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
     const ros::Duration& wait_for_servers)
-  : MoveGroupInterface(opt, tf, ros::WallDuration(wait_for_servers.toSec()))
+  : MoveGroupInterface(opt, tf_buffer, ros::WallDuration(wait_for_servers.toSec()))
 {
 }
 
@@ -1746,8 +1746,7 @@ bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const g
 bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const Eigen::Affine3d& eef_pose,
                                                                          const std::string& end_effector_link)
 {
-  geometry_msgs::Pose msg;
-  tf::poseEigenToMsg(eef_pose, msg);
+  geometry_msgs::Pose msg = tf2::toMsg(eef_pose);
   return setJointValueTarget(msg, end_effector_link);
 }
 
@@ -1766,8 +1765,7 @@ bool moveit::planning_interface::MoveGroupInterface::setApproximateJointValueTar
 bool moveit::planning_interface::MoveGroupInterface::setApproximateJointValueTarget(
     const Eigen::Affine3d& eef_pose, const std::string& end_effector_link)
 {
-  geometry_msgs::Pose msg;
-  tf::poseEigenToMsg(eef_pose, msg);
+  geometry_msgs::Pose msg = tf2::toMsg(eef_pose);
   return setApproximateJointValueTarget(msg, end_effector_link);
 }
 
@@ -1817,7 +1815,7 @@ bool moveit::planning_interface::MoveGroupInterface::setPoseTarget(const Eigen::
                                                                    const std::string& end_effector_link)
 {
   std::vector<geometry_msgs::PoseStamped> pose_msg(1);
-  tf::poseEigenToMsg(pose, pose_msg[0].pose);
+  pose_msg[0].pose = tf2::toMsg(pose);
   pose_msg[0].header.frame_id = getPoseReferenceFrame();
   pose_msg[0].header.stamp = ros::Time::now();
   return setPoseTargets(pose_msg, end_effector_link);
@@ -1848,7 +1846,7 @@ bool moveit::planning_interface::MoveGroupInterface::setPoseTargets(const EigenS
   const std::string& frame_id = getPoseReferenceFrame();
   for (std::size_t i = 0; i < target.size(); ++i)
   {
-    tf::poseEigenToMsg(target[i], pose_out[i].pose);
+    pose_out[i].pose = tf2::toMsg(target[i]);
     pose_out[i].header.stamp = tm;
     pose_out[i].header.frame_id = frame_id;
   }
@@ -1899,19 +1897,15 @@ moveit::planning_interface::MoveGroupInterface::getPoseTargets(const std::string
 
 namespace
 {
-inline void transformPose(const tf::Transformer& tf, const std::string& desired_frame,
+inline void transformPose(const tf2_ros::Buffer& tf_buffer, const std::string& desired_frame,
                           geometry_msgs::PoseStamped& target)
 {
   if (desired_frame != target.header.frame_id)
   {
-    tf::Pose pose;
-    tf::poseMsgToTF(target.pose, pose);
-    tf::Stamped<tf::Pose> stamped_target(pose, target.header.stamp, target.header.frame_id);
-    tf::Stamped<tf::Pose> stamped_target_out;
-    tf.transformPose(desired_frame, stamped_target, stamped_target_out);
-    target.header.frame_id = stamped_target_out.frame_id_;
-    //    target.header.stamp = stamped_target_out.stamp_; // we leave the stamp to ros::Time(0) on purpose
-    tf::poseTFToMsg(stamped_target_out, target.pose);
+    geometry_msgs::PoseStamped target_in(target);
+    tf_buffer.transform(target_in, target, desired_frame);
+    // we leave the stamp to ros::Time(0) on purpose
+    target.header.stamp =  ros::Time(0);
   }
 }
 }
@@ -1958,8 +1952,9 @@ bool moveit::planning_interface::MoveGroupInterface::setRPYTarget(double r, doub
     target.pose.position.z = 0.0;
     target.header.frame_id = impl_->getPoseReferenceFrame();
   }
-
-  tf::quaternionTFToMsg(tf::createQuaternionFromRPY(r, p, y), target.pose.orientation);
+  tf2::Quaternion q;
+  q.setRPY(r, p, y);
+  target.pose.orientation = tf2::toMsg(q);
   bool result = setPoseTarget(target, end_effector_link);
   impl_->setTargetType(ORIENTATION);
   return result;
@@ -2086,7 +2081,7 @@ moveit::planning_interface::MoveGroupInterface::getRandomPose(const std::string&
   geometry_msgs::PoseStamped pose_msg;
   pose_msg.header.stamp = ros::Time::now();
   pose_msg.header.frame_id = impl_->getRobotModel()->getModelFrame();
-  tf::poseEigenToMsg(pose, pose_msg.pose);
+  pose_msg.pose = tf2::toMsg(pose);
   return pose_msg;
 }
 
@@ -2111,7 +2106,7 @@ moveit::planning_interface::MoveGroupInterface::getCurrentPose(const std::string
   geometry_msgs::PoseStamped pose_msg;
   pose_msg.header.stamp = ros::Time::now();
   pose_msg.header.frame_id = impl_->getRobotModel()->getModelFrame();
-  tf::poseEigenToMsg(pose, pose_msg.pose);
+  pose_msg.pose = tf2::toMsg(pose);
   return pose_msg;
 }
 
@@ -2130,10 +2125,9 @@ std::vector<double> moveit::planning_interface::MoveGroupInterface::getCurrentRP
       if (lm)
       {
         result.resize(3);
-        tf::Matrix3x3 ptf;
-        tf::matrixEigenToTF(current_state->getGlobalLinkTransform(lm).rotation(), ptf);
-        tfScalar pitch, roll, yaw;
-        ptf.getRPY(roll, pitch, yaw);
+        geometry_msgs::TransformStamped tfs = tf2::eigenToTransform(current_state->getGlobalLinkTransform(lm));
+        double pitch, roll, yaw;
+        tf2::getEulerYPR<geometry_msgs::Quaternion>(tfs.transform.rotation, yaw, pitch, roll);
         result[0] = roll;
         result[1] = pitch;
         result[2] = yaw;

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -46,7 +46,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/buffer.h>
 
-
 #include <boost/python.hpp>
 #include <memory>
 #include <Python.h>
@@ -342,7 +341,8 @@ public:
   {
     std::vector<double> v = py_bindings_tools::doubleFromList(pose);
     geometry_msgs::Pose msg;
-    if (v.size() == 6){
+    if (v.size() == 6)
+    {
       tf2::Quaternion q;
       q.setRPY(v[3], v[4], v[5]);
       tf2::convert(q, msg.orientation);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -41,11 +41,14 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
-#include <eigen_conversions/eigen_msg.h>
-#include <tf_conversions/tf_eigen.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/buffer.h>
+
 
 #include <boost/python.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <Python.h>
 
 /** @cond IGNORE */
@@ -65,7 +68,7 @@ public:
                             const std::string& ns = "")
     : py_bindings_tools::ROScppInitializer()
     , MoveGroupInterface(Options(group_name, robot_description, ros::NodeHandle(ns)),
-                         boost::shared_ptr<tf::Transformer>(), ros::WallDuration(5, 0))
+                         std::shared_ptr<tf2_ros::Buffer>(), ros::WallDuration(5, 0))
   {
   }
 
@@ -287,15 +290,16 @@ public:
         Eigen::Affine3d p;
         if (v.size() == 6)
         {
-          Eigen::Quaterniond q;
-          tf::quaternionTFToEigen(tf::createQuaternionFromRPY(v[3], v[4], v[5]), q);
-          p = Eigen::Affine3d(q);
+          tf2::Quaternion tq;
+          tq.setRPY(v[3], v[4], v[5]);
+          Eigen::Quaterniond eq;
+          tf2::convert(tq, eq);
+          p = Eigen::Affine3d(eq);
         }
         else
           p = Eigen::Affine3d(Eigen::Quaterniond(v[6], v[3], v[4], v[5]));
         p.translation() = Eigen::Vector3d(v[0], v[1], v[2]);
-        geometry_msgs::Pose pm;
-        tf::poseEigenToMsg(p, pm);
+        geometry_msgs::Pose pm = tf2::toMsg(p);
         msg.push_back(pm);
       }
       else
@@ -338,8 +342,11 @@ public:
   {
     std::vector<double> v = py_bindings_tools::doubleFromList(pose);
     geometry_msgs::Pose msg;
-    if (v.size() == 6)
-      tf::quaternionTFToMsg(tf::createQuaternionFromRPY(v[3], v[4], v[5]), msg.orientation);
+    if (v.size() == 6){
+      tf2::Quaternion q;
+      q.setRPY(v[3], v[4], v[5]);
+      tf2::convert(q, msg.orientation);
+    }
     else if (v.size() == 7)
     {
       msg.orientation.x = v[3];

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -26,9 +26,11 @@
   <build_depend>rospy</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>actionlib</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>eigen_conversions</build_depend>
-  <build_depend>tf_conversions</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>python</build_depend>
   <build_depend>eigen</build_depend>
 
@@ -40,9 +42,11 @@
   <run_depend>rospy</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>actionlib</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>eigen_conversions</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>python</run_depend>
 
   <test_depend>moveit_resources</test_depend>

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -11,9 +11,10 @@ find_package(Boost REQUIRED thread)
 find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   interactive_markers
-  eigen_conversions
-  tf_conversions
-  tf
+  tf2
+  tf2_eigen
+  tf2_geometry_msgs
+  tf2_ros
   roscpp
 )
 

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -43,7 +43,6 @@
 #include <moveit/robot_state/robot_state.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
-#include <tf/tf.h>
 
 namespace moveit
 {

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -42,7 +42,7 @@
 //#include <moveit/robot_interaction/robot_interaction.h>
 #include <visualization_msgs/InteractiveMarkerFeedback.h>
 #include <interactive_markers/menu_handler.h>
-#include <tf/tf.h>
+#include <tf2_ros/buffer.h>
 
 namespace robot_interaction
 {
@@ -79,18 +79,18 @@ public:
   // Use this constructor if you have an initial RobotState already.
   InteractionHandler(const RobotInteractionPtr& robot_interaction, const std::string& name,
                      const robot_state::RobotState& initial_robot_state,
-                     const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>());
+                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   // Use this constructor to start with a default state.
   InteractionHandler(const RobotInteractionPtr& robot_interaction, const std::string& name,
-                     const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>());
+                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   // DEPRECATED.
   InteractionHandler(const std::string& name, const robot_state::RobotState& initial_robot_state,
-                     const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>());
+                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
   // DEPRECATED.
   InteractionHandler(const std::string& name, const robot_model::RobotModelConstPtr& model,
-                     const boost::shared_ptr<tf::Transformer>& tf = boost::shared_ptr<tf::Transformer>());
+                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   virtual ~InteractionHandler()
   {
@@ -229,7 +229,7 @@ protected:
 
   const std::string name_;
   const std::string planning_frame_;
-  boost::shared_ptr<tf::Transformer> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 
 private:
   typedef boost::function<void(InteractionHandler*)> StateChangeCallbackFn;

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -19,15 +19,19 @@
 
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>interactive_markers</build_depend>
   <build_depend version_gte="1.10.4">pluginlib</build_depend>
 
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend version_gte="1.10.4">pluginlib</run_depend>
 

--- a/moveit_ros/robot_interaction/src/interactive_marker_helpers.cpp
+++ b/moveit_ros/robot_interaction/src/interactive_marker_helpers.cpp
@@ -35,7 +35,8 @@
 /* Author: Ioan Sucan, Acorn Pooley, Adam Leeper */
 
 #include <moveit/robot_interaction/interactive_marker_helpers.h>
-#include <tf/transform_datatypes.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <boost/math/constants/constants.hpp>
 
@@ -67,10 +68,11 @@ void addTArrowMarker(visualization_msgs::InteractiveMarker& im)
   m.header = im.header;
   m.pose = im.pose;
   // Arrow points along Z
-  tf::Quaternion imq;
-  tf::quaternionMsgToTF(m.pose.orientation, imq);
-  imq = imq * tf::createQuaternionFromRPY(0, -boost::math::constants::pi<double>() / 2.0, 0);
-  tf::quaternionTFToMsg(imq, m.pose.orientation);
+  tf2::Quaternion imq, tmq;
+  tf2::fromMsg(m.pose.orientation, imq);
+  tmq.setRPY(0, -boost::math::constants::pi<double>() / 2.0, 0);
+  imq = imq * tmq;
+  m.pose.orientation = tf2::toMsg(imq);
   m.color.r = 0.0f;
   m.color.g = 1.0f;
   m.color.b = 0.0f;
@@ -87,9 +89,10 @@ void addTArrowMarker(visualization_msgs::InteractiveMarker& im)
   mc.header = im.header;
   mc.pose = im.pose;
   // Cylinder points along Y
-  tf::quaternionMsgToTF(mc.pose.orientation, imq);
-  imq = imq * tf::createQuaternionFromRPY(boost::math::constants::pi<double>() / 2.0, 0, 0);
-  tf::quaternionTFToMsg(imq, mc.pose.orientation);
+  tf2::fromMsg(mc.pose.orientation, imq);
+  tmq.setRPY(boost::math::constants::pi<double>() / 2.0, 0, 0);
+  imq = imq * tmq;
+  mc.pose.orientation = tf2::toMsg(imq);
   mc.pose.position.x -= 0.04;
   mc.pose.position.z += 0.01;
   mc.color.r = 0.0f;

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -42,8 +42,9 @@
 #include <moveit/transforms/transforms.h>
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/menu_handler.h>
-#include <eigen_conversions/eigen_msg.h>
-#include <tf_conversions/tf_eigen.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/LinearMath/Transform.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/algorithm/string.hpp>
@@ -405,8 +406,8 @@ void RobotInteraction::addEndEffectorMarkers(const ::robot_interaction::Interact
   const std::vector<std::string>& link_names = rstate->getJointModelGroup(eef.eef_group)->getLinkModelNames();
   visualization_msgs::MarkerArray marker_array;
   rstate->getRobotMarkers(marker_array, link_names, marker_color, eef.eef_group, ros::Duration());
-  tf::Pose tf_root_to_link;
-  tf::poseEigenToTF(rstate->getGlobalLinkTransform(eef.parent_link), tf_root_to_link);
+  tf2::Transform tf_root_to_link;
+  tf2::fromMsg(tf2::toMsg(rstate->getGlobalLinkTransform(eef.parent_link)), tf_root_to_link);
   // Release the ptr count on the kinematic state
   rstate.reset();
 
@@ -415,14 +416,14 @@ void RobotInteraction::addEndEffectorMarkers(const ::robot_interaction::Interact
     marker_array.markers[i].header = im.header;
     marker_array.markers[i].mesh_use_embedded_materials = true;
     // - - - - - - Do some math for the offset - - - - - -
-    tf::Pose tf_root_to_im, tf_root_to_mesh, tf_im_to_eef;
-    tf::poseMsgToTF(im.pose, tf_root_to_im);
-    tf::poseMsgToTF(marker_array.markers[i].pose, tf_root_to_mesh);
-    tf::poseMsgToTF(im_to_eef, tf_im_to_eef);
-    tf::Pose tf_eef_to_mesh = tf_root_to_link.inverse() * tf_root_to_mesh;
-    tf::Pose tf_im_to_mesh = tf_im_to_eef * tf_eef_to_mesh;
-    tf::Pose tf_root_to_mesh_new = tf_root_to_im * tf_im_to_mesh;
-    tf::poseTFToMsg(tf_root_to_mesh_new, marker_array.markers[i].pose);
+    tf2::Transform tf_root_to_im, tf_root_to_mesh, tf_im_to_eef;
+    tf2::fromMsg(im.pose, tf_root_to_im);
+    tf2::fromMsg(marker_array.markers[i].pose, tf_root_to_mesh);
+    tf2::fromMsg(im_to_eef, tf_im_to_eef);
+    tf2::Transform tf_eef_to_mesh = tf_root_to_link.inverse() * tf_root_to_mesh;
+    tf2::Transform tf_im_to_mesh = tf_im_to_eef * tf_eef_to_mesh;
+    tf2::Transform tf_root_to_mesh_new = tf_root_to_im * tf_im_to_mesh;
+    tf2::toMsg(tf_root_to_mesh_new, marker_array.markers[i].pose);
     // - - - - - - - - - - - - - - - - - - - - - - - - - -
     m_control.markers.push_back(marker_array.markers[i]);
   }
@@ -520,7 +521,7 @@ void RobotInteraction::addInteractiveMarkers(const ::robot_interaction::Interact
       geometry_msgs::PoseStamped pose;
       pose.header.frame_id = robot_model_->getModelFrame();
       pose.header.stamp = ros::Time::now();
-      tf::poseEigenToMsg(s->getGlobalLinkTransform(active_vj_[i].connecting_link), pose.pose);
+      pose.pose = tf2::toMsg(s->getGlobalLinkTransform(active_vj_[i].connecting_link));
       std::string marker_name = getMarkerName(handler, active_vj_[i]);
       shown_markers_[marker_name] = i;
 
@@ -597,17 +598,17 @@ void RobotInteraction::computeMarkerPose(const ::robot_interaction::InteractionH
                                          geometry_msgs::Pose& pose, geometry_msgs::Pose& control_to_eef_tf) const
 {
   // Need to allow for control pose offsets
-  tf::Transform tf_root_to_link, tf_root_to_control;
-  tf::poseEigenToTF(robot_state.getGlobalLinkTransform(eef.parent_link), tf_root_to_link);
+  tf2::Transform tf_root_to_link, tf_root_to_control;
+  tf2::fromMsg(tf2::toMsg(robot_state.getGlobalLinkTransform(eef.parent_link)), tf_root_to_link);
 
   geometry_msgs::Pose msg_link_to_control;
   if (handler->getPoseOffset(eef, msg_link_to_control))
   {
-    tf::Transform tf_link_to_control;
-    tf::poseMsgToTF(msg_link_to_control, tf_link_to_control);
+    tf2::Transform tf_link_to_control;
+    tf2::fromMsg(msg_link_to_control, tf_link_to_control);
 
     tf_root_to_control = tf_root_to_link * tf_link_to_control;
-    tf::poseTFToMsg(tf_link_to_control.inverse(), control_to_eef_tf);
+    tf2::toMsg(tf_link_to_control.inverse(), control_to_eef_tf);
   }
   else
   {
@@ -618,7 +619,7 @@ void RobotInteraction::computeMarkerPose(const ::robot_interaction::InteractionH
     control_to_eef_tf.orientation.w = 1.0;
   }
 
-  tf::poseTFToMsg(tf_root_to_control, pose);
+   tf2::toMsg(tf_root_to_control, pose);
 }
 
 void RobotInteraction::updateInteractiveMarkers(const ::robot_interaction::InteractionHandlerPtr& handler)
@@ -642,7 +643,7 @@ void RobotInteraction::updateInteractiveMarkers(const ::robot_interaction::Inter
     for (std::size_t i = 0; i < active_vj_.size(); ++i)
     {
       std::string marker_name = getMarkerName(handler, active_vj_[i]);
-      tf::poseEigenToMsg(s->getGlobalLinkTransform(active_vj_[i].connecting_link), pose_updates[marker_name]);
+      pose_updates[marker_name] = tf2::toMsg(s->getGlobalLinkTransform(active_vj_[i].connecting_link));
     }
 
     for (std::size_t i = 0; i < active_generic_.size(); ++i)

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -619,7 +619,7 @@ void RobotInteraction::computeMarkerPose(const ::robot_interaction::InteractionH
     control_to_eef_tf.orientation.w = 1.0;
   }
 
-   tf2::toMsg(tf_root_to_control, pose);
+  tf2::toMsg(tf_root_to_control, pose);
 }
 
 void RobotInteraction::updateInteractiveMarkers(const ::robot_interaction::InteractionHandlerPtr& handler)

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -23,12 +23,11 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_robot_interaction
   moveit_ros_warehouse
   moveit_ros_perception
-  eigen_conversions
   geometric_shapes
   interactive_markers
   class_loader
   rviz
-  tf
+  tf2_eigen
   roscpp
   rosconsole
   object_recognition_msgs

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -315,7 +315,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     try
     {
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
-          opt, context_->getFrameManager()->getTFClientPtr()->getTF2BufferPtr(), ros::WallDuration(30, 0)));
+          opt, context_->getFrameManager()->getTF2BufferPtr(), ros::WallDuration(30, 0)));
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -51,6 +51,8 @@
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
+#include <tf2_ros/buffer.h>
+
 namespace moveit_rviz_plugin
 {
 MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::DisplayContext* context,
@@ -313,7 +315,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     try
     {
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
-          opt, context_->getFrameManager()->getTFClientPtr(), ros::WallDuration(30, 0)));
+          opt, context_->getFrameManager()->getTFClientPtr()->getTF2BufferPtr(), ros::WallDuration(30, 0)));
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -47,7 +47,7 @@
 #include <rviz/frame_manager.h>
 #include <rviz/window_manager_interface.h>
 
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <geometric_shapes/shape_operations.h>
 
 #include <QMessageBox>
@@ -361,7 +361,7 @@ void MotionPlanningFrame::imProcessFeedback(visualization_msgs::InteractiveMarke
   ui_->object_z->blockSignals(oldState);
 
   Eigen::Quaterniond q;
-  tf::quaternionMsgToEigen(feedback.pose.orientation, q);
+  tf2::fromMsg(feedback.pose.orientation, q);
   Eigen::Vector3d xyz = q.matrix().eulerAngles(0, 1, 2);
 
   oldState = ui_->object_rx->blockSignals(true);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -49,8 +49,6 @@
 #include <rviz/display_context.h>
 #include <rviz/window_manager_interface.h>
 
-#include <eigen_conversions/eigen_msg.h>
-
 #include <QMessageBox>
 #include <QInputDialog>
 

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -32,6 +32,7 @@
   <build_depend>moveit_ros_perception</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>tf2_eigen</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rviz</run_depend>
@@ -44,6 +45,7 @@
   <run_depend>object_recognition_msgs</run_depend>
   <run_depend>moveit_ros_perception</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>tf2_eigen</run_depend>
 
   <test_depend>rostest</test_depend>
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -487,7 +487,7 @@ void PlanningSceneDisplay::unsetLinkColor(rviz::Robot* robot, const std::string&
 planning_scene_monitor::PlanningSceneMonitorPtr PlanningSceneDisplay::createPlanningSceneMonitor()
 {
   return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
-      robot_description_property_->getStdString(), context_->getFrameManager()->getTFClientPtr()->getTF2BufferPtr(),
+      robot_description_property_->getStdString(), context_->getFrameManager()->getTF2BufferPtr(),
       getNameStd() + "_planning_scene_monitor"));
 }
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -52,7 +52,7 @@
 #include <rviz/properties/enum_property.h>
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
@@ -487,7 +487,7 @@ void PlanningSceneDisplay::unsetLinkColor(rviz::Robot* robot, const std::string&
 planning_scene_monitor::PlanningSceneMonitorPtr PlanningSceneDisplay::createPlanningSceneMonitor()
 {
   return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
-      robot_description_property_->getStdString(), context_->getFrameManager()->getTFClientPtr(),
+      robot_description_property_->getStdString(), context_->getFrameManager()->getTFClientPtr()->getTF2BufferPtr(),
       getNameStd() + "_planning_scene_monitor"));
 }
 

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -14,7 +14,8 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosconsole
   warehouse_ros
-  tf
+  tf2_eigen
+  tf2_ros
 )
 
 catkin_package(

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -20,12 +20,14 @@
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_ros</build_depend>
 
   <run_depend>warehouse_ros</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
-  <run_depend>tf</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_ros</run_depend>
 
 </package>

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -40,7 +40,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/robot_state/conversions.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
@@ -141,7 +141,7 @@ void parseLinkConstraint(std::istream& in, planning_scene_monitor::PlanningScene
   if (have_position && have_orientation)
   {
     geometry_msgs::PoseStamped pose;
-    tf::poseEigenToMsg(pos * rot, pose.pose);
+    pose.pose = tf2::toMsg(pos * rot);
     pose.header.frame_id = psm->getRobotModel()->getModelFrame();
     moveit_msgs::Constraints constr = kinematic_constraints::constructGoalConstraints(link_name, pose);
     constr.name = name;

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -142,7 +142,8 @@ int main(int argc, char** argv)
 
   ros::NodeHandle nh;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener =
+      std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
   planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf_buffer);
   if (!psm.getPlanningScene())
   {

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -44,6 +44,7 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <ros/ros.h>
+#include <tf2_ros/transform_listener.h>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
@@ -140,8 +141,9 @@ int main(int argc, char** argv)
   spinner.start();
 
   ros::NodeHandle nh;
-  boost::shared_ptr<tf::TransformListener> tf(new tf::TransformListener());
-  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf);
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION, tf_buffer);
   if (!psm.getPlanningScene())
   {
     ROS_ERROR("Unable to initialize PlanningSceneMonitor");

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -37,7 +37,6 @@
 #ifndef MOVEIT_MOVEIT_SETUP_ASSISTANT_TOOLS_MOVEIT_CONFIG_DATA_
 #define MOVEIT_MOVEIT_SETUP_ASSISTANT_TOOLS_MOVEIT_CONFIG_DATA_
 
-#include <boost/shared_ptr.hpp>
 #include <srdfdom/model.h>        // use their struct datastructures
 #include <srdfdom/srdf_writer.h>  // for writing srdf data
 #include <urdf/model.h>           // to share throughout app


### PR DESCRIPTION
This will resolve https://github.com/ros-planning/moveit/issues/745 and complete a checkbox for [Release to Melodic](https://github.com/ros-planning/moveit/issues/806).

This is the migration from `tf` to `tf2` required for `ROS2`. It depends on https://github.com/ros/geometry2/pull/292 for a handful of additional conversions. It **breaks API compatibility, so it can only be merged into the `melodic-devel` branch**.

This PR depends on the following upstream API changes for Melodic:
https://github.com/ros/geometry/pull/163 (Exposing `tf2_ros::Buffer` object from TransformListener)
https://github.com/ros/geometry2/pull/292 (tf2 Type conversions)
https://github.com/ros/geometry2/pull/294 (Additional tf2 Type conversions)
https://github.com/ros-visualization/rviz/pull/1236 (Exposing tf2 without ROS deprecation warnings)

### Highlights:
- All type conversions now depend on `geometry2` ROS packages, rather than `geometry`
- Removed all `boost::shared_ptr<tf::TransformListener>` from the API, and replaced them with `std::shared_ptr<tf2_ros::Buffer>`'s. I figured boost was only kept to preserve API, but please correct me if that is a bad assumption.
- Piped `tf2_ros::Buffer`'s everywhere where `tf::TransformListener`s were used

### Things left **TODO**:
- [x] Finish converting moveit_ros/robot_interaction/src/robot_interaction.cpp
- [x] Finish converting moveit_ros/perception/mesh_filter/src/transform_provider.cpp
- [x] Figure out a better method for retrieving RViz' internal `tf2_ros::Buffer` instance, as RViz APi only gives access to the `boost::shared_ptr<tf::TransformListener>` instance: 
https://github.com/ros-visualization/rviz/issues/1215
- [x] Fix **one rather large bug** likely caused by my work around to the above point: when wiggling around the interactive markers in RViz, I can periodically get in a state where the marker detaches from the robot's end effector, and this error prints out:
```
[ERROR] [1523131812.122517887]: Cannot transform from frame 'base' to frame '/base' (no TF instance provided)
[ERROR] [1523131812.148109554]: Cannot transform from frame 'base' to frame '/base' (no TF instance provided)
[ERROR] [1523131812.179335945]: Cannot transform from frame 'base' to frame '/base' (no TF instance provided)
```
My solution was to just pass in a null `Buffer` to  the `move_group` when we would have used RViz's `TransformListener`. This almost seems to work, aside for the bug.

### Checklist
- [x]  Code is (sort-of) auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code), but I ignored some reformats that looked strange. I'll run it again after review changes.
- [ ] TBD: Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] TBD: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] As this breaks API/ABI, this PR is `melodic-devel` **only**

