### PR TITLE
computeCartesianPath: only test for jump if there's something to check

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1945,7 +1945,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
     last_valid_percentage = percentage;
   }
 
-  if (test_joint_space_jump)
+  if (test_joint_space_jump && traj.size() > 1)
   {
     last_valid_percentage *= testJointSpaceJump(group, traj, jump_threshold);
   }


### PR DESCRIPTION
If the trajectory consists only of the first (current) robot state,
there is no need to test for joint space jumps and thus we avoid
printing the new warning "too few points to test" in this case.