### PR TITLE
Document hidden functionality in trajectory execution manager

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1519,8 +1519,9 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
 
 bool TrajectoryExecutionManager::waitForRobotToStop(const TrajectoryExecutionContext& context, double wait_time)
 {
-  if (allowed_start_tolerance_ == 0)  // skip validation on this magic number
-    return true;
+  double tolerance = allowed_start_tolerance_;
+  if (tolerance <= 0)  // don't skip the tolerance check on a zero threshold (only on zero wait_time)
+    tolerance = 1.e-4;  // but fallback to small default threshold
 
   ros::WallTime start = ros::WallTime::now();
   double time_remaining = wait_time;
@@ -1554,7 +1555,7 @@ bool TrajectoryExecutionManager::waitForRobotToStop(const TrajectoryExecutionCon
         if (!jm)
           continue;  // joint vanished from robot state (shouldn't happen), but we don't care
 
-        if (fabs(cur_state->getJointPositions(jm)[0] - prev_state->getJointPositions(jm)[0]) > allowed_start_tolerance_)
+        if (fabs(cur_state->getJointPositions(jm)[0] - prev_state->getJointPositions(jm)[0]) > tolerance)
         {
           moved = true;
           no_motion_count = 0;

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
@@ -10,12 +10,12 @@
   <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
-  <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state. If set to zero will skip -->
-  <!-- waiting for robot to stop after execution -->
+
+  <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state.
+       If set to zero, this sanity check will be skipped. The same threshold is used as a stopping criterium. -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
 
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="[ROBOT_NAME]" />
   <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" />
-
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <!-- This file makes it easy to include the settings for trajectory execution  -->  
+  <!-- This file makes it easy to include the settings for trajectory execution  -->
 
   <!-- Flag indicating whether MoveIt! is allowed to load/unload  or switch controllers -->
   <arg name="moveit_manage_controllers" default="true"/>
@@ -10,11 +10,12 @@
   <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
-  <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
+  <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state. If set to zero will skip -->
+  <!-- waiting for robot to stop after execution -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
-  
+
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="[ROBOT_NAME]" />
   <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" />
-  
+
 </launch>


### PR DESCRIPTION
Why this number is used to disable waiting after execution does not make sense to me, but the first step is to at least document it:

https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp#L940