### PR TITLE
Testing for Cartesian space Jumps in Cartesian paths

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -71,8 +71,8 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
 struct JumpThreshold
 {
   double factor;
-  double revolute;    // Radians
-  double prismatic;   // Meters
+  double revolute;   // Radians
+  double prismatic;  // Meters
 
   explicit JumpThreshold() : factor(0.0), revolute(0.0), prismatic(0.0)
   {
@@ -85,8 +85,8 @@ struct JumpThreshold
 
   explicit JumpThreshold(double jt_revolute, double jt_prismatic) : JumpThreshold()
   {
-    revolute = jt_revolute;     // Radians
-    prismatic = jt_prismatic;   // Meters
+    revolute = jt_revolute;    // Radians
+    prismatic = jt_prismatic;  // Meters
   }
 };
 
@@ -95,8 +95,8 @@ struct JumpThreshold
     Setting translation to zero will disable checking for translations and the same goes for rotation */
 struct MaxEEFStep
 {
-  double translation; // Meters
-  double rotation;    // Radians
+  double translation;  // Meters
+  double rotation;     // Radians
 
   explicit MaxEEFStep() : translation(0.0), rotation(0.0)
   {
@@ -1191,11 +1191,13 @@ as the new values that correspond to the group */
 
   /** \brief Helper function that calls both testJointSpaceJump and testCartesianSpaceJump
   */
-  static double testForJumps(const JointModelGroup* group, const LinkModel* link, std::vector<RobotStatePtr>& traj,
-                             const JumpThreshold& jump_threshold, const MaxEEFStep& max_step);
+  static double trimJointAndCartesianSaceJumps(const JointModelGroup* group, const LinkModel* link,
+                                               std::vector<RobotStatePtr>& traj, const JumpThreshold& jump_threshold,
+                                               const MaxEEFStep& max_step);
 
-  static double testForJumps(const JointModelGroup* group, const std::string& link, std::vector<RobotStatePtr>& traj,
-                             const JumpThreshold& jump_threshold, const MaxEEFStep& max_step)
+  static double trimJointAndCartesianSaceJumps(const JointModelGroup* group, const std::string& link,
+                                               std::vector<RobotStatePtr>& traj, const JumpThreshold& jump_threshold,
+                                               const MaxEEFStep& max_step)
   {
     return testForJumps(group, group->getLinkModel(link), traj, jump_threshold, max_step);
   }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1072,9 +1072,9 @@ as the new values that correspond to the group */
                           const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
-  /** \brief Set the joint values from a cartesian velocity applied during a time dt
+  /** \brief Set the joint values from a Cartesian velocity applied during a time dt
    * @param group the group of joints this function operates on
-   * @param twist a cartesian velocity on the 'tip' frame
+   * @param twist a Cartesian velocity on the 'tip' frame
    * @param tip the frame for which the twist is given
    * @param dt a time interval (seconds)
    * @param st a secondary task computation function
@@ -1082,9 +1082,9 @@ as the new values that correspond to the group */
   bool setFromDiffIK(const JointModelGroup* group, const Eigen::VectorXd& twist, const std::string& tip, double dt,
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn());
 
-  /** \brief Set the joint values from a cartesian velocity applied during a time dt
+  /** \brief Set the joint values from a Cartesian velocity applied during a time dt
    * @param group the group of joints this function operates on
-   * @param twist a cartesian velocity on the 'tip' frame
+   * @param twist a Cartesian velocity on the 'tip' frame
    * @param tip the frame for which the twist is given
    * @param dt a time interval (seconds)
    * @param st a secondary task computation function
@@ -1247,7 +1247,7 @@ as the new values that correspond to the group */
   static double testAbsoluteJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                            double revolute_jump_threshold, double prismatic_jump_threshold);
 
-  /** \brief Tests for large cartesian space jumps of a trajectory at the end effector.
+  /** \brief Tests for large Cartesian space jumps of a trajectory at the end effector.
 
      Takes the midpoint between points in the trajectory and solves the FK. If the pose at the midpoint is further than
      the max_step from either the preceding point or the following point, then the returned path is truncated up to

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -66,15 +66,15 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
 /** \brief Struct for containing jump_threshold.
 
     For the purposes of maintaining API, we support both \e jump_threshold_factor which provides a scaling factor for
-    detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute
+    detecting joint space jumps and \e revolute_jump_threshold and \e prismatic_jump_threshold which provide abolute
     thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
   double factor;
-  double revolute;
-  double prismatic;
+  double revolute;    // Radians
+  double prismatic;   // Meters
 
-  explicit JumpThreshold() : factor(0.0), prismatic(0.0), revolute(0.0)
+  explicit JumpThreshold() : factor(0.0), revolute(0.0), prismatic(0.0)
   {
   }
 
@@ -85,8 +85,8 @@ struct JumpThreshold
 
   explicit JumpThreshold(double jt_revolute, double jt_prismatic) : JumpThreshold()
   {
-    prismatic = jt_prismatic;
-    revolute = jt_revolute;
+    revolute = jt_revolute;     // Radians
+    prismatic = jt_prismatic;   // Meters
   }
 };
 
@@ -95,8 +95,8 @@ struct JumpThreshold
     Setting translation to zero will disable checking for translations and the same goes for rotation */
 struct MaxEEFStep
 {
-  double translation;
-  double rotation;
+  double translation; // Meters
+  double rotation;    // Radians
 
   explicit MaxEEFStep() : translation(0.0), rotation(0.0)
   {
@@ -1115,19 +1115,18 @@ as the new values that correspond to the group */
      During the computation of the trajectory, it is usually preferred if consecutive joint values do not 'jump' by a
      large amount in joint space, even if the Cartesian distance between the corresponding points is small as expected.
      To account for this, the \e jump_threshold struct is provided, which comprises three fields:
-     \e jump_threshold_factor, \e prismatic_jump_threshold and \e revolute_jump_threshold.
-     If either \e prismatic_jump_threshold or \e revolute_jump_threshold are non-zero, we test for absolute jumps.
+     \e jump_threshold_factor, \e revolute_jump_threshold and \e prismatic_jump_threshold.
+     If either \e revolute_jump_threshold or \e prismatic_jump_threshold  are non-zero, we test for absolute jumps.
      If \e jump_threshold_factor is non-zero, we test for relative jumps. Otherwise (all params are zero), jump
-     detection is
-     disabled.
+     detection is disabled.
 
      For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
      computed. If any individual joint-space motion delta is larger then this average distance by a factor of
      \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
      before the jump.
 
-     For absolute jump thresholds, if any individual joint-space motion delta is larger then \e prismatic_jump_threshold
-     for prismatic joints or \e revolute_jump_threshold for revolute joints then this step is considered a failure and
+     For absolute jump thresholds, if any individual joint-space motion delta is larger then \e revolute_jump_threshold
+     for revolute joints or \e prismatic_jump_threshold for prismatic joints then this step is considered a failure and
      the returned path is truncated up to just before the jump.*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
@@ -1204,7 +1203,7 @@ as the new values that correspond to the group */
   /** \brief Tests joint space jumps of a trajectory.
 
      If \e jump_threshold_factor is non-zero, we test for relative jumps.
-     If \e prismatic_jump_threshold or \e revolute_jump_threshold are non-zero, we test for absolute jumps.
+     If \e revolute_jump_threshold  or \e prismatic_jump_threshold are non-zero, we test for absolute jumps.
      Both tests can be combined. If all params are zero, jump detection is disabled.
      For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
      computed. If any individual joint-space motion delta is larger then this average distance by a factor of
@@ -1235,9 +1234,9 @@ as the new values that correspond to the group */
 
   /** \brief Tests for absolute joint space jumps of the trajectory \e traj.
 
-     The joint-space difference between consecutive waypoints is computed for each active joint and compared to
-     the absolute thresholds \e prismatic_jump_threshold for prismatic joints or \e revolute_jump_threshold for
-     revolute joints. If these thresholds are exceeded, the trajectory is truncated.
+     The joint-space difference between consecutive waypoints is computed for each active joint and compared to the
+     absolute thresholds \e revolute_jump_threshold for revolute joints and \e prismatic_jump_threshold for prismatic
+     joints. If these thresholds are exceeded, the trajectory is truncated.
 
      @param group The joint model group of the robot state.
      @param traj The trajectory that should be tested.

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1281,7 +1281,7 @@ as the new values that correspond to the group */
   */
   static double testCartesianSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const MaxEEFStep& max_step)
   {
-    double percent_valid;
+    double percent_valid = 1.0;
     std::vector<const LinkModel*> links = group->getLinkModels();
     for (auto& link : links)
     {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2109,9 +2109,9 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
 double RobotState::testCartesianSpaceJump(const JointModelGroup* group, const LinkModel* link,
                                           std::vector<RobotStatePtr>& traj, const MaxEEFStep& max_step)
 {
-  double percentage = 1.0;
+  double percent_valid = 1.0;
   if (traj.size() <= 1)
-    return percentage;
+    return percent_valid;
 
   Eigen::Affine3d start_pose = traj[0]->getGlobalLinkTransform(link);
   Eigen::Affine3d mid_pose;
@@ -2151,9 +2151,11 @@ double RobotState::testCartesianSpaceJump(const JointModelGroup* group, const Li
     start_pose = end_pose;
     start_quaternion = end_quaternion;
   }
-  percentage = (double)(traj_ix) / (double)(traj.size());
+
+  // This trims the trajectory before the jump if one is found. If no jump is found traj_ix is equal to the size of the trajectory leaving the trajectory unchanged
+  percent_valid = (double)(traj_ix) / (double)(traj.size());
   traj.resize(traj_ix);
-  return percentage;
+  return percent_valid;
 }
 
 void RobotState::computeAABB(std::vector<double>& aabb) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1951,7 +1951,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
     last_valid_percentage = percentage;
   }
 
-  last_valid_percentage *= testForJumps(group, link, traj, jump_threshold, max_step);
+  last_valid_percentage *= trimJointAndCartesianSpaceJumps(group, link, traj, jump_threshold, max_step);
 
   return last_valid_percentage;
 }
@@ -1990,13 +1990,14 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
     }
   }
 
-  percentage_solved *= testForJumps(group, link, traj, jump_threshold, max_step);
+  percentage_solved *= trimJointAndCartesianSpaceJumps(group, link, traj, jump_threshold, max_step);
 
   return percentage_solved;
 }
 
-double RobotState::testForJumps(const JointModelGroup* group, const LinkModel* link, std::vector<RobotStatePtr>& traj,
-                                const JumpThreshold& jump_threshold, const MaxEEFStep& max_step)
+double RobotState::trimJointAndCartesianSpaceJumps(const JointModelGroup* group, const LinkModel* link,
+                                                   std::vector<RobotStatePtr>& traj,
+                                                   const JumpThreshold& jump_threshold, const MaxEEFStep& max_step)
 {
   double percentage_solved = 1.0;
   if (traj.size() <= 1)
@@ -2022,7 +2023,7 @@ double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<
     return percentage_solved;
 
   if (jump_threshold.factor > 0.0)
-     percentage_solved *= testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
+    percentage_solved *= testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
 
   if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
     percentage_solved *= testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2110,7 +2110,7 @@ double RobotState::testCartesianSpaceJump(const JointModelGroup* group, const Li
                                           std::vector<RobotStatePtr>& traj, const MaxEEFStep& max_step)
 {
   double percent_valid = 1.0;
-  if (traj.size() <= 1)
+  if (traj.size() <= 1 || max_step.rotation == 0.0 && max_step.translation == 0.0)
     return percent_valid;
 
   Eigen::Affine3d start_pose = traj[0]->getGlobalLinkTransform(link);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2005,7 +2005,7 @@ double RobotState::testForJumps(const JointModelGroup* group, const LinkModel* l
   if (jump_threshold.factor > 0.0)
     percentage_solved *= testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
 
-  if (jump_threshold.prismatic > 0.0 || jump_threshold.revolute > 0.0)
+  if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
     percentage_solved *= testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
 
   if (max_step.translation > 0.0 || max_step.rotation > 0.0)
@@ -2017,13 +2017,17 @@ double RobotState::testForJumps(const JointModelGroup* group, const LinkModel* l
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                       const JumpThreshold& jump_threshold)
 {
-  if (jump_threshold.factor > 0.0 && traj.size() > 1)
-    return testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
+  double percentage_solved = 1.0;
+  if (traj.size() <= 1)
+    return percentage_solved;
 
-  if (jump_threshold.prismatic > 0.0 || jump_threshold.revolute > 0.0 && traj.size() > 1)
-    return testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+  if (jump_threshold.factor > 0.0)
+     percentage_solved *= testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
 
-  return 1.0;
+  if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
+    percentage_solved *= testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+
+  return percentage_solved;
 }
 
 double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -33,7 +33,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman */
+/* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman, Mike Lautman */
 
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/transforms/transforms.h>

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1996,21 +1996,21 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 }
 
 double RobotState::trimJointAndCartesianSpaceJumps(const JointModelGroup* group, const LinkModel* link,
-                                                   std::vector<RobotStatePtr>& traj,
+                                                   std::vector<RobotStatePtr>& trajectory,
                                                    const JumpThreshold& jump_threshold, const MaxEEFStep& max_step)
 {
   double percentage_solved = 1.0;
-  if (traj.size() <= 1)
+  if (trajectory.size() <= 1)
     return percentage_solved;
 
   if (jump_threshold.factor > 0.0)
-    percentage_solved *= testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
+    percentage_solved *= testRelativeJointSpaceJump(group, trajectory, jump_threshold.factor);
 
   if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
-    percentage_solved *= testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+    percentage_solved *= testAbsoluteJointSpaceJump(group, trajectory, jump_threshold.revolute, jump_threshold.prismatic);
 
   if (max_step.translation > 0.0 || max_step.rotation > 0.0)
-    percentage_solved *= testCartesianSpaceJump(group, link, traj, max_step);
+    percentage_solved *= testCartesianSpaceJump(group, link, trajectory, max_step);
 
   return percentage_solved;
 }
@@ -2098,9 +2098,9 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
 
     if (!still_valid)
     {
-      double percentage = (double)(traj_ix + 1) / (double)(traj.size());
+      double percent_valid = (double)(traj_ix + 1) / (double)(traj.size());
       traj.resize(traj_ix + 1);
-      return percentage;
+      return percent_valid;
     }
   }
   return 1.0;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1919,16 +1919,16 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
   double translation_distance = (rotated_target.translation() - start_pose.translation()).norm();
 
   // decide how many steps we will need for this trajectory
-  unsigned int translation_steps = 0;
+  std::size_t translation_steps = 0;
   if (max_step.translation > 0.0)
     translation_steps = floor(translation_distance / max_step.translation);
 
-  unsigned int rotation_steps = 0;
+  std::size_t rotation_steps = 0;
   if (max_step.rotation > 0.0)
     rotation_steps = floor(rotation_distance / max_step.rotation);
 
   // If we are testing for relative jumps, we always want at least MIN_STEPS_FOR_JUMP_THRESH steps
-  unsigned int steps = std::max(translation_steps, rotation_steps) + 1;
+  std::size_t steps = std::max(translation_steps, rotation_steps) + 1;
   if (jump_threshold.factor > 0 && steps < MIN_STEPS_FOR_JUMP_THRESH)
     steps = MIN_STEPS_FOR_JUMP_THRESH;
 
@@ -1936,7 +1936,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
   traj.push_back(RobotStatePtr(new RobotState(*this)));
 
   double last_valid_percentage = 0.0;
-  for (unsigned int i = 1; i <= steps; ++i)
+  for (std::size_t i = 1; i <= steps; ++i)
   {
     double percentage = (double)i / (double)steps;
 

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -655,8 +655,8 @@ TEST_F(LoadPR2, testAbsoluteJointSpaceJump)
 
   // Indirect call of relative version using testJumps
   full_traj_len = generateTestTraj(traj, robot_model_, joint_model_group_);
-  fraction = robot_state::RobotState::testForJumps(joint_model_group_, link_name_, traj,
-                                                   robot_state::JumpThreshold(1.0, 1.0), robot_state::MaxEEFStep());
+  fraction = robot_state::RobotState::trimJointAndCartesianSpaceJumps(
+      joint_model_group_, link_name_, traj, robot_state::JumpThreshold(1.0, 1.0), robot_state::MaxEEFStep());
   EXPECT_EQ(full_traj_len, expected_full_traj_len);         // full traj should be 7 waypoints long
   EXPECT_EQ(traj.size(), expected_absolute_jump_traj_len);  // traj should be cut
   EXPECT_NEAR(fraction, (double)expected_absolute_jump_traj_len / (double)full_traj_len, 0.01);
@@ -698,8 +698,8 @@ TEST_F(LoadPR2, testRelativeJointSpaceJump)
 
   // Indirect call of relative version using testJumps
   full_traj_len = generateTestTraj(traj, robot_model_, joint_model_group_);
-  fraction = robot_state::RobotState::testForJumps(joint_model_group_, link_name_, traj,
-                                                   robot_state::JumpThreshold(1.0), robot_state::MaxEEFStep());
+  fraction = robot_state::RobotState::trimJointAndCartesianSpaceJumps(
+      joint_model_group_, link_name_, traj, robot_state::JumpThreshold(1.0), robot_state::MaxEEFStep());
   EXPECT_EQ(full_traj_len, expected_full_traj_len);         // full traj should be 7 waypoints long
   EXPECT_EQ(traj.size(), expected_relative_jump_traj_len);  // traj should be cut
   EXPECT_NEAR(fraction, (double)expected_relative_jump_traj_len / (double)full_traj_len, 0.01);
@@ -750,8 +750,8 @@ TEST_F(LoadPR2, testCartSpaceJumpCutoff)
 
   // Indirect call of the cartesian jump test
   full_traj_len = generateTestTraj(traj, robot_model_, joint_model_group_);
-  fraction = robot_state::RobotState::testForJumps(joint_model_group_, link_name_, traj, robot_state::JumpThreshold(),
-                                                   robot_state::MaxEEFStep(0.05));
+  fraction = robot_state::RobotState::trimJointAndCartesianSpaceJumps(
+      joint_model_group_, link_name_, traj, robot_state::JumpThreshold(), robot_state::MaxEEFStep(0.05));
   EXPECT_EQ(full_traj_len, expected_full_traj_len);             // full traj should be 7 waypoints long
   EXPECT_NEAR(traj.size(), expected_cart_jump_traj_len, 0.01);  // traj should be cut
   EXPECT_NEAR(fraction, (double)expected_cart_jump_traj_len / (double)full_traj_len, 0.01);  // traj should be cut

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -576,8 +576,8 @@ protected:
   urdf::ModelInterfaceSharedPtr urdf_model_;
   srdf::ModelSharedPtr srdf_model_;
   moveit::core::RobotModelConstPtr robot_model_;
-  std::string link_name_ = "r_wrist_roll_link";
-  std::string group_name_ = "right_arm";
+  const std::string link_name_ = "r_wrist_roll_link";
+  const std::string group_name_ = "right_arm";
   const robot_model::JointModelGroup* joint_model_group_;
 };
 


### PR DESCRIPTION
### Description

In this PR which builds off of #843 (#821) I make additional improvements to the Cartesian planner by adding functionality to detect Cartesian space jumps at the end effector. I use testCartesianSpaceJump to ensure that the midpoint between two successive waypoints doesn't deviate by more than the max_step from either the preceding or following waypoints. This approach is based on [this](https://pdfs.semanticscholar.org/e01a/58608f4e68f31c7b9e7cdbddceae645727bb.pdf) paper on Bounded Deviation Joint Paths.

Note that this approach recycles the max_step parameter to test for Cartesian space jumps. I considered adding a flag to the MaxEEFStep struct that would disable the testCartesianSpaceJump test but I couldn't come up with a use case and it would have dirtied up the code

I think @rhaschke will want to review this
### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

This PR was sponsored by [Sesto Robotics](https://www.sestorobotics.com/)