### PR TITLE
Fix get joint value target

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -124,8 +124,9 @@ public:
     const robot_state::RobotState& values = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
     bp::list l;
     std::vector<std::string> names = getActiveJoints();
-    for(std::vector<std::string>::const_iterator it = names.begin(); it != names.end(); ++it) {
-        l.append(*values.getJointPositions(*it));
+    for (std::vector<std::string>::const_iterator it = names.begin(); it != names.end(); ++it)
+    {
+      l.append(*values.getJointPositions(*it));
     }
     return l;
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -123,8 +123,10 @@ public:
   {
     const robot_state::RobotState& values = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
     bp::list l;
-    for (const double *it = values.getVariablePositions(), *end = it + getVariableCount(); it != end; ++it)
-      l.append(*it);
+    std::vector<std::string> names = getActiveJoints();
+    for(std::vector<std::string>::const_iterator it = names.begin(); it != names.end(); ++it) {
+        l.append(*values.getJointPositions(*it));
+    }
     return l;
   }
 
@@ -596,6 +598,7 @@ static void wrap_move_group_interface()
                               &MoveGroupInterfaceWrapper::setJointValueTargetFromJointStatePython);
 
   MoveGroupInterfaceClass.def("get_joint_value_target", &MoveGroupInterfaceWrapper::getJointValueTargetPythonList);
+  MoveGroupInterfaceClass.def("get_joint_state_target", &MoveGroupInterfaceWrapper::getJointValueTarget);
 
   MoveGroupInterfaceClass.def("set_named_target", &MoveGroupInterfaceWrapper::setNamedTarget);
   MoveGroupInterfaceClass.def("set_random_target", &MoveGroupInterfaceWrapper::setRandomTarget);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -123,11 +123,8 @@ public:
   {
     const robot_state::RobotState& values = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
     bp::list l;
-    std::vector<std::string> names = getActiveJoints();
-    for (std::vector<std::string>::const_iterator it = names.begin(); it != names.end(); ++it)
-    {
-      l.append(*values.getJointPositions(*it));
-    }
+    for (const double *it = values.getVariablePositions(), *end = it + values.getVariableCount(); it != end; ++it)
+      l.append(*it);
     return l;
   }
 


### PR DESCRIPTION
a test would require a big change to moveit_resources, but essentially if you have a robot that has multiple planning groups the get_joint_value_target function doesnt seem to correctly fill in the joint values.

this change will retrieve joint values for all active joints in the group.
I'm not sure if it is intended to return all joint values (not just active) but this seemed to be correct imo

also added a `get_joint_state_target` to expose the getJointValueTarget which returns a robot state message