### PR TITLE
fix #786: set robot visible after loading

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -396,6 +396,7 @@ void RobotStateDisplay::update(float wall_dt, float ros_dt)
   {
     loadRobotModel();
     changedRobotStateTopic();
+    robot_->setVisible(true);
   }
 
   calculateOffsetPosition();


### PR DESCRIPTION
This fixes issue #786, that is due to a missing `robot_->setVisible(true)`, which was lost in #607.