### PR TITLE
Remove variable name KinematicConstraint::print() to avoid compilation warning

### DIFF
--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -145,7 +145,7 @@ public:
    *
    * @param [in] out The file descriptor for printing
    */
-  virtual void print(std::ostream& out = std::cout) const
+  virtual void print(std::ostream& = std::cout) const
   {
   }
 


### PR DESCRIPTION
### Description

I removed the variable name in the `KinematicConstraint::print()` member function to avoid a compilation warning when gcc is used with the following flags: `-Wall -Wextra`

I discovered this warning when working on improving https://github.com/ros-industrial-consortium/descartes/pull/223

Example warning (from `descartes`):
```bash
In file included from /home/victor/code/catkin_workspace/src/descartes/descartes_core/include/descartes_core/robot_model.h:23:0,
                 from /home/victor/code/catkin_workspace/src/descartes/descartes_core/include/descartes_core/trajectory_pt.h:33,
                 from /home/victor/code/catkin_workspace/src/descartes/descartes_trajectory/include/descartes_trajectory/trajectory.h:29,
                 from /home/victor/code/catkin_workspace/src/descartes/descartes_trajectory/src/trajectory.cpp:25:
/opt/ros/kinetic/include/moveit/kinematic_constraints/kinematic_constraint.h: In member function ‘virtual void kinematic_constraints::KinematicConstraint::print(std::ostream&) const’:
/opt/ros/kinetic/include/moveit/kinematic_constraints/kinematic_constraint.h:148:47: warning: unused parameter ‘out’ [-Wunused-parameter]
   virtual void print(std::ostream& out = std::cout) const
                                               ^~~~
```

### Checklist
- [x] : Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- I don't know if this should be cherry-picked, you decide :)