### PR TITLE
fix testAbsoluteJointSpaceJump

### DIFF
--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -34,7 +34,6 @@
 
 /* Author: Ioan Sucan */
 #include <moveit_resources/config.h>
-#include <moveit/rdf_loader/rdf_loader.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <urdf_parser/urdf_parser.h>
@@ -215,184 +214,198 @@ TEST(LoadingAndFK, SimpleRobot)
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("base_link").translation(), Eigen::Vector3d(5, 4, 0));
 }
 
-TEST(FK, OneRobot)
+class OneRobot : public testing::Test
 {
-  static const std::string MODEL2 =
-      "<?xml version=\"1.0\" ?>"
-      "<robot name=\"one_robot\">"
-      "<link name=\"base_link\">"
-      "  <inertial>"
-      "    <mass value=\"2.81\"/>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-      "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-      "  </inertial>"
-      "  <collision name=\"my_collision\">"
-      "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </collision>"
-      "  <visual>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </visual>"
-      "</link>"
-      "<joint name=\"joint_a\" type=\"continuous\">"
-      "   <axis xyz=\"0 0 1\"/>"
-      "   <parent link=\"base_link\"/>"
-      "   <child link=\"link_a\"/>"
-      "   <origin rpy=\" 0.0 0 0 \" xyz=\"0.0 0 0 \"/>"
-      "</joint>"
-      "<link name=\"link_a\">"
-      "  <inertial>"
-      "    <mass value=\"1.0\"/>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-      "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-      "  </inertial>"
-      "  <collision>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </collision>"
-      "  <visual>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </visual>"
-      "</link>"
-      "<joint name=\"joint_b\" type=\"fixed\">"
-      "  <parent link=\"link_a\"/>"
-      "  <child link=\"link_b\"/>"
-      "  <origin rpy=\" 0.0 -0.42 0 \" xyz=\"0.0 0.5 0 \"/>"
-      "</joint>"
-      "<link name=\"link_b\">"
-      "  <inertial>"
-      "    <mass value=\"1.0\"/>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-      "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-      "  </inertial>"
-      "  <collision>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </collision>"
-      "  <visual>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </visual>"
-      "</link>"
-      "  <joint name=\"joint_c\" type=\"prismatic\">"
-      "    <axis xyz=\"1 0 0\"/>"
-      "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.09\" velocity=\"0.2\"/>"
-      "    <safety_controller k_position=\"20.0\" k_velocity=\"500.0\" soft_lower_limit=\"0.0\" "
-      "soft_upper_limit=\"0.089\"/>"
-      "    <parent link=\"link_b\"/>"
-      "    <child link=\"link_c\"/>"
-      "    <origin rpy=\" 0.0 0.42 0.0 \" xyz=\"0.0 -0.1 0 \"/>"
-      "  </joint>"
-      "<link name=\"link_c\">"
-      "  <inertial>"
-      "    <mass value=\"1.0\"/>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 .0\"/>"
-      "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-      "  </inertial>"
-      "  <collision>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </collision>"
-      "  <visual>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </visual>"
-      "</link>"
-      "  <joint name=\"mim_f\" type=\"prismatic\">"
-      "    <axis xyz=\"1 0 0\"/>"
-      "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
-      "    <parent link=\"link_c\"/>"
-      "    <child link=\"link_d\"/>"
-      "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
-      "    <mimic joint=\"joint_f\" multiplier=\"1.5\" offset=\"0.1\"/>"
-      "  </joint>"
-      "  <joint name=\"joint_f\" type=\"prismatic\">"
-      "    <axis xyz=\"1 0 0\"/>"
-      "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
-      "    <parent link=\"link_d\"/>"
-      "    <child link=\"link_e\"/>"
-      "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
-      "  </joint>"
-      "<link name=\"link_d\">"
-      "  <collision>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </collision>"
-      "  <visual>"
-      "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </visual>"
-      "</link>"
-      "<link name=\"link_e\">"
-      "  <collision>"
-      "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </collision>"
-      "  <visual>"
-      "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
-      "    <geometry>"
-      "      <box size=\"1 2 1\" />"
-      "    </geometry>"
-      "  </visual>"
-      "</link>"
-      "</robot>";
+protected:
+  virtual void SetUp()
+  {
+    static const std::string MODEL2 =
+        "<?xml version=\"1.0\" ?>"
+        "<robot name=\"one_robot\">"
+        "<link name=\"base_link\">"
+        "  <inertial>"
+        "    <mass value=\"2.81\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision name=\"my_collision\">"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "<joint name=\"joint_a\" type=\"continuous\">"
+        "   <axis xyz=\"0 0 1\"/>"
+        "   <parent link=\"base_link\"/>"
+        "   <child link=\"link_a\"/>"
+        "   <origin rpy=\" 0.0 0 0 \" xyz=\"0.0 0 0 \"/>"
+        "</joint>"
+        "<link name=\"link_a\">"
+        "  <inertial>"
+        "    <mass value=\"1.0\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "<joint name=\"joint_b\" type=\"fixed\">"
+        "  <parent link=\"link_a\"/>"
+        "  <child link=\"link_b\"/>"
+        "  <origin rpy=\" 0.0 -0.42 0 \" xyz=\"0.0 0.5 0 \"/>"
+        "</joint>"
+        "<link name=\"link_b\">"
+        "  <inertial>"
+        "    <mass value=\"1.0\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "  <joint name=\"joint_c\" type=\"prismatic\">"
+        "    <axis xyz=\"1 0 0\"/>"
+        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.09\" velocity=\"0.2\"/>"
+        "    <safety_controller k_position=\"20.0\" k_velocity=\"500.0\" soft_lower_limit=\"0.0\" "
+        "soft_upper_limit=\"0.089\"/>"
+        "    <parent link=\"link_b\"/>"
+        "    <child link=\"link_c\"/>"
+        "    <origin rpy=\" 0.0 0.42 0.0 \" xyz=\"0.0 -0.1 0 \"/>"
+        "  </joint>"
+        "<link name=\"link_c\">"
+        "  <inertial>"
+        "    <mass value=\"1.0\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "  <joint name=\"mim_f\" type=\"prismatic\">"
+        "    <axis xyz=\"1 0 0\"/>"
+        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
+        "    <parent link=\"link_c\"/>"
+        "    <child link=\"link_d\"/>"
+        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
+        "    <mimic joint=\"joint_f\" multiplier=\"1.5\" offset=\"0.1\"/>"
+        "  </joint>"
+        "  <joint name=\"joint_f\" type=\"prismatic\">"
+        "    <axis xyz=\"1 0 0\"/>"
+        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
+        "    <parent link=\"link_d\"/>"
+        "    <child link=\"link_e\"/>"
+        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
+        "  </joint>"
+        "<link name=\"link_d\">"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "<link name=\"link_e\">"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "</robot>";
 
-  static const std::string SMODEL2 =
-      "<?xml version=\"1.0\" ?>"
-      "<robot name=\"one_robot\">"
-      "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"planar\"/>"
-      "<group name=\"base_from_joints\">"
-      "<joint name=\"base_joint\"/>"
-      "<joint name=\"joint_a\"/>"
-      "<joint name=\"joint_c\"/>"
-      "</group>"
-      "<group name=\"mim_joints\">"
-      "<joint name=\"joint_f\"/>"
-      "<joint name=\"mim_f\"/>"
-      "</group>"
-      "<group name=\"base_with_subgroups\">"
-      "<group name=\"base_from_base_to_tip\"/>"
-      "<joint name=\"joint_c\"/>"
-      "</group>"
-      "<group name=\"base_from_base_to_tip\">"
-      "<chain base_link=\"base_link\" tip_link=\"link_b\"/>"
-      "<joint name=\"base_joint\"/>"
-      "</group>"
-      "<group name=\"base_with_bad_subgroups\">"
-      "<group name=\"error\"/>"
-      "</group>"
-      "</robot>";
+    static const std::string SMODEL2 =
+        "<?xml version=\"1.0\" ?>"
+        "<robot name=\"one_robot\">"
+        "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"planar\"/>"
+        "<group name=\"base_from_joints\">"
+        "<joint name=\"base_joint\"/>"
+        "<joint name=\"joint_a\"/>"
+        "<joint name=\"joint_c\"/>"
+        "</group>"
+        "<group name=\"mim_joints\">"
+        "<joint name=\"joint_f\"/>"
+        "<joint name=\"mim_f\"/>"
+        "</group>"
+        "<group name=\"base_with_subgroups\">"
+        "<group name=\"base_from_base_to_tip\"/>"
+        "<joint name=\"joint_c\"/>"
+        "</group>"
+        "<group name=\"base_from_base_to_tip\">"
+        "<chain base_link=\"base_link\" tip_link=\"link_b\"/>"
+        "<joint name=\"base_joint\"/>"
+        "</group>"
+        "<group name=\"base_with_bad_subgroups\">"
+        "<group name=\"error\"/>"
+        "</group>"
+        "</robot>";
 
-  urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(MODEL2);
+    urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(MODEL2);
+    srdf::ModelSharedPtr srdf_model(new srdf::Model());
+    srdf_model->initString(*urdf_model, SMODEL2);
+    robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
+  }
 
-  srdf::ModelSharedPtr srdfModel(new srdf::Model());
-  srdfModel->initString(*urdfModel, SMODEL2);
+  virtual void TearDown()
+  {
+  }
 
-  moveit::core::RobotModelPtr model(new moveit::core::RobotModel(urdfModel, srdfModel));
+protected:
+  moveit::core::RobotModelConstPtr robot_model;
+};
+
+TEST_F(OneRobot, FK)
+{
+  moveit::core::RobotModelConstPtr model = robot_model;
 
   // testing that the two planning groups are the same
   const moveit::core::JointModelGroup* g_one = model->getJointModelGroup("base_from_joints");
@@ -554,29 +567,6 @@ TEST(FK, OneRobot)
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_e").translation(), Eigen::Vector3d(2.8, 0.6, 0));
 }
 
-class LoadPR2 : public testing::Test
-{
-protected:
-  virtual void SetUp()
-  {
-    std::string res_path(MOVEIT_TEST_RESOURCES_DIR);
-
-    urdf_model = urdf::parseURDFFile(res_path + "/pr2_description/urdf/robot.xml");
-    srdf_model.reset(new srdf::Model());
-    srdf_model->initFile(*urdf_model, res_path + "/pr2_description/srdf/robot.xml");
-    robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
-  }
-
-  virtual void TearDown()
-  {
-  }
-
-protected:
-  urdf::ModelInterfaceSharedPtr urdf_model;
-  srdf::ModelSharedPtr srdf_model;
-  moveit::core::RobotModelConstPtr robot_model;
-};
-
 void generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& traj,
                       const moveit::core::RobotModelConstPtr& robot_model,
                       const robot_model::JointModelGroup* joint_model_group)
@@ -593,14 +583,15 @@ void generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& tra
   robot_state.reset(new robot_state::RobotState(*robot_state));
   std::vector<double> joint_positions;
   robot_state->copyJointGroupPositions(joint_model_group, joint_positions);
-  joint_positions[0] -= 1.01;
+  // first joint is planar (3DoF), second joint is revolute
+  joint_positions[3] -= 1.01;
   robot_state->setJointGroupPositions(joint_model_group, joint_positions);
   traj.push_back(robot_state);
 }
 
-TEST_F(LoadPR2, testAbsoluteJointSpaceJump)
+TEST_F(OneRobot, testAbsoluteJointSpaceJump)
 {
-  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("right_arm");
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("base_from_base_to_tip");
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
 
   // direct call of absolute version
@@ -622,9 +613,9 @@ TEST_F(LoadPR2, testAbsoluteJointSpaceJump)
   EXPECT_NEAR(fraction, 4. / 4., 0.01);
 }
 
-TEST_F(LoadPR2, testRelativeJointSpaceJump)
+TEST_F(OneRobot, testRelativeJointSpaceJump)
 {
-  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("right_arm");
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup("base_from_base_to_tip");
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
 
   // direct call of absolute version: factor slightly smaller than 3 (1.01 > 2.99 * 1.01 / 3)


### PR DESCRIPTION
The PR2-based testing for joint-space jumps introduced in #843 by @mlautman depends on `moveit_ros_planning`, which should be avoided in `moveit_core`. Hence, I removed the PR2 stuff again (which is not needed here to test for joint-space jumps).
Additionally, I hopefully improved code readability in `testAbsoluteJointSpaceJump`.

**This fixes the broken ros build farm**:
http://build.ros.org/job/Kdev__moveit__ubuntu_xenial_amd64/261/consoleFull#console-section-16