### PR TITLE
Expose the getJointValueTarget c++ method in python wrapper

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -596,6 +596,7 @@ static void wrap_move_group_interface()
                               &MoveGroupInterfaceWrapper::setJointValueTargetFromJointStatePython);
 
   MoveGroupInterfaceClass.def("get_joint_value_target", &MoveGroupInterfaceWrapper::getJointValueTargetPythonList);
+  MoveGroupInterfaceClass.def("get_joint_state_target", &MoveGroupInterfaceWrapper::getJointValueTarget);
 
   MoveGroupInterfaceClass.def("set_named_target", &MoveGroupInterfaceWrapper::setNamedTarget);
   MoveGroupInterfaceClass.def("set_random_target", &MoveGroupInterfaceWrapper::setRandomTarget);


### PR DESCRIPTION
Enables user to gain access to calling the `getJointValueTarget` as defined from python wrapper
while waiting for #845 