### PR TITLE
improve [get|set]JointValueTarget in python wrapper

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -385,7 +385,7 @@ public:
 
       If these values are out of bounds then false is returned BUT THE VALUES
       ARE STILL SET AS THE GOAL. */
-  MOVEIT_DEPRECATED bool setJointValueTarget(const robot_state::RobotState& robot_state);
+  bool setJointValueTarget(const robot_state::RobotState& robot_state);
 
   /** \brief Set the JointValueTarget and use it for future planning requests.
 

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -368,7 +368,7 @@ public:
 
       If these values are out of bounds then false is returned BUT THE VALUES
       ARE STILL SET AS THE GOAL. */
-  bool setJointValueTarget(const robot_state::RobotState& robot_state);
+  MOVEIT_DEPRECATED bool setJointValueTarget(const robot_state::RobotState& robot_state);
 
   /** \brief Set the JointValueTarget and use it for future planning requests.
 
@@ -406,7 +406,7 @@ public:
 
       If these values are out of bounds then false is returned BUT THE VALUES
       ARE STILL SET AS THE GOAL. */
-  bool setJointValueTarget(const sensor_msgs::JointState& state);
+  MOVEIT_DEPRECATED bool setJointValueTarget(const sensor_msgs::JointState& state);
 
   /** \brief Set the joint state goal for a particular joint by computing IK.
 

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -330,9 +330,8 @@ public:
 
   /** \brief Set the JointValueTarget and use it for future planning requests.
 
-      \e group_variable_values MUST contain exactly one value per joint
-      variable in the same order as returned by
-      getJointValueTarget().getJointModelGroup(getName())->getVariableNames().
+      \e group_variable_values MUST exactly match the variable order as returned by
+      getJointValueTarget(std::vector<double>&).
 
       This always sets all of the group's joint values.
 
@@ -494,6 +493,9 @@ public:
   /** \brief Set the current joint values to be ones previously remembered by rememberJointValues() or, if not found,
       that are specified in the SRDF under the name \e name as a group state*/
   bool setNamedTarget(const std::string& name);
+
+  /** \brief Get the current joint state goal in a form compatible to setJointValueTarget() */
+  void getJointValueTarget(std::vector<double>& group_variable_values) const;
 
   /// Get the currently set joint state goal
   const robot_state::RobotState& getJointValueTarget() const;

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -497,8 +497,8 @@ public:
   /** \brief Get the current joint state goal in a form compatible to setJointValueTarget() */
   void getJointValueTarget(std::vector<double>& group_variable_values) const;
 
-  /// Get the currently set joint state goal
-  const robot_state::RobotState& getJointValueTarget() const;
+  /// Get the currently set joint state goal, replaced by private getTargetRobotState()
+  MOVEIT_DEPRECATED const robot_state::RobotState& getJointValueTarget() const;
 
   /**@}*/
 
@@ -931,6 +931,10 @@ public:
   void clearTrajectoryConstraints();
 
   /**@}*/
+
+protected:
+  /** return the full RobotState of the joint-space target, only for internal use */
+  const robot_state::RobotState& getTargetRobotState() const;
 
 private:
   std::map<std::string, std::vector<double> > remembered_joint_values_;

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -361,6 +361,23 @@ public:
 
   /** \brief Set the JointValueTarget and use it for future planning requests.
 
+      \e variable_names are variable joint names and variable_values are
+      variable joint positions. Joints in the group are used to set the
+      JointValueTarget.  Joints in the model but not in the group are ignored.
+      An exception is thrown if a joint name is not found in the model.
+      Joint variables in the group that are missing from \e variable_names
+      remain unchanged (to reset all target variables to their current values
+      in the robot use setJointValueTarget(getCurrentJointValues())).
+
+      After this call, the JointValueTarget is used \b instead of any
+      previously set Position, Orientation, or Pose targets.
+
+      If these values are out of bounds then false is returned BUT THE VALUES
+      ARE STILL SET AS THE GOAL. */
+  bool setJointValueTarget(const std::vector<std::string>& variable_names, const std::vector<double>& variable_values);
+
+  /** \brief Set the JointValueTarget and use it for future planning requests.
+
       The target for all joints in the group are set to the value in \e robot_state.
 
       After this call, the JointValueTarget is used \b instead of any
@@ -406,7 +423,7 @@ public:
 
       If these values are out of bounds then false is returned BUT THE VALUES
       ARE STILL SET AS THE GOAL. */
-  MOVEIT_DEPRECATED bool setJointValueTarget(const sensor_msgs::JointState& state);
+  bool setJointValueTarget(const sensor_msgs::JointState& state);
 
   /** \brief Set the joint state goal for a particular joint by computing IK.
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1603,6 +1603,12 @@ bool moveit::planning_interface::MoveGroupInterface::setNamedTarget(const std::s
   }
 }
 
+void moveit::planning_interface::MoveGroupInterface::getJointValueTarget(
+    std::vector<double>& group_variable_values) const
+{
+  impl_->getJointStateTarget().copyJointGroupPositions(impl_->getJointModelGroup(), group_variable_values);
+}
+
 bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const std::vector<double>& joint_values)
 {
   if (joint_values.size() != impl_->getJointModelGroup()->getVariableCount())

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1702,6 +1702,11 @@ const robot_state::RobotState& moveit::planning_interface::MoveGroupInterface::g
   return impl_->getJointStateTarget();
 }
 
+const robot_state::RobotState& moveit::planning_interface::MoveGroupInterface::getTargetRobotState() const
+{
+  return impl_->getJointStateTarget();
+}
+
 const std::string& moveit::planning_interface::MoveGroupInterface::getEndEffectorLink() const
 {
   return impl_->getEndEffectorLink();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1639,6 +1639,7 @@ bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(
 
 bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const robot_state::RobotState& rstate)
 {
+  ROS_WARN("Use of setJointValueTarget(RobotState) is deprecated!");
   impl_->setTargetType(JOINT);
   impl_->getTargetRobotState() = rstate;
   return impl_->getTargetRobotState().satisfiesBounds(impl_->getGoalJointTolerance());
@@ -1667,6 +1668,7 @@ bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const s
 
 bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const sensor_msgs::JointState& state)
 {
+  ROS_WARN("Use of setJointValueTarget(JointState) is deprecated!");
   impl_->setTargetType(JOINT);
   impl_->getTargetRobotState().setVariableValues(state);
   return impl_->getTargetRobotState().satisfiesBounds(impl_->getGoalJointTolerance());

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -123,10 +123,11 @@ public:
 
   bp::list getJointValueTargetPythonList()
   {
-    const robot_state::RobotState& values = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
+    std::vector<double> values;
+    MoveGroupInterface::getJointValueTarget(values);
     bp::list l;
-    for (const double *it = values.getVariablePositions(), *end = it + getVariableCount(); it != end; ++it)
-      l.append(*it);
+    for (const double value : values)
+      l.append(value);
     return l;
   }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -112,15 +112,6 @@ public:
     return setJointValueTarget(js_msg);
   }
 
-  bool setStateValueTarget(const std::string& state_str)
-  {
-    moveit_msgs::RobotState msg;
-    py_bindings_tools::deserializeMsg(state_str, msg);
-    robot_state::RobotState state(moveit::planning_interface::MoveGroupInterface::getTargetRobotState());
-    moveit::core::robotStateMsgToRobotState(msg, state);
-    return moveit::planning_interface::MoveGroupInterface::setJointValueTarget(state);
-  }
-
   bp::list getJointValueTargetPythonList()
   {
     std::vector<double> values;
@@ -586,7 +577,6 @@ static void wrap_move_group_interface()
   bool (MoveGroupInterfaceWrapper::*set_joint_value_target_4)(const std::string&, double) =
       &MoveGroupInterfaceWrapper::setJointValueTarget;
   move_group_interface_class.def("set_joint_value_target", set_joint_value_target_4);
-  move_group_interface_class.def("set_state_value_target", &MoveGroupInterfaceWrapper::setStateValueTarget);
 
   move_group_interface_class.def("set_joint_value_target_from_pose",
                                  &MoveGroupInterfaceWrapper::setJointValueTargetFromPosePython);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -116,7 +116,7 @@ public:
   {
     moveit_msgs::RobotState msg;
     py_bindings_tools::deserializeMsg(state_str, msg);
-    robot_state::RobotState state(moveit::planning_interface::MoveGroupInterface::getJointValueTarget());
+    robot_state::RobotState state(moveit::planning_interface::MoveGroupInterface::getTargetRobotState());
     moveit::core::robotStateMsgToRobotState(msg, state);
     return moveit::planning_interface::MoveGroupInterface::setJointValueTarget(state);
   }
@@ -134,7 +134,7 @@ public:
   std::string getJointValueTarget()
   {
     moveit_msgs::RobotState msg;
-    const robot_state::RobotState state = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
+    const robot_state::RobotState state = moveit::planning_interface::MoveGroupInterface::getTargetRobotState();
     moveit::core::robotStateToRobotStateMsg(state, msg);
     return py_bindings_tools::serializeMsg(msg);
   }


### PR DESCRIPTION
As pointed out in #845, the signature and semantics of `getJointValueTarget()` doesn't match the one of the corresponding setter, which renders both functions rather useless. As I pointed out in https://github.com/ros-planning/moveit/pull/845#issuecomment-382644155 a proper solution of this issue, should consider: 

- Add a new method `MoveGroupInterface::getJointValueTarget(std::vector<double>&)` that matches the corresponding `setJointValueTarget(const std::vector<double>&)` method and should use `RobotState::copyJointGroupPositions(const JointModelGroup*, std::vector<double>&)` to do so.
- Depreacate the old method `MoveGroupInterface::getJointValueTarget()`
(currently returning the full `RobotState`) and 
- Instead add a better-named method `MoveGroupInterface::getJointStateTarget()` to correctly reflect the semantics of returning the full robot state.
- To make the difference even clearer, one could think about renaming the getter to `getTargetRobotState()`, both in `MoveGroupInterface` and `MoveGroupInterfaceImpl`.
- Deprecate the dangerous functions `setJointValueTarget(const robot_state::RobotState&)` and `setJointValueTarget(const sensor_msgs::JointState&)`, which allow to set joint values that are not member of the `JointModelGroup`.

This PR considers all of them as well as a sanity check in some other joint setters.