### PR TITLE
Fix and Test for #842

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -57,9 +57,9 @@ except:
 class PlanningSceneInterface(object):
     """ Simple interface to making updates to a planning scene """
 
-    def __init__(self):
+    def __init__(self, ns=''):
         """ Create a planning scene interface; it uses both C++ wrapped methods and scene manipulation topics. """
-        self._psi = _moveit_planning_scene_interface.PlanningSceneInterface()
+        self._psi = _moveit_planning_scene_interface.PlanningSceneInterface(ns)
 
         self._pub_co = rospy.Publisher('/collision_object', CollisionObject, queue_size=100)
         self._pub_aco = rospy.Publisher('/attached_collision_object', AttachedCollisionObject, queue_size=100)

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -40,7 +40,7 @@ import rospy
 import rostest
 import os
 
-from moveit_commander import RobotCommander
+from moveit_commander import RobotCommander, PlanningSceneInterface
 
 
 class PythonMoveitCommanderTest(unittest.TestCase):
@@ -91,6 +91,8 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         plan3 = self.plan(current)
         self.assertTrue(self.group.execute(plan3))
 
+    def test_planning_scene_interface(self):
+        planning_scene = PlanningSceneInterface()
 
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'


### PR DESCRIPTION
### Description

Fixes an interface change on the C++ side of PlanningSceneInterface that was not changed on the python side. Adds a test that fails without this change.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] ~Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)~
- [x] ~Include a screenshot if changing a GUI~
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
