### PR TITLE
bugfix for chomp fixed base joint bug

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -204,7 +204,11 @@ void ChompOptimizer::initialize()
   for (size_t i = 0; i < joint_model_group_->getFixedJointModels().size(); i++)
   {
     const moveit::core::JointModel* model = joint_model_group_->getFixedJointModels()[i];
-    fixed_link_resolution_map[model->getName()] = model->getParentLinkModel()->getParentJointModel()->getName();
+    // In case this is the base joint (eg: a fixed virtual_joint) then we need to check for NULL
+    if (model->getParentLinkModel())
+    {
+      fixed_link_resolution_map[model->getName()] = model->getParentLinkModel()->getParentJointModel()->getName();
+    }
   }
 
   // TODO - is this just the joint_roots_?

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -201,14 +201,12 @@ void ChompOptimizer::initialize()
     fixed_link_resolution_map[joint_names_[i]] = joint_names_[i];
   }
 
-  for (size_t i = 0; i < joint_model_group_->getFixedJointModels().size(); i++)
+  for (const moveit::core::JointModel* jm : joint_model_group_->getFixedJointModels())
   {
-    const moveit::core::JointModel* model = joint_model_group_->getFixedJointModels()[i];
-    // In case this is the base joint (eg: a fixed virtual_joint) then we need to check for NULL
-    if (model->getParentLinkModel())
-    {
-      fixed_link_resolution_map[model->getName()] = model->getParentLinkModel()->getParentJointModel()->getName();
-    }
+    if (!jm->getParentLinkModel())  // root joint doesn't have a parent
+      continue;
+
+    fixed_link_resolution_map[jm->getName()] = jm->getParentLinkModel()->getParentJointModel()->getName();
   }
 
   // TODO - is this just the joint_roots_?


### PR DESCRIPTION
### Description

This fixes an issue where where the chomp optimizer was requesting the parent joint of a fixed base joint without checking for Null [moveit_tutorials #164](https://github.com/ros-planning/moveit_tutorials/issues/164)

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
