### PR TITLE
improve travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: required
 dist: trusty
 services:
   - docker
-language: generic
+language: cpp
 cache: ccache
-compiler:
-  - gcc
+compiler: gcc
+
 notifications:
   email:
     recipients:
@@ -22,4 +22,4 @@ env:
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:
-  - source .moveit_ci/travis.sh
+  - .moveit_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   matrix:
+    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
-    - ROS_DISTRO=kinetic TEST=clang-format         UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=lunar   ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=lunar   ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
-    - ROS_DISTRO=lunar   TEST=clang-format         UPSTREAM_WORKSPACE=moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:


### PR DESCRIPTION
* Finally get ccache working for Travis, which dramatically reduces compile time (8-10min vs 40-50min):
  https://travis-ci.org/ros-planning/moveit/builds/372196233
* Perform a single clang-format check only.
* ~~No need to specify ROS distro for clang-format~~
~~This depends on https://github.com/ros-planning/moveit_ci/pull/33.~~
