### PR TITLE
[Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -42,6 +42,7 @@ COMPONENTS
   random_numbers
   roslib
   rostime
+  rosconsole
   sensor_msgs
   shape_msgs
   srdfdom

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -12,8 +12,6 @@ endif()
 
 find_package(Boost REQUIRED system filesystem date_time thread iostreams)
 
-find_package(console_bridge REQUIRED)
-
 find_package(Eigen3 REQUIRED)
 
 # Eigen 3.2 (Wily) only provides EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
@@ -130,7 +128,6 @@ catkin_package(
     EIGEN3
     LIBFCL
     OCTOMAP
-    console_bridge
     urdfdom
     urdfdom_headers
     )
@@ -143,7 +140,6 @@ include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${VERSION_FILE_PATH}
                     ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
-                    ${console_bridge_INCLUDE_DIRS}
                     ${urdfdom_INCLUDE_DIRS}
                     ${urdfdom_headers_INCLUDE_DIRS}
                     ${OCTOMAP_INCLUDE_DIRS}

--- a/moveit_core/background_processing/CMakeLists.txt
+++ b/moveit_core/background_processing/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_background_processing)
 add_library(${MOVEIT_LIB_NAME} src/background_processing.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/background_processing/background_processing.h>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 
 moveit::tools::BackgroundProcessing::BackgroundProcessing()
 {
@@ -73,13 +73,14 @@ void moveit::tools::BackgroundProcessing::processingThread()
       action_lock_.unlock();
       try
       {
-        CONSOLE_BRIDGE_logDebug("moveit.background: Begin executing '%s'", action_name.c_str());
+        ROS_DEBUG_NAMED("background_processing", "moveit.background: Begin executing '%s'", action_name.c_str());
         fn();
-        CONSOLE_BRIDGE_logDebug("moveit.background: Done executing '%s'", action_name.c_str());
+        ROS_DEBUG_NAMED("background_processing", "moveit.background: Done executing '%s'", action_name.c_str());
       }
       catch (std::exception& ex)
       {
-        CONSOLE_BRIDGE_logError("Exception caught while processing action '%s': %s", action_name.c_str(), ex.what());
+        ROS_ERROR_NAMED("background_processing", "Exception caught while processing action '%s': %s",
+                        action_name.c_str(), ex.what());
       }
       processing_ = false;
       if (queue_change_event_)

--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -73,9 +73,9 @@ void moveit::tools::BackgroundProcessing::processingThread()
       action_lock_.unlock();
       try
       {
-        ROS_DEBUG_NAMED("background_processing", "moveit.background: Begin executing '%s'", action_name.c_str());
+        ROS_DEBUG_NAMED("background_processing", "Begin executing '%s'", action_name.c_str());
         fn();
-        ROS_DEBUG_NAMED("background_processing", "moveit.background: Done executing '%s'", action_name.c_str());
+        ROS_DEBUG_NAMED("background_processing", "Done executing '%s'", action_name.c_str());
       }
       catch (std::exception& ex)
       {

--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -13,16 +13,16 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 # unit tests
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_world test/test_world.cpp)
-  target_link_libraries(test_world ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+  target_link_libraries(test_world ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
   catkin_add_gtest(test_world_diff test/test_world_diff.cpp)
-  target_link_libraries(test_world_diff ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+  target_link_libraries(test_world_diff ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -44,7 +44,6 @@
 #include <map>
 #include <set>
 #include <Eigen/Core>
-#include <console_bridge/console.h>
 #include <moveit/robot_model/robot_model.h>
 
 namespace collision_detection

--- a/moveit_core/collision_detection/src/allvalid/collision_robot_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_robot_allvalid.cpp
@@ -51,7 +51,7 @@ void collision_detection::CollisionRobotAllValid::checkSelfCollision(const Colli
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
@@ -60,7 +60,7 @@ void collision_detection::CollisionRobotAllValid::checkSelfCollision(const Colli
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
@@ -69,7 +69,7 @@ void collision_detection::CollisionRobotAllValid::checkSelfCollision(const Colli
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
@@ -79,7 +79,7 @@ void collision_detection::CollisionRobotAllValid::checkSelfCollision(const Colli
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -89,7 +89,7 @@ void collision_detection::CollisionRobotAllValid::checkOtherCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -100,7 +100,7 @@ void collision_detection::CollisionRobotAllValid::checkOtherCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -112,7 +112,7 @@ void collision_detection::CollisionRobotAllValid::checkOtherCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionRobotAllValid::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -125,7 +125,7 @@ void collision_detection::CollisionRobotAllValid::checkOtherCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 double collision_detection::CollisionRobotAllValid::distanceSelf(const robot_state::RobotState& state) const

--- a/moveit_core/collision_detection/src/allvalid/collision_world_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_world_allvalid.cpp
@@ -55,7 +55,7 @@ void collision_detection::CollisionWorldAllValid::checkRobotCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionWorldAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -65,7 +65,7 @@ void collision_detection::CollisionWorldAllValid::checkRobotCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionWorldAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -75,7 +75,7 @@ void collision_detection::CollisionWorldAllValid::checkRobotCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionWorldAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -86,7 +86,7 @@ void collision_detection::CollisionWorldAllValid::checkRobotCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionWorldAllValid::checkWorldCollision(const CollisionRequest& req, CollisionResult& res,
@@ -94,7 +94,7 @@ void collision_detection::CollisionWorldAllValid::checkWorldCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 void collision_detection::CollisionWorldAllValid::checkWorldCollision(const CollisionRequest& req, CollisionResult& res,
@@ -103,7 +103,7 @@ void collision_detection::CollisionWorldAllValid::checkWorldCollision(const Coll
 {
   res.collision = false;
   if (req.verbose)
-    CONSOLE_BRIDGE_logInform("Using AllValid collision detection. No collision checking is performed.");
+    ROS_INFO_NAMED("collision_detection", "Using AllValid collision detection. No collision checking is performed.");
 }
 
 double collision_detection::CollisionWorldAllValid::distanceRobot(const CollisionRobot& robot,

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -53,9 +53,8 @@ collision_detection::AllowedCollisionMatrix::AllowedCollisionMatrix(const moveit
 {
   if (msg.entry_names.size() != msg.entry_values.size() ||
       msg.default_entry_names.size() != msg.default_entry_values.size())
-    ROS_ERROR_NAMED("collision_detection",
-                    "The number of links does not match the number of entries in AllowedCollisionMatrix "
-                    "message");
+    ROS_ERROR_NAMED("collision_detection", "The number of links does not match the number of entries "
+                                           "in AllowedCollisionMatrix message");
   else
   {
     for (std::size_t i = 0; i < msg.entry_names.size(); ++i)

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -53,14 +53,16 @@ collision_detection::AllowedCollisionMatrix::AllowedCollisionMatrix(const moveit
 {
   if (msg.entry_names.size() != msg.entry_values.size() ||
       msg.default_entry_names.size() != msg.default_entry_values.size())
-    CONSOLE_BRIDGE_logError("The number of links does not match the number of entries in AllowedCollisionMatrix "
-                            "message");
+    ROS_ERROR_NAMED("collision_detection",
+                    "The number of links does not match the number of entries in AllowedCollisionMatrix "
+                    "message");
   else
   {
     for (std::size_t i = 0; i < msg.entry_names.size(); ++i)
       if (msg.entry_values[i].enabled.size() != msg.entry_names.size())
-        CONSOLE_BRIDGE_logError("Number of entries is incorrect for link '%s' in AllowedCollisionMatrix message",
-                                msg.entry_names[i].c_str());
+        ROS_ERROR_NAMED("collision_detection",
+                        "Number of entries is incorrect for link '%s' in AllowedCollisionMatrix message",
+                        msg.entry_names[i].c_str());
       else
         for (std::size_t j = i + 1; j < msg.entry_values[i].enabled.size(); ++j)
           setEntry(msg.entry_names[i], msg.entry_names[j], msg.entry_values[i].enabled[j]);

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -64,12 +64,12 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
 {
   if (!object)
   {
-    CONSOLE_BRIDGE_logError("No valid Object passed in, cannot refine Normals!");
+    ROS_ERROR_NAMED("collision_detection", "No valid Object passed in, cannot refine Normals!");
     return 0;
   }
   if (res.contact_count < 1)
   {
-    CONSOLE_BRIDGE_logWarn("There do not appear to be any contacts, so there is nothing to refine!");
+    ROS_WARN_NAMED("collision_detection", "There do not appear to be any contacts, so there is nothing to refine!");
     return 0;
   }
 
@@ -125,15 +125,17 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
             {
               count++;
               node_centers.push_back(pt);
-              // CONSOLE_BRIDGE_logInform("Adding point %d with prob %.3f at [%.3f, %.3f, %.3f]",
+              // ROS_INFO_NAMED("collision_detection", "Adding point %d with prob %.3f at [%.3f, %.3f, %.3f]",
               //                          count, prob, pt.x(), pt.y(), pt.z());
             }
           }
-          // CONSOLE_BRIDGE_logInform("Contact point at [%.3f, %.3f, %.3f], cell size %.3f, occupied cells %d",
+          // ROS_INFO_NAMED("collision_detection", "Contact point at [%.3f, %.3f, %.3f], cell size %.3f, occupied cells
+          // %d",
           //                          contact_point.x(), contact_point.y(), contact_point.z(), cell_size, count);
 
           // octree->getOccupiedLeafsBBX(node_centers, bbx_min, bbx_max);
-          // CONSOLE_BRIDGE_logError("bad stuff in collision_octomap_filter.cpp; need to port octomap call for groovy");
+          // ROS_ERROR_NAMED("collision_detection", "bad stuff in collision_octomap_filter.cpp; need to port octomap
+          // call for groovy");
 
           octomath::Vector3 n;
           double depth;
@@ -145,7 +147,8 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
             if (divergence > allowed_angle_divergence)
             {
               modified++;
-              // CONSOLE_BRIDGE_logInform("Normals differ by %.3f, changing: [%.3f, %.3f, %.3f] -> [%.3f, %.3f, %.3f]",
+              // ROS_INFO_NAMED("collision_detection", "Normals differ by %.3f, changing: [%.3f, %.3f, %.3f] -> [%.3f,
+              // %.3f, %.3f]",
               //                          divergence, contact_normal.x(), contact_normal.y(), contact_normal.z(),
               //                          n.x(), n.y(), n.z());
               contact_info.normal = Eigen::Vector3d(n.x(), n.y(), n.z());
@@ -266,7 +269,7 @@ bool sampleCloud(const octomap::point3d_list& cloud, const double& spacing, cons
     }
     else
     {
-      CONSOLE_BRIDGE_logError("This should not be called!");
+      ROS_ERROR_NAMED("collision_detection", "This should not be called!");
     }
 
     double f_val = 0;
@@ -292,7 +295,7 @@ bool sampleCloud(const octomap::point3d_list& cloud, const double& spacing, cons
     }
     else
     {
-      CONSOLE_BRIDGE_logError("This should not be called!");
+      ROS_ERROR_NAMED("collision_detection", "This should not be called!");
       double r_scaled = r / R;
       // TODO still need to address the scaling...
       f_val = pow((1 - r_scaled), 4) * (4 * r_scaled + 1);

--- a/moveit_core/collision_detection/src/collision_robot.cpp
+++ b/moveit_core/collision_detection/src/collision_robot.cpp
@@ -41,12 +41,12 @@ static inline bool validateScale(double scale)
 {
   if (scale < std::numeric_limits<double>::epsilon())
   {
-    CONSOLE_BRIDGE_logError("Scale must be positive");
+    ROS_ERROR_NAMED("collision_detection", "Scale must be positive");
     return false;
   }
   if (scale > std::numeric_limits<double>::max())
   {
-    CONSOLE_BRIDGE_logError("Scale must be finite");
+    ROS_ERROR_NAMED("collision_detection", "Scale must be finite");
     return false;
   }
   return true;
@@ -56,12 +56,12 @@ static inline bool validatePadding(double padding)
 {
   if (padding < 0.0)
   {
-    CONSOLE_BRIDGE_logError("Padding cannot be negative");
+    ROS_ERROR_NAMED("collision_detection", "Padding cannot be negative");
     return false;
   }
   if (padding > std::numeric_limits<double>::max())
   {
-    CONSOLE_BRIDGE_logError("Padding must be finite");
+    ROS_ERROR_NAMED("collision_detection", "Padding must be finite");
     return false;
   }
   return true;

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -64,9 +64,8 @@ void collision_detection::World::addToObject(const std::string& id, const std::v
 {
   if (shapes.size() != poses.size())
   {
-    ROS_ERROR_NAMED("collision_detection",
-                    "Number of shapes and number of poses do not match. Not adding this object to collision "
-                    "world.");
+    ROS_ERROR_NAMED("collision_detection", "Number of shapes and number of poses do not match. "
+                                           "Not adding this object to collision world.");
     return;
   }
 

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -35,7 +35,7 @@
 /* Author: Acorn Pooley, Ioan Sucan */
 
 #include <moveit/collision_detection/world.h>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 
 collision_detection::World::World()
 {
@@ -64,8 +64,9 @@ void collision_detection::World::addToObject(const std::string& id, const std::v
 {
   if (shapes.size() != poses.size())
   {
-    CONSOLE_BRIDGE_logError("Number of shapes and number of poses do not match. Not adding this object to collision "
-                            "world.");
+    ROS_ERROR_NAMED("collision_detection",
+                    "Number of shapes and number of poses do not match. Not adding this object to collision "
+                    "world.");
     return;
   }
 

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -88,16 +88,17 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       {
         always_allow_collision = true;
         if (cdata->req_->verbose)
-          CONSOLE_BRIDGE_logDebug(
-              "Collision between '%s' (type '%s') and '%s' (type '%s') is always allowed. No contacts are computed.",
-              cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(), cd2->getTypeString().c_str());
+          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision between '%s' (type '%s') and '%s' (type '%s') is "
+                                                     "always allowed. No contacts are computed.",
+                          cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
+                          cd2->getTypeString().c_str());
       }
       else if (type == AllowedCollision::CONDITIONAL)
       {
         cdata->acm_->getAllowedCollision(cd1->getID(), cd2->getID(), dcf);
         if (cdata->req_->verbose)
-          CONSOLE_BRIDGE_logDebug("Collision between '%s' and '%s' is conditionally allowed", cd1->getID().c_str(),
-                                  cd2->getID().c_str());
+          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision between '%s' and '%s' is conditionally allowed",
+                          cd1->getID().c_str(), cd2->getID().c_str());
       }
     }
   }
@@ -110,8 +111,9 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     {
       always_allow_collision = true;
       if (cdata->req_->verbose)
-        CONSOLE_BRIDGE_logDebug("Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
-                                cd1->getID().c_str(), cd2->getID().c_str());
+        ROS_DEBUG_NAMED("collision_detection_fcl",
+                        "Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
+                        cd1->getID().c_str(), cd2->getID().c_str());
     }
   }
   else if (cd2->type == BodyTypes::ROBOT_LINK && cd1->type == BodyTypes::ROBOT_ATTACHED)
@@ -121,8 +123,9 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     {
       always_allow_collision = true;
       if (cdata->req_->verbose)
-        CONSOLE_BRIDGE_logDebug("Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
-                                cd2->getID().c_str(), cd1->getID().c_str());
+        ROS_DEBUG_NAMED("collision_detection_fcl",
+                        "Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
+                        cd2->getID().c_str(), cd1->getID().c_str());
     }
   }
   // bodies attached to the same link should not collide
@@ -137,8 +140,8 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     return false;
 
   if (cdata->req_->verbose)
-    CONSOLE_BRIDGE_logDebug("Actually checking collisions between %s and %s", cd1->getID().c_str(),
-                            cd2->getID().c_str());
+    ROS_DEBUG_NAMED("collision_detection_fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
+                    cd2->getID().c_str());
 
   // see if we need to compute a contact
   std::size_t want_contact_count = 0;
@@ -174,9 +177,10 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     if (num_contacts > 0)
     {
       if (cdata->req_->verbose)
-        CONSOLE_BRIDGE_logInform("Found %d contacts between '%s' and '%s'. These contacts will be evaluated to check "
-                                 "if they are accepted or not",
-                                 num_contacts, cd1->getID().c_str(), cd2->getID().c_str());
+        ROS_INFO_NAMED("collision_detection_fcl",
+                       "Found %d contacts between '%s' and '%s'. These contacts will be evaluated to "
+                       "check if they are accepted or not",
+                       num_contacts, cd1->getID().c_str(), cd2->getID().c_str());
       Contact c;
       const std::pair<std::string, std::string>& pc = cd1->getID() < cd2->getID() ?
                                                           std::make_pair(cd1->getID(), cd2->getID()) :
@@ -194,13 +198,15 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
             cdata->res_->contacts[pc].push_back(c);
             cdata->res_->contact_count++;
             if (cdata->req_->verbose)
-              CONSOLE_BRIDGE_logInform("Found unacceptable contact between '%s' and '%s'. Contact was stored.",
-                                       cd1->getID().c_str(), cd2->getID().c_str());
+              ROS_INFO_NAMED("collision_detection_fcl",
+                             "Found unacceptable contact between '%s' and '%s'. Contact was stored.",
+                             cd1->getID().c_str(), cd2->getID().c_str());
           }
           else if (cdata->req_->verbose)
-            CONSOLE_BRIDGE_logInform(
-                "Found unacceptable contact between '%s' (type '%s') and '%s' (type '%s'). Contact was stored.",
-                cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(), cd2->getTypeString().c_str());
+            ROS_INFO_NAMED("collision_detection_fcl", "Found unacceptable contact between '%s' (type '%s') and '%s' "
+                                                      "(type '%s'). Contact was stored.",
+                           cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
+                           cd2->getTypeString().c_str());
           cdata->res_->collision = true;
           if (want_contact_count == 0)
             break;
@@ -250,10 +256,10 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
         }
 
         if (cdata->req_->verbose)
-          CONSOLE_BRIDGE_logInform("Found %d contacts between '%s' (type '%s') and '%s' (type '%s'), which constitute "
-                                   "a collision. %d contacts will be stored",
-                                   num_contacts_initial, cd1->getID().c_str(), cd1->getTypeString().c_str(),
-                                   cd2->getID().c_str(), cd2->getTypeString().c_str(), num_contacts);
+          ROS_INFO_NAMED("collision_detection_fcl", "Found %d contacts between '%s' (type '%s') and '%s' (type '%s'), "
+                                                    "which constitute a collision. %d contacts will be stored",
+                         num_contacts_initial, cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
+                         cd2->getTypeString().c_str(), num_contacts);
 
         const std::pair<std::string, std::string>& pc = cd1->getID() < cd2->getID() ?
                                                             std::make_pair(cd1->getID(), cd2->getID()) :
@@ -295,10 +301,11 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       {
         cdata->res_->collision = true;
         if (cdata->req_->verbose)
-          CONSOLE_BRIDGE_logInform(
-              "Found a contact between '%s' (type '%s') and '%s' (type '%s'), which constitutes a collision. "
-              "Contact information is not stored.",
-              cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(), cd2->getTypeString().c_str());
+          ROS_INFO_NAMED("collision_detection_fcl", "Found a contact between '%s' (type '%s') and '%s' (type '%s'), "
+                                                    "which constitutes a collision. "
+                                                    "Contact information is not stored.",
+                         cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
+                         cd2->getTypeString().c_str());
       }
 
       if (enable_cost)
@@ -324,19 +331,20 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       if (!cdata->req_->cost)
         cdata->done_ = true;
       if (cdata->req_->verbose)
-        CONSOLE_BRIDGE_logInform("Collision checking is considered complete (collision was found and %u contacts are "
-                                 "stored)",
-                                 (unsigned int)cdata->res_->contact_count);
+        ROS_INFO_NAMED("collision_detection_fcl",
+                       "Collision checking is considered complete (collision was found and %u "
+                       "contacts are stored)",
+                       (unsigned int)cdata->res_->contact_count);
     }
 
   if (!cdata->done_ && cdata->req_->is_done)
   {
     cdata->done_ = cdata->req_->is_done(*cdata->res_);
     if (cdata->done_ && cdata->req_->verbose)
-      CONSOLE_BRIDGE_logInform(
-          "Collision checking is considered complete due to external callback. %s was found. %u contacts are "
-          "stored.",
-          cdata->res_->collision ? "Collision" : "No collision", (unsigned int)cdata->res_->contact_count);
+      ROS_INFO_NAMED("collision_detection_fcl", "Collision checking is considered complete due to external callback. "
+                                                "%s was found. %u contacts are "
+                                                "stored.",
+                     cdata->res_->collision ? "Collision" : "No collision", (unsigned int)cdata->res_->contact_count);
   }
 
   return cdata->done_;
@@ -368,7 +376,8 @@ struct FCLShapeCache
           map_.erase(it);
         it = nit;
       }
-      //      CONSOLE_BRIDGE_logDebug("Cleaning up cache for FCL objects that correspond to static shapes. Cache size
+      //      ROS_DEBUG_NAMED("collision_detection_fcl", "Cleaning up cache for FCL objects that correspond to static
+      //      shapes. Cache size
       //      reduced from %u
       //      to %u", from, (unsigned int)map_.size());
     }
@@ -426,8 +435,9 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         always_allow_collision = true;
         if (cdata->req->verbose)
-          CONSOLE_BRIDGE_logDebug("Collision between '%s' and '%s' is always allowed. No distances are computed.",
-                                  cd1->getID().c_str(), cd2->getID().c_str());
+          ROS_DEBUG_NAMED("collision_detection_fcl",
+                          "Collision between '%s' and '%s' is always allowed. No distances are computed.",
+                          cd1->getID().c_str(), cd2->getID().c_str());
       }
     }
   }
@@ -440,8 +450,9 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     {
       always_allow_collision = true;
       if (cdata->req->verbose)
-        CONSOLE_BRIDGE_logDebug("Robot link '%s' is allowed to touch attached object '%s'. No distances are computed.",
-                                cd1->getID().c_str(), cd2->getID().c_str());
+        ROS_DEBUG_NAMED("collision_detection_fcl",
+                        "Robot link '%s' is allowed to touch attached object '%s'. No distances are computed.",
+                        cd1->getID().c_str(), cd2->getID().c_str());
     }
   }
   else
@@ -453,9 +464,10 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         always_allow_collision = true;
         if (cdata->req->verbose)
-          CONSOLE_BRIDGE_logDebug("Robot link '%s' is allowed to touch attached object '%s'. No distances are "
-                                  "computed.",
-                                  cd2->getID().c_str(), cd1->getID().c_str());
+          ROS_DEBUG_NAMED("collision_detection_fcl",
+                          "Robot link '%s' is allowed to touch attached object '%s'. No distances are "
+                          "computed.",
+                          cd2->getID().c_str(), cd1->getID().c_str());
       }
     }
   }
@@ -465,8 +477,8 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     return false;
   }
   if (cdata->req->verbose)
-    CONSOLE_BRIDGE_logDebug("Actually checking collisions between %s and %s", cd1->getID().c_str(),
-                            cd2->getID().c_str());
+    ROS_DEBUG_NAMED("collision_detection_fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
+                    cd2->getID().c_str());
 
   fcl::DistanceResult fcl_result;
   DistanceResultsData dist_result;
@@ -640,14 +652,16 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
     {
       if (cache_it->second->collision_geometry_data_->ptr.raw == (void*)data)
       {
-        //        CONSOLE_BRIDGE_logDebug("Collision data structures for object %s retrieved from cache.",
+        //        ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for object %s retrieved from
+        //        cache.",
         //        cache_it->second->collision_geometry_data_->getID().c_str());
         return cache_it->second;
       }
       else if (cache_it->second.unique())
       {
         const_cast<FCLGeometry*>(cache_it->second.get())->updateCollisionGeometryData(data, shape_index, false);
-        //          CONSOLE_BRIDGE_logDebug("Collision data structures for object %s retrieved from cache after updating
+        //          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for object %s retrieved from
+        //          cache after updating
         //          the source
         //          object.", cache_it->second->collision_geometry_data_->getID().c_str());
         return cache_it->second;
@@ -678,7 +692,8 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
         // update the CollisionGeometryData; nobody has a pointer to this, so we can safely modify it
         const_cast<FCLGeometry*>(obj_cache.get())->updateCollisionGeometryData(data, shape_index, true);
 
-        //        CONSOLE_BRIDGE_logDebug("Collision data structures for attached body %s retrieved from the cache for
+        //        ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for attached body %s retrieved
+        //        from the cache for
         //        world objects.",
         //        obj_cache->collision_geometry_data_->getID().c_str());
 
@@ -715,7 +730,8 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
         // update the CollisionGeometryData; nobody has a pointer to this, so we can safely modify it
         const_cast<FCLGeometry*>(obj_cache.get())->updateCollisionGeometryData(data, shape_index, true);
 
-        //          CONSOLE_BRIDGE_logDebug("Collision data structures for world object %s retrieved from the cache for
+        //          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for world object %s retrieved
+        //          from the cache for
         //          attached
         //          bodies.",
         //                   obj_cache->collision_geometry_data_->getID().c_str());
@@ -804,7 +820,8 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       }
       break;
       default:
-        CONSOLE_BRIDGE_logError("This shape type (%d) is not supported using FCL yet", (int)shape->type);
+        ROS_ERROR_NAMED("collision_detection_fcl", "This shape type (%d) is not supported using FCL yet",
+                        (int)shape->type);
         cg_g = nullptr;
     }
   }

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -88,7 +88,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       {
         always_allow_collision = true;
         if (cdata->req_->verbose)
-          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision between '%s' (type '%s') and '%s' (type '%s') is "
+          ROS_DEBUG_NAMED("collision_detection.fcl", "Collision between '%s' (type '%s') and '%s' (type '%s') is "
                                                      "always allowed. No contacts are computed.",
                           cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
                           cd2->getTypeString().c_str());
@@ -97,7 +97,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       {
         cdata->acm_->getAllowedCollision(cd1->getID(), cd2->getID(), dcf);
         if (cdata->req_->verbose)
-          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision between '%s' and '%s' is conditionally allowed",
+          ROS_DEBUG_NAMED("collision_detection.fcl", "Collision between '%s' and '%s' is conditionally allowed",
                           cd1->getID().c_str(), cd2->getID().c_str());
       }
     }
@@ -111,7 +111,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     {
       always_allow_collision = true;
       if (cdata->req_->verbose)
-        ROS_DEBUG_NAMED("collision_detection_fcl",
+        ROS_DEBUG_NAMED("collision_detection.fcl",
                         "Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
                         cd1->getID().c_str(), cd2->getID().c_str());
     }
@@ -123,7 +123,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     {
       always_allow_collision = true;
       if (cdata->req_->verbose)
-        ROS_DEBUG_NAMED("collision_detection_fcl",
+        ROS_DEBUG_NAMED("collision_detection.fcl",
                         "Robot link '%s' is allowed to touch attached object '%s'. No contacts are computed.",
                         cd2->getID().c_str(), cd1->getID().c_str());
     }
@@ -140,7 +140,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     return false;
 
   if (cdata->req_->verbose)
-    ROS_DEBUG_NAMED("collision_detection_fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
+    ROS_DEBUG_NAMED("collision_detection.fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
                     cd2->getID().c_str());
 
   // see if we need to compute a contact
@@ -177,7 +177,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     if (num_contacts > 0)
     {
       if (cdata->req_->verbose)
-        ROS_INFO_NAMED("collision_detection_fcl",
+        ROS_INFO_NAMED("collision_detection.fcl",
                        "Found %d contacts between '%s' and '%s'. These contacts will be evaluated to "
                        "check if they are accepted or not",
                        num_contacts, cd1->getID().c_str(), cd2->getID().c_str());
@@ -198,12 +198,12 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
             cdata->res_->contacts[pc].push_back(c);
             cdata->res_->contact_count++;
             if (cdata->req_->verbose)
-              ROS_INFO_NAMED("collision_detection_fcl",
+              ROS_INFO_NAMED("collision_detection.fcl",
                              "Found unacceptable contact between '%s' and '%s'. Contact was stored.",
                              cd1->getID().c_str(), cd2->getID().c_str());
           }
           else if (cdata->req_->verbose)
-            ROS_INFO_NAMED("collision_detection_fcl", "Found unacceptable contact between '%s' (type '%s') and '%s' "
+            ROS_INFO_NAMED("collision_detection.fcl", "Found unacceptable contact between '%s' (type '%s') and '%s' "
                                                       "(type '%s'). Contact was stored.",
                            cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
                            cd2->getTypeString().c_str());
@@ -256,7 +256,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
         }
 
         if (cdata->req_->verbose)
-          ROS_INFO_NAMED("collision_detection_fcl", "Found %d contacts between '%s' (type '%s') and '%s' (type '%s'), "
+          ROS_INFO_NAMED("collision_detection.fcl", "Found %d contacts between '%s' (type '%s') and '%s' (type '%s'), "
                                                     "which constitute a collision. %d contacts will be stored",
                          num_contacts_initial, cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
                          cd2->getTypeString().c_str(), num_contacts);
@@ -301,7 +301,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       {
         cdata->res_->collision = true;
         if (cdata->req_->verbose)
-          ROS_INFO_NAMED("collision_detection_fcl", "Found a contact between '%s' (type '%s') and '%s' (type '%s'), "
+          ROS_INFO_NAMED("collision_detection.fcl", "Found a contact between '%s' (type '%s') and '%s' (type '%s'), "
                                                     "which constitutes a collision. "
                                                     "Contact information is not stored.",
                          cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
@@ -331,7 +331,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       if (!cdata->req_->cost)
         cdata->done_ = true;
       if (cdata->req_->verbose)
-        ROS_INFO_NAMED("collision_detection_fcl",
+        ROS_INFO_NAMED("collision_detection.fcl",
                        "Collision checking is considered complete (collision was found and %u "
                        "contacts are stored)",
                        (unsigned int)cdata->res_->contact_count);
@@ -341,7 +341,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
   {
     cdata->done_ = cdata->req_->is_done(*cdata->res_);
     if (cdata->done_ && cdata->req_->verbose)
-      ROS_INFO_NAMED("collision_detection_fcl", "Collision checking is considered complete due to external callback. "
+      ROS_INFO_NAMED("collision_detection.fcl", "Collision checking is considered complete due to external callback. "
                                                 "%s was found. %u contacts are "
                                                 "stored.",
                      cdata->res_->collision ? "Collision" : "No collision", (unsigned int)cdata->res_->contact_count);
@@ -376,7 +376,7 @@ struct FCLShapeCache
           map_.erase(it);
         it = nit;
       }
-      //      ROS_DEBUG_NAMED("collision_detection_fcl", "Cleaning up cache for FCL objects that correspond to static
+      //      ROS_DEBUG_NAMED("collision_detection.fcl", "Cleaning up cache for FCL objects that correspond to static
       //      shapes. Cache size
       //      reduced from %u
       //      to %u", from, (unsigned int)map_.size());
@@ -435,7 +435,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         always_allow_collision = true;
         if (cdata->req->verbose)
-          ROS_DEBUG_NAMED("collision_detection_fcl",
+          ROS_DEBUG_NAMED("collision_detection.fcl",
                           "Collision between '%s' and '%s' is always allowed. No distances are computed.",
                           cd1->getID().c_str(), cd2->getID().c_str());
       }
@@ -450,7 +450,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     {
       always_allow_collision = true;
       if (cdata->req->verbose)
-        ROS_DEBUG_NAMED("collision_detection_fcl",
+        ROS_DEBUG_NAMED("collision_detection.fcl",
                         "Robot link '%s' is allowed to touch attached object '%s'. No distances are computed.",
                         cd1->getID().c_str(), cd2->getID().c_str());
     }
@@ -464,7 +464,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         always_allow_collision = true;
         if (cdata->req->verbose)
-          ROS_DEBUG_NAMED("collision_detection_fcl",
+          ROS_DEBUG_NAMED("collision_detection.fcl",
                           "Robot link '%s' is allowed to touch attached object '%s'. No distances are "
                           "computed.",
                           cd2->getID().c_str(), cd1->getID().c_str());
@@ -477,7 +477,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     return false;
   }
   if (cdata->req->verbose)
-    ROS_DEBUG_NAMED("collision_detection_fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
+    ROS_DEBUG_NAMED("collision_detection.fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
                     cd2->getID().c_str());
 
   fcl::DistanceResult fcl_result;
@@ -652,7 +652,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
     {
       if (cache_it->second->collision_geometry_data_->ptr.raw == (void*)data)
       {
-        //        ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for object %s retrieved from
+        //        ROS_DEBUG_NAMED("collision_detection.fcl", "Collision data structures for object %s retrieved from
         //        cache.",
         //        cache_it->second->collision_geometry_data_->getID().c_str());
         return cache_it->second;
@@ -660,7 +660,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       else if (cache_it->second.unique())
       {
         const_cast<FCLGeometry*>(cache_it->second.get())->updateCollisionGeometryData(data, shape_index, false);
-        //          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for object %s retrieved from
+        //          ROS_DEBUG_NAMED("collision_detection.fcl", "Collision data structures for object %s retrieved from
         //          cache after updating
         //          the source
         //          object.", cache_it->second->collision_geometry_data_->getID().c_str());
@@ -692,7 +692,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
         // update the CollisionGeometryData; nobody has a pointer to this, so we can safely modify it
         const_cast<FCLGeometry*>(obj_cache.get())->updateCollisionGeometryData(data, shape_index, true);
 
-        //        ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for attached body %s retrieved
+        //        ROS_DEBUG_NAMED("collision_detection.fcl", "Collision data structures for attached body %s retrieved
         //        from the cache for
         //        world objects.",
         //        obj_cache->collision_geometry_data_->getID().c_str());
@@ -730,7 +730,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
         // update the CollisionGeometryData; nobody has a pointer to this, so we can safely modify it
         const_cast<FCLGeometry*>(obj_cache.get())->updateCollisionGeometryData(data, shape_index, true);
 
-        //          ROS_DEBUG_NAMED("collision_detection_fcl", "Collision data structures for world object %s retrieved
+        //          ROS_DEBUG_NAMED("collision_detection.fcl", "Collision data structures for world object %s retrieved
         //          from the cache for
         //          attached
         //          bodies.",
@@ -820,7 +820,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       }
       break;
       default:
-        ROS_ERROR_NAMED("collision_detection_fcl", "This shape type (%d) is not supported using FCL yet",
+        ROS_ERROR_NAMED("collision_detection.fcl", "This shape type (%d) is not supported using FCL yet",
                         (int)shape->type);
         cg_g = nullptr;
     }

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -88,10 +88,10 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       {
         always_allow_collision = true;
         if (cdata->req_->verbose)
-          ROS_DEBUG_NAMED("collision_detection.fcl", "Collision between '%s' (type '%s') and '%s' (type '%s') is "
-                                                     "always allowed. No contacts are computed.",
-                          cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(),
-                          cd2->getTypeString().c_str());
+          ROS_DEBUG_NAMED(
+              "collision_detection.fcl", "Collision between '%s' (type '%s') and '%s' (type '%s') is always allowed. "
+                                         "No contacts are computed.",
+              cd1->getID().c_str(), cd1->getTypeString().c_str(), cd2->getID().c_str(), cd2->getTypeString().c_str());
       }
       else if (type == AllowedCollision::CONDITIONAL)
       {
@@ -178,8 +178,8 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     {
       if (cdata->req_->verbose)
         ROS_INFO_NAMED("collision_detection.fcl",
-                       "Found %d contacts between '%s' and '%s'. These contacts will be evaluated to "
-                       "check if they are accepted or not",
+                       "Found %d contacts between '%s' and '%s'. "
+                       "These contacts will be evaluated to check if they are accepted or not",
                        num_contacts, cd1->getID().c_str(), cd2->getID().c_str());
       Contact c;
       const std::pair<std::string, std::string>& pc = cd1->getID() < cd2->getID() ?
@@ -332,8 +332,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
         cdata->done_ = true;
       if (cdata->req_->verbose)
         ROS_INFO_NAMED("collision_detection.fcl",
-                       "Collision checking is considered complete (collision was found and %u "
-                       "contacts are stored)",
+                       "Collision checking is considered complete (collision was found and %u contacts are stored)",
                        (unsigned int)cdata->res_->contact_count);
     }
 
@@ -342,8 +341,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     cdata->done_ = cdata->req_->is_done(*cdata->res_);
     if (cdata->done_ && cdata->req_->verbose)
       ROS_INFO_NAMED("collision_detection.fcl", "Collision checking is considered complete due to external callback. "
-                                                "%s was found. %u contacts are "
-                                                "stored.",
+                                                "%s was found. %u contacts are stored.",
                      cdata->res_->collision ? "Collision" : "No collision", (unsigned int)cdata->res_->contact_count);
   }
 
@@ -465,8 +463,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
         always_allow_collision = true;
         if (cdata->req->verbose)
           ROS_DEBUG_NAMED("collision_detection.fcl",
-                          "Robot link '%s' is allowed to touch attached object '%s'. No distances are "
-                          "computed.",
+                          "Robot link '%s' is allowed to touch attached object '%s'. No distances are computed.",
                           cd2->getID().c_str(), cd1->getID().c_str());
       }
     }

--- a/moveit_core/collision_detection_fcl/src/collision_robot_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_robot_fcl.cpp
@@ -62,7 +62,8 @@ collision_detection::CollisionRobotFCL::CollisionRobotFCL(const robot_model::Rob
         fcl_objs_[index] = FCLCollisionObjectConstPtr(new fcl::CollisionObject(g->collision_geometry_));
       }
       else
-        CONSOLE_BRIDGE_logError("Unable to construct collision geometry for link '%s'", link->getName().c_str());
+        ROS_ERROR_NAMED("collision_detection_fcl", "Unable to construct collision geometry for link '%s'",
+                        link->getName().c_str());
     }
 }
 
@@ -151,7 +152,7 @@ void collision_detection::CollisionRobotFCL::checkSelfCollision(const CollisionR
                                                                 const robot_state::RobotState& state1,
                                                                 const robot_state::RobotState& state2) const
 {
-  CONSOLE_BRIDGE_logError("FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
@@ -159,7 +160,7 @@ void collision_detection::CollisionRobotFCL::checkSelfCollision(const CollisionR
                                                                 const robot_state::RobotState& state2,
                                                                 const AllowedCollisionMatrix& acm) const
 {
-  CONSOLE_BRIDGE_logError("FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
@@ -208,7 +209,7 @@ void collision_detection::CollisionRobotFCL::checkOtherCollision(const Collision
                                                                  const robot_state::RobotState& other_state1,
                                                                  const robot_state::RobotState& other_state2) const
 {
-  CONSOLE_BRIDGE_logError("FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -219,7 +220,7 @@ void collision_detection::CollisionRobotFCL::checkOtherCollision(const Collision
                                                                  const robot_state::RobotState& other_state2,
                                                                  const AllowedCollisionMatrix& acm) const
 {
-  CONSOLE_BRIDGE_logError("FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkOtherCollisionHelper(const CollisionRequest& req,
@@ -275,7 +276,7 @@ void collision_detection::CollisionRobotFCL::updatedPaddingOrScaling(const std::
       }
     }
     else
-      CONSOLE_BRIDGE_logError("Updating padding or scaling for unknown link: '%s'", link.c_str());
+      ROS_ERROR_NAMED("collision_detection_fcl", "Updating padding or scaling for unknown link: '%s'", link.c_str());
   }
 }
 

--- a/moveit_core/collision_detection_fcl/src/collision_robot_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_robot_fcl.cpp
@@ -62,7 +62,7 @@ collision_detection::CollisionRobotFCL::CollisionRobotFCL(const robot_model::Rob
         fcl_objs_[index] = FCLCollisionObjectConstPtr(new fcl::CollisionObject(g->collision_geometry_));
       }
       else
-        ROS_ERROR_NAMED("collision_detection_fcl", "Unable to construct collision geometry for link '%s'",
+        ROS_ERROR_NAMED("collision_detection.fcl", "Unable to construct collision geometry for link '%s'",
                         link->getName().c_str());
     }
 }
@@ -152,7 +152,7 @@ void collision_detection::CollisionRobotFCL::checkSelfCollision(const CollisionR
                                                                 const robot_state::RobotState& state1,
                                                                 const robot_state::RobotState& state2) const
 {
-  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection.fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
@@ -160,7 +160,7 @@ void collision_detection::CollisionRobotFCL::checkSelfCollision(const CollisionR
                                                                 const robot_state::RobotState& state2,
                                                                 const AllowedCollisionMatrix& acm) const
 {
-  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection.fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
@@ -209,7 +209,7 @@ void collision_detection::CollisionRobotFCL::checkOtherCollision(const Collision
                                                                  const robot_state::RobotState& other_state1,
                                                                  const robot_state::RobotState& other_state2) const
 {
-  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection.fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -220,7 +220,7 @@ void collision_detection::CollisionRobotFCL::checkOtherCollision(const Collision
                                                                  const robot_state::RobotState& other_state2,
                                                                  const AllowedCollisionMatrix& acm) const
 {
-  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection.fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionRobotFCL::checkOtherCollisionHelper(const CollisionRequest& req,
@@ -276,7 +276,7 @@ void collision_detection::CollisionRobotFCL::updatedPaddingOrScaling(const std::
       }
     }
     else
-      ROS_ERROR_NAMED("collision_detection_fcl", "Updating padding or scaling for unknown link: '%s'", link.c_str());
+      ROS_ERROR_NAMED("collision_detection.fcl", "Updating padding or scaling for unknown link: '%s'", link.c_str());
   }
 }
 

--- a/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -103,7 +103,7 @@ void collision_detection::CollisionWorldFCL::checkRobotCollision(const Collision
                                                                  const robot_state::RobotState& state1,
                                                                  const robot_state::RobotState& state2) const
 {
-  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection.fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionWorldFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -112,7 +112,7 @@ void collision_detection::CollisionWorldFCL::checkRobotCollision(const Collision
                                                                  const robot_state::RobotState& state2,
                                                                  const AllowedCollisionMatrix& acm) const
 {
-  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection.fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionWorldFCL::checkRobotCollisionHelper(const CollisionRequest& req,

--- a/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -103,7 +103,7 @@ void collision_detection::CollisionWorldFCL::checkRobotCollision(const Collision
                                                                  const robot_state::RobotState& state1,
                                                                  const robot_state::RobotState& state2) const
 {
-  CONSOLE_BRIDGE_logError("FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionWorldFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -112,7 +112,7 @@ void collision_detection::CollisionWorldFCL::checkRobotCollision(const Collision
                                                                  const robot_state::RobotState& state2,
                                                                  const AllowedCollisionMatrix& acm) const
 {
-  CONSOLE_BRIDGE_logError("FCL continuous collision checking not yet implemented");
+  ROS_ERROR_NAMED("collision_detection_fcl", "FCL continuous collision checking not yet implemented");
 }
 
 void collision_detection::CollisionWorldFCL::checkRobotCollisionHelper(const CollisionRequest& req,

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -499,7 +499,7 @@ TEST_F(FclCollisionDetectionTester, TestCollisionMapAdditionSpeed)
   EXPECT_GE(1.0, t);
   // this is not really a failure; it is just that slow;
   // looking into doing collision checking with a voxel grid.
-  CONSOLE_BRIDGE_logInform("Adding boxes took %g", t);
+  ROS_INFO_NAMED("collision_detection_fcl", "Adding boxes took %g", t);
 }
 
 TEST_F(FclCollisionDetectionTester, MoveMesh)

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -499,7 +499,7 @@ TEST_F(FclCollisionDetectionTester, TestCollisionMapAdditionSpeed)
   EXPECT_GE(1.0, t);
   // this is not really a failure; it is just that slow;
   // looking into doing collision checking with a voxel grid.
-  ROS_INFO_NAMED("collision_detection_fcl", "Adding boxes took %g", t);
+  ROS_INFO_NAMED("collision_detection.fcl", "Adding boxes took %g", t);
 }
 
 TEST_F(FclCollisionDetectionTester, MoveMesh)

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_kinematic_constraints
   moveit_kinematics_base
   moveit_planning_scene
-  ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+  ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
@@ -40,7 +40,6 @@ if(CATKIN_ENABLE_TESTING)
     ${MOVEIT_LIB_NAME}
     ${catkin_LIBRARIES}
     ${angles_LIBRARIES}
-    ${console_bridge_LIBRARIES}
     ${orocos_kdl_LIBRARIES}
     ${tf_conversions_LIBRARIES}
     ${urdfdom_LIBRARIES}

--- a/moveit_core/constraint_samplers/src/constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler.cpp
@@ -43,7 +43,7 @@ constraint_samplers::ConstraintSampler::ConstraintSampler(const planning_scene::
   jmg_ = scene->getRobotModel()->getJointModelGroup(group_name);
   if (!jmg_)
   {
-    CONSOLE_BRIDGE_logError("A JointModelGroup should have been specified for the constraint sampler");
+    ROS_ERROR_NAMED("constraint_samplers", "A JointModelGroup should have been specified for the constraint sampler");
   }
 }
 

--- a/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
@@ -60,16 +60,18 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
     return constraint_samplers::ConstraintSamplerPtr();
   std::stringstream ss;
   ss << constr;
-  CONSOLE_BRIDGE_logDebug("Attempting to construct constrained state sampler for group '%s', using constraints:\n%s.\n",
-                          jmg->getName().c_str(), ss.str().c_str());
+  ROS_DEBUG_NAMED("constraint_samplers",
+                  "Attempting to construct constrained state sampler for group '%s', using constraints:\n%s.\n",
+                  jmg->getName().c_str(), ss.str().c_str());
 
   ConstraintSamplerPtr joint_sampler;  // location to put chosen joint sampler if needed
   // if there are joint constraints, we could possibly get a sampler from those
   if (!constr.joint_constraints.empty())
   {
-    CONSOLE_BRIDGE_logDebug("There are joint constraints specified. Attempting to construct a JointConstraintSampler "
-                            "for group '%s'",
-                            jmg->getName().c_str());
+    ROS_DEBUG_NAMED("constraint_samplers",
+                    "There are joint constraints specified. Attempting to construct a JointConstraintSampler "
+                    "for group '%s'",
+                    jmg->getName().c_str());
 
     std::map<std::string, bool> joint_coverage;
     for (std::size_t i = 0; i < jmg->getVariableNames().size(); ++i)
@@ -105,8 +107,8 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
       JointConstraintSamplerPtr sampler(new JointConstraintSampler(scene, jmg->getName()));
       if (sampler->configure(jc))
       {
-        CONSOLE_BRIDGE_logDebug("Allocated a sampler satisfying joint constraints for group '%s'",
-                                jmg->getName().c_str());
+        ROS_DEBUG_NAMED("constraint_samplers", "Allocated a sampler satisfying joint constraints for group '%s'",
+                        jmg->getName().c_str());
         return sampler;
       }
     }
@@ -118,9 +120,10 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
       JointConstraintSamplerPtr sampler(new JointConstraintSampler(scene, jmg->getName()));
       if (sampler->configure(jc))
       {
-        CONSOLE_BRIDGE_logDebug("Temporary sampler satisfying joint constraints for group '%s' allocated. "
-                                "Looking for different types of constraints before returning though.",
-                                jmg->getName().c_str());
+        ROS_DEBUG_NAMED("constraint_samplers",
+                        "Temporary sampler satisfying joint constraints for group '%s' allocated. "
+                        "Looking for different types of constraints before returning though.",
+                        jmg->getName().c_str());
         joint_sampler = sampler;
       }
     }
@@ -138,9 +141,9 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
   // should be used
   if (ik_alloc)
   {
-    CONSOLE_BRIDGE_logDebug("There is an IK allocator for '%s'. "
-                            "Checking for corresponding position and/or orientation constraints",
-                            jmg->getName().c_str());
+    ROS_DEBUG_NAMED("constraint_samplers", "There is an IK allocator for '%s'. "
+                                           "Checking for corresponding position and/or orientation constraints",
+                    jmg->getName().c_str());
 
     // keep track of which links we constrained
     std::map<std::string, IKConstraintSamplerPtr> usedL;
@@ -173,9 +176,9 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
               {
                 // assign the link to a new constraint sampler
                 usedL[constr.position_constraints[p].link_name] = iks;
-                CONSOLE_BRIDGE_logDebug("Allocated an IK-based sampler for group '%s' "
-                                        "satisfying position and orientation constraints on link '%s'",
-                                        jmg->getName().c_str(), constr.position_constraints[p].link_name.c_str());
+                ROS_DEBUG_NAMED("constraint_samplers", "Allocated an IK-based sampler for group '%s' "
+                                                       "satisfying position and orientation constraints on link '%s'",
+                                jmg->getName().c_str(), constr.position_constraints[p].link_name.c_str());
               }
             }
           }
@@ -205,9 +208,9 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
           if (use)
           {
             usedL[constr.position_constraints[p].link_name] = iks;
-            CONSOLE_BRIDGE_logDebug("Allocated an IK-based sampler for group '%s' "
-                                    "satisfying position constraints on link '%s'",
-                                    jmg->getName().c_str(), constr.position_constraints[p].link_name.c_str());
+            ROS_DEBUG_NAMED("constraint_samplers", "Allocated an IK-based sampler for group '%s' "
+                                                   "satisfying position constraints on link '%s'",
+                            jmg->getName().c_str(), constr.position_constraints[p].link_name.c_str());
           }
         }
       }
@@ -234,9 +237,9 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
           if (use)
           {
             usedL[constr.orientation_constraints[o].link_name] = iks;
-            CONSOLE_BRIDGE_logDebug("Allocated an IK-based sampler for group '%s' "
-                                    "satisfying orientation constraints on link '%s'",
-                                    jmg->getName().c_str(), constr.orientation_constraints[o].link_name.c_str());
+            ROS_DEBUG_NAMED("constraint_samplers", "Allocated an IK-based sampler for group '%s' "
+                                                   "satisfying orientation constraints on link '%s'",
+                            jmg->getName().c_str(), constr.orientation_constraints[o].link_name.c_str());
           }
         }
       }
@@ -254,8 +257,9 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
     }
     else if (usedL.size() > 1)
     {
-      CONSOLE_BRIDGE_logDebug("Too many IK-based samplers for group '%s'. Keeping the one with minimal sampling volume",
-                              jmg->getName().c_str());
+      ROS_DEBUG_NAMED("constraint_samplers",
+                      "Too many IK-based samplers for group '%s'. Keeping the one with minimal sampling volume",
+                      jmg->getName().c_str());
       // find the sampler with the smallest sampling volume; delete the rest
       IKConstraintSamplerPtr iks = usedL.begin()->second;
       double msv = iks->getSamplingVolume();
@@ -284,9 +288,9 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
   // we now check to see if we can use samplers from subgroups
   if (!ik_subgroup_alloc.empty())
   {
-    CONSOLE_BRIDGE_logDebug("There are IK allocators for subgroups of group '%s'. "
-                            "Checking for corresponding position and/or orientation constraints",
-                            jmg->getName().c_str());
+    ROS_DEBUG_NAMED("constraint_samplers", "There are IK allocators for subgroups of group '%s'. "
+                                           "Checking for corresponding position and/or orientation constraints",
+                    jmg->getName().c_str());
 
     bool some_sampler_valid = false;
 
@@ -315,14 +319,14 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
       // if some matching constraints were found, construct the allocator
       if (!sub_constr.orientation_constraints.empty() || !sub_constr.position_constraints.empty())
       {
-        CONSOLE_BRIDGE_logDebug("Attempting to construct a sampler for the '%s' subgroup of '%s'",
-                                it->first->getName().c_str(), jmg->getName().c_str());
+        ROS_DEBUG_NAMED("constraint_samplers", "Attempting to construct a sampler for the '%s' subgroup of '%s'",
+                        it->first->getName().c_str(), jmg->getName().c_str());
         ConstraintSamplerPtr cs = selectDefaultSampler(scene, it->first->getName(), sub_constr);
         if (cs)
         {
-          CONSOLE_BRIDGE_logDebug("Constructed a sampler for the joints corresponding to group '%s', "
-                                  "but part of group '%s'",
-                                  it->first->getName().c_str(), jmg->getName().c_str());
+          ROS_DEBUG_NAMED("constraint_samplers", "Constructed a sampler for the joints corresponding to group '%s', "
+                                                 "but part of group '%s'",
+                          it->first->getName().c_str(), jmg->getName().c_str());
           some_sampler_valid = true;
           samplers.push_back(cs);
         }
@@ -330,8 +334,8 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
     }
     if (some_sampler_valid)
     {
-      CONSOLE_BRIDGE_logDebug("Constructing sampler for group '%s' as a union of %zu samplers", jmg->getName().c_str(),
-                              samplers.size());
+      ROS_DEBUG_NAMED("constraint_samplers", "Constructing sampler for group '%s' as a union of %zu samplers",
+                      jmg->getName().c_str(), samplers.size());
       return ConstraintSamplerPtr(new UnionConstraintSampler(scene, jmg->getName(), samplers));
     }
   }
@@ -339,11 +343,12 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
   // if we've gotten here, just return joint sampler
   if (joint_sampler)
   {
-    CONSOLE_BRIDGE_logDebug("Allocated a sampler satisfying joint constraints for group '%s'", jmg->getName().c_str());
+    ROS_DEBUG_NAMED("constraint_samplers", "Allocated a sampler satisfying joint constraints for group '%s'",
+                    jmg->getName().c_str());
     return joint_sampler;
   }
 
-  CONSOLE_BRIDGE_logDebug("No constraints sampler allocated for group '%s'", jmg->getName().c_str());
+  ROS_DEBUG_NAMED("constraint_samplers", "No constraints sampler allocated for group '%s'", jmg->getName().c_str());
 
   return ConstraintSamplerPtr();
 }

--- a/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
@@ -68,9 +68,8 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
   // if there are joint constraints, we could possibly get a sampler from those
   if (!constr.joint_constraints.empty())
   {
-    ROS_DEBUG_NAMED("constraint_samplers",
-                    "There are joint constraints specified. Attempting to construct a JointConstraintSampler "
-                    "for group '%s'",
+    ROS_DEBUG_NAMED("constraint_samplers", "There are joint constraints specified. "
+                                           "Attempting to construct a JointConstraintSampler for group '%s'",
                     jmg->getName().c_str());
 
     std::map<std::string, bool> joint_coverage;

--- a/moveit_core/constraint_samplers/src/constraint_sampler_tools.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_tools.cpp
@@ -59,7 +59,7 @@ double constraint_samplers::countSamplesPerSecond(const ConstraintSamplerPtr& sa
 {
   if (!sampler)
   {
-    CONSOLE_BRIDGE_logError("No sampler specified for counting samples per second");
+    ROS_ERROR_NAMED("constraint_samplers", "No sampler specified for counting samples per second");
     return 0.0;
   }
   robot_state::RobotState ks(reference_state);
@@ -86,7 +86,7 @@ void constraint_samplers::visualizeDistribution(const ConstraintSamplerPtr& samp
 {
   if (!sampler)
   {
-    CONSOLE_BRIDGE_logError("No sampler specified for visualizing distribution of samples");
+    ROS_ERROR_NAMED("constraint_samplers", "No sampler specified for visualizing distribution of samples");
     return;
   }
   const robot_state::LinkModel* lm = reference_state.getLinkModel(link_name);

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -99,8 +99,8 @@ bool constraint_samplers::JointConstraintSampler::configure(
       std::stringstream cs;
       jc[i].print(cs);
       ROS_ERROR_NAMED("constraint_samplers",
-                      "The constraints for joint '%s' are such that there are no possible values for the "
-                      "joint: min_bound: %g, max_bound: %g. Failing.\n",
+                      "The constraints for joint '%s' are such that "
+                      "there are no possible values for the joint: min_bound: %g, max_bound: %g. Failing.\n",
                       jm->getName().c_str(), ji.min_bound_, ji.max_bound_);
       clear();
       return false;
@@ -258,8 +258,8 @@ bool constraint_samplers::IKConstraintSampler::configure(const IKSamplingPose& s
         sampling_pose_.orientation_constraint_->getLinkModel()->getName())
     {
       ROS_ERROR_NAMED("constraint_samplers",
-                      "Position and orientation constraints need to be specified for the same link in "
-                      "order to use IK-based sampling");
+                      "Position and orientation constraints need to be specified for the same link "
+                      "in order to use IK-based sampling");
       return false;
     }
 
@@ -355,8 +355,8 @@ bool constraint_samplers::IKConstraintSampler::loadIKSolver()
     if (!jmg_->getParentModel().hasLinkModel(ik_frame_))
     {
       ROS_ERROR_NAMED("constraint_samplers",
-                      "The IK solver expects requests in frame '%s' but this frame is not known to the "
-                      "sampler. Ignoring transformation (IK may fail)",
+                      "The IK solver expects requests in frame '%s' but this frame is not known to the sampler. "
+                      "Ignoring transformation (IK may fail)",
                       ik_frame_.c_str());
       transform_ik_ = false;
     }

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -61,7 +61,7 @@ bool constraint_samplers::JointConstraintSampler::configure(
 
   if (!jmg_)
   {
-    CONSOLE_BRIDGE_logError("NULL group specified for constraint sampler");
+    ROS_ERROR_NAMED("constraint_samplers", "NULL group specified for constraint sampler");
     return false;
   }
 
@@ -91,16 +91,17 @@ bool constraint_samplers::JointConstraintSampler::configure(
         std::max(joint_bounds.min_position_, jc[i].getDesiredJointPosition() - jc[i].getJointToleranceBelow()),
         std::min(joint_bounds.max_position_, jc[i].getDesiredJointPosition() + jc[i].getJointToleranceAbove()));
 
-    CONSOLE_BRIDGE_logDebug("Bounds for %s JointConstraint are %g %g", jc[i].getJointVariableName().c_str(),
-                            ji.min_bound_, ji.max_bound_);
+    ROS_DEBUG_NAMED("constraint_samplers", "Bounds for %s JointConstraint are %g %g",
+                    jc[i].getJointVariableName().c_str(), ji.min_bound_, ji.max_bound_);
 
     if (ji.min_bound_ > ji.max_bound_ + std::numeric_limits<double>::epsilon())
     {
       std::stringstream cs;
       jc[i].print(cs);
-      CONSOLE_BRIDGE_logError("The constraints for joint '%s' are such that there are no possible values for the "
-                              "joint: min_bound: %g, max_bound: %g. Failing.\n",
-                              jm->getName().c_str(), ji.min_bound_, ji.max_bound_);
+      ROS_ERROR_NAMED("constraint_samplers",
+                      "The constraints for joint '%s' are such that there are no possible values for the "
+                      "joint: min_bound: %g, max_bound: %g. Failing.\n",
+                      jm->getName().c_str(), ji.min_bound_, ji.max_bound_);
       clear();
       return false;
     }
@@ -109,7 +110,7 @@ bool constraint_samplers::JointConstraintSampler::configure(
 
   if (!some_valid_constraint)
   {
-    CONSOLE_BRIDGE_logWarn("No valid joint constraints");
+    ROS_WARN_NAMED("constraint_samplers", "No valid joint constraints");
     return false;
   }
 
@@ -151,7 +152,7 @@ bool constraint_samplers::JointConstraintSampler::sample(robot_state::RobotState
 {
   if (!is_valid_)
   {
-    CONSOLE_BRIDGE_logWarn("JointConstraintSampler not configured, won't sample");
+    ROS_WARN_NAMED("constraint_samplers", "JointConstraintSampler not configured, won't sample");
     return false;
   }
 
@@ -246,7 +247,7 @@ bool constraint_samplers::IKConstraintSampler::configure(const IKSamplingPose& s
       (sp.position_constraint_ && sp.orientation_constraint_ && !sp.position_constraint_->enabled() &&
        !sp.orientation_constraint_->enabled()))
   {
-    CONSOLE_BRIDGE_logWarn("No enabled constraints in sampling pose");
+    ROS_WARN_NAMED("constraint_samplers", "No enabled constraints in sampling pose");
     return false;
   }
 
@@ -256,8 +257,9 @@ bool constraint_samplers::IKConstraintSampler::configure(const IKSamplingPose& s
     if (sampling_pose_.position_constraint_->getLinkModel()->getName() !=
         sampling_pose_.orientation_constraint_->getLinkModel()->getName())
     {
-      CONSOLE_BRIDGE_logError("Position and orientation constraints need to be specified for the same link in "
-                              "order to use IK-based sampling");
+      ROS_ERROR_NAMED("constraint_samplers",
+                      "Position and orientation constraints need to be specified for the same link in "
+                      "order to use IK-based sampling");
       return false;
     }
 
@@ -268,7 +270,7 @@ bool constraint_samplers::IKConstraintSampler::configure(const IKSamplingPose& s
   kb_ = jmg_->getSolverInstance();
   if (!kb_)
   {
-    CONSOLE_BRIDGE_logWarn("No solver instance in setup");
+    ROS_WARN_NAMED("constraint_samplers", "No solver instance in setup");
     is_valid_ = false;
     return false;
   }
@@ -340,7 +342,7 @@ bool constraint_samplers::IKConstraintSampler::loadIKSolver()
 {
   if (!kb_)
   {
-    CONSOLE_BRIDGE_logError("No IK solver");
+    ROS_ERROR_NAMED("constraint_samplers", "No IK solver");
     return false;
   }
 
@@ -352,9 +354,10 @@ bool constraint_samplers::IKConstraintSampler::loadIKSolver()
   if (transform_ik_)
     if (!jmg_->getParentModel().hasLinkModel(ik_frame_))
     {
-      CONSOLE_BRIDGE_logError("The IK solver expects requests in frame '%s' but this frame is not known to the "
-                              "sampler. Ignoring transformation (IK may fail)",
-                              ik_frame_.c_str());
+      ROS_ERROR_NAMED("constraint_samplers",
+                      "The IK solver expects requests in frame '%s' but this frame is not known to the "
+                      "sampler. Ignoring transformation (IK may fail)",
+                      ik_frame_.c_str());
       transform_ik_ = false;
     }
 
@@ -398,11 +401,12 @@ bool constraint_samplers::IKConstraintSampler::loadIKSolver()
 
   if (wrong_link)
   {
-    CONSOLE_BRIDGE_logError("IK cannot be performed for link '%s'. The solver can report IK solutions for link '%s'.",
-                            sampling_pose_.position_constraint_ ?
-                                sampling_pose_.position_constraint_->getLinkModel()->getName().c_str() :
-                                sampling_pose_.orientation_constraint_->getLinkModel()->getName().c_str(),
-                            kb_->getTipFrame().c_str());
+    ROS_ERROR_NAMED("constraint_samplers",
+                    "IK cannot be performed for link '%s'. The solver can report IK solutions for link '%s'.",
+                    sampling_pose_.position_constraint_ ?
+                        sampling_pose_.position_constraint_->getLinkModel()->getName().c_str() :
+                        sampling_pose_.orientation_constraint_->getLinkModel()->getName().c_str(),
+                    kb_->getTipFrame().c_str());
     return false;
   }
   return true;
@@ -414,8 +418,9 @@ bool constraint_samplers::IKConstraintSampler::samplePose(Eigen::Vector3d& pos, 
   if (ks.dirtyLinkTransforms())
   {
     // samplePose below requires accurate transforms
-    CONSOLE_BRIDGE_logError("IKConstraintSampler received dirty robot state, but valid transforms are required. "
-                            "Failing.");
+    ROS_ERROR_NAMED("constraint_samplers",
+                    "IKConstraintSampler received dirty robot state, but valid transforms are required. "
+                    "Failing.");
     return false;
   }
 
@@ -434,14 +439,14 @@ bool constraint_samplers::IKConstraintSampler::samplePose(Eigen::Vector3d& pos, 
         }
       if (!found)
       {
-        CONSOLE_BRIDGE_logError("Unable to sample a point inside the constraint region");
+        ROS_ERROR_NAMED("constraint_samplers", "Unable to sample a point inside the constraint region");
         return false;
       }
     }
     else
     {
-      CONSOLE_BRIDGE_logError("Unable to sample a point inside the constraint region. "
-                              "Constraint region is empty when it should not be.");
+      ROS_ERROR_NAMED("constraint_samplers", "Unable to sample a point inside the constraint region. "
+                                             "Constraint region is empty when it should not be.");
       return false;
     }
 
@@ -535,7 +540,7 @@ bool constraint_samplers::IKConstraintSampler::sampleHelper(robot_state::RobotSt
 {
   if (!is_valid_)
   {
-    CONSOLE_BRIDGE_logWarn("IKConstraintSampler not configured, won't sample");
+    ROS_WARN_NAMED("constraint_samplers", "IKConstraintSampler not configured, won't sample");
     return false;
   }
 
@@ -552,7 +557,7 @@ bool constraint_samplers::IKConstraintSampler::sampleHelper(robot_state::RobotSt
     if (!samplePose(point, quat, reference_state, max_attempts))
     {
       if (verbose_)
-        CONSOLE_BRIDGE_logInform("IK constraint sampler was unable to produce a pose to run IK for");
+        ROS_INFO_NAMED("constraint_samplers", "IK constraint sampler was unable to produce a pose to run IK for");
       return false;
     }
 
@@ -643,9 +648,9 @@ bool constraint_samplers::IKConstraintSampler::callIK(
     if (error.val != moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION &&
         error.val != moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE &&
         error.val != moveit_msgs::MoveItErrorCodes::TIMED_OUT)
-      CONSOLE_BRIDGE_logError("IK solver failed with error %d", error.val);
+      ROS_ERROR_NAMED("constraint_samplers", "IK solver failed with error %d", error.val);
     else if (verbose_)
-      CONSOLE_BRIDGE_logInform("IK failed");
+      ROS_INFO_NAMED("constraint_samplers", "IK failed");
   }
   return false;
 }

--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -80,8 +80,9 @@ struct OrderSamplers
         }
     if (b_depends_on_a && a_depends_on_b)
     {
-      ROS_WARN_NAMED("constraint_samplers", "Circular frame dependency! Sampling will likely produce invalid results "
-                                            "(sampling for groups '%s' and '%s')",
+      ROS_WARN_NAMED("constraint_samplers",
+                     "Circular frame dependency! "
+                     "Sampling will likely produce invalid results (sampling for groups '%s' and '%s')",
                      a->getJointModelGroup()->getName().c_str(), b->getJointModelGroup()->getName().c_str());
       return true;
     }

--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -80,9 +80,9 @@ struct OrderSamplers
         }
     if (b_depends_on_a && a_depends_on_b)
     {
-      CONSOLE_BRIDGE_logWarn("Circular frame dependency! Sampling will likely produce invalid results "
-                             "(sampling for groups '%s' and '%s')",
-                             a->getJointModelGroup()->getName().c_str(), b->getJointModelGroup()->getName().c_str());
+      ROS_WARN_NAMED("constraint_samplers", "Circular frame dependency! Sampling will likely produce invalid results "
+                                            "(sampling for groups '%s' and '%s')",
+                     a->getJointModelGroup()->getName().c_str(), b->getJointModelGroup()->getName().c_str());
       return true;
     }
     if (b_depends_on_a && !a_depends_on_b)
@@ -118,8 +118,8 @@ constraint_samplers::UnionConstraintSampler::UnionConstraintSampler(const planni
     for (std::size_t j = 0; j < fd.size(); ++j)
       frame_depends_.push_back(fd[j]);
 
-    CONSOLE_BRIDGE_logDebug("Union sampler for group '%s' includes sampler for group '%s'", jmg_->getName().c_str(),
-                            samplers_[i]->getJointModelGroup()->getName().c_str());
+    ROS_DEBUG_NAMED("constraint_samplers", "Union sampler for group '%s' includes sampler for group '%s'",
+                    jmg_->getName().c_str(), samplers_[i]->getJointModelGroup()->getName().c_str());
   }
 }
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -66,9 +66,9 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
     if (!joint)
     {
       if (link->parent_joint)
-        ROS_ERROR_NAMED("constraint_samplers", "Could not find joint: %s", link->parent_joint->name.c_str());
+        ROS_ERROR_NAMED("pr2_arm_kinematics_plugin", "Could not find joint: %s", link->parent_joint->name.c_str());
       else
-        ROS_ERROR_NAMED("constraint_samplers", "Link %s has no parent joint", link->name.c_str());
+        ROS_ERROR_NAMED("pr2_arm_kinematics_plugin", "Link %s has no parent joint", link->name.c_str());
       return false;
     }
     if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)
@@ -76,8 +76,8 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
       link_offset.push_back(link->parent_joint->parent_to_joint_origin_transform);
       angle_multipliers_.push_back(joint->axis.x * fabs(joint->axis.x) + joint->axis.y * fabs(joint->axis.y) +
                                    joint->axis.z * fabs(joint->axis.z));
-      ROS_DEBUG_NAMED("constraint_samplers", "Joint axis: %d, %f, %f, %f", 6 - num_joints, joint->axis.x, joint->axis.y,
-                      joint->axis.z);
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Joint axis: %d, %f, %f, %f", 6 - num_joints, joint->axis.x,
+                      joint->axis.y, joint->axis.z);
       if (joint->type != urdf::Joint::CONTINUOUS)
       {
         if (joint->safety)
@@ -96,7 +96,7 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
           {
             min_angles_.push_back(0.0);
             max_angles_.push_back(0.0);
-            ROS_WARN_NAMED("constraint_samplers", "No joint limits or joint '%s'", joint->name.c_str());
+            ROS_WARN_NAMED("pr2_arm_kinematics_plugin", "No joint limits or joint '%s'", joint->name.c_str());
           }
         }
         continuous_joint_.push_back(false);
@@ -128,8 +128,8 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
 
   if (num_joints != 7)
   {
-    ROS_ERROR_NAMED("constraint_samplers", "PR2ArmIK:: Chain from %s to %s does not have 7 joints", root_name.c_str(),
-                    tip_name.c_str());
+    ROS_ERROR_NAMED("pr2_arm_kinematics_plugin", "PR2ArmIK:: Chain from %s to %s does not have 7 joints",
+                    root_name.c_str(), tip_name.c_str());
     return false;
   }
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -35,7 +35,6 @@
 /* Author: Sachin Chitta, E. Gil Jones */
 
 #include <angles/angles.h>
-#include <console_bridge/console.h>
 #include "pr2_arm_ik.h"
 
 /**** List of angles (for reference) *******
@@ -67,9 +66,9 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
     if (!joint)
     {
       if (link->parent_joint)
-        CONSOLE_BRIDGE_logError("Could not find joint: %s", link->parent_joint->name.c_str());
+        ROS_ERROR_NAMED("constraint_samplers", "Could not find joint: %s", link->parent_joint->name.c_str());
       else
-        CONSOLE_BRIDGE_logError("Link %s has no parent joint", link->name.c_str());
+        ROS_ERROR_NAMED("constraint_samplers", "Link %s has no parent joint", link->name.c_str());
       return false;
     }
     if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)
@@ -77,8 +76,8 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
       link_offset.push_back(link->parent_joint->parent_to_joint_origin_transform);
       angle_multipliers_.push_back(joint->axis.x * fabs(joint->axis.x) + joint->axis.y * fabs(joint->axis.y) +
                                    joint->axis.z * fabs(joint->axis.z));
-      CONSOLE_BRIDGE_logDebug("Joint axis: %d, %f, %f, %f", 6 - num_joints, joint->axis.x, joint->axis.y,
-                              joint->axis.z);
+      ROS_DEBUG_NAMED("constraint_samplers", "Joint axis: %d, %f, %f, %f", 6 - num_joints, joint->axis.x, joint->axis.y,
+                      joint->axis.z);
       if (joint->type != urdf::Joint::CONTINUOUS)
       {
         if (joint->safety)
@@ -97,7 +96,7 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
           {
             min_angles_.push_back(0.0);
             max_angles_.push_back(0.0);
-            CONSOLE_BRIDGE_logWarn("No joint limits or joint '%s'", joint->name.c_str());
+            ROS_WARN_NAMED("constraint_samplers", "No joint limits or joint '%s'", joint->name.c_str());
           }
         }
         continuous_joint_.push_back(false);
@@ -129,8 +128,8 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
 
   if (num_joints != 7)
   {
-    CONSOLE_BRIDGE_logError("PR2ArmIK:: Chain from %s to %s does not have 7 joints", root_name.c_str(),
-                            tip_name.c_str());
+    ROS_ERROR_NAMED("constraint_samplers", "PR2ArmIK:: Chain from %s to %s does not have 7 joints", root_name.c_str(),
+                    tip_name.c_str());
     return false;
   }
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -106,7 +106,7 @@ int PR2ArmIKSolver::CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_i
   if (free_angle_ == 0)
   {
     if (verbose)
-      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "Solving with %f", q_init(0));
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Solving with %f", q_init(0));
     pr2_arm_ik_.computeIKShoulderPan(b, q_init(0), solution_ik);
   }
   else
@@ -124,14 +124,14 @@ int PR2ArmIKSolver::CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_i
   {
     if (verbose)
     {
-      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "Solution : %d", (int)solution_ik.size());
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Solution : %d", (int)solution_ik.size());
 
       for (int j = 0; j < (int)solution_ik[i].size(); j++)
       {
-        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "%d: %f", j, solution_ik[i][j]);
+        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "%d: %f", j, solution_ik[i][j]);
       }
-      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", " ");
-      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", " ");
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", " ");
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", " ");
     }
     double tmp_distance = computeEuclideanDistance(solution_ik[i], q_init);
     if (tmp_distance < min_distance)
@@ -170,7 +170,7 @@ int PR2ArmIKSolver::CartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame&
   int num_negative_increments =
       (int)((initial_guess - pr2_arm_ik_.solver_info_.limits[free_angle_].min_position) / search_discretization_angle_);
   if (verbose)
-    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "%f %f %f %d %d \n\n", initial_guess,
+    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "%f %f %f %d %d \n\n", initial_guess,
                     pr2_arm_ik_.solver_info_.limits[free_angle_].max_position,
                     pr2_arm_ik_.solver_info_.limits[free_angle_].min_position, num_positive_increments,
                     num_negative_increments);
@@ -182,17 +182,17 @@ int PR2ArmIKSolver::CartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame&
       return -1;
     q_init(free_angle_) = initial_guess + search_discretization_angle_ * count;
     if (verbose)
-      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "%d, %f", count, q_init(free_angle_));
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "%d, %f", count, q_init(free_angle_));
     loop_time = (ros::Time::now() - start_time).toSec();
   }
   if (loop_time >= timeout)
   {
-    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "IK Timed out in %f seconds", timeout);
+    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "IK Timed out in %f seconds", timeout);
     return TIMED_OUT;
   }
   else
   {
-    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "No IK solution was found");
+    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "No IK solution was found");
     return NO_IK_SOLUTION;
   }
   return NO_IK_SOLUTION;
@@ -275,7 +275,7 @@ bool PR2ArmKinematicsPlugin::initialize(const std::string& robot_description, co
   std::string xml_string;
   dimension_ = 7;
 
-  ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "Loading KDL Tree");
+  ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Loading KDL Tree");
   if (!getKDLChain(*robot_model_.get(), base_frame_, tip_frame_, kdl_chain_))
   {
     active_ = false;
@@ -301,21 +301,20 @@ bool PR2ArmKinematicsPlugin::initialize(const std::string& robot_description, co
     {
       for (unsigned int i = 0; i < ik_solver_info_.joint_names.size(); i++)
       {
-        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2Kinematics:: joint name: %s",
+        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2Kinematics:: joint name: %s",
                         ik_solver_info_.joint_names[i].c_str());
       }
       for (unsigned int i = 0; i < ik_solver_info_.link_names.size(); i++)
       {
-        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2Kinematics can solve IK for %s",
+        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2Kinematics can solve IK for %s",
                         ik_solver_info_.link_names[i].c_str());
       }
       for (unsigned int i = 0; i < fk_solver_info_.link_names.size(); i++)
       {
-        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2Kinematics can solve FK for %s",
+        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2Kinematics can solve FK for %s",
                         fk_solver_info_.link_names[i].c_str());
       }
-      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2KinematicsPlugin::active for %s",
-                      group_name.c_str());
+      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2KinematicsPlugin::active for %s", group_name.c_str());
     }
     active_ = true;
   }
@@ -373,7 +372,7 @@ bool PR2ArmKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose
   }
   else
   {
-    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "An IK solution could not be found");
+    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "An IK solution could not be found");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -106,7 +106,7 @@ int PR2ArmIKSolver::CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_i
   if (free_angle_ == 0)
   {
     if (verbose)
-      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Solving with %f", q_init(0));
+      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "Solving with %f", q_init(0));
     pr2_arm_ik_.computeIKShoulderPan(b, q_init(0), solution_ik);
   }
   else
@@ -124,14 +124,14 @@ int PR2ArmIKSolver::CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_i
   {
     if (verbose)
     {
-      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Solution : %d", (int)solution_ik.size());
+      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "Solution : %d", (int)solution_ik.size());
 
       for (int j = 0; j < (int)solution_ik[i].size(); j++)
       {
-        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "%d: %f", j, solution_ik[i][j]);
+        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "%d: %f", j, solution_ik[i][j]);
       }
-      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", " ");
-      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", " ");
+      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", " ");
+      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", " ");
     }
     double tmp_distance = computeEuclideanDistance(solution_ik[i], q_init);
     if (tmp_distance < min_distance)
@@ -170,7 +170,7 @@ int PR2ArmIKSolver::CartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame&
   int num_negative_increments =
       (int)((initial_guess - pr2_arm_ik_.solver_info_.limits[free_angle_].min_position) / search_discretization_angle_);
   if (verbose)
-    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "%f %f %f %d %d \n\n", initial_guess,
+    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "%f %f %f %d %d \n\n", initial_guess,
                     pr2_arm_ik_.solver_info_.limits[free_angle_].max_position,
                     pr2_arm_ik_.solver_info_.limits[free_angle_].min_position, num_positive_increments,
                     num_negative_increments);
@@ -182,17 +182,17 @@ int PR2ArmIKSolver::CartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame&
       return -1;
     q_init(free_angle_) = initial_guess + search_discretization_angle_ * count;
     if (verbose)
-      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "%d, %f", count, q_init(free_angle_));
+      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "%d, %f", count, q_init(free_angle_));
     loop_time = (ros::Time::now() - start_time).toSec();
   }
   if (loop_time >= timeout)
   {
-    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "IK Timed out in %f seconds", timeout);
+    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "IK Timed out in %f seconds", timeout);
     return TIMED_OUT;
   }
   else
   {
-    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "No IK solution was found");
+    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "No IK solution was found");
     return NO_IK_SOLUTION;
   }
   return NO_IK_SOLUTION;
@@ -275,7 +275,7 @@ bool PR2ArmKinematicsPlugin::initialize(const std::string& robot_description, co
   std::string xml_string;
   dimension_ = 7;
 
-  ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "Loading KDL Tree");
+  ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "Loading KDL Tree");
   if (!getKDLChain(*robot_model_.get(), base_frame_, tip_frame_, kdl_chain_))
   {
     active_ = false;
@@ -301,20 +301,21 @@ bool PR2ArmKinematicsPlugin::initialize(const std::string& robot_description, co
     {
       for (unsigned int i = 0; i < ik_solver_info_.joint_names.size(); i++)
       {
-        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2Kinematics:: joint name: %s",
+        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2Kinematics:: joint name: %s",
                         ik_solver_info_.joint_names[i].c_str());
       }
       for (unsigned int i = 0; i < ik_solver_info_.link_names.size(); i++)
       {
-        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2Kinematics can solve IK for %s",
+        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2Kinematics can solve IK for %s",
                         ik_solver_info_.link_names[i].c_str());
       }
       for (unsigned int i = 0; i < fk_solver_info_.link_names.size(); i++)
       {
-        ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2Kinematics can solve FK for %s",
+        ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2Kinematics can solve FK for %s",
                         fk_solver_info_.link_names[i].c_str());
       }
-      ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "PR2KinematicsPlugin::active for %s", group_name.c_str());
+      ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "PR2KinematicsPlugin::active for %s",
+                      group_name.c_str());
     }
     active_ = true;
   }
@@ -372,7 +373,7 @@ bool PR2ArmKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose
   }
   else
   {
-    ROS_DEBUG_NAMED("pr2_arm_kinematics_plugin", "An IK solution could not be found");
+    ROS_DEBUG_NAMED("constraint_samplers", "pr2_arm_kinematics_plugin", "An IK solution could not be found");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1128,7 +1128,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
     if (s->sample(ks, ks_const, 1))
       succ++;
   }
-  ROS_INFO_NAMED("constraint_samplers",
+  ROS_INFO_NAMED("pr2_arm_kinematics_plugin",
                  "Success rate for IK Constraint Sampler with position & orientation constraints for both "
                  "arms: %lf",
                  (double)succ / (double)NT);

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1129,8 +1129,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
       succ++;
   }
   ROS_INFO_NAMED("pr2_arm_kinematics_plugin",
-                 "Success rate for IK Constraint Sampler with position & orientation constraints for both "
-                 "arms: %lf",
+                 "Success rate for IK Constraint Sampler with position & orientation constraints for both arms: %lf",
                  (double)succ / (double)NT);
 }
 

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1128,9 +1128,10 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
     if (s->sample(ks, ks_const, 1))
       succ++;
   }
-  CONSOLE_BRIDGE_logInform("Success rate for IK Constraint Sampler with position & orientation constraints for both "
-                           "arms: %lf",
-                           (double)succ / (double)NT);
+  ROS_INFO_NAMED("constraint_samplers",
+                 "Success rate for IK Constraint Sampler with position & orientation constraints for both "
+                 "arms: %lf",
+                 (double)succ / (double)NT);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
   )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -521,14 +521,14 @@ private:
   void initNeighborhoods();
 
   /**
-   * \brief Debug function that prints all voxels in a set to CONSOLE_BRIDGE_logDebug
+   * \brief Debug function that prints all voxels in a set to ROS_DEBUG_NAMED
    *
    * @param set Voxel set to print
    */
   void print(const VoxelSet& set);
 
   /**
-   * \brief Debug function that prints all points in a vector to CONSOLE_BRIDGE_logDebug
+   * \brief Debug function that prints all points in a vector to ROS_DEBUG_NAMED
    *
    * @param points Points to print
    */

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -38,7 +38,7 @@
 #include <moveit/distance_field/find_internal_points.h>
 #include <geometric_shapes/body_operations.h>
 #include <eigen_conversions/eigen_msg.h>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 #include <octomap/octomap.h>
 #include <octomap/OcTree.h>
 
@@ -203,7 +203,7 @@ bool distance_field::DistanceField::getShapePoints(const shapes::Shape* shape, c
     const shapes::OcTree* oc = dynamic_cast<const shapes::OcTree*>(shape);
     if (!oc)
     {
-      CONSOLE_BRIDGE_logError("Problem dynamic casting shape that claims to be OcTree");
+      ROS_ERROR_NAMED("distance_field", "Problem dynamic casting shape that claims to be OcTree");
       return false;
     }
     getOcTreePoints(oc->octree.get(), points);
@@ -291,7 +291,7 @@ void distance_field::DistanceField::moveShapeInField(const shapes::Shape* shape,
 {
   if (shape->type == shapes::OCTREE)
   {
-    CONSOLE_BRIDGE_logWarn("Move shape not supported for Octree");
+    ROS_WARN_NAMED("distance_field", "Move shape not supported for Octree");
     return;
   }
   bodies::Body* body = bodies::createBodyFromShape(shape);

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <visualization_msgs/Marker.h>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
@@ -101,26 +101,26 @@ int PropagationDistanceField::eucDistSq(Eigen::Vector3i point1, Eigen::Vector3i 
 
 void PropagationDistanceField::print(const VoxelSet& set)
 {
-  CONSOLE_BRIDGE_logDebug("[");
+  ROS_DEBUG_NAMED("distance_field", "[");
   VoxelSet::const_iterator it;
   for (it = set.begin(); it != set.end(); ++it)
   {
     Eigen::Vector3i loc1 = *it;
-    CONSOLE_BRIDGE_logDebug("%d, %d, %d ", loc1.x(), loc1.y(), loc1.z());
+    ROS_DEBUG_NAMED("distance_field", "%d, %d, %d ", loc1.x(), loc1.y(), loc1.z());
   }
-  CONSOLE_BRIDGE_logDebug("] size=%u\n", (unsigned int)set.size());
+  ROS_DEBUG_NAMED("distance_field", "] size=%u\n", (unsigned int)set.size());
 }
 
 void PropagationDistanceField::print(const EigenSTL::vector_Vector3d& points)
 {
-  CONSOLE_BRIDGE_logDebug("[");
+  ROS_DEBUG_NAMED("distance_field", "[");
   EigenSTL::vector_Vector3d::const_iterator it;
   for (it = points.begin(); it != points.end(); ++it)
   {
     Eigen::Vector3d loc1 = *it;
-    CONSOLE_BRIDGE_logDebug("%g, %g, %g ", loc1.x(), loc1.y(), loc1.z());
+    ROS_DEBUG_NAMED("distance_field", "%g, %g, %g ", loc1.x(), loc1.y(), loc1.z());
   }
-  CONSOLE_BRIDGE_logDebug("] size=%u\n", (unsigned int)points.size());
+  ROS_DEBUG_NAMED("distance_field", "] size=%u\n", (unsigned int)points.size());
 }
 
 void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector3d& old_points,
@@ -166,19 +166,19 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
     {
       new_not_in_current.push_back(new_not_old[i]);
     }
-    // CONSOLE_BRIDGE_logInform("Adding obstacle voxel %d %d %d", (*it).x(), (*it).y(), (*it).z());
+    // ROS_INFO_NAMED("distance_field", "Adding obstacle voxel %d %d %d", (*it).x(), (*it).y(), (*it).z());
   }
 
   removeObstacleVoxels(old_not_new);
   addNewObstacleVoxels(new_not_in_current);
 
-  // CONSOLE_BRIDGE_logDebug( "new=" );
+  // ROS_DEBUG_NAMED("distance_field",  "new=" );
   // print(points_added);
-  // CONSOLE_BRIDGE_logDebug( "removed=" );
+  // ROS_DEBUG_NAMED("distance_field",  "removed=" );
   // print(points_removed);
-  // CONSOLE_BRIDGE_logDebug( "obstacle_voxel_locations_=" );
+  // ROS_DEBUG_NAMED("distance_field",  "obstacle_voxel_locations_=" );
   // print(object_voxel_locations_);
-  // CONSOLE_BRIDGE_logDebug("");
+  // ROS_DEBUG_NAMED("distance_field", "");
 }
 
 void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d& points)
@@ -415,7 +415,8 @@ void PropagationDistanceField::propagatePositive()
       // This will never happen.  update_direction_ is always set before voxel is added to bucket queue.
       if (vptr->update_direction_ < 0 || vptr->update_direction_ > 26)
       {
-        CONSOLE_BRIDGE_logError("PROGRAMMING ERROR: Invalid update direction detected: %d", vptr->update_direction_);
+        ROS_ERROR_NAMED("distance_field", "PROGRAMMING ERROR: Invalid update direction detected: %d",
+                        vptr->update_direction_);
         continue;
       }
 
@@ -473,7 +474,8 @@ void PropagationDistanceField::propagateNegative()
       // negative_bucket_queue_.
       if (vptr->negative_update_direction_ < 0 || vptr->negative_update_direction_ > 26)
       {
-        CONSOLE_BRIDGE_logError("PROGRAMMING ERROR: Invalid update direction detected: %d", vptr->update_direction_);
+        ROS_ERROR_NAMED("distance_field", "PROGRAMMING ERROR: Invalid update direction detected: %d",
+                        vptr->update_direction_);
         continue;
       }
 

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -42,6 +42,7 @@
 #include <geometric_shapes/body_operations.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <octomap/octomap.h>
+#include <ros/console.h>
 
 #include <memory>
 

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -39,7 +39,6 @@
 #include <moveit/distance_field/voxel_grid.h>
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <moveit/distance_field/find_internal_points.h>
-#include <console_bridge/console.h>
 #include <geometric_shapes/body_operations.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <octomap/octomap.h>
@@ -91,7 +90,7 @@ void print(PropagationDistanceField& pdf, int numX, int numY, int numZ)
       {
         if (pdf.getCell(x, y, z).distance_square_ == 0)
         {
-          // CONSOLE_BRIDGE_logInform("Obstacle cell %d %d %d", x, y, z);
+          // ROS_INFO_NAMED("distance_field", "Obstacle cell %d %d %d", x, y, z);
         }
       }
     }
@@ -353,7 +352,7 @@ TEST(TestPropagationDistanceField, TestAddRemovePoints)
   EigenSTL::vector_Vector3d points;
   points.push_back(point1);
   points.push_back(point2);
-  CONSOLE_BRIDGE_logInform("Adding %u points", points.size());
+  ROS_INFO_NAMED("distance_field", "Adding %u points", points.size());
   df.addPointsToField(points);
   // print(df, numX, numY, numZ);
 
@@ -469,7 +468,7 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
   }
 
   df.reset();
-  CONSOLE_BRIDGE_logInform("Adding %u points", points.size());
+  ROS_INFO_NAMED("distance_field", "Adding %u points", points.size());
   df.addPointsToField(points);
   // print(df, numX, numY, numZ);
   // printNeg(df, numX, numY, numZ);
@@ -767,7 +766,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
 
         if (!valid)
         {
-          CONSOLE_BRIDGE_logWarn("Something wrong");
+          ROS_WARN_NAMED("distance_field", "Something wrong");
           continue;
         }
         bad_vec.push_back(loc);

--- a/moveit_core/dynamics_solver/CMakeLists.txt
+++ b/moveit_core/dynamics_solver/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_dynamics_solver)
 add_library(${MOVEIT_LIB_NAME} src/dynamics_solver.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -74,16 +74,16 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
 
   if (!joint_model_group_->isChain())
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Group '%s' is not a chain. Will not initialize dynamics solver",
-                            group_name.c_str());
+    ROS_ERROR_NAMED("dynamics_solver", "Group '%s' is not a chain. Will not initialize dynamics solver",
+                    group_name.c_str());
     joint_model_group_ = NULL;
     return;
   }
 
   if (joint_model_group_->getMimicJointModels().size() > 0)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Group '%s' has a mimic joint. Will not initialize dynamics solver",
-                            group_name.c_str());
+    ROS_ERROR_NAMED("dynamics_solver", "Group '%s' has a mimic joint. Will not initialize dynamics solver",
+                    group_name.c_str());
     joint_model_group_ = NULL;
     return;
   }
@@ -91,7 +91,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
   const robot_model::JointModel* joint = joint_model_group_->getJointRoots()[0];
   if (!joint->getParentLinkModel())
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Group '%s' does not have a parent link", group_name.c_str());
+    ROS_ERROR_NAMED("dynamics_solver", "Group '%s' does not have a parent link", group_name.c_str());
     joint_model_group_ = NULL;
     return;
   }
@@ -99,8 +99,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
   base_name_ = joint->getParentLinkModel()->getName();
 
   tip_name_ = joint_model_group_->getLinkModelNames().back();
-  CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Base name: '%s', Tip name: '%s'", base_name_.c_str(),
-                          tip_name_.c_str());
+  ROS_DEBUG_NAMED("dynamics_solver", "Base name: '%s', Tip name: '%s'", base_name_.c_str(), tip_name_.c_str());
 
   const urdf::ModelInterfaceSharedPtr urdf_model = robot_model_->getURDF();
   const srdf::ModelConstSharedPtr srdf_model = robot_model_->getSRDF();
@@ -108,13 +107,13 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
 
   if (!kdl_parser::treeFromUrdfModel(*urdf_model, tree))
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Could not initialize tree object");
+    ROS_ERROR_NAMED("dynamics_solver", "Could not initialize tree object");
     joint_model_group_ = NULL;
     return;
   }
   if (!tree.getChain(base_name_, tip_name_, kdl_chain_))
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Could not initialize chain object");
+    ROS_ERROR_NAMED("dynamics_solver", "Could not initialize chain object");
     joint_model_group_ = NULL;
     return;
   }
@@ -137,7 +136,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
   KDL::Vector gravity(gravity_vector.x, gravity_vector.y,
                       gravity_vector.z);  // \todo Not sure if KDL expects the negative of this (Sachin)
   gravity_ = gravity.Norm();
-  CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Gravity norm set to %f", gravity_);
+  ROS_DEBUG_NAMED("dynamics_solver", "Gravity norm set to %f", gravity_);
 
   chain_id_solver_.reset(new KDL::ChainIdSolver_RNE(kdl_chain_, gravity));
 }
@@ -148,33 +147,33 @@ bool DynamicsSolver::getTorques(const std::vector<double>& joint_angles, const s
 {
   if (!joint_model_group_)
   {
-    CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Did not construct DynamicsSolver object properly. "
-                            "Check error logs.");
+    ROS_DEBUG_NAMED("dynamics_solver", "Did not construct DynamicsSolver object properly. "
+                                       "Check error logs.");
     return false;
   }
   if (joint_angles.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Joint angles vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Joint angles vector should be size %d", num_joints_);
     return false;
   }
   if (joint_velocities.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Joint velocities vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Joint velocities vector should be size %d", num_joints_);
     return false;
   }
   if (joint_accelerations.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Joint accelerations vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Joint accelerations vector should be size %d", num_joints_);
     return false;
   }
   if (wrenches.size() != num_segments_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Wrenches vector should be size %d", num_segments_);
+    ROS_ERROR_NAMED("dynamics_solver", "Wrenches vector should be size %d", num_segments_);
     return false;
   }
   if (torques.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Torques vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Torques vector should be size %d", num_joints_);
     return false;
   }
 
@@ -202,7 +201,7 @@ bool DynamicsSolver::getTorques(const std::vector<double>& joint_angles, const s
 
   if (chain_id_solver_->CartToJnt(kdl_angles, kdl_velocities, kdl_accelerations, kdl_wrenches, kdl_torques) < 0)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Something went wrong computing torques");
+    ROS_ERROR_NAMED("dynamics_solver", "Something went wrong computing torques");
     return false;
   }
 
@@ -217,13 +216,13 @@ bool DynamicsSolver::getMaxPayload(const std::vector<double>& joint_angles, doub
 {
   if (!joint_model_group_)
   {
-    CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Did not construct DynamicsSolver object properly. "
-                            "Check error logs.");
+    ROS_DEBUG_NAMED("dynamics_solver", "Did not construct DynamicsSolver object properly. "
+                                       "Check error logs.");
     return false;
   }
   if (joint_angles.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Joint angles vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Joint angles vector should be size %d", num_joints_);
     return false;
   }
   std::vector<double> joint_velocities(num_joints_, 0.0), joint_accelerations(num_joints_, 0.0);
@@ -251,8 +250,8 @@ bool DynamicsSolver::getMaxPayload(const std::vector<double>& joint_angles, doub
   wrenches.back().force = transformVector(transform, wrenches.back().force);
   wrenches.back().torque = transformVector(transform, wrenches.back().torque);
 
-  CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: New wrench (local frame): %f %f %f", wrenches.back().force.x,
-                          wrenches.back().force.y, wrenches.back().force.z);
+  ROS_DEBUG_NAMED("dynamics_solver", "New wrench (local frame): %f %f %f", wrenches.back().force.x,
+                  wrenches.back().force.y, wrenches.back().force.z);
 
   if (!getTorques(joint_angles, joint_velocities, joint_accelerations, wrenches, torques))
     return false;
@@ -263,9 +262,9 @@ bool DynamicsSolver::getMaxPayload(const std::vector<double>& joint_angles, doub
     double payload_joint = std::max<double>((max_torques_[i] - zero_torques[i]) / (torques[i] - zero_torques[i]),
                                             (-max_torques_[i] - zero_torques[i]) /
                                                 (torques[i] - zero_torques[i]));  // because we set the payload to 1.0
-    CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Joint: %d, Actual Torque: %f, Max Allowed: %f, Gravity: %f", i,
-                            torques[i], max_torques_[i], zero_torques[i]);
-    CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Joint: %d, Payload Allowed (N): %f", i, payload_joint);
+    ROS_DEBUG_NAMED("dynamics_solver", "Joint: %d, Actual Torque: %f, Max Allowed: %f, Gravity: %f", i, torques[i],
+                    max_torques_[i], zero_torques[i]);
+    ROS_DEBUG_NAMED("dynamics_solver", "Joint: %d, Payload Allowed (N): %f", i, payload_joint);
     if (payload_joint < min_payload)
     {
       min_payload = payload_joint;
@@ -273,7 +272,7 @@ bool DynamicsSolver::getMaxPayload(const std::vector<double>& joint_angles, doub
     }
   }
   payload = min_payload / gravity_;
-  CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Max payload (kg): %f", payload);
+  ROS_DEBUG_NAMED("dynamics_solver", "Max payload (kg): %f", payload);
   return true;
 }
 
@@ -282,18 +281,18 @@ bool DynamicsSolver::getPayloadTorques(const std::vector<double>& joint_angles, 
 {
   if (!joint_model_group_)
   {
-    CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: Did not construct DynamicsSolver object properly. "
-                            "Check error logs.");
+    ROS_DEBUG_NAMED("dynamics_solver", "Did not construct DynamicsSolver object properly. "
+                                       "Check error logs.");
     return false;
   }
   if (joint_angles.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Joint angles vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Joint angles vector should be size %d", num_joints_);
     return false;
   }
   if (joint_torques.size() != num_joints_)
   {
-    CONSOLE_BRIDGE_logError("moveit.dynamics_solver: Joint torques vector should be size %d", num_joints_);
+    ROS_ERROR_NAMED("dynamics_solver", "Joint torques vector should be size %d", num_joints_);
     return false;
   }
   std::vector<double> joint_velocities(num_joints_, 0.0), joint_accelerations(num_joints_, 0.0);
@@ -307,8 +306,8 @@ bool DynamicsSolver::getPayloadTorques(const std::vector<double>& joint_angles, 
   wrenches.back().force = transformVector(transform, wrenches.back().force);
   wrenches.back().torque = transformVector(transform, wrenches.back().torque);
 
-  CONSOLE_BRIDGE_logDebug("moveit.dynamics_solver: New wrench (local frame): %f %f %f", wrenches.back().force.x,
-                          wrenches.back().force.y, wrenches.back().force.z);
+  ROS_DEBUG_NAMED("dynamics_solver", "New wrench (local frame): %f %f %f", wrenches.back().force.x,
+                  wrenches.back().force.y, wrenches.back().force.z);
 
   if (!getTorques(joint_angles, joint_velocities, joint_accelerations, wrenches, joint_torques))
     return false;

--- a/moveit_core/exceptions/CMakeLists.txt
+++ b/moveit_core/exceptions/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_exceptions)
 add_library(${MOVEIT_LIB_NAME} src/exceptions.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/moveit_core/exceptions/src/exceptions.cpp
+++ b/moveit_core/exceptions/src/exceptions.cpp
@@ -35,14 +35,14 @@
 /* Author: Acorn Pooley, Ioan Sucan */
 
 #include <moveit/exceptions/exceptions.h>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 
 moveit::ConstructException::ConstructException(const std::string& what_arg) : std::runtime_error(what_arg)
 {
-  CONSOLE_BRIDGE_logError("Error during construction of object: %s\nException thrown.", what_arg.c_str());
+  ROS_ERROR_NAMED("exceptions", "Error during construction of object: %s\nException thrown.", what_arg.c_str());
 }
 
 moveit::Exception::Exception(const std::string& what_arg) : std::runtime_error(what_arg)
 {
-  CONSOLE_BRIDGE_logError("%s\nException thrown.", what_arg.c_str());
+  ROS_ERROR_NAMED("exceptions", "%s\nException thrown.", what_arg.c_str());
 }

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -7,7 +7,7 @@ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VE
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_model moveit_kinematics_base moveit_robot_state moveit_collision_detection_fcl
-  ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+  ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -59,8 +59,9 @@ moveit_msgs::Constraints kinematic_constraints::mergeConstraints(const moveit_ms
         double low = std::max(a.position - a.tolerance_below, b.position - b.tolerance_below);
         double high = std::min(a.position + a.tolerance_above, b.position + b.tolerance_above);
         if (low > high)
-          CONSOLE_BRIDGE_logError("Attempted to merge incompatible constraints for joint '%s'. Discarding constraint.",
-                                  a.joint_name.c_str());
+          ROS_ERROR_NAMED("kinematic_constraints",
+                          "Attempted to merge incompatible constraints for joint '%s'. Discarding constraint.",
+                          a.joint_name.c_str());
         else
         {
           m.joint_name = a.joint_name;

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -6,7 +6,7 @@ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VE
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -314,8 +314,7 @@ public:
     }
 
     // Otherwise throw error because this function should have been implemented
-    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver "
-                                       "does not support searchPositionIK with multiple poses");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support searchPositionIK with multiple poses");
     return false;
   }
 
@@ -392,8 +391,8 @@ public:
       return initialize(robot_description, group_name, base_frame, tip_frames[0], search_discretization);
     }
 
-    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver "
-                                       "does not support initialization with more than one tip frames");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support initialization "
+                                       "with more than one tip frames");
     return false;
   }
 

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -41,7 +41,6 @@
 #include <moveit_msgs/MoveItErrorCodes.h>
 #include <moveit/macros/class_forward.h>
 #include <ros/node_handle.h>
-#include <console_bridge/console.h>
 
 #include <boost/function.hpp>
 #include <string>
@@ -315,8 +314,8 @@ public:
     }
 
     // Otherwise throw error because this function should have been implemented
-    CONSOLE_BRIDGE_logError("moveit.kinematics_base: This kinematic solver "
-                            "does not support searchPositionIK with multiple poses");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver "
+                                       "does not support searchPositionIK with multiple poses");
     return false;
   }
 
@@ -393,8 +392,8 @@ public:
       return initialize(robot_description, group_name, base_frame, tip_frames[0], search_discretization);
     }
 
-    CONSOLE_BRIDGE_logError("moveit.kinematics_base: This kinematic solver "
-                            "does not support initialization with more than one tip frames");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver "
+                                       "does not support initialization with more than one tip frames");
     return false;
   }
 
@@ -427,8 +426,8 @@ public:
   virtual const std::string& getTipFrame() const
   {
     if (tip_frames_.size() > 1)
-      CONSOLE_BRIDGE_logError("moveit.kinematics_base: This kinematic solver has more than one tip frame, "
-                              "do not call getTipFrame()");
+      ROS_ERROR_NAMED("kinematics_base", "This kinematic solver has more than one tip frame, "
+                                         "do not call getTipFrame()");
 
     return tip_frame_;  // for backwards-compatibility. should actually use tip_frames_[0]
   }

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -143,8 +143,7 @@ bool kinematics::KinematicsBase::getPositionIK(const std::vector<geometry_msgs::
 
   if (ik_poses.size() != 1)
   {
-    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver "
-                                       "does not support getPositionIK for multiple poses");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support getPositionIK for multiple poses");
     result.kinematic_error = kinematics::KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -143,15 +143,15 @@ bool kinematics::KinematicsBase::getPositionIK(const std::vector<geometry_msgs::
 
   if (ik_poses.size() != 1)
   {
-    CONSOLE_BRIDGE_logError("moveit.kinematics_base: This kinematic solver "
-                            "does not support getPositionIK for multiple poses");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver "
+                                       "does not support getPositionIK for multiple poses");
     result.kinematic_error = kinematics::KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }
 
   if (ik_poses.size() == 0)
   {
-    CONSOLE_BRIDGE_logError("moveit.kinematics_base: Input ik_poses array is empty");
+    ROS_ERROR_NAMED("kinematics_base", "Input ik_poses array is empty");
     result.kinematic_error = kinematics::KinematicErrors::EMPTY_TIP_POSES;
     return false;
   }

--- a/moveit_core/kinematics_metrics/CMakeLists.txt
+++ b/moveit_core/kinematics_metrics/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_kinematics_metrics)
 add_library(${MOVEIT_LIB_NAME} src/kinematics_metrics.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -122,7 +122,7 @@ bool KinematicsMetrics::getManipulabilityIndex(const robot_state::RobotState& st
       manipulability_index = 1.0;
       for (unsigned int i = 0; i < singular_values.rows(); ++i)
       {
-        CONSOLE_BRIDGE_logDebug("moveit.kin_metrics: Singular value: %d %f", i, singular_values(i, 0));
+        ROS_DEBUG_NAMED("kinematics_metrics", "Singular value: %d %f", i, singular_values(i, 0));
         manipulability_index *= singular_values(i, 0);
       }
       // Get manipulability index
@@ -145,7 +145,7 @@ bool KinematicsMetrics::getManipulabilityIndex(const robot_state::RobotState& st
       manipulability_index = 1.0;
       for (unsigned int i = 0; i < singular_values.rows(); ++i)
       {
-        CONSOLE_BRIDGE_logDebug("moveit.kin_metrics: Singular value: %d %f", i, singular_values(i, 0));
+        ROS_DEBUG_NAMED("kinematics_metrics", "Singular value: %d %f", i, singular_values(i, 0));
         manipulability_index *= singular_values(i, 0);
       }
       // Get manipulability index
@@ -218,7 +218,7 @@ bool KinematicsMetrics::getManipulability(const robot_state::RobotState& state,
     Eigen::JacobiSVD<Eigen::MatrixXd> svdsolver(jacobian.topLeftCorner(3, jacobian.cols()));
     Eigen::MatrixXd singular_values = svdsolver.singularValues();
     for (int i = 0; i < singular_values.rows(); ++i)
-      CONSOLE_BRIDGE_logDebug("moveit.kin_metrics: Singular value: %d %f", i, singular_values(i, 0));
+      ROS_DEBUG_NAMED("kinematics_metrics", "Singular value: %d %f", i, singular_values(i, 0));
     manipulability = penalty * singular_values.minCoeff() / singular_values.maxCoeff();
   }
   else
@@ -227,7 +227,7 @@ bool KinematicsMetrics::getManipulability(const robot_state::RobotState& state,
     Eigen::JacobiSVD<Eigen::MatrixXd> svdsolver(jacobian);
     Eigen::MatrixXd singular_values = svdsolver.singularValues();
     for (int i = 0; i < singular_values.rows(); ++i)
-      CONSOLE_BRIDGE_logDebug("moveit.kin_metrics: Singular value: %d %f", i, singular_values(i, 0));
+      ROS_DEBUG_NAMED("kinematics_metrics", "Singular value: %d %f", i, singular_values(i, 0));
     manipulability = penalty * singular_values.minCoeff() / singular_values.maxCoeff();
   }
   return true;

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -38,6 +38,7 @@
   <build_depend>random_numbers</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rostime</build_depend>
+  <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>shape_msgs</build_depend>
   <build_depend>srdfdom</build_depend>
@@ -63,6 +64,7 @@
   <run_depend>octomap_msgs</run_depend>
   <run_depend>random_numbers</run_depend>
   <run_depend>rostime</run_depend>
+  <run_depend>rosconsole</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>srdfdom</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/moveit_core/planning_interface/CMakeLists.txt
+++ b/moveit_core/planning_interface/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state moveit_robot_trajectory ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state moveit_robot_trajectory ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/planning_interface/src/planning_interface.cpp
+++ b/moveit_core/planning_interface/src/planning_interface.cpp
@@ -79,12 +79,14 @@ void planning_interface::PlanningContext::setMotionPlanRequest(const MotionPlanR
   request_ = request;
   if (request_.allowed_planning_time <= 0.0)
   {
-    CONSOLE_BRIDGE_logInform("The timeout for planning must be positive (%lf specified). Assuming one second instead.",
-                             request_.allowed_planning_time);
+    ROS_INFO_NAMED("planning_interface",
+                   "The timeout for planning must be positive (%lf specified). Assuming one second instead.",
+                   request_.allowed_planning_time);
     request_.allowed_planning_time = 1.0;
   }
   if (request_.num_planning_attempts < 0)
-    CONSOLE_BRIDGE_logError("The number of desired planning attempts should be positive. Assuming one attempt.");
+    ROS_ERROR_NAMED("planning_interface", "The number of desired planning attempts should be positive. Assuming one "
+                                          "attempt.");
   request_.num_planning_attempts = std::max(1, request_.num_planning_attempts);
 }
 

--- a/moveit_core/planning_interface/src/planning_interface.cpp
+++ b/moveit_core/planning_interface/src/planning_interface.cpp
@@ -85,8 +85,8 @@ void planning_interface::PlanningContext::setMotionPlanRequest(const MotionPlanR
     request_.allowed_planning_time = 1.0;
   }
   if (request_.num_planning_attempts < 0)
-    ROS_ERROR_NAMED("planning_interface", "The number of desired planning attempts should be positive. Assuming one "
-                                          "attempt.");
+    ROS_ERROR_NAMED("planning_interface", "The number of desired planning attempts should be positive. "
+                                          "Assuming one attempt.");
   request_.num_planning_attempts = std::max(1, request_.num_planning_attempts);
 }
 

--- a/moveit_core/planning_request_adapter/CMakeLists.txt
+++ b/moveit_core/planning_request_adapter/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_planning_request_adapter)
 add_library(${MOVEIT_LIB_NAME} src/planning_request_adapter.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_planning_scene ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_planning_scene ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -92,8 +92,8 @@ bool callAdapter1(const PlanningRequestAdapter* adapter, const planning_interfac
   }
   catch (std::exception& ex)
   {
-    CONSOLE_BRIDGE_logError("Exception caught executing *final* adapter '%s': %s", adapter->getDescription().c_str(),
-                            ex.what());
+    ROS_ERROR_NAMED("planning_request_adapter", "Exception caught executing *final* adapter '%s': %s",
+                    adapter->getDescription().c_str(), ex.what());
     added_path_index.clear();
     return callPlannerInterfaceSolve(planner.get(), planning_scene, req, res);
   }
@@ -110,8 +110,8 @@ bool callAdapter2(const PlanningRequestAdapter* adapter, const PlanningRequestAd
   }
   catch (std::exception& ex)
   {
-    CONSOLE_BRIDGE_logError("Exception caught executing *next* adapter '%s': %s", adapter->getDescription().c_str(),
-                            ex.what());
+    ROS_ERROR_NAMED("planning_request_adapter", "Exception caught executing *next* adapter '%s': %s",
+                    adapter->getDescription().c_str(), ex.what());
     added_path_index.clear();
     return planner(planning_scene, req, res);
   }

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_kinematic_constraints
   moveit_robot_trajectory
   moveit_trajectory_processing
-  ${LIBOCTOMAP_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+  ${LIBOCTOMAP_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1442,22 +1442,22 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
   {
     if (object.object.primitives.size() != object.object.primitive_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match "
-                                        "number of poses in attached collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match number of poses "
+                                        "in attached collision object message");
       return false;
     }
 
     if (object.object.meshes.size() != object.object.mesh_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of meshes does not match number of poses in attached collision object "
-                                        "message");
+      ROS_ERROR_NAMED("planning_scene", "Number of meshes does not match number of poses "
+                                        "in attached collision object message");
       return false;
     }
 
     if (object.object.planes.size() != object.object.plane_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of planes does not match number of poses in attached collision object "
-                                        "message");
+      ROS_ERROR_NAMED("planning_scene", "Number of planes does not match number of poses "
+                                        "in attached collision object message");
       return false;
     }
 
@@ -1505,8 +1505,9 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
             ROS_INFO_NAMED("planning_scene", "Removing world object with the same name as newly attached object: '%s'",
                            object.object.id.c_str());
           else
-            ROS_WARN_NAMED("planning_scene", "You tried to append geometry to an attached object "
-                                             "that is actually a world object ('%s'). World geometry is ignored.",
+            ROS_WARN_NAMED("planning_scene",
+                           "You tried to append geometry to an attached object that is actually a world object ('%s'). "
+                           "World geometry is ignored.",
                            object.object.id.c_str());
         }
 
@@ -1641,8 +1642,8 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
 
       if (world_->hasObject(name))
         ROS_WARN_NAMED("planning_scene",
-                       "The collision world already has an object with the same name as the body about to be "
-                       "detached. NOT adding the detached body '%s' to the collision world.",
+                       "The collision world already has an object with the same name as the body about to be detached. "
+                       "NOT adding the detached body '%s' to the collision world.",
                        object.object.id.c_str());
       else
       {
@@ -1685,8 +1686,8 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
 
     if (object.primitives.size() != object.primitive_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match number of poses in collision object "
-                                        "message");
+      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match number of poses "
+                                        "in collision object message");
       return false;
     }
 
@@ -1796,8 +1797,9 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
       }
       else
       {
-        ROS_ERROR_NAMED("planning_scene", "Number of supplied poses (%zu) for object '%s' "
-                                          "does not match number of shapes (%zu). Not moving.",
+        ROS_ERROR_NAMED("planning_scene",
+                        "Number of supplied poses (%zu) for object '%s' does not match number of shapes (%zu). "
+                        "Not moving.",
                         new_poses.size(), object.id.c_str(), obj->shapes_.size());
         return false;
       }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1212,7 +1212,7 @@ bool planning_scene::PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::P
 {
   bool result = true;
 
-  ROS_DEBUG_NAMED("planning_scene", "moveit.planning_scene: Adding planning scene diff");
+  ROS_DEBUG_NAMED("planning_scene", "Adding planning scene diff");
   if (!scene_msg.name.empty())
     name_ = scene_msg.name;
 
@@ -1269,7 +1269,7 @@ bool planning_scene::PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::P
 
 bool planning_scene::PlanningScene::setPlanningSceneMsg(const moveit_msgs::PlanningScene& scene_msg)
 {
-  ROS_DEBUG_NAMED("planning_scene", "moveit.planning_scene: Setting new planning scene: '%s'", scene_msg.name.c_str());
+  ROS_DEBUG_NAMED("planning_scene", "Setting new planning scene: '%s'", scene_msg.name.c_str());
   name_ = scene_msg.name;
 
   if (!scene_msg.robot_model_name.empty() && scene_msg.robot_model_name != getRobotModel()->getName())

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -355,9 +355,10 @@ bool planning_scene::PlanningScene::setActiveCollisionDetector(const std::string
   }
   else
   {
-    CONSOLE_BRIDGE_logError("Cannot setActiveCollisionDetector to '%s' -- it has been added to PlanningScene. "
-                            "Keeping existing active collision detector '%s'",
-                            collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    ROS_ERROR_NAMED("planning_scene",
+                    "Cannot setActiveCollisionDetector to '%s' -- it has been added to PlanningScene. "
+                    "Keeping existing active collision detector '%s'",
+                    collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return false;
   }
 }
@@ -376,8 +377,9 @@ planning_scene::PlanningScene::getCollisionWorld(const std::string& collision_de
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    CONSOLE_BRIDGE_logError("Could not get CollisionWorld named '%s'.  Returning active CollisionWorld '%s' instead",
-                            collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    ROS_ERROR_NAMED("planning_scene",
+                    "Could not get CollisionWorld named '%s'.  Returning active CollisionWorld '%s' instead",
+                    collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->cworld_const_;
   }
 
@@ -390,8 +392,9 @@ planning_scene::PlanningScene::getCollisionRobot(const std::string& collision_de
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    CONSOLE_BRIDGE_logError("Could not get CollisionRobot named '%s'.  Returning active CollisionRobot '%s' instead",
-                            collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    ROS_ERROR_NAMED("planning_scene",
+                    "Could not get CollisionRobot named '%s'.  Returning active CollisionRobot '%s' instead",
+                    collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->getCollisionRobot();
   }
 
@@ -404,9 +407,9 @@ planning_scene::PlanningScene::getCollisionRobotUnpadded(const std::string& coll
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    CONSOLE_BRIDGE_logError("Could not get CollisionRobotUnpadded named '%s'. "
-                            "Returning active CollisionRobotUnpadded '%s' instead",
-                            collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    ROS_ERROR_NAMED("planning_scene", "Could not get CollisionRobotUnpadded named '%s'. "
+                                      "Returning active CollisionRobotUnpadded '%s' instead",
+                    collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->getCollisionRobotUnpadded();
   }
 
@@ -900,8 +903,9 @@ bool planning_scene::PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose&
       tf::poseEigenToMsg(map->shape_poses_[0], octomap.origin);
       return true;
     }
-    CONSOLE_BRIDGE_logError("Unexpected number of shapes in octomap collision object. Not including '%s' object",
-                            OCTOMAP_NS.c_str());
+    ROS_ERROR_NAMED("planning_scene",
+                    "Unexpected number of shapes in octomap collision object. Not including '%s' object",
+                    OCTOMAP_NS.c_str());
   }
   return false;
 }
@@ -1120,9 +1124,9 @@ void planning_scene::PlanningScene::setCurrentState(const moveit_msgs::RobotStat
   {
     if (!state.is_diff && state.attached_collision_objects[i].object.operation != moveit_msgs::CollisionObject::ADD)
     {
-      CONSOLE_BRIDGE_logError("The specified RobotState is not marked as is_diff. "
-                              "The request to modify the object '%s' is not supported. Object is ignored.",
-                              state.attached_collision_objects[i].object.id.c_str());
+      ROS_ERROR_NAMED("planning_scene", "The specified RobotState is not marked as is_diff. "
+                                        "The request to modify the object '%s' is not supported. Object is ignored.",
+                      state.attached_collision_objects[i].object.id.c_str());
       continue;
     }
     processAttachedCollisionObjectMsg(state.attached_collision_objects[i]);
@@ -1208,13 +1212,13 @@ bool planning_scene::PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::P
 {
   bool result = true;
 
-  CONSOLE_BRIDGE_logDebug("moveit.planning_scene: Adding planning scene diff");
+  ROS_DEBUG_NAMED("planning_scene", "moveit.planning_scene: Adding planning scene diff");
   if (!scene_msg.name.empty())
     name_ = scene_msg.name;
 
   if (!scene_msg.robot_model_name.empty() && scene_msg.robot_model_name != getRobotModel()->getName())
-    CONSOLE_BRIDGE_logWarn("Setting the scene for model '%s' but model '%s' is loaded.",
-                           scene_msg.robot_model_name.c_str(), getRobotModel()->getName().c_str());
+    ROS_WARN_NAMED("planning_scene", "Setting the scene for model '%s' but model '%s' is loaded.",
+                   scene_msg.robot_model_name.c_str(), getRobotModel()->getName().c_str());
 
   // there is at least one transform in the list of fixed transform: from model frame to itself;
   // if the list is empty, then nothing has been set
@@ -1265,12 +1269,12 @@ bool planning_scene::PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::P
 
 bool planning_scene::PlanningScene::setPlanningSceneMsg(const moveit_msgs::PlanningScene& scene_msg)
 {
-  CONSOLE_BRIDGE_logDebug("moveit.planning_scene: Setting new planning scene: '%s'", scene_msg.name.c_str());
+  ROS_DEBUG_NAMED("planning_scene", "moveit.planning_scene: Setting new planning scene: '%s'", scene_msg.name.c_str());
   name_ = scene_msg.name;
 
   if (!scene_msg.robot_model_name.empty() && scene_msg.robot_model_name != getRobotModel()->getName())
-    CONSOLE_BRIDGE_logWarn("Setting the scene for model '%s' but model '%s' is loaded.",
-                           scene_msg.robot_model_name.c_str(), getRobotModel()->getName().c_str());
+    ROS_WARN_NAMED("planning_scene", "Setting the scene for model '%s' but model '%s' is loaded.",
+                   scene_msg.robot_model_name.c_str(), getRobotModel()->getName().c_str());
 
   if (parent_)
     decoupleParent();
@@ -1323,7 +1327,8 @@ void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octoma
 
   if (map.id != "OcTree")
   {
-    CONSOLE_BRIDGE_logError("Received octomap is of type '%s' but type 'OcTree' is expected.", map.id.c_str());
+    ROS_ERROR_NAMED("planning_scene", "Received octomap is of type '%s' but type 'OcTree' is expected.",
+                    map.id.c_str());
     return;
   }
 
@@ -1361,7 +1366,8 @@ void planning_scene::PlanningScene::processOctomapMsg(const octomap_msgs::Octoma
 
   if (map.octomap.id != "OcTree")
   {
-    CONSOLE_BRIDGE_logError("Received octomap is of type '%s' but type 'OcTree' is expected.", map.octomap.id.c_str());
+    ROS_ERROR_NAMED("planning_scene", "Received octomap is of type '%s' but type 'OcTree' is expected.",
+                    map.octomap.id.c_str());
     return;
   }
 
@@ -1412,13 +1418,15 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
 {
   if (object.object.operation == moveit_msgs::CollisionObject::ADD && !getRobotModel()->hasLinkModel(object.link_name))
   {
-    CONSOLE_BRIDGE_logError("Unable to attach a body to link '%s' (link not found)", object.link_name.c_str());
+    ROS_ERROR_NAMED("planning_scene", "Unable to attach a body to link '%s' (link not found)",
+                    object.link_name.c_str());
     return false;
   }
 
   if (object.object.id == OCTOMAP_NS)
   {
-    CONSOLE_BRIDGE_logError("The ID '%s' cannot be used for collision objects (name reserved)", OCTOMAP_NS.c_str());
+    ROS_ERROR_NAMED("planning_scene", "The ID '%s' cannot be used for collision objects (name reserved)",
+                    OCTOMAP_NS.c_str());
     return false;
   }
 
@@ -1434,20 +1442,22 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
   {
     if (object.object.primitives.size() != object.object.primitive_poses.size())
     {
-      CONSOLE_BRIDGE_logError("Number of primitive shapes does not match "
-                              "number of poses in attached collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match "
+                                        "number of poses in attached collision object message");
       return false;
     }
 
     if (object.object.meshes.size() != object.object.mesh_poses.size())
     {
-      CONSOLE_BRIDGE_logError("Number of meshes does not match number of poses in attached collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of meshes does not match number of poses in attached collision object "
+                                        "message");
       return false;
     }
 
     if (object.object.planes.size() != object.object.plane_poses.size())
     {
-      CONSOLE_BRIDGE_logError("Number of planes does not match number of poses in attached collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of planes does not match number of poses in attached collision object "
+                                        "message");
       return false;
     }
 
@@ -1464,8 +1474,8 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
         collision_detection::CollisionWorld::ObjectConstPtr obj = world_->getObject(object.object.id);
         if (obj)
         {
-          CONSOLE_BRIDGE_logInform("Attaching world object '%s' to link '%s'", object.object.id.c_str(),
-                                   object.link_name.c_str());
+          ROS_INFO_NAMED("planning_scene", "Attaching world object '%s' to link '%s'", object.object.id.c_str(),
+                         object.link_name.c_str());
 
           // extract the shapes from the world
           shapes = obj->shapes_;
@@ -1480,9 +1490,9 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
         }
         else
         {
-          CONSOLE_BRIDGE_logError("Attempting to attach object '%s' to link '%s' but no geometry specified "
-                                  "and such an object does not exist in the collision world",
-                                  object.object.id.c_str(), object.link_name.c_str());
+          ROS_ERROR_NAMED("planning_scene", "Attempting to attach object '%s' to link '%s' but no geometry specified "
+                                            "and such an object does not exist in the collision world",
+                          object.object.id.c_str(), object.link_name.c_str());
           return false;
         }
       }
@@ -1492,12 +1502,12 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
         if (world_->removeObject(object.object.id))
         {
           if (object.object.operation == moveit_msgs::CollisionObject::ADD)
-            CONSOLE_BRIDGE_logInform("Removing world object with the same name as newly attached object: '%s'",
-                                     object.object.id.c_str());
+            ROS_INFO_NAMED("planning_scene", "Removing world object with the same name as newly attached object: '%s'",
+                           object.object.id.c_str());
           else
-            CONSOLE_BRIDGE_logWarn("You tried to append geometry to an attached object "
-                                   "that is actually a world object ('%s'). World geometry is ignored.",
-                                   object.object.id.c_str());
+            ROS_WARN_NAMED("planning_scene", "You tried to append geometry to an attached object "
+                                             "that is actually a world object ('%s'). World geometry is ignored.",
+                           object.object.id.c_str());
         }
 
         for (std::size_t i = 0; i < object.object.primitives.size(); ++i)
@@ -1546,8 +1556,8 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
 
       if (shapes.empty())
       {
-        CONSOLE_BRIDGE_logError("There is no geometry to attach to link '%s' as part of attached body '%s'",
-                                object.link_name.c_str(), object.object.id.c_str());
+        ROS_ERROR_NAMED("planning_scene", "There is no geometry to attach to link '%s' as part of attached body '%s'",
+                        object.link_name.c_str(), object.object.id.c_str());
         return false;
       }
 
@@ -1558,13 +1568,13 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
       {
         // there should not exist an attached object with this name
         if (kstate_->clearAttachedBody(object.object.id))
-          CONSOLE_BRIDGE_logInform("The robot state already had an object named '%s' attached to link '%s'. "
-                                   "The object was replaced.",
-                                   object.object.id.c_str(), object.link_name.c_str());
+          ROS_INFO_NAMED("planning_scene", "The robot state already had an object named '%s' attached to link '%s'. "
+                                           "The object was replaced.",
+                         object.object.id.c_str(), object.link_name.c_str());
         kstate_->attachBody(object.object.id, shapes, poses, object.touch_links, object.link_name,
                             object.detach_posture);
-        CONSOLE_BRIDGE_logInform("Attached object '%s' to link '%s'", object.object.id.c_str(),
-                                 object.link_name.c_str());
+        ROS_INFO_NAMED("planning_scene", "Attached object '%s' to link '%s'", object.object.id.c_str(),
+                       object.link_name.c_str());
       }
       else
       {
@@ -1579,14 +1589,14 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
           kstate_->attachBody(object.object.id, shapes, poses, ab_touch_links, object.link_name, detach_posture);
         else
           kstate_->attachBody(object.object.id, shapes, poses, object.touch_links, object.link_name, detach_posture);
-        CONSOLE_BRIDGE_logInform("Added shapes to object '%s' attached to link '%s'", object.object.id.c_str(),
-                                 object.link_name.c_str());
+        ROS_INFO_NAMED("planning_scene", "Added shapes to object '%s' attached to link '%s'", object.object.id.c_str(),
+                       object.link_name.c_str());
       }
 
       return true;
     }
     else
-      CONSOLE_BRIDGE_logError("Robot state is not compatible with robot model. This could be fatal.");
+      ROS_ERROR_NAMED("planning_scene", "Robot state is not compatible with robot model. This could be fatal.");
   }
   else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE)
   {
@@ -1630,14 +1640,15 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
       kstate_->clearAttachedBody(name);
 
       if (world_->hasObject(name))
-        CONSOLE_BRIDGE_logWarn("The collision world already has an object with the same name as the body about to be "
-                               "detached. NOT adding the detached body '%s' to the collision world.",
-                               object.object.id.c_str());
+        ROS_WARN_NAMED("planning_scene",
+                       "The collision world already has an object with the same name as the body about to be "
+                       "detached. NOT adding the detached body '%s' to the collision world.",
+                       object.object.id.c_str());
       else
       {
         world_->addToObject(name, shapes, poses);
-        CONSOLE_BRIDGE_logInform("Detached object '%s' from link '%s' and added it back in the collision world",
-                                 name.c_str(), object.link_name.c_str());
+        ROS_INFO_NAMED("planning_scene", "Detached object '%s' from link '%s' and added it back in the collision world",
+                       name.c_str(), object.link_name.c_str());
       }
     }
     if (!attached_bodies.empty() || object.object.id.empty())
@@ -1645,11 +1656,11 @@ bool planning_scene::PlanningScene::processAttachedCollisionObjectMsg(
   }
   else if (object.object.operation == moveit_msgs::CollisionObject::MOVE)
   {
-    CONSOLE_BRIDGE_logError("Move for attached objects not yet implemented");
+    ROS_ERROR_NAMED("planning_scene", "Move for attached objects not yet implemented");
   }
   else
   {
-    CONSOLE_BRIDGE_logError("Unknown collision object operation: %d", object.object.operation);
+    ROS_ERROR_NAMED("planning_scene", "Unknown collision object operation: %d", object.object.operation);
   }
 
   return false;
@@ -1659,7 +1670,8 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
 {
   if (object.id == OCTOMAP_NS)
   {
-    CONSOLE_BRIDGE_logError("The ID '%s' cannot be used for collision objects (name reserved)", OCTOMAP_NS.c_str());
+    ROS_ERROR_NAMED("planning_scene", "The ID '%s' cannot be used for collision objects (name reserved)",
+                    OCTOMAP_NS.c_str());
     return false;
   }
 
@@ -1667,25 +1679,26 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
   {
     if (object.primitives.empty() && object.meshes.empty() && object.planes.empty())
     {
-      CONSOLE_BRIDGE_logError("There are no shapes specified in the collision object message");
+      ROS_ERROR_NAMED("planning_scene", "There are no shapes specified in the collision object message");
       return false;
     }
 
     if (object.primitives.size() != object.primitive_poses.size())
     {
-      CONSOLE_BRIDGE_logError("Number of primitive shapes does not match number of poses in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match number of poses in collision object "
+                                        "message");
       return false;
     }
 
     if (object.meshes.size() != object.mesh_poses.size())
     {
-      CONSOLE_BRIDGE_logError("Number of meshes does not match number of poses in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of meshes does not match number of poses in collision object message");
       return false;
     }
 
     if (object.planes.size() != object.plane_poses.size())
     {
-      CONSOLE_BRIDGE_logError("Number of planes does not match number of poses in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of planes does not match number of poses in collision object message");
       return false;
     }
 
@@ -1748,8 +1761,9 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
     if (world_->hasObject(object.id))
     {
       if (!object.primitives.empty() || !object.meshes.empty() || !object.planes.empty())
-        CONSOLE_BRIDGE_logWarn("Move operation for object '%s' ignores the geometry specified in the message.",
-                               object.id.c_str());
+        ROS_WARN_NAMED("planning_scene",
+                       "Move operation for object '%s' ignores the geometry specified in the message.",
+                       object.id.c_str());
 
       const Eigen::Affine3d& t = getTransforms().getTransform(object.header.frame_id);
       EigenSTL::vector_Affine3d new_poses;
@@ -1782,18 +1796,18 @@ bool planning_scene::PlanningScene::processCollisionObjectMsg(const moveit_msgs:
       }
       else
       {
-        CONSOLE_BRIDGE_logError("Number of supplied poses (%zu) for object '%s' "
-                                "does not match number of shapes (%zu). Not moving.",
-                                new_poses.size(), object.id.c_str(), obj->shapes_.size());
+        ROS_ERROR_NAMED("planning_scene", "Number of supplied poses (%zu) for object '%s' "
+                                          "does not match number of shapes (%zu). Not moving.",
+                        new_poses.size(), object.id.c_str(), obj->shapes_.size());
         return false;
       }
       return true;
     }
     else
-      CONSOLE_BRIDGE_logError("World object '%s' does not exist. Cannot move.", object.id.c_str());
+      ROS_ERROR_NAMED("planning_scene", "World object '%s' does not exist. Cannot move.", object.id.c_str());
   }
   else
-    CONSOLE_BRIDGE_logError("Unknown collision object operation: %d", object.operation);
+    ROS_ERROR_NAMED("planning_scene", "Unknown collision object operation: %d", object.operation);
   return false;
 }
 
@@ -1822,7 +1836,8 @@ const Eigen::Affine3d& planning_scene::PlanningScene::getFrameTransform(const ro
     collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(id);
     if (obj->shape_poses_.size() > 1)
     {
-      CONSOLE_BRIDGE_logWarn("More than one shapes in object '%s'. Using first one to decide transform", id.c_str());
+      ROS_WARN_NAMED("planning_scene", "More than one shapes in object '%s'. Using first one to decide transform",
+                     id.c_str());
       return obj->shape_poses_[0];
     }
     else if (obj->shape_poses_.size() == 1)
@@ -1937,7 +1952,7 @@ void planning_scene::PlanningScene::setObjectColor(const std::string& id, const 
 {
   if (id.empty())
   {
-    CONSOLE_BRIDGE_logError("Cannot set color of object with empty id.");
+    ROS_ERROR_NAMED("planning_scene", "Cannot set color of object with empty id.");
     return;
   }
   if (!object_colors_)
@@ -2170,7 +2185,7 @@ bool planning_scene::PlanningScene::isPathValid(const robot_trajectory::RobotTra
       if (!found)
       {
         if (verbose)
-          CONSOLE_BRIDGE_logInform("Goal not satisfied");
+          ROS_INFO_NAMED("planning_scene", "Goal not satisfied");
         if (invalid_index)
           invalid_index->push_back(i);
         result = false;

--- a/moveit_core/profiler/CMakeLists.txt
+++ b/moveit_core/profiler/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_profiler)
 add_library(${MOVEIT_LIB_NAME} src/profiler.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/moveit_core/profiler/src/profiler.cpp
+++ b/moveit_core/profiler/src/profiler.cpp
@@ -44,7 +44,7 @@ moveit::tools::Profiler& moveit::tools::Profiler::Instance(void)
 
 #if MOVEIT_ENABLE_PROFILING
 
-#include <console_bridge/console.h>
+#include <ros/console.h>
 #include <vector>
 #include <algorithm>
 #include <sstream>
@@ -172,7 +172,7 @@ void moveit::tools::Profiler::console(void)
   std::stringstream ss;
   ss << std::endl;
   status(ss, true);
-  CONSOLE_BRIDGE_logInform(ss.str().c_str());
+  ROS_INFO_NAMED("profiler", ss.str().c_str());
 }
 
 /// @cond IGNORE

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(${MOVEIT_LIB_NAME}
   )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_profiler moveit_exceptions moveit_kinematics_base ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_profiler moveit_exceptions moveit_kinematics_base ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
@@ -22,7 +22,7 @@ if(CATKIN_ENABLE_TESTING)
   include_directories(${moveit_resources_INCLUDE_DIRS})
 
   catkin_add_gtest(test_robot_model test/test.cpp)
-  target_link_libraries(test_robot_model ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_robot_model ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -40,7 +40,6 @@
 
 #include <moveit/macros/class_forward.h>
 #include <moveit/exceptions/exceptions.h>
-#include <console_bridge/console.h>
 #include <urdf/model.h>
 #include <srdfdom/model.h>
 

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -37,7 +37,7 @@
 
 #include <moveit/robot_model/floating_joint_model.h>
 #include <boost/math/constants/constants.hpp>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 #include <limits>
 #include <cmath>
 
@@ -173,7 +173,7 @@ bool FloatingJointModel::normalizeRotation(double* values) const
     double norm = sqrt(normSqr);
     if (norm < std::numeric_limits<double>::epsilon() * 100.0)
     {
-      CONSOLE_BRIDGE_logWarn("Quaternion is zero in RobotState representation. Setting to identity");
+      ROS_WARN_NAMED("robot_model", "Quaternion is zero in RobotState representation. Setting to identity");
       values[3] = 0.0;
       values[4] = 0.0;
       values[5] = 0.0;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -39,7 +39,6 @@
 #include <moveit/robot_model/joint_model_group.h>
 #include <moveit/robot_model/revolute_joint_model.h>
 #include <moveit/exceptions/exceptions.h>
-#include <console_bridge/console.h>
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include "order_robot_model_items.inc"
@@ -295,7 +294,7 @@ const LinkModel* JointModelGroup::getLinkModel(const std::string& name) const
   LinkModelMapConst::const_iterator it = link_model_map_.find(name);
   if (it == link_model_map_.end())
   {
-    CONSOLE_BRIDGE_logError("Link '%s' not found in group '%s'", name.c_str(), name_.c_str());
+    ROS_ERROR_NAMED("robot_model", "Link '%s' not found in group '%s'", name.c_str(), name_.c_str());
     return NULL;
   }
   return it->second;
@@ -306,7 +305,7 @@ const JointModel* JointModelGroup::getJointModel(const std::string& name) const
   JointModelMapConst::const_iterator it = joint_model_map_.find(name);
   if (it == joint_model_map_.end())
   {
-    CONSOLE_BRIDGE_logError("Joint '%s' not found in group '%s'", name.c_str(), name_.c_str());
+    ROS_ERROR_NAMED("robot_model", "Joint '%s' not found in group '%s'", name.c_str(), name_.c_str());
     return NULL;
   }
   return it->second;
@@ -348,7 +347,8 @@ void JointModelGroup::getVariableRandomPositionsNearBy(
     if (iter != distance_map.end())
       distance = iter->second;
     else
-      CONSOLE_BRIDGE_logWarn("Did not pass in distance for '%s'", active_joint_model_vector_[i]->getName().c_str());
+      ROS_WARN_NAMED("robot_model", "Did not pass in distance for '%s'",
+                     active_joint_model_vector_[i]->getName().c_str());
     active_joint_model_vector_[i]->getVariableRandomPositionsNearBy(
         rng, values + active_joint_model_start_index_[i], *active_joint_bounds[i],
         near + active_joint_model_start_index_[i], distance);
@@ -505,7 +505,7 @@ bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) co
     const JointModelGroup* eef = parent_model_->getEndEffector(getAttachedEndEffectorNames()[i]);
     if (!eef)
     {
-      CONSOLE_BRIDGE_logError("Unable to find joint model group for eef");
+      ROS_ERROR_NAMED("robot_model", "Unable to find joint model group for eef");
       return false;
     }
     const std::string& eef_parent = eef->getEndEffectorParentGroup().second;
@@ -513,7 +513,7 @@ bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) co
     const LinkModel* eef_link = parent_model_->getLinkModel(eef_parent);
     if (!eef_link)
     {
-      CONSOLE_BRIDGE_logError("Unable to find end effector link for eef");
+      ROS_ERROR_NAMED("robot_model", "Unable to find end effector link for eef");
       return false;
     }
 
@@ -529,9 +529,10 @@ const LinkModel* JointModelGroup::getOnlyOneEndEffectorTip() const
   if (tips.size() == 1)
     return tips.front();
   else if (tips.size() > 1)
-    CONSOLE_BRIDGE_logError("More than one end effector tip found for joint model group, so cannot return only one");
+    ROS_ERROR_NAMED("robot_model", "More than one end effector tip found for joint model group, so cannot return only "
+                                   "one");
   else
-    CONSOLE_BRIDGE_logError("No end effector tips found in joint model group");
+    ROS_ERROR_NAMED("robot_model", "No end effector tips found in joint model group");
   return NULL;
 }
 
@@ -540,7 +541,7 @@ int JointModelGroup::getVariableGroupIndex(const std::string& variable) const
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);
   if (it == joint_variables_index_map_.end())
   {
-    CONSOLE_BRIDGE_logError("Variable '%s' is not part of group '%s'", variable.c_str(), name_.c_str());
+    ROS_ERROR_NAMED("robot_model", "Variable '%s' is not part of group '%s'", variable.c_str(), name_.c_str());
     return -1;
   }
   return it->second;
@@ -574,9 +575,9 @@ bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik
       // skip reported fixed joints
       if (hasJointModel(ik_jnames[i]) && getJointModel(ik_jnames[i])->getType() == JointModel::FIXED)
         continue;
-      CONSOLE_BRIDGE_logError("IK solver computes joint values for joint '%s' "
-                              "but group '%s' does not contain such a joint.",
-                              ik_jnames[i].c_str(), getName().c_str());
+      ROS_ERROR_NAMED("robot_model", "IK solver computes joint values for joint '%s' "
+                                     "but group '%s' does not contain such a joint.",
+                      ik_jnames[i].c_str(), getName().c_str());
       return false;
     }
     const JointModel* jm = getJointModel(ik_jnames[i]);
@@ -630,7 +631,7 @@ bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
 
   if (tip_frames.empty())
   {
-    CONSOLE_BRIDGE_logDebug("Group %s has no tip frame(s)", name_.c_str());
+    ROS_DEBUG_NAMED("robot_model", "Group %s has no tip frame(s)", name_.c_str());
     return false;
   }
 
@@ -640,8 +641,9 @@ bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
     // remove frame reference, if specified
     const std::string& tip_local = tip[0] == '/' ? tip.substr(1) : tip;
     const std::string& tip_frame_local = tip_frames[i][0] == '/' ? tip_frames[i].substr(1) : tip_frames[i];
-    CONSOLE_BRIDGE_logDebug("joint_model_group.canSetStateFromIK: comparing input tip: %s to this groups tip: %s ",
-                            tip_local.c_str(), tip_frame_local.c_str());
+    ROS_DEBUG_NAMED("robot_model",
+                    "joint_model_group.canSetStateFromIK: comparing input tip: %s to this groups tip: %s ",
+                    tip_local.c_str(), tip_frame_local.c_str());
 
     // Check if the IK solver's tip is the same as the frame of inquiry
     if (tip_local != tip_frame_local)

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -641,9 +641,8 @@ bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
     // remove frame reference, if specified
     const std::string& tip_local = tip[0] == '/' ? tip.substr(1) : tip;
     const std::string& tip_frame_local = tip_frames[i][0] == '/' ? tip_frames[i].substr(1) : tip_frames[i];
-    ROS_DEBUG_NAMED("robot_model",
-                    "joint_model_group.canSetStateFromIK: comparing input tip: %s to this groups tip: %s ",
-                    tip_local.c_str(), tip_frame_local.c_str());
+    ROS_DEBUG_NAMED("robot_model", "comparing input tip: %s to this groups tip: %s ", tip_local.c_str(),
+                    tip_frame_local.c_str());
 
     // Check if the IK solver's tip is the same as the frame of inquiry
     if (tip_local != tip_frame_local)

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -529,9 +529,8 @@ const LinkModel* JointModelGroup::getOnlyOneEndEffectorTip() const
   if (tips.size() == 1)
     return tips.front();
   else if (tips.size() > 1)
-    ROS_ERROR_NAMED("robot_model.jmg",
-                    "More than one end effector tip found for joint model group, so cannot return only "
-                    "one");
+    ROS_ERROR_NAMED("robot_model.jmg", "More than one end effector tip found for joint model group, "
+                                       "so cannot return only one");
   else
     ROS_ERROR_NAMED("robot_model.jmg", "No end effector tips found in joint model group");
   return NULL;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -294,7 +294,7 @@ const LinkModel* JointModelGroup::getLinkModel(const std::string& name) const
   LinkModelMapConst::const_iterator it = link_model_map_.find(name);
   if (it == link_model_map_.end())
   {
-    ROS_ERROR_NAMED("robot_model", "Link '%s' not found in group '%s'", name.c_str(), name_.c_str());
+    ROS_ERROR_NAMED("robot_model.jmg", "Link '%s' not found in group '%s'", name.c_str(), name_.c_str());
     return NULL;
   }
   return it->second;
@@ -305,7 +305,7 @@ const JointModel* JointModelGroup::getJointModel(const std::string& name) const
   JointModelMapConst::const_iterator it = joint_model_map_.find(name);
   if (it == joint_model_map_.end())
   {
-    ROS_ERROR_NAMED("robot_model", "Joint '%s' not found in group '%s'", name.c_str(), name_.c_str());
+    ROS_ERROR_NAMED("robot_model.jmg", "Joint '%s' not found in group '%s'", name.c_str(), name_.c_str());
     return NULL;
   }
   return it->second;
@@ -347,7 +347,7 @@ void JointModelGroup::getVariableRandomPositionsNearBy(
     if (iter != distance_map.end())
       distance = iter->second;
     else
-      ROS_WARN_NAMED("robot_model", "Did not pass in distance for '%s'",
+      ROS_WARN_NAMED("robot_model.jmg", "Did not pass in distance for '%s'",
                      active_joint_model_vector_[i]->getName().c_str());
     active_joint_model_vector_[i]->getVariableRandomPositionsNearBy(
         rng, values + active_joint_model_start_index_[i], *active_joint_bounds[i],
@@ -505,7 +505,7 @@ bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) co
     const JointModelGroup* eef = parent_model_->getEndEffector(getAttachedEndEffectorNames()[i]);
     if (!eef)
     {
-      ROS_ERROR_NAMED("robot_model", "Unable to find joint model group for eef");
+      ROS_ERROR_NAMED("robot_model.jmg", "Unable to find joint model group for eef");
       return false;
     }
     const std::string& eef_parent = eef->getEndEffectorParentGroup().second;
@@ -513,7 +513,7 @@ bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) co
     const LinkModel* eef_link = parent_model_->getLinkModel(eef_parent);
     if (!eef_link)
     {
-      ROS_ERROR_NAMED("robot_model", "Unable to find end effector link for eef");
+      ROS_ERROR_NAMED("robot_model.jmg", "Unable to find end effector link for eef");
       return false;
     }
 
@@ -529,10 +529,11 @@ const LinkModel* JointModelGroup::getOnlyOneEndEffectorTip() const
   if (tips.size() == 1)
     return tips.front();
   else if (tips.size() > 1)
-    ROS_ERROR_NAMED("robot_model", "More than one end effector tip found for joint model group, so cannot return only "
-                                   "one");
+    ROS_ERROR_NAMED("robot_model.jmg",
+                    "More than one end effector tip found for joint model group, so cannot return only "
+                    "one");
   else
-    ROS_ERROR_NAMED("robot_model", "No end effector tips found in joint model group");
+    ROS_ERROR_NAMED("robot_model.jmg", "No end effector tips found in joint model group");
   return NULL;
 }
 
@@ -541,7 +542,7 @@ int JointModelGroup::getVariableGroupIndex(const std::string& variable) const
   VariableIndexMap::const_iterator it = joint_variables_index_map_.find(variable);
   if (it == joint_variables_index_map_.end())
   {
-    ROS_ERROR_NAMED("robot_model", "Variable '%s' is not part of group '%s'", variable.c_str(), name_.c_str());
+    ROS_ERROR_NAMED("robot_model.jmg", "Variable '%s' is not part of group '%s'", variable.c_str(), name_.c_str());
     return -1;
   }
   return it->second;
@@ -575,8 +576,8 @@ bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik
       // skip reported fixed joints
       if (hasJointModel(ik_jnames[i]) && getJointModel(ik_jnames[i])->getType() == JointModel::FIXED)
         continue;
-      ROS_ERROR_NAMED("robot_model", "IK solver computes joint values for joint '%s' "
-                                     "but group '%s' does not contain such a joint.",
+      ROS_ERROR_NAMED("robot_model.jmg", "IK solver computes joint values for joint '%s' "
+                                         "but group '%s' does not contain such a joint.",
                       ik_jnames[i].c_str(), getName().c_str());
       return false;
     }
@@ -631,7 +632,7 @@ bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
 
   if (tip_frames.empty())
   {
-    ROS_DEBUG_NAMED("robot_model", "Group %s has no tip frame(s)", name_.c_str());
+    ROS_DEBUG_NAMED("robot_model.jmg", "Group %s has no tip frame(s)", name_.c_str());
     return false;
   }
 
@@ -641,7 +642,7 @@ bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
     // remove frame reference, if specified
     const std::string& tip_local = tip[0] == '/' ? tip.substr(1) : tip;
     const std::string& tip_frame_local = tip_frames[i][0] == '/' ? tip_frames[i].substr(1) : tip_frames[i];
-    ROS_DEBUG_NAMED("robot_model", "comparing input tip: %s to this groups tip: %s ", tip_local.c_str(),
+    ROS_DEBUG_NAMED("robot_model.jmg", "comparing input tip: %s to this groups tip: %s ", tip_local.c_str(),
                     tip_frame_local.c_str());
 
     // Check if the IK solver's tip is the same as the frame of inquiry

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model moveit_kinematics_base moveit_transforms ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model moveit_kinematics_base moveit_transforms ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
@@ -22,11 +22,11 @@ if(CATKIN_ENABLE_TESTING)
   include_directories(${moveit_resources_INCLUDE_DIRS})
 
   catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
-  target_link_libraries(test_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_robot_state ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)
-  target_link_libraries(test_robot_state_complex ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_robot_state_complex ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 
   catkin_add_gtest(test_aabb test/test_aabb.cpp)
-  target_link_libraries(test_aabb ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_aabb ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -552,7 +552,7 @@ public:
   {
     if (has_acceleration_)
     {
-      CONSOLE_BRIDGE_logError("Unable to set joint efforts because array is being used for accelerations");
+      ROS_ERROR_NAMED("robot_state", "Unable to set joint efforts because array is being used for accelerations");
       return;
     }
     has_effort_ = true;

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -54,8 +54,8 @@ static bool _jointStateToRobotState(const sensor_msgs::JointState& joint_state, 
 {
   if (joint_state.name.size() != joint_state.position.size())
   {
-    CONSOLE_BRIDGE_logError("Different number of names and positions in JointState message: %zu, %zu",
-                            joint_state.name.size(), joint_state.position.size());
+    ROS_ERROR_NAMED("robot_state", "Different number of names and positions in JointState message: %zu, %zu",
+                    joint_state.name.size(), joint_state.position.size());
     return false;
   }
 
@@ -70,7 +70,7 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
   std::size_t nj = mjs.joint_names.size();
   if (nj != mjs.transforms.size())
   {
-    CONSOLE_BRIDGE_logError("Different number of names, values or frames in MultiDOFJointState message.");
+    ROS_ERROR_NAMED("robot_state", "Different number of names, values or frames in MultiDOFJointState message.");
     return false;
   }
 
@@ -92,16 +92,16 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
       }
       catch (std::exception& ex)
       {
-        CONSOLE_BRIDGE_logError("Caught %s", ex.what());
+        ROS_ERROR_NAMED("robot_state", "Caught %s", ex.what());
         error = true;
       }
     else
       error = true;
 
     if (error)
-      CONSOLE_BRIDGE_logWarn("The transform for multi-dof joints was specified in frame '%s' "
-                             "but it was not possible to transform that to frame '%s'",
-                             mjs.header.frame_id.c_str(), state.getRobotModel()->getModelFrame().c_str());
+      ROS_WARN_NAMED("robot_state", "The transform for multi-dof joints was specified in frame '%s' "
+                                    "but it was not possible to transform that to frame '%s'",
+                     mjs.header.frame_id.c_str(), state.getRobotModel()->getModelFrame().c_str());
   }
 
   for (std::size_t i = 0; i < nj; ++i)
@@ -109,7 +109,7 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
     const std::string& joint_name = mjs.joint_names[i];
     if (!state.getRobotModel()->hasJointModel(joint_name))
     {
-      CONSOLE_BRIDGE_logWarn("No joint matching multi-dof joint '%s'", joint_name.c_str());
+      ROS_WARN_NAMED("robot_state", "No joint matching multi-dof joint '%s'", joint_name.c_str());
       error = true;
       continue;
     }
@@ -225,20 +225,20 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
     {
       if (aco.object.primitives.size() != aco.object.primitive_poses.size())
       {
-        CONSOLE_BRIDGE_logError("Number of primitive shapes does not match "
-                                "number of poses in collision object message");
+        ROS_ERROR_NAMED("robot_state", "Number of primitive shapes does not match "
+                                       "number of poses in collision object message");
         return;
       }
 
       if (aco.object.meshes.size() != aco.object.mesh_poses.size())
       {
-        CONSOLE_BRIDGE_logError("Number of meshes does not match number of poses in collision object message");
+        ROS_ERROR_NAMED("robot_state", "Number of meshes does not match number of poses in collision object message");
         return;
       }
 
       if (aco.object.planes.size() != aco.object.plane_poses.size())
       {
-        CONSOLE_BRIDGE_logError("Number of planes does not match number of poses in collision object message");
+        ROS_ERROR_NAMED("robot_state", "Number of planes does not match number of poses in collision object message");
         return;
       }
 
@@ -294,9 +294,9 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           else
           {
             t0.setIdentity();
-            CONSOLE_BRIDGE_logError("Cannot properly transform from frame '%s'. "
-                                    "The pose of the attached body may be incorrect",
-                                    aco.object.header.frame_id.c_str());
+            ROS_ERROR_NAMED("robot_state", "Cannot properly transform from frame '%s'. "
+                                           "The pose of the attached body may be incorrect",
+                            aco.object.header.frame_id.c_str());
           }
           Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
           for (std::size_t i = 0; i < poses.size(); ++i)
@@ -304,30 +304,31 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
         }
 
         if (shapes.empty())
-          CONSOLE_BRIDGE_logError("There is no geometry to attach to link '%s' as part of attached body '%s'",
-                                  aco.link_name.c_str(), aco.object.id.c_str());
+          ROS_ERROR_NAMED("robot_state", "There is no geometry to attach to link '%s' as part of attached body '%s'",
+                          aco.link_name.c_str(), aco.object.id.c_str());
         else
         {
           if (state.clearAttachedBody(aco.object.id))
-            CONSOLE_BRIDGE_logDebug("The robot state already had an object named '%s' attached to link '%s'. "
-                                    "The object was replaced.",
-                                    aco.object.id.c_str(), aco.link_name.c_str());
+            ROS_DEBUG_NAMED("robot_state", "The robot state already had an object named '%s' attached to link '%s'. "
+                                           "The object was replaced.",
+                            aco.object.id.c_str(), aco.link_name.c_str());
           state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture);
-          CONSOLE_BRIDGE_logDebug("Attached object '%s' to link '%s'", aco.object.id.c_str(), aco.link_name.c_str());
+          ROS_DEBUG_NAMED("robot_state", "Attached object '%s' to link '%s'", aco.object.id.c_str(),
+                          aco.link_name.c_str());
         }
       }
     }
     else
-      CONSOLE_BRIDGE_logError("The attached body for link '%s' has no geometry", aco.link_name.c_str());
+      ROS_ERROR_NAMED("robot_state", "The attached body for link '%s' has no geometry", aco.link_name.c_str());
   }
   else if (aco.object.operation == moveit_msgs::CollisionObject::REMOVE)
   {
     if (!state.clearAttachedBody(aco.object.id))
-      CONSOLE_BRIDGE_logError("The attached body '%s' can not be removed because it does not exist",
-                              aco.link_name.c_str());
+      ROS_ERROR_NAMED("robot_state", "The attached body '%s' can not be removed because it does not exist",
+                      aco.link_name.c_str());
   }
   else
-    CONSOLE_BRIDGE_logError("Unknown collision object operation: %d", aco.object.operation);
+    ROS_ERROR_NAMED("robot_state", "Unknown collision object operation: %d", aco.object.operation);
 }
 
 static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_msgs::RobotState& robot_state,
@@ -338,7 +339,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
 
   if (!rs.is_diff && rs.joint_state.name.empty() && rs.multi_dof_joint_state.joint_names.empty())
   {
-    CONSOLE_BRIDGE_logError("Found empty JointState message");
+    ROS_ERROR_NAMED("robot_state", "Found empty JointState message");
     return false;
   }
 
@@ -437,12 +438,12 @@ bool moveit::core::jointTrajPointToRobotState(const trajectory_msgs::JointTrajec
 {
   if (trajectory.points.empty() || point_id > trajectory.points.size() - 1)
   {
-    CONSOLE_BRIDGE_logError("Invalid point_id");
+    ROS_ERROR_NAMED("robot_state", "Invalid point_id");
     return false;
   }
   if (trajectory.joint_names.empty())
   {
-    CONSOLE_BRIDGE_logError("No joint names specified");
+    ROS_ERROR_NAMED("robot_state", "No joint names specified");
     return false;
   }
 
@@ -533,7 +534,7 @@ void moveit::core::streamToRobotState(RobotState& state, const std::string& line
   {
     // Get a variable
     if (!std::getline(lineStream, cell, separator[0]))
-      CONSOLE_BRIDGE_logError("Missing variable %i", i);
+      ROS_ERROR_NAMED("robot_state", "Missing variable %i", i);
 
     state.getVariablePositions()[i] = boost::lexical_cast<double>(cell.c_str());
   }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1450,8 +1450,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    ROS_ERROR_NAMED("robot_state", "Invalid number (%d) of sets of consistency limits "
-                                   "for a setFromIK request that is being solved by a single IK solver",
+    ROS_ERROR_NAMED("robot_state", "Invalid number (%d) of sets of consistency limits for a setFromIK request "
+                                   "that is being solved by a single IK solver",
                     consistency_limit_sets.size());
     return false;
   }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -164,7 +164,7 @@ bool RobotState::checkJointTransforms(const JointModel* joint) const
 {
   if (dirtyJointTransform(joint))
   {
-    CONSOLE_BRIDGE_logWarn("Returning dirty joint transforms for joint '%s'", joint->getName().c_str());
+    ROS_WARN_NAMED("robot_state", "Returning dirty joint transforms for joint '%s'", joint->getName().c_str());
     return false;
   }
   return true;
@@ -174,7 +174,7 @@ bool RobotState::checkLinkTransforms() const
 {
   if (dirtyLinkTransforms())
   {
-    CONSOLE_BRIDGE_logWarn("Returning dirty link transforms");
+    ROS_WARN_NAMED("robot_state", "Returning dirty link transforms");
     return false;
   }
   return true;
@@ -184,7 +184,7 @@ bool RobotState::checkCollisionTransforms() const
 {
   if (dirtyCollisionBodyTransforms())
   {
-    CONSOLE_BRIDGE_logWarn("Returning dirty collision body transforms");
+    ROS_WARN_NAMED("robot_state", "Returning dirty collision body transforms");
     return false;
   }
   return true;
@@ -847,7 +847,7 @@ const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
   std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
   {
-    CONSOLE_BRIDGE_logError("Attached body '%s' not found", id.c_str());
+    ROS_ERROR_NAMED("robot_state", "Attached body '%s' not found", id.c_str());
     return NULL;
   }
   else
@@ -988,21 +988,22 @@ const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) cons
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    CONSOLE_BRIDGE_logError("Transform from frame '%s' to frame '%s' is not known "
-                            "('%s' should be a link name or an attached body id).",
-                            id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
+    ROS_ERROR_NAMED("robot_state", "Transform from frame '%s' to frame '%s' is not known "
+                                   "('%s' should be a link name or an attached body id).",
+                    id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
   }
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   if (tf.empty())
   {
-    CONSOLE_BRIDGE_logError("Attached body '%s' has no geometry associated to it. No transform to return.", id.c_str());
+    ROS_ERROR_NAMED("robot_state", "Attached body '%s' has no geometry associated to it. No transform to return.",
+                    id.c_str());
     return identity_transform;
   }
   if (tf.size() > 1)
-    CONSOLE_BRIDGE_logDebug("There are multiple geometries associated to attached body '%s'. "
-                            "Returning the transform for the first one.",
-                            id.c_str());
+    ROS_DEBUG_NAMED("robot_state", "There are multiple geometries associated to attached body '%s'. "
+                                   "Returning the transform for the first one.",
+                    id.c_str());
   return tf[0];
 }
 
@@ -1038,7 +1039,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std
   ros::Time tm = ros::Time::now();
   for (std::size_t i = 0; i < link_names.size(); ++i)
   {
-    CONSOLE_BRIDGE_logDebug("Trying to get marker for link '%s'", link_names[i].c_str());
+    ROS_DEBUG_NAMED("robot_state", "Trying to get marker for link '%s'", link_names[i].c_str());
     const LinkModel* lm = robot_model_->getLinkModel(link_names[i]);
     if (!lm)
       continue;
@@ -1118,14 +1119,14 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
 
   if (!group->isChain())
   {
-    CONSOLE_BRIDGE_logError("The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
+    ROS_ERROR_NAMED("robot_state", "The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
     return false;
   }
 
   if (!group->isLinkUpdated(link->getName()))
   {
-    CONSOLE_BRIDGE_logError("Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
-                            link->getName().c_str(), group->getName().c_str());
+    ROS_ERROR_NAMED("robot_state", "Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
+                    link->getName().c_str(), group->getName().c_str());
     return false;
   }
 
@@ -1141,7 +1142,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   Eigen::Vector3d point_transform = link_transform * reference_point_position;
 
   /*
-  CONSOLE_BRIDGE_logDebug("Point from reference origin expressed in world coordinates: %f %f %f",
+  ROS_DEBUG_NAMED("robot_state", "Point from reference origin expressed in world coordinates: %f %f %f",
            point_transform.x(),
            point_transform.y(),
            point_transform.z());
@@ -1153,11 +1154,11 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   while (link)
   {
     /*
-    CONSOLE_BRIDGE_logDebug("Link: %s, %f %f %f",link_state->getName().c_str(),
+    ROS_DEBUG_NAMED("robot_state", "Link: %s, %f %f %f",link_state->getName().c_str(),
              link_state->getGlobalLinkTransform().translation().x(),
              link_state->getGlobalLinkTransform().translation().y(),
              link_state->getGlobalLinkTransform().translation().z());
-    CONSOLE_BRIDGE_logDebug("Joint: %s",link_state->getParentJointState()->getName().c_str());
+    ROS_DEBUG_NAMED("robot_state", "Joint: %s",link_state->getParentJointState()->getName().c_str());
     */
     const JointModel* pjm = link->getParentJointModel();
     if (pjm->getVariableCount() > 0)
@@ -1190,7 +1191,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
         jacobian.block<3, 1>(3, joint_index + 2) = jacobian.block<3, 1>(3, joint_index + 2) + joint_axis;
       }
       else
-        CONSOLE_BRIDGE_logError("Unknown type of joint in Jacobian computation");
+        ROS_ERROR_NAMED("robot_state", "Unknown type of joint in Jacobian computation");
     }
     if (pjm == root_joint_model)
       break;
@@ -1295,7 +1296,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
   {
-    CONSOLE_BRIDGE_logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+    ROS_ERROR_NAMED("robot_state", "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
   return setFromIK(jmg, pose, solver->getTipFrame(), attempts, timeout, constraint, options);
@@ -1318,7 +1319,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& po
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
   {
-    CONSOLE_BRIDGE_logError("No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+    ROS_ERROR_NAMED("robot_state", "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
   static std::vector<double> consistency_limits;
@@ -1405,7 +1406,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   // Error check
   if (poses_in.size() != tips_in.size())
   {
-    CONSOLE_BRIDGE_logError("moveit.robot_state: Number of poses must be the same as number of tips");
+    ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Number of poses must be the same as number of tips");
     return false;
   }
 
@@ -1424,8 +1425,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     std::string error_msg;
     if (!solver->supportsGroup(jmg, &error_msg))
     {
-      CONSOLE_BRIDGE_logError("moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
-                              typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
+      ROS_ERROR_NAMED("robot_state",
+                      "moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
+                      typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
       valid_solver = false;
     }
   }
@@ -1440,8 +1442,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     }
     else
     {
-      CONSOLE_BRIDGE_logError("moveit.robot_state: No kinematics solver instantiated for group '%s'",
-                              jmg->getName().c_str());
+      ROS_ERROR_NAMED("robot_state", "moveit.robot_state: No kinematics solver instantiated for group '%s'",
+                      jmg->getName().c_str());
       return false;
     }
   }
@@ -1450,9 +1452,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    CONSOLE_BRIDGE_logError("moveit.robot_state: Invalid number (%d) of sets of consistency limits "
-                            "for a setFromIK request that is being solved by a single IK solver",
-                            consistency_limit_sets.size());
+    ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Invalid number (%d) of sets of consistency limits "
+                                   "for a setFromIK request that is being solved by a single IK solver",
+                    consistency_limit_sets.size());
     return false;
   }
   else if (consistency_limit_sets.size() == 1)
@@ -1507,8 +1509,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
           const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
-            CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot use an attached body "
-                                    "with multiple geometries as a reference frame.");
+            ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Cannot use an attached body "
+                                           "with multiple geometries as a reference frame.");
             return false;
           }
           pose_frame = ab->getAttachedLinkName();
@@ -1543,13 +1545,13 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     // Make sure one of the tip frames worked
     if (!found_valid_frame)
     {
-      CONSOLE_BRIDGE_logError("moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i,
-                              pose_frame.c_str());
+      ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i,
+                      pose_frame.c_str());
       // Debug available tip frames
       std::stringstream ss;
       for (solver_tip_id = 0; solver_tip_id < solver_tip_frames.size(); ++solver_tip_id)
         ss << solver_tip_frames[solver_tip_id] << ", ";
-      CONSOLE_BRIDGE_logError("Available tip frames: [%s]", ss.str().c_str());
+      ROS_ERROR_NAMED("robot_state", "Available tip frames: [%s]", ss.str().c_str());
       return false;
     }
 
@@ -1628,7 +1630,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     }
     else
     {
-      CONSOLE_BRIDGE_logDebug("moveit.robot_state: Rerunning IK solver with random joint positions");
+      ROS_DEBUG_NAMED("robot_state", "moveit.robot_state: Rerunning IK solver with random joint positions");
 
       // sample a random seed
       random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
@@ -1679,21 +1681,21 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   // Error check
   if (poses_in.size() != sub_groups.size())
   {
-    CONSOLE_BRIDGE_logError("Number of poses (%u) must be the same as number of sub-groups (%u)", poses_in.size(),
-                            sub_groups.size());
+    ROS_ERROR_NAMED("robot_state", "Number of poses (%u) must be the same as number of sub-groups (%u)",
+                    poses_in.size(), sub_groups.size());
     return false;
   }
 
   if (tips_in.size() != sub_groups.size())
   {
-    CONSOLE_BRIDGE_logError("Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(),
-                            sub_groups.size());
+    ROS_ERROR_NAMED("robot_state", "Number of tip names (%u) must be same as number of sub-groups (%u)", tips_in.size(),
+                    sub_groups.size());
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != sub_groups.size())
   {
-    CONSOLE_BRIDGE_logError("Number of consistency limit vectors must be the same as number of sub-groups");
+    ROS_ERROR_NAMED("robot_state", "Number of consistency limit vectors must be the same as number of sub-groups");
     return false;
   }
 
@@ -1701,8 +1703,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      CONSOLE_BRIDGE_logError("Number of joints in consistency_limits is %zu but it should be should be %u", i,
-                              sub_groups[i]->getVariableCount());
+      ROS_ERROR_NAMED("robot_state", "Number of joints in consistency_limits is %zu but it should be should be %u", i,
+                      sub_groups[i]->getVariableCount());
       return false;
     }
   }
@@ -1714,7 +1716,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
     kinematics::KinematicsBaseConstPtr solver = sub_groups[i]->getSolverInstance();
     if (!solver)
     {
-      CONSOLE_BRIDGE_logError("Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
+      ROS_ERROR_NAMED("robot_state", "Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
       return false;
     }
     solvers.push_back(solver);
@@ -1750,7 +1752,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
         const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
         if (ab_trans.size() != 1)
         {
-          CONSOLE_BRIDGE_logError("Cannot use an attached body with multiple geometries as a reference frame.");
+          ROS_ERROR_NAMED("robot_state", "Cannot use an attached body with multiple geometries as a reference frame.");
           return false;
         }
         pose_frame = ab->getAttachedLinkName();
@@ -1774,8 +1776,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 
     if (pose_frame != solver_tip_frame)
     {
-      CONSOLE_BRIDGE_logError("Cannot compute IK for query pose reference frame '%s', desired: '%s'",
-                              pose_frame.c_str(), solver_tip_frame.c_str());
+      ROS_ERROR_NAMED("robot_state", "Cannot compute IK for query pose reference frame '%s', desired: '%s'",
+                      pose_frame.c_str(), solver_tip_frame.c_str());
       return false;
     }
   }
@@ -1848,7 +1850,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
         found_solution = false;
         break;
       }
-      CONSOLE_BRIDGE_logDebug("IK attempt: %d of %d", st, attempts);
+      ROS_DEBUG_NAMED("robot_state", "IK attempt: %d of %d", st, attempts);
     }
     if (found_solution)
     {
@@ -1856,7 +1858,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
       copyJointGroupPositions(jmg, full_solution);
       if (constraint ? constraint(this, jmg, &full_solution[0]) : true)
       {
-        CONSOLE_BRIDGE_logDebug("Found IK solution");
+        ROS_DEBUG_NAMED("robot_state", "Found IK solution");
         return true;
       }
     }
@@ -2006,9 +2008,9 @@ double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std:
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
-    CONSOLE_BRIDGE_logWarn("The computed trajectory is too short to detect jumps in joint-space "
-                           "Need at least %zu steps, only got %zu. Try a lower max_step.",
-                           MIN_STEPS_FOR_JUMP_THRESH, traj.size());
+    ROS_WARN_NAMED("robot_state", "The computed trajectory is too short to detect jumps in joint-space "
+                                  "Need at least %zu steps, only got %zu. Try a lower max_step.",
+                   MIN_STEPS_FOR_JUMP_THRESH, traj.size());
   }
 
   std::vector<double> dist_vector;
@@ -2027,7 +2029,7 @@ double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std:
   for (std::size_t i = 0; i < dist_vector.size(); ++i)
     if (dist_vector[i] > thres)
     {
-      CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump in joint-space distance");
+      ROS_DEBUG_NAMED("robot_state", "Truncating Cartesian path due to detected jump in joint-space distance");
       percentage = (double)(i + 1) / (double)(traj.size());
       traj.resize(i + 1);
       break;
@@ -2049,9 +2051,9 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
     {
       if (!joint->getType() == JointModel::PRISMATIC && !joint->getType() == JointModel::REVOLUTE)
       {
-        CONSOLE_BRIDGE_logWarn("Joint %s is of unsupported type %s. \n"
-                               "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
-                               joint->getName().c_str(), joint->getTypeName().c_str());
+        ROS_WARN_NAMED("robot_state", "Joint %s is of unsupported type %s. \n"
+                                      "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
+                       joint->getName().c_str(), joint->getTypeName().c_str());
       }
 
       double distance = traj[traj_ix]->distance(*traj[traj_ix + 1], joint);
@@ -2059,8 +2061,8 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
           (test_prismatic && joint->getType() == JointModel::PRISMATIC && distance > prismatic_threshold))
       {
         double limit = joint->getType() == JointModel::REVOLUTE ? revolute_threshold : prismatic_threshold;
-        CONSOLE_BRIDGE_logDebug("Truncating Cartesian path due to detected jump of %.4f > %.4f in joint %s", distance,
-                                limit, joint->getName().c_str());
+        ROS_DEBUG_NAMED("robot_state", "Truncating Cartesian path due to detected jump of %.4f > %.4f in joint %s",
+                        distance, limit, joint->getName().c_str());
         still_valid = false;
         break;
       }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1406,7 +1406,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   // Error check
   if (poses_in.size() != tips_in.size())
   {
-    ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Number of poses must be the same as number of tips");
+    ROS_ERROR_NAMED("robot_state", "Number of poses must be the same as number of tips");
     return false;
   }
 
@@ -1425,8 +1425,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     std::string error_msg;
     if (!solver->supportsGroup(jmg, &error_msg))
     {
-      ROS_ERROR_NAMED("robot_state",
-                      "moveit.robot_state: Kinematics solver %s does not support joint group %s.  Error: %s",
+      ROS_ERROR_NAMED("robot_state", "Kinematics solver %s does not support joint group %s.  Error: %s",
                       typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
       valid_solver = false;
     }
@@ -1442,8 +1441,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     }
     else
     {
-      ROS_ERROR_NAMED("robot_state", "moveit.robot_state: No kinematics solver instantiated for group '%s'",
-                      jmg->getName().c_str());
+      ROS_ERROR_NAMED("robot_state", "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
       return false;
     }
   }
@@ -1452,7 +1450,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Invalid number (%d) of sets of consistency limits "
+    ROS_ERROR_NAMED("robot_state", "Invalid number (%d) of sets of consistency limits "
                                    "for a setFromIK request that is being solved by a single IK solver",
                     consistency_limit_sets.size());
     return false;
@@ -1509,7 +1507,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
           const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
-            ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Cannot use an attached body "
+            ROS_ERROR_NAMED("robot_state", "Cannot use an attached body "
                                            "with multiple geometries as a reference frame.");
             return false;
           }
@@ -1545,8 +1543,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     // Make sure one of the tip frames worked
     if (!found_valid_frame)
     {
-      ROS_ERROR_NAMED("robot_state", "moveit.robot_state: Cannot compute IK for query %u pose reference frame '%s'", i,
-                      pose_frame.c_str());
+      ROS_ERROR_NAMED("robot_state", "Cannot compute IK for query %u pose reference frame '%s'", i, pose_frame.c_str());
       // Debug available tip frames
       std::stringstream ss;
       for (solver_tip_id = 0; solver_tip_id < solver_tip_frames.size(); ++solver_tip_id)
@@ -1630,7 +1627,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     }
     else
     {
-      ROS_DEBUG_NAMED("robot_state", "moveit.robot_state: Rerunning IK solver with random joint positions");
+      ROS_DEBUG_NAMED("robot_state", "Rerunning IK solver with random joint positions");
 
       // sample a random seed
       random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();

--- a/moveit_core/robot_trajectory/CMakeLists.txt
+++ b/moveit_core/robot_trajectory/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_robot_trajectory)
 add_library(${MOVEIT_LIB_NAME} src/robot_trajectory.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model moveit_robot_state ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model moveit_robot_state ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -458,7 +458,8 @@ bool robot_trajectory::RobotTrajectory::getStateAtDurationFromStart(const double
   int before = 0, after = 0;
   double blend = 1.0;
   findWayPointIndicesForDurationAfterStart(request_duration, before, after, blend);
-  // CONSOLE_BRIDGE_logDebug("Interpolating %.3f of the way between index %d and %d.", blend, before, after);
+  // ROS_DEBUG_NAMED("robot_trajectory", "Interpolating %.3f of the way between index %d and %d.", blend, before,
+  // after);
   waypoints_[before]->interpolate(*waypoints_[after], blend, *output_state);
   return true;
 }

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state moveit_robot_trajectory ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_state moveit_robot_trajectory ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
@@ -20,5 +20,5 @@ if(CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   include_directories(${moveit_resources_INCLUDE_DIRS})
   catkin_add_gtest(test_time_parameterization test/test_time_parameterization.cpp)
-  target_link_libraries(test_time_parameterization ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_time_parameterization ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -92,9 +92,8 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
-                    "It looks like the planner did not set the group the plan was computed "
-                    "for");
+    ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization", "It looks like the planner did not set "
+                                                                               "the group the plan was computed for");
     return false;
   }
   const robot_model::RobotModel& rmodel = group->getParentModel();
@@ -229,8 +228,8 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     if (t2[j].max_velocity <= 0.0 || t2[j].max_acceleration <= 0.0)
     {
       ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
-                      "Joint %d max velocity %f and max acceleration %f must be greater than zero or a "
-                      "solution won't be found.\n",
+                      "Joint %d max velocity %f and max acceleration %f must be greater than zero "
+                      "or a solution won't be found.\n",
                       j, t2[j].max_velocity, t2[j].max_acceleration);
       return false;
     }

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -36,7 +36,6 @@
 
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit_msgs/JointLimits.h>
-#include <console_bridge/console.h>
 #include <moveit/robot_state/conversions.h>
 #include <vector>
 
@@ -93,7 +92,8 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    CONSOLE_BRIDGE_logError("It looks like the planner did not set the group the plan was computed for");
+    ROS_ERROR_NAMED("trajectory_processing", "It looks like the planner did not set the group the plan was computed "
+                                             "for");
     return false;
   }
   const robot_model::RobotModel& rmodel = group->getParentModel();
@@ -108,20 +108,24 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
     velocity_scaling_factor = max_velocity_scaling_factor;
   else if (max_velocity_scaling_factor == 0.0)
-    CONSOLE_BRIDGE_logDebug("A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                            velocity_scaling_factor);
+    ROS_DEBUG_NAMED("trajectory_processing",
+                    "A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
+                    velocity_scaling_factor);
   else
-    CONSOLE_BRIDGE_logWarn("Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
-                           max_velocity_scaling_factor, velocity_scaling_factor);
+    ROS_WARN_NAMED("trajectory_processing",
+                   "Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
+                   max_velocity_scaling_factor, velocity_scaling_factor);
 
   if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
     acceleration_scaling_factor = max_acceleration_scaling_factor;
   else if (max_acceleration_scaling_factor == 0.0)
-    CONSOLE_BRIDGE_logDebug("A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                            acceleration_scaling_factor);
+    ROS_DEBUG_NAMED("trajectory_processing",
+                    "A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
+                    acceleration_scaling_factor);
   else
-    CONSOLE_BRIDGE_logWarn("Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
-                           max_acceleration_scaling_factor, acceleration_scaling_factor);
+    ROS_WARN_NAMED("trajectory_processing",
+                   "Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
+                   max_acceleration_scaling_factor, acceleration_scaling_factor);
 
   // No wrapped angles.
   trajectory.unwind();
@@ -223,16 +227,18 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     // Error out if bounds don't make sense
     if (t2[j].max_velocity <= 0.0 || t2[j].max_acceleration <= 0.0)
     {
-      CONSOLE_BRIDGE_logError("Joint %d max velocity %f and max acceleration %f must be greater than zero or a "
-                              "solution won't be found.\n",
-                              j, t2[j].max_velocity, t2[j].max_acceleration);
+      ROS_ERROR_NAMED("trajectory_processing",
+                      "Joint %d max velocity %f and max acceleration %f must be greater than zero or a "
+                      "solution won't be found.\n",
+                      j, t2[j].max_velocity, t2[j].max_acceleration);
       return false;
     }
     if (t2[j].min_velocity >= 0.0 || t2[j].min_acceleration >= 0.0)
     {
-      CONSOLE_BRIDGE_logError("Joint %d min velocity %f and min acceleration %f must be less than zero "
-                              "or a solution won't be found.\n",
-                              j, t2[j].min_velocity, t2[j].min_acceleration);
+      ROS_ERROR_NAMED("trajectory_processing",
+                      "Joint %d min velocity %f and min acceleration %f must be less than zero "
+                      "or a solution won't be found.\n",
+                      j, t2[j].min_velocity, t2[j].min_acceleration);
       return false;
     }
   }
@@ -240,31 +246,32 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   // Error check
   if (num_points < 4)
   {
-    CONSOLE_BRIDGE_logError("number of waypoints %d, needs to be greater than 3.\n", num_points);
+    ROS_ERROR_NAMED("trajectory_processing", "number of waypoints %d, needs to be greater than 3.\n", num_points);
     return false;
   }
   for (unsigned int j = 0; j < num_joints; j++)
   {
     if (t2[j].velocities[0] > t2[j].max_velocity || t2[j].velocities[0] < t2[j].min_velocity)
     {
-      CONSOLE_BRIDGE_logError("Initial velocity %f out of bounds\n", t2[j].velocities[0]);
+      ROS_ERROR_NAMED("trajectory_processing", "Initial velocity %f out of bounds\n", t2[j].velocities[0]);
       return false;
     }
     else if (t2[j].velocities[num_points - 1] > t2[j].max_velocity ||
              t2[j].velocities[num_points - 1] < t2[j].min_velocity)
     {
-      CONSOLE_BRIDGE_logError("Final velocity %f out of bounds\n", t2[j].velocities[num_points - 1]);
+      ROS_ERROR_NAMED("trajectory_processing", "Final velocity %f out of bounds\n", t2[j].velocities[num_points - 1]);
       return false;
     }
     else if (t2[j].accelerations[0] > t2[j].max_acceleration || t2[j].accelerations[0] < t2[j].min_acceleration)
     {
-      CONSOLE_BRIDGE_logError("Initial acceleration %f out of bounds\n", t2[j].accelerations[0]);
+      ROS_ERROR_NAMED("trajectory_processing", "Initial acceleration %f out of bounds\n", t2[j].accelerations[0]);
       return false;
     }
     else if (t2[j].accelerations[num_points - 1] > t2[j].max_acceleration ||
              t2[j].accelerations[num_points - 1] < t2[j].min_acceleration)
     {
-      CONSOLE_BRIDGE_logError("Final acceleration %f out of bounds\n", t2[j].accelerations[num_points - 1]);
+      ROS_ERROR_NAMED("trajectory_processing", "Final acceleration %f out of bounds\n",
+                      t2[j].accelerations[num_points - 1]);
       return false;
     }
   }

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -92,8 +92,9 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    ROS_ERROR_NAMED("trajectory_processing", "It looks like the planner did not set the group the plan was computed "
-                                             "for");
+    ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
+                    "It looks like the planner did not set the group the plan was computed "
+                    "for");
     return false;
   }
   const robot_model::RobotModel& rmodel = group->getParentModel();
@@ -108,22 +109,22 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
     velocity_scaling_factor = max_velocity_scaling_factor;
   else if (max_velocity_scaling_factor == 0.0)
-    ROS_DEBUG_NAMED("trajectory_processing",
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_spline_parameterization",
                     "A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
                     velocity_scaling_factor);
   else
-    ROS_WARN_NAMED("trajectory_processing",
+    ROS_WARN_NAMED("trajectory_processing.iterative_spline_parameterization",
                    "Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
                    max_velocity_scaling_factor, velocity_scaling_factor);
 
   if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
     acceleration_scaling_factor = max_acceleration_scaling_factor;
   else if (max_acceleration_scaling_factor == 0.0)
-    ROS_DEBUG_NAMED("trajectory_processing",
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_spline_parameterization",
                     "A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
                     acceleration_scaling_factor);
   else
-    ROS_WARN_NAMED("trajectory_processing",
+    ROS_WARN_NAMED("trajectory_processing.iterative_spline_parameterization",
                    "Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
                    max_acceleration_scaling_factor, acceleration_scaling_factor);
 
@@ -227,7 +228,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     // Error out if bounds don't make sense
     if (t2[j].max_velocity <= 0.0 || t2[j].max_acceleration <= 0.0)
     {
-      ROS_ERROR_NAMED("trajectory_processing",
+      ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
                       "Joint %d max velocity %f and max acceleration %f must be greater than zero or a "
                       "solution won't be found.\n",
                       j, t2[j].max_velocity, t2[j].max_acceleration);
@@ -235,7 +236,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     }
     if (t2[j].min_velocity >= 0.0 || t2[j].min_acceleration >= 0.0)
     {
-      ROS_ERROR_NAMED("trajectory_processing",
+      ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
                       "Joint %d min velocity %f and min acceleration %f must be less than zero "
                       "or a solution won't be found.\n",
                       j, t2[j].min_velocity, t2[j].min_acceleration);
@@ -246,32 +247,36 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   // Error check
   if (num_points < 4)
   {
-    ROS_ERROR_NAMED("trajectory_processing", "number of waypoints %d, needs to be greater than 3.\n", num_points);
+    ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
+                    "number of waypoints %d, needs to be greater than 3.\n", num_points);
     return false;
   }
   for (unsigned int j = 0; j < num_joints; j++)
   {
     if (t2[j].velocities[0] > t2[j].max_velocity || t2[j].velocities[0] < t2[j].min_velocity)
     {
-      ROS_ERROR_NAMED("trajectory_processing", "Initial velocity %f out of bounds\n", t2[j].velocities[0]);
+      ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization", "Initial velocity %f out of bounds\n",
+                      t2[j].velocities[0]);
       return false;
     }
     else if (t2[j].velocities[num_points - 1] > t2[j].max_velocity ||
              t2[j].velocities[num_points - 1] < t2[j].min_velocity)
     {
-      ROS_ERROR_NAMED("trajectory_processing", "Final velocity %f out of bounds\n", t2[j].velocities[num_points - 1]);
+      ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization", "Final velocity %f out of bounds\n",
+                      t2[j].velocities[num_points - 1]);
       return false;
     }
     else if (t2[j].accelerations[0] > t2[j].max_acceleration || t2[j].accelerations[0] < t2[j].min_acceleration)
     {
-      ROS_ERROR_NAMED("trajectory_processing", "Initial acceleration %f out of bounds\n", t2[j].accelerations[0]);
+      ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
+                      "Initial acceleration %f out of bounds\n", t2[j].accelerations[0]);
       return false;
     }
     else if (t2[j].accelerations[num_points - 1] > t2[j].max_acceleration ||
              t2[j].accelerations[num_points - 1] < t2[j].min_acceleration)
     {
-      ROS_ERROR_NAMED("trajectory_processing", "Final acceleration %f out of bounds\n",
-                      t2[j].accelerations[num_points - 1]);
+      ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization",
+                      "Final acceleration %f out of bounds\n", t2[j].accelerations[num_points - 1]);
       return false;
     }
   }

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -469,9 +469,8 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    ROS_ERROR_NAMED("trajectory_processing.iterative_time_parameterization",
-                    "It looks like the planner did not set the group the plan was computed "
-                    "for");
+    ROS_ERROR_NAMED("trajectory_processing.iterative_time_parameterization", "It looks like the planner did not set "
+                                                                             "the group the plan was computed for");
     return false;
   }
 

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -36,7 +36,6 @@
 
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 #include <moveit_msgs/JointLimits.h>
-#include <console_bridge/console.h>
 #include <moveit/robot_state/conversions.h>
 
 namespace trajectory_processing
@@ -59,38 +58,38 @@ namespace
 {
 void printPoint(const trajectory_msgs::JointTrajectoryPoint& point, std::size_t i)
 {
-  CONSOLE_BRIDGE_logDebug(" time   [%i]= %f", i, point.time_from_start.toSec());
+  ROS_DEBUG_NAMED("trajectory_processing", " time   [%i]= %f", i, point.time_from_start.toSec());
   if (point.positions.size() >= 7)
   {
-    CONSOLE_BRIDGE_logDebug(" pos_   [%i]= %f %f %f %f %f %f %f", i, point.positions[0], point.positions[1],
-                            point.positions[2], point.positions[3], point.positions[4], point.positions[5],
-                            point.positions[6]);
+    ROS_DEBUG_NAMED("trajectory_processing", " pos_   [%i]= %f %f %f %f %f %f %f", i, point.positions[0],
+                    point.positions[1], point.positions[2], point.positions[3], point.positions[4], point.positions[5],
+                    point.positions[6]);
   }
   if (point.velocities.size() >= 7)
   {
-    CONSOLE_BRIDGE_logDebug("  vel_  [%i]= %f %f %f %f %f %f %f", i, point.velocities[0], point.velocities[1],
-                            point.velocities[2], point.velocities[3], point.velocities[4], point.velocities[5],
-                            point.velocities[6]);
+    ROS_DEBUG_NAMED("trajectory_processing", "  vel_  [%i]= %f %f %f %f %f %f %f", i, point.velocities[0],
+                    point.velocities[1], point.velocities[2], point.velocities[3], point.velocities[4],
+                    point.velocities[5], point.velocities[6]);
   }
   if (point.accelerations.size() >= 7)
   {
-    CONSOLE_BRIDGE_logDebug("   acc_ [%i]= %f %f %f %f %f %f %f", i, point.accelerations[0], point.accelerations[1],
-                            point.accelerations[2], point.accelerations[3], point.accelerations[4],
-                            point.accelerations[5], point.accelerations[6]);
+    ROS_DEBUG_NAMED("trajectory_processing", "   acc_ [%i]= %f %f %f %f %f %f %f", i, point.accelerations[0],
+                    point.accelerations[1], point.accelerations[2], point.accelerations[3], point.accelerations[4],
+                    point.accelerations[5], point.accelerations[6]);
   }
 }
 
 void printStats(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<moveit_msgs::JointLimits>& limits)
 {
-  CONSOLE_BRIDGE_logDebug("jointNames= %s %s %s %s %s %s %s", limits[0].joint_name.c_str(),
-                          limits[1].joint_name.c_str(), limits[2].joint_name.c_str(), limits[3].joint_name.c_str(),
-                          limits[4].joint_name.c_str(), limits[5].joint_name.c_str(), limits[6].joint_name.c_str());
-  CONSOLE_BRIDGE_logDebug("maxVelocities= %f %f %f %f %f %f %f", limits[0].max_velocity, limits[1].max_velocity,
-                          limits[2].max_velocity, limits[3].max_velocity, limits[4].max_velocity,
-                          limits[5].max_velocity, limits[6].max_velocity);
-  CONSOLE_BRIDGE_logDebug("maxAccelerations= %f %f %f %f %f %f %f", limits[0].max_acceleration,
-                          limits[1].max_acceleration, limits[2].max_acceleration, limits[3].max_acceleration,
-                          limits[4].max_acceleration, limits[5].max_acceleration, limits[6].max_acceleration);
+  ROS_DEBUG_NAMED("trajectory_processing", "jointNames= %s %s %s %s %s %s %s", limits[0].joint_name.c_str(),
+                  limits[1].joint_name.c_str(), limits[2].joint_name.c_str(), limits[3].joint_name.c_str(),
+                  limits[4].joint_name.c_str(), limits[5].joint_name.c_str(), limits[6].joint_name.c_str());
+  ROS_DEBUG_NAMED("trajectory_processing", "maxVelocities= %f %f %f %f %f %f %f", limits[0].max_velocity,
+                  limits[1].max_velocity, limits[2].max_velocity, limits[3].max_velocity, limits[4].max_velocity,
+                  limits[5].max_velocity, limits[6].max_velocity);
+  ROS_DEBUG_NAMED("trajectory_processing", "maxAccelerations= %f %f %f %f %f %f %f", limits[0].max_acceleration,
+                  limits[1].max_acceleration, limits[2].max_acceleration, limits[3].max_acceleration,
+                  limits[4].max_acceleration, limits[5].max_acceleration, limits[6].max_acceleration);
   // for every point in time:
   for (std::size_t i = 0; i < trajectory.points.size(); ++i)
     printPoint(trajectory.points[i], i);
@@ -113,11 +112,13 @@ void IterativeParabolicTimeParameterization::applyVelocityConstraints(robot_traj
   if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
     velocity_scaling_factor = max_velocity_scaling_factor;
   else if (max_velocity_scaling_factor == 0.0)
-    CONSOLE_BRIDGE_logDebug("A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                            velocity_scaling_factor);
+    ROS_DEBUG_NAMED("trajectory_processing",
+                    "A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
+                    velocity_scaling_factor);
   else
-    CONSOLE_BRIDGE_logWarn("Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
-                           max_velocity_scaling_factor, velocity_scaling_factor);
+    ROS_WARN_NAMED("trajectory_processing",
+                   "Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
+                   max_velocity_scaling_factor, velocity_scaling_factor);
 
   for (int i = 0; i < num_points - 1; ++i)
   {
@@ -327,11 +328,13 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
   if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
     acceleration_scaling_factor = max_acceleration_scaling_factor;
   else if (max_acceleration_scaling_factor == 0.0)
-    CONSOLE_BRIDGE_logDebug("A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                            acceleration_scaling_factor);
+    ROS_DEBUG_NAMED("trajectory_processing",
+                    "A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
+                    acceleration_scaling_factor);
   else
-    CONSOLE_BRIDGE_logWarn("Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
-                           max_acceleration_scaling_factor, acceleration_scaling_factor);
+    ROS_WARN_NAMED("trajectory_processing",
+                   "Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
+                   max_acceleration_scaling_factor, acceleration_scaling_factor);
 
   do
   {
@@ -448,7 +451,7 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
         backwards = !backwards;
       }
     }
-    // CONSOLE_BRIDGE_logDebug("applyAcceleration: num_updates=%i", num_updates);
+    // ROS_DEBUG_NAMED("trajectory_processing", "applyAcceleration: num_updates=%i", num_updates);
   } while (num_updates > 0 && iteration < static_cast<int>(max_iterations_));
 }
 
@@ -462,7 +465,8 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    CONSOLE_BRIDGE_logError("It looks like the planner did not set the group the plan was computed for");
+    ROS_ERROR_NAMED("trajectory_processing", "It looks like the planner did not set the group the plan was computed "
+                                             "for");
     return false;
   }
 

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -58,38 +58,41 @@ namespace
 {
 void printPoint(const trajectory_msgs::JointTrajectoryPoint& point, std::size_t i)
 {
-  ROS_DEBUG_NAMED("trajectory_processing", " time   [%i]= %f", i, point.time_from_start.toSec());
+  ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", " time   [%i]= %f", i,
+                  point.time_from_start.toSec());
   if (point.positions.size() >= 7)
   {
-    ROS_DEBUG_NAMED("trajectory_processing", " pos_   [%i]= %f %f %f %f %f %f %f", i, point.positions[0],
-                    point.positions[1], point.positions[2], point.positions[3], point.positions[4], point.positions[5],
-                    point.positions[6]);
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", " pos_   [%i]= %f %f %f %f %f %f %f", i,
+                    point.positions[0], point.positions[1], point.positions[2], point.positions[3], point.positions[4],
+                    point.positions[5], point.positions[6]);
   }
   if (point.velocities.size() >= 7)
   {
-    ROS_DEBUG_NAMED("trajectory_processing", "  vel_  [%i]= %f %f %f %f %f %f %f", i, point.velocities[0],
-                    point.velocities[1], point.velocities[2], point.velocities[3], point.velocities[4],
-                    point.velocities[5], point.velocities[6]);
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", "  vel_  [%i]= %f %f %f %f %f %f %f", i,
+                    point.velocities[0], point.velocities[1], point.velocities[2], point.velocities[3],
+                    point.velocities[4], point.velocities[5], point.velocities[6]);
   }
   if (point.accelerations.size() >= 7)
   {
-    ROS_DEBUG_NAMED("trajectory_processing", "   acc_ [%i]= %f %f %f %f %f %f %f", i, point.accelerations[0],
-                    point.accelerations[1], point.accelerations[2], point.accelerations[3], point.accelerations[4],
-                    point.accelerations[5], point.accelerations[6]);
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", "   acc_ [%i]= %f %f %f %f %f %f %f", i,
+                    point.accelerations[0], point.accelerations[1], point.accelerations[2], point.accelerations[3],
+                    point.accelerations[4], point.accelerations[5], point.accelerations[6]);
   }
 }
 
 void printStats(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<moveit_msgs::JointLimits>& limits)
 {
-  ROS_DEBUG_NAMED("trajectory_processing", "jointNames= %s %s %s %s %s %s %s", limits[0].joint_name.c_str(),
-                  limits[1].joint_name.c_str(), limits[2].joint_name.c_str(), limits[3].joint_name.c_str(),
-                  limits[4].joint_name.c_str(), limits[5].joint_name.c_str(), limits[6].joint_name.c_str());
-  ROS_DEBUG_NAMED("trajectory_processing", "maxVelocities= %f %f %f %f %f %f %f", limits[0].max_velocity,
-                  limits[1].max_velocity, limits[2].max_velocity, limits[3].max_velocity, limits[4].max_velocity,
-                  limits[5].max_velocity, limits[6].max_velocity);
-  ROS_DEBUG_NAMED("trajectory_processing", "maxAccelerations= %f %f %f %f %f %f %f", limits[0].max_acceleration,
-                  limits[1].max_acceleration, limits[2].max_acceleration, limits[3].max_acceleration,
-                  limits[4].max_acceleration, limits[5].max_acceleration, limits[6].max_acceleration);
+  ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", "jointNames= %s %s %s %s %s %s %s",
+                  limits[0].joint_name.c_str(), limits[1].joint_name.c_str(), limits[2].joint_name.c_str(),
+                  limits[3].joint_name.c_str(), limits[4].joint_name.c_str(), limits[5].joint_name.c_str(),
+                  limits[6].joint_name.c_str());
+  ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", "maxVelocities= %f %f %f %f %f %f %f",
+                  limits[0].max_velocity, limits[1].max_velocity, limits[2].max_velocity, limits[3].max_velocity,
+                  limits[4].max_velocity, limits[5].max_velocity, limits[6].max_velocity);
+  ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", "maxAccelerations= %f %f %f %f %f %f %f",
+                  limits[0].max_acceleration, limits[1].max_acceleration, limits[2].max_acceleration,
+                  limits[3].max_acceleration, limits[4].max_acceleration, limits[5].max_acceleration,
+                  limits[6].max_acceleration);
   // for every point in time:
   for (std::size_t i = 0; i < trajectory.points.size(); ++i)
     printPoint(trajectory.points[i], i);
@@ -112,11 +115,11 @@ void IterativeParabolicTimeParameterization::applyVelocityConstraints(robot_traj
   if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
     velocity_scaling_factor = max_velocity_scaling_factor;
   else if (max_velocity_scaling_factor == 0.0)
-    ROS_DEBUG_NAMED("trajectory_processing",
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization",
                     "A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
                     velocity_scaling_factor);
   else
-    ROS_WARN_NAMED("trajectory_processing",
+    ROS_WARN_NAMED("trajectory_processing.iterative_time_parameterization",
                    "Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
                    max_velocity_scaling_factor, velocity_scaling_factor);
 
@@ -328,11 +331,11 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
   if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
     acceleration_scaling_factor = max_acceleration_scaling_factor;
   else if (max_acceleration_scaling_factor == 0.0)
-    ROS_DEBUG_NAMED("trajectory_processing",
+    ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization",
                     "A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
                     acceleration_scaling_factor);
   else
-    ROS_WARN_NAMED("trajectory_processing",
+    ROS_WARN_NAMED("trajectory_processing.iterative_time_parameterization",
                    "Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
                    max_acceleration_scaling_factor, acceleration_scaling_factor);
 
@@ -451,7 +454,8 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
         backwards = !backwards;
       }
     }
-    // ROS_DEBUG_NAMED("trajectory_processing", "applyAcceleration: num_updates=%i", num_updates);
+    // ROS_DEBUG_NAMED("trajectory_processing.iterative_time_parameterization", "applyAcceleration: num_updates=%i",
+    // num_updates);
   } while (num_updates > 0 && iteration < static_cast<int>(max_iterations_));
 }
 
@@ -465,8 +469,9 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    ROS_ERROR_NAMED("trajectory_processing", "It looks like the planner did not set the group the plan was computed "
-                                             "for");
+    ROS_ERROR_NAMED("trajectory_processing.iterative_time_parameterization",
+                    "It looks like the planner did not set the group the plan was computed "
+                    "for");
     return false;
   }
 

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -86,7 +86,7 @@ int initRepeatedPointTrajectory(robot_trajectory::RobotTrajectory& trajectory)
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    CONSOLE_BRIDGE_logError("Need to set the group");
+    ROS_ERROR_NAMED("trajectory_processing", "Need to set the group");
     return -1;
   }
   // leave initial velocity/acceleration unset
@@ -116,7 +116,7 @@ int initStraightTrajectory(robot_trajectory::RobotTrajectory& trajectory, double
   const robot_model::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
-    CONSOLE_BRIDGE_logError("Need to set the group");
+    ROS_ERROR_NAMED("trajectory_processing", "Need to set the group");
     return -1;
   }
   // leave initial velocity/acceleration unset

--- a/moveit_core/transforms/CMakeLists.txt
+++ b/moveit_core/transforms/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_transforms)
 add_library(${MOVEIT_LIB_NAME} src/transforms.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/transforms/src/transforms.cpp
+++ b/moveit_core/transforms/src/transforms.cpp
@@ -37,19 +37,20 @@
 #include <moveit/transforms/transforms.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <boost/algorithm/string/trim.hpp>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 
 moveit::core::Transforms::Transforms(const std::string& target_frame) : target_frame_(target_frame)
 {
   boost::trim(target_frame_);
   if (target_frame_.empty())
-    CONSOLE_BRIDGE_logError("The target frame for MoveIt Transforms cannot be empty.");
+    ROS_ERROR_NAMED("transforms", "The target frame for MoveIt Transforms cannot be empty.");
   else
   {
     if (target_frame_[0] != '/')
     {
-      CONSOLE_BRIDGE_logWarn("Frame '%s' specified as target frame for MoveIt Transforms. Assuming '/%s' instead.",
-                             target_frame_.c_str(), target_frame_.c_str());
+      ROS_WARN_NAMED("transforms",
+                     "Frame '%s' specified as target frame for MoveIt Transforms. Assuming '/%s' instead.",
+                     target_frame_.c_str(), target_frame_.c_str());
       target_frame_ = '/' + target_frame_;
     }
     transforms_[target_frame_] = Eigen::Affine3d::Identity();
@@ -104,8 +105,8 @@ const Eigen::Affine3d& moveit::core::Transforms::getTransform(const std::string&
       return it->second;
   }
 
-  CONSOLE_BRIDGE_logError("Unable to transform from frame '%s' to frame '%s'. Returning identity.", from_frame.c_str(),
-                          target_frame_.c_str());
+  ROS_ERROR_NAMED("transforms", "Unable to transform from frame '%s' to frame '%s'. Returning identity.",
+                  from_frame.c_str(), target_frame_.c_str());
 
   // return identity
   static const Eigen::Affine3d identity = Eigen::Affine3d::Identity();
@@ -124,13 +125,13 @@ bool moveit::core::Transforms::canTransform(const std::string& from_frame) const
 void moveit::core::Transforms::setTransform(const Eigen::Affine3d& t, const std::string& from_frame)
 {
   if (from_frame.empty())
-    CONSOLE_BRIDGE_logError("Cannot record transform with empty name");
+    ROS_ERROR_NAMED("transforms", "Cannot record transform with empty name");
   else
   {
     if (from_frame[0] != '/')
     {
-      CONSOLE_BRIDGE_logWarn("Transform specified for frame '%s'. Assuming '/%s' instead", from_frame.c_str(),
-                             from_frame.c_str());
+      ROS_WARN_NAMED("transforms", "Transform specified for frame '%s'. Assuming '/%s' instead", from_frame.c_str(),
+                     from_frame.c_str());
       transforms_['/' + from_frame] = t;
     }
     else
@@ -148,8 +149,8 @@ void moveit::core::Transforms::setTransform(const geometry_msgs::TransformStampe
   }
   else
   {
-    CONSOLE_BRIDGE_logError("Given transform is to frame '%s', but frame '%s' was expected.",
-                            transform.child_frame_id.c_str(), target_frame_.c_str());
+    ROS_ERROR_NAMED("transforms", "Given transform is to frame '%s', but frame '%s' was expected.",
+                    transform.child_frame_id.c_str(), target_frame_.c_str());
   }
 }
 

--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -21,6 +21,7 @@ COMPONENTS
   visualization_msgs
   roslib
   rostime
+  rosconsole
   pluginlib
   cmake_modules
 )

--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -24,7 +24,6 @@ COMPONENTS
   pluginlib
   cmake_modules
 )
-find_package(console_bridge REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 # Eigen 3.2 (Wily) only provides EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
@@ -66,7 +65,6 @@ catkin_package(
     Boost
     urdfdom
     urdfdom_headers
-    console_bridge
 )
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
@@ -75,7 +73,6 @@ include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIR}
                     ${catkin_INCLUDE_DIRS}
-                    ${console_bridge_INCLUDE_DIRS}
                     ${urdfdom_INCLUDE_DIRS}
                     ${urdfdom_headers_INCLUDE_DIRS}
                     ${OCTOMAP_INCLUDE_DIRS}

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -52,7 +52,7 @@
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <console_bridge/console.h>
+#include <ros/console.h>
 
 namespace collision_detection
 {
@@ -406,7 +406,7 @@ public:
   {
     if (i >= decomp_vector_.size())
     {
-      logInform("No body decomposition");
+      ROS_INFO_NAMED("collision_distance_field", "No body decomposition");
       return empty_ptr_;
     }
     return decomp_vector_[i];
@@ -416,7 +416,7 @@ public:
   {
     if (ind >= decomp_vector_.size())
     {
-      logWarn("Can't update pose");
+      ROS_WARN_NAMED("collision_distance_field", "Can't update pose");
       return;
     }
     decomp_vector_[ind]->updatePose(pose);
@@ -469,7 +469,7 @@ public:
   {
     if (i >= decomp_vector_.size())
     {
-      logInform("No body decomposition");
+      ROS_INFO_NAMED("collision_distance_field", "No body decomposition");
       return empty_ptr_;
     }
     return decomp_vector_[i];
@@ -483,7 +483,7 @@ public:
     }
     else
     {
-      logWarn("Can't update pose");
+      ROS_WARN_NAMED("collision_distance_field", "Can't update pose");
       return;
     }
   }

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
@@ -104,7 +104,7 @@ public:
                                   collision_detection::CollisionResult& res, const moveit::core::RobotState& state1,
                                   const moveit::core::RobotState& state2) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   };
 
   virtual void checkSelfCollision(const collision_detection::CollisionRequest& req,
@@ -112,14 +112,14 @@ public:
                                   const moveit::core::RobotState& state2,
                                   const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   };
 
   virtual void checkOtherCollision(const collision_detection::CollisionRequest& req,
                                    collision_detection::CollisionResult& res, const moveit::core::RobotState& state,
                                    const CollisionRobot& other_robot, const moveit::core::RobotState& other_state) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   };
 
   virtual void checkOtherCollision(const collision_detection::CollisionRequest& req,
@@ -127,7 +127,7 @@ public:
                                    const CollisionRobot& other_robot, const moveit::core::RobotState& other_state,
                                    const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   };
 
   virtual void checkOtherCollision(const collision_detection::CollisionRequest& req,
@@ -136,7 +136,7 @@ public:
                                    const moveit::core::RobotState& other_state1,
                                    const moveit::core::RobotState& other_state2) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   };
 
   virtual void checkOtherCollision(const collision_detection::CollisionRequest& req,
@@ -146,7 +146,7 @@ public:
                                    const moveit::core::RobotState& other_state2,
                                    const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   };
 
   void createCollisionModelMarker(const moveit::core::RobotState& state,
@@ -175,13 +175,13 @@ public:
 
   virtual void distanceSelf(const DistanceRequest& req, DistanceResult& res, const robot_state::RobotState& state) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
 
   virtual void distanceOther(const DistanceRequest& req, DistanceResult& res, const robot_state::RobotState& state,
                              const CollisionRobot& other_robot, const robot_state::RobotState& other_state) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
 
   DistanceFieldCacheEntryConstPtr getLastDistanceFieldEntry() const

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
@@ -143,12 +143,12 @@ public:
   virtual void distanceRobot(const DistanceRequest& req, DistanceResult& res, const CollisionRobot& robot,
                              const robot_state::RobotState& state) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
 
   virtual void distanceWorld(const DistanceRequest& req, DistanceResult& res, const CollisionWorld& world) const
   {
-    logError("Not implemented");
+    ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
 
   virtual void setWorld(const WorldPtr& world);

--- a/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
@@ -449,8 +449,9 @@ void collision_detection::getProximityGradientMarkers(
 {
   if (gradients.size() != posed_decompositions.size() + posed_vector_decompositions.size())
   {
-    logWarn("Size mismatch between gradients %u and decompositions %u", (unsigned int)gradients.size(),
-            (unsigned int)(posed_decompositions.size() + posed_vector_decompositions.size()));
+    ROS_WARN_NAMED("collision_distance_field", "Size mismatch between gradients %u and decompositions %u",
+                   (unsigned int)gradients.size(),
+                   (unsigned int)(posed_decompositions.size() + posed_vector_decompositions.size()));
     return;
   }
   for (unsigned int i = 0; i < gradients.size(); i++)
@@ -482,12 +483,14 @@ void collision_detection::getProximityGradientMarkers(
         }
         else
         {
-          logDebug("Negative length for %u %d %lf", i, arrow_mark.id, gradients[i].gradients[j].norm());
+          ROS_DEBUG_NAMED("collision_distance_field", "Negative length for %u %d %lf", i, arrow_mark.id,
+                          gradients[i].gradients[j].norm());
         }
       }
       else
       {
-        logDebug("Negative dist %lf for %u %d", gradients[i].distances[j], i, arrow_mark.id);
+        ROS_DEBUG_NAMED("collision_distance_field", "Negative dist %lf for %u %d", gradients[i].distances[j], i,
+                        arrow_mark.id);
       }
       arrow_mark.points.resize(2);
       if (i < posed_decompositions.size())
@@ -549,8 +552,9 @@ void collision_detection::getCollisionMarkers(
 {
   if (gradients.size() != posed_decompositions.size() + posed_vector_decompositions.size())
   {
-    logWarn("Size mismatch between gradients %u and decompositions ", (unsigned int)gradients.size(),
-            (unsigned int)(posed_decompositions.size() + posed_vector_decompositions.size()));
+    ROS_WARN_NAMED("collision_distance_field", "Size mismatch between gradients %u and decompositions ",
+                   (unsigned int)gradients.size(),
+                   (unsigned int)(posed_decompositions.size() + posed_vector_decompositions.size()));
     return;
   }
   for (unsigned int i = 0; i < gradients.size(); i++)

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -140,7 +140,7 @@ void CollisionRobotDistanceField::generateCollisionCheckingStructures(
   DistanceFieldCacheEntryConstPtr dfce = getDistanceFieldCacheEntry(group_name, state, acm);
   if (!dfce || (generate_distance_field && !dfce->distance_field_))
   {
-    // ROS_DEBUG_STREAM_NAMED("distance_field","Generating new
+    // ROS_DEBUG_STREAM_NAMED("collision_distance_field", "Generating new
     // DistanceFieldCacheEntry for CollisionRobot");
     DistanceFieldCacheEntryPtr new_dfce =
         generateDistanceFieldCacheEntry(group_name, state, acm, generate_distance_field);
@@ -194,7 +194,7 @@ DistanceFieldCacheEntryConstPtr CollisionRobotDistanceField::getDistanceFieldCac
   else if (!compareCacheEntryToState(cur, state))
   {
     // Regenerating distance field as state has changed from last time
-    // ROS_DEBUG_STREAM_NAMED("distance_field","Regenerating distance field as
+    // ROS_DEBUG_STREAM_NAMED("collision_distance_field", "Regenerating distance field as
     // state has changed from last time");
     return ret;
   }
@@ -1087,7 +1087,7 @@ CollisionRobotDistanceField::getPosedLinkBodyPointDecomposition(const moveit::co
   std::map<std::string, unsigned int>::const_iterator it = link_body_decomposition_index_map_.find(ls->getName());
   if (it == link_body_decomposition_index_map_.end())
   {
-    logError("No link body decomposition for link %s.", ls->getName().c_str());
+    ROS_ERROR_NAMED("collision_distance_field", "No link body decomposition for link %s.", ls->getName().c_str());
     return ret;
   }
   ret.reset(new PosedBodyPointDecomposition(link_body_decomposition_vector_[it->second]));

--- a/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
@@ -491,7 +491,8 @@ void CollisionWorldDistanceField::notifyObjectChange(CollisionWorldDistanceField
     self->distance_field_cache_entry_->distance_field_->addPointsToField(add_points);
   }
 
-  logDebug("Modifying object %s took %lf s", obj->id_.c_str(), (ros::WallTime::now() - n).toSec());
+  ROS_DEBUG_NAMED("collision_distance_field", "Modifying object %s took %lf s", obj->id_.c_str(),
+                  (ros::WallTime::now() - n).toSec());
 }
 
 void CollisionWorldDistanceField::updateDistanceObject(const std::string& id, DistanceFieldCacheEntryPtr& dfce,

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
@@ -77,11 +77,13 @@ void KinematicsCache::setup(const KinematicsCache::Options& opt)
   kinematics_cache_points_with_solution_ = 0;
   kinematics_cache_vector_.resize(kinematics_cache_size_ * size_grid_node_, 0.0);
   num_solutions_vector_.resize(kinematics_cache_size_, 0);
-  logDebug("Origin: %f %f %f", cache_origin_.x, cache_origin_.y, cache_origin_.z);
-  logDebug("Cache size (num points x,y,z): %d %d %d", cache_size_x_, cache_size_y_, cache_size_z_);
-  logDebug("Cache resolution: %f %f %f", cache_resolution_x_, cache_resolution_y_, cache_resolution_z_);
-  logDebug("Solutions per grid location: %d", (int)max_solutions_per_grid_location_);
-  logDebug("Solution dimension: %d", (int)solution_dimension_);
+  ROS_DEBUG_NAMED("kinematics_cache", "Origin: %f %f %f", cache_origin_.x, cache_origin_.y, cache_origin_.z);
+  ROS_DEBUG_NAMED("kinematics_cache", "Cache size (num points x,y,z): %d %d %d", cache_size_x_, cache_size_y_,
+                  cache_size_z_);
+  ROS_DEBUG_NAMED("kinematics_cache", "Cache resolution: %f %f %f", cache_resolution_x_, cache_resolution_y_,
+                  cache_resolution_z_);
+  ROS_DEBUG_NAMED("kinematics_cache", "Solutions per grid location: %d", (int)max_solutions_per_grid_location_);
+  ROS_DEBUG_NAMED("kinematics_cache", "Solution dimension: %d", (int)solution_dimension_);
 }
 
 bool KinematicsCache::generateCacheMap(double timeout)
@@ -102,16 +104,18 @@ bool KinematicsCache::generateCacheMap(double timeout)
     joint_state_group_->getVariableValues(fk_values);
     if (!kinematics_solver_->getPositionFK(fk_names, fk_values, poses))
     {
-      logError("Fk failed");
+      ROS_ERROR_NAMED("kinematics_cache", "Fk failed");
       return false;
     }
     if (!addToCache(poses[0], fk_values))
     {
-      logDebug("Adding to cache failed for: %f %f %f", poses[0].position.x, poses[0].position.y, poses[0].position.z);
+      ROS_DEBUG_NAMED("kinematics_cache", "Adding to cache failed for: %f %f %f", poses[0].position.x,
+                      poses[0].position.y, poses[0].position.z);
     }
-    logDebug("Adding: %d", kinematics_cache_points_with_solution_);
+    ROS_DEBUG_NAMED("kinematics_cache", "Adding: %d", kinematics_cache_points_with_solution_);
   }
-  logDebug("Cache map generated with %d valid points", kinematics_cache_points_with_solution_);
+  ROS_DEBUG_NAMED("kinematics_cache", "Cache map generated with %d valid points",
+                  kinematics_cache_points_with_solution_);
   return true;
 }
 
@@ -121,13 +125,13 @@ bool KinematicsCache::addToCache(const geometry_msgs::Pose& pose, const std::vec
   unsigned int grid_index;
   if (!getGridIndex(pose, grid_index))
   {
-    logDebug("Failed to get grid index");
+    ROS_DEBUG_NAMED("kinematics_cache", "Failed to get grid index");
     return false;
   }
   unsigned int num_solutions = num_solutions_vector_[grid_index];
   if (!overwrite && num_solutions >= max_solutions_per_grid_location_)
   {
-    logDebug("Pose already has max number of solutions");
+    ROS_DEBUG_NAMED("kinematics_cache", "Pose already has max number of solutions");
     return true;
   }
   if (num_solutions == 0)
@@ -154,20 +158,23 @@ bool KinematicsCache::getGridIndex(const geometry_msgs::Pose& pose, unsigned int
 
   if (x_index >= (int)cache_size_x_ || x_index < 0)
   {
-    logDebug("X position %f,%d lies outside grid: %d %d", pose.position.x, x_index, 0, cache_size_x_);
+    ROS_DEBUG_NAMED("kinematics_cache", "X position %f,%d lies outside grid: %d %d", pose.position.x, x_index, 0,
+                    cache_size_x_);
     return false;
   }
   if (y_index >= (int)cache_size_y_ || y_index < 0)
   {
-    logDebug("Y position %f,%d lies outside grid: %d %d", pose.position.y, y_index, 0, cache_size_y_);
+    ROS_DEBUG_NAMED("kinematics_cache", "Y position %f,%d lies outside grid: %d %d", pose.position.y, y_index, 0,
+                    cache_size_y_);
     return false;
   }
   if (z_index >= (int)cache_size_z_ || z_index < 0)
   {
-    logDebug("Z position %f,%d lies outside grid: %d %d", pose.position.z, z_index, 0, cache_size_z_);
+    ROS_DEBUG_NAMED("kinematics_cache", "Z position %f,%d lies outside grid: %d %d", pose.position.z, z_index, 0,
+                    cache_size_z_);
     return false;
   }
-  logDebug("Grid indices: %d %d %d", x_index, y_index, z_index);
+  ROS_DEBUG_NAMED("kinematics_cache", "Grid indices: %d %d %d", x_index, y_index, z_index);
   grid_index = (x_index + y_index * cache_size_x_ + z_index * cache_size_x_ * cache_size_y_);
   return true;
 }
@@ -184,8 +191,8 @@ bool KinematicsCache::getNumSolutions(const geometry_msgs::Pose& pose, unsigned 
 
 unsigned int KinematicsCache::getSolutionLocation(unsigned int& grid_index, unsigned int& solution_index) const
 {
-  logDebug("[Grid Index, Solution number location]: %d, %d", grid_index,
-           grid_index * size_grid_node_ + solution_index * solution_dimension_);
+  ROS_DEBUG_NAMED("kinematics_cache", "[Grid Index, Solution number location]: %d, %d", grid_index,
+                  grid_index * size_grid_node_ + solution_index * solution_dimension_);
   return (grid_index * size_grid_node_ + solution_index * solution_dimension_);
 }
 
@@ -234,21 +241,21 @@ bool KinematicsCache::readFromFile(const std::string& filename)
   std::ifstream file(filename.c_str());
   if (!file.is_open())
   {
-    logDebug("Could not open file: %s", filename.c_str());
+    ROS_DEBUG_NAMED("kinematics_cache", "Could not open file: %s", filename.c_str());
     return false;
   }
   std::string group_name;
   std::getline(file, group_name);
   if (group_name.empty())
   {
-    logError("Could not find group_name in file: %s", group_name.c_str());
+    ROS_ERROR_NAMED("kinematics_cache", "Could not find group_name in file: %s", group_name.c_str());
     file.close();
     return false;
   }
   if (group_name != kinematics_solver_->getGroupName())
   {
-    logError("Input file group name %s does not match solver group name %s", group_name.c_str(),
-             kinematics_solver_->getGroupName().c_str());
+    ROS_ERROR_NAMED("kinematics_cache", "Input file group name %s does not match solver group name %s",
+                    group_name.c_str(), kinematics_solver_->getGroupName().c_str());
     file.close();
     return false;
   }
@@ -318,18 +325,20 @@ bool KinematicsCache::readFromFile(const std::string& filename)
 
   kinematics_cache_vector_ = kinematics_cache_vector;
   num_solutions_vector_ = num_solutions_vector;
-  logDebug("Read %d total points from file: %s", (int)num_solutions_vector_.size(), filename.c_str());
+  ROS_DEBUG_NAMED("kinematics_cache", "Read %d total points from file: %s", (int)num_solutions_vector_.size(),
+                  filename.c_str());
   return true;
 }
 
 bool KinematicsCache::writeToFile(const std::string& filename)
 {
-  logDebug("Writing %d total points to file: %s", (int)num_solutions_vector_.size(), filename.c_str());
+  ROS_DEBUG_NAMED("kinematics_cache", "Writing %d total points to file: %s", (int)num_solutions_vector_.size(),
+                  filename.c_str());
   std::ofstream file;
   file.open(filename.c_str());
   if (!file.is_open())
   {
-    logDebug("Could not open file: %s", filename.c_str());
+    ROS_DEBUG_NAMED("kinematics_cache", "Could not open file: %s", filename.c_str());
     return false;
   }
   if (file.good())

--- a/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
+++ b/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
@@ -303,8 +303,9 @@ bool KinematicsConstraintAware::convertServiceRequest(
 
   if (!request.ik_request.ik_link_names.empty() && request.ik_request.ik_link_names.size() != sub_groups_names_.size())
   {
-    ROS_ERROR_NAMED("kinematics_constraint_aware", "Number of ik_link_names in request: %d must match number of sub "
-                                                   "groups %d in this group or must be zero",
+    ROS_ERROR_NAMED("kinematics_constraint_aware",
+                    "Number of ik_link_names in request: "
+                    "%d must match number of sub groups %d in this group or must be zero",
                     request.ik_request.ik_link_names.size(), sub_groups_names_.size());
     kinematics_response.error_code_.val = kinematics_response.error_code_.INVALID_GROUP_NAME;
     return false;

--- a/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
+++ b/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
@@ -50,7 +50,7 @@ KinematicsConstraintAware::KinematicsConstraintAware(const robot_model::RobotMod
 {
   if (!kinematic_model->hasJointModelGroup(group_name))
   {
-    logError("The group %s does not exist", group_name.c_str());
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "The group %s does not exist", group_name.c_str());
     joint_model_group_ = NULL;
     return;
   }
@@ -64,7 +64,8 @@ KinematicsConstraintAware::KinematicsConstraintAware(const robot_model::RobotMod
   }
   else
   {
-    logDebug("No kinematics solver instance defined for group %s", group_name.c_str());
+    ROS_DEBUG_NAMED("kinematics_constraint_aware", "No kinematics solver instance defined for group %s",
+                    group_name.c_str());
     bool is_solvable_group = true;
     if (!(joint_model_group_->getSubgroupNames().empty()))
     {
@@ -79,7 +80,8 @@ KinematicsConstraintAware::KinematicsConstraintAware(const robot_model::RobotMod
       }
       if (is_solvable_group)
       {
-        logDebug("Group %s is a group for which we can solve IK", joint_model_group_->getName().c_str());
+        ROS_DEBUG_NAMED("kinematics_constraint_aware", "Group %s is a group for which we can solve IK",
+                        joint_model_group_->getName().c_str());
         sub_groups_names_ = sub_groups_names;
       }
       else
@@ -91,7 +93,7 @@ KinematicsConstraintAware::KinematicsConstraintAware(const robot_model::RobotMod
     else
     {
       joint_model_group_ = NULL;
-      logInform("No solver allocated for group %s", group_name.c_str());
+      ROS_INFO_NAMED("kinematics_constraint_aware", "No solver allocated for group %s", group_name.c_str());
     }
     has_sub_groups_ = true;
   }
@@ -104,13 +106,13 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
 {
   if (!joint_model_group_)
   {
-    logError("This solver has not been constructed properly");
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "This solver has not been constructed properly");
     return false;
   }
 
   if (!planning_scene)
   {
-    logError("Planning scene must be allocated");
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "Planning scene must be allocated");
     return false;
   }
 
@@ -148,8 +150,8 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
       else if (!kinematic_model_->getJointModelGroup(sub_groups_names_[i])
                     ->canSetStateFromIK(request.ik_link_names_[i]))
       {
-        logError("Could not find IK solver for link %s for group %s", request.ik_link_names_[i].c_str(),
-                 sub_groups_names_[i].c_str());
+        ROS_ERROR_NAMED("kinematics_constraint_aware", "Could not find IK solver for link %s for group %s",
+                        request.ik_link_names_[i].c_str(), sub_groups_names_[i].c_str());
         return false;
       }
     }
@@ -210,7 +212,7 @@ bool KinematicsConstraintAware::validityCallbackFn(const planning_scene::Plannin
     planning_scene->checkCollision(collision_request, collision_result, *joint_state_group->getRobotState());
     if (collision_result.collision)
     {
-      logDebug("IK solution is in collision");
+      ROS_DEBUG_NAMED("kinematics_constraint_aware", "IK solution is in collision");
       response.error_code_.val = response.error_code_.GOAL_IN_COLLISION;
       return false;
     }
@@ -224,7 +226,7 @@ bool KinematicsConstraintAware::validityCallbackFn(const planning_scene::Plannin
         request.constraints_->decide(*joint_state_group->getRobotState(), response.constraint_eval_results_);
     if (!constraint_result.satisfied)
     {
-      logDebug("IK solution violates constraints");
+      ROS_DEBUG_NAMED("kinematics_constraint_aware", "IK solution violates constraints");
       response.error_code_.val = response.error_code_.GOAL_VIOLATES_PATH_CONSTRAINTS;
       return false;
     }
@@ -235,7 +237,7 @@ bool KinematicsConstraintAware::validityCallbackFn(const planning_scene::Plannin
   {
     if (!request.constraint_callback_(joint_state_group, joint_group_variable_values))
     {
-      logDebug("IK solution violates user specified constraints");
+      ROS_DEBUG_NAMED("kinematics_constraint_aware", "IK solution violates user specified constraints");
       response.error_code_.val = response.error_code_.GOAL_VIOLATES_PATH_CONSTRAINTS;
       return false;
     }
@@ -250,13 +252,13 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
 {
   if (!joint_model_group_)
   {
-    logError("This solver has not been constructed properly");
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "This solver has not been constructed properly");
     return false;
   }
 
   if (!planning_scene)
   {
-    logError("Planning scene must be allocated");
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "Planning scene must be allocated");
     return false;
   }
 
@@ -283,7 +285,8 @@ bool KinematicsConstraintAware::convertServiceRequest(
 {
   if (request.ik_request.group_name != group_name_)
   {
-    logError("This kinematics solver does not support requests for group: %s", request.ik_request.group_name.c_str());
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "This kinematics solver does not support requests for group: %s",
+                    request.ik_request.group_name.c_str());
     kinematics_response.error_code_.val = kinematics_response.error_code_.INVALID_GROUP_NAME;
     return false;
   }
@@ -291,16 +294,18 @@ bool KinematicsConstraintAware::convertServiceRequest(
   if (!request.ik_request.pose_stamped_vector.empty() &&
       request.ik_request.pose_stamped_vector.size() != sub_groups_names_.size())
   {
-    logError("Number of poses in request: %d must match number of sub groups %d in this group",
-             request.ik_request.pose_stamped_vector.size(), sub_groups_names_.size());
+    ROS_ERROR_NAMED("kinematics_constraint_aware",
+                    "Number of poses in request: %d must match number of sub groups %d in this group",
+                    request.ik_request.pose_stamped_vector.size(), sub_groups_names_.size());
     kinematics_response.error_code_.val = kinematics_response.error_code_.INVALID_GROUP_NAME;
     return false;
   }
 
   if (!request.ik_request.ik_link_names.empty() && request.ik_request.ik_link_names.size() != sub_groups_names_.size())
   {
-    logError("Number of ik_link_names in request: %d must match number of sub groups %d in this group or must be zero",
-             request.ik_request.ik_link_names.size(), sub_groups_names_.size());
+    ROS_ERROR_NAMED("kinematics_constraint_aware", "Number of ik_link_names in request: %d must match number of sub "
+                                                   "groups %d in this group or must be zero",
+                    request.ik_request.ik_link_names.size(), sub_groups_names_.size());
     kinematics_response.error_code_.val = kinematics_response.error_code_.INVALID_GROUP_NAME;
     return false;
   }

--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -39,6 +39,7 @@
   <build_depend version_gte="0.3.4">geometric_shapes</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rostime</build_depend>
+  <build_depend>rosconsole</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>moveit_core</build_depend>
 
@@ -55,6 +56,7 @@
   <run_depend>eigen_conversions</run_depend>
   <run_depend version_gte="0.3.4">geometric_shapes</run_depend>
   <run_depend>rostime</run_depend>
+  <run_depend>rosconsole</run_depend>
   <run_depend>octomap_msgs</run_depend>
   <run_depend>moveit_msgs</run_depend>
   <run_depend>actionlib_msgs</run_depend>

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -58,7 +58,7 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& r
   // call initialize method of wrapped class
   if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
   {
-    ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "failed to initialized caching plugin");
+    ROS_ERROR_NAMED("cached_ik", "failed to initialized caching plugin");
     return false;
   }
 
@@ -91,7 +91,7 @@ bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::s
   // call initialize method of wrapped class
   if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames, search_discretization))
   {
-    ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "failed to initialized caching plugin");
+    ROS_ERROR_NAMED("cached_ik", "failed to initialized caching plugin");
     return false;
   }
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -95,9 +95,8 @@ void IKCache::initializeCache(const std::string& robot_description, const std::s
     unsigned int num_tips;
     cache_file.read((char*)&num_tips, sizeof(unsigned int));
 
-    ROS_INFO_NAMED("cached_ik_kinematics_plugin",
-                   "Found %d IK solutions for a %d-dof system with %d end effectors in %s", last_saved_cache_size_,
-                   num_dofs, num_tips, cache_file_name_.string().c_str());
+    ROS_INFO_NAMED("cached_ik", "Found %d IK solutions for a %d-dof system with %d end effectors in %s",
+                   last_saved_cache_size_, num_dofs, num_tips, cache_file_name_.string().c_str());
 
     unsigned int position_size = 3 * sizeof(tf2Scalar);
     unsigned int orientation_size = 4 * sizeof(tf2Scalar);
@@ -124,9 +123,9 @@ void IKCache::initializeCache(const std::string& robot_description, const std::s
       memcpy(&entry.second[0], buffer + offset_conf, config_size);
       ik_cache_.push_back(entry);
     }
-    ROS_INFO_NAMED("cached_ik_kinematics_plugin", "freeing buffer");
+    ROS_INFO_NAMED("cached_ik", "freeing buffer");
     delete buffer;
-    ROS_INFO_NAMED("cached_ik_kinematics_plugin", "freed buffer");
+    ROS_INFO_NAMED("cached_ik", "freed buffer");
     std::vector<IKEntry*> ik_entry_ptrs(last_saved_cache_size_);
     for (unsigned int i = 0; i < last_saved_cache_size_; ++i)
       ik_entry_ptrs[i] = &ik_cache_[i];
@@ -135,7 +134,7 @@ void IKCache::initializeCache(const std::string& robot_description, const std::s
 
   num_joints_ = num_joints;
 
-  ROS_INFO_NAMED("cached_ik_kinematics_plugin", "cache file %s initialized!", cache_file_name_.string().c_str());
+  ROS_INFO_NAMED("cached_ik", "cache file %s initialized!", cache_file_name_.string().c_str());
 }
 
 double IKCache::configDistance2(const std::vector<double>& config1, const std::vector<double>& config2) const
@@ -217,10 +216,9 @@ void IKCache::updateCache(const IKEntry& nearest, const std::vector<Pose>& poses
 void IKCache::saveCache() const
 {
   if (cache_file_name_.empty())
-    ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "can't save cache before initialization");
+    ROS_ERROR_NAMED("cached_ik", "can't save cache before initialization");
 
-  ROS_INFO_NAMED("cached_ik_kinematics_plugin", "writing %ld IK solutions to %s", ik_cache_.size(),
-                 cache_file_name_.string().c_str());
+  ROS_INFO_NAMED("cached_ik", "writing %ld IK solutions to %s", ik_cache_.size(), cache_file_name_.string().c_str());
 
   boost::filesystem::ofstream cache_file(cache_file_name_, std::ios_base::binary | std::ios_base::out);
   unsigned int position_size = 3 * sizeof(tf2Scalar);
@@ -268,9 +266,9 @@ void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const
     if (error > max_error)
       max_error = error;
     if (error > 1e-4)
-      ROS_ERROR_NAMED("cached_ik_kinematics_plugin", "Cache entry is invalid, error = %g", error);
+      ROS_ERROR_NAMED("cached_ik", "Cache entry is invalid, error = %g", error);
   }
-  ROS_INFO_NAMED("cached_ik_kinematics_plugin", "Max. error in cache entries is %g", max_error);
+  ROS_INFO_NAMED("cached_ik", "Max. error in cache entries is %g", max_error);
 }
 
 IKCache::Pose::Pose(const geometry_msgs::Pose& pose)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -139,13 +139,13 @@ int main(int argc, char* argv[])
         num_failed_calls++;
       ++i;
       if (i % 100 == 0)
-        ROS_INFO_NAMED("measure_ik_call_cost",
+        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
                        "Avg. time per IK solver call is %g after %d calls. %g%% of calls failed to return a solution. "
                        "%g%% of random joint configurations were ignored due to self-collisions.",
                        ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
                        100. * num_self_collisions / (num_self_collisions + i));
     }
-    ROS_INFO_NAMED("measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
+    ROS_INFO_NAMED("cached_ik_kinematics_plugin", "Summary for group %s: %g %g %g", group->getName().c_str(),
                    ik_time.count() / (double)i, 100. * num_failed_calls / i,
                    100. * num_self_collisions / (num_self_collisions + i));
   }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -139,14 +139,15 @@ int main(int argc, char* argv[])
         num_failed_calls++;
       ++i;
       if (i % 100 == 0)
-        ROS_INFO_NAMED("cached_ik",
+        ROS_INFO_NAMED("cached_ik.measure_ik_call_cost",
                        "Avg. time per IK solver call is %g after %d calls. %g%% of calls failed to return a solution. "
                        "%g%% of random joint configurations were ignored due to self-collisions.",
                        ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
                        100. * num_self_collisions / (num_self_collisions + i));
     }
-    ROS_INFO_NAMED("cached_ik", "Summary for group %s: %g %g %g", group->getName().c_str(), ik_time.count() / (double)i,
-                   100. * num_failed_calls / i, 100. * num_self_collisions / (num_self_collisions + i));
+    ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
+                   ik_time.count() / (double)i, 100. * num_failed_calls / i,
+                   100. * num_self_collisions / (num_self_collisions + i));
   }
 
   ros::shutdown();

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -139,15 +139,14 @@ int main(int argc, char* argv[])
         num_failed_calls++;
       ++i;
       if (i % 100 == 0)
-        ROS_INFO_NAMED("cached_ik_kinematics_plugin",
+        ROS_INFO_NAMED("cached_ik",
                        "Avg. time per IK solver call is %g after %d calls. %g%% of calls failed to return a solution. "
                        "%g%% of random joint configurations were ignored due to self-collisions.",
                        ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
                        100. * num_self_collisions / (num_self_collisions + i));
     }
-    ROS_INFO_NAMED("cached_ik_kinematics_plugin", "Summary for group %s: %g %g %g", group->getName().c_str(),
-                   ik_time.count() / (double)i, 100. * num_failed_calls / i,
-                   100. * num_self_collisions / (num_self_collisions + i));
+    ROS_INFO_NAMED("cached_ik", "Summary for group %s: %g %g %g", group->getName().c_str(), ik_time.count() / (double)i,
+                   100. * num_failed_calls / i, 100. * num_self_collisions / (num_self_collisions + i));
   }
 
   ros::shutdown();

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -161,7 +161,7 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   const size_t num_joints_;
   std::vector<int> free_params_;
   bool active_;  // Internal variable that indicates whether solvers are configured and ready
-  const std::string name_{ "ikfast_kinematics_plugin" };
+  const std::string name_{ "ikfast" };
 
   const std::vector<std::string>& getJointNames() const
   {

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -161,7 +161,7 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   const size_t num_joints_;
   std::vector<int> free_params_;
   bool active_;  // Internal variable that indicates whether solvers are configured and ready
-  const std::string name_{ "ikfast" };
+  const std::string name_{ "ikfast_kinematics_plugin" };
 
   const std::vector<std::string>& getJointNames() const
   {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
@@ -52,19 +52,19 @@ ChainIkSolverPos_NR_JL_Mimic::ChainIkSolverPos_NR_JL_Mimic(const Chain& _chain, 
   {
     mimic_joints[i].reset(i);
   }
-  ROS_DEBUG_NAMED("kdl", "Limits");
+  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Limits");
   for (std::size_t i = 0; i < q_min.rows(); ++i)
   {
-    ROS_DEBUG_NAMED("kdl", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
   }
-  ROS_DEBUG_NAMED("kdl", " ");
+  ROS_DEBUG_NAMED("kdl_kinematics_plugin", " ");
 }
 
 bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimic>& _mimic_joints)
 {
   if (_mimic_joints.size() != chain.getNrOfJoints())
   {
-    ROS_ERROR_NAMED("kdl", "Mimic Joint info should be same size as number of joints in chain: %d",
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Mimic Joint info should be same size as number of joints in chain: %d",
                     chain.getNrOfJoints());
     return false;
   }
@@ -73,7 +73,7 @@ bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinemati
   {
     if (_mimic_joints[i].map_index >= chain.getNrOfJoints())
     {
-      ROS_ERROR_NAMED("kdl", "Mimic Joint index should be less than number of joints in chain: %d",
+      ROS_ERROR_NAMED("kdl_kinematics_plugin", "Mimic Joint index should be less than number of joints in chain: %d",
                       chain.getNrOfJoints());
       return false;
     }
@@ -84,7 +84,7 @@ bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinemati
   //  qToqMimic(q_min,q_min_mimic);
   //  qToqMimic(q_max,q_max_mimic);
 
-  ROS_DEBUG_NAMED("kdl", "Set mimic joints");
+  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Set mimic joints");
   return true;
 }
 
@@ -119,9 +119,9 @@ int ChainIkSolverPos_NR_JL_Mimic::CartToJntAdvanced(const JntArray& q_init, cons
   //  qToqMimic(q_init,q_temp);
 
   q_temp = q_init;
-  ROS_DEBUG_STREAM_NAMED("kdl", "Input:");
+  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Input:");
   for (std::size_t i = 0; i < q_out.rows(); ++i)
-    ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_out(i));
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_out(i));
 
   unsigned int i;
   for (i = 0; i < maxiter; ++i)
@@ -140,21 +140,21 @@ int ChainIkSolverPos_NR_JL_Mimic::CartToJntAdvanced(const JntArray& q_init, cons
         break;
     }
 
-    ROS_DEBUG_STREAM_NAMED("kdl", "delta_twist");
+    ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "delta_twist");
     for (std::size_t i = 0; i < 6; ++i)
-      ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, delta_twist(i));
+      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, delta_twist(i));
 
     iksolver.CartToJnt(q_temp, delta_twist, delta_q);
 
     Add(q_temp, delta_q, q_temp);
 
-    ROS_DEBUG_STREAM_NAMED("kdl", "delta_q");
+    ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "delta_q");
     for (std::size_t i = 0; i < delta_q.rows(); ++i)
-      ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, delta_q(i));
+      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, delta_q(i));
 
-    ROS_DEBUG_STREAM_NAMED("kdl", "q_temp");
+    ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "q_temp");
     for (std::size_t i = 0; i < q_temp.rows(); ++i)
-      ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_temp(i));
+      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_temp(i));
 
     for (std::size_t j = 0; j < q_min.rows(); ++j)
     {
@@ -177,13 +177,13 @@ int ChainIkSolverPos_NR_JL_Mimic::CartToJntAdvanced(const JntArray& q_init, cons
 
   //  qMimicToq(q_temp, q_out);
   q_out = q_temp;
-  ROS_DEBUG_STREAM_NAMED("kdl", "Full Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Full Solution:");
   for (std::size_t i = 0; i < q_temp.rows(); ++i)
-    ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_temp(i));
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_temp(i));
 
-  ROS_DEBUG_STREAM_NAMED("kdl", "Actual Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Actual Solution:");
   for (std::size_t i = 0; i < q_out.rows(); ++i)
-    ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_out(i));
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_out(i));
 
   if (i != maxiter)
     return 0;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
@@ -52,19 +52,19 @@ ChainIkSolverPos_NR_JL_Mimic::ChainIkSolverPos_NR_JL_Mimic(const Chain& _chain, 
   {
     mimic_joints[i].reset(i);
   }
-  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Limits");
+  ROS_DEBUG_NAMED("kdl", "Limits");
   for (std::size_t i = 0; i < q_min.rows(); ++i)
   {
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
+    ROS_DEBUG_NAMED("kdl", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
   }
-  ROS_DEBUG_NAMED("kdl_kinematics_plugin", " ");
+  ROS_DEBUG_NAMED("kdl", " ");
 }
 
 bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimic>& _mimic_joints)
 {
   if (_mimic_joints.size() != chain.getNrOfJoints())
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Mimic Joint info should be same size as number of joints in chain: %d",
+    ROS_ERROR_NAMED("kdl", "Mimic Joint info should be same size as number of joints in chain: %d",
                     chain.getNrOfJoints());
     return false;
   }
@@ -73,7 +73,7 @@ bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinemati
   {
     if (_mimic_joints[i].map_index >= chain.getNrOfJoints())
     {
-      ROS_ERROR_NAMED("kdl_kinematics_plugin", "Mimic Joint index should be less than number of joints in chain: %d",
+      ROS_ERROR_NAMED("kdl", "Mimic Joint index should be less than number of joints in chain: %d",
                       chain.getNrOfJoints());
       return false;
     }
@@ -84,7 +84,7 @@ bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinemati
   //  qToqMimic(q_min,q_min_mimic);
   //  qToqMimic(q_max,q_max_mimic);
 
-  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Set mimic joints");
+  ROS_DEBUG_NAMED("kdl", "Set mimic joints");
   return true;
 }
 
@@ -119,9 +119,9 @@ int ChainIkSolverPos_NR_JL_Mimic::CartToJntAdvanced(const JntArray& q_init, cons
   //  qToqMimic(q_init,q_temp);
 
   q_temp = q_init;
-  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Input:");
+  ROS_DEBUG_STREAM_NAMED("kdl", "Input:");
   for (std::size_t i = 0; i < q_out.rows(); ++i)
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_out(i));
+    ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_out(i));
 
   unsigned int i;
   for (i = 0; i < maxiter; ++i)
@@ -140,21 +140,21 @@ int ChainIkSolverPos_NR_JL_Mimic::CartToJntAdvanced(const JntArray& q_init, cons
         break;
     }
 
-    ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "delta_twist");
+    ROS_DEBUG_STREAM_NAMED("kdl", "delta_twist");
     for (std::size_t i = 0; i < 6; ++i)
-      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, delta_twist(i));
+      ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, delta_twist(i));
 
     iksolver.CartToJnt(q_temp, delta_twist, delta_q);
 
     Add(q_temp, delta_q, q_temp);
 
-    ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "delta_q");
+    ROS_DEBUG_STREAM_NAMED("kdl", "delta_q");
     for (std::size_t i = 0; i < delta_q.rows(); ++i)
-      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, delta_q(i));
+      ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, delta_q(i));
 
-    ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "q_temp");
+    ROS_DEBUG_STREAM_NAMED("kdl", "q_temp");
     for (std::size_t i = 0; i < q_temp.rows(); ++i)
-      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_temp(i));
+      ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_temp(i));
 
     for (std::size_t j = 0; j < q_min.rows(); ++j)
     {
@@ -177,13 +177,13 @@ int ChainIkSolverPos_NR_JL_Mimic::CartToJntAdvanced(const JntArray& q_init, cons
 
   //  qMimicToq(q_temp, q_out);
   q_out = q_temp;
-  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Full Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl", "Full Solution:");
   for (std::size_t i = 0; i < q_temp.rows(); ++i)
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_temp(i));
+    ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_temp(i));
 
-  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Actual Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl", "Actual Solution:");
   for (std::size_t i = 0; i < q_out.rows(); ++i)
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d: %f", (int)i, q_out(i));
+    ROS_DEBUG_NAMED("kdl", "%d: %f", (int)i, q_out(i));
 
   if (i != maxiter)
     return 0;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -210,7 +210,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJntRedundant(const JntArray& q_in, const 
     else
       qdot_out_locked(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("kdl", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Solution:");
 
   if (num_mimic_joints > 0)
   {
@@ -312,7 +312,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJnt(const JntArray& q_in, const Twist& v_
     else
       qdot_out(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("kdl", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Solution:");
   if (num_mimic_joints > 0)
   {
     for (i = 0; i < chain.getNrOfJoints(); ++i)

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -210,7 +210,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJntRedundant(const JntArray& q_in, const 
     else
       qdot_out_locked(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl", "Solution:");
 
   if (num_mimic_joints > 0)
   {
@@ -312,7 +312,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJnt(const JntArray& q_in, const Twist& v_
     else
       qdot_out(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("kdl", "Solution:");
   if (num_mimic_joints > 0)
   {
     for (i = 0; i < chain.getNrOfJoints(); ++i)

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -137,7 +137,7 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!urdf_model || !srdf)
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
+    ROS_ERROR_NAMED("kdl", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
     return false;
   }
 
@@ -149,13 +149,12 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->isChain())
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Group '%s' is not a chain", group_name.c_str());
+    ROS_ERROR_NAMED("kdl", "Group '%s' is not a chain", group_name.c_str());
     return false;
   }
   if (!joint_model_group->isSingleDOFJoints())
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Group '%s' includes joints that have more than 1 DOF",
-                    group_name.c_str());
+    ROS_ERROR_NAMED("kdl", "Group '%s' includes joints that have more than 1 DOF", group_name.c_str());
     return false;
   }
 
@@ -163,12 +162,12 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!kdl_parser::treeFromUrdfModel(*urdf_model, kdl_tree))
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not initialize tree object");
+    ROS_ERROR_NAMED("kdl", "Could not initialize tree object");
     return false;
   }
   if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not initialize chain object");
+    ROS_ERROR_NAMED("kdl", "Could not initialize chain object");
     return false;
   }
 
@@ -190,7 +189,7 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->hasLinkModel(getTipFrame()))
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not find tip name in joint group '%s'", group_name.c_str());
+    ROS_ERROR_NAMED("kdl", "Could not find tip name in joint group '%s'", group_name.c_str());
     return false;
   }
   ik_chain_info_.link_names.push_back(getTipFrame());
@@ -213,10 +212,10 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
   lookupParam("max_solver_iterations", max_solver_iterations, 500);
   lookupParam("epsilon", epsilon, 1e-5);
   lookupParam("position_only_ik", position_ik, false);
-  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Looking for param name: position_only_ik");
+  ROS_DEBUG_NAMED("kdl", "Looking for param name: position_only_ik");
 
   if (position_ik)
-    ROS_INFO_NAMED("kdl_kinematics_plugin", "Using position only ik");
+    ROS_INFO_NAMED("kdl", "Using position only ik");
 
   num_possible_redundant_joints_ =
       kdl_chain_.getNrOfJoints() - joint_model_group->getMimicJointModels().size() - (position_ik ? 3 : 6);
@@ -283,7 +282,7 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
   epsilon_ = epsilon;
 
   active_ = true;
-  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "KDL solver initialized");
+  ROS_DEBUG_NAMED("kdl", "KDL solver initialized");
   return true;
 }
 
@@ -291,13 +290,12 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
 {
   if (num_possible_redundant_joints_ < 0)
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "This group cannot have redundant joints");
+    ROS_ERROR_NAMED("kdl", "This group cannot have redundant joints");
     return false;
   }
   if (static_cast<int>(redundant_joints.size()) > num_possible_redundant_joints_)
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "This group can only have %d redundant joints",
-                    num_possible_redundant_joints_);
+    ROS_ERROR_NAMED("kdl", "This group can only have %d redundant joints", num_possible_redundant_joints_);
     return false;
   }
   /*
@@ -310,7 +308,7 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
       {
         ROS_ASSERT(joint_list[i].getType() == XmlRpc::XmlRpcValue::TypeString);
         redundant_joints.push_back(static_cast<std::string>(joint_list[i]));
-        ROS_INFO_NAMED("kdl_kinematics_plugin","Designated joint: %s as redundant joint",
+        ROS_INFO_NAMED("kdl","Designated joint: %s as redundant joint",
     redundant_joints.back().c_str());
       }
     }
@@ -340,8 +338,7 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
     }
   }
   for (std::size_t i = 0; i < redundant_joints_map_index.size(); ++i)
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Redundant joint map index: %d %d", (int)i,
-                    (int)redundant_joints_map_index[i]);
+    ROS_DEBUG_NAMED("kdl", "Redundant joint map index: %d %d", (int)i, (int)redundant_joints_map_index[i]);
 
   redundant_joints_map_index_ = redundant_joints_map_index;
   redundant_joint_indices_ = redundant_joints;
@@ -441,24 +438,23 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "kinematics not active");
+    ROS_ERROR_NAMED("kdl", "kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("kdl_kinematics_plugin", "Seed state must have size " << dimension_ << " instead of size "
-                                                                                 << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("kdl", "Seed state must have size " << dimension_ << " instead of size "
+                                                               << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("kdl_kinematics_plugin", "Consistency limits be empty or must have size "
-                                                        << dimension_ << " instead of size "
-                                                        << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("kdl", "Consistency limits be empty or must have size " << dimension_ << " instead of size "
+                                                                                   << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -477,7 +473,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
   if ((redundant_joint_indices_.size() > 0) && !ik_solver_vel.setRedundantJointsMapIndex(redundant_joints_map_index_))
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not set redundant joints");
+    ROS_ERROR_NAMED("kdl", "Could not set redundant joints");
     return false;
   }
 
@@ -491,11 +487,10 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   KDL::Frame pose_desired;
   tf::poseMsgToKDL(ik_pose, pose_desired);
 
-  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "searchPositionIK2: Position request pose is "
-                                                      << ik_pose.position.x << " " << ik_pose.position.y << " "
-                                                      << ik_pose.position.z << " " << ik_pose.orientation.x << " "
-                                                      << ik_pose.orientation.y << " " << ik_pose.orientation.z << " "
-                                                      << ik_pose.orientation.w);
+  ROS_DEBUG_STREAM_NAMED("kdl", "searchPositionIK2: Position request pose is "
+                                    << ik_pose.position.x << " " << ik_pose.position.y << " " << ik_pose.position.z
+                                    << " " << ik_pose.orientation.x << " " << ik_pose.orientation.y << " "
+                                    << ik_pose.orientation.z << " " << ik_pose.orientation.w);
   // Do the IK
   for (unsigned int i = 0; i < dimension_; i++)
     jnt_seed_state(i) = ik_seed_state[i];
@@ -504,42 +499,42 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   unsigned int counter(0);
   while (1)
   {
-    //    ROS_DEBUG_NAMED("kdl_kinematics_plugin","Iteration: %d, time: %f, Timeout:
+    //    ROS_DEBUG_NAMED("kdl","Iteration: %d, time: %f, Timeout:
     //    %f",counter,(ros::WallTime::now()-n1).toSec(),timeout);
     counter++;
     if (timedOut(n1, timeout))
     {
-      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "IK timed out");
+      ROS_DEBUG_NAMED("kdl", "IK timed out");
       error_code.val = error_code.TIMED_OUT;
       ik_solver_vel.unlockRedundantJoints();
       return false;
     }
     int ik_valid = ik_solver_pos.CartToJnt(jnt_pos_in, pose_desired, jnt_pos_out);
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "IK valid: %d", ik_valid);
+    ROS_DEBUG_NAMED("kdl", "IK valid: %d", ik_valid);
     if (!consistency_limits.empty())
     {
       getRandomConfiguration(jnt_seed_state, consistency_limits, jnt_pos_in, options.lock_redundant_joints);
       if ((ik_valid < 0 && !options.return_approximate_solution) ||
           !checkConsistency(jnt_seed_state, consistency_limits, jnt_pos_out))
       {
-        ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Could not find IK solution: does not match consistency limits");
+        ROS_DEBUG_NAMED("kdl", "Could not find IK solution: does not match consistency limits");
         continue;
       }
     }
     else
     {
       getRandomConfiguration(jnt_pos_in, options.lock_redundant_joints);
-      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "New random configuration");
+      ROS_DEBUG_NAMED("kdl", "New random configuration");
       for (unsigned int j = 0; j < dimension_; j++)
-        ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d %f", j, jnt_pos_in(j));
+        ROS_DEBUG_NAMED("kdl", "%d %f", j, jnt_pos_in(j));
 
       if (ik_valid < 0 && !options.return_approximate_solution)
       {
-        ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Could not find IK solution");
+        ROS_DEBUG_NAMED("kdl", "Could not find IK solution");
         continue;
       }
     }
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Found IK solution");
+    ROS_DEBUG_NAMED("kdl", "Found IK solution");
     for (unsigned int j = 0; j < dimension_; j++)
       solution[j] = jnt_pos_out(j);
     if (!solution_callback.empty())
@@ -549,13 +544,13 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
     if (error_code.val == error_code.SUCCESS)
     {
-      ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Solved after " << counter << " iterations");
+      ROS_DEBUG_STREAM_NAMED("kdl", "Solved after " << counter << " iterations");
       ik_solver_vel.unlockRedundantJoints();
       return true;
     }
   }
-  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "An IK that satisifes the constraints and is collision free could not be "
-                                           "found");
+  ROS_DEBUG_NAMED("kdl", "An IK that satisifes the constraints and is collision free could not be "
+                         "found");
   error_code.val = error_code.NO_IK_SOLUTION;
   ik_solver_vel.unlockRedundantJoints();
   return false;
@@ -568,13 +563,13 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "kinematics not active");
+    ROS_ERROR_NAMED("kdl", "kinematics not active");
     return false;
   }
   poses.resize(link_names.size());
   if (joint_angles.size() != dimension_)
   {
-    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Joint angles vector must have size: %d", dimension_);
+    ROS_ERROR_NAMED("kdl", "Joint angles vector must have size: %d", dimension_);
     return false;
   }
 
@@ -593,14 +588,14 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   bool valid = true;
   for (unsigned int i = 0; i < poses.size(); i++)
   {
-    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
+    ROS_DEBUG_NAMED("kdl", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
     if (fk_solver.JntToCart(jnt_pos_in, p_out, getKDLSegmentIndex(link_names[i])) >= 0)
     {
       tf::poseKDLToMsg(p_out, poses[i]);
     }
     else
     {
-      ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not compute FK for %s", link_names[i].c_str());
+      ROS_ERROR_NAMED("kdl", "Could not compute FK for %s", link_names[i].c_str());
       valid = false;
     }
   }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -549,8 +549,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
       return true;
     }
   }
-  ROS_DEBUG_NAMED("kdl", "An IK that satisifes the constraints and is collision free could not be "
-                         "found");
+  ROS_DEBUG_NAMED("kdl", "An IK that satisifes the constraints and is collision free could not be found");
   error_code.val = error_code.NO_IK_SOLUTION;
   ik_solver_vel.unlockRedundantJoints();
   return false;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -137,7 +137,7 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!urdf_model || !srdf)
   {
-    ROS_ERROR_NAMED("kdl", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
     return false;
   }
 
@@ -149,12 +149,13 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->isChain())
   {
-    ROS_ERROR_NAMED("kdl", "Group '%s' is not a chain", group_name.c_str());
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Group '%s' is not a chain", group_name.c_str());
     return false;
   }
   if (!joint_model_group->isSingleDOFJoints())
   {
-    ROS_ERROR_NAMED("kdl", "Group '%s' includes joints that have more than 1 DOF", group_name.c_str());
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Group '%s' includes joints that have more than 1 DOF",
+                    group_name.c_str());
     return false;
   }
 
@@ -162,12 +163,12 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!kdl_parser::treeFromUrdfModel(*urdf_model, kdl_tree))
   {
-    ROS_ERROR_NAMED("kdl", "Could not initialize tree object");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not initialize tree object");
     return false;
   }
   if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
-    ROS_ERROR_NAMED("kdl", "Could not initialize chain object");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not initialize chain object");
     return false;
   }
 
@@ -189,7 +190,7 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->hasLinkModel(getTipFrame()))
   {
-    ROS_ERROR_NAMED("kdl", "Could not find tip name in joint group '%s'", group_name.c_str());
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not find tip name in joint group '%s'", group_name.c_str());
     return false;
   }
   ik_chain_info_.link_names.push_back(getTipFrame());
@@ -212,10 +213,10 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
   lookupParam("max_solver_iterations", max_solver_iterations, 500);
   lookupParam("epsilon", epsilon, 1e-5);
   lookupParam("position_only_ik", position_ik, false);
-  ROS_DEBUG_NAMED("kdl", "Looking for param name: position_only_ik");
+  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Looking for param name: position_only_ik");
 
   if (position_ik)
-    ROS_INFO_NAMED("kdl", "Using position only ik");
+    ROS_INFO_NAMED("kdl_kinematics_plugin", "Using position only ik");
 
   num_possible_redundant_joints_ =
       kdl_chain_.getNrOfJoints() - joint_model_group->getMimicJointModels().size() - (position_ik ? 3 : 6);
@@ -282,7 +283,7 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
   epsilon_ = epsilon;
 
   active_ = true;
-  ROS_DEBUG_NAMED("kdl", "KDL solver initialized");
+  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "KDL solver initialized");
   return true;
 }
 
@@ -290,12 +291,13 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
 {
   if (num_possible_redundant_joints_ < 0)
   {
-    ROS_ERROR_NAMED("kdl", "This group cannot have redundant joints");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "This group cannot have redundant joints");
     return false;
   }
   if (static_cast<int>(redundant_joints.size()) > num_possible_redundant_joints_)
   {
-    ROS_ERROR_NAMED("kdl", "This group can only have %d redundant joints", num_possible_redundant_joints_);
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "This group can only have %d redundant joints",
+                    num_possible_redundant_joints_);
     return false;
   }
   /*
@@ -308,7 +310,8 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
       {
         ROS_ASSERT(joint_list[i].getType() == XmlRpc::XmlRpcValue::TypeString);
         redundant_joints.push_back(static_cast<std::string>(joint_list[i]));
-        ROS_INFO_NAMED("kdl","Designated joint: %s as redundant joint", redundant_joints.back().c_str());
+        ROS_INFO_NAMED("kdl_kinematics_plugin","Designated joint: %s as redundant joint",
+    redundant_joints.back().c_str());
       }
     }
   */
@@ -337,7 +340,8 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
     }
   }
   for (std::size_t i = 0; i < redundant_joints_map_index.size(); ++i)
-    ROS_DEBUG_NAMED("kdl", "Redundant joint map index: %d %d", (int)i, (int)redundant_joints_map_index[i]);
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Redundant joint map index: %d %d", (int)i,
+                    (int)redundant_joints_map_index[i]);
 
   redundant_joints_map_index_ = redundant_joints_map_index;
   redundant_joint_indices_ = redundant_joints;
@@ -437,23 +441,24 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("kdl", "kinematics not active");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("kdl", "Seed state must have size " << dimension_ << " instead of size "
-                                                               << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("kdl_kinematics_plugin", "Seed state must have size " << dimension_ << " instead of size "
+                                                                                 << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("kdl", "Consistency limits be empty or must have size " << dimension_ << " instead of size "
-                                                                                   << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("kdl_kinematics_plugin", "Consistency limits be empty or must have size "
+                                                        << dimension_ << " instead of size "
+                                                        << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -472,7 +477,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
   if ((redundant_joint_indices_.size() > 0) && !ik_solver_vel.setRedundantJointsMapIndex(redundant_joints_map_index_))
   {
-    ROS_ERROR_NAMED("kdl", "Could not set redundant joints");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not set redundant joints");
     return false;
   }
 
@@ -486,10 +491,11 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   KDL::Frame pose_desired;
   tf::poseMsgToKDL(ik_pose, pose_desired);
 
-  ROS_DEBUG_STREAM_NAMED("kdl", "searchPositionIK2: Position request pose is "
-                                    << ik_pose.position.x << " " << ik_pose.position.y << " " << ik_pose.position.z
-                                    << " " << ik_pose.orientation.x << " " << ik_pose.orientation.y << " "
-                                    << ik_pose.orientation.z << " " << ik_pose.orientation.w);
+  ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "searchPositionIK2: Position request pose is "
+                                                      << ik_pose.position.x << " " << ik_pose.position.y << " "
+                                                      << ik_pose.position.z << " " << ik_pose.orientation.x << " "
+                                                      << ik_pose.orientation.y << " " << ik_pose.orientation.z << " "
+                                                      << ik_pose.orientation.w);
   // Do the IK
   for (unsigned int i = 0; i < dimension_; i++)
     jnt_seed_state(i) = ik_seed_state[i];
@@ -498,42 +504,42 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   unsigned int counter(0);
   while (1)
   {
-    //    ROS_DEBUG_NAMED("kdl","Iteration: %d, time: %f, Timeout:
+    //    ROS_DEBUG_NAMED("kdl_kinematics_plugin","Iteration: %d, time: %f, Timeout:
     //    %f",counter,(ros::WallTime::now()-n1).toSec(),timeout);
     counter++;
     if (timedOut(n1, timeout))
     {
-      ROS_DEBUG_NAMED("kdl", "IK timed out");
+      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "IK timed out");
       error_code.val = error_code.TIMED_OUT;
       ik_solver_vel.unlockRedundantJoints();
       return false;
     }
     int ik_valid = ik_solver_pos.CartToJnt(jnt_pos_in, pose_desired, jnt_pos_out);
-    ROS_DEBUG_NAMED("kdl", "IK valid: %d", ik_valid);
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "IK valid: %d", ik_valid);
     if (!consistency_limits.empty())
     {
       getRandomConfiguration(jnt_seed_state, consistency_limits, jnt_pos_in, options.lock_redundant_joints);
       if ((ik_valid < 0 && !options.return_approximate_solution) ||
           !checkConsistency(jnt_seed_state, consistency_limits, jnt_pos_out))
       {
-        ROS_DEBUG_NAMED("kdl", "Could not find IK solution: does not match consistency limits");
+        ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Could not find IK solution: does not match consistency limits");
         continue;
       }
     }
     else
     {
       getRandomConfiguration(jnt_pos_in, options.lock_redundant_joints);
-      ROS_DEBUG_NAMED("kdl", "New random configuration");
+      ROS_DEBUG_NAMED("kdl_kinematics_plugin", "New random configuration");
       for (unsigned int j = 0; j < dimension_; j++)
-        ROS_DEBUG_NAMED("kdl", "%d %f", j, jnt_pos_in(j));
+        ROS_DEBUG_NAMED("kdl_kinematics_plugin", "%d %f", j, jnt_pos_in(j));
 
       if (ik_valid < 0 && !options.return_approximate_solution)
       {
-        ROS_DEBUG_NAMED("kdl", "Could not find IK solution");
+        ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Could not find IK solution");
         continue;
       }
     }
-    ROS_DEBUG_NAMED("kdl", "Found IK solution");
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "Found IK solution");
     for (unsigned int j = 0; j < dimension_; j++)
       solution[j] = jnt_pos_out(j);
     if (!solution_callback.empty())
@@ -543,12 +549,13 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
     if (error_code.val == error_code.SUCCESS)
     {
-      ROS_DEBUG_STREAM_NAMED("kdl", "Solved after " << counter << " iterations");
+      ROS_DEBUG_STREAM_NAMED("kdl_kinematics_plugin", "Solved after " << counter << " iterations");
       ik_solver_vel.unlockRedundantJoints();
       return true;
     }
   }
-  ROS_DEBUG_NAMED("kdl", "An IK that satisifes the constraints and is collision free could not be found");
+  ROS_DEBUG_NAMED("kdl_kinematics_plugin", "An IK that satisifes the constraints and is collision free could not be "
+                                           "found");
   error_code.val = error_code.NO_IK_SOLUTION;
   ik_solver_vel.unlockRedundantJoints();
   return false;
@@ -561,13 +568,13 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("kdl", "kinematics not active");
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "kinematics not active");
     return false;
   }
   poses.resize(link_names.size());
   if (joint_angles.size() != dimension_)
   {
-    ROS_ERROR_NAMED("kdl", "Joint angles vector must have size: %d", dimension_);
+    ROS_ERROR_NAMED("kdl_kinematics_plugin", "Joint angles vector must have size: %d", dimension_);
     return false;
   }
 
@@ -586,14 +593,14 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   bool valid = true;
   for (unsigned int i = 0; i < poses.size(); i++)
   {
-    ROS_DEBUG_NAMED("kdl", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
+    ROS_DEBUG_NAMED("kdl_kinematics_plugin", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
     if (fk_solver.JntToCart(jnt_pos_in, p_out, getKDLSegmentIndex(link_names[i])) >= 0)
     {
       tf::poseKDLToMsg(p_out, poses[i]);
     }
     else
     {
-      ROS_ERROR_NAMED("kdl", "Could not compute FK for %s", link_names[i].c_str());
+      ROS_ERROR_NAMED("kdl_kinematics_plugin", "Could not compute FK for %s", link_names[i].c_str());
       valid = false;
     }
   }

--- a/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_pos_lma_jl_mimic.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_pos_lma_jl_mimic.cpp
@@ -61,19 +61,19 @@ ChainIkSolverPos_LMA_JL_Mimic::ChainIkSolverPos_LMA_JL_Mimic(const Chain& _chain
   {
     mimic_joints[i].reset(i);
   }
-  ROS_DEBUG_NAMED("lma_kinematics_plugin", "Limits");
+  ROS_DEBUG_NAMED("lma", "Limits");
   for (std::size_t i = 0; i < q_min.rows(); ++i)
   {
-    ROS_DEBUG_NAMED("lma_kinematics_plugin", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
+    ROS_DEBUG_NAMED("lma", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
   }
-  ROS_DEBUG_NAMED("lma_kinematics_plugin", " ");
+  ROS_DEBUG_NAMED("lma", " ");
 }
 
 bool ChainIkSolverPos_LMA_JL_Mimic::setMimicJoints(const std::vector<lma_kinematics_plugin::JointMimic>& _mimic_joints)
 {
   if (_mimic_joints.size() != chain.getNrOfJoints())
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Mimic Joint info should be same size as number of joints in chain: %d",
+    ROS_ERROR_NAMED("lma", "Mimic Joint info should be same size as number of joints in chain: %d",
                     chain.getNrOfJoints());
     return false;
   }
@@ -82,7 +82,7 @@ bool ChainIkSolverPos_LMA_JL_Mimic::setMimicJoints(const std::vector<lma_kinemat
   {
     if (_mimic_joints[i].map_index >= chain.getNrOfJoints())
     {
-      ROS_ERROR_NAMED("lma_kinematics_plugin", "Mimic Joint index should be less than number of joints in chain: %d",
+      ROS_ERROR_NAMED("lma", "Mimic Joint index should be less than number of joints in chain: %d",
                       chain.getNrOfJoints());
       return false;
     }
@@ -93,7 +93,7 @@ bool ChainIkSolverPos_LMA_JL_Mimic::setMimicJoints(const std::vector<lma_kinemat
   //  qToqMimic(q_min,q_min_mimic);
   //  qToqMimic(q_max,q_max_mimic);
 
-  ROS_DEBUG_NAMED("lma_kinematics_plugin", "Set mimic joints");
+  ROS_DEBUG_NAMED("lma", "Set mimic joints");
   return true;
 }
 
@@ -143,9 +143,8 @@ bool ChainIkSolverPos_LMA_JL_Mimic::obeysLimits(const KDL::JntArray& q_out)
     {
       // One element of solution is not within limits
       obeys_limits = false;
-      ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Not in limits! " << i << " value " << q_out(i)
-                                                                        << " has limit being  " << q_min(i) << " to "
-                                                                        << q_max(i));
+      ROS_DEBUG_STREAM_NAMED("lma", "Not in limits! " << i << " value " << q_out(i) << " has limit being  " << q_min(i)
+                                                      << " to " << q_max(i));
       break;
     }
   }

--- a/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_pos_lma_jl_mimic.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_pos_lma_jl_mimic.cpp
@@ -61,19 +61,19 @@ ChainIkSolverPos_LMA_JL_Mimic::ChainIkSolverPos_LMA_JL_Mimic(const Chain& _chain
   {
     mimic_joints[i].reset(i);
   }
-  ROS_DEBUG_NAMED("lma", "Limits");
+  ROS_DEBUG_NAMED("lma_kinematics_plugin", "Limits");
   for (std::size_t i = 0; i < q_min.rows(); ++i)
   {
-    ROS_DEBUG_NAMED("lma", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
+    ROS_DEBUG_NAMED("lma_kinematics_plugin", "%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
   }
-  ROS_DEBUG_NAMED("lma", " ");
+  ROS_DEBUG_NAMED("lma_kinematics_plugin", " ");
 }
 
 bool ChainIkSolverPos_LMA_JL_Mimic::setMimicJoints(const std::vector<lma_kinematics_plugin::JointMimic>& _mimic_joints)
 {
   if (_mimic_joints.size() != chain.getNrOfJoints())
   {
-    ROS_ERROR_NAMED("lma", "Mimic Joint info should be same size as number of joints in chain: %d",
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Mimic Joint info should be same size as number of joints in chain: %d",
                     chain.getNrOfJoints());
     return false;
   }
@@ -82,7 +82,7 @@ bool ChainIkSolverPos_LMA_JL_Mimic::setMimicJoints(const std::vector<lma_kinemat
   {
     if (_mimic_joints[i].map_index >= chain.getNrOfJoints())
     {
-      ROS_ERROR_NAMED("lma", "Mimic Joint index should be less than number of joints in chain: %d",
+      ROS_ERROR_NAMED("lma_kinematics_plugin", "Mimic Joint index should be less than number of joints in chain: %d",
                       chain.getNrOfJoints());
       return false;
     }
@@ -93,7 +93,7 @@ bool ChainIkSolverPos_LMA_JL_Mimic::setMimicJoints(const std::vector<lma_kinemat
   //  qToqMimic(q_min,q_min_mimic);
   //  qToqMimic(q_max,q_max_mimic);
 
-  ROS_DEBUG_NAMED("lma", "Set mimic joints");
+  ROS_DEBUG_NAMED("lma_kinematics_plugin", "Set mimic joints");
   return true;
 }
 
@@ -143,8 +143,9 @@ bool ChainIkSolverPos_LMA_JL_Mimic::obeysLimits(const KDL::JntArray& q_out)
     {
       // One element of solution is not within limits
       obeys_limits = false;
-      ROS_DEBUG_STREAM_NAMED("lma", "Not in limits! " << i << " value " << q_out(i) << " has limit being  " << q_min(i)
-                                                      << " to " << q_max(i));
+      ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Not in limits! " << i << " value " << q_out(i)
+                                                                        << " has limit being  " << q_min(i) << " to "
+                                                                        << q_max(i));
       break;
     }
   }

--- a/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -221,7 +221,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJntRedundant(const JntArray& q_in, const 
     else
       qdot_out_locked(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("lma", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Solution:");
 
   if (num_mimic_joints > 0)
   {
@@ -323,7 +323,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJnt(const JntArray& q_in, const Twist& v_
     else
       qdot_out(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("lma", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Solution:");
   if (num_mimic_joints > 0)
   {
     for (i = 0; i < chain.getNrOfJoints(); ++i)

--- a/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -221,7 +221,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJntRedundant(const JntArray& q_in, const 
     else
       qdot_out_locked(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("lma", "Solution:");
 
   if (num_mimic_joints > 0)
   {
@@ -323,7 +323,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJnt(const JntArray& q_in, const Twist& v_
     else
       qdot_out(i) = sum;
   }
-  ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Solution:");
+  ROS_DEBUG_STREAM_NAMED("lma", "Solution:");
   if (num_mimic_joints > 0)
   {
     for (i = 0; i < chain.getNrOfJoints(); ++i)

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -559,8 +559,7 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
       return true;
     }
   }
-  ROS_DEBUG_NAMED("lma", "An IK that satisifes the constraints and is collision free could not be "
-                         "found");
+  ROS_DEBUG_NAMED("lma", "An IK that satisifes the constraints and is collision free could not be found");
   error_code.val = error_code.NO_IK_SOLUTION;
   ik_solver_vel.unlockRedundantJoints();
   return false;

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -136,7 +136,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!urdf_model || !srdf)
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
+    ROS_ERROR_NAMED("lma", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
     return false;
   }
 
@@ -148,13 +148,12 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->isChain())
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Group '%s' is not a chain", group_name.c_str());
+    ROS_ERROR_NAMED("lma", "Group '%s' is not a chain", group_name.c_str());
     return false;
   }
   if (!joint_model_group->isSingleDOFJoints())
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Group '%s' includes joints that have more than 1 DOF",
-                    group_name.c_str());
+    ROS_ERROR_NAMED("lma", "Group '%s' includes joints that have more than 1 DOF", group_name.c_str());
     return false;
   }
 
@@ -162,12 +161,12 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!kdl_parser::treeFromUrdfModel(*urdf_model, kdl_tree))
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not initialize tree object");
+    ROS_ERROR_NAMED("lma", "Could not initialize tree object");
     return false;
   }
   if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not initialize chain object");
+    ROS_ERROR_NAMED("lma", "Could not initialize chain object");
     return false;
   }
 
@@ -189,7 +188,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->hasLinkModel(getTipFrame()))
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not find tip name in joint group '%s'", group_name.c_str());
+    ROS_ERROR_NAMED("lma", "Could not find tip name in joint group '%s'", group_name.c_str());
     return false;
   }
   ik_chain_info_.link_names.push_back(getTipFrame());
@@ -212,10 +211,10 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
   lookupParam("max_solver_iterations", max_solver_iterations, 500);
   lookupParam("epsilon", epsilon, 1e-5);
   lookupParam("position_only_ik", position_ik, false);
-  ROS_DEBUG_NAMED("lma_kinematics_plugin", "Looking for param name: position_only_ik");
+  ROS_DEBUG_NAMED("lma", "Looking for param name: position_only_ik");
 
   if (position_ik)
-    ROS_INFO_NAMED("lma_kinematics_plugin", "Using position only ik");
+    ROS_INFO_NAMED("lma", "Using position only ik");
 
   num_possible_redundant_joints_ =
       kdl_chain_.getNrOfJoints() - joint_model_group->getMimicJointModels().size() - (position_ik ? 3 : 6);
@@ -283,7 +282,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
   epsilon_ = epsilon;
 
   active_ = true;
-  ROS_DEBUG_NAMED("lma_kinematics_plugin", "KDL solver initialized");
+  ROS_DEBUG_NAMED("lma", "KDL solver initialized");
   return true;
 }
 
@@ -291,13 +290,12 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
 {
   if (num_possible_redundant_joints_ < 0)
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "This group cannot have redundant joints");
+    ROS_ERROR_NAMED("lma", "This group cannot have redundant joints");
     return false;
   }
   if (redundant_joints.size() > num_possible_redundant_joints_)
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "This group can only have %d redundant joints",
-                    num_possible_redundant_joints_);
+    ROS_ERROR_NAMED("lma", "This group can only have %d redundant joints", num_possible_redundant_joints_);
     return false;
   }
   /*
@@ -310,7 +308,7 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
       {
         ROS_ASSERT(joint_list[i].getType() == XmlRpc::XmlRpcValue::TypeString);
         redundant_joints.push_back(static_cast<std::string>(joint_list[i]));
-        ROS_INFO_NAMED("lma_kinematics_plugin","Designated joint: %s as redundant joint",
+        ROS_INFO_NAMED("lma","Designated joint: %s as redundant joint",
     redundant_joints.back().c_str());
       }
     }
@@ -340,8 +338,7 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
     }
   }
   for (std::size_t i = 0; i < redundant_joints_map_index.size(); ++i)
-    ROS_DEBUG_NAMED("lma_kinematics_plugin", "Redundant joint map index: %d %d", (int)i,
-                    (int)redundant_joints_map_index[i]);
+    ROS_DEBUG_NAMED("lma", "Redundant joint map index: %d %d", (int)i, (int)redundant_joints_map_index[i]);
 
   redundant_joints_map_index_ = redundant_joints_map_index;
   redundant_joint_indices_ = redundant_joints;
@@ -441,24 +438,23 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "kinematics not active");
+    ROS_ERROR_NAMED("lma", "kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("lma_kinematics_plugin", "Seed state must have size " << dimension_ << " instead of size "
-                                                                                 << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("lma", "Seed state must have size " << dimension_ << " instead of size "
+                                                               << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("lma_kinematics_plugin", "Consistency limits be empty or must have size "
-                                                        << dimension_ << " instead of size "
-                                                        << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("lma", "Consistency limits be empty or must have size " << dimension_ << " instead of size "
+                                                                                   << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -487,7 +483,7 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
   if ((redundant_joint_indices_.size() > 0) && !ik_solver_vel.setRedundantJointsMapIndex(redundant_joints_map_index_))
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not set redundant joints");
+    ROS_ERROR_NAMED("lma", "Could not set redundant joints");
     return false;
   }
 
@@ -501,11 +497,10 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   KDL::Frame pose_desired;
   tf::poseMsgToKDL(ik_pose, pose_desired);
 
-  ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "searchPositionIK2: Position request pose is "
-                                                      << ik_pose.position.x << " " << ik_pose.position.y << " "
-                                                      << ik_pose.position.z << " " << ik_pose.orientation.x << " "
-                                                      << ik_pose.orientation.y << " " << ik_pose.orientation.z << " "
-                                                      << ik_pose.orientation.w);
+  ROS_DEBUG_STREAM_NAMED("lma", "searchPositionIK2: Position request pose is "
+                                    << ik_pose.position.x << " " << ik_pose.position.y << " " << ik_pose.position.z
+                                    << " " << ik_pose.orientation.x << " " << ik_pose.orientation.y << " "
+                                    << ik_pose.orientation.z << " " << ik_pose.orientation.w);
   // Do the IK
   for (unsigned int i = 0; i < dimension_; i++)
     jnt_seed_state(i) = ik_seed_state[i];
@@ -514,42 +509,42 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   unsigned int counter(0);
   while (1)
   {
-    //    ROS_DEBUG_NAMED("lma_kinematics_plugin","Iteration: %d, time: %f, Timeout:
+    //    ROS_DEBUG_NAMED("lma","Iteration: %d, time: %f, Timeout:
     //    %f",counter,(ros::WallTime::now()-n1).toSec(),timeout);
     counter++;
     if (timedOut(n1, timeout))
     {
-      ROS_DEBUG_NAMED("lma_kinematics_plugin", "IK timed out");
+      ROS_DEBUG_NAMED("lma", "IK timed out");
       error_code.val = error_code.TIMED_OUT;
       ik_solver_vel.unlockRedundantJoints();
       return false;
     }
     int ik_valid = ik_solver_pos.CartToJnt(jnt_pos_in, pose_desired, jnt_pos_out);
-    ROS_DEBUG_NAMED("lma_kinematics_plugin", "IK valid: %d", ik_valid);
+    ROS_DEBUG_NAMED("lma", "IK valid: %d", ik_valid);
     if (!consistency_limits.empty())
     {
       getRandomConfiguration(jnt_seed_state, consistency_limits, jnt_pos_in, options.lock_redundant_joints);
       if ((ik_valid < 0 && !options.return_approximate_solution) ||
           !checkConsistency(jnt_seed_state, consistency_limits, jnt_pos_out))
       {
-        ROS_DEBUG_NAMED("lma_kinematics_plugin", "Could not find IK solution: does not match consistency limits");
+        ROS_DEBUG_NAMED("lma", "Could not find IK solution: does not match consistency limits");
         continue;
       }
     }
     else
     {
       getRandomConfiguration(jnt_pos_in, options.lock_redundant_joints);
-      ROS_DEBUG_NAMED("lma_kinematics_plugin", "New random configuration");
+      ROS_DEBUG_NAMED("lma", "New random configuration");
       for (unsigned int j = 0; j < dimension_; j++)
-        ROS_DEBUG_NAMED("lma_kinematics_plugin", "%d %f", j, jnt_pos_in(j));
+        ROS_DEBUG_NAMED("lma", "%d %f", j, jnt_pos_in(j));
 
       if (ik_valid < 0 && !options.return_approximate_solution)
       {
-        ROS_DEBUG_NAMED("lma_kinematics_plugin", "Could not find IK solution");
+        ROS_DEBUG_NAMED("lma", "Could not find IK solution");
         continue;
       }
     }
-    ROS_DEBUG_NAMED("lma_kinematics_plugin", "Found IK solution");
+    ROS_DEBUG_NAMED("lma", "Found IK solution");
     for (unsigned int j = 0; j < dimension_; j++)
       solution[j] = jnt_pos_out(j);
     if (!solution_callback.empty())
@@ -559,13 +554,13 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
     if (error_code.val == error_code.SUCCESS)
     {
-      ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Solved after " << counter << " iterations");
+      ROS_DEBUG_STREAM_NAMED("lma", "Solved after " << counter << " iterations");
       ik_solver_vel.unlockRedundantJoints();
       return true;
     }
   }
-  ROS_DEBUG_NAMED("lma_kinematics_plugin", "An IK that satisifes the constraints and is collision free could not be "
-                                           "found");
+  ROS_DEBUG_NAMED("lma", "An IK that satisifes the constraints and is collision free could not be "
+                         "found");
   error_code.val = error_code.NO_IK_SOLUTION;
   ik_solver_vel.unlockRedundantJoints();
   return false;
@@ -578,13 +573,13 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "kinematics not active");
+    ROS_ERROR_NAMED("lma", "kinematics not active");
     return false;
   }
   poses.resize(link_names.size());
   if (joint_angles.size() != dimension_)
   {
-    ROS_ERROR_NAMED("lma_kinematics_plugin", "Joint angles vector must have size: %d", dimension_);
+    ROS_ERROR_NAMED("lma", "Joint angles vector must have size: %d", dimension_);
     return false;
   }
 
@@ -603,14 +598,14 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   bool valid = true;
   for (unsigned int i = 0; i < poses.size(); i++)
   {
-    ROS_DEBUG_NAMED("lma_kinematics_plugin", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
+    ROS_DEBUG_NAMED("lma", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
     if (fk_solver.JntToCart(jnt_pos_in, p_out, getKDLSegmentIndex(link_names[i])) >= 0)
     {
       tf::poseKDLToMsg(p_out, poses[i]);
     }
     else
     {
-      ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not compute FK for %s", link_names[i].c_str());
+      ROS_ERROR_NAMED("lma", "Could not compute FK for %s", link_names[i].c_str());
       valid = false;
     }
   }

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -136,7 +136,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!urdf_model || !srdf)
   {
-    ROS_ERROR_NAMED("lma", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
     return false;
   }
 
@@ -148,12 +148,13 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->isChain())
   {
-    ROS_ERROR_NAMED("lma", "Group '%s' is not a chain", group_name.c_str());
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Group '%s' is not a chain", group_name.c_str());
     return false;
   }
   if (!joint_model_group->isSingleDOFJoints())
   {
-    ROS_ERROR_NAMED("lma", "Group '%s' includes joints that have more than 1 DOF", group_name.c_str());
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Group '%s' includes joints that have more than 1 DOF",
+                    group_name.c_str());
     return false;
   }
 
@@ -161,12 +162,12 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!kdl_parser::treeFromUrdfModel(*urdf_model, kdl_tree))
   {
-    ROS_ERROR_NAMED("lma", "Could not initialize tree object");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not initialize tree object");
     return false;
   }
   if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
-    ROS_ERROR_NAMED("lma", "Could not initialize chain object");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not initialize chain object");
     return false;
   }
 
@@ -188,7 +189,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!joint_model_group->hasLinkModel(getTipFrame()))
   {
-    ROS_ERROR_NAMED("lma", "Could not find tip name in joint group '%s'", group_name.c_str());
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not find tip name in joint group '%s'", group_name.c_str());
     return false;
   }
   ik_chain_info_.link_names.push_back(getTipFrame());
@@ -211,10 +212,10 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
   lookupParam("max_solver_iterations", max_solver_iterations, 500);
   lookupParam("epsilon", epsilon, 1e-5);
   lookupParam("position_only_ik", position_ik, false);
-  ROS_DEBUG_NAMED("lma", "Looking for param name: position_only_ik");
+  ROS_DEBUG_NAMED("lma_kinematics_plugin", "Looking for param name: position_only_ik");
 
   if (position_ik)
-    ROS_INFO_NAMED("lma", "Using position only ik");
+    ROS_INFO_NAMED("lma_kinematics_plugin", "Using position only ik");
 
   num_possible_redundant_joints_ =
       kdl_chain_.getNrOfJoints() - joint_model_group->getMimicJointModels().size() - (position_ik ? 3 : 6);
@@ -282,7 +283,7 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
   epsilon_ = epsilon;
 
   active_ = true;
-  ROS_DEBUG_NAMED("lma", "KDL solver initialized");
+  ROS_DEBUG_NAMED("lma_kinematics_plugin", "KDL solver initialized");
   return true;
 }
 
@@ -290,12 +291,13 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
 {
   if (num_possible_redundant_joints_ < 0)
   {
-    ROS_ERROR_NAMED("lma", "This group cannot have redundant joints");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "This group cannot have redundant joints");
     return false;
   }
   if (redundant_joints.size() > num_possible_redundant_joints_)
   {
-    ROS_ERROR_NAMED("lma", "This group can only have %d redundant joints", num_possible_redundant_joints_);
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "This group can only have %d redundant joints",
+                    num_possible_redundant_joints_);
     return false;
   }
   /*
@@ -308,7 +310,8 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
       {
         ROS_ASSERT(joint_list[i].getType() == XmlRpc::XmlRpcValue::TypeString);
         redundant_joints.push_back(static_cast<std::string>(joint_list[i]));
-        ROS_INFO_NAMED("lma","Designated joint: %s as redundant joint", redundant_joints.back().c_str());
+        ROS_INFO_NAMED("lma_kinematics_plugin","Designated joint: %s as redundant joint",
+    redundant_joints.back().c_str());
       }
     }
   */
@@ -337,7 +340,8 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
     }
   }
   for (std::size_t i = 0; i < redundant_joints_map_index.size(); ++i)
-    ROS_DEBUG_NAMED("lma", "Redundant joint map index: %d %d", (int)i, (int)redundant_joints_map_index[i]);
+    ROS_DEBUG_NAMED("lma_kinematics_plugin", "Redundant joint map index: %d %d", (int)i,
+                    (int)redundant_joints_map_index[i]);
 
   redundant_joints_map_index_ = redundant_joints_map_index;
   redundant_joint_indices_ = redundant_joints;
@@ -437,23 +441,24 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("lma", "kinematics not active");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("lma", "Seed state must have size " << dimension_ << " instead of size "
-                                                               << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("lma_kinematics_plugin", "Seed state must have size " << dimension_ << " instead of size "
+                                                                                 << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("lma", "Consistency limits be empty or must have size " << dimension_ << " instead of size "
-                                                                                   << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("lma_kinematics_plugin", "Consistency limits be empty or must have size "
+                                                        << dimension_ << " instead of size "
+                                                        << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -482,7 +487,7 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
   if ((redundant_joint_indices_.size() > 0) && !ik_solver_vel.setRedundantJointsMapIndex(redundant_joints_map_index_))
   {
-    ROS_ERROR_NAMED("lma", "Could not set redundant joints");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not set redundant joints");
     return false;
   }
 
@@ -496,10 +501,11 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   KDL::Frame pose_desired;
   tf::poseMsgToKDL(ik_pose, pose_desired);
 
-  ROS_DEBUG_STREAM_NAMED("lma", "searchPositionIK2: Position request pose is "
-                                    << ik_pose.position.x << " " << ik_pose.position.y << " " << ik_pose.position.z
-                                    << " " << ik_pose.orientation.x << " " << ik_pose.orientation.y << " "
-                                    << ik_pose.orientation.z << " " << ik_pose.orientation.w);
+  ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "searchPositionIK2: Position request pose is "
+                                                      << ik_pose.position.x << " " << ik_pose.position.y << " "
+                                                      << ik_pose.position.z << " " << ik_pose.orientation.x << " "
+                                                      << ik_pose.orientation.y << " " << ik_pose.orientation.z << " "
+                                                      << ik_pose.orientation.w);
   // Do the IK
   for (unsigned int i = 0; i < dimension_; i++)
     jnt_seed_state(i) = ik_seed_state[i];
@@ -508,42 +514,42 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
   unsigned int counter(0);
   while (1)
   {
-    //    ROS_DEBUG_NAMED("lma","Iteration: %d, time: %f, Timeout:
+    //    ROS_DEBUG_NAMED("lma_kinematics_plugin","Iteration: %d, time: %f, Timeout:
     //    %f",counter,(ros::WallTime::now()-n1).toSec(),timeout);
     counter++;
     if (timedOut(n1, timeout))
     {
-      ROS_DEBUG_NAMED("lma", "IK timed out");
+      ROS_DEBUG_NAMED("lma_kinematics_plugin", "IK timed out");
       error_code.val = error_code.TIMED_OUT;
       ik_solver_vel.unlockRedundantJoints();
       return false;
     }
     int ik_valid = ik_solver_pos.CartToJnt(jnt_pos_in, pose_desired, jnt_pos_out);
-    ROS_DEBUG_NAMED("lma", "IK valid: %d", ik_valid);
+    ROS_DEBUG_NAMED("lma_kinematics_plugin", "IK valid: %d", ik_valid);
     if (!consistency_limits.empty())
     {
       getRandomConfiguration(jnt_seed_state, consistency_limits, jnt_pos_in, options.lock_redundant_joints);
       if ((ik_valid < 0 && !options.return_approximate_solution) ||
           !checkConsistency(jnt_seed_state, consistency_limits, jnt_pos_out))
       {
-        ROS_DEBUG_NAMED("lma", "Could not find IK solution: does not match consistency limits");
+        ROS_DEBUG_NAMED("lma_kinematics_plugin", "Could not find IK solution: does not match consistency limits");
         continue;
       }
     }
     else
     {
       getRandomConfiguration(jnt_pos_in, options.lock_redundant_joints);
-      ROS_DEBUG_NAMED("lma", "New random configuration");
+      ROS_DEBUG_NAMED("lma_kinematics_plugin", "New random configuration");
       for (unsigned int j = 0; j < dimension_; j++)
-        ROS_DEBUG_NAMED("lma", "%d %f", j, jnt_pos_in(j));
+        ROS_DEBUG_NAMED("lma_kinematics_plugin", "%d %f", j, jnt_pos_in(j));
 
       if (ik_valid < 0 && !options.return_approximate_solution)
       {
-        ROS_DEBUG_NAMED("lma", "Could not find IK solution");
+        ROS_DEBUG_NAMED("lma_kinematics_plugin", "Could not find IK solution");
         continue;
       }
     }
-    ROS_DEBUG_NAMED("lma", "Found IK solution");
+    ROS_DEBUG_NAMED("lma_kinematics_plugin", "Found IK solution");
     for (unsigned int j = 0; j < dimension_; j++)
       solution[j] = jnt_pos_out(j);
     if (!solution_callback.empty())
@@ -553,12 +559,13 @@ bool LMAKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 
     if (error_code.val == error_code.SUCCESS)
     {
-      ROS_DEBUG_STREAM_NAMED("lma", "Solved after " << counter << " iterations");
+      ROS_DEBUG_STREAM_NAMED("lma_kinematics_plugin", "Solved after " << counter << " iterations");
       ik_solver_vel.unlockRedundantJoints();
       return true;
     }
   }
-  ROS_DEBUG_NAMED("lma", "An IK that satisifes the constraints and is collision free could not be found");
+  ROS_DEBUG_NAMED("lma_kinematics_plugin", "An IK that satisifes the constraints and is collision free could not be "
+                                           "found");
   error_code.val = error_code.NO_IK_SOLUTION;
   ik_solver_vel.unlockRedundantJoints();
   return false;
@@ -571,13 +578,13 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("lma", "kinematics not active");
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "kinematics not active");
     return false;
   }
   poses.resize(link_names.size());
   if (joint_angles.size() != dimension_)
   {
-    ROS_ERROR_NAMED("lma", "Joint angles vector must have size: %d", dimension_);
+    ROS_ERROR_NAMED("lma_kinematics_plugin", "Joint angles vector must have size: %d", dimension_);
     return false;
   }
 
@@ -596,14 +603,14 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   bool valid = true;
   for (unsigned int i = 0; i < poses.size(); i++)
   {
-    ROS_DEBUG_NAMED("lma", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
+    ROS_DEBUG_NAMED("lma_kinematics_plugin", "End effector index: %d", getKDLSegmentIndex(link_names[i]));
     if (fk_solver.JntToCart(jnt_pos_in, p_out, getKDLSegmentIndex(link_names[i])) >= 0)
     {
       tf::poseKDLToMsg(p_out, poses[i]);
     }
     else
     {
-      ROS_ERROR_NAMED("lma", "Could not compute FK for %s", link_names[i].c_str());
+      ROS_ERROR_NAMED("lma_kinematics_plugin", "Could not compute FK for %s", link_names[i].c_str());
       valid = false;
     }
   }

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -63,7 +63,7 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
 {
   bool debug = false;
 
-  ROS_INFO_STREAM_NAMED("srv_kinematics_plugin", "SrvKinematicsPlugin initializing");
+  ROS_INFO_STREAM_NAMED("srv", "SrvKinematicsPlugin initializing");
 
   setValues(robot_description, group_name, base_frame, tip_frames, search_discretization);
 
@@ -73,8 +73,7 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (!urdf_model || !srdf)
   {
-    ROS_ERROR_NAMED("srv_kinematics_plugin",
-                    "URDF and SRDF must be loaded for SRV kinematics solver to work.");  // TODO: is this true?
+    ROS_ERROR_NAMED("srv", "URDF and SRDF must be loaded for SRV kinematics solver to work.");  // TODO: is this true?
     return false;
   }
 
@@ -94,11 +93,10 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
 
   // Get the dimension of the planning group
   dimension_ = joint_model_group_->getVariableCount();
-  ROS_INFO_STREAM_NAMED("srv_kinematics_plugin",
-                        "Dimension planning group '"
-                            << group_name << "': " << dimension_
-                            << ". Active Joints Models: " << joint_model_group_->getActiveJointModels().size()
-                            << ". Mimic Joint Models: " << joint_model_group_->getMimicJointModels().size());
+  ROS_INFO_STREAM_NAMED("srv", "Dimension planning group '"
+                                   << group_name << "': " << dimension_
+                                   << ". Active Joints Models: " << joint_model_group_->getActiveJointModels().size()
+                                   << ". Mimic Joint Models: " << joint_model_group_->getMimicJointModels().size());
 
   // Copy joint names
   for (std::size_t i = 0; i < joint_model_group_->getJointModels().size(); ++i)
@@ -108,7 +106,7 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
 
   if (debug)
   {
-    ROS_ERROR_STREAM_NAMED("temp", "tip links available:");
+    ROS_ERROR_STREAM_NAMED("srv", "tip links available:");
     std::copy(tip_frames_.begin(), tip_frames_.end(), std::ostream_iterator<std::string>(std::cout, "\n"));
   }
 
@@ -117,16 +115,16 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
   {
     if (!joint_model_group_->hasLinkModel(tip_frames_[i]))
     {
-      ROS_ERROR_NAMED("srv_kinematics_plugin", "Could not find tip name '%s' in joint group '%s'",
-                      tip_frames_[i].c_str(), group_name.c_str());
+      ROS_ERROR_NAMED("srv", "Could not find tip name '%s' in joint group '%s'", tip_frames_[i].c_str(),
+                      group_name.c_str());
       return false;
     }
     ik_group_info_.link_names.push_back(tip_frames_[i]);
   }
 
   // Choose what ROS service to send IK requests to
-  ROS_DEBUG_STREAM_NAMED("srv_kinematics_plugin", "Looking for ROS service name on rosparam server with param: "
-                                                      << "/kinematics_solver_service_name");
+  ROS_DEBUG_STREAM_NAMED("srv", "Looking for ROS service name on rosparam server with param: "
+                                    << "/kinematics_solver_service_name");
   std::string ik_service_name;
   lookupParam("kinematics_solver_service_name", ik_service_name, std::string("solve_ik"));
 
@@ -139,14 +137,13 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
   ik_service_client_ = std::make_shared<ros::ServiceClient>(
       nonprivate_handle.serviceClient<moveit_msgs::GetPositionIK>(ik_service_name));
   if (!ik_service_client_->waitForExistence(ros::Duration(0.1)))  // wait 0.1 seconds, blocking
-    ROS_WARN_STREAM_NAMED("srv_kinematics_plugin",
+    ROS_WARN_STREAM_NAMED("srv",
                           "Unable to connect to ROS service client with name: " << ik_service_client_->getService());
   else
-    ROS_INFO_STREAM_NAMED("srv_kinematics_plugin",
-                          "Service client started with ROS service name: " << ik_service_client_->getService());
+    ROS_INFO_STREAM_NAMED("srv", "Service client started with ROS service name: " << ik_service_client_->getService());
 
   active_ = true;
-  ROS_DEBUG_NAMED("srv_kinematics_plugin", "ROS service-based kinematics solver initialized");
+  ROS_DEBUG_NAMED("srv", "ROS service-based kinematics solver initialized");
   return true;
 }
 
@@ -154,13 +151,12 @@ bool SrvKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
 {
   if (num_possible_redundant_joints_ < 0)
   {
-    ROS_ERROR_NAMED("srv_kinematics_plugin", "This group cannot have redundant joints");
+    ROS_ERROR_NAMED("srv", "This group cannot have redundant joints");
     return false;
   }
   if (redundant_joints.size() > num_possible_redundant_joints_)
   {
-    ROS_ERROR_NAMED("srv_kinematics_plugin", "This group can only have %d redundant joints",
-                    num_possible_redundant_joints_);
+    ROS_ERROR_NAMED("srv", "This group can only have %d redundant joints", num_possible_redundant_joints_);
     return false;
   }
 
@@ -269,7 +265,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Check if active
   if (!active_)
   {
-    ROS_ERROR_NAMED("srv_kinematics_plugin", "kinematics not active");
+    ROS_ERROR_NAMED("srv", "kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -277,8 +273,8 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Check if seed state correct
   if (ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "Seed state must have size " << dimension_ << " instead of size "
-                                                                                 << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("srv", "Seed state must have size " << dimension_ << " instead of size "
+                                                               << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -286,9 +282,9 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Check that we have the same number of poses as tips
   if (tip_frames_.size() != ik_poses.size())
   {
-    ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "Mismatched number of pose requests ("
-                                                        << ik_poses.size() << ") to tip frames (" << tip_frames_.size()
-                                                        << ") in searchPositionIK");
+    ROS_ERROR_STREAM_NAMED("srv", "Mismatched number of pose requests (" << ik_poses.size() << ") to tip frames ("
+                                                                         << tip_frames_.size()
+                                                                         << ") in searchPositionIK");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -324,15 +320,15 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
     ik_srv.request.ik_request.ik_link_name = getTipFrames()[0];
   }
 
-  ROS_DEBUG_STREAM_NAMED("srv_kinematics_plugin", "Calling service: " << ik_service_client_->getService());
+  ROS_DEBUG_STREAM_NAMED("srv", "Calling service: " << ik_service_client_->getService());
   if (ik_service_client_->call(ik_srv))
   {
     // Check error code
     error_code.val = ik_srv.response.error_code.val;
     if (error_code.val != error_code.SUCCESS)
     {
-      ROS_DEBUG_NAMED("srv_kinematics_plugin", "An IK that satisifes the constraints and is collision free could not "
-                                               "be found.");
+      ROS_DEBUG_NAMED("srv", "An IK that satisifes the constraints and is collision free could not "
+                             "be found.");
       switch (error_code.val)
       {
         // Debug mode for failure:
@@ -340,13 +336,13 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
         ROS_DEBUG_STREAM("Response was: \n" << ik_srv.response.solution);
 
         case moveit_msgs::MoveItErrorCodes::FAILURE:
-          ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "Service failed with with error code: FAILURE");
+          ROS_ERROR_STREAM_NAMED("srv", "Service failed with with error code: FAILURE");
           break;
         case moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION:
-          ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "Service failed with with error code: NO IK SOLUTION");
+          ROS_ERROR_STREAM_NAMED("srv", "Service failed with with error code: NO IK SOLUTION");
           break;
         default:
-          ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "Service failed with with error code: " << error_code.val);
+          ROS_ERROR_STREAM_NAMED("srv", "Service failed with with error code: " << error_code.val);
       }
       return false;
     }
@@ -361,9 +357,8 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Convert the robot state message to our robot_state representation
   if (!moveit::core::robotStateMsgToRobotState(ik_srv.response.solution, *robot_state_))
   {
-    ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin",
-                           "An error occured converting recieved robot state message into internal robot "
-                           "state.");
+    ROS_ERROR_STREAM_NAMED("srv", "An error occured converting recieved robot state message into internal robot "
+                                  "state.");
     error_code.val = error_code.FAILURE;
     return false;
   }
@@ -374,7 +369,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Run the solution callback (i.e. collision checker) if available
   if (!solution_callback.empty())
   {
-    ROS_DEBUG_STREAM_NAMED("srv_kinematics_plugin", "Calling solution callback on IK solution");
+    ROS_DEBUG_STREAM_NAMED("srv", "Calling solution callback on IK solution");
 
     // hack: should use all poses, not just the 0th
     solution_callback(ik_poses[0], solution, error_code);
@@ -384,21 +379,20 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
       switch (error_code.val)
       {
         case moveit_msgs::MoveItErrorCodes::FAILURE:
-          ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "IK solution callback failed with with error code: FAILURE");
+          ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: FAILURE");
           break;
         case moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION:
-          ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "IK solution callback failed with with error code: NO IK "
-                                                          "SOLUTION");
+          ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: NO IK "
+                                        "SOLUTION");
           break;
         default:
-          ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin",
-                                 "IK solution callback failed with with error code: " << error_code.val);
+          ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: " << error_code.val);
       }
       return false;
     }
   }
 
-  ROS_INFO_STREAM_NAMED("srv_kinematics_plugin", "IK Solver Succeeded!");
+  ROS_INFO_STREAM_NAMED("srv", "IK Solver Succeeded!");
   return true;
 }
 
@@ -409,17 +403,17 @@ bool SrvKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
   ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
-    ROS_ERROR_NAMED("srv_kinematics_plugin", "kinematics not active");
+    ROS_ERROR_NAMED("srv", "kinematics not active");
     return false;
   }
   poses.resize(link_names.size());
   if (joint_angles.size() != dimension_)
   {
-    ROS_ERROR_NAMED("srv_kinematics_plugin", "Joint angles vector must have size: %d", dimension_);
+    ROS_ERROR_NAMED("srv", "Joint angles vector must have size: %d", dimension_);
     return false;
   }
 
-  ROS_ERROR_STREAM_NAMED("srv_kinematics_plugin", "Forward kinematics not implemented");
+  ROS_ERROR_STREAM_NAMED("srv", "Forward kinematics not implemented");
 
   return false;
 }

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -327,8 +327,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
     error_code.val = ik_srv.response.error_code.val;
     if (error_code.val != error_code.SUCCESS)
     {
-      ROS_DEBUG_NAMED("srv", "An IK that satisifes the constraints and is collision free could not "
-                             "be found.");
+      ROS_DEBUG_NAMED("srv", "An IK that satisifes the constraints and is collision free could not be found.");
       switch (error_code.val)
       {
         // Debug mode for failure:
@@ -382,8 +381,8 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
           ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: FAILURE");
           break;
         case moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION:
-          ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: NO IK "
-                                        "SOLUTION");
+          ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: "
+                                        "NO IK SOLUTION");
           break;
         default:
           ROS_ERROR_STREAM_NAMED("srv", "IK solution callback failed with with error code: " << error_code.val);

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -53,21 +53,21 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 {
   if (!planning_scene)
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "No planning scene initialized.");
+    ROS_ERROR_STREAM("No planning scene initialized.");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
     return false;
   }
 
   if (req.start_state.joint_state.position.empty())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Start state is empty");
+    ROS_ERROR_STREAM("Start state is empty");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
 
   if (not planning_scene->getRobotModel()->satisfiesPositionBounds(req.start_state.joint_state.position.data()))
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Start state violates joint limits");
+    ROS_ERROR_STREAM("Start state violates joint limits");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
@@ -79,14 +79,14 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   if (req.goal_constraints.empty())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "No goal constraints specified!");
+    ROS_ERROR_STREAM("No goal constraints specified!");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
 
   if (req.goal_constraints[0].joint_constraints.empty())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Only joint-space goals are supported");
+    ROS_ERROR_STREAM("Only joint-space goals are supported");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
@@ -128,7 +128,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   if (not planning_scene->getRobotModel()->satisfiesPositionBounds(goal_state.data()))
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Goal state violates joint limits");
+    ROS_ERROR_STREAM("Goal state violates joint limits");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
@@ -145,19 +145,17 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ChompOptimizer optimizer(&trajectory, planning_scene, req.group_name, &params, start_state);
   if (!optimizer.isInitialized())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Could not initialize optimizer");
+    ROS_ERROR_STREAM("Could not initialize optimizer");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
-  ROS_DEBUG_NAMED("chomp_motion_planner", "Optimization took %f sec to create",
-                  (ros::WallTime::now() - create_time).toSec());
+  ROS_DEBUG("Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
   optimizer.optimize();
-  ROS_DEBUG_NAMED("chomp_motion_planner", "Optimization actually took %f sec to run",
-                  (ros::WallTime::now() - create_time).toSec());
+  ROS_DEBUG("Optimization actually took %f sec to run", (ros::WallTime::now() - create_time).toSec());
   create_time = ros::WallTime::now();
   // assume that the trajectory is now optimized, fill in the output structure:
 
-  ROS_DEBUG_NAMED("chomp_motion_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
+  ROS_DEBUG("Output trajectory has %d joints", trajectory.getNumJoints());
 
   res.trajectory.resize(1);
 
@@ -182,10 +180,10 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     res.trajectory[0].joint_trajectory.points[i].time_from_start = ros::Duration(0.0);
   }
 
-  ROS_DEBUG_NAMED("chomp_motion_planner", "Bottom took %f sec to create", (ros::WallTime::now() - create_time).toSec());
-  ROS_DEBUG_NAMED("chomp_motion_planner", "Serviced planning request in %f wall-seconds, trajectory duration is %f",
-                  (ros::WallTime::now() - start_time).toSec(),
-                  res.trajectory[0].joint_trajectory.points[goal_index].time_from_start.toSec());
+  ROS_DEBUG("Bottom took %f sec to create", (ros::WallTime::now() - create_time).toSec());
+  ROS_DEBUG("Serviced planning request in %f wall-seconds, trajectory duration is %f",
+            (ros::WallTime::now() - start_time).toSec(),
+            res.trajectory[0].joint_trajectory.points[goal_index].time_from_start.toSec());
   res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
   res.processing_time.push_back((ros::WallTime::now() - start_time).toSec());
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -53,21 +53,21 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 {
   if (!planning_scene)
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "No planning scene initialized.");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "No planning scene initialized.");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
     return false;
   }
 
   if (req.start_state.joint_state.position.empty())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Start state is empty");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Start state is empty");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
 
   if (not planning_scene->getRobotModel()->satisfiesPositionBounds(req.start_state.joint_state.position.data()))
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Start state violates joint limits");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Start state violates joint limits");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
@@ -79,14 +79,14 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   if (req.goal_constraints.empty())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "No goal constraints specified!");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "No goal constraints specified!");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
 
   if (req.goal_constraints[0].joint_constraints.empty())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Only joint-space goals are supported");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Only joint-space goals are supported");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
@@ -128,7 +128,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   if (not planning_scene->getRobotModel()->satisfiesPositionBounds(goal_state.data()))
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal state violates joint limits");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Goal state violates joint limits");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
@@ -145,18 +145,19 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ChompOptimizer optimizer(&trajectory, planning_scene, req.group_name, &params, start_state);
   if (!optimizer.isInitialized())
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Could not initialize optimizer");
+    ROS_ERROR_STREAM_NAMED("chomp_motion_planner", "Could not initialize optimizer");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
-  ROS_DEBUG_NAMED("chomp_planner", "Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
+  ROS_DEBUG_NAMED("chomp_motion_planner", "Optimization took %f sec to create",
+                  (ros::WallTime::now() - create_time).toSec());
   optimizer.optimize();
-  ROS_DEBUG_NAMED("chomp_planner", "Optimization actually took %f sec to run",
+  ROS_DEBUG_NAMED("chomp_motion_planner", "Optimization actually took %f sec to run",
                   (ros::WallTime::now() - create_time).toSec());
   create_time = ros::WallTime::now();
   // assume that the trajectory is now optimized, fill in the output structure:
 
-  ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
+  ROS_DEBUG_NAMED("chomp_motion_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
 
   res.trajectory.resize(1);
 
@@ -181,8 +182,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     res.trajectory[0].joint_trajectory.points[i].time_from_start = ros::Duration(0.0);
   }
 
-  ROS_DEBUG_NAMED("chomp_planner", "Bottom took %f sec to create", (ros::WallTime::now() - create_time).toSec());
-  ROS_DEBUG_NAMED("chomp_planner", "Serviced planning request in %f wall-seconds, trajectory duration is %f",
+  ROS_DEBUG_NAMED("chomp_motion_planner", "Bottom took %f sec to create", (ros::WallTime::now() - create_time).toSec());
+  ROS_DEBUG_NAMED("chomp_motion_planner", "Serviced planning request in %f wall-seconds, trajectory duration is %f",
                   (ros::WallTime::now() - start_time).toSec(),
                   res.trajectory[0].joint_trajectory.points[goal_index].time_from_start.toSec());
   res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -318,9 +318,8 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
       std::size_t sum = 0;
       for (std::size_t i = 0; i < cass->size(); ++i)
         sum += cass->getMetadata(i).first.size();
-      ROS_INFO_NAMED("constraints_library",
-                     "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) for "
-                     "constraint named '%s'%s",
+      ROS_INFO_NAMED("constraints_library", "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) "
+                                            "for constraint named '%s'%s",
                      cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
                      msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
     }

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -270,12 +270,12 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
   std::ifstream fin((path + "/manifest").c_str());
   if (!fin.good())
   {
-    ROS_WARN_NAMED("ompl_interface", "Manifest not found in folder '%s'. Not loading constraint approximations.",
+    ROS_WARN_NAMED("constraints_library", "Manifest not found in folder '%s'. Not loading constraint approximations.",
                    path.c_str());
     return;
   }
 
-  ROS_INFO_NAMED("ompl_interface", "Loading constrained space approximations from '%s'...", path.c_str());
+  ROS_INFO_NAMED("constraints_library", "Loading constrained space approximations from '%s'...", path.c_str());
 
   while (fin.good() && !fin.eof())
   {
@@ -298,7 +298,7 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     if (fin.eof())
       break;
     fin >> filename;
-    ROS_INFO_NAMED("ompl_interface", "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
+    ROS_INFO_NAMED("constraints_library", "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
                    state_space_parameterization.c_str(), group.c_str(), filename.c_str());
     const ModelBasedPlanningContextPtr& pc = context_manager_.getPlanningContext(group, state_space_parameterization);
     if (pc)
@@ -312,23 +312,25 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
                                                                  msg, filename, ompl::base::StateStoragePtr(cass),
                                                                  milestones));
       if (constraint_approximations_.find(cap->getName()) != constraint_approximations_.end())
-        ROS_WARN_NAMED("ompl_interface", "Overwriting constraint approximation named '%s'", cap->getName().c_str());
+        ROS_WARN_NAMED("constraints_library", "Overwriting constraint approximation named '%s'",
+                       cap->getName().c_str());
       constraint_approximations_[cap->getName()] = cap;
       std::size_t sum = 0;
       for (std::size_t i = 0; i < cass->size(); ++i)
         sum += cass->getMetadata(i).first.size();
-      ROS_INFO_NAMED("ompl_interface", "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) for "
-                                       "constraint named '%s'%s",
+      ROS_INFO_NAMED("constraints_library",
+                     "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) for "
+                     "constraint named '%s'%s",
                      cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
                      msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
     }
   }
-  ROS_INFO_NAMED("ompl_interface", "Done loading constrained space approximations.");
+  ROS_INFO_NAMED("constraints_library", "Done loading constrained space approximations.");
 }
 
 void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std::string& path)
 {
-  ROS_INFO_NAMED("ompl_interface", "Saving %u constrained space approximations to '%s'",
+  ROS_INFO_NAMED("constraints_library", "Saving %u constrained space approximations to '%s'",
                  (unsigned int)constraint_approximations_.size(), path.c_str());
   try
   {
@@ -355,7 +357,7 @@ void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std:
         it->second->getStateStorage()->store((path + "/" + it->second->getFilename()).c_str());
     }
   else
-    ROS_ERROR_NAMED("ompl_interface", "Unable to save constraint approximation to '%s'", path.c_str());
+    ROS_ERROR_NAMED("constraints_library", "Unable to save constraint approximation to '%s'", path.c_str());
   fout.close();
 }
 
@@ -413,7 +415,7 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
 
     ros::WallTime start = ros::WallTime::now();
     ompl::base::StateStoragePtr ss = constructConstraintApproximation(pc, constr_sampling, constr_hard, options, res);
-    ROS_INFO_NAMED("ompl_interface", "Spent %lf seconds constructing the database",
+    ROS_INFO_NAMED("constraints_library", "Spent %lf seconds constructing the database",
                    (ros::WallTime::now() - start).toSec());
     if (ss)
     {
@@ -423,12 +425,13 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
               ".ompldb",
           ss, res.milestones));
       if (constraint_approximations_.find(ca->getName()) != constraint_approximations_.end())
-        ROS_WARN_NAMED("ompl_interface", "Overwriting constraint approximation named '%s'", ca->getName().c_str());
+        ROS_WARN_NAMED("constraints_library", "Overwriting constraint approximation named '%s'", ca->getName().c_str());
       constraint_approximations_[ca->getName()] = ca;
       res.approx = ca;
     }
     else
-      ROS_ERROR_NAMED("ompl_interface", "Unable to construct constraint approximation for group '%s'", group.c_str());
+      ROS_ERROR_NAMED("constraints_library", "Unable to construct constraint approximation for group '%s'",
+                      group.c_str());
   }
   return res;
 }
@@ -482,19 +485,19 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     if (done != done_now)
     {
       done = done_now;
-      ROS_INFO_NAMED("ompl_interface", "%d%% complete (kept %0.1lf%% sampled states)", done,
+      ROS_INFO_NAMED("constraints_library", "%d%% complete (kept %0.1lf%% sampled states)", done,
                      100.0 * (double)sstor->size() / (double)attempts);
     }
 
     if (!slow_warn && attempts > 10 && attempts > sstor->size() * 100)
     {
       slow_warn = true;
-      ROS_WARN_NAMED("ompl_interface", "Computation of valid state database is very slow...");
+      ROS_WARN_NAMED("constraints_library", "Computation of valid state database is very slow...");
     }
 
     if (attempts > options.samples && sstor->size() == 0)
     {
-      ROS_ERROR_NAMED("ompl_interface", "Unable to generate any samples");
+      ROS_ERROR_NAMED("constraints_library", "Unable to generate any samples");
       break;
     }
 
@@ -511,18 +514,18 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
   }
 
   result.state_sampling_time = ompl::time::seconds(ompl::time::now() - start);
-  ROS_INFO_NAMED("ompl_interface", "Generated %u states in %lf seconds", (unsigned int)sstor->size(),
+  ROS_INFO_NAMED("constraints_library", "Generated %u states in %lf seconds", (unsigned int)sstor->size(),
                  result.state_sampling_time);
   if (csmp)
   {
     result.sampling_success_rate = csmp->getConstrainedSamplingRate();
-    ROS_INFO_NAMED("ompl_interface", "Constrained sampling rate: %lf", result.sampling_success_rate);
+    ROS_INFO_NAMED("constraints_library", "Constrained sampling rate: %lf", result.sampling_success_rate);
   }
 
   result.milestones = sstor->size();
   if (options.edges_per_sample > 0)
   {
-    ROS_INFO_NAMED("ompl_interface", "Computing graph connections (max %u edges per sample) ...",
+    ROS_INFO_NAMED("constraints_library", "Computing graph connections (max %u edges per sample) ...",
                    options.edges_per_sample);
 
     // construct connexions
@@ -541,7 +544,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
       if (done != done_now)
       {
         done = done_now;
-        ROS_INFO_NAMED("ompl_interface", "%d%% complete", done);
+        ROS_INFO_NAMED("constraints_library", "%d%% complete", done);
       }
       if (cass->getMetadata(j).first.size() >= options.edges_per_sample)
         continue;
@@ -598,7 +601,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     }
 
     result.state_connection_time = ompl::time::seconds(ompl::time::now() - start);
-    ROS_INFO_NAMED("ompl_interface", "Computed possible connexions in %lf seconds. Added %d connexions",
+    ROS_INFO_NAMED("constraints_library", "Computed possible connexions in %lf seconds. Added %d connexions",
                    result.state_connection_time, good);
     pcontext->getOMPLSimpleSetup()->getSpaceInformation()->freeStates(int_states);
 

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -270,11 +270,12 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
   std::ifstream fin((path + "/manifest").c_str());
   if (!fin.good())
   {
-    logWarn("Manifest not found in folder '%s'. Not loading constraint approximations.", path.c_str());
+    ROS_WARN_NAMED("ompl_interface", "Manifest not found in folder '%s'. Not loading constraint approximations.",
+                   path.c_str());
     return;
   }
 
-  logInform("Loading constrained space approximations from '%s'...", path.c_str());
+  ROS_INFO_NAMED("ompl_interface", "Loading constrained space approximations from '%s'...", path.c_str());
 
   while (fin.good() && !fin.eof())
   {
@@ -297,8 +298,8 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     if (fin.eof())
       break;
     fin >> filename;
-    logInform("Loading constraint approximation of type '%s' for group '%s' from '%s'...",
-              state_space_parameterization.c_str(), group.c_str(), filename.c_str());
+    ROS_INFO_NAMED("ompl_interface", "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
+                   state_space_parameterization.c_str(), group.c_str(), filename.c_str());
     const ModelBasedPlanningContextPtr& pc = context_manager_.getPlanningContext(group, state_space_parameterization);
     if (pc)
     {
@@ -311,23 +312,24 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
                                                                  msg, filename, ompl::base::StateStoragePtr(cass),
                                                                  milestones));
       if (constraint_approximations_.find(cap->getName()) != constraint_approximations_.end())
-        logWarn("Overwriting constraint approximation named '%s'", cap->getName().c_str());
+        ROS_WARN_NAMED("ompl_interface", "Overwriting constraint approximation named '%s'", cap->getName().c_str());
       constraint_approximations_[cap->getName()] = cap;
       std::size_t sum = 0;
       for (std::size_t i = 0; i < cass->size(); ++i)
         sum += cass->getMetadata(i).first.size();
-      logInform("Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) for constraint named '%s'%s",
-                cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
-                msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
+      ROS_INFO_NAMED("ompl_interface", "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) for "
+                                       "constraint named '%s'%s",
+                     cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
+                     msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
     }
   }
-  logInform("Done loading constrained space approximations.");
+  ROS_INFO_NAMED("ompl_interface", "Done loading constrained space approximations.");
 }
 
 void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std::string& path)
 {
-  logInform("Saving %u constrained space approximations to '%s'", (unsigned int)constraint_approximations_.size(),
-            path.c_str());
+  ROS_INFO_NAMED("ompl_interface", "Saving %u constrained space approximations to '%s'",
+                 (unsigned int)constraint_approximations_.size(), path.c_str());
   try
   {
     boost::filesystem::create_directories(path);
@@ -353,7 +355,7 @@ void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std:
         it->second->getStateStorage()->store((path + "/" + it->second->getFilename()).c_str());
     }
   else
-    logError("Unable to save constraint approximation to '%s'", path.c_str());
+    ROS_ERROR_NAMED("ompl_interface", "Unable to save constraint approximation to '%s'", path.c_str());
   fout.close();
 }
 
@@ -411,7 +413,8 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
 
     ros::WallTime start = ros::WallTime::now();
     ompl::base::StateStoragePtr ss = constructConstraintApproximation(pc, constr_sampling, constr_hard, options, res);
-    logInform("Spent %lf seconds constructing the database", (ros::WallTime::now() - start).toSec());
+    ROS_INFO_NAMED("ompl_interface", "Spent %lf seconds constructing the database",
+                   (ros::WallTime::now() - start).toSec());
     if (ss)
     {
       ConstraintApproximationPtr ca(new ConstraintApproximation(
@@ -420,12 +423,12 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
               ".ompldb",
           ss, res.milestones));
       if (constraint_approximations_.find(ca->getName()) != constraint_approximations_.end())
-        logWarn("Overwriting constraint approximation named '%s'", ca->getName().c_str());
+        ROS_WARN_NAMED("ompl_interface", "Overwriting constraint approximation named '%s'", ca->getName().c_str());
       constraint_approximations_[ca->getName()] = ca;
       res.approx = ca;
     }
     else
-      logError("Unable to construct constraint approximation for group '%s'", group.c_str());
+      ROS_ERROR_NAMED("ompl_interface", "Unable to construct constraint approximation for group '%s'", group.c_str());
   }
   return res;
 }
@@ -479,18 +482,19 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     if (done != done_now)
     {
       done = done_now;
-      logInform("%d%% complete (kept %0.1lf%% sampled states)", done, 100.0 * (double)sstor->size() / (double)attempts);
+      ROS_INFO_NAMED("ompl_interface", "%d%% complete (kept %0.1lf%% sampled states)", done,
+                     100.0 * (double)sstor->size() / (double)attempts);
     }
 
     if (!slow_warn && attempts > 10 && attempts > sstor->size() * 100)
     {
       slow_warn = true;
-      logWarn("Computation of valid state database is very slow...");
+      ROS_WARN_NAMED("ompl_interface", "Computation of valid state database is very slow...");
     }
 
     if (attempts > options.samples && sstor->size() == 0)
     {
-      logError("Unable to generate any samples");
+      ROS_ERROR_NAMED("ompl_interface", "Unable to generate any samples");
       break;
     }
 
@@ -507,17 +511,19 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
   }
 
   result.state_sampling_time = ompl::time::seconds(ompl::time::now() - start);
-  logInform("Generated %u states in %lf seconds", (unsigned int)sstor->size(), result.state_sampling_time);
+  ROS_INFO_NAMED("ompl_interface", "Generated %u states in %lf seconds", (unsigned int)sstor->size(),
+                 result.state_sampling_time);
   if (csmp)
   {
     result.sampling_success_rate = csmp->getConstrainedSamplingRate();
-    logInform("Constrained sampling rate: %lf", result.sampling_success_rate);
+    ROS_INFO_NAMED("ompl_interface", "Constrained sampling rate: %lf", result.sampling_success_rate);
   }
 
   result.milestones = sstor->size();
   if (options.edges_per_sample > 0)
   {
-    logInform("Computing graph connections (max %u edges per sample) ...", options.edges_per_sample);
+    ROS_INFO_NAMED("ompl_interface", "Computing graph connections (max %u edges per sample) ...",
+                   options.edges_per_sample);
 
     // construct connexions
     const ob::StateSpacePtr& space = pcontext->getOMPLSimpleSetup()->getStateSpace();
@@ -535,7 +541,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
       if (done != done_now)
       {
         done = done_now;
-        logInform("%d%% complete", done);
+        ROS_INFO_NAMED("ompl_interface", "%d%% complete", done);
       }
       if (cass->getMetadata(j).first.size() >= options.edges_per_sample)
         continue;
@@ -592,7 +598,8 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     }
 
     result.state_connection_time = ompl::time::seconds(ompl::time::now() - start);
-    logInform("Computed possible connexions in %lf seconds. Added %d connexions", result.state_connection_time, good);
+    ROS_INFO_NAMED("ompl_interface", "Computed possible connexions in %lf seconds. Added %d connexions",
+                   result.state_connection_time, good);
     pcontext->getOMPLSimpleSetup()->getSpaceInformation()->freeStates(int_states);
 
     return sstor;

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -54,7 +54,7 @@ ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(
 {
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
-  ROS_DEBUG_NAMED("ompl_interface", "Constructed a ConstrainedGoalSampler instance at address %p", this);
+  ROS_DEBUG_NAMED("constrained_goal_sampler", "Constructed a ConstrainedGoalSampler instance at address %p", this);
   startSampling();
 }
 
@@ -134,9 +134,9 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
           if (!warned_invalid_samples_ && invalid_sampled_constraints_ >= (attempts_so_far * 8) / 10)
           {
             warned_invalid_samples_ = true;
-            ROS_WARN_NAMED("ompl_interface", "More than 80%% of the sampled goal states fail to satisfy the "
-                                             "constraints imposed on the goal "
-                                             "sampler. Is the constrained sampler working correctly?");
+            ROS_WARN_NAMED("constrained_goal_sampler", "More than 80%% of the sampled goal states fail to satisfy the "
+                                                       "constraints imposed on the goal "
+                                                       "sampler. Is the constrained sampler working correctly?");
           }
         }
       }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -54,7 +54,7 @@ ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(
 {
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
-  logDebug("Constructed a ConstrainedGoalSampler instance at address %p", this);
+  ROS_DEBUG_NAMED("ompl_interface", "Constructed a ConstrainedGoalSampler instance at address %p", this);
   startSampling();
 }
 
@@ -134,8 +134,9 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
           if (!warned_invalid_samples_ && invalid_sampled_constraints_ >= (attempts_so_far * 8) / 10)
           {
             warned_invalid_samples_ = true;
-            logWarn("More than 80%% of the sampled goal states fail to satisfy the constraints imposed on the goal "
-                    "sampler. Is the constrained sampler working correctly?");
+            ROS_WARN_NAMED("ompl_interface", "More than 80%% of the sampled goal states fail to satisfy the "
+                                             "constraints imposed on the goal "
+                                             "sampler. Is the constrained sampler working correctly?");
           }
         }
       }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -134,9 +134,9 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
           if (!warned_invalid_samples_ && invalid_sampled_constraints_ >= (attempts_so_far * 8) / 10)
           {
             warned_invalid_samples_ = true;
-            ROS_WARN_NAMED("constrained_goal_sampler", "More than 80%% of the sampled goal states fail to satisfy the "
-                                                       "constraints imposed on the goal "
-                                                       "sampler. Is the constrained sampler working correctly?");
+            ROS_WARN_NAMED("constrained_goal_sampler", "More than 80%% of the sampled goal states "
+                                                       "fail to satisfy the constraints imposed on the goal sampler. "
+                                                       "Is the constrained sampler working correctly?");
           }
         }
       }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -50,7 +50,8 @@ ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
   inv_dim_ = si_->getStateSpace()->getDimension() > 0 ? 1.0 / (double)si_->getStateSpace()->getDimension() : 1.0;
-  ROS_DEBUG_NAMED("ompl_interface", "Constructed a ValidConstrainedSampler instance at address %p", this);
+  ROS_DEBUG_NAMED("constrained_valid_state_sampler", "Constructed a ValidConstrainedSampler instance at address %p",
+                  this);
 }
 
 bool ompl_interface::ValidConstrainedSampler::project(ompl::base::State* state)

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -50,7 +50,7 @@ ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
   inv_dim_ = si_->getStateSpace()->getDimension() > 0 ? 1.0 / (double)si_->getStateSpace()->getDimension() : 1.0;
-  logDebug("Constructed a ValidConstrainedSampler instance at address %p", this);
+  ROS_DEBUG_NAMED("ompl_interface", "Constructed a ValidConstrainedSampler instance at address %p", this);
 }
 
 bool ompl_interface::ValidConstrainedSampler::project(ompl::base::State* state)

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -116,7 +116,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
     return false;
   }
 
@@ -146,7 +146,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
     return false;
   }
 
@@ -188,7 +188,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
@@ -240,7 +240,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(0.0);
     return false;
   }

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -116,7 +116,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
+      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
     return false;
   }
 
@@ -146,7 +146,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
+      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
     return false;
   }
 
@@ -188,7 +188,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
+      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
@@ -240,7 +240,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("ompl_interface", "State outside bounds");
+      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(0.0);
     return false;
   }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -89,7 +89,7 @@ void ompl_interface::ModelBasedPlanningContext::setProjectionEvaluator(const std
 {
   if (!spec_.state_space_)
   {
-    logError("No state space is configured yet");
+    ROS_ERROR_NAMED("ompl_interface", "No state space is configured yet");
     return;
   }
   ob::ProjectionEvaluatorPtr pe = getProjectionEvaluator(peval);
@@ -106,9 +106,10 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
     if (getRobotModel()->hasLinkModel(link_name))
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorLinkPose(this, link_name));
     else
-      logError("Attempted to set projection evaluator with respect to position of link '%s', but that link is not "
-               "known to the kinematic model.",
-               link_name.c_str());
+      ROS_ERROR_NAMED("ompl_interface", "Attempted to set projection evaluator with respect to position of link '%s', "
+                                        "but that link is not "
+                                        "known to the kinematic model.",
+                      link_name.c_str());
   }
   else if (peval.find_first_of("joints(") == 0 && peval[peval.length() - 1] == ')')
   {
@@ -130,20 +131,23 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
             j.push_back(idx + q);
         }
         else
-          logWarn("%s: Ignoring joint '%s' in projection since it has 0 DOF", name_.c_str(), v.c_str());
+          ROS_WARN_NAMED("ompl_interface", "%s: Ignoring joint '%s' in projection since it has 0 DOF", name_.c_str(),
+                         v.c_str());
       }
       else
-        logError("%s: Attempted to set projection evaluator with respect to value of joint '%s', but that joint is not "
-                 "known to the group '%s'.",
-                 name_.c_str(), v.c_str(), getGroupName().c_str());
+        ROS_ERROR_NAMED("ompl_interface", "%s: Attempted to set projection evaluator with respect to value of joint "
+                                          "'%s', but that joint is not "
+                                          "known to the group '%s'.",
+                        name_.c_str(), v.c_str(), getGroupName().c_str());
     }
     if (j.empty())
-      logError("%s: No valid joints specified for joint projection", name_.c_str());
+      ROS_ERROR_NAMED("ompl_interface", "%s: No valid joints specified for joint projection", name_.c_str());
     else
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorJointValue(this, j));
   }
   else
-    logError("Unable to allocate projection evaluator based on description: '%s'", peval.c_str());
+    ROS_ERROR_NAMED("ompl_interface", "Unable to allocate projection evaluator based on description: '%s'",
+                    peval.c_str());
   return ob::ProjectionEvaluatorPtr();
 }
 
@@ -152,11 +156,13 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 {
   if (spec_.state_space_.get() != ss)
   {
-    logError("%s: Attempted to allocate a state sampler for an unknown state space", name_.c_str());
+    ROS_ERROR_NAMED("ompl_interface", "%s: Attempted to allocate a state sampler for an unknown state space",
+                    name_.c_str());
     return ompl::base::StateSamplerPtr();
   }
 
-  logDebug("%s: Allocating a new state sampler (attempts to use path constraints)", name_.c_str());
+  ROS_DEBUG_NAMED("ompl_interface", "%s: Allocating a new state sampler (attempts to use path constraints)",
+                  name_.c_str());
 
   if (path_constraints_)
   {
@@ -172,8 +178,9 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
           ompl::base::StateSamplerPtr res = c_ssa(ss);
           if (res)
           {
-            logInform("%s: Using precomputed state sampler (approximated constraint space) for constraint '%s'",
-                      name_.c_str(), path_constraints_msg_.name.c_str());
+            ROS_INFO_NAMED("ompl_interface",
+                           "%s: Using precomputed state sampler (approximated constraint space) for constraint '%s'",
+                           name_.c_str(), path_constraints_msg_.name.c_str());
             return res;
           }
         }
@@ -187,11 +194,11 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 
     if (cs)
     {
-      logInform("%s: Allocating specialized state sampler for state space", name_.c_str());
+      ROS_INFO_NAMED("ompl_interface", "%s: Allocating specialized state sampler for state space", name_.c_str());
       return ob::StateSamplerPtr(new ConstrainedSampler(this, cs));
     }
   }
-  logDebug("%s: Allocating default state sampler for state space", name_.c_str());
+  ROS_DEBUG_NAMED("ompl_interface", "%s: Allocating default state sampler for state space", name_.c_str());
   return ss->allocDefaultStateSampler();
 }
 
@@ -210,7 +217,7 @@ void ompl_interface::ModelBasedPlanningContext::configure()
     if (ca)
     {
       getOMPLStateSpace()->setInterpolationFunction(ca->getInterpolationFunction());
-      logInform("Using precomputed interpolation states");
+      ROS_INFO_NAMED("ompl_interface", "Using precomputed interpolation states");
     }
   }
 
@@ -243,7 +250,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     optimizer = "PathLengthOptimizationObjective";
-    logDebug("No optimization objective specified, defaulting to %s", optimizer.c_str());
+    ROS_DEBUG_NAMED("ompl_interface", "No optimization objective specified, defaulting to %s", optimizer.c_str());
   }
   else
   {
@@ -283,7 +290,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     if (name_ != getGroupName())
-      logWarn("%s: Attribute 'type' not specified in planner configuration", name_.c_str());
+      ROS_WARN_NAMED("ompl_interface", "%s: Attribute 'type' not specified in planner configuration", name_.c_str());
   }
   else
   {
@@ -291,9 +298,10 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     cfg.erase(it);
     ompl_simple_setup_->setPlannerAllocator(
         boost::bind(spec_.planner_selector_(type), _1, name_ != getGroupName() ? name_ : "", spec_));
-    logInform("Planner configuration '%s' will use planner '%s'. Additional configuration parameters will be set when "
-              "the planner is constructed.",
-              name_.c_str(), type.c_str());
+    ROS_INFO_NAMED("ompl_interface", "Planner configuration '%s' will use planner '%s'. Additional configuration "
+                                     "parameters will be set when "
+                                     "the planner is constructed.",
+                   name_.c_str(), type.c_str());
   }
 
   // call the setParams() after setup(), so we know what the params are
@@ -308,11 +316,12 @@ void ompl_interface::ModelBasedPlanningContext::setPlanningVolume(const moveit_m
   if (wparams.min_corner.x == wparams.max_corner.x && wparams.min_corner.x == 0.0 &&
       wparams.min_corner.y == wparams.max_corner.y && wparams.min_corner.y == 0.0 &&
       wparams.min_corner.z == wparams.max_corner.z && wparams.min_corner.z == 0.0)
-    logWarn("It looks like the planning volume was not specified.");
+    ROS_WARN_NAMED("ompl_interface", "It looks like the planning volume was not specified.");
 
-  logDebug("%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = [%f, %f], z = [%f, %f]",
-           name_.c_str(), wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y, wparams.max_corner.y,
-           wparams.min_corner.z, wparams.max_corner.z);
+  ROS_DEBUG_NAMED("ompl_interface", "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
+                                    "[%f, %f], z = [%f, %f]",
+                  name_.c_str(), wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y, wparams.max_corner.y,
+                  wparams.min_corner.z, wparams.max_corner.z);
 
   spec_.state_space_->setPlanningVolume(wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y,
                                         wparams.max_corner.y, wparams.min_corner.z, wparams.max_corner.z);
@@ -381,7 +390,7 @@ ompl::base::GoalPtr ompl_interface::ModelBasedPlanningContext::constructGoal()
   if (!goals.empty())
     return goals.size() == 1 ? goals[0] : ompl::base::GoalPtr(new GoalSampleableRegionMux(goals));
   else
-    logError("Unable to construct goal representation");
+    ROS_ERROR_NAMED("ompl_interface", "Unable to construct goal representation");
 
   return ob::GoalPtr();
 }
@@ -433,7 +442,7 @@ bool ompl_interface::ModelBasedPlanningContext::setGoalConstraints(
 
   if (goal_constraints_.empty())
   {
-    logWarn("%s: No goal constraints specified. There is no problem to solve.", name_.c_str());
+    ROS_WARN_NAMED("ompl_interface", "%s: No goal constraints specified. There is no problem to solve.", name_.c_str());
     if (error)
       error->val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
@@ -501,10 +510,10 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
   stopSampling();
   int v = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getValidMotionCount();
   int iv = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getInvalidMotionCount();
-  logDebug("There were %d valid motions and %d invalid motions.", v, iv);
+  ROS_DEBUG_NAMED("ompl_interface", "There were %d valid motions and %d invalid motions.", v, iv);
 
   if (ompl_simple_setup_->getProblemDefinition()->hasApproximateSolution())
-    logWarn("Computed solution is approximate");
+    ROS_WARN_NAMED("ompl_interface", "Computed solution is approximate");
 }
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)
@@ -520,8 +529,8 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
     interpolateSolution();
 
     // fill the response
-    logDebug("%s: Returning successful solution with %lu states", getName().c_str(),
-             getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED("ompl_interface", "%s: Returning successful solution with %lu states", getName().c_str(),
+                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
 
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(getRobotModel(), getGroupName()));
     getSolutionPath(*res.trajectory_);
@@ -530,7 +539,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
   }
   else
   {
-    logInform("Unable to solve the planning problem");
+    ROS_INFO_NAMED("ompl_interface", "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -570,13 +579,13 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
     getSolutionPath(*res.trajectory_.back());
 
     // fill the response
-    logDebug("%s: Returning successful solution with %lu states", getName().c_str(),
-             getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED("ompl_interface", "%s: Returning successful solution with %lu states", getName().c_str(),
+                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
     return true;
   }
   else
   {
-    logInform("Unable to solve the planning problem");
+    ROS_INFO_NAMED("ompl_interface", "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -591,7 +600,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   bool result = false;
   if (count <= 1)
   {
-    logDebug("%s: Solving the planning problem once...", name_.c_str());
+    ROS_DEBUG_NAMED("ompl_interface", "%s: Solving the planning problem once...", name_.c_str());
     ob::PlannerTerminationCondition ptc =
         ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start));
     registerTerminationCondition(ptc);
@@ -601,7 +610,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   }
   else
   {
-    logDebug("%s: Solving the planning problem %u times...", name_.c_str(), count);
+    ROS_DEBUG_NAMED("ompl_interface", "%s: Solving the planning problem %u times...", name_.c_str(), count);
     ompl_parallel_plan_.clearHybridizationPaths();
     if (count <= max_planning_threads_)
     {

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -89,7 +89,7 @@ void ompl_interface::ModelBasedPlanningContext::setProjectionEvaluator(const std
 {
   if (!spec_.state_space_)
   {
-    ROS_ERROR_NAMED("ompl_interface", "No state space is configured yet");
+    ROS_ERROR_NAMED("model_based_planning_context", "No state space is configured yet");
     return;
   }
   ob::ProjectionEvaluatorPtr pe = getProjectionEvaluator(peval);
@@ -106,9 +106,10 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
     if (getRobotModel()->hasLinkModel(link_name))
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorLinkPose(this, link_name));
     else
-      ROS_ERROR_NAMED("ompl_interface", "Attempted to set projection evaluator with respect to position of link '%s', "
-                                        "but that link is not "
-                                        "known to the kinematic model.",
+      ROS_ERROR_NAMED("model_based_planning_context",
+                      "Attempted to set projection evaluator with respect to position of link '%s', "
+                      "but that link is not "
+                      "known to the kinematic model.",
                       link_name.c_str());
   }
   else if (peval.find_first_of("joints(") == 0 && peval[peval.length() - 1] == ')')
@@ -131,23 +132,25 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
             j.push_back(idx + q);
         }
         else
-          ROS_WARN_NAMED("ompl_interface", "%s: Ignoring joint '%s' in projection since it has 0 DOF", name_.c_str(),
-                         v.c_str());
+          ROS_WARN_NAMED("model_based_planning_context", "%s: Ignoring joint '%s' in projection since it has 0 DOF",
+                         name_.c_str(), v.c_str());
       }
       else
-        ROS_ERROR_NAMED("ompl_interface", "%s: Attempted to set projection evaluator with respect to value of joint "
-                                          "'%s', but that joint is not "
-                                          "known to the group '%s'.",
+        ROS_ERROR_NAMED("model_based_planning_context",
+                        "%s: Attempted to set projection evaluator with respect to value of joint "
+                        "'%s', but that joint is not "
+                        "known to the group '%s'.",
                         name_.c_str(), v.c_str(), getGroupName().c_str());
     }
     if (j.empty())
-      ROS_ERROR_NAMED("ompl_interface", "%s: No valid joints specified for joint projection", name_.c_str());
+      ROS_ERROR_NAMED("model_based_planning_context", "%s: No valid joints specified for joint projection",
+                      name_.c_str());
     else
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorJointValue(this, j));
   }
   else
-    ROS_ERROR_NAMED("ompl_interface", "Unable to allocate projection evaluator based on description: '%s'",
-                    peval.c_str());
+    ROS_ERROR_NAMED("model_based_planning_context",
+                    "Unable to allocate projection evaluator based on description: '%s'", peval.c_str());
   return ob::ProjectionEvaluatorPtr();
 }
 
@@ -156,13 +159,13 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 {
   if (spec_.state_space_.get() != ss)
   {
-    ROS_ERROR_NAMED("ompl_interface", "%s: Attempted to allocate a state sampler for an unknown state space",
-                    name_.c_str());
+    ROS_ERROR_NAMED("model_based_planning_context",
+                    "%s: Attempted to allocate a state sampler for an unknown state space", name_.c_str());
     return ompl::base::StateSamplerPtr();
   }
 
-  ROS_DEBUG_NAMED("ompl_interface", "%s: Allocating a new state sampler (attempts to use path constraints)",
-                  name_.c_str());
+  ROS_DEBUG_NAMED("model_based_planning_context",
+                  "%s: Allocating a new state sampler (attempts to use path constraints)", name_.c_str());
 
   if (path_constraints_)
   {
@@ -178,7 +181,7 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
           ompl::base::StateSamplerPtr res = c_ssa(ss);
           if (res)
           {
-            ROS_INFO_NAMED("ompl_interface",
+            ROS_INFO_NAMED("model_based_planning_context",
                            "%s: Using precomputed state sampler (approximated constraint space) for constraint '%s'",
                            name_.c_str(), path_constraints_msg_.name.c_str());
             return res;
@@ -194,11 +197,13 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 
     if (cs)
     {
-      ROS_INFO_NAMED("ompl_interface", "%s: Allocating specialized state sampler for state space", name_.c_str());
+      ROS_INFO_NAMED("model_based_planning_context", "%s: Allocating specialized state sampler for state space",
+                     name_.c_str());
       return ob::StateSamplerPtr(new ConstrainedSampler(this, cs));
     }
   }
-  ROS_DEBUG_NAMED("ompl_interface", "%s: Allocating default state sampler for state space", name_.c_str());
+  ROS_DEBUG_NAMED("model_based_planning_context", "%s: Allocating default state sampler for state space",
+                  name_.c_str());
   return ss->allocDefaultStateSampler();
 }
 
@@ -217,7 +222,7 @@ void ompl_interface::ModelBasedPlanningContext::configure()
     if (ca)
     {
       getOMPLStateSpace()->setInterpolationFunction(ca->getInterpolationFunction());
-      ROS_INFO_NAMED("ompl_interface", "Using precomputed interpolation states");
+      ROS_INFO_NAMED("model_based_planning_context", "Using precomputed interpolation states");
     }
   }
 
@@ -250,7 +255,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     optimizer = "PathLengthOptimizationObjective";
-    ROS_DEBUG_NAMED("ompl_interface", "No optimization objective specified, defaulting to %s", optimizer.c_str());
+    ROS_DEBUG_NAMED("model_based_planning_context", "No optimization objective specified, defaulting to %s",
+                    optimizer.c_str());
   }
   else
   {
@@ -290,7 +296,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     if (name_ != getGroupName())
-      ROS_WARN_NAMED("ompl_interface", "%s: Attribute 'type' not specified in planner configuration", name_.c_str());
+      ROS_WARN_NAMED("model_based_planning_context", "%s: Attribute 'type' not specified in planner configuration",
+                     name_.c_str());
   }
   else
   {
@@ -298,9 +305,10 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     cfg.erase(it);
     ompl_simple_setup_->setPlannerAllocator(
         boost::bind(spec_.planner_selector_(type), _1, name_ != getGroupName() ? name_ : "", spec_));
-    ROS_INFO_NAMED("ompl_interface", "Planner configuration '%s' will use planner '%s'. Additional configuration "
-                                     "parameters will be set when "
-                                     "the planner is constructed.",
+    ROS_INFO_NAMED("model_based_planning_context",
+                   "Planner configuration '%s' will use planner '%s'. Additional configuration "
+                   "parameters will be set when "
+                   "the planner is constructed.",
                    name_.c_str(), type.c_str());
   }
 
@@ -316,10 +324,11 @@ void ompl_interface::ModelBasedPlanningContext::setPlanningVolume(const moveit_m
   if (wparams.min_corner.x == wparams.max_corner.x && wparams.min_corner.x == 0.0 &&
       wparams.min_corner.y == wparams.max_corner.y && wparams.min_corner.y == 0.0 &&
       wparams.min_corner.z == wparams.max_corner.z && wparams.min_corner.z == 0.0)
-    ROS_WARN_NAMED("ompl_interface", "It looks like the planning volume was not specified.");
+    ROS_WARN_NAMED("model_based_planning_context", "It looks like the planning volume was not specified.");
 
-  ROS_DEBUG_NAMED("ompl_interface", "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
-                                    "[%f, %f], z = [%f, %f]",
+  ROS_DEBUG_NAMED("model_based_planning_context",
+                  "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
+                  "[%f, %f], z = [%f, %f]",
                   name_.c_str(), wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y, wparams.max_corner.y,
                   wparams.min_corner.z, wparams.max_corner.z);
 
@@ -390,7 +399,7 @@ ompl::base::GoalPtr ompl_interface::ModelBasedPlanningContext::constructGoal()
   if (!goals.empty())
     return goals.size() == 1 ? goals[0] : ompl::base::GoalPtr(new GoalSampleableRegionMux(goals));
   else
-    ROS_ERROR_NAMED("ompl_interface", "Unable to construct goal representation");
+    ROS_ERROR_NAMED("model_based_planning_context", "Unable to construct goal representation");
 
   return ob::GoalPtr();
 }
@@ -442,7 +451,8 @@ bool ompl_interface::ModelBasedPlanningContext::setGoalConstraints(
 
   if (goal_constraints_.empty())
   {
-    ROS_WARN_NAMED("ompl_interface", "%s: No goal constraints specified. There is no problem to solve.", name_.c_str());
+    ROS_WARN_NAMED("model_based_planning_context", "%s: No goal constraints specified. There is no problem to solve.",
+                   name_.c_str());
     if (error)
       error->val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
@@ -510,10 +520,10 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
   stopSampling();
   int v = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getValidMotionCount();
   int iv = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getInvalidMotionCount();
-  ROS_DEBUG_NAMED("ompl_interface", "There were %d valid motions and %d invalid motions.", v, iv);
+  ROS_DEBUG_NAMED("model_based_planning_context", "There were %d valid motions and %d invalid motions.", v, iv);
 
   if (ompl_simple_setup_->getProblemDefinition()->hasApproximateSolution())
-    ROS_WARN_NAMED("ompl_interface", "Computed solution is approximate");
+    ROS_WARN_NAMED("model_based_planning_context", "Computed solution is approximate");
 }
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)
@@ -529,8 +539,8 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
     interpolateSolution();
 
     // fill the response
-    ROS_DEBUG_NAMED("ompl_interface", "%s: Returning successful solution with %lu states", getName().c_str(),
-                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Returning successful solution with %lu states",
+                    getName().c_str(), getOMPLSimpleSetup()->getSolutionPath().getStateCount());
 
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(getRobotModel(), getGroupName()));
     getSolutionPath(*res.trajectory_);
@@ -539,7 +549,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
   }
   else
   {
-    ROS_INFO_NAMED("ompl_interface", "Unable to solve the planning problem");
+    ROS_INFO_NAMED("model_based_planning_context", "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -579,13 +589,13 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
     getSolutionPath(*res.trajectory_.back());
 
     // fill the response
-    ROS_DEBUG_NAMED("ompl_interface", "%s: Returning successful solution with %lu states", getName().c_str(),
-                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Returning successful solution with %lu states",
+                    getName().c_str(), getOMPLSimpleSetup()->getSolutionPath().getStateCount());
     return true;
   }
   else
   {
-    ROS_INFO_NAMED("ompl_interface", "Unable to solve the planning problem");
+    ROS_INFO_NAMED("model_based_planning_context", "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -600,7 +610,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   bool result = false;
   if (count <= 1)
   {
-    ROS_DEBUG_NAMED("ompl_interface", "%s: Solving the planning problem once...", name_.c_str());
+    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Solving the planning problem once...", name_.c_str());
     ob::PlannerTerminationCondition ptc =
         ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start));
     registerTerminationCondition(ptc);
@@ -610,7 +620,8 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   }
   else
   {
-    ROS_DEBUG_NAMED("ompl_interface", "%s: Solving the planning problem %u times...", name_.c_str(), count);
+    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Solving the planning problem %u times...", name_.c_str(),
+                    count);
     ompl_parallel_plan_.clearHybridizationPaths();
     if (count <= max_planning_threads_)
     {

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -108,8 +108,7 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
     else
       ROS_ERROR_NAMED("model_based_planning_context",
                       "Attempted to set projection evaluator with respect to position of link '%s', "
-                      "but that link is not "
-                      "known to the kinematic model.",
+                      "but that link is not known to the kinematic model.",
                       link_name.c_str());
   }
   else if (peval.find_first_of("joints(") == 0 && peval[peval.length() - 1] == ')')
@@ -138,8 +137,7 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
       else
         ROS_ERROR_NAMED("model_based_planning_context",
                         "%s: Attempted to set projection evaluator with respect to value of joint "
-                        "'%s', but that joint is not "
-                        "known to the group '%s'.",
+                        "'%s', but that joint is not known to the group '%s'.",
                         name_.c_str(), v.c_str(), getGroupName().c_str());
     }
     if (j.empty())
@@ -306,9 +304,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     ompl_simple_setup_->setPlannerAllocator(
         boost::bind(spec_.planner_selector_(type), _1, name_ != getGroupName() ? name_ : "", spec_));
     ROS_INFO_NAMED("model_based_planning_context",
-                   "Planner configuration '%s' will use planner '%s'. Additional configuration "
-                   "parameters will be set when "
-                   "the planner is constructed.",
+                   "Planner configuration '%s' will use planner '%s'. "
+                   "Additional configuration parameters will be set when the planner is constructed.",
                    name_.c_str(), type.c_str());
   }
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -49,7 +49,7 @@ ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(const ModelBasedState
   // make sure we have bounds for every joint stored within the spec (use default bounds if not specified)
   if (!spec_.joint_bounds_.empty() && spec_.joint_bounds_.size() != joint_model_vector_.size())
   {
-    ROS_ERROR_NAMED("ompl_interface",
+    ROS_ERROR_NAMED("model_based_state_space",
                     "Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
                     spec_.joint_model_group_->getName().c_str());
     spec_.joint_bounds_.clear();
@@ -87,9 +87,10 @@ double ompl_interface::ModelBasedStateSpace::getTagSnapToSegment() const
 void ompl_interface::ModelBasedStateSpace::setTagSnapToSegment(double snap)
 {
   if (snap < 0.0 || snap > 1.0)
-    ROS_WARN_NAMED("ompl_interface", "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
-                                     "Value remains as previously "
-                                     "set (%lf)",
+    ROS_WARN_NAMED("model_based_state_space",
+                   "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
+                   "Value remains as previously "
+                   "set (%lf)",
                    tag_snap_to_segment_);
   else
   {

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -49,8 +49,9 @@ ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(const ModelBasedState
   // make sure we have bounds for every joint stored within the spec (use default bounds if not specified)
   if (!spec_.joint_bounds_.empty() && spec_.joint_bounds_.size() != joint_model_vector_.size())
   {
-    logError("Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
-             spec_.joint_model_group_->getName().c_str());
+    ROS_ERROR_NAMED("ompl_interface",
+                    "Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
+                    spec_.joint_model_group_->getName().c_str());
     spec_.joint_bounds_.clear();
   }
 
@@ -86,9 +87,10 @@ double ompl_interface::ModelBasedStateSpace::getTagSnapToSegment() const
 void ompl_interface::ModelBasedStateSpace::setTagSnapToSegment(double snap)
 {
   if (snap < 0.0 || snap > 1.0)
-    logWarn("Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. Value remains as previously "
-            "set (%lf)",
-            tag_snap_to_segment_);
+    ROS_WARN_NAMED("ompl_interface", "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
+                                     "Value remains as previously "
+                                     "set (%lf)",
+                   tag_snap_to_segment_);
   else
   {
     tag_snap_to_segment_ = snap;

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -89,8 +89,7 @@ void ompl_interface::ModelBasedStateSpace::setTagSnapToSegment(double snap)
   if (snap < 0.0 || snap > 1.0)
     ROS_WARN_NAMED("model_based_state_space",
                    "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
-                   "Value remains as previously "
-                   "set (%lf)",
+                   "Value remains as previously set (%lf)",
                    tag_snap_to_segment_);
   else
   {

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -54,7 +54,7 @@ ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSp
       poses_.push_back(PoseComponent(it->first, it->second));
   }
   if (poses_.empty())
-    logError("No kinematics solvers specified. Unable to construct a PoseModelStateSpace");
+    ROS_ERROR_NAMED("ompl_interface", "No kinematics solvers specified. Unable to construct a PoseModelStateSpace");
   else
     std::sort(poses_.begin(), poses_.end());
   setName(getName() + "_" + PARAMETERIZATION_TYPE);

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -54,7 +54,8 @@ ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSp
       poses_.push_back(PoseComponent(it->first, it->second));
   }
   if (poses_.empty())
-    ROS_ERROR_NAMED("ompl_interface", "No kinematics solvers specified. Unable to construct a PoseModelStateSpace");
+    ROS_ERROR_NAMED("pose_model_state_space", "No kinematics solvers specified. Unable to construct a "
+                                              "PoseModelStateSpace");
   else
     std::sort(poses_.begin(), poses_.end());
   setName(getName() + "_" + PARAMETERIZATION_TYPE);

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -154,7 +154,7 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
     return it->second;
   else
   {
-    logError("Unknown planner: '%s'", planner.c_str());
+    ROS_ERROR_NAMED("ompl_interface", "Unknown planner: '%s'", planner.c_str());
     return ConfiguredPlannerAllocator();
   }
 }
@@ -217,7 +217,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
   }
   else
   {
-    logError("Planning configuration '%s' was not found", config.c_str());
+    ROS_ERROR_NAMED("ompl_interface", "Planning configuration '%s' was not found", config.c_str());
     return ModelBasedPlanningContextPtr();
   }
 }
@@ -240,7 +240,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       for (std::size_t i = 0; i < cc->second.size(); ++i)
         if (cc->second[i].unique())
         {
-          logDebug("Reusing cached planning context");
+          ROS_DEBUG_NAMED("ompl_interface", "Reusing cached planning context");
           context = cc->second[i];
           break;
         }
@@ -279,7 +279,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       }
     }
 
-    logDebug("Creating new planning context");
+    ROS_DEBUG_NAMED("ompl_interface", "Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
     context->useStateValidityCache(state_validity_cache);
     {
@@ -314,7 +314,7 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
     return f->second;
   else
   {
-    logError("Factory of type '%s' was not found", factory_type.c_str());
+    ROS_ERROR_NAMED("ompl_interface", "Factory of type '%s' was not found", factory_type.c_str());
     static const ModelBasedStateSpaceFactoryPtr empty;
     return empty;
   }
@@ -340,13 +340,13 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
 
   if (best == state_space_factories_.end())
   {
-    logError("There are no known state spaces that can represent the given planning problem");
+    ROS_ERROR_NAMED("ompl_interface", "There are no known state spaces that can represent the given planning problem");
     static const ModelBasedStateSpaceFactoryPtr empty;
     return empty;
   }
   else
   {
-    logDebug("Using '%s' parameterization for solving problem", best->first.c_str());
+    ROS_DEBUG_NAMED("ompl_interface", "Using '%s' parameterization for solving problem", best->first.c_str());
     return best->second;
   }
 }
@@ -357,7 +357,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 {
   if (req.group_name.empty())
   {
-    logError("No group specified to plan for");
+    ROS_ERROR_NAMED("ompl_interface", "No group specified to plan for");
     error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
     return ModelBasedPlanningContextPtr();
   }
@@ -366,7 +366,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 
   if (!planning_scene)
   {
-    logError("No planning scene supplied as input");
+    ROS_ERROR_NAMED("ompl_interface", "No planning scene supplied as input");
     return ModelBasedPlanningContextPtr();
   }
 
@@ -378,8 +378,9 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
                                    req.group_name + "[" + req.planner_id + "]" :
                                    req.planner_id);
     if (pc == planner_configs_.end())
-      logWarn("Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
-              req.group_name.c_str(), req.planner_id.c_str());
+      ROS_WARN_NAMED("ompl_interface",
+                     "Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
+                     req.group_name.c_str(), req.planner_id.c_str());
   }
 
   if (pc == planner_configs_.end())
@@ -387,7 +388,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     pc = planner_configs_.find(req.group_name);
     if (pc == planner_configs_.end())
     {
-      logError("Cannot find planning configuration for group '%s'", req.group_name.c_str());
+      ROS_ERROR_NAMED("ompl_interface", "Cannot find planning configuration for group '%s'", req.group_name.c_str());
       return ModelBasedPlanningContextPtr();
     }
   }
@@ -431,12 +432,12 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     try
     {
       context->configure();
-      logDebug("%s: New planning context is set.", context->getName().c_str());
+      ROS_DEBUG_NAMED("ompl_interface", "%s: New planning context is set.", context->getName().c_str());
       error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     }
     catch (ompl::Exception& ex)
     {
-      logError("OMPL encountered an error: %s", ex.what());
+      ROS_ERROR_NAMED("ompl_interface", "OMPL encountered an error: %s", ex.what());
       context.reset();
     }
   }

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -154,7 +154,7 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
     return it->second;
   else
   {
-    ROS_ERROR_NAMED("ompl_interface", "Unknown planner: '%s'", planner.c_str());
+    ROS_ERROR_NAMED("planning_context_manager", "Unknown planner: '%s'", planner.c_str());
     return ConfiguredPlannerAllocator();
   }
 }
@@ -217,7 +217,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
   }
   else
   {
-    ROS_ERROR_NAMED("ompl_interface", "Planning configuration '%s' was not found", config.c_str());
+    ROS_ERROR_NAMED("planning_context_manager", "Planning configuration '%s' was not found", config.c_str());
     return ModelBasedPlanningContextPtr();
   }
 }
@@ -240,7 +240,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       for (std::size_t i = 0; i < cc->second.size(); ++i)
         if (cc->second[i].unique())
         {
-          ROS_DEBUG_NAMED("ompl_interface", "Reusing cached planning context");
+          ROS_DEBUG_NAMED("planning_context_manager", "Reusing cached planning context");
           context = cc->second[i];
           break;
         }
@@ -279,7 +279,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       }
     }
 
-    ROS_DEBUG_NAMED("ompl_interface", "Creating new planning context");
+    ROS_DEBUG_NAMED("planning_context_manager", "Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
     context->useStateValidityCache(state_validity_cache);
     {
@@ -314,7 +314,7 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
     return f->second;
   else
   {
-    ROS_ERROR_NAMED("ompl_interface", "Factory of type '%s' was not found", factory_type.c_str());
+    ROS_ERROR_NAMED("planning_context_manager", "Factory of type '%s' was not found", factory_type.c_str());
     static const ModelBasedStateSpaceFactoryPtr empty;
     return empty;
   }
@@ -340,13 +340,14 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
 
   if (best == state_space_factories_.end())
   {
-    ROS_ERROR_NAMED("ompl_interface", "There are no known state spaces that can represent the given planning problem");
+    ROS_ERROR_NAMED("planning_context_manager", "There are no known state spaces that can represent the given planning "
+                                                "problem");
     static const ModelBasedStateSpaceFactoryPtr empty;
     return empty;
   }
   else
   {
-    ROS_DEBUG_NAMED("ompl_interface", "Using '%s' parameterization for solving problem", best->first.c_str());
+    ROS_DEBUG_NAMED("planning_context_manager", "Using '%s' parameterization for solving problem", best->first.c_str());
     return best->second;
   }
 }
@@ -357,7 +358,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 {
   if (req.group_name.empty())
   {
-    ROS_ERROR_NAMED("ompl_interface", "No group specified to plan for");
+    ROS_ERROR_NAMED("planning_context_manager", "No group specified to plan for");
     error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
     return ModelBasedPlanningContextPtr();
   }
@@ -366,7 +367,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 
   if (!planning_scene)
   {
-    ROS_ERROR_NAMED("ompl_interface", "No planning scene supplied as input");
+    ROS_ERROR_NAMED("planning_context_manager", "No planning scene supplied as input");
     return ModelBasedPlanningContextPtr();
   }
 
@@ -378,7 +379,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
                                    req.group_name + "[" + req.planner_id + "]" :
                                    req.planner_id);
     if (pc == planner_configs_.end())
-      ROS_WARN_NAMED("ompl_interface",
+      ROS_WARN_NAMED("planning_context_manager",
                      "Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
                      req.group_name.c_str(), req.planner_id.c_str());
   }
@@ -388,7 +389,8 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     pc = planner_configs_.find(req.group_name);
     if (pc == planner_configs_.end())
     {
-      ROS_ERROR_NAMED("ompl_interface", "Cannot find planning configuration for group '%s'", req.group_name.c_str());
+      ROS_ERROR_NAMED("planning_context_manager", "Cannot find planning configuration for group '%s'",
+                      req.group_name.c_str());
       return ModelBasedPlanningContextPtr();
     }
   }
@@ -432,12 +434,12 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     try
     {
       context->configure();
-      ROS_DEBUG_NAMED("ompl_interface", "%s: New planning context is set.", context->getName().c_str());
+      ROS_DEBUG_NAMED("planning_context_manager", "%s: New planning context is set.", context->getName().c_str());
       error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     }
     catch (ompl::Exception& ex)
     {
-      ROS_ERROR_NAMED("ompl_interface", "OMPL encountered an error: %s", ex.what());
+      ROS_ERROR_NAMED("planning_context_manager", "OMPL encountered an error: %s", ex.what());
       context.reset();
     }
   }

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -99,7 +99,7 @@ TEST_F(LoadPlanningModelsPr2, StateSpace)
   }
   catch (ompl::Exception& ex)
   {
-    logError("Sanity checks did not pass: %s", ex.what());
+    ROS_ERROR_NAMED("ompl_interface", "Sanity checks did not pass: %s", ex.what());
   }
   EXPECT_TRUE(passed);
 }
@@ -142,7 +142,7 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   }
   catch (ompl::Exception& ex)
   {
-    logError("Sanity checks did not pass: %s", ex.what());
+    ROS_ERROR_NAMED("ompl_interface", "Sanity checks did not pass: %s", ex.what());
   }
   EXPECT_TRUE(passed);
 

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -99,7 +99,7 @@ TEST_F(LoadPlanningModelsPr2, StateSpace)
   }
   catch (ompl::Exception& ex)
   {
-    ROS_ERROR_NAMED("ompl_interface", "Sanity checks did not pass: %s", ex.what());
+    ROS_ERROR("Sanity checks did not pass: %s", ex.what());
   }
   EXPECT_TRUE(passed);
 }
@@ -142,7 +142,7 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   }
   catch (ompl::Exception& ex)
   {
-    ROS_ERROR_NAMED("ompl_interface", "Sanity checks did not pass: %s", ex.what());
+    ROS_ERROR("Sanity checks did not pass: %s", ex.what());
   }
   EXPECT_TRUE(passed);
 

--- a/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
@@ -129,7 +129,7 @@ void EnvironmentChain3D::PrintState(int stateID, bool bVerbose, FILE* fOut /*=NU
 
   // if(stateID == EnvChain.goalHashEntry->stateID && bVerbose)
   // {
-  //   //ROS_DEBUG_NAMED("sbpl_interface", fOut, "the state is a goal state\n");
+  //   //ROS_DEBUG_NAMED("environment_chain3d", fOut, "the state is a goal state\n");
   //   bGoal = true;
   // }
 

--- a/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
@@ -129,7 +129,7 @@ void EnvironmentChain3D::PrintState(int stateID, bool bVerbose, FILE* fOut /*=NU
 
   // if(stateID == EnvChain.goalHashEntry->stateID && bVerbose)
   // {
-  //   //ROS_DEBUG_NAMED(fOut, "the state is a goal state\n");
+  //   //ROS_DEBUG_NAMED("sbpl_interface", fOut, "the state is a goal state\n");
   //   bGoal = true;
   // }
 

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -56,7 +56,7 @@ public:
   {
     if (!node_handle_.hasParam("controller_list"))
     {
-      ROS_ERROR_STREAM("MoveItFakeControllerManager: No controller_list specified.");
+      ROS_ERROR_STREAM_NAMED("MoveItFakeControllerManager", "No controller_list specified.");
       return;
     }
 
@@ -64,7 +64,7 @@ public:
     node_handle_.getParam("controller_list", controller_list);
     if (controller_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
     {
-      ROS_ERROR("MoveItFakeControllerManager: controller_list should be specified as an array");
+      ROS_ERROR_NAMED("MoveItFakeControllerManager", "controller_list should be specified as an array");
       return;
     }
 
@@ -84,7 +84,7 @@ public:
     {
       if (!controller_list[i].hasMember("name") || !controller_list[i].hasMember("joints"))
       {
-        ROS_ERROR("MoveItFakeControllerManager: Name and joints must be specifed for each controller");
+        ROS_ERROR_NAMED("MoveItFakeControllerManager", "Name and joints must be specified for each controller");
         continue;
       }
 
@@ -94,8 +94,8 @@ public:
 
         if (controller_list[i]["joints"].getType() != XmlRpc::XmlRpcValue::TypeArray)
         {
-          ROS_ERROR_STREAM("MoveItFakeControllerManager: The list of joints for controller "
-                           << name << " is not specified as an array");
+          ROS_ERROR_STREAM_NAMED("MoveItFakeControllerManager", "The list of joints for controller "
+                                                                    << name << " is not specified as an array");
           continue;
         }
         std::vector<std::string> joints;
@@ -115,7 +115,7 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR("MoveItFakeControllerManager: Caught unknown exception while parsing controller information");
+        ROS_ERROR_NAMED("MoveItFakeControllerManager", "Caught unknown exception while parsing controller information");
       }
     }
   }

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -40,6 +40,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <sensor_msgs/JointState.h>
 #include <pluginlib/class_list_macros.h>
+#include <ros/console.h>
 #include <map>
 #include <iterator>
 

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -80,7 +80,7 @@ public:
     {
       while (ros::ok() && !controller_action_client_->waitForServer(ros::Duration(5.0)))
       {
-        ROS_WARN_STREAM("ActionBasedController: Waiting for " << getActionName() << " to come up");
+        ROS_WARN_STREAM_NAMED("ActionBasedController", "Waiting for " << getActionName() << " to come up");
         ros::Duration(1).sleep();
       }
     }
@@ -88,13 +88,13 @@ public:
     {
       while (ros::ok() && !controller_action_client_->waitForServer(ros::Duration(timeout / 3)) && ++attempts < 3)
       {
-        ROS_WARN_STREAM("ActionBasedController: Waiting for " << getActionName() << " to come up");
+        ROS_WARN_STREAM_NAMED("ActionBasedController", "Waiting for " << getActionName() << " to come up");
         ros::Duration(1).sleep();
       }
     }
     if (!controller_action_client_->isServerConnected())
     {
-      ROS_ERROR_STREAM("ActionBasedController: Action client not connected: " << getActionName());
+      ROS_ERROR_STREAM_NAMED("ActionBasedController", "Action client not connected: " << getActionName());
       controller_action_client_.reset();
     }
 
@@ -112,7 +112,7 @@ public:
       return false;
     if (!done_)
     {
-      ROS_INFO_STREAM("ActionBasedController: Cancelling execution for " << name_);
+      ROS_INFO_STREAM_NAMED("ActionBasedController", "Cancelling execution for " << name_);
       controller_action_client_->cancelGoal();
       last_exec_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
       done_ = true;
@@ -154,8 +154,8 @@ protected:
 
   void finishControllerExecution(const actionlib::SimpleClientGoalState& state)
   {
-    ROS_DEBUG_STREAM("ActionBasedController: Controller " << name_ << " is done with state " << state.toString() << ": "
-                                                          << state.getText());
+    ROS_DEBUG_STREAM_NAMED("ActionBasedController", "Controller " << name_ << " is done with state " << state.toString()
+                                                                  << ": " << state.getText());
     if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
       last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
     else if (state == actionlib::SimpleClientGoalState::ABORTED)

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -80,7 +80,7 @@ public:
     {
       while (ros::ok() && !controller_action_client_->waitForServer(ros::Duration(5.0)))
       {
-        ROS_WARN_STREAM_NAMED("moveit_simple_controller_manager", "Waiting for " << getActionName() << " to come up");
+        ROS_WARN_STREAM("ActionBasedController: Waiting for " << getActionName() << " to come up");
         ros::Duration(1).sleep();
       }
     }
@@ -88,13 +88,13 @@ public:
     {
       while (ros::ok() && !controller_action_client_->waitForServer(ros::Duration(timeout / 3)) && ++attempts < 3)
       {
-        ROS_WARN_STREAM_NAMED("moveit_simple_controller_manager", "Waiting for " << getActionName() << " to come up");
+        ROS_WARN_STREAM("ActionBasedController: Waiting for " << getActionName() << " to come up");
         ros::Duration(1).sleep();
       }
     }
     if (!controller_action_client_->isServerConnected())
     {
-      ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Action client not connected: " << getActionName());
+      ROS_ERROR_STREAM("ActionBasedController: Action client not connected: " << getActionName());
       controller_action_client_.reset();
     }
 
@@ -112,7 +112,7 @@ public:
       return false;
     if (!done_)
     {
-      ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Cancelling execution for " << name_);
+      ROS_INFO_STREAM("ActionBasedController: Cancelling execution for " << name_);
       controller_action_client_->cancelGoal();
       last_exec_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
       done_ = true;
@@ -154,9 +154,8 @@ protected:
 
   void finishControllerExecution(const actionlib::SimpleClientGoalState& state)
   {
-    ROS_DEBUG_STREAM_NAMED("moveit_simple_controller_manager", "Controller " << name_ << " is done with state "
-                                                                             << state.toString() << ": "
-                                                                             << state.getText());
+    ROS_DEBUG_STREAM("ActionBasedController: Controller " << name_ << " is done with state " << state.toString() << ": "
+                                                          << state.getText());
     if (state == actionlib::SimpleClientGoalState::SUCCEEDED)
       last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
     else if (state == actionlib::SimpleClientGoalState::ABORTED)

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -58,21 +58,21 @@ public:
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)
   {
-    ROS_DEBUG_STREAM("FollowJointTrajectoryController: new trajectory to " << name_);
+    ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryController", "new trajectory to " << name_);
 
     if (!controller_action_client_)
       return false;
 
     if (!trajectory.multi_dof_joint_trajectory.points.empty())
     {
-      ROS_WARN("FollowJointTrajectoryController: %s cannot execute multi-dof trajectories.", name_.c_str());
+      ROS_WARN_NAMED("FollowJointTrajectoryController", "%s cannot execute multi-dof trajectories.", name_.c_str());
     }
 
     if (done_)
-      ROS_DEBUG_STREAM("FollowJointTrajectoryController: sending trajectory to " << name_);
+      ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryController", "sending trajectory to " << name_);
     else
-      ROS_DEBUG_STREAM("FollowJointTrajectoryController: sending continuation for the currently executed trajectory to "
-                       << name_);
+      ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryController",
+                             "sending continuation for the currently executed trajectory to " << name_);
 
     control_msgs::FollowJointTrajectoryGoal goal;
     goal.trajectory = trajectory.joint_trajectory;
@@ -121,7 +121,7 @@ protected:
 
   void controllerActiveCallback()
   {
-    ROS_DEBUG_STREAM("FollowJointTrajectoryController: " << name_ << " started execution");
+    ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryController", name_ << " started execution");
   }
 
   void controllerFeedbackCallback(const control_msgs::FollowJointTrajectoryFeedbackConstPtr& feedback)

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -61,31 +61,31 @@ public:
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)
   {
-    ROS_DEBUG_STREAM("GripperController: Received new trajectory for " << name_);
+    ROS_DEBUG_STREAM_NAMED("GripperController", "Received new trajectory for " << name_);
 
     if (!controller_action_client_)
       return false;
 
     if (!trajectory.multi_dof_joint_trajectory.points.empty())
     {
-      ROS_ERROR("GripperController: Gripper cannot execute multi-dof trajectories.");
+      ROS_ERROR_NAMED("GripperController", "Gripper cannot execute multi-dof trajectories.");
       return false;
     }
 
     if (trajectory.joint_trajectory.points.empty())
     {
-      ROS_ERROR("GripperController: GripperController requires at least one joint trajectory point.");
+      ROS_ERROR_NAMED("GripperController", "GripperController requires at least one joint trajectory point.");
       return false;
     }
 
     if (trajectory.joint_trajectory.points.size() > 1)
     {
-      ROS_DEBUG_STREAM("GripperController: Trajectory: " << trajectory.joint_trajectory);
+      ROS_DEBUG_STREAM_NAMED("GripperController", "Trajectory: " << trajectory.joint_trajectory);
     }
 
     if (trajectory.joint_trajectory.joint_names.empty())
     {
-      ROS_ERROR("GripperController: No joint names specified");
+      ROS_ERROR_NAMED("GripperController", "No joint names specified");
       return false;
     }
 
@@ -102,7 +102,7 @@ public:
 
     if (gripper_joint_indexes.empty())
     {
-      ROS_WARN("GripperController: No command_joint was specified for the MoveIt controller gripper handle. \
+      ROS_WARN_NAMED("GripperController", "No command_joint was specified for the MoveIt controller gripper handle. \
                       Please see GripperControllerHandle::addCommandJoint() and \
                       GripperControllerHandle::setCommandJoint(). Assuming index 0.");
       gripper_joint_indexes.push_back(0);
@@ -115,7 +115,7 @@ public:
 
     // send last point
     int tpoint = trajectory.joint_trajectory.points.size() - 1;
-    ROS_DEBUG("GripperController: Sending command from trajectory point %d", tpoint);
+    ROS_DEBUG_NAMED("GripperController", "Sending command from trajectory point %d", tpoint);
 
     // fill in goal from last point
     for (std::size_t i = 0; i < gripper_joint_indexes.size(); ++i)
@@ -124,10 +124,10 @@ public:
 
       if (trajectory.joint_trajectory.points[tpoint].positions.size() <= idx)
       {
-        ROS_ERROR("GripperController: GripperController expects a joint trajectory with one \
+        ROS_ERROR_NAMED("GripperController", "GripperController expects a joint trajectory with one \
                          point that specifies at least the position of joint \
                          '%s', but insufficient positions provided",
-                  trajectory.joint_trajectory.joint_names[idx].c_str());
+                        trajectory.joint_trajectory.joint_names[idx].c_str());
         return false;
       }
       goal.command.position += trajectory.joint_trajectory.points[tpoint].positions[idx];
@@ -181,7 +181,7 @@ private:
 
   void controllerActiveCallback()
   {
-    ROS_DEBUG_STREAM("GripperController: " << name_ << " started execution");
+    ROS_DEBUG_STREAM_NAMED("GripperController", name_ << " started execution");
   }
 
   void controllerFeedbackCallback(const control_msgs::GripperCommandFeedbackConstPtr& feedback)

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -61,31 +61,31 @@ public:
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)
   {
-    ROS_DEBUG_STREAM_NAMED("GripperController", "Received new trajectory for " << name_);
+    ROS_DEBUG_STREAM("GripperController: Received new trajectory for " << name_);
 
     if (!controller_action_client_)
       return false;
 
     if (!trajectory.multi_dof_joint_trajectory.points.empty())
     {
-      ROS_ERROR_NAMED("GripperController", "Gripper cannot execute multi-dof trajectories.");
+      ROS_ERROR("GripperController: Gripper cannot execute multi-dof trajectories.");
       return false;
     }
 
     if (trajectory.joint_trajectory.points.empty())
     {
-      ROS_ERROR_NAMED("GripperController", "GripperController requires at least one joint trajectory point.");
+      ROS_ERROR("GripperController: GripperController requires at least one joint trajectory point.");
       return false;
     }
 
     if (trajectory.joint_trajectory.points.size() > 1)
     {
-      ROS_DEBUG_STREAM_NAMED("GripperController", "Trajectory: " << trajectory.joint_trajectory);
+      ROS_DEBUG_STREAM("GripperController: Trajectory: " << trajectory.joint_trajectory);
     }
 
     if (trajectory.joint_trajectory.joint_names.empty())
     {
-      ROS_ERROR_NAMED("GripperController", "No joint names specified");
+      ROS_ERROR("GripperController: No joint names specified");
       return false;
     }
 
@@ -102,7 +102,7 @@ public:
 
     if (gripper_joint_indexes.empty())
     {
-      ROS_WARN_NAMED("GripperController", "No command_joint was specified for the MoveIt controller gripper handle. \
+      ROS_WARN("GripperController: No command_joint was specified for the MoveIt controller gripper handle. \
                       Please see GripperControllerHandle::addCommandJoint() and \
                       GripperControllerHandle::setCommandJoint(). Assuming index 0.");
       gripper_joint_indexes.push_back(0);
@@ -115,7 +115,7 @@ public:
 
     // send last point
     int tpoint = trajectory.joint_trajectory.points.size() - 1;
-    ROS_DEBUG_NAMED("GripperController", "Sending command from trajectory point %d", tpoint);
+    ROS_DEBUG("GripperController: Sending command from trajectory point %d", tpoint);
 
     // fill in goal from last point
     for (std::size_t i = 0; i < gripper_joint_indexes.size(); ++i)
@@ -124,10 +124,10 @@ public:
 
       if (trajectory.joint_trajectory.points[tpoint].positions.size() <= idx)
       {
-        ROS_ERROR_NAMED("GripperController", "GripperController expects a joint trajectory with one \
+        ROS_ERROR("GripperController: GripperController expects a joint trajectory with one \
                          point that specifies at least the position of joint \
                          '%s', but insufficient positions provided",
-                        trajectory.joint_trajectory.joint_names[idx].c_str());
+                  trajectory.joint_trajectory.joint_names[idx].c_str());
         return false;
       }
       goal.command.position += trajectory.joint_trajectory.points[tpoint].positions[idx];
@@ -181,7 +181,7 @@ private:
 
   void controllerActiveCallback()
   {
-    ROS_DEBUG_STREAM_NAMED("GripperController", name_ << " started execution");
+    ROS_DEBUG_STREAM("GripperController: " << name_ << " started execution");
   }
 
   void controllerFeedbackCallback(const control_msgs::GripperCommandFeedbackConstPtr& feedback)

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -52,7 +52,7 @@ public:
   {
     if (!node_handle_.hasParam("controller_list"))
     {
-      ROS_ERROR_STREAM_NAMED("manager", "No controller_list specified.");
+      ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "No controller_list specified.");
       return;
     }
 
@@ -69,7 +69,8 @@ public:
     {
       if (!controller_list[i].hasMember("name") || !controller_list[i].hasMember("joints"))
       {
-        ROS_ERROR_STREAM_NAMED("manager", "Name and joints must be specifed for each controller");
+        ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Name and joints must be specifed for each "
+                                                                   "controller");
         continue;
       }
 
@@ -82,23 +83,25 @@ public:
         {
           /* TODO: this used to be called "ns", renaming to "action_ns" and will remove in the future */
           action_ns = std::string(controller_list[i]["ns"]);
-          ROS_WARN_NAMED("manager", "Use of 'ns' is deprecated, use 'action_ns' instead.");
+          ROS_WARN_NAMED("moveit_simple_controller_manager", "Use of 'ns' is deprecated, use 'action_ns' instead.");
         }
         else if (controller_list[i].hasMember("action_ns"))
           action_ns = std::string(controller_list[i]["action_ns"]);
         else
-          ROS_WARN_NAMED("manager", "Please note that 'action_ns' no longer has a default value.");
+          ROS_WARN_NAMED("moveit_simple_controller_manager", "Please note that 'action_ns' no longer has a default "
+                                                             "value.");
 
         if (controller_list[i]["joints"].getType() != XmlRpc::XmlRpcValue::TypeArray)
         {
-          ROS_ERROR_STREAM_NAMED("manager", "The list of joints for controller " << name << " is not specified as an "
-                                                                                            "array");
+          ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "The list of joints for controller "
+                                                                         << name << " is not specified as an "
+                                                                                    "array");
           continue;
         }
 
         if (!controller_list[i].hasMember("type"))
         {
-          ROS_ERROR_STREAM_NAMED("manager", "No type specified for controller " << name);
+          ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "No type specified for controller " << name);
           continue;
         }
 
@@ -114,7 +117,8 @@ public:
             {
               if (controller_list[i]["joints"].size() != 2)
               {
-                ROS_ERROR_STREAM_NAMED("manager", "Parallel Gripper requires exactly two joints");
+                ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Parallel Gripper requires exactly two "
+                                                                           "joints");
                 continue;
               }
               static_cast<GripperControllerHandle*>(new_handle.get())
@@ -133,7 +137,7 @@ public:
             if (controller_list[i].hasMember("allow_failure"))
               static_cast<GripperControllerHandle*>(new_handle.get())->allowFailure(true);
 
-            ROS_INFO_STREAM_NAMED("manager", "Added GripperCommand controller for " << name);
+            ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Added GripperCommand controller for " << name);
             controllers_[name] = new_handle;
           }
         }
@@ -142,13 +146,14 @@ public:
           new_handle.reset(new FollowJointTrajectoryControllerHandle(name, action_ns));
           if (static_cast<FollowJointTrajectoryControllerHandle*>(new_handle.get())->isConnected())
           {
-            ROS_INFO_STREAM_NAMED("manager", "Added FollowJointTrajectory controller for " << name);
+            ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Added FollowJointTrajectory controller for "
+                                                                          << name);
             controllers_[name] = new_handle;
           }
         }
         else
         {
-          ROS_ERROR_STREAM_NAMED("manager", "Unknown controller type: " << type.c_str());
+          ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Unknown controller type: " << type.c_str());
           continue;
         }
         if (!controllers_[name])
@@ -163,7 +168,8 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR_STREAM_NAMED("manager", "Caught unknown exception while parsing controller information");
+        ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Caught unknown exception while parsing controller "
+                                                                   "information");
       }
     }
   }
@@ -181,7 +187,7 @@ public:
     if (it != controllers_.end())
       return static_cast<moveit_controller_manager::MoveItControllerHandlePtr>(it->second);
     else
-      ROS_FATAL_STREAM_NAMED("manager", "No such controller: " << name);
+      ROS_FATAL_STREAM_NAMED("moveit_simple_controller_manager", "No such controller: " << name);
     return moveit_controller_manager::MoveItControllerHandlePtr();
   }
 
@@ -193,7 +199,7 @@ public:
     for (std::map<std::string, ActionBasedControllerHandleBasePtr>::const_iterator it = controllers_.begin();
          it != controllers_.end(); ++it)
       names.push_back(it->first);
-    ROS_INFO_STREAM_NAMED("manager", "Returned " << names.size() << " controllers in list");
+    ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Returned " << names.size() << " controllers in list");
   }
 
   /*
@@ -225,8 +231,9 @@ public:
     }
     else
     {
-      ROS_WARN_NAMED("manager", "The joints for controller '%s' are not known. Perhaps the controller configuration is "
-                                "not loaded on the param server?",
+      ROS_WARN_NAMED("moveit_simple_controller_manager",
+                     "The joints for controller '%s' are not known. Perhaps the controller configuration is "
+                     "not loaded on the param server?",
                      name.c_str());
       joints.clear();
     }

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -52,7 +52,7 @@ public:
   {
     if (!node_handle_.hasParam("controller_list"))
     {
-      ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "No controller_list specified.");
+      ROS_ERROR_STREAM_NAMED("manager", "No controller_list specified.");
       return;
     }
 
@@ -69,8 +69,8 @@ public:
     {
       if (!controller_list[i].hasMember("name") || !controller_list[i].hasMember("joints"))
       {
-        ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Name and joints must be specifed for each "
-                                                                   "controller");
+        ROS_ERROR_STREAM_NAMED("manager", "Name and joints must be specifed for each "
+                                          "controller");
         continue;
       }
 
@@ -83,25 +83,24 @@ public:
         {
           /* TODO: this used to be called "ns", renaming to "action_ns" and will remove in the future */
           action_ns = std::string(controller_list[i]["ns"]);
-          ROS_WARN_NAMED("moveit_simple_controller_manager", "Use of 'ns' is deprecated, use 'action_ns' instead.");
+          ROS_WARN_NAMED("manager", "Use of 'ns' is deprecated, use 'action_ns' instead.");
         }
         else if (controller_list[i].hasMember("action_ns"))
           action_ns = std::string(controller_list[i]["action_ns"]);
         else
-          ROS_WARN_NAMED("moveit_simple_controller_manager", "Please note that 'action_ns' no longer has a default "
-                                                             "value.");
+          ROS_WARN_NAMED("manager", "Please note that 'action_ns' no longer has a default "
+                                    "value.");
 
         if (controller_list[i]["joints"].getType() != XmlRpc::XmlRpcValue::TypeArray)
         {
-          ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "The list of joints for controller "
-                                                                         << name << " is not specified as an "
-                                                                                    "array");
+          ROS_ERROR_STREAM_NAMED("manager", "The list of joints for controller " << name << " is not specified as an "
+                                                                                            "array");
           continue;
         }
 
         if (!controller_list[i].hasMember("type"))
         {
-          ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "No type specified for controller " << name);
+          ROS_ERROR_STREAM_NAMED("manager", "No type specified for controller " << name);
           continue;
         }
 
@@ -117,8 +116,8 @@ public:
             {
               if (controller_list[i]["joints"].size() != 2)
               {
-                ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Parallel Gripper requires exactly two "
-                                                                           "joints");
+                ROS_ERROR_STREAM_NAMED("manager", "Parallel Gripper requires exactly two "
+                                                  "joints");
                 continue;
               }
               static_cast<GripperControllerHandle*>(new_handle.get())
@@ -137,7 +136,7 @@ public:
             if (controller_list[i].hasMember("allow_failure"))
               static_cast<GripperControllerHandle*>(new_handle.get())->allowFailure(true);
 
-            ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Added GripperCommand controller for " << name);
+            ROS_INFO_STREAM_NAMED("manager", "Added GripperCommand controller for " << name);
             controllers_[name] = new_handle;
           }
         }
@@ -146,14 +145,13 @@ public:
           new_handle.reset(new FollowJointTrajectoryControllerHandle(name, action_ns));
           if (static_cast<FollowJointTrajectoryControllerHandle*>(new_handle.get())->isConnected())
           {
-            ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Added FollowJointTrajectory controller for "
-                                                                          << name);
+            ROS_INFO_STREAM_NAMED("manager", "Added FollowJointTrajectory controller for " << name);
             controllers_[name] = new_handle;
           }
         }
         else
         {
-          ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Unknown controller type: " << type.c_str());
+          ROS_ERROR_STREAM_NAMED("manager", "Unknown controller type: " << type.c_str());
           continue;
         }
         if (!controllers_[name])
@@ -168,8 +166,8 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR_STREAM_NAMED("moveit_simple_controller_manager", "Caught unknown exception while parsing controller "
-                                                                   "information");
+        ROS_ERROR_STREAM_NAMED("manager", "Caught unknown exception while parsing controller "
+                                          "information");
       }
     }
   }
@@ -187,7 +185,7 @@ public:
     if (it != controllers_.end())
       return static_cast<moveit_controller_manager::MoveItControllerHandlePtr>(it->second);
     else
-      ROS_FATAL_STREAM_NAMED("moveit_simple_controller_manager", "No such controller: " << name);
+      ROS_FATAL_STREAM_NAMED("manager", "No such controller: " << name);
     return moveit_controller_manager::MoveItControllerHandlePtr();
   }
 
@@ -199,7 +197,7 @@ public:
     for (std::map<std::string, ActionBasedControllerHandleBasePtr>::const_iterator it = controllers_.begin();
          it != controllers_.end(); ++it)
       names.push_back(it->first);
-    ROS_INFO_STREAM_NAMED("moveit_simple_controller_manager", "Returned " << names.size() << " controllers in list");
+    ROS_INFO_STREAM_NAMED("manager", "Returned " << names.size() << " controllers in list");
   }
 
   /*
@@ -231,9 +229,8 @@ public:
     }
     else
     {
-      ROS_WARN_NAMED("moveit_simple_controller_manager",
-                     "The joints for controller '%s' are not known. Perhaps the controller configuration is "
-                     "not loaded on the param server?",
+      ROS_WARN_NAMED("manager", "The joints for controller '%s' are not known. Perhaps the controller configuration is "
+                                "not loaded on the param server?",
                      name.c_str());
       joints.clear();
     }

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -69,8 +69,7 @@ public:
     {
       if (!controller_list[i].hasMember("name") || !controller_list[i].hasMember("joints"))
       {
-        ROS_ERROR_STREAM_NAMED("manager", "Name and joints must be specifed for each "
-                                          "controller");
+        ROS_ERROR_STREAM_NAMED("manager", "Name and joints must be specifed for each controller");
         continue;
       }
 
@@ -88,8 +87,7 @@ public:
         else if (controller_list[i].hasMember("action_ns"))
           action_ns = std::string(controller_list[i]["action_ns"]);
         else
-          ROS_WARN_NAMED("manager", "Please note that 'action_ns' no longer has a default "
-                                    "value.");
+          ROS_WARN_NAMED("manager", "Please note that 'action_ns' no longer has a default value.");
 
         if (controller_list[i]["joints"].getType() != XmlRpc::XmlRpcValue::TypeArray)
         {
@@ -166,8 +164,7 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR_STREAM_NAMED("manager", "Caught unknown exception while parsing controller "
-                                          "information");
+        ROS_ERROR_STREAM_NAMED("manager", "Caught unknown exception while parsing controller information");
       }
     }
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -481,8 +481,8 @@ public:
         }
         else
         {
-          logError("Unable to transform from frame '%s' to frame '%s'", frame.c_str(),
-                   getRobotModel()->getModelFrame().c_str());
+          ROS_ERROR_NAMED("Unable to transform from frame '%s' to frame '%s'", frame.c_str(),
+                          getRobotModel()->getModelFrame().c_str());
           return false;
         }
       }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -288,14 +288,14 @@ public:
     {
       if (execute_service_.exists())
       {
-        ROS_WARN_NAMED("planning_interface",
+        ROS_WARN_NAMED("move_group_interface",
                        "\nDeprecation warning: Trajectory execution service is deprecated (was replaced by an action)."
                        "\nReplace 'MoveGroupExecuteService' with 'MoveGroupExecuteTrajectoryAction' in "
                        "move_group.launch");
       }
       else
       {
-        ROS_ERROR_STREAM_NAMED("planning_interface",
+        ROS_ERROR_STREAM_NAMED("move_group_interface",
                                "Unable to find execution action on topic: "
                                    << node_handle_.getNamespace() + move_group::EXECUTE_ACTION_NAME << " or service: "
                                    << node_handle_.getNamespace() + move_group::EXECUTE_SERVICE_NAME);
@@ -481,7 +481,7 @@ public:
         }
         else
         {
-          ROS_ERROR_NAMED("Unable to transform from frame '%s' to frame '%s'", frame.c_str(),
+          ROS_ERROR_NAMED("move_group_interface", "Unable to transform from frame '%s' to frame '%s'", frame.c_str(),
                           getRobotModel()->getModelFrame().c_str());
           return false;
         }


### PR DESCRIPTION
### Description

This pull request is an extended version of #859 and inspired by #860. As suggested by @davetcoleman and @v4hn, I switched to use ROS_LOGGER from CONSOLE_BRIDGE and removed the dependency from some cmake files.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"