### PR TITLE
Can now get the jacobian of a child link of a move group.

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1151,21 +1151,6 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   Eigen::Vector3d joint_axis;
   Eigen::Affine3d joint_transform;
 
-  // Travel up the chain to ensure link is a part of group.
-  const LinkModel* given_link = link;
-  while (not group->hasLinkModel(link->getName()))
-  {
-    link = link->getParentLinkModel();
-    if (not link)
-    {
-      ROS_ERROR_NAMED("robot_state",
-                      "Given link '%s' is a child of the chain, but the chain is never reach when going up.",
-                      given_link->getName().c_str());
-      return false;
-    }
-  }
-  // Link is now guaranteed to be a part of group.
-
   while (link)
   {
     /*
@@ -1180,8 +1165,8 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     {
       if (not group->hasJointModel(pjm->getName()))
       {
-        ROS_ERROR_NAMED("robot_state", "Joint %s is not in the current group.", pjm->getName().c_str());
-        return false;
+        link = pjm->getPalentLinkModel();
+        continue;
       }
       unsigned int joint_index = group->getVariableGroupIndex(pjm->getName());
       if (pjm->getType() == robot_model::JointModel::REVOLUTE)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1165,7 +1165,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     {
       if (not group->hasJointModel(pjm->getName()))
       {
-        link = pjm->getPalentLinkModel();
+        link = pjm->getParentLinkModel();
         continue;
       }
       unsigned int joint_index = group->getVariableGroupIndex(pjm->getName());


### PR DESCRIPTION
### Description

Originally, if you were to try to get the Jacobian of a link that was at the end of a move group, but not a part of that move group (say a point on a gripper link at the end of a UR robot), then MoveIt would complain that this link was not a part of the move group, even though you should be able to find the jacobian for this point.

This change fixes that, and allows you to get the jacobian of any link that is a child of the move group being queried.

Don't quite have the time to make a test for this, considering there aren't any jacobian tests yet.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] ~Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)~
- [x] ~Include a screenshot if changing a GUI~
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
