### PR TITLE
Max eef step

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -102,9 +102,8 @@ struct MaxEEFStep
   {
   }
 
-  explicit MaxEEFStep(double max_translation) : MaxEEFStep()
+  explicit MaxEEFStep(double max_translation) : translation(max_translation), rotation(0.0)
   {
-    translation = max_translation;
   }
 
   explicit MaxEEFStep(double max_translation, double max_rotation)

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -66,13 +66,13 @@ typedef boost::function<bool(RobotState* robot_state, const JointModelGroup* joi
 /** \brief Struct for containing jump_threshold.
 
     For the purposes of maintaining API, we support both \e jump_threshold_factor which provides a scaling factor for
-    detecting joint space jumps and \e prismatic_jump_threshold and \e revolute_jump_threshold which provide abolute
+    detecting joint space jumps and \e revolute_jump_threshold and \e prismatic_jump_threshold which provide abolute
     thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
   double factor;
-  double revolute;
-  double prismatic;
+  double revolute;   // Radians
+  double prismatic;  // Meters
 
   explicit JumpThreshold() : factor(0.0), revolute(0.0), prismatic(0.0)
   {
@@ -85,8 +85,31 @@ struct JumpThreshold
 
   explicit JumpThreshold(double jt_revolute, double jt_prismatic) : JumpThreshold()
   {
-    revolute = jt_revolute;
-    prismatic = jt_prismatic;
+    revolute = jt_revolute;    // Radians
+    prismatic = jt_prismatic;  // Meters
+  }
+};
+
+/** \brief Struct for containing max_step for computeCartesianPath
+
+    Setting translation to zero will disable checking for translations and the same goes for rotation */
+struct MaxEEFStep
+{
+  double translation;  // Meters
+  double rotation;     // Radians
+
+  explicit MaxEEFStep() : translation(0.0), rotation(0.0)
+  {
+  }
+
+  explicit MaxEEFStep(double max_translation) : MaxEEFStep()
+  {
+    translation = max_translation;
+  }
+
+  explicit MaxEEFStep(double max_translation, double max_rotation)
+    : translation(max_translation), rotation(max_rotation)
+  {
   }
 };
 
@@ -1049,9 +1072,9 @@ as the new values that correspond to the group */
                           const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
-  /** \brief Set the joint values from a cartesian velocity applied during a time dt
+  /** \brief Set the joint values from a Cartesian velocity applied during a time dt
    * @param group the group of joints this function operates on
-   * @param twist a cartesian velocity on the 'tip' frame
+   * @param twist a Cartesian velocity on the 'tip' frame
    * @param tip the frame for which the twist is given
    * @param dt a time interval (seconds)
    * @param st a secondary task computation function
@@ -1059,9 +1082,9 @@ as the new values that correspond to the group */
   bool setFromDiffIK(const JointModelGroup* group, const Eigen::VectorXd& twist, const std::string& tip, double dt,
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn());
 
-  /** \brief Set the joint values from a cartesian velocity applied during a time dt
+  /** \brief Set the joint values from a Cartesian velocity applied during a time dt
    * @param group the group of joints this function operates on
-   * @param twist a cartesian velocity on the 'tip' frame
+   * @param twist a Cartesian velocity on the 'tip' frame
    * @param tip the frame for which the twist is given
    * @param dt a time interval (seconds)
    * @param st a secondary task computation function
@@ -1075,28 +1098,33 @@ as the new values that correspond to the group */
      The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
      of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local
      reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated
-     accordingly. The link needs to move in a straight line, following the specified direction, for the desired
-     \e distance. The resulting joint values are stored in the vector \e traj, one by one.
-     The maximum distance in Cartesian space between consecutive points on the resulting path is specified by
-     \e max_step.
-     If a \e validCallback is specified, this is passed to the internal call to setFromIK(). In case of IK failure,
-     the computation of the path stops and the value returned corresponds to the distance that was computed and for
-     which corresponding states were added to the path.  At the end of the function call, the state of the group
-     corresponds to the last attempted Cartesian pose.
+     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
+     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     Cartesian space between consecutive points on the resulting path is specified in the \e MaxEEFStep struct which
+     provides two fields: translation and rotation. If a \e validCallback is specified, this is passed to the internal
+     call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to
+     the distance that was computed and for which corresponding states were added to the path.  At the end of the
+     function call, the state of the group corresponds to the last attempted Cartesian pose.
+
      During the computation of the trajectory, it is usually preferred if consecutive joint values do not 'jump' by a
      large amount in joint space, even if the Cartesian distance between the corresponding points is small as expected.
      To account for this, the \e jump_threshold struct is provided, which comprises three fields:
-     \e jump_threshold_factor, \e prismatic_jump_threshold and \e revolute_jump_threshold.
-     If \e prismatic_jump_threshold or \e revolute_jump_threshold are non-zero, we test for absolute jumps.
+     \e jump_threshold_factor, \e revolute_jump_threshold and \e prismatic_jump_threshold.
+     If either \e revolute_jump_threshold or \e prismatic_jump_threshold  are non-zero, we test for absolute jumps.
      If \e jump_threshold_factor is non-zero, we test for relative jumps. Otherwise (all params are zero), jump
      detection is disabled.
+
      For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
      computed. If any individual joint-space motion delta is larger then this average distance by a factor of
      \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
-     before the jump. */
+     before the jump.
+
+     For absolute jump thresholds, if any individual joint-space motion delta is larger then \e revolute_jump_threshold
+     for revolute joints or \e prismatic_jump_threshold for prismatic joints then this step is considered a failure and
+     the returned path is truncated up to just before the jump.*/
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
                               const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
-                              double max_step, const JumpThreshold& jump_threshold,
+                              const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -1106,8 +1134,9 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance, max_step,
-                                JumpThreshold(jump_threshold_factor), validCallback, options);
+    return computeCartesianPath(group, traj, link, direction, global_reference_frame, distance,
+                                MaxEEFStep(max_step, max_step), JumpThreshold(jump_threshold_factor), validCallback,
+                                options);
   }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
@@ -1115,10 +1144,9 @@ as the new values that correspond to the group */
      In contrast to the previous function, the Cartesian path is specified as a target frame to be reached (\e target)
      for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or
      in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is
-     rotated accordingly.
-     All other comments from the previous function apply. */
+     rotated accordingly. All other comments from the previous function apply. */
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
-                              const Eigen::Affine3d& target, bool global_reference_frame, double max_step,
+                              const Eigen::Affine3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
                               const JumpThreshold& jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
@@ -1129,7 +1157,7 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, target, global_reference_frame, max_step,
+    return computeCartesianPath(group, traj, link, target, global_reference_frame, MaxEEFStep(max_step),
                                 JumpThreshold(jump_threshold_factor), validCallback, options);
   }
 
@@ -1140,8 +1168,8 @@ as the new values that correspond to the group */
      frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move
      in a straight line between two consecutive waypoints. All other comments apply. */
   double computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
-                              const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame, double max_step,
-                              const JumpThreshold& jump_threshold,
+                              const EigenSTL::vector_Affine3d& waypoints, bool global_reference_frame,
+                              const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -1151,24 +1179,26 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, max_step,
+    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, MaxEEFStep(max_step),
                                 JumpThreshold(jump_threshold_factor), validCallback, options);
   }
 
   /** \brief Tests joint space jumps of a trajectory.
 
      If \e jump_threshold_factor is non-zero, we test for relative jumps.
-     If \e prismatic_jump_threshold or \e revolute_jump_threshold are non-zero, we test for absolute jumps.
+     If \e revolute_jump_threshold  or \e prismatic_jump_threshold are non-zero, we test for absolute jumps.
      Both tests can be combined. If all params are zero, jump detection is disabled.
      For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
      computed. If any individual joint-space motion delta is larger then this average distance by a factor of
      \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
      before the jump.
+
      @param group The joint model group of the robot state.
      @param traj The trajectory that should be tested.
      @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
      @return The fraction of the trajectory that passed.
   */
+
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                    const JumpThreshold& jump_threshold);
 
@@ -1176,6 +1206,7 @@ as the new values that correspond to the group */
 
      First, the average distance between adjacent trajectory points is computed. If two adjacent trajectory points
      have distance > \e jump_threshold_factor * average, the trajectory is truncated at this point.
+
      @param group The joint model group of the robot state.
      @param traj The trajectory that should be tested.
      @param jump_threshold_factor The threshold to determine if a joint space jump has occurred .
@@ -1186,9 +1217,10 @@ as the new values that correspond to the group */
 
   /** \brief Tests for absolute joint space jumps of the trajectory \e traj.
 
-     The joint-space difference between consecutive waypoints is computed for each active joint and compared to
-     the absolute thresholds \e prismatic_jump_threshold for prismatic joints or \e revolute_jump_threshold for
-     revolute joints. If these thresholds are exceeded, the trajectory is truncated.
+     The joint-space difference between consecutive waypoints is computed for each active joint and compared to the
+     absolute thresholds \e revolute_jump_threshold for revolute joints and \e prismatic_jump_threshold for prismatic
+     joints. If these thresholds are exceeded, the trajectory is truncated.
+
      @param group The joint model group of the robot state.
      @param traj The trajectory that should be tested.
      @param revolute_jump_threshold Absolute joint-space threshold for revolute joints.

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1147,7 +1147,7 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, target, global_reference_frame, MaxEEFStep(max_step, max_step),
+    return computeCartesianPath(group, traj, link, target, global_reference_frame, MaxEEFStep(max_step),
                                 JumpThreshold(jump_threshold_factor), validCallback, options);
   }
 
@@ -1169,7 +1169,7 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, MaxEEFStep(max_step, max_step),
+    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, MaxEEFStep(max_step),
                                 JumpThreshold(jump_threshold_factor), validCallback, options);
   }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -95,21 +95,12 @@ struct JumpThreshold
     Setting translation to zero will disable checking for translations and the same goes for rotation */
 struct MaxEEFStep
 {
+  MaxEEFStep(double translation = 0.0, double rotation = 0.0) : translation(translation), rotation(rotation)
+  {
+  }
+
   double translation;  // Meters
   double rotation;     // Radians
-
-  explicit MaxEEFStep() : translation(0.0), rotation(0.0)
-  {
-  }
-
-  explicit MaxEEFStep(double max_translation) : translation(max_translation), rotation(0.0)
-  {
-  }
-
-  explicit MaxEEFStep(double max_translation, double max_rotation)
-    : translation(max_translation), rotation(max_rotation)
-  {
-  }
 };
 
 /** \brief Representation of a robot's state. This includes position,
@@ -1156,7 +1147,7 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, target, global_reference_frame, MaxEEFStep(max_step),
+    return computeCartesianPath(group, traj, link, target, global_reference_frame, MaxEEFStep(max_step, max_step),
                                 JumpThreshold(jump_threshold_factor), validCallback, options);
   }
 
@@ -1178,7 +1169,7 @@ as the new values that correspond to the group */
                               const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
-    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, MaxEEFStep(max_step),
+    return computeCartesianPath(group, traj, link, waypoints, global_reference_frame, MaxEEFStep(max_step, max_step),
                                 JumpThreshold(jump_threshold_factor), validCallback, options);
   }
 
@@ -1197,7 +1188,6 @@ as the new values that correspond to the group */
      @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
      @return The fraction of the trajectory that passed.
   */
-
   static double testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                    const JumpThreshold& jump_threshold);
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -33,7 +33,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman, Mike Lautman */
+/* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman */
 
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/transforms/transforms.h>

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -33,7 +33,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman */
+/* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman, Mike Lautman */
 
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/transforms/transforms.h>
@@ -1866,7 +1866,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                         const LinkModel* link, const Eigen::Vector3d& direction,
-                                        bool global_reference_frame, double distance, double max_step,
+                                        bool global_reference_frame, double distance, const MaxEEFStep& max_step,
                                         const JumpThreshold& jump_threshold,
                                         const GroupStateValidityCallbackFn& validCallback,
                                         const kinematics::KinematicsQueryOptions& options)
@@ -1888,7 +1888,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                         const LinkModel* link, const Eigen::Affine3d& target,
-                                        bool global_reference_frame, double max_step,
+                                        bool global_reference_frame, const MaxEEFStep& max_step,
                                         const JumpThreshold& jump_threshold,
                                         const GroupStateValidityCallbackFn& validCallback,
                                         const kinematics::KinematicsQueryOptions& options)
@@ -1906,22 +1906,30 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
   Eigen::Quaterniond start_quaternion(start_pose.rotation());
   Eigen::Quaterniond target_quaternion(rotated_target.rotation());
-  double distance = start_quaternion.dot(target_quaternion);
-  if (distance < 0)  // need to bring quaternions to same half sphere?
+
+  if (max_step.translation <= 0.0 && max_step.rotation <= 0.0)
   {
-    target_quaternion.w() = -target_quaternion.w();
-    target_quaternion.x() = -target_quaternion.x();
-    target_quaternion.y() = -target_quaternion.y();
-    target_quaternion.z() = -target_quaternion.z();
+    ROS_ERROR_NAMED("robot_state",
+                    "Invalid MaxEEFStep passed into computeCartesianPath. Both the MaxEEFStep.rotation and "
+                    "MaxEEFStep.translation components must be non-negative and at least one component must be "
+                    "greater than zero");
+    return 0.0;
   }
 
+  double rotation_distance = start_quaternion.angularDistance(target_quaternion);
+  double translation_distance = (rotated_target.translation() - start_pose.translation()).norm();
+
   // decide how many steps we will need for this trajectory
-  // TODO: use separate max_step arguments for translational and rotational motion
-  distance = std::max((rotated_target.translation() - start_pose.translation()).norm(),
-                      std::acos(start_quaternion.dot(target_quaternion)));
+  std::size_t translation_steps = 0;
+  if (max_step.translation > 0.0)
+    translation_steps = floor(translation_distance / max_step.translation);
+
+  std::size_t rotation_steps = 0;
+  if (max_step.rotation > 0.0)
+    rotation_steps = floor(rotation_distance / max_step.rotation);
 
   // If we are testing for relative jumps, we always want at least MIN_STEPS_FOR_JUMP_THRESH steps
-  unsigned int steps = floor(distance / max_step) + 1;
+  std::size_t steps = std::max(translation_steps, rotation_steps) + 1;
   if (jump_threshold.factor > 0 && steps < MIN_STEPS_FOR_JUMP_THRESH)
     steps = MIN_STEPS_FOR_JUMP_THRESH;
 
@@ -1929,7 +1937,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
   traj.push_back(RobotStatePtr(new RobotState(*this)));
 
   double last_valid_percentage = 0.0;
-  for (unsigned int i = 1; i <= steps; ++i)
+  for (std::size_t i = 1; i <= steps; ++i)
   {
     double percentage = (double)i / (double)steps;
 
@@ -1937,11 +1945,10 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
     pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
 
     if (setFromIK(group, pose, link->getName(), 1, 0.0, validCallback, options))
-    {
       traj.push_back(RobotStatePtr(new RobotState(*this)));
-    }
     else
       break;
+
     last_valid_percentage = percentage;
   }
 
@@ -1952,7 +1959,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
 double RobotState::computeCartesianPath(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                         const LinkModel* link, const EigenSTL::vector_Affine3d& waypoints,
-                                        bool global_reference_frame, double max_step,
+                                        bool global_reference_frame, const MaxEEFStep& max_step,
                                         const JumpThreshold& jump_threshold,
                                         const GroupStateValidityCallbackFn& validCallback,
                                         const kinematics::KinematicsQueryOptions& options)
@@ -1961,7 +1968,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
   for (std::size_t i = 0; i < waypoints.size(); ++i)
   {
     // Don't test joint space jumps for every waypoint, test them later on the whole trajectory.
-    static const double no_joint_space_jump_test = 0.0;
+    static const JumpThreshold no_joint_space_jump_test;
     std::vector<RobotStatePtr> waypoint_traj;
     double wp_percentage_solved = computeCartesianPath(group, waypoint_traj, link, waypoints[i], global_reference_frame,
                                                        max_step, no_joint_space_jump_test, validCallback, options);
@@ -1992,13 +1999,17 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 double RobotState::testJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
                                       const JumpThreshold& jump_threshold)
 {
-  if (jump_threshold.factor > 0.0 && traj.size() > 1)
-    return testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
+  double percentage_solved = 1.0;
+  if (traj.size() <= 1)
+    return percentage_solved;
 
-  if (jump_threshold.prismatic > 0.0 || jump_threshold.revolute > 0.0)
-    return testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+  if (jump_threshold.factor > 0.0)
+    percentage_solved *= testRelativeJointSpaceJump(group, traj, jump_threshold.factor);
 
-  return 1.0;
+  if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
+    percentage_solved *= testAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+
+  return percentage_solved;
 }
 
 double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std::vector<RobotStatePtr>& traj,
@@ -2082,9 +2093,9 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
 
     if (!still_valid)
     {
-      double percentage = (double)(traj_ix + 1) / (double)(traj.size());
+      double percent_valid = (double)(traj_ix + 1) / (double)(traj.size());
       traj.resize(traj_ix + 1);
-      return percentage;
+      return percent_valid;
     }
   }
   return 1.0;

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -640,10 +640,8 @@ TEST_F(OneRobot, testAbsoluteJointSpaceJump)
 
   // Pre-compute expected results for tests
   std::size_t full_traj_len = generateTestTraj(traj, robot_model, joint_model_group);
-  const double expected_revolute_jump_fraction =
-      (double)expected_revolute_jump_traj_len / (double)full_traj_len;
-  const double expected_prismatic_jump_fraction =
-      (double)expected_prismatic_jump_traj_len / (double)full_traj_len;
+  const double expected_revolute_jump_fraction = (double)expected_revolute_jump_traj_len / (double)full_traj_len;
+  const double expected_prismatic_jump_fraction = (double)expected_prismatic_jump_traj_len / (double)full_traj_len;
 
   // Container for results
   double fraction;
@@ -688,8 +686,7 @@ TEST_F(OneRobot, testRelativeJointSpaceJump)
 
   // Pre-compute expected results for tests
   std::size_t full_traj_len = generateTestTraj(traj, robot_model, joint_model_group);
-  const double expected_relative_jump_fraction =
-      (double)expected_relative_jump_traj_len / (double)full_traj_len;
+  const double expected_relative_jump_fraction = (double)expected_relative_jump_traj_len / (double)full_traj_len;
 
   // Container for results
   double fraction;


### PR DESCRIPTION
### Description

These are the max_eef step changes from #844 I am separating the changes into 2 pr's. This one has everything except the additional Cartesian space jump tests, Changes include: the  MaxEEFStep parameter, minor changes to the tests to make them more comprehensive (and pass), and some minor fixes to comments and parameter names. 

@davetcoleman 
@rhaschke 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
