### PR TITLE
Fix allocator type to pass GCC8 static assert.

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/link_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/link_model.h
@@ -65,7 +65,7 @@ typedef std::map<std::string, const LinkModel*> LinkModelMapConst;
 
 /** \brief Map from link model instances to Eigen transforms */
 typedef std::map<const LinkModel*, Eigen::Affine3d, std::less<const LinkModel*>,
-                 Eigen::aligned_allocator<std::pair<const LinkModel*, Eigen::Affine3d> > >
+                 Eigen::aligned_allocator<std::pair<const LinkModel* const, Eigen::Affine3d> > >
     LinkTransformMap;
 
 /** \brief A link from the robot. Contains the constant transform applied to the link and its geometry */


### PR DESCRIPTION
GCC8 now comes with a static assert that checks that the value type of an `std::map` and it's allocator are the same. The value type of a map is `std::pair<Key const, Value>`.

In this particular case, the key type of the map is `LinkModel const *`, so the value type is `std::pair<LinkModel const * const, Eigen::Affine3d>`, not `std::pair<LinkModel const *, Eigen::Affine3d>`.

Without this PR, compiling moveit-core with GCC8 results in this error:
```
In file included from /usr/include/c++/8.1.0/map:61,
                 from /opt/ros/lunar/include/geometry_msgs/PoseStamped.h:11,
                 from /build/ros-lunar-moveit-core/src/moveit-release-release-lunar-moveit_core-0.9.11-0/kinematics_base/include/moveit/kinematics_base/kinematics_base.h:40,
                 from /build/ros-lunar-moveit-core/src/moveit-release-release-lunar-moveit_core-0.9.11-0/kinematics_base/src/kinematics_base.cpp:37:
/usr/include/c++/8.1.0/bits/stl_map.h: In instantiation of ‘class std::map<const moveit::core::LinkModel*, Eigen::Transform<double, 3, 2>, std::less<const moveit::core::LinkModel*>, Eigen::aligned_allocator<std::pair<const moveit::core::LinkModel*, Eigen::Transform<double, 3, 2> > > >’:
/build/ros-lunar-moveit-core/src/moveit-release-release-lunar-moveit_core-0.9.11-0/robot_model/include/moveit/robot_model/link_model.h:251:20:   required from here
/usr/include/c++/8.1.0/bits/stl_map.h:122:21: error: static assertion failed: std::map must have the same value_type as its allocator
       static_assert(is_same<typename _Alloc::value_type, value_type>::value,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

With this PR, it should compile again.