### PR TITLE
Replace createUnmanagedInstance with createUniqueInstance

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -134,10 +134,10 @@ private:
       try
       {
         printf(MOVEIT_CONSOLE_COLOR_CYAN "Loading '%s'...\n" MOVEIT_CONSOLE_COLOR_RESET, plugin->c_str());
-        MoveGroupCapability* cap = capability_plugin_loader_->createUnmanagedInstance(*plugin);
+        MoveGroupCapabilityPtr cap = capability_plugin_loader_->createUniqueInstance(*plugin);
         cap->setContext(context_);
         cap->initialize();
-        capabilities_.push_back(MoveGroupCapabilityPtr(cap));
+        capabilities_.push_back(cap);
       }
       catch (pluginlib::PluginlibException& ex)
       {

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -128,7 +128,7 @@ void OccupancyMapMonitor::initialize()
           OccupancyMapUpdaterPtr up;
           try
           {
-            up.reset(updater_plugin_loader_->createUnmanagedInstance(sensor_plugin));
+            up = updater_plugin_loader_->createUniqueInstance(sensor_plugin);
             up->setMonitor(this);
           }
           catch (pluginlib::PluginlibException& ex)

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -58,7 +58,7 @@ public:
     CollisionPluginPtr plugin;
     try
     {
-      plugin.reset(loader_->createUnmanagedInstance(name));
+      plugin = loader_->createUniqueInstance(name);
       plugins_[name] = plugin;
     }
     catch (pluginlib::PluginlibException& ex)

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -67,9 +67,9 @@ public:
       {
         try
         {
-          constraint_samplers::ConstraintSamplerAllocator* csa =
-              constraint_sampler_plugin_loader_->createUnmanagedInstance(*beg);
-          csm->registerSamplerAllocator(constraint_samplers::ConstraintSamplerAllocatorPtr(csa));
+          constraint_samplers::ConstraintSamplerAllocatorPtr csa =
+              constraint_sampler_plugin_loader_->createUniqueInstance(*beg);
+          csm->registerSamplerAllocator(csa);
           ROS_INFO("Loaded constraint sampling plugin %s", std::string(*beg).c_str());
         }
         catch (pluginlib::PluginlibException& ex)

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -113,7 +113,7 @@ void planning_pipeline::PlanningPipeline::configure()
   }
   try
   {
-    planner_instance_.reset(planner_plugin_loader_->createUnmanagedInstance(planner_plugin_name_));
+    planner_instance_ = planner_plugin_loader_->createUniqueInstance(planner_plugin_name_);
     if (!planner_instance_->initialize(kmodel_, nh_.getNamespace()))
       throw std::runtime_error("Unable to initialize planning plugin");
     ROS_INFO_STREAM("Using planning interface '" << planner_instance_->getDescription() << "'");
@@ -145,7 +145,7 @@ void planning_pipeline::PlanningPipeline::configure()
         planning_request_adapter::PlanningRequestAdapterConstPtr ad;
         try
         {
-          ad.reset(adapter_plugin_loader_->createUnmanagedInstance(adapter_plugin_names_[i]));
+          ad = adapter_plugin_loader_->createUniqueInstance(adapter_plugin_names_[i]);
         }
         catch (pluginlib::PluginlibException& ex)
         {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
     planning_request_adapter::PlanningRequestAdapterConstPtr ad;
     try
     {
-      ad.reset(loader->createUnmanagedInstance(classes[i]));
+      ad = loader->createUniqueInstance(classes[i]);
     }
     catch (pluginlib::PluginlibException& ex)
     {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -163,7 +163,7 @@ void TrajectoryExecutionManager::initialize()
     if (!controller.empty())
       try
       {
-        controller_manager_.reset(controller_manager_loader_->createUnmanagedInstance(controller));
+        controller_manager_ = controller_manager_loader_->createUniqueInstance(controller);
       }
       catch (pluginlib::PluginlibException& ex)
       {


### PR DESCRIPTION
### Description

Small refactor eliminating use of raw pointers from pluginlib. 
Fixes #866
Although the API mentioned there hasn't been propagated to pluginlib yet, hence the use of `createUniqueInstance()` instead of `createSharedInstance()` but regardless, `std::unique_ptr` converts to `std::shared_ptr`.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
