### PR TITLE
Remove boost shared ptrs

### DIFF
--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
@@ -42,7 +42,7 @@
 #include <planning_models/robot_model.h>
 #include <planning_models/kinematic_state.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace kinematics_cache
 {
@@ -174,7 +174,7 @@ private:
 
   const planning_models::RobotModel::JointModelGroup* joint_model_group_; /** Joint model group associated with this
                                                                              cache */
-  boost::shared_ptr<planning_models::RobotState* ::JointStateGroup> joint_state_group_; /** Joint state corresponding
+  std::shared_ptr<planning_models::RobotState* ::JointStateGroup> joint_state_group_; /** Joint state corresponding
                                                                                            to cache */
 
   //    mutable std::vector<double> solution_local_; /** Local pre-allocated storage */
@@ -182,7 +182,7 @@ private:
   double min_squared_distance_, max_squared_distance_;
 };
 
-typedef boost::shared_ptr<KinematicsCache> KinematicsCachePtr;
+typedef std::shared_ptr<KinematicsCache> KinematicsCachePtr;
 }
 
 #endif

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/include/kinematics_cache_ros/kinematics_cache_ros.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/include/kinematics_cache_ros/kinematics_cache_ros.h
@@ -63,8 +63,9 @@ public:
 private:
   kinematics::KinematicsBase* kinematics_solver_; /** An instance of a kinematics solver needed by this class */
 
-  boost::shared_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> >
-      kinematics_loader_; /** A loader needed to load the instance of a kinematics solver */
+  std::shared_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> > kinematics_loader_; /** A loader needed to load
+                                                                                              the instance of a
+                                                                                              kinematics solver */
 
   planning_models::RobotModelPtr kinematic_model_; /** A kinematics model */
 };

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/src/kinematics_cache_ros.cpp
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/src/kinematics_cache_ros.cpp
@@ -37,9 +37,6 @@
 
 #include <kinematics_cache_ros/kinematics_cache_ros.h>
 
-// ROS
-#include <boost/shared_ptr.hpp>
-
 // MoveIt!
 #include <planning_models/kinematic_state.h>
 #include <rdf_loader/rdf_loader.h>

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
@@ -42,8 +42,6 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 
-#include <boost/shared_ptr.hpp>
-
 namespace kinematics_cache
 {
 class KinematicsCache
@@ -172,15 +170,15 @@ private:
   robot_model::RobotModelConstPtr kinematic_model_; /** An instance of the kinematic model */
   robot_state::RobotStatePtr kinematic_state_;      /** An instance of the kinematic state */
 
-  const robot_model::JointModelGroup* joint_model_group_; /** Joint model group associated with this cache */
-  boost::shared_ptr<robot_state::JointStateGroup> joint_state_group_; /** Joint state corresponding to cache */
+  const robot_model::JointModelGroup* joint_model_group_;           /** Joint model group associated with this cache */
+  std::shared_ptr<robot_state::JointStateGroup> joint_state_group_; /** Joint state corresponding to cache */
 
   //    mutable std::vector<double> solution_local_; /** Local pre-allocated storage */
 
   double min_squared_distance_, max_squared_distance_;
 };
 
-typedef boost::shared_ptr<KinematicsCache> KinematicsCachePtr;
+typedef std::shared_ptr<KinematicsCache> KinematicsCachePtr;
 }
 
 #endif

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
@@ -39,7 +39,6 @@
 #define MOVEIT_KINEMATICS_CONSTRAINT_AWARE_
 
 // System
-#include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 
 // ROS msgs
@@ -62,8 +61,8 @@
 namespace kinematics_constraint_aware
 {
 class KinematicsConstraintAware;
-typedef boost::shared_ptr<KinematicsConstraintAware> KinematicsConstraintAwarePtr;
-typedef boost::shared_ptr<const KinematicsConstraintAware> KinematicsConstraintAwareConstPtr;
+typedef std::shared_ptr<KinematicsConstraintAware> KinematicsConstraintAwarePtr;
+typedef std::shared_ptr<const KinematicsConstraintAware> KinematicsConstraintAwareConstPtr;
 
 /**
  * @class A kinematics solver that can be used with multiple arms

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_request_response.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_request_response.h
@@ -38,9 +38,6 @@
 #ifndef MOVEIT_KINEMATICS_CONSTRAINT_AWARE_KINEMATICS_REQUEST_RESPONSE_
 #define MOVEIT_KINEMATICS_CONSTRAINT_AWARE_KINEMATICS_REQUEST_RESPONSE_
 
-// System
-#include <boost/shared_ptr.hpp>
-
 // ROS msgs
 #include <geometry_msgs/PoseStamped.h>
 

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -40,7 +40,6 @@
 #include <string>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_ptr.hpp>
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/mesh_filter/mesh_filter_base.h>

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -471,7 +471,7 @@ void InteractionHandler::setRobotInteraction(RobotInteraction* robot_interaction
 
   // from now on the InteractionHandler shares the same KinematicOptionsMap
   // with RobotInteraction.
-  // The old *kinematic_options_map_ is automatically deleted by boost::shared_ptr.
+  // The old *kinematic_options_map_ is automatically deleted by std::shared_ptr.
   //
   // This is a nop if a constructor with a robot_interaction parameter is used.
   kinematic_options_map_ = shared_kinematic_options_map;


### PR DESCRIPTION
### Description

I've removed all actively used occurences of `boost::shared_ptr`.

~~It seems that the issue that kept us using it was the rviz API for fetching the tf listener. I have solved it by adding a conversion function (in separate commit) although it is questionable if we should stick to this rviz API at all. The [updated API](https://github.com/ros-visualization/rviz/blob/melodic-devel/src/rviz/frame_manager.h#L243) works with `tf2`. I think we should use that but it implies further refactoring of the `PlanningSceneMonitor` and everything related (which is pretty much everything else in MoveIt).~~

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
