### PR TITLE
removing moveit_tutorials from moveit.rosinstall

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -17,10 +17,6 @@
     uri: https://github.com/ros-planning/moveit_visual_tools.git
     version: melodic-devel
 - git:
-    local-name: moveit_tutorials
-    uri: https://github.com/ros-planning/moveit_tutorials.git
-    version: kinetic-devel
-- git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
     version: melodic-devel


### PR DESCRIPTION
This partially reverts 068dcc0b82e512c7405cfa51009652516ccc9b2b, which added the tutorials just recently. However, as the tutorials package is
broken, the main repo fails to build in Travis too now.