### PR TITLE
Cleanup + Fixes to Dockerfiles for Melodic

### DIFF
--- a/.docker/ci-shadow-fixed/Dockerfile
+++ b/.docker/ci-shadow-fixed/Dockerfile
@@ -1,79 +1,15 @@
 # moveit/moveit:melodic-ci-shadow-fixed
 # Sets up a base image to use for running Continuous Integration on Travis
 
-FROM ubuntu:18.04
+FROM moveit/moveit:melodic-ci
 MAINTAINER Dave Coleman dave@picknik.ai
 
-# TODO(davetcoleman): depend on ros:melodic-ros-base once OSRF makes
-# this available (currently melodic is not released yet)
-# https://github.com/osrf/docker_images/issues/134
+# Switch to ros-shadow-fixed
+RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list
 
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    dirmngr \
-    gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+# Upgrade packages to ros-shadow-fixed and clean apt-cache within one command
+RUN apt-get -qq update && \
+	apt-get -qq dist-upgrade && \
 
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
-
-# setup sources.list with shadow-fixed
-RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
-
-# hack to fix issue with tzdata install
-# https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN=true
-
-# install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
-
-# setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-# bootstrap rosdep
-RUN rosdep init \
-    && rosdep update
-
-ENV ROS_DISTRO melodic
-ENV TERM xterm
-
-# Setup catkin workspace
-ENV CATKIN_WS=/root/ws_moveit
-RUN mkdir -p $CATKIN_WS/src
-WORKDIR $CATKIN_WS/src
-
-# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
-RUN wstool init . && \
-    # Download moveit source so that we can get necessary dependencies
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
-    wstool update && \
-    # Update apt-get because previous images clear this cache
-    apt-get -qq update && \
-    # Temp hack, see https://github.com/ros/ros_comm/issues/904
-    #apt-get -qq remove -y ros-${ROS_DISTRO}-rostest && \
-    # Do a dist-upgrade to ensure our CI is building on top of the latest version of packages
-    apt-get -qq dist-upgrade && \
-    # Install some base dependencies
-    apt-get -qq install -y \
-        # Some source builds require a package.xml be downloaded via wget from an external location
-        wget \
-        # Required for rosdep command
-        sudo \
-        # Preferred build tool
-        python-catkin-tools && \
-    # Download all dependencies of MoveIt!
-    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
-    # Remove the source code from this container. TODO: in the future we may want to keep this here for further optimization of later containers
-    cd .. && \
-    rm -rf src/ && \
-    # Clear apt-cache to reduce image size
-    rm -rf /var/lib/apt/lists/*
-
-# Continous Integration Setting
-ENV IN_DOCKER 1
+	# Clear apt-cache to reduce image size
+	rm -rf /var/lib/apt/lists/*

--- a/.docker/ci-shadow-fixed/Dockerfile
+++ b/.docker/ci-shadow-fixed/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Dave Coleman dave@picknik.ai
 # Switch to ros-shadow-fixed
 RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list
 
-# Upgrade packages to ros-shadow-fixed and clean apt-cache within one command
+# Upgrade packages to ros-shadow-fixed and clean apt-cache within one RUN command
 RUN apt-get -qq update && \
 	apt-get -qq dist-upgrade && \
 

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -1,75 +1,49 @@
 # moveit/moveit:melodic-ci
 # Sets up a base image to use for running Continuous Integration on Travis
 
-FROM ubuntu:18.04
+FROM ros:melodic-ros-base
 MAINTAINER Dave Coleman dave@picknik.ai
 
-# TODO(davetcoleman): depend on ros:melodic-ros-base once OSRF makes
-# this available (currently melodic is not released yet)
-# https://github.com/osrf/docker_images/issues/134
-
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    dirmngr \
-    gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
-
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
-
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
-
-# hack to fix issue with tzdata install
-# https://stackoverflow.com/questions/8671308/non-interactive-method-for-dpkg-reconfigure-tzdata
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN=true
-
-# install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
-
-# setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-# bootstrap rosdep
-RUN rosdep init \
-    && rosdep update
-
-ENV ROS_DISTRO melodic
 ENV TERM xterm
 
 # Setup catkin workspace
 ENV CATKIN_WS=/root/ws_moveit
-RUN mkdir -p $CATKIN_WS/src
-WORKDIR $CATKIN_WS/src
+WORKDIR $CATKIN_WS
 
-# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
-RUN wstool init . && \
-    # Download moveit source so that we can get necessary dependencies
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
-    wstool update && \
-    # Update apt because previous images clear this cache
-    apt-get -qq update && \
-    # Install some base dependencies
-    apt-get -qq install -y \
-        # Some source builds require a package.xml be downloaded via wget from an external location
-        wget \
-        # Required for rosdep command
-        sudo \
-        # Preferred build tool
-        python-catkin-tools && \
-    # Download all dependencies of MoveIt!
-    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
-    # Remove the source code from this container. TODO: in the future we may want to keep this here for further optimization of later containers
-    cd .. && \
-    rm -rf src/ && \
-    # Clear apt-cache to reduce image size
-    rm -rf /var/lib/apt/lists/*
+# Perform a single RUN command only to optimize docker performance (reduce no. of layers)
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
+RUN \
+	mkdir src && \
+	cd src && \
+
+	# Download moveit source so that we can get necessary dependencies
+	wstool init . && \
+	wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+	wstool update && \
+
+	# Update apt package list as previous containers clear the cache
+	apt-get -qq update && \
+	apt-get -qq dist-upgrade && \
+
+	# Install some base dependencies
+	apt-get -qq install -y \
+		# Some source builds require a package.xml be downloaded via wget from an external location
+		wget \
+		# Required for rosdep command
+		sudo \
+		# Preferred build tools
+		python-catkin-tools \
+		ccache && \
+        
+	rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+
+	# Remove the source code from this container
+	# TODO: in the future we may want to keep this here for further optimization of later containers
+	cd .. && \
+	rm -rf src/ && \
+
+	# Clear apt-cache to reduce image size
+	rm -rf /var/lib/apt/lists/*
 
 # Continous Integration Setting
 ENV IN_DOCKER 1

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -10,7 +10,7 @@ ENV TERM xterm
 ENV CATKIN_WS=/root/ws_moveit
 WORKDIR $CATKIN_WS
 
-# Perform a single RUN command only to optimize docker performance (reduce no. of layers)
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 RUN \
 	mkdir src && \
@@ -34,7 +34,9 @@ RUN \
 		# Preferred build tools
 		python-catkin-tools \
 		ccache && \
-        
+
+	# Download all dependencies of MoveIt!
+	rosdep update && \
 	rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
 
 	# Remove the source code from this container

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -4,7 +4,7 @@
 FROM ros:melodic-ros-base
 MAINTAINER Dave Coleman dave@picknik.ai
 
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 RUN apt-get update && \
 	apt-get install -y ros-${ROS_DISTRO}-moveit-* && \
-
 	rm -rf /var/lib/apt/lists/*

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -1,11 +1,10 @@
 # moveit/moveit:melodic-release
 # Full debian-based install of MoveIt! using apt-get
 
-FROM moveit/moveit:melodic-ci
+FROM ros:melodic-ros-base
 MAINTAINER Dave Coleman dave@picknik.ai
 
-# Commands are combined in single RUN statement with "lists" folder removal to reduce image size
 RUN apt-get update && \
-    apt-get install -y \
-        ros-${ROS_DISTRO}-moveit-* && \
-    rm -rf /var/lib/apt/lists/*
+	apt-get install -y ros-${ROS_DISTRO}-moveit-* && \
+
+	rm -rf /var/lib/apt/lists/*

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Dave Coleman dave@picknik.ai
 
 ENV PYTHONIOENCODING UTF-8
 
-# Perform a single RUN command only to optimize docker performance (reduce no. of layers)
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 RUN \
 	mkdir src && \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,35 +4,31 @@
 FROM moveit/moveit:melodic-ci-shadow-fixed
 MAINTAINER Dave Coleman dave@picknik.ai
 
-ENV CATKIN_WS=/root/ws_moveit
-RUN mkdir -p $CATKIN_WS/src
-WORKDIR $CATKIN_WS/src
+ENV PYTHONIOENCODING UTF-8
 
-# Download moveit source
-RUN wstool init . && \
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
-    wstool update
+# Perform a single RUN command only to optimize docker performance (reduce no. of layers)
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
+RUN \
+	mkdir src && \
+	cd src && \
 
-# Update apt-get because osrf image clears this cache. download deps
-# Note that because we're building on top of melodic-ci, there should not be any deps installed
-# unless something has changed in the source code since the other container was made
-# (they are triggered together so should only be one-build out of sync)
-RUN apt-get -qq update && \
-    apt-get -qq install -y \
-        wget && \
+	# Download moveit source so that we can get necessary dependencies
+	wstool init . && \
+	wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+	wstool update && \
+
+	# Update apt package list as cache is cleared in previous container
+	# Usually upgrading involves a few packages only (if container builds became out-of-sync)
+	apt-get -qq update && \
+	apt-get -qq dist-upgrade && \
+
     rosdep update && \
-    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
-    rm -rf /var/lib/apt/lists/*
-
-# Replacing shell with bash for later docker build commands
-RUN mv /bin/sh /bin/sh-old && \
-    ln -s /bin/bash /bin/sh
+	rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+	rm -rf /var/lib/apt/lists/*
 
 # Build repo
-WORKDIR $CATKIN_WS
-ENV TERM xterm
-ENV PYTHONIOENCODING UTF-8
 RUN catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
-    # Status rate is limited so that just enough info is shown to keep Docker from timing out, but not too much
-    # such that the Docker log gets too long (another form of timeout)
-    catkin build --jobs 1 --limit-status-rate 0.001 --no-notify
+
+	# Status rate is limited so that just enough info is shown to keep Docker from timing out, but not too much
+	# such that the Docker log gets too long (another form of timeout)
+	catkin build --jobs 1 --limit-status-rate 0.001 --no-notify


### PR DESCRIPTION
This PR comprises several fixes for Melodic:
* First of all, I fixed the Travis build for Melodic, providing appropriate melodic-ci docker images.
  * `ros:melodic-ros-base` docker images are now available. No need for hacks anymore.
  * clang-format-3.8 is only available in Xenial, but not Bionic anymore. Hence this check is run on Xenial/Kinetic. @davetcoleman I'm curious how you can ensure clang-format-3.8 on Bionic as pointed out in https://github.com/ros-planning/moveit_ci/pull/31#issuecomment-385500450.
* The following changes were separated out into #906:
  * Next, I hot-fixed KDL solvers, as Melodic comes with KDL 1.4 and API changes.
  * Finally, we need to explicitly build-depend on Qt and Ogre.

Locally, this setup successfully built all packages, except #901.
After being merged, the docker setting for `melodic-ci-*` should be updated [here](https://hub.docker.com/r/moveit/moveit/~/settings/automated-builds).

There is joint Travis test running for this and #830 [here](https://travis-ci.org/ros-planning/moveit/builds/380463856).