### PR TITLE
Fix multi dof validate trajectory

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -944,7 +944,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
   if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
   {
     ROS_WARN_NAMED(name_, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
-    //return false;
+    return false;
   }
 
   for (const auto& trajectory : context.trajectory_parts_)

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -944,7 +944,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
   if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
   {
     ROS_WARN_NAMED(name_, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
-    return false;
+    //return false;
   }
 
   for (const auto& trajectory : context.trajectory_parts_)
@@ -989,7 +989,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
       // Check multi-dof trajectory
       const std::vector<geometry_msgs::Transform>& transforms =
           trajectory.multi_dof_joint_trajectory.points.front().transforms;
-      const std::vector<std::string>& joint_names = trajectory.joint_trajectory.joint_names;
+      const std::vector<std::string>& joint_names = trajectory.multi_dof_joint_trajectory.joint_names;
       if (transforms.size() != joint_names.size())
       {
         ROS_ERROR_NAMED(name_, "Wrong trajectory: #joints: %zu != #transforms: %zu", joint_names.size(),


### PR DESCRIPTION
### Description
The function TrajectoryExecutionManager::validate was checking the single joint names in the multi dof join case. I just change it to check the correct name. 

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
