### PR TITLE
find_package ompl via upstream cmake config

### DIFF
--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
   )
 
-find_package(OMPL REQUIRED)
+find_package(ompl REQUIRED)
 
 generate_dynamic_reconfigure_options("ompl_interface/cfg/OMPLDynamicReconfigure.cfg")
 


### PR DESCRIPTION
The "OMPL" config was generated by the catkin/bloom infrastructure,
"ompl" is provided by upstream.

Recently, the former fails to work and we discussed
to change to the latter already half a year ago.

For more details see
https://github.com/ros/catkin/issues/938#issuecomment-390285366
https://github.com/ros-planning/moveit/issues/806#issuecomment-390353709
and
https://github.com/ros-planning/moveit/issues/169#issuecomment-353238742

@rhaschke this should resolve the missing cmake config problem you encountered with melodic too.