### PR TITLE
include fixed tfs to siblings in links

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -436,8 +436,9 @@ public:
   void setKinematicsAllocators(const std::map<std::string, SolverAllocatorFn>& allocators);
 
 protected:
-  void computeFixedTransformsBelow(const LinkModel* link, const Eigen::Affine3d& transform,
-                                   LinkTransformMap& associated_transforms);
+  /** \brief Get the transforms between link and all its rigidly attached descendants */
+  void computeFixedTransforms(const LinkModel* link, const Eigen::Affine3d& transform,
+                              LinkTransformMap& associated_transforms);
 
   /** \brief Given two joints, find their common root */
   const JointModel* computeCommonRoot(const JointModel* a, const JointModel* b) const;

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -436,8 +436,8 @@ public:
   void setKinematicsAllocators(const std::map<std::string, SolverAllocatorFn>& allocators);
 
 protected:
-  void computeFixedTransforms(const LinkModel* link, const Eigen::Affine3d& transform,
-                              LinkTransformMap& associated_transforms);
+  void computeFixedTransformsBelow(const LinkModel* link, const Eigen::Affine3d& transform,
+                                   LinkTransformMap& associated_transforms);
 
   /** \brief Given two joints, find their common root */
   const JointModel* computeCommonRoot(const JointModel* a, const JointModel* b) const;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -294,26 +294,21 @@ void RobotModel::buildJointInfo()
   }
 
   bool link_considered[link_model_vector_.size()] = { false };
-  for (std::size_t i = 0; i < link_model_vector_.size(); ++i)
+  for (const LinkModel* link : link_model_vector_)
   {
-    if (link_considered[i])
+    if (link_considered[link->getLinkIndex()])
       continue;
 
     LinkTransformMap associated_transforms;
-    computeFixedTransforms(link_model_vector_[i], link_model_vector_[i]->getJointOriginTransform().inverse(),
-                           associated_transforms);
+    computeFixedTransforms(link, link->getJointOriginTransform().inverse(), associated_transforms);
     for (auto& tf_base : associated_transforms)
     {
       link_considered[tf_base.first->getLinkIndex()] = true;
       for (auto& tf_target : associated_transforms)
       {
         if (&tf_base != &tf_target)
-        {
-          // this const-cast is equivalent to
-          // associated_transforms[tf_base.first->getLinkIndex()]
-          const_cast<LinkModel*>(tf_base.first)
+          const_cast<LinkModel*>(tf_base.first)  // regain write access to base LinkModel*
               ->addAssociatedFixedTransform(tf_target.first, tf_base.second.inverse() * tf_target.second);
-        }
       }
     }
   }

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -300,8 +300,8 @@ void RobotModel::buildJointInfo()
       continue;
 
     LinkTransformMap associated_transforms;
-    computeFixedTransformsBelow(link_model_vector_[i], link_model_vector_[i]->getJointOriginTransform().inverse(),
-                                associated_transforms);
+    computeFixedTransforms(link_model_vector_[i], link_model_vector_[i]->getJointOriginTransform().inverse(),
+                           associated_transforms);
     for (auto& tf_base : associated_transforms)
     {
       link_considered[tf_base.first->getLinkIndex()] = true;
@@ -1397,14 +1397,14 @@ void RobotModel::printModelInfo(std::ostream& out) const
     joint_model_groups_[i]->printGroupInfo(out);
 }
 
-void moveit::core::RobotModel::computeFixedTransformsBelow(const LinkModel* link, const Eigen::Affine3d& transform,
-                                                           LinkTransformMap& associated_transforms)
+void RobotModel::computeFixedTransforms(const LinkModel* link, const Eigen::Affine3d& transform,
+                                        LinkTransformMap& associated_transforms)
 {
   associated_transforms[link] = transform * link->getJointOriginTransform();
   for (std::size_t i = 0; i < link->getChildJointModels().size(); ++i)
     if (link->getChildJointModels()[i]->getType() == JointModel::FIXED)
-      computeFixedTransformsBelow(link->getChildJointModels()[i]->getChildLinkModel(),
-                                  transform * link->getJointOriginTransform(), associated_transforms);
+      computeFixedTransforms(link->getChildJointModels()[i]->getChildLinkModel(),
+                             transform * link->getJointOriginTransform(), associated_transforms);
 }
 
 }  // end of namespace core

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -296,7 +296,7 @@ void RobotModel::buildJointInfo()
   for (std::size_t i = 0; i < link_model_vector_.size(); ++i)
   {
     LinkTransformMap associated_transforms;
-    computeFixedTransforms(link_model_vector_[i], link_model_vector_[i]->getJointOriginTransform().inverse(),
+    computeFixedTransformsBelow(link_model_vector_[i], link_model_vector_[i]->getJointOriginTransform().inverse(),
                            associated_transforms);
     if (associated_transforms.size() > 1)
     {
@@ -1388,14 +1388,14 @@ void RobotModel::printModelInfo(std::ostream& out) const
     joint_model_groups_[i]->printGroupInfo(out);
 }
 
-void RobotModel::computeFixedTransforms(const LinkModel* link, const Eigen::Affine3d& transform,
-                                        LinkTransformMap& associated_transforms)
+void moveit::core::RobotModel::computeFixedTransformsBelow(const LinkModel* link, const Eigen::Affine3d& transform,
+                                                           LinkTransformMap& associated_transforms)
 {
   associated_transforms[link] = transform * link->getJointOriginTransform();
   for (std::size_t i = 0; i < link->getChildJointModels().size(); ++i)
     if (link->getChildJointModels()[i]->getType() == JointModel::FIXED)
-      computeFixedTransforms(link->getChildJointModels()[i]->getChildLinkModel(),
-                             transform * link->getJointOriginTransform(), associated_transforms);
+      computeFixedTransformsBelow(link->getChildJointModels()[i]->getChildLinkModel(),
+                                  transform * link->getJointOriginTransform(), associated_transforms);
 }
 
 }  // end of namespace core


### PR DESCRIPTION
If the robot structure contains y-paths made up of fixed transforms, the
previous implementation missed these associations in the associated_transforms.

The structure

- a - b - c
 \
  - d

only added associationed fixed transforms for a and b to c, but missed d.

I missed to submit this request when I wrote it two months ago
and it just popped up again [here](https://github.com/ros-planning/moveit/pull/877#issuecomment-390494029).