### PR TITLE
OMPL logging that uses rosconsole

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -60,51 +60,53 @@ class OMPLPlannerManager : public planning_interface::PlannerManager
 public:
   OMPLPlannerManager() : planning_interface::PlannerManager(), nh_("~"), display_random_valid_states_(false)
   {
-      class OutputHandler : public ompl::msg::OutputHandler
+    class OutputHandler : public ompl::msg::OutputHandler
+    {
+      const char* format = "[OMPL] %s";
+
+    public:
+      OutputHandler() : ompl::msg::OutputHandler()
       {
-      public:
-          OutputHandler() : ompl::msg::OutputHandler()
-          {
-          }
+      }
 
-          ~OutputHandler() override
-          {
-          }
+      ~OutputHandler() override
+      {
+      }
 
-          void log(const std::string &text, ompl::msg::LogLevel level, const char *filename, int line) override
-          {
-              std::unique_lock<std::mutex> lock(lock_);
-              std::stringstream ss;
-              ss << filename << ":" << line;
+      void log(const std::string& text, ompl::msg::LogLevel level, const char* filename, int line) override
+      {
+        std::unique_lock<std::mutex> lock(lock_);
+        std::stringstream ss;
+        ss << filename << ":" << line;
 
-              switch (level)
-              {
-              case ompl::msg::LOG_DEV2:
-              case ompl::msg::LOG_DEV1:
-              case ompl::msg::LOG_DEBUG:
-                  ROS_DEBUG_NAMED(ss.str().c_str(), "%s", text.c_str());
-                  break;
-              case ompl::msg::LOG_INFO:
-                  ROS_INFO_NAMED(ss.str().c_str(), "%s", text.c_str());
-                  break;
-              case ompl::msg::LOG_WARN:
-                  ROS_WARN_NAMED(ss.str().c_str(), "%s", text.c_str());
-                  break;
-              case ompl::msg::LOG_ERROR:
-                  ROS_ERROR_NAMED(ss.str().c_str(), "%s", text.c_str());
-                  break;
-              case ompl::msg::LOG_NONE:
-              default:
-                  /* ignore */
-                  break;
-              }
-          }
+        switch (level)
+        {
+          case ompl::msg::LOG_DEV2:
+          case ompl::msg::LOG_DEV1:
+          case ompl::msg::LOG_DEBUG:
+            ROS_DEBUG_NAMED(ss.str().c_str(), format, text.c_str());
+            break;
+          case ompl::msg::LOG_INFO:
+            ROS_INFO_NAMED(ss.str().c_str(), format, text.c_str());
+            break;
+          case ompl::msg::LOG_WARN:
+            ROS_WARN_NAMED(ss.str().c_str(), format, text.c_str());
+            break;
+          case ompl::msg::LOG_ERROR:
+            ROS_ERROR_NAMED(ss.str().c_str(), format, text.c_str());
+            break;
+          case ompl::msg::LOG_NONE:
+          default:
+            /* ignore */
+            break;
+        }
+      }
 
-          std::mutex lock_;
-      };
+      std::mutex lock_;
+    };
 
-      output_handler_.reset(new OutputHandler());
-      ompl::msg::useOutputHandler(output_handler_.get());
+    output_handler_.reset(new OutputHandler());
+    ompl::msg::useOutputHandler(output_handler_.get());
   }
 
   virtual bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& ns)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -55,9 +55,9 @@ namespace ompl_interface
 {
 using namespace moveit_planners_ompl;
 
-#define OMPL_ROS_LOG                                                                                                   \
+#define OMPL_ROS_LOG(ros_log_level)                                                                                    \
   {                                                                                                                    \
-    ROSCONSOLE_DEFINE_LOCATION(true, ::ros::console::levels::Debug, ROSCONSOLE_NAME_PREFIX ".ompl");                   \
+    ROSCONSOLE_DEFINE_LOCATION(true, ros_log_level, ROSCONSOLE_NAME_PREFIX ".ompl");                                   \
     if (ROS_UNLIKELY(__rosconsole_define_location__enabled))                                                           \
       ::ros::console::print(0, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_,    \
                             filename, line, __ROSCONSOLE_FUNCTION__, "%s", text.c_str());                              \

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -55,6 +55,14 @@ namespace ompl_interface
 {
 using namespace moveit_planners_ompl;
 
+#define OMPL_ROS_LOG                                                                                                   \
+  {                                                                                                                    \
+    ROSCONSOLE_DEFINE_LOCATION(true, ::ros::console::levels::Debug, ROSCONSOLE_NAME_PREFIX ".ompl");                   \
+    if (ROS_UNLIKELY(__rosconsole_define_location__enabled))                                                           \
+      ::ros::console::print(0, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_,    \
+                            filename, line, __ROSCONSOLE_FUNCTION__, "%s", text.c_str());                              \
+  }
+
 class OMPLPlannerManager : public planning_interface::PlannerManager
 {
 public:
@@ -62,38 +70,24 @@ public:
   {
     class OutputHandler : public ompl::msg::OutputHandler
     {
-      const char* format = "[OMPL] %s";
-
     public:
-      OutputHandler() : ompl::msg::OutputHandler()
-      {
-      }
-
-      ~OutputHandler() override
-      {
-      }
-
       void log(const std::string& text, ompl::msg::LogLevel level, const char* filename, int line) override
       {
-        std::unique_lock<std::mutex> lock(lock_);
-        std::stringstream ss;
-        ss << filename << ":" << line;
-
         switch (level)
         {
           case ompl::msg::LOG_DEV2:
           case ompl::msg::LOG_DEV1:
           case ompl::msg::LOG_DEBUG:
-            ROS_DEBUG_NAMED(ss.str().c_str(), format, text.c_str());
+            OMPL_ROS_LOG(::ros::console::levels::Debug);
             break;
           case ompl::msg::LOG_INFO:
-            ROS_INFO_NAMED(ss.str().c_str(), format, text.c_str());
+            OMPL_ROS_LOG(::ros::console::levels::Info);
             break;
           case ompl::msg::LOG_WARN:
-            ROS_WARN_NAMED(ss.str().c_str(), format, text.c_str());
+            OMPL_ROS_LOG(::ros::console::levels::Warn);
             break;
           case ompl::msg::LOG_ERROR:
-            ROS_ERROR_NAMED(ss.str().c_str(), format, text.c_str());
+            OMPL_ROS_LOG(::ros::console::levels::Error);
             break;
           case ompl::msg::LOG_NONE:
           default:
@@ -101,8 +95,6 @@ public:
             break;
         }
       }
-
-      std::mutex lock_;
     };
 
     output_handler_.reset(new OutputHandler());


### PR DESCRIPTION
### Description

Fixes #719. Adds a custom `ompl::msg::OutputHandler` that uses `rosconsole` to log OMPL messages at the appropriate logging level.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)