### PR TITLE
Fix README example for using moveit_ros_control_interface

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/README.md
+++ b/moveit_plugins/moveit_ros_control_interface/README.md
@@ -19,7 +19,7 @@ Currently plugins for `position_controllers/JointTrajectoryController`, `velocit
 ### Setup
 In your MoveIt! launch file (e.g. `ROBOT_moveit_config/launch/ROBOT_moveit_controller_manager.launch.xml`) set the `moveit_controller_manager` parameter:
 ```
-<arg name="moveit_controller_manager" default="moveit_ros_control_interface::MoveItControllerManager" />
+<param name="moveit_controller_manager" value="moveit_ros_control_interface::MoveItControllerManager" />
 ```
 
 And make sure to set the `ros_control_namespace` parameter to the namespace (without the /controller_manager/ part) of the ros_control-based node you like to interface.
@@ -58,5 +58,5 @@ It spawns `moveit_ros_control_interface::MoveItControllerManager` instances with
 ### Setup
 Just set the `moveit_controller_manager` parameter in your MoveIt! launch file (e.g. `ROBOT_moveit_config/launch/ROBOT_moveit_controller_manager.launch.xml`)
 ```
-<arg name="moveit_controller_manager" default="moveit_ros_control_interface::MoveItMultiControllerManager" />
+<param name="moveit_controller_manager" value="moveit_ros_control_interface::MoveItMultiControllerManager" />
 ```


### PR DESCRIPTION
### Description
The README text says "Just set the `moveit_controller_manager` parameter" but the example uses a `arg` instead of `param`.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
