### PR TITLE
Added check for whitespace in planning group name

### DIFF
--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1106,6 +1106,16 @@ bool PlanningGroupsWidget::saveGroupScreen()
     QMessageBox::warning(this, "Error Saving", "A name must be given for the group!");
     return false;
   }
+   
+   // Check for whitespace in planning group name 
+   for(int i=0; i< group_name.length(); i++)
+   {
+    if (isspace(group_name.at(i)))
+       {
+	      QMessageBox::warning(this, "Error Saving", "Make sure the group name does not use any whitespace anywhere!");
+         return false;
+       }
+    }
 
   // Check if this is an existing group
   if (!current_edit_group_.empty())

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1107,15 +1107,15 @@ bool PlanningGroupsWidget::saveGroupScreen()
     return false;
   }
    
-   // Check for whitespace in planning group name 
-   for(int i=0; i< group_name.length(); i++)
-   {
+  // Check for whitespace in planning group name
+  for (int i = 0; i < group_name.length(); i++)
+  {
     if (isspace(group_name.at(i)))
-       {
-	      QMessageBox::warning(this, "Error Saving", "Make sure the group name does not use any whitespace anywhere!");
-         return false;
-       }
+    {
+      QMessageBox::warning(this, "Error Saving", "Make sure the group name does not use any whitespace anywhere!");
+      return false;
     }
+  }
 
   // Check if this is an existing group
   if (!current_edit_group_.empty())


### PR DESCRIPTION
### Description

When the planning group name has any unintentional whitespace at the start or end, the group name is accepted. However, if we try adding robot poses, it will show the following error message. In this case, the planning group name was manipulator with an added whitespace at the end. 

> Unable to find joint model group for group: manipulator  Are you sure this group has associated joints/links?

I have added a check for any additional whitespace, which reminds the user to not use whitespace in the group name. This similar issue had been raised in a [ROS Answers question](https://answers.ros.org/question/290983/error-in-planning-group-with-moveit-setup-assistant/) as well as [this PR](https://github.com/ros-industrial/industrial_training/pull/199) related to the ROS Industrial training material.

Tested using ROS Kinetic with Ubuntu 16.04.

![Message Box showing warning](https://user-images.githubusercontent.com/21336582/40570100-ea4c238e-60a4-11e8-820f-6d5dbf91e21d.png)

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
