### PR TITLE
MSA: trim group + link names

### DIFF
--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -919,8 +919,8 @@ void PlanningGroupsWidget::saveChainScreen()
   srdf::Model::Group* searched_group = config_data_->findGroupByName(current_edit_group_);
 
   // Get a reference to the supplied strings
-  const std::string& tip = chain_widget_->tip_link_field_->text().toStdString();
-  const std::string& base = chain_widget_->base_link_field_->text().toStdString();
+  const std::string& tip = chain_widget_->tip_link_field_->text().trimmed().toStdString();
+  const std::string& base = chain_widget_->base_link_field_->text().trimmed().toStdString();
 
   // Check that box the tip and base, or neither, have text
   if ((!tip.empty() && base.empty()) || (tip.empty() && !base.empty()))
@@ -1091,7 +1091,7 @@ void PlanningGroupsWidget::saveSubgroupsScreen()
 bool PlanningGroupsWidget::saveGroupScreen()
 {
   // Get a reference to the supplied strings
-  const std::string& group_name = group_edit_widget_->group_name_field_->text().toStdString();
+  const std::string& group_name = group_edit_widget_->group_name_field_->text().trimmed().toStdString();
   const std::string& kinematics_solver = group_edit_widget_->kinematics_solver_field_->currentText().toStdString();
   const std::string& default_planner = group_edit_widget_->default_planner_field_->currentText().toStdString();
   const std::string& kinematics_resolution = group_edit_widget_->kinematics_resolution_field_->text().toStdString();

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -445,8 +445,8 @@ void VirtualJointsWidget::deleteSelected()
 void VirtualJointsWidget::doneEditing()
 {
   // Get a reference to the supplied strings
-  const std::string vjoint_name = vjoint_name_field_->text().toStdString();
-  const std::string parent_name = parent_name_field_->text().toStdString();
+  const std::string vjoint_name = vjoint_name_field_->text().trimmed().toStdString();
+  const std::string parent_name = parent_name_field_->text().trimmed().toStdString();
 
   // Used for editing existing groups
   srdf::Model::VirtualJoint* searched_data = NULL;


### PR DESCRIPTION
As pointed out in #919, leading and/or trailing white space in group names (but also link and joint names) cause issues. The underlying reason is that srdfdom actually [trims those names during parsing](https://github.com/ros-planning/srdfdom/blob/kinetic-devel/src/model.cpp#L106). Hence, MSA should do the same. This PR fixes the most important occurences, but other names probably need trimming too...