### PR TITLE
CSM: copy dynamics to output if enabled

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -102,6 +102,24 @@ void planning_scene_monitor::CurrentStateMonitor::setToCurrentState(robot_state:
   boost::mutex::scoped_lock slock(state_update_lock_);
   const double* pos = robot_state_.getVariablePositions();
   upd.setVariablePositions(pos);
+  if (copy_dynamics_)
+  {
+    if (robot_state_.hasVelocities())
+    {
+      const double* vel = robot_state_.getVariableVelocities();
+      upd.setVariableVelocities(vel);
+    }
+    if (robot_state_.hasAccelerations())
+    {
+      const double* acc = robot_state_.getVariableAccelerations();
+      upd.setVariableAccelerations(acc);
+    }
+    if (robot_state_.hasEffort())
+    {
+      const double* eff = robot_state_.getVariableEffort();
+      upd.setVariableEffort(eff);
+    }
+  }
 }
 
 void planning_scene_monitor::CurrentStateMonitor::addUpdateCallback(const JointStateUpdateCallback& fn)


### PR DESCRIPTION
The monitor optionally kept track of velocities, accelerations & effort too,
but never wrote them to the output variable when asked for the current state...

With this change the monitored planning scene of the move_group node contains current dynamics information too, if enabled.