### PR TITLE
disable waitForCurrentRobotState()

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -53,7 +53,8 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
 {
   ROS_INFO("Received new planning service request...");
   // before we start planning, ensure that we have the latest robot state received...
-  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
+  // for now disable this (see https://github.com/ros-planning/moveit/issues/868)
+  // context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   bool solved = false;


### PR DESCRIPTION
As discussed in maintainer meeting, quick fix for #868.
Later a separate EventQueue and spinner should be used.
@v4hn Please review