### PR TITLE
add minimum required pluginlib version

### DIFF
--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
@@ -43,7 +43,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>moveit_core</build_depend>
 
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -22,13 +22,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
 
   <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
 

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -15,7 +15,7 @@
 
   <depend>roscpp</depend>
   <depend>moveit_core</depend>
-  <depend>pluginlib</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
 
   <build_depend>chomp_motion_planner</build_depend>
   <build_depend>moveit_experimental</build_depend>

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -23,7 +23,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>ompl</run_depend>
@@ -32,7 +32,7 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
 
   <test_depend>moveit_resources</test_depend>
 

--- a/moveit_plugins/moveit_controller_manager_example/package.xml
+++ b/moveit_plugins/moveit_controller_manager_example/package.xml
@@ -17,11 +17,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
 
   <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>roscpp</run_depend>
 
   <export>

--- a/moveit_plugins/moveit_fake_controller_manager/package.xml
+++ b/moveit_plugins/moveit_fake_controller_manager/package.xml
@@ -18,12 +18,12 @@
 
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>roscpp</run_depend>
 
   <export>

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -19,13 +19,13 @@
 
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>control_msgs</build_depend>
   <build_depend>actionlib</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>actionlib</run_depend>
 

--- a/moveit_ros/manipulation/package.xml
+++ b/moveit_ros/manipulation/package.xml
@@ -27,7 +27,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>eigen</build_depend>
 
   <run_depend>actionlib</run_depend>
@@ -39,7 +39,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
 
   <export>
     <moveit_ros_move_group plugin="${prefix}/pick_place_capability_plugin_description.xml"/>

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -21,7 +21,7 @@
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>std_srvs</build_depend>
 
   <run_depend>moveit_core</run_depend>
@@ -29,7 +29,7 @@
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>std_srvs</run_depend>
 
   <test_depend>rostest</test_depend>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -26,7 +26,7 @@
   <build_depend>tf_conversions</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>octomap</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>glut</build_depend>
   <build_depend>libglew-dev</build_depend>
@@ -44,7 +44,7 @@
   <run_depend>tf_conversions</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>octomap</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>glut</run_depend>
   <run_depend>libglew-dev</run_depend>

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -25,7 +25,7 @@
   <build_depend>moveit_ros_planning_interface</build_depend>
   <build_depend>moveit_ros_warehouse</build_depend>
   <build_depend>moveit_ros_robot_interaction</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>interactive_markers</build_depend>
   <build_depend>geometric_shapes</build_depend>
   <build_depend>object_recognition_msgs</build_depend>
@@ -38,7 +38,7 @@
   <run_depend>moveit_ros_planning_interface</run_depend>
   <run_depend>moveit_ros_warehouse</run_depend>
   <run_depend>moveit_ros_robot_interaction</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend>geometric_shapes</run_depend>
   <run_depend>object_recognition_msgs</run_depend>


### PR DESCRIPTION
### Description

Follow-up of https://github.com/ros-planning/moveit/pull/827.

Some people having outdated version of pluginlib cannot compile the latest version of moveit that uses the new pluginlib headers.
Specifying the minimum required version in the package.xml makes the version constraint explicit and partially address the problem of users having mismatching versions.