### PR TITLE
allow optional namespace args

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -175,9 +175,9 @@ public:
 
   bp::dict getRememberedJointValuesPython() const
   {
-    const std::map<std::string, std::vector<double> >& rv = getRememberedJointValues();
+    const std::map<std::string, std::vector<double>>& rv = getRememberedJointValues();
     bp::dict d;
-    for (std::map<std::string, std::vector<double> >::const_iterator it = rv.begin(); it != rv.end(); ++it)
+    for (std::map<std::string, std::vector<double>>::const_iterator it = rv.begin(); it != rv.end(); ++it)
       d[it->first] = py_bindings_tools::listFromDouble(it->second);
     return d;
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -529,7 +529,7 @@ public:
 static void wrap_move_group_interface()
 {
   bp::class_<MoveGroupInterfaceWrapper, boost::noncopyable> MoveGroupInterfaceClass(
-      "MoveGroupInterface", bp::init<std::string, std::string, std::string>());
+      "MoveGroupInterface", bp::init<std::string, std::string, bp::optional<std::string>>());
 
   MoveGroupInterfaceClass.def("async_move", &MoveGroupInterfaceWrapper::asyncMovePython);
   MoveGroupInterfaceClass.def("move", &MoveGroupInterfaceWrapper::movePython);

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -55,7 +55,7 @@ class PlanningSceneInterfaceWrapper : protected py_bindings_tools::ROScppInitial
 {
 public:
   // ROSInitializer is constructed first, and ensures ros::init() was called, if needed
-  PlanningSceneInterfaceWrapper(const std::string& ns)
+  PlanningSceneInterfaceWrapper(const std::string& ns = "")
     : py_bindings_tools::ROScppInitializer(), PlanningSceneInterface(ns)
   {
   }
@@ -114,7 +114,8 @@ public:
 
 static void wrap_planning_scene_interface()
 {
-  bp::class_<PlanningSceneInterfaceWrapper> PlanningSceneClass("PlanningSceneInterface", bp::init<std::string>());
+  bp::class_<PlanningSceneInterfaceWrapper> PlanningSceneClass("PlanningSceneInterface",
+                                                               bp::init<bp::optional<std::string>>());
 
   PlanningSceneClass.def("get_known_object_names", &PlanningSceneInterfaceWrapper::getKnownObjectNamesPython);
   PlanningSceneClass.def("get_known_object_names_in_roi",

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -373,7 +373,7 @@ static void wrap_robot_interface()
 {
   using namespace moveit;
 
-  bp::class_<RobotInterfacePython> RobotClass("RobotInterface", bp::init<std::string, std::string>());
+  bp::class_<RobotInterfacePython> RobotClass("RobotInterface", bp::init<std::string, bp::optional<std::string>>());
 
   RobotClass.def("get_joint_names", &RobotInterfacePython::getJointNames);
   RobotClass.def("get_group_joint_names", &RobotInterfacePython::getGroupJointNames);

--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -348,7 +348,7 @@ class StatusHistory():
 
 class MoveitJoy:
     def parseSRDF(self):
-        ri = RobotInterface("/robot_description", "")
+        ri = RobotInterface("/robot_description")
         planning_groups = {}
         for g in ri.get_group_names():
             self.planning_groups_tips[g] = ri.get_group_joint_tips(g)


### PR DESCRIPTION
This fixes another regression introduced by #835: The newly introduced optional ns args are not declared as optional to python, thus resulting in errors like the following if omitted:

```
Traceback (most recent call last):
  File "/homes/rhaschke/src/ros/src/agni/agni-manipulation/agni_grasp_manager/scripts/grasp_manager.py", line 78, in __init__
    r = RobotInterface("robot_description")
Boost.Python.ArgumentError: Python argument types in
    RobotInterface.__init__(RobotInterface, str)
did not match C++ signature:
    __init__(_object*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
```
