### PR TITLE
fix PS getDiffMsg

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -710,7 +710,10 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
   if (kstate_)
     robot_state::robotStateToRobotStateMsg(*kstate_, scene_msg.robot_state);
   else
+  {
     scene_msg.robot_state = moveit_msgs::RobotState();
+    scene_msg.robot_state.is_diff = true;
+  }
 
   if (acm_)
     acm_->getMessage(scene_msg.allowed_collision_matrix);


### PR DESCRIPTION
The robot state should be marked as diff, otherwise
PlanningScene::isEmpty(RobotState&) will not acknowledge
it as empty.

@rhaschke