### PR TITLE
allow execution of empty trajectories

### DIFF
--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -345,9 +345,6 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
   int prev = -1;
   for (std::size_t i = 0; i < plan.plan_components_.size(); ++i)
   {
-    if (!plan.plan_components_[i].trajectory_ || plan.plan_components_[i].trajectory_->empty())
-      continue;
-
     // \todo should this be in trajectory_execution ? Maybe. Then that will have to use kinematic_trajectory too;
     // spliting trajectories for controllers becomes interesting: tied to groups instead of joints. this could cause
     // some problems
@@ -377,7 +374,8 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
         plan.plan_components_[i].trajectory_->unwind(plan.plan_components_[prev].trajectory_->getLastWayPoint());
     }
 
-    prev = i;
+    if (plan.plan_components_[i].trajectory_ && !plan.plan_components_[i].trajectory_->empty())
+      prev = i;
 
     // convert to message, pass along
     moveit_msgs::RobotTrajectory msg;
@@ -504,12 +502,11 @@ void plan_execution::PlanExecution::successfulTrajectorySegmentExecution(const E
     }
 
   // if there is a next trajectory, check it for validity, before we start execution
-  std::size_t test_index = index;
-  while (++test_index < plan->plan_components_.size())
-    if (plan->plan_components_[test_index].trajectory_ && !plan->plan_components_[test_index].trajectory_->empty())
-    {
-      if (!isRemainingPathValid(*plan, std::make_pair<int>(test_index, 0)))
-        path_became_invalid_ = true;
-      break;
-    }
+  ++index;
+  if (index < plan->plan_components_.size() && plan->plan_components_[index].trajectory_ &&
+      !plan->plan_components_[index].trajectory_->empty())
+  {
+    if (!isRemainingPathValid(*plan, std::make_pair<int>(index, 0)))
+      path_became_invalid_ = true;
+  }
 }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1034,8 +1034,8 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
 {
   if (trajectory.multi_dof_joint_trajectory.points.empty() && trajectory.joint_trajectory.points.empty())
   {
-    ROS_WARN_NAMED(name_, "The trajectory to execute is empty");
-    return false;
+    // empty trajectories don't need to configure anything
+    return true;
   }
   std::set<std::string> actuated_joints;
 


### PR DESCRIPTION
This is useful because the plan_execution allows arbitrary callbacks
to run after successful execution of individual plan_components_.

So although the *trajectory* might be empty, we miss to run the
associated callbacks if we just skip the component/trajectory altogether.

This mechanism is very convenient for modular plans where some components
only invoke side effects.

@rhaschke 