### PR TITLE
Read and write ROS controllers yaml file

### DIFF
--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -141,3 +141,15 @@ install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY resources DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY templates DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+# Unit tests
+if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
+  catkin_add_gtest(test_writing_ros_controllers test/moveit_config_data_test.cpp)
+  target_link_libraries(test_writing_ros_controllers  ${PROJECT_NAME}_tools
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${MOVEIT_LIB_NAME})
+endif()

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1057,6 +1057,22 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     addTemplateString("[OTHER_DEPENDENCIES]", deps.str());  // not relative to a ROS package
   }
 
+  // Pair 9 - Add ROS Controllers to ros_controllers.launch file
+  if (config_data_->getROSControllers().empty())
+  {
+    addTemplateString("[ROS_CONTROLLERS]", "");
+  }
+  else
+  {
+    std::stringstream controllers;
+    for (std::vector<ROSControlConfig>::iterator controller_it = config_data_->getROSControllers().begin();
+         controller_it != config_data_->getROSControllers().end(); ++controller_it)
+    {
+      controllers << controller_it->name_ << " ";
+    }
+    addTemplateString("[ROS_CONTROLLERS]", controllers.str());
+  }
+
   addTemplateString("[AUTHOR_NAME]", config_data_->author_name_);
   addTemplateString("[AUTHOR_EMAIL]", config_data_->author_email_);
 }

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -431,6 +431,11 @@ bool StartScreenWidget::loadExistingFiles()
                              .append(kinematics_yaml_path.make_preferred().native().c_str()));
   }
 
+  // Load ros controllers yaml file if available-----------------------------------------------
+  fs::path ros_controllers_yaml_path = config_data_->config_pkg_path_;
+  ros_controllers_yaml_path /= "config/ros_controllers.yaml";
+  config_data_->inputROSControllersYAML(ros_controllers_yaml_path.make_preferred().native().c_str());
+
   fs::path ompl_yaml_path = config_data_->config_pkg_path_;
   ompl_yaml_path /= "config/ompl_planning.yaml";
   config_data_->inputOMPLYAML(ompl_yaml_path.make_preferred().native().c_str());

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ros_controllers.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ros_controllers.launch
@@ -6,7 +6,7 @@
 
   <!-- Load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" ns="[ROBOT_NAME]" args="spawn joint_state_controller position_trajectory_controller"/>
+    output="screen" ns="[ROBOT_NAME]" args="[ROS_CONTROLLERS]"/>
 
   <!-- Convert joint states to TF transforms for rviz, etc -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -1,0 +1,126 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2018, Mohamad Ayman.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Mohamad Ayman */
+#include <gtest/gtest.h>
+#include <sstream>
+#include <ctype.h>
+#include <iostream>  // For writing yaml and launch files
+#include <urdf_parser/urdf_parser.h>
+#include <fstream>
+#include <string>
+#include <boost/filesystem/path.hpp>
+#include <moveit_resources/config.h>
+#include <boost/filesystem.hpp>  // for creating/deleting folders/files
+#include <moveit/setup_assistant/tools/moveit_config_data.h>
+
+// This tests writing/parsing of ros_controller.yaml
+class MoveItConfigData : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+
+    srdf_model.reset(new srdf::Model());
+    std::string xml_string;
+    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
+    if (xml_file.is_open())
+    {
+      while (xml_file.good())
+      {
+        std::string line;
+        std::getline(xml_file, line);
+        xml_string += (line + "\n");
+      }
+      xml_file.close();
+      urdf_model = urdf::parseURDF(xml_string);
+    }
+    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
+    robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
+  };
+
+protected:
+  urdf::ModelInterfaceSharedPtr urdf_model;
+  srdf::ModelSharedPtr srdf_model;
+  moveit::core::RobotModelPtr robot_model;
+};
+
+TEST_F(MoveItConfigData, ReadingControllers)
+{
+  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+
+  // Contains all the configuration data for the setup assistant
+  moveit_setup_assistant::MoveItConfigDataPtr config_data_;
+
+  config_data_.reset(new moveit_setup_assistant::MoveItConfigData());
+  config_data_->srdf_->srdf_model_ = srdf_model;
+  config_data_->setRobotModel(robot_model);
+
+  // Initially no controllers
+  EXPECT_EQ(config_data_->getROSControllers().size(), 0);
+
+  // Adding default controllers, a controller for each planning group
+  config_data_->addDefaultControllers();
+
+  // Number of the planning groups defined in the model srdf
+  int group_count = config_data_->srdf_->srdf_model_->getGroups().size();
+
+  // Test that addDefaultControllers() did accually add a controller for the new_group
+  EXPECT_EQ(config_data_->getROSControllers().size(), group_count);
+
+  // ros_controller.yaml written correctly
+  EXPECT_EQ(config_data_->outputROSControllersYAML((res_path / "ros_controller.yaml").string()), true);
+
+  // Reset moveit config MoveItConfigData
+  config_data_.reset(new moveit_setup_assistant::MoveItConfigData());
+
+  // Initially no controllers
+  EXPECT_EQ(config_data_->getROSControllers().size(), 0);
+
+  // ros_controllers.yaml read correctly
+  EXPECT_EQ(config_data_->inputROSControllersYAML((res_path / "ros_controller.yaml").string()), true);
+
+  // ros_controllers.yaml parsed correctly
+  EXPECT_EQ(config_data_->getROSControllers().size(), group_count);
+
+  // Remove ros_controllers.yaml temp file which was used in testing
+  boost::filesystem::remove((res_path / "ros_controller.yaml").string());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Description

Adding functions to read and write `ros_contollers.yaml` file.
Adding an automated way to add FollowJointTrajectory action controller for each planning group, e.g. 
```
  controller_list:
  - name: g1_controller
    action_ns: follow_joint_trajectory
    default: True
    type: FollowJointTrajectory
    joints:
      - joint1
      - joint2
```

@davetcoleman @mcevoyandy 
### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [needed] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
