### PR TITLE
Simulation Screen for the SA

### DIFF
--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -74,6 +74,7 @@ set(HEADERS
   src/widgets/perception_widget.h
   src/widgets/configuration_files_widget.h
   src/widgets/setup_screen_widget.h
+  src/widgets/simulation_widget.h
   src/widgets/author_information_widget.h
 )
 
@@ -111,6 +112,7 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/header_widget.cpp
   src/widgets/setup_assistant_widget.cpp
   src/widgets/setup_screen_widget.cpp
+  src/widgets/simulation_widget.cpp
   src/widgets/author_information_widget.cpp
   ${HEADERS}
 )

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -231,6 +231,9 @@ public:
   /// URDF robot model
   urdf::ModelSharedPtr urdf_model_;
 
+  /// URDF robot model string
+  std::string urdf_string_;
+
   // ******************************************************************************************
   // SRDF Data
   // ******************************************************************************************
@@ -323,6 +326,13 @@ public:
   void outputFollowJointTrajectoryYAML(YAML::Emitter& emitter);
   bool outputROSControllersYAML(const std::string& file_path);
   bool output3DSensorPluginYAML(const std::string& file_path);
+
+  /**
+   * \brief Parses the existing urdf and constructs a string from it with the elements required by gazebo simulator
+   * added
+   * \return gazebo compatible urdf or empty if error encountered
+   */
+  std::string getGazeboCompatibleURDF();
 
   /**
    * \brief Set list of collision link pairs in SRDF; sorted; with optional filter

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -372,6 +372,63 @@ bool MoveItConfigData::outputKinematicsYAML(const std::string& file_path)
   return true;  // file created successfully
 }
 
+// ******************************************************************************************
+// Writes a Gazebo compatible robot URDF to gazebo_compatible_urdf_string_
+// ******************************************************************************************
+std::string MoveItConfigData::getGazeboCompatibleURDF()
+{
+  bool new_urdf_needed = false;
+  TiXmlDocument urdf_document;
+
+  // Used to convert XmlDocument to std string
+  TiXmlPrinter printer;
+  urdf_document.Parse((const char*)urdf_string_.c_str(), 0, TIXML_ENCODING_UTF8);
+  try
+  {
+    for (TiXmlElement* link_element = urdf_document.RootElement()->FirstChildElement(); link_element != NULL;
+         link_element = link_element->NextSiblingElement())
+    {
+      if (((std::string)link_element->Value()).find("link") == std::string::npos)
+        continue;
+      // Before adding inertial elements, make sure there is none and the link has collision element
+      if (link_element->FirstChildElement("inertial") == NULL && link_element->FirstChildElement("collision") != NULL)
+      {
+        new_urdf_needed = true;
+        TiXmlElement inertia_link("inertial");
+        TiXmlElement mass("mass");
+        TiXmlElement inertia_joint("inertia");
+
+        mass.SetAttribute("value", "0.1");
+
+        inertia_joint.SetAttribute("ixx", "0.03");
+        inertia_joint.SetAttribute("iyy", "0.03");
+        inertia_joint.SetAttribute("izz", "0.03");
+        inertia_joint.SetAttribute("ixy", "0.0");
+        inertia_joint.SetAttribute("ixz", "0.0");
+        inertia_joint.SetAttribute("iyz", "0.0");
+
+        inertia_link.InsertEndChild(mass);
+        inertia_link.InsertEndChild(inertia_joint);
+
+        link_element->InsertEndChild(inertia_link);
+      }
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    ROS_ERROR_STREAM_NAMED("moveit_config_data", e.what());
+    return std::string("");
+  }
+
+  if (new_urdf_needed)
+  {
+    urdf_document.Accept(&printer);
+    return std::string(printer.CStr());
+  }
+
+  return std::string("");
+}
+
 bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
 {
   YAML::Emitter emitter;

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -14,8 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
+ *   * The name of Mohamad Ayman may not be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -127,6 +127,7 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
   nav_name_list_ << "End Effectors";
   nav_name_list_ << "Passive Joints";
   nav_name_list_ << "Perception";
+  nav_name_list_ << "Simulation";
   nav_name_list_ << "Author Information";
   nav_name_list_ << "Configuration Files";
 
@@ -305,6 +306,16 @@ void SetupAssistantWidget::progressPastStartScreen()
   connect(perception_widget_, SIGNAL(highlightGroup(const std::string&)), this,
           SLOT(highlightGroup(const std::string&)));
   connect(perception_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+
+  // Simulation Screen
+  simulation_widget_ = new SimulationWidget(this, config_data_);
+  main_content_->addWidget(simulation_widget_);
+  connect(simulation_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(simulation_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+          SLOT(highlightLink(const std::string&, const QColor&)));
+  connect(simulation_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(simulation_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Author Information
   author_information_widget_ = new AuthorInformationWidget(this, config_data_);

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
@@ -59,6 +59,7 @@
 #include "virtual_joints_widget.h"
 #include "passive_joints_widget.h"
 #include "author_information_widget.h"
+#include "simulation_widget.h"
 #include "configuration_files_widget.h"
 #include "perception_widget.h"
 
@@ -223,6 +224,7 @@ private:
   PassiveJointsWidget* passive_joints_widget_;
   AuthorInformationWidget* author_information_widget_;
   ConfigurationFilesWidget* configuration_files_widget_;
+  SimulationWidget* simulation_widget_;
   PerceptionWidget* perception_widget_;
 
   /// Contains all the configuration data for the setup assistant

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -1,0 +1,202 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Mohamad Ayman.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * The name of Mohamad Ayman may not be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mohamad Ayman */
+
+// SA
+#include "simulation_widget.h"
+
+// Qt
+#include <QVBoxLayout>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QColor>
+
+#include <moveit/robot_state/conversions.h>
+#include <moveit_msgs/DisplayRobotState.h>
+
+#include <regex>
+
+namespace moveit_setup_assistant
+{
+// ******************************************************************************************
+// Constructor
+// ******************************************************************************************
+SimulationWidget::SimulationWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data)
+  : SetupScreenWidget(parent), config_data_(config_data)
+{
+  // Basic widget container
+  QVBoxLayout* layout = new QVBoxLayout();
+  layout->setAlignment(Qt::AlignTop);
+
+  // Top Header Area ------------------------------------------------
+
+  HeaderWidget* header =
+      new HeaderWidget("Simulation With Gazebo", "The following tool will auto-generate the URDF changes needed "
+                                                 "for Gazebo compatibility with ROSControl and MoveIt!. The "
+                                                 "needed changes are shown in green.",
+                       this);
+  layout->addWidget(header);
+
+  // Spacing
+  QSpacerItem* blank_space = new QSpacerItem(1, 8);
+  layout->addSpacerItem(blank_space);
+
+  QLabel* instructions = new QLabel(this);
+  instructions->setText("You can run the following command to quickly find the necessary URDF file to edit:");
+  layout->addWidget(instructions);
+
+  QTextEdit* instructions_command = new QTextEdit(this);
+  instructions_command->setText(std::string("roscd " + config_data->urdf_pkg_name_).c_str());
+  instructions_command->setReadOnly(true);
+  instructions_command->setMaximumHeight(30);
+  layout->addWidget(instructions_command);
+
+  // Spacing
+  blank_space = new QSpacerItem(1, 6);
+  layout->addSpacerItem(blank_space);
+
+  // Used to make the new URDF visible
+  QPushButton* btn_generate = new QPushButton("&Generate URDF", this);
+  btn_generate->setMinimumWidth(180);
+  btn_generate->setMinimumHeight(40);
+  layout->addWidget(btn_generate);
+  layout->setAlignment(btn_generate, Qt::AlignLeft);
+  connect(btn_generate, SIGNAL(clicked()), this, SLOT(generateURDFClick()));
+
+  // When there wa no change to be made
+  no_changes_label_ = new QLabel(this);
+  no_changes_label_->setText("No Changes To Be Made");
+  layout->addWidget(no_changes_label_);
+  no_changes_label_->setVisible(false);
+
+  // URDF text
+  simulation_text_ = new QTextEdit(this);
+  simulation_text_->setLineWrapMode(QTextEdit::NoWrap);
+  layout->addWidget(simulation_text_);
+
+  // Copy URDF link, hidden initially
+  copy_urdf_ = new QLabel(this);
+  copy_urdf_->setText("<a href='contract'>Copy to Clipboard</a>");
+  connect(copy_urdf_, SIGNAL(linkActivated(const QString)), this, SLOT(copyURDF(const QString)));
+  copy_urdf_->setVisible(false);
+  layout->addWidget(copy_urdf_);
+
+  // Finish Layout --------------------------------------------------
+  this->setLayout(layout);
+}
+
+// ******************************************************************************************
+// Called when generate URDF button is clicked
+// ******************************************************************************************
+void SimulationWidget::generateURDFClick()
+{
+  simulation_text_->setVisible(true);
+  std::string gazebo_compatible_urdf_string = config_data_->getGazeboCompatibleURDF();
+  // Check if the urdf do need new elements to be added
+  if (gazebo_compatible_urdf_string.length() > 0)
+  {
+    // Split the added elements from the original urdf to view them in different colors
+    std::smatch start_match;
+    std::smatch end_match;
+    std::regex start_reg_ex("<inertial");
+    std::regex end_reg_ex("</inertial");
+
+    // Search for inertial elemnts using regex
+    std::regex_search(gazebo_compatible_urdf_string, start_match, start_reg_ex);
+    std::regex_search(gazebo_compatible_urdf_string, end_match, end_reg_ex);
+
+    std::string urdf_sub_string;
+
+    // Used to cache the positions of the opening and closing of the inertial elements
+    std::vector<int> inertial_opening_matches;
+    std::vector<int> inertial_closing_matches;
+
+    inertial_closing_matches.push_back(0);
+
+    // Cache the positions of the openings of the inertial elements
+    for (auto it = std::sregex_iterator(gazebo_compatible_urdf_string.begin(), gazebo_compatible_urdf_string.end(),
+                                        start_reg_ex);
+         it != std::sregex_iterator(); ++it)
+    {
+      inertial_opening_matches.push_back(it->position());
+    }
+
+    inertial_opening_matches.push_back(gazebo_compatible_urdf_string.length());
+
+    // Cache the positions of the closings of the inertial elements
+    for (auto it = std::sregex_iterator(gazebo_compatible_urdf_string.begin(), gazebo_compatible_urdf_string.end(),
+                                        end_reg_ex);
+         it != std::sregex_iterator(); ++it)
+    {
+      inertial_closing_matches.push_back(it->position());
+    }
+
+    for (std::size_t match_number = 0; match_number < inertial_opening_matches.size(); match_number++)
+    {
+      // Show the unmodified elements in black
+      simulation_text_->setTextColor(QColor("black"));
+      urdf_sub_string = gazebo_compatible_urdf_string.substr(inertial_closing_matches[match_number],
+                                                             inertial_opening_matches[match_number] -
+                                                                 inertial_closing_matches[match_number]);
+      simulation_text_->append(QString(urdf_sub_string.c_str()));
+
+      // Show the added elements in green
+      simulation_text_->setTextColor(QColor("green"));
+      urdf_sub_string = gazebo_compatible_urdf_string.substr(inertial_opening_matches[match_number],
+                                                             inertial_closing_matches[match_number + 1] -
+                                                                 inertial_opening_matches[match_number] + 11);
+      simulation_text_->append(QString(urdf_sub_string.c_str()));
+      inertial_closing_matches[match_number + 1] += 11;
+    }
+
+    // Copy link appears after the text is ready
+    copy_urdf_->setVisible(true);
+  }
+  else
+  {
+    simulation_text_->append(QString(gazebo_compatible_urdf_string.c_str()));
+    no_changes_label_->setVisible(true);
+  }
+}
+
+// ******************************************************************************************
+// Called the copy to clipboard button is clicked
+// ******************************************************************************************
+void SimulationWidget::copyURDF(const QString& link)
+{
+  simulation_text_->selectAll();
+  simulation_text_->copy();
+}
+
+}  // namespace

--- a/moveit_setup_assistant/src/widgets/simulation_widget.h
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.h
@@ -33,15 +33,13 @@
 
 /* Author: Mohamad Ayman */
 
-#ifndef MOVEIT_MOVEIT_SETUP_ASSISTANT_WIDGETS_PERCEPTION_WIDGET_
-#define MOVEIT_MOVEIT_SETUP_ASSISTANT_WIDGETS_PERCEPTION_WIDGET_
+#ifndef MOVEIT_MOVEIT_SETUP_ASSISTANT_WIDGETS_SIMULATION_WIDGET_H
+#define MOVEIT_MOVEIT_SETUP_ASSISTANT_WIDGETS_SIMULATION_WIDGET_H
 
 // Qt
-#include <QWidget>
-#include <QComboBox>
-#include <QGroupBox>
+#include <QScrollArea>
+#include <QTextEdit>
 #include <QString>
-#include <QLineEdit>
 
 // SA
 #ifndef Q_MOC_RUN
@@ -54,9 +52,11 @@
 namespace moveit_setup_assistant
 {
 // ******************************************************************************************
-// User Interface for setting up 3D sensor config
 // ******************************************************************************************
-class PerceptionWidget : public SetupScreenWidget
+// Class for showing changes needed to help user bring his robot into gazebo simulation
+// ******************************************************************************************
+// ******************************************************************************************
+class SimulationWidget : public SetupScreenWidget
 {
   Q_OBJECT
 
@@ -65,46 +65,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  PerceptionWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
-
-  /// Recieved when this widget is chosen from the navigation menu
-  virtual void focusGiven();
-
-  /// Recieved when another widget is chosen from the navigation menu
-  virtual bool focusLost();
-
-  /// Populate the combo dropdown box with sensor plugins
-  void loadSensorPluginsComboBox();
-
-  // ******************************************************************************************
-  // Qt Components
-  // ******************************************************************************************
-
-  QComboBox* sensor_plugin_field_;
-
-  // Group form for each plugin option
-  QGroupBox* point_cloud_group_;
-  QGroupBox* depth_map_group_;
-
-  // Point Cloud plugin feilds
-  QLineEdit* point_cloud_topic_field_;
-  QLineEdit* max_range_field_;
-  QLineEdit* point_subsample_field_;
-  QLineEdit* padding_offset_field_;
-  QLineEdit* padding_scale_field_;
-  QLineEdit* max_update_rate_field_;
-  QLineEdit* filtered_cloud_topic_field_;
-
-  // Depth Map plugin feilds
-  QLineEdit* image_topic_field_;
-  QLineEdit* queue_size_field_;
-  QLineEdit* near_clipping_field_;
-  QLineEdit* far_clipping_field_;
-  QLineEdit* shadow_threshold_field_;
-  QLineEdit* depth_padding_scale_field_;
-  QLineEdit* depth_padding_offset_field_;
-  QLineEdit* depth_filtered_cloud_topic_field_;
-  QLineEdit* depth_max_update_rate_field_;
+  SimulationWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
 private Q_SLOTS:
 
@@ -112,13 +73,20 @@ private Q_SLOTS:
   // Slot Event Functions
   // ******************************************************************************************
 
-  /// Called when the selected item in the sensor_plugin_field_ combobox is changed
-  void sensorPluginChanged(int index);
+  // Called the copy to clipboard button is clicked
+  void copyURDF(const QString& link);
+
+  /// Generate URDF button clicked
+  void generateURDFClick();
 
 private:
   // ******************************************************************************************
-  // Variables
+  // Qt Components
   // ******************************************************************************************
+
+  QTextEdit* simulation_text_;
+  QLabel* no_changes_label_;
+  QLabel* copy_urdf_;
 
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -567,22 +567,21 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const st
 {
   const std::vector<std::string> xacro_args_ = { xacro_args };
 
-  std::string urdf_string;
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string, urdf_file_path, xacro_args_))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(config_data_->urdf_string_, urdf_file_path, xacro_args_))
   {
     QMessageBox::warning(this, "Error Loading Files",
                          QString("URDF/COLLADA file not found: ").append(urdf_file_path.c_str()));
     return false;
   }
 
-  if (urdf_string.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_file_path))
+  if (config_data_->urdf_string_.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_file_path))
   {
     QMessageBox::warning(this, "Error Loading Files", "Running xacro failed.\nPlease check console for errors.");
     return false;
   }
 
   // Verify that file is in correct format / not an XACRO by loading into robot model
-  if (!config_data_->urdf_model_->initString(urdf_string))
+  if (!config_data_->urdf_model_->initString(config_data_->urdf_string_))
   {
     QMessageBox::warning(this, "Error Loading Files", "URDF/COLLADA file is not a valid robot model.");
     return false;
@@ -604,7 +603,7 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const st
 
   ROS_INFO("Setting Param Server with Robot Description");
   // ROS_WARN("Ignore the following error message 'Failed to contact master'. This is a known issue.");
-  nh.setParam("/robot_description", urdf_string);
+  nh.setParam("/robot_description", config_data_->urdf_string_);
 
   return true;
 }


### PR DESCRIPTION
### Description

This PR is a part of improving the integration between gazebo, moveit and ros [issue 894](https://github.com/ros-planning/moveit/issues/894).

For a robot to be rendered in gazebo [it has to has an `inertial` element for each link](http://gazebosim.org/tutorials/?tut=ros_urdf), this PR tells the user if the urdf didn't contain them.
and views the new `urdf` on the simulation window for the user.

![](https://raw.githubusercontent.com/MohmadAyman/school/aa94c1792d4ce113865de600c4f343c875fba18f/simulationscreen.gif)
Added `elements`  which the user should add to his `urdf` are colored in green.

Once this PR is merged, the `[gazebo.launch]`(https://github.com/ros-planning/moveit/pull/936) will point to this new urdf.

The documentation of the setup assistant are updated in this [PR](https://github.com/ros-planning/moveit_tutorials/pull/184).

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
