### PR TITLE
CHOMP motion planner cleanup of unused parameters and code + addition of trajectory initialization methods (linear, cubic, quintic-spline)

### DIFF
--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -70,6 +70,7 @@ void CHOMPInterface::loadParams()
   nh_.param("collision_threshold", params_.collision_threshold_, 0.07);
   nh_.param("random_jump_amount", params_.random_jump_amount_, 1.0);
   nh_.param("use_stochastic_descent", params_.use_stochastic_descent_, true);
+  nh_.param("interpolation_method", params_.trajectory_initialization_method_, std::string("quintic-spline"));
   // filter_mode_ = false;
 }
 }

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -51,24 +51,19 @@ void CHOMPInterface::loadParams()
   nh_.param("smoothness_cost_weight", params_.smoothness_cost_weight_, 0.1);
   nh_.param("obstacle_cost_weight", params_.obstacle_cost_weight_, 1.0);
   nh_.param("learning_rate", params_.learning_rate_, 0.01);
-  nh_.param("animate_path", params_.animate_path_, true);
-  nh_.param("add_randomness", params_.add_randomness_, false);
+
   nh_.param("smoothness_cost_velocity", params_.smoothness_cost_velocity_, 0.0);
   nh_.param("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
   nh_.param("smoothness_cost_jerk", params_.smoothness_cost_jerk_, 0.0);
-  nh_.param("hmc_discretization", params_.hmc_discretization_, 0.01);
-  nh_.param("hmc_stochasticity", params_.hmc_stochasticity_, 0.01);
-  nh_.param("hmc_annealing_factor", params_.hmc_annealing_factor_, 0.99);
-  nh_.param("use_hamiltonian_monte_carlo", params_.use_hamiltonian_monte_carlo_, false);
+
   nh_.param("ridge_factor", params_.ridge_factor_, 0.0);
   nh_.param("use_pseudo_inverse", params_.use_pseudo_inverse_, false);
   nh_.param("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
-  nh_.param("animate_endeffector", params_.animate_endeffector_, false);
-  nh_.param("animate_endeffector_segment", params_.animate_endeffector_segment_, std::string("r_gripper_tool_frame"));
+
   nh_.param("joint_update_limit", params_.joint_update_limit_, 0.1);
   nh_.param("collision_clearence", params_.min_clearence_, 0.2);
   nh_.param("collision_threshold", params_.collision_threshold_, 0.07);
-  nh_.param("random_jump_amount", params_.random_jump_amount_, 1.0);
+
   nh_.param("use_stochastic_descent", params_.use_stochastic_descent_, true);
   nh_.param("interpolation_method", params_.trajectory_initialization_method_, std::string("quintic-spline"));
   // filter_mode_ = false;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -53,28 +53,23 @@ public:
   int getMaxIterationsAfterCollisionFree() const;
   double getSmoothnessCostWeight() const;
   double getObstacleCostWeight() const;
-  bool getAnimatePath() const;
+
   double getLearningRate() const;
   double getSmoothnessCostVelocity() const;
   double getSmoothnessCostAcceleration() const;
   double getSmoothnessCostJerk() const;
-  bool getAddRandomness() const;
-  bool getUseHamiltonianMonteCarlo() const;
-  double getHmcDiscretization() const;
-  double getHmcStochasticity() const;
-  double getHmcAnnealingFactor() const;
+
+
   double getRidgeFactor() const;
   bool getUsePseudoInverse() const;
   double getPseudoInverseRidgeFactor() const;
-  bool getAnimateEndeffector() const;
-  std::string getAnimateEndeffectorSegment() const;
+
   double getJointUpdateLimit() const;
   double getMinClearence() const;
   double getCollisionThreshold() const;
   bool getFilterMode() const;
   void setFilterMode(bool mode);
-  double getRandomJumpAmount() const;
-  void setRandomJumpAmount(double amount);
+
   bool getUseStochasticDescent() const;
   std::string getTrajectoryInitializationMethod() const;
 
@@ -85,40 +80,29 @@ public:
   double smoothness_cost_weight_;
   double obstacle_cost_weight_;
   double learning_rate_;
-  bool animate_path_;
+
   double smoothness_cost_velocity_;
   double smoothness_cost_acceleration_;
   double smoothness_cost_jerk_;
-  bool add_randomness_;
-  bool use_hamiltonian_monte_carlo_;
+
+
   bool use_stochastic_descent_;
-  double hmc_stochasticity_;
-  double hmc_discretization_;
-  double hmc_annealing_factor_;
+
+
   double ridge_factor_;
   bool use_pseudo_inverse_;
   double pseudo_inverse_ridge_factor_;
-  bool animate_endeffector_;
-  std::string animate_endeffector_segment_;
+
   double joint_update_limit_;
   double min_clearence_;
   double collision_threshold_;
   bool filter_mode_;
-  double random_jump_amount_;
+
   std::string trajectory_initialization_method_;
 };
 
 /////////////////////// inline functions follow ////////////////////////
 
-inline double ChompParameters::getRandomJumpAmount() const
-{
-  return random_jump_amount_;
-}
-
-inline void ChompParameters::setRandomJumpAmount(double amount)
-{
-  random_jump_amount_ = amount;
-}
 
 inline double ChompParameters::getCollisionThreshold() const
 {
@@ -180,15 +164,6 @@ inline double ChompParameters::getLearningRate() const
   return learning_rate_;
 }
 
-inline bool ChompParameters::getAnimatePath() const
-{
-  return animate_path_;
-}
-
-inline bool ChompParameters::getAddRandomness() const
-{
-  return add_randomness_;
-}
 
 inline double ChompParameters::getSmoothnessCostVelocity() const
 {
@@ -205,25 +180,7 @@ inline double ChompParameters::getSmoothnessCostJerk() const
   return smoothness_cost_jerk_;
 }
 
-inline double ChompParameters::getHmcDiscretization() const
-{
-  return hmc_discretization_;
-}
 
-inline double ChompParameters::getHmcStochasticity() const
-{
-  return hmc_stochasticity_;
-}
-
-inline double ChompParameters::getHmcAnnealingFactor() const
-{
-  return hmc_annealing_factor_;
-}
-
-inline bool ChompParameters::getUseHamiltonianMonteCarlo() const
-{
-  return use_hamiltonian_monte_carlo_;
-}
 
 inline double ChompParameters::getRidgeFactor() const
 {
@@ -240,20 +197,12 @@ inline double ChompParameters::getPseudoInverseRidgeFactor() const
   return pseudo_inverse_ridge_factor_;
 }
 
-inline bool ChompParameters::getAnimateEndeffector() const
-{
-  return animate_endeffector_;
-}
 
 inline bool ChompParameters::getUseStochasticDescent() const
 {
   return use_stochastic_descent_;
 }
 
-inline std::string ChompParameters::getAnimateEndeffectorSegment() const
-{
-  return animate_endeffector_segment_;
-}
 
 inline std::string ChompParameters::getTrajectoryInitializationMethod() const
 {

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -76,6 +76,7 @@ public:
   double getRandomJumpAmount() const;
   void setRandomJumpAmount(double amount);
   bool getUseStochasticDescent() const;
+  std::string getTrajectoryInitializationMethod() const;
 
 public:
   double planning_time_limit_;
@@ -104,6 +105,7 @@ public:
   double collision_threshold_;
   bool filter_mode_;
   double random_jump_amount_;
+  std::string trajectory_initialization_method_;
 };
 
 /////////////////////// inline functions follow ////////////////////////
@@ -251,6 +253,11 @@ inline bool ChompParameters::getUseStochasticDescent() const
 inline std::string ChompParameters::getAnimateEndeffectorSegment() const
 {
   return animate_endeffector_segment_;
+}
+
+inline std::string ChompParameters::getTrajectoryInitializationMethod() const
+{
+  return trajectory_initialization_method_;
 }
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -179,15 +179,13 @@ private:
   int num_joints_;                  /**< Number of joints in each trajectory point */
   double discretization_;           /**< Discretization of the trajectory */
   double duration_;                 /**< Duration of the trajectory */
-
+  Eigen::MatrixXd trajectory_;      /**< Storage for the actual trajectory */
   int start_index_; /**< Start index (inclusive) of trajectory to be optimized (everything before it will not be
                        modified) */
   int end_index_; /**< End index (inclusive) of trajectory to be optimized (everything after it will not be modified) */
   std::vector<int> full_trajectory_index_; /**< If this is a "group" trajectory, the index from the original traj which
                                               each
                                               element here was copied */
-public:
-    Eigen::MatrixXd trajectory_;      /**< Storage for the actual trajectory */
 };
 
 ///////////////////////// inline functions follow //////////////////////

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -115,6 +115,11 @@ public:
    */
   void fillInMinJerk();
 
+
+  void fillInLinearInterpolation();
+
+  void fillInCubicInterpolation();
+
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
    *
@@ -174,13 +179,15 @@ private:
   int num_joints_;                  /**< Number of joints in each trajectory point */
   double discretization_;           /**< Discretization of the trajectory */
   double duration_;                 /**< Duration of the trajectory */
-  Eigen::MatrixXd trajectory_;      /**< Storage for the actual trajectory */
+
   int start_index_; /**< Start index (inclusive) of trajectory to be optimized (everything before it will not be
                        modified) */
   int end_index_; /**< End index (inclusive) of trajectory to be optimized (everything after it will not be modified) */
   std::vector<int> full_trajectory_index_; /**< If this is a "group" trajectory, the index from the original traj which
                                               each
                                               element here was copied */
+public:
+    Eigen::MatrixXd trajectory_;      /**< Storage for the actual trajectory */
 };
 
 ///////////////////////// inline functions follow //////////////////////

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -242,19 +242,6 @@ void ChompOptimizer::initialize()
     }
   }
 
-  // for(map<string, map<string, bool> >::iterator it = joint_parent_map_.begin(); it != joint_parent_map_.end(); it++)
-  // {
-  //   stringstream ss;
-  //   ss << it->first << " Parents : {";
-
-  //   for(map<string, bool>::iterator it2 = it->second.begin(); it2 != it->second.end(); it2++)
-  //   {
-  //     ss << it2->first << ",";
-  //   }
-  //   ss << "}";
-  //   ROS_INFO("%s",ss.str().c_str());
-  // }
-
   int start = free_vars_start_;
   int end = free_vars_end_;
   for (int i = start; i <= end; ++i)
@@ -335,10 +322,6 @@ void ChompOptimizer::optimize()
   double minimaThreshold = 0.05;
   bool should_break_out = false;
 
-  // if(parameters_->getAnimatePath())
-  // {
-  //   animatePath();
-  // }
 
   // iterate
   for (iteration_ = 0; iteration_ < parameters_->getMaxIterations(); iteration_++)
@@ -352,22 +335,6 @@ void ChompOptimizer::optimize()
 
     // ROS_INFO_STREAM("Collision cost " << cCost << " smoothness cost " << sCost);
 
-    // if(parameters_->getAddRandomness() && currentCostIter != -1)
-    // {
-    //   costs[currentCostIter] = cCost;
-    //   currentCostIter++;
-
-    //   if(currentCostIter >= costWindow)
-    //   {
-    //     for(int i = 1; i < costWindow; i++)
-    //     {
-    //       averageCostVelocity += (costs.at(i) - costs.at(i - 1));
-    //     }
-
-    //     averageCostVelocity /= (double)(costWindow);
-    //     currentCostIter = -1;
-    //   }
-    // }
     if (iteration_ == 0)
     {
       best_group_trajectory_ = group_trajectory_.getTrajectory();
@@ -388,19 +355,9 @@ void ChompOptimizer::optimize()
     // ROS_INFO_STREAM("Collision increments took " << (ros::WallTime::now()-coll_time));
     calculateTotalIncrements();
 
-    // if(!parameters_->getUseHamiltonianMonteCarlo())
-    // {
-    //   // non-stochastic version:
+
     addIncrementsToTrajectory();
-    // }
-    // else
-    // {
-    //   // hamiltonian monte carlo updates:
-    //   getRandomMomentum();
-    //   updateMomentum();
-    //   updatePositionFromMomentum();
-    //   stochasticity_factor_ *= parameters_->getHmcAnnealingFactor();
-    // }
+
     handleJointLimits();
     updateFullTrajectory();
 
@@ -415,28 +372,6 @@ void ChompOptimizer::optimize()
         iteration_++;
         should_break_out = true;
       }
-      // } else if(safety == CollisionProximitySpace::InCollisionSafe) {
-
-      // ROS_DEBUG("Trajectory cost: %f (s=%f, c=%f)", getTrajectoryCost(), getSmoothnessCost(), getCollisionCost());
-      // CollisionProximitySpace::TrajectorySafety safety = checkCurrentIterValidity();
-      // if(safety == CollisionProximitySpace::MeshToMeshSafe)
-      // {
-      //   num_collision_free_iterations_ = 0;
-      //   ROS_INFO("Chomp Got mesh to mesh safety at iter %d. Breaking out early.", iteration_);
-      //   is_collision_free_ = true;
-      //   iteration_++;
-      //   should_break_out = true;
-      // } else if(safety == CollisionProximitySpace::InCollisionSafe) {
-      //   num_collision_free_iterations_ = parameters_->getMaxIterationsAfterCollisionFree();
-      //   ROS_INFO("Chomp Got in collision safety at iter %d. Breaking out soon.", iteration_);
-      //   is_collision_free_ = true;
-      //   iteration_++;
-      //   should_break_out = true;
-      // }
-      // else
-      // {
-      //   is_collision_free_ = false;
-      // }
     }
 
     if (!parameters_->getFilterMode())
@@ -461,61 +396,7 @@ void ChompOptimizer::optimize()
       break;
     }
 
-    // if(fabs(averageCostVelocity) < minimaThreshold && currentCostIter == -1 && !is_collision_free_ &&
-    // parameters_->getAddRandomness())
-    // {
-    //   ROS_INFO("Detected local minima. Attempting to break out!");
-    //   int iter = 0;
-    //   bool success = false;
-    //   while(iter < 20 && !success)
-    //   {
-    //     performForwardKinematics();
-    //     double original_cost = getTrajectoryCost();
-    //     group_trajectory_backup_ = group_trajectory_.getTrajectory();
-    //     perturbTrajectory();
-    //     handleJointLimits();
-    //     updateFullTrajectory();
-    //     performForwardKinematics();
-    //     double new_cost = getTrajectoryCost();
-    //     iter ++;
-    //     if(new_cost < original_cost)
-    //     {
-    //       ROS_INFO("Got out of minimum in %d iters!", iter);
-    //       averageCostVelocity = 0.0;
-    //       currentCostIter = 0;
-    //       success = true;
-    //     }
-    //     else
-    //     {
-    //       group_trajectory_.getTrajectory() = group_trajectory_backup_;
-    //       updateFullTrajectory();
-    //       currentCostIter = 0;
-    //       averageCostVelocity = 0.0;
-    //       success = false;
-    //     }
 
-    //   }
-
-    //   if(!success)
-    //   {
-    //     ROS_INFO("Failed to exit minimum!");
-    //   }
-    //}
-    else if (currentCostIter == -1)
-    {
-      currentCostIter = 0;
-      averageCostVelocity = 0.0;
-    }
-
-    // if(parameters_->getAnimateEndeffector())
-    // {
-    //   animateEndeffector();
-    // }
-
-    // if(parameters_->getAnimatePath() && iteration_ % 25 == 0)
-    // {
-    //   animatePath();
-    // }
 
     if (should_break_out)
     {
@@ -526,11 +407,6 @@ void ChompOptimizer::optimize()
       }
       else if (collision_free_iteration_ > num_collision_free_iterations_)
       {
-        // CollisionProximitySpace::TrajectorySafety safety = checkCurrentIterValidity();
-        // if(safety != CollisionProximitySpace::MeshToMeshSafe &&
-        //    safety != CollisionProximitySpace::InCollisionSafe) {
-        //   ROS_WARN_STREAM("Apparently regressed");
-        // }
         break;
       }
     }
@@ -545,16 +421,8 @@ void ChompOptimizer::optimize()
     ROS_ERROR("Chomp path is not collision free!");
   }
 
-  // if(parameters_->getAnimatePath())
-  // {
-  //   animatePath();
-  // }
-
   group_trajectory_.getTrajectory() = best_group_trajectory_;
   updateFullTrajectory();
-
-  // if(parameters_->getAnimatePath())
-  //   animatePath();
 
   ROS_INFO("Terminated after %d iterations, using path from iteration %d", iteration_, last_improvement_iteration_);
   ROS_INFO("Optimization core finished in %f sec", (ros::WallTime::now() - start_time).toSec());
@@ -580,36 +448,6 @@ bool ChompOptimizer::isCurrentTrajectoryMeshToMeshCollisionFree() const
   return planning_scene_->isPathValid(start_state_msg, traj, planning_group_);
 }
 
-// CollisionProximitySpace::TrajectorySafety ChompOptimizer::checkCurrentIterValidity()
-// {
-//   JointTrajectory jointTrajectory;
-//   jointTrajectory.joint_names = joint_names_;
-//   jointTrajectory.header.frame_id = collision_space_->getCollisionModelsInterface()->getRobotFrameId();
-//   jointTrajectory.header.stamp = ros::Time::now();
-//   Constraints goalConstraints;
-//   Constraints pathConstraints;
-//   ArmNavigationErrorCodes errorCode;
-//   vector<ArmNavigationErrorCodes> trajectoryErrorCodes;
-//   for(int i = 0; i < group_trajectory_.getNumPoints(); i++)
-//   {
-//     JointTrajectoryPoint point;
-//     for(int j = 0; j < group_trajectory_.getNumJoints(); j++)
-//     {
-//       point.positions.push_back(best_group_trajectory_(i, j));
-//     }
-//     jointTrajectory.points.push_back(point);
-//   }
-
-//   return collision_space_->isTrajectorySafe(jointTrajectory, goalConstraints, pathConstraints, planning_group_);
-//   /*
-//     bool valid = collision_space_->getCollisionModelsInterface()->isJointTrajectoryValid(*state_,
-//     jointTrajectory,
-//     goalConstraints,
-//     pathConstraints, errorCode,
-//     trajectoryErrorCodes, false);
-//   */
-
-// }
 
 void ChompOptimizer::calculateSmoothnessIncrements()
 {
@@ -686,12 +524,6 @@ void ChompOptimizer::calculateCollisionIncrements()
         collision_increments_.row(i - free_vars_start_).transpose() -= jacobian_.transpose() * cartesian_gradient;
       }
 
-      /*
-        if(point_is_in_collision_[i][j])
-        {
-        break;
-        }
-      */
     }
   }
   // cout << collision_increments_ << endl;
@@ -992,15 +824,7 @@ void ChompOptimizer::performForwardKinematics()
           if (point_is_in_collision_[i][j])
           {
             state_is_in_collision_[i] = true;
-            // if(is_collision_free_ == true) {
-            //   ROS_INFO_STREAM("We know it's not collision free " << g);
-            //   ROS_INFO_STREAM("Sphere location " << info.sphere_locations[k].x() << " " <<
-            //   info.sphere_locations[k].y() << " " << info.sphere_locations[k].z());
-            //   ROS_INFO_STREAM("Gradient " << info.gradients[k].x() << " " << info.gradients[k].y() << " " <<
-            //   info.gradients[k].z() << " distance " << info.distances[k] << " radii " << info.sphere_radii[k]);
-            //   ROS_INFO_STREAM("Radius " << info.sphere_radii[k] << " potential " <<
-            //   collision_point_potential_[i][j]);
-            // }
+
             is_collision_free_ = false;
           }
           j++;
@@ -1046,224 +870,6 @@ void ChompOptimizer::setRobotStateFromPoint(ChompTrajectory& group_trajectory, i
   state_.update();
 }
 
-void ChompOptimizer::perturbTrajectory()
-{
-  // int mid_point = (free_vars_start_ + free_vars_end_) / 2;
-  if (worst_collision_cost_state_ < 0)
-    return;
-  int mid_point = worst_collision_cost_state_;
-  moveit::core::RobotState random_state = state_;
-  const moveit::core::JointModelGroup* planning_group = state_.getJointModelGroup(planning_group_);
-  random_state.setToRandomPositions(planning_group);
-  std::vector<double> vals;
-  random_state.copyJointGroupPositions(planning_group_, vals);
-  double* ptr = &vals[0];
-  Eigen::Map<Eigen::VectorXd> random_matrix(ptr, vals.size());
-  // Eigen::VectorXd random_matrix = vals;
 
-  // convert the state into an increment
-  random_matrix -= group_trajectory_.getTrajectoryPoint(mid_point).transpose();
-
-  // project the increment orthogonal to joint velocities
-  group_trajectory_.getJointVelocities(mid_point, joint_state_velocities_);
-  joint_state_velocities_.normalize();
-  random_matrix = (Eigen::MatrixXd::Identity(num_joints_, num_joints_) -
-                   joint_state_velocities_ * joint_state_velocities_.transpose()) *
-                  random_matrix;
-
-  int mp_free_vars_index = mid_point - free_vars_start_;
-  for (int i = 0; i < num_joints_; i++)
-  {
-    group_trajectory_.getFreeJointTrajectoryBlock(i) +=
-        joint_costs_[i].getQuadraticCostInverse().col(mp_free_vars_index) * random_state_(i);
-  }
-}
-
-// void ChompOptimizer::getRandomState(const RobotState currentState, const string& groupName, Eigen::VectorXd&
-// state_vec)
-// {
-//   const vector<RobotState *::JointState*>& jointStates =
-//     currentState->getJointStateGroup(groupName)->getJointStateVector();
-//   for(size_t i = 0; i < jointStates.size(); i++)
-//   {
-
-//     bool continuous = false;
-
-//     RobotState *::JointState* jointState = jointStates[i];
-//     const RevoluteJointModel* revolute_joint
-//       = dynamic_cast<const RevoluteJointModel*>(jointState->getJointModel());
-//     if(revolute_joint && revolute_joint->continuous_) {
-//       continuous = true;
-//     }
-
-//     map<string, pair<double, double> > bounds = jointState->getJointModel()->getAllVariableBounds();
-//     int j = 0;
-//     for(map<string, pair<double, double> >::iterator it = bounds.begin(); it != bounds.end(); it++)
-//     {
-//       double randVal = jointState->getJointStateValues()[j] + (getRandomDouble()
-//                                                                * (parameters_->getRandomJumpAmount()) -
-//                                                                getRandomDouble() *
-//                                                                (parameters_->getRandomJumpAmount()));
-
-//       if(!continuous)
-//       {
-//         if(randVal > it->second.second)
-//         {
-//           randVal = it->second.second;
-//         }
-//         else if(randVal < it->second.first)
-//         {
-//           randVal = it->second.first;
-//         }
-//       }
-
-//       ROS_DEBUG_STREAM("Joint " << it->first << " old value " << jointState->getJointStateValues()[j] << " new value
-//       " << randVal);
-//       state_vec(i) = randVal;
-
-//       j++;
-//     }
-//   }
-// }
-
-void ChompOptimizer::getRandomMomentum()
-{
-  if (is_collision_free_)
-    random_momentum_.setZero(num_vars_free_, num_joints_);
-  else
-    for (int i = 0; i < num_joints_; ++i)
-    {
-      multivariate_gaussian_[i].sample(random_joint_momentum_);
-      random_momentum_.col(i) = stochasticity_factor_ * random_joint_momentum_;
-    }
-}
-
-void ChompOptimizer::updateMomentum()
-{
-  // double alpha = 1.0 - parameters_->getHmcStochasticity();
-  double eps = parameters_->getHmcDiscretization();
-  if (iteration_ > 0)
-    momentum_ = (momentum_ + eps * final_increments_);
-  else
-    momentum_ = random_momentum_;
-  // momentum_ = alpha * (momentum_ + eps*final_increments_) + sqrt(1.0-alpha*alpha)*random_momentum_;
-}
-
-void ChompOptimizer::updatePositionFromMomentum()
-{
-  double eps = parameters_->getHmcDiscretization();
-  group_trajectory_.getFreeTrajectoryBlock() += eps * momentum_;
-}
-
-// void ChompOptimizer::animatePath()
-// {
-//   for(int i = free_vars_start_; i <= free_vars_end_; i++)
-//   {
-//     visualizeState(i);
-//     //ros::WallDuration(group_trajectory_.getDiscretization()).sleep();
-//     ros::WallDuration(.05).sleep();
-//   }
-// }
-
-// void ChompOptimizer::animateEndeffector()
-// {
-//   visualization_msgs::Marker msg;
-//   msg.points.resize(num_vars_free_);
-//   // int joint_index = planning_group_->chomp_joints_[num_joints_-1].kdl_joint_index_;
-//   int sn = (int)(num_collision_points_ - 1);
-//   for(int i = 0; i < num_vars_free_; ++i)
-//   {
-//     int j = i + free_vars_start_;
-//     msg.points[i].x = collision_point_pos_eigen_[j][sn][0];
-//     msg.points[i].y = collision_point_pos_eigen_[j][sn][1];
-//     msg.points[i].z = collision_point_pos_eigen_[j][sn][2];
-//   }
-//   msg.header.frame_id = collision_space_->getCollisionModelsInterface()->getRobotFrameId();
-//   msg.header.stamp = ros::Time();
-//   msg.ns = "chomp_endeffector";
-//   msg.id = 0;
-//   msg.type = visualization_msgs::Marker::SPHERE_LIST;
-//   msg.action = visualization_msgs::Marker::ADD;
-//   double scale = 0.05;
-//   msg.scale.x = scale;
-//   msg.scale.y = scale;
-//   msg.scale.z = scale;
-//   msg.color.a = 0.6;
-//   msg.color.r = 0.5;
-//   msg.color.g = 1.0;
-//   msg.color.b = 0.3;
-//   vis_marker_pub_.publish(msg);
-//   ros::WallDuration(0.1).sleep();
-
-// }
-
-// void ChompOptimizer::visualizeState(int index)
-// {
-
-//   visualization_msgs::MarkerArray msg;
-//   msg.markers.resize(num_collision_points_ + num_joints_);
-//   int num_arrows = 0;
-//   double potential_threshold = 1e-10;
-//   for(int i = 0; i < num_collision_points_; i++)
-//   {
-//     msg.markers[i].header.frame_id = collision_space_->getCollisionModelsInterface()->getRobotFrameId();
-//     msg.markers[i].header.stamp = ros::Time();
-//     msg.markers[i].ns = "chomp_collisions";
-//     msg.markers[i].id = i;
-//     msg.markers[i].type = visualization_msgs::Marker::SPHERE;
-//     msg.markers[i].action = visualization_msgs::Marker::ADD;
-//     msg.markers[i].pose.position.x = collision_point_pos_eigen_[index][i][0];
-//     msg.markers[i].pose.position.y = collision_point_pos_eigen_[index][i][1];
-//     msg.markers[i].pose.position.z = collision_point_pos_eigen_[index][i][2];
-//     msg.markers[i].pose.orientation.x = 0.0;
-//     msg.markers[i].pose.orientation.y = 0.0;
-//     msg.markers[i].pose.orientation.z = 0.0;
-//     msg.markers[i].pose.orientation.w = 1.0;
-//     double scale = 0.1;
-//     msg.markers[i].scale.x = scale;
-//     msg.markers[i].scale.y = scale;
-//     msg.markers[i].scale.z = scale;
-//     msg.markers[i].color.a = 0.6;
-//     msg.markers[i].color.r = 0.5;
-//     msg.markers[i].color.g = 1.0;
-//     msg.markers[i].color.b = 0.3;
-//     if(collision_point_potential_[index][i] > potential_threshold)
-//       num_arrows++;
-//   }
-
-//   vis_marker_array_pub_.publish(msg);
-
-//   // publish arrows for distance field:
-//   msg.markers.resize(0);
-//   msg.markers.resize(num_collision_points_);
-//   for(int i = 0; i < num_collision_points_; i++)
-//   {
-//     msg.markers[i].header.frame_id = collision_space_->getCollisionModelsInterface()->getRobotFrameId();
-//     msg.markers[i].header.stamp = ros::Time();
-//     msg.markers[i].ns = "chomp_arrows";
-//     msg.markers[i].id = i;
-//     msg.markers[i].type = visualization_msgs::Marker::ARROW;
-//     msg.markers[i].action = visualization_msgs::Marker::ADD;
-//     msg.markers[i].points.resize(2);
-//     msg.markers[i].points[0].x = collision_point_pos_eigen_[index][i](0);
-//     msg.markers[i].points[0].y = collision_point_pos_eigen_[index][i](1);
-//     msg.markers[i].points[0].z = collision_point_pos_eigen_[index][i](2);
-//     msg.markers[i].points[1] = msg.markers[i].points[0];
-//     double scale = 0.25f;
-//     if(collision_point_potential_[index][i] <= potential_threshold)
-//       scale = 0.0;
-//     msg.markers[i].points[1].x += scale * collision_point_potential_gradient_[index][i](0);
-//     msg.markers[i].points[1].y += scale * collision_point_potential_gradient_[index][i](1);
-//     msg.markers[i].points[1].z += scale * collision_point_potential_gradient_[index][i](2);
-//     msg.markers[i].scale.x = 0.01;
-//     msg.markers[i].scale.y = 0.03;
-//     msg.markers[i].color.a = 0.5;
-//     msg.markers[i].color.r = 0.5;
-//     msg.markers[i].color.g = 0.5;
-//     msg.markers[i].color.b = 1.0;
-//   }
-//   vis_marker_array_pub_.publish(msg);
-
-// }
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -180,10 +180,7 @@ void ChompOptimizer::initialize()
 
   last_improvement_iteration_ = -1;
 
-  // HMC initialization:
-  momentum_ = Eigen::MatrixXd::Zero(num_vars_free_, num_joints_);
-  random_momentum_ = Eigen::MatrixXd::Zero(num_vars_free_, num_joints_);
-  random_joint_momentum_ = Eigen::VectorXd::Zero(num_vars_free_);
+
   multivariate_gaussian_.clear();
   stochasticity_factor_ = 1.0;
   for (int i = 0; i < num_joints_; i++)
@@ -389,8 +386,7 @@ void ChompOptimizer::optimize()
       }
     }
 
-    if ((ros::WallTime::now() - start_time).toSec() > parameters_->getPlanningTimeLimit() &&
-        !parameters_->getAnimatePath() && !parameters_->getAnimateEndeffector())
+    if ((ros::WallTime::now() - start_time).toSec() > parameters_->getPlanningTimeLimit() )
     {
       ROS_WARN("Breaking out early due to time limit constraints.");
       break;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -46,24 +46,19 @@ ChompParameters::ChompParameters()
   smoothness_cost_weight_ = 0.1;
   obstacle_cost_weight_ = 1.0;
   learning_rate_ = 0.01;
-  animate_path_ = true;
-  add_randomness_ = false;
+
   smoothness_cost_velocity_ = 0.0;
   smoothness_cost_acceleration_ = 1.0;
   smoothness_cost_jerk_ = 0.0;
-  hmc_discretization_ = 0.01;
-  hmc_stochasticity_ = 0.01;
-  hmc_annealing_factor_ = 0.99;
-  use_hamiltonian_monte_carlo_ = false;
+
   ridge_factor_ = 0.0;
   use_pseudo_inverse_ = false;
   pseudo_inverse_ridge_factor_ = 1e-4;
-  animate_endeffector_ = false;
-  animate_endeffector_segment_ = std::string("r_gripper_tool_frame");
+
   joint_update_limit_ = 0.1;
   min_clearence_ = 0.2;
   collision_threshold_ = 0.07;
-  random_jump_amount_ = 1.0;
+
   use_stochastic_descent_ = true;
   filter_mode_ = false;
   trajectory_initialization_method_ = std::string("quintic-spline");

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -66,6 +66,7 @@ ChompParameters::ChompParameters()
   random_jump_amount_ = 1.0;
   use_stochastic_descent_ = true;
   filter_mode_ = false;
+  trajectory_initialization_method_ = std::string("quintic-spline");
 }
 
 ChompParameters::~ChompParameters()

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -75,14 +75,14 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ros::WallTime start_time = ros::WallTime::now();
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
 
-  //std::cout << trajectory.getTrajectory() << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  // std::cout << trajectory.getTrajectory() << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" <<
+  // std::endl;
 
   jointStateToArray(planning_scene->getRobotModel(), req.start_state.joint_state, req.group_name,
                     trajectory.getTrajectoryPoint(0));
 
-  //std::cout << trajectory.getTrajectory() << " 2.  complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
-
-
+  // std::cout << trajectory.getTrajectory() << " 2.  complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" <<
+  // std::endl;
 
   if (req.goal_constraints.empty())
   {
@@ -145,7 +145,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     return false;
   }
 
-  //std::cout << trajectory.getTrajectory() << "3. complete initialized TRAJECTORY in CHOMP_PLANNER before min jerk..!!!!!" << std::endl;
+  // std::cout << trajectory.getTrajectory() << "3. complete initialized TRAJECTORY in CHOMP_PLANNER before min
+  // jerk..!!!!!" << std::endl;
 
   if(params.trajectory_initialization_method_.compare("quintic-spline") == 0)
     trajectory.fillInMinJerk();
@@ -161,8 +162,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   //trajectory.fillInCubicInterpolation();
   //std::cout << " using initialization method: " << params.interpolation_method_ << std::endl;
 
-  //std::cout << trajectory.getTrajectory() << "4. complete initialized TRAJECTORY in CHOMP_PLANNER after min jerk..!!!!!" << std::endl;
-
+  // std::cout << trajectory.getTrajectory() << "4. complete initialized TRAJECTORY in CHOMP_PLANNER after min
+  // jerk..!!!!!" << std::endl;
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());
@@ -170,8 +171,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   start_state.update();
 
   ros::WallTime create_time = ros::WallTime::now();
-  //std::cout << trajectory.getTrajectory() << "5. complete initialized TRAJECTORY in CHOMP_PLANNER before optimizer object creation..!!!!!" << std::endl;
-
+  // std::cout << trajectory.getTrajectory() << "5. complete initialized TRAJECTORY in CHOMP_PLANNER before optimizer
+  // object creation..!!!!!" << std::endl;
 
   ChompOptimizer optimizer(&trajectory, planning_scene, req.group_name, &params, start_state);
   if (!optimizer.isInitialized())
@@ -182,8 +183,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
   ROS_DEBUG_NAMED("chomp_planner", "Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
 
-  //std::cout << trajectory.getTrajectory() << "6. complete initialized TRAJECTORY in CHOMP_PLANNER before OPTIMIZATION..!!!!!" << std::endl;
-
+  // std::cout << trajectory.getTrajectory() << "6. complete initialized TRAJECTORY in CHOMP_PLANNER before
+  // OPTIMIZATION..!!!!!" << std::endl;
 
   optimizer.optimize();
   ROS_DEBUG_NAMED("chomp_planner", "Optimization actually took %f sec to run",
@@ -193,7 +194,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
 
-  //std::cout << trajectory.getTrajectory() << "7. complete initialized TRAJECTORY in CHOMP_PLANNER after OPTIMIZATION..!!!!!" << std::endl;
+  // std::cout << trajectory.getTrajectory() << "7. complete initialized TRAJECTORY in CHOMP_PLANNER after
+  // OPTIMIZATION..!!!!!" << std::endl;
 
   res.trajectory.resize(1);
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -75,12 +75,12 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ros::WallTime start_time = ros::WallTime::now();
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
 
-  std::cout << trajectory.trajectory_ << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  //std::cout << trajectory.trajectory_ << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
 
   jointStateToArray(planning_scene->getRobotModel(), req.start_state.joint_state, req.group_name,
                     trajectory.getTrajectoryPoint(0));
 
-  std::cout << trajectory.trajectory_ << " 2.  complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  //std::cout << trajectory.trajectory_ << " 2.  complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
 
 
 
@@ -145,7 +145,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     return false;
   }
 
-  std::cout << trajectory.trajectory_ << "3. complete initialized TRAJECTORY in CHOMP_PLANNER before min jerk..!!!!!" << std::endl;
+  //std::cout << trajectory.trajectory_ << "3. complete initialized TRAJECTORY in CHOMP_PLANNER before min jerk..!!!!!" << std::endl;
 
   if(params.trajectory_initialization_method_.compare("quintic-spline") == 0)
     trajectory.fillInMinJerk();
@@ -170,7 +170,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   start_state.update();
 
   ros::WallTime create_time = ros::WallTime::now();
-  std::cout << trajectory.trajectory_ << "5. complete initialized TRAJECTORY in CHOMP_PLANNER before optimizer object creation..!!!!!" << std::endl;
+  //std::cout << trajectory.trajectory_ << "5. complete initialized TRAJECTORY in CHOMP_PLANNER before optimizer object creation..!!!!!" << std::endl;
 
 
   ChompOptimizer optimizer(&trajectory, planning_scene, req.group_name, &params, start_state);
@@ -182,7 +182,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
   ROS_DEBUG_NAMED("chomp_planner", "Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
 
-  std::cout << trajectory.trajectory_ << "6. complete initialized TRAJECTORY in CHOMP_PLANNER before OPTIMIZATION..!!!!!" << std::endl;
+  //std::cout << trajectory.trajectory_ << "6. complete initialized TRAJECTORY in CHOMP_PLANNER before OPTIMIZATION..!!!!!" << std::endl;
 
 
   optimizer.optimize();
@@ -193,7 +193,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
 
-  std::cout << trajectory.trajectory_ << "7. complete initialized TRAJECTORY in CHOMP_PLANNER after OPTIMIZATION..!!!!!" << std::endl;
+  //std::cout << trajectory.trajectory_ << "7. complete initialized TRAJECTORY in CHOMP_PLANNER after OPTIMIZATION..!!!!!" << std::endl;
 
   res.trajectory.resize(1);
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -75,12 +75,12 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ros::WallTime start_time = ros::WallTime::now();
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
 
-  //std::cout << trajectory.trajectory_ << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
 
   jointStateToArray(planning_scene->getRobotModel(), req.start_state.joint_state, req.group_name,
                     trajectory.getTrajectoryPoint(0));
 
-  //std::cout << trajectory.trajectory_ << " 2.  complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << " 2.  complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
 
 
 
@@ -145,7 +145,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     return false;
   }
 
-  //std::cout << trajectory.trajectory_ << "3. complete initialized TRAJECTORY in CHOMP_PLANNER before min jerk..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << "3. complete initialized TRAJECTORY in CHOMP_PLANNER before min jerk..!!!!!" << std::endl;
 
   if(params.trajectory_initialization_method_.compare("quintic-spline") == 0)
     trajectory.fillInMinJerk();
@@ -161,7 +161,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   //trajectory.fillInCubicInterpolation();
   //std::cout << " using initialization method: " << params.interpolation_method_ << std::endl;
 
-  //std::cout << trajectory.trajectory_ << "4. complete initialized TRAJECTORY in CHOMP_PLANNER after min jerk..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << "4. complete initialized TRAJECTORY in CHOMP_PLANNER after min jerk..!!!!!" << std::endl;
 
 
   // optimize!
@@ -170,7 +170,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   start_state.update();
 
   ros::WallTime create_time = ros::WallTime::now();
-  //std::cout << trajectory.trajectory_ << "5. complete initialized TRAJECTORY in CHOMP_PLANNER before optimizer object creation..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << "5. complete initialized TRAJECTORY in CHOMP_PLANNER before optimizer object creation..!!!!!" << std::endl;
 
 
   ChompOptimizer optimizer(&trajectory, planning_scene, req.group_name, &params, start_state);
@@ -182,7 +182,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
   ROS_DEBUG_NAMED("chomp_planner", "Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
 
-  //std::cout << trajectory.trajectory_ << "6. complete initialized TRAJECTORY in CHOMP_PLANNER before OPTIMIZATION..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << "6. complete initialized TRAJECTORY in CHOMP_PLANNER before OPTIMIZATION..!!!!!" << std::endl;
 
 
   optimizer.optimize();
@@ -193,7 +193,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
 
-  //std::cout << trajectory.trajectory_ << "7. complete initialized TRAJECTORY in CHOMP_PLANNER after OPTIMIZATION..!!!!!" << std::endl;
+  //std::cout << trajectory.getTrajectory() << "7. complete initialized TRAJECTORY in CHOMP_PLANNER after OPTIMIZATION..!!!!!" << std::endl;
 
   res.trajectory.resize(1);
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -189,7 +189,7 @@ void ChompTrajectory::fillInLinearInterpolation()
   double start_index  = start_index_ - 1;
   double end_index    = end_index_ + 1;
   int time_steps = end_index - start_index;
-  for(int i = 0; i<num_joints_ ; i++)
+  for(int i = 0; i < num_joints_ ; i++)
   {
     double theta = ((*this)(end_index, i) - (*this)(start_index,i)) / (end_index- 1);
     for(int j=start_index+1 ; j< end_index ; j++)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -54,9 +54,6 @@ ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_m
   const moveit::core::JointModelGroup* model_group = robot_model->getJointModelGroup(planning_group_name_);
   num_joints_ = model_group->getActiveJointModels().size();
   init();
-
-  std::cout << trajectory_ << " complete initialized TRAJECTORY in first constructor..!!!!!" << std::endl;
-
 }
 
 ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, int num_points,

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -189,7 +189,7 @@ void ChompTrajectory::fillInLinearInterpolation()
   double start_index  = start_index_ - 1;
   double end_index    = end_index_ + 1;
   int time_steps = end_index - start_index;
-  for(int i = 0; i < num_joints_ ; i++)
+  for (int i = 0; i < num_joints_; i++)
   {
     double theta = ((*this)(end_index, i) - (*this)(start_index,i)) / (end_index- 1);
     for(int j=start_index+1 ; j< end_index ; j++)


### PR DESCRIPTION
### CHOMP Motion planner cleanup of code and new trajectory initialization methods
This pull request is a part of Google summer of code 2018 work by Raghavender Sahdev. This pull request removes any unused parameters and code for the CHOMP planner. It also has the code from [Pull request #899](https://github.com/ros-planning/moveit/pull/899/commits).

### Checklist
- [ ] removed unused code pertaining to unused CHOMP parameters
- [ ] removed commented code in chomp_optimizer.cpp file.
- [ ] addition of trajectory initialization methods for CHOMP


