### PR TITLE
reset moveit_msgs::RobotState.is_diff to false

### DIFF
--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -389,6 +389,7 @@ bool robotStateMsgToRobotState(const Transforms& tf, const moveit_msgs::RobotSta
 
 void robotStateToRobotStateMsg(const RobotState& state, moveit_msgs::RobotState& robot_state, bool copy_attached_bodies)
 {
+  robot_state.is_diff = false;
   robotStateToJointStateMsg(state, robot_state.joint_state);
   _robotStateToMultiDOFJointState(state, robot_state.multi_dof_joint_state);
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -328,19 +328,22 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
 {
   ROS_DEBUG_NAMED(LOGNAME, "Started scene publishing thread ...");
 
-  // publish the full planning scene
-  moveit_msgs::PlanningScene msg;
+  // publish the full planning scene once
   {
-    occupancy_map_monitor::OccMapTree::ReadLock lock;
-    if (octomap_monitor_)
-      lock = octomap_monitor_->getOcTreePtr()->reading();
-    scene_->getPlanningSceneMsg(msg);
+    moveit_msgs::PlanningScene msg;
+    {
+      occupancy_map_monitor::OccMapTree::ReadLock lock;
+      if (octomap_monitor_)
+        lock = octomap_monitor_->getOcTreePtr()->reading();
+      scene_->getPlanningSceneMsg(msg);
+    }
+    planning_scene_publisher_.publish(msg);
+    ROS_DEBUG_NAMED(LOGNAME, "Published the full planning scene: '%s'", msg.name.c_str());
   }
-  planning_scene_publisher_.publish(msg);
-  ROS_DEBUG_NAMED(LOGNAME, "Published the full planning scene: '%s'", msg.name.c_str());
 
   do
   {
+    moveit_msgs::PlanningScene msg;
     bool publish_msg = false;
     bool is_full = false;
     ros::Rate rate(publish_planning_scene_frequency_);


### PR DESCRIPTION
Currently once robot_state.is_diff has been set to true it will stay so. This breaks detaching attached objects. This is a fix for a regression introduced in #939 