### PR TITLE
Perception screen added for the SA

### DIFF
--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -71,6 +71,7 @@ set(HEADERS
   src/widgets/end_effectors_widget.h
   src/widgets/virtual_joints_widget.h
   src/widgets/passive_joints_widget.h
+  src/widgets/perception_widget.h
   src/widgets/configuration_files_widget.h
   src/widgets/setup_screen_widget.h
   src/widgets/author_information_widget.h
@@ -104,6 +105,7 @@ add_library(${PROJECT_NAME}_widgets
   src/widgets/end_effectors_widget.cpp
   src/widgets/virtual_joints_widget.cpp
   src/widgets/passive_joints_widget.cpp
+  src/widgets/perception_widget.cpp
   src/widgets/configuration_files_widget.cpp
   src/widgets/navigation_widget.cpp
   src/widgets/header_widget.cpp
@@ -146,9 +148,8 @@ install(DIRECTORY templates DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   include_directories(${moveit_resources_INCLUDE_DIRS})
-
-  catkin_add_gtest(test_writing_ros_controllers test/moveit_config_data_test.cpp)
-  target_link_libraries(test_writing_ros_controllers  ${PROJECT_NAME}_tools
+  catkin_add_gtest(test_reading_writing_config test/moveit_config_data_test.cpp)
+  target_link_libraries(test_reading_writing_config  ${PROJECT_NAME}_tools
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
   ${MOVEIT_LIB_NAME})

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -79,16 +79,6 @@ struct GroupMetaData
 };
 
 /**
- * Reusable parameter struct which may be used in reading and writing configuration files
- */
-struct GenericParameter
-{
-  std::string name;     // name of parameter
-  std::string value;    // value parameter will receive (but as a string)
-  std::string comment;  // comment briefly describing what this parameter does
-};
-
-/**
  * ROS Controllers settings which may be set in the config files
  */
 struct ROSControlConfig
@@ -96,6 +86,16 @@ struct ROSControlConfig
   std::string name_;                 // controller name
   std::string type_;                 // controller type
   std::vector<std::string> joints_;  // joints controller by this controller
+};
+
+/**
+ * Planning parameters which may be set in the config files
+ */
+struct OmplPlanningParameter
+{
+  std::string name;     // name of parameter
+  std::string value;    // value parameter will receive (but as a string)
+  std::string comment;  // comment briefly describing what this parameter does
 };
 
 /** \brief This class describes the OMPL planners by name, type, and parameter list, used to create the
@@ -122,17 +122,59 @@ public:
    * @parameter: value: value of parameter as a string
    *  @parameter: value: value of parameter as a string
    */
-  void addGenericParameter(const std::string& name, const std::string& value = "", const std::string& comment = "")
+  void addParameter(const std::string& name, const std::string& value = "", const std::string& comment = "")
   {
-    GenericParameter temp;
+    OmplPlanningParameter temp;
     temp.name = name;
     temp.value = value;
     temp.comment = comment;
     parameter_list_.push_back(temp);
   }
-  std::vector<GenericParameter> parameter_list_;
+  std::vector<OmplPlanningParameter> parameter_list_;
   std::string name_;  // name of planner
   std::string type_;  // type of planner (geometric)
+};
+
+/**
+ * Reusable parameter class which may be used in reading and writing configuration files
+ */
+class GenericParameter
+{
+public:
+  GenericParameter()
+  {
+    comment_ = "";
+  };
+
+  void setName(std::string name)
+  {
+    name_ = name;
+  };
+  void setValue(std::string value)
+  {
+    value_ = value;
+  };
+  void setComment(std::string comment)
+  {
+    comment_ = comment;
+  };
+  std::string getName()
+  {
+    return name_;
+  };
+  std::string getValue()
+  {
+    return value_;
+  };
+  std::string getComment()
+  {
+    return comment_;
+  };
+
+private:
+  std::string name_;     // name of parameter
+  std::string value_;    // value parameter will receive (but as a string)
+  std::string comment_;  // comment briefly describing what this parameter does
 };
 
 MOVEIT_CLASS_FORWARD(MoveItConfigData);

--- a/moveit_setup_assistant/resources/default_config/sensors_3d.yaml
+++ b/moveit_setup_assistant/resources/default_config/sensors_3d.yaml
@@ -1,0 +1,22 @@
+# This YAML configuration file holds the default values used for configuring 3D sensors.
+# The name of this file shouldn't be changed, or else the Setup Assistant won't detect it.
+# Values may not be ideal defaults, original source unclear.
+sensors:
+  - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
+    point_cloud_topic: /head_mount_kinect/depth_registered/points
+    max_range: 5.0
+    point_subsample: 1
+    padding_offset: 0.1
+    padding_scale: 1.0
+    max_update_rate: 1.0
+    filtered_cloud_topic: filtered_cloud
+  - sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
+    image_topic: /head_mount_kinect/depth_registered/image_raw
+    queue_size: 5
+    near_clipping_plane_distance: 0.3
+    far_clipping_plane_distance: 5.0
+    shadow_threshold: 0.2
+    padding_scale: 4.0
+    padding_offset: 0.03
+    max_update_rate: 1.0
+    filtered_cloud_topic: filtered_cloud

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -83,7 +83,6 @@ MoveItConfigData::~MoveItConfigData()
 void MoveItConfigData::setRobotModel(robot_model::RobotModelPtr robot_model)
 {
   robot_model_ = robot_model;
-  robot_model_const_ = robot_model;
 }
 
 // ******************************************************************************************
@@ -95,10 +94,9 @@ robot_model::RobotModelConstPtr MoveItConfigData::getRobotModel()
   {
     // Initialize with a URDF Model Interface and a SRDF Model
     robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_->srdf_model_));
-    robot_model_const_ = robot_model_;
   }
 
-  return robot_model_const_;
+  return robot_model_;
 }
 
 // ******************************************************************************************
@@ -113,7 +111,6 @@ void MoveItConfigData::updateRobotModel()
 
   // Create new kin model
   robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_->srdf_model_));
-  robot_model_const_ = robot_model_;
 
   // Reset the planning scene
   planning_scene_.reset();
@@ -847,6 +844,50 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
 }
 
 // ******************************************************************************************
+// Output 3D Sensor configuration file
+// ******************************************************************************************
+bool MoveItConfigData::output3DSensorPluginYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  emitter << YAML::Comment("The name of this file shouldn't be changed, or else the Setup Assistant won't detect it");
+  emitter << YAML::Key << "sensors";
+  emitter << YAML::Value << YAML::BeginSeq;
+
+  // Can we have more than one plugin config?
+  emitter << YAML::BeginMap;
+
+  // Make sure sensors_plugin_config_parameter_list_ is not empty
+  if (sensors_plugin_config_parameter_list_.size() == 1)
+  {
+    for (auto& parameter : sensors_plugin_config_parameter_list_[0])
+    {
+      emitter << YAML::Key << parameter.first;
+      emitter << YAML::Value << parameter.second.value;
+    }
+  }
+
+  emitter << YAML::EndMap;
+
+  emitter << YAML::EndSeq;
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    ROS_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
 // Output joint limits config files
 // ******************************************************************************************
 bool MoveItConfigData::outputJointLimitsYAML(const std::string& file_path)
@@ -1400,6 +1441,113 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
 }
 
 // ******************************************************************************************
+// Input sensors_3d yaml file
+// ******************************************************************************************
+bool MoveItConfigData::input3DSensorsYAML(const std::string& default_file_path, const std::string& file_path)
+{
+  // Load default parameters file
+  std::ifstream default_input_stream(default_file_path.c_str());
+  if (!default_input_stream.good())
+  {
+    ROS_ERROR_STREAM_NAMED("sensors_3d.yaml", "Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  // Parse default parameters values
+  try
+  {
+    const YAML::Node& doc = YAML::Load(default_input_stream);
+
+    // Get sensors node
+    if (const YAML::Node& sensors_node = doc["sensors"])
+    {
+      // Make sue that the sensors are written as a sequence
+      if (sensors_node.IsSequence())
+      {
+        GenericParameter sensor_param;
+        std::map<std::string, GenericParameter> sensor_map;
+
+        // Loop over the sensors available in the file
+        for (std::size_t i = 0; i < sensors_node.size(); ++i)
+        {
+          if (const YAML::Node& sensor_node = sensors_node[i])
+          {
+            for (YAML::const_iterator sensor_it = sensor_node.begin(); sensor_it != sensor_node.end(); ++sensor_it)
+            {
+              sensor_param.name = sensor_it->first.as<std::string>();
+              sensor_param.value = sensor_it->second.as<std::string>();
+
+              // Set the key as the parameter name to make accessing it easier
+              sensor_map[sensor_param.name] = sensor_param;
+            }
+            sensors_plugin_config_parameter_list_.push_back(sensor_map);
+          }
+        }
+      }
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    ROS_ERROR_STREAM("Error parsing default sensors yaml: " << e.what());
+  }
+
+  // Is there a sensors config in the package?
+  if (file_path.empty())
+  {
+    return true;
+  }
+
+  // Load file
+  std::ifstream input_stream(file_path.c_str());
+  if (!input_stream.good())
+  {
+    ROS_ERROR_STREAM_NAMED("sensors_3d.yaml", "Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  // Begin parsing
+  try
+  {
+    const YAML::Node& doc = YAML::Load(input_stream);
+
+    // Get sensors node
+    if (const YAML::Node& sensors_node = doc["sensors"])
+    {
+      // Make sue that the sensors are written as a sequence
+      if (sensors_node.IsSequence())
+      {
+        GenericParameter sensor_param;
+        std::map<std::string, GenericParameter> sensor_map;
+
+        // Loop over the sensors available in the file
+        for (std::size_t i = 0; i < sensors_node.size(); ++i)
+        {
+          if (const YAML::Node& sensor_node = sensors_node[i])
+          {
+            for (YAML::const_iterator sensor_it = sensor_node.begin(); sensor_it != sensor_node.end(); ++sensor_it)
+            {
+              sensor_param.name = sensor_it->first.as<std::string>();
+              sensor_param.value = sensor_it->second.as<std::string>();
+
+              // Set the key as the parameter name to make accessing it easier
+              sensor_map[sensor_param.name] = sensor_param;
+            }
+            sensors_plugin_config_parameter_list_.push_back(sensor_map);
+          }
+        }
+      }
+    }
+    return true;
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    ROS_ERROR_STREAM("Error parsing sensors yaml: " << e.what());
+  }
+
+  return false;  // if it gets to this point an error has occured
+}
+
+// ******************************************************************************************
 // Helper Function for joining a file path and a file name, or two file paths, etc, in a cross-platform way
 // ******************************************************************************************
 std::string MoveItConfigData::appendPaths(const std::string& path1, const std::string& path2)
@@ -1476,6 +1624,32 @@ bool MoveItConfigData::addROSController(const ROSControlConfig& new_controller)
 std::vector<ROSControlConfig> MoveItConfigData::getROSControllers()
 {
   return ros_controllers_config_;
+}
+
+// ******************************************************************************************
+// Used to add a sensor plugin configuation parameter to the sensor plugin configuration parameter list
+// ******************************************************************************************
+void MoveItConfigData::addGenericParameterToSensorPluginConfig(const std::string& name, const std::string& value,
+                                                               const std::string& comment)
+{
+  // Use index 0 since we only write one plugin
+  sensors_plugin_config_parameter_list_[0][name] = {.name = name, .value = value, .comment = comment };
+}
+
+// ******************************************************************************************
+// Used to get sensor plugin configuration parameter list
+// ******************************************************************************************
+std::vector<std::map<std::string, GenericParameter>> MoveItConfigData::getSensorPluginConfig()
+{
+  return sensors_plugin_config_parameter_list_;
+}
+
+// ******************************************************************************************
+// Used to clear sensor plugin configuration parameter list
+// ******************************************************************************************
+void MoveItConfigData::clearSensorPluginConfig()
+{
+  sensors_plugin_config_parameter_list_.clear();
 }
 
 }  // namespace

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -864,7 +864,7 @@ bool MoveItConfigData::output3DSensorPluginYAML(const std::string& file_path)
     for (auto& parameter : sensors_plugin_config_parameter_list_[0])
     {
       emitter << YAML::Key << parameter.first;
-      emitter << YAML::Value << parameter.second.value;
+      emitter << YAML::Value << parameter.second.getValue();
     }
   }
 
@@ -1474,11 +1474,11 @@ bool MoveItConfigData::input3DSensorsYAML(const std::string& default_file_path, 
           {
             for (YAML::const_iterator sensor_it = sensor_node.begin(); sensor_it != sensor_node.end(); ++sensor_it)
             {
-              sensor_param.name = sensor_it->first.as<std::string>();
-              sensor_param.value = sensor_it->second.as<std::string>();
+              sensor_param.setName(sensor_it->first.as<std::string>());
+              sensor_param.setValue(sensor_it->second.as<std::string>());
 
               // Set the key as the parameter name to make accessing it easier
-              sensor_map[sensor_param.name] = sensor_param;
+              sensor_map[sensor_it->first.as<std::string>()] = sensor_param;
             }
             sensors_plugin_config_parameter_list_.push_back(sensor_map);
           }
@@ -1526,11 +1526,11 @@ bool MoveItConfigData::input3DSensorsYAML(const std::string& default_file_path, 
           {
             for (YAML::const_iterator sensor_it = sensor_node.begin(); sensor_it != sensor_node.end(); ++sensor_it)
             {
-              sensor_param.name = sensor_it->first.as<std::string>();
-              sensor_param.value = sensor_it->second.as<std::string>();
+              sensor_param.setName(sensor_it->first.as<std::string>());
+              sensor_param.setValue(sensor_it->second.as<std::string>());
 
               // Set the key as the parameter name to make accessing it easier
-              sensor_map[sensor_param.name] = sensor_param;
+              sensor_map[sensor_it->first.as<std::string>()] = sensor_param;
             }
             sensors_plugin_config_parameter_list_.push_back(sensor_map);
           }
@@ -1633,7 +1633,10 @@ void MoveItConfigData::addGenericParameterToSensorPluginConfig(const std::string
                                                                const std::string& comment)
 {
   // Use index 0 since we only write one plugin
-  sensors_plugin_config_parameter_list_[0][name] = {.name = name, .value = value, .comment = comment };
+  GenericParameter new_parameter;
+  new_parameter.setName(name);
+  new_parameter.setValue(value);
+  sensors_plugin_config_parameter_list_[0][name] = new_parameter;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -309,6 +309,14 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
+  // sensors_3d.yaml --------------------------------------------------------------------------------------
+  file.file_name_ = "sensors_3d.yaml";
+  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.description_ = "Creates configurations 3d sensors.";
+  file.gen_func_ = boost::bind(&MoveItConfigData::output3DSensorPluginYAML, config_data_, _1);
+  file.write_on_changes = MoveItConfigData::SENSORS_CONFIG;
+  gen_files_.push_back(file);
+
   // -------------------------------------------------------------------------------------------------------------------
   // LAUNCH FILES ------------------------------------------------------------------------------------------------------
   // -------------------------------------------------------------------------------------------------------------------

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -308,29 +308,31 @@ void PerceptionWidget::loadSensorPluginsComboBox()
   std::vector<std::map<std::string, GenericParameter> > sensors_vec_map = config_data_->getSensorPluginConfig();
   for (std::size_t i = 0; i < sensors_vec_map.size(); ++i)
   {
-    if (sensors_vec_map[i]["sensor_plugin"].value == std::string("occupancy_map_monitor/PointCloudOctomapUpdater"))
+    if (sensors_vec_map[i]["sensor_plugin"].getValue() == std::string("occupancy_map_monitor/PointCloudOctomapUpdater"))
     {
       sensor_plugin_field_->setCurrentIndex(1);
-      point_cloud_topic_field_->setText(QString(sensors_vec_map[i]["point_cloud_topic"].value.c_str()));
-      max_range_field_->setText(QString(sensors_vec_map[i]["max_range"].value.c_str()));
-      point_subsample_field_->setText(QString(sensors_vec_map[i]["point_subsample"].value.c_str()));
-      padding_offset_field_->setText(QString(sensors_vec_map[i]["padding_offset"].value.c_str()));
-      padding_scale_field_->setText(QString(sensors_vec_map[i]["padding_scale"].value.c_str()));
-      max_update_rate_field_->setText(QString(sensors_vec_map[i]["max_update_rate"].value.c_str()));
-      filtered_cloud_topic_field_->setText(QString(sensors_vec_map[i]["filtered_cloud_topic"].value.c_str()));
+      point_cloud_topic_field_->setText(QString(sensors_vec_map[i]["point_cloud_topic"].getValue().c_str()));
+      max_range_field_->setText(QString(sensors_vec_map[i]["max_range"].getValue().c_str()));
+      point_subsample_field_->setText(QString(sensors_vec_map[i]["point_subsample"].getValue().c_str()));
+      padding_offset_field_->setText(QString(sensors_vec_map[i]["padding_offset"].getValue().c_str()));
+      padding_scale_field_->setText(QString(sensors_vec_map[i]["padding_scale"].getValue().c_str()));
+      max_update_rate_field_->setText(QString(sensors_vec_map[i]["max_update_rate"].getValue().c_str()));
+      filtered_cloud_topic_field_->setText(QString(sensors_vec_map[i]["filtered_cloud_topic"].getValue().c_str()));
     }
-    else if (sensors_vec_map[i]["sensor_plugin"].value == std::string("occupancy_map_monitor/DepthImageOctomapUpdater"))
+    else if (sensors_vec_map[i]["sensor_plugin"].getValue() ==
+             std::string("occupancy_map_monitor/DepthImageOctomapUpdater"))
     {
       sensor_plugin_field_->setCurrentIndex(2);
-      image_topic_field_->setText(QString(sensors_vec_map[i]["image_topic"].value.c_str()));
-      queue_size_field_->setText(QString(sensors_vec_map[i]["queue_size"].value.c_str()));
-      near_clipping_field_->setText(QString(sensors_vec_map[i]["near_clipping_plane_distance"].value.c_str()));
-      far_clipping_field_->setText(QString(sensors_vec_map[i]["far_clipping_plane_distance"].value.c_str()));
-      shadow_threshold_field_->setText(QString(sensors_vec_map[i]["shadow_threshold"].value.c_str()));
-      depth_padding_scale_field_->setText(QString(sensors_vec_map[i]["padding_scale"].value.c_str()));
-      depth_padding_offset_field_->setText(QString(sensors_vec_map[i]["padding_offset"].value.c_str()));
-      depth_filtered_cloud_topic_field_->setText(QString(sensors_vec_map[i]["filtered_cloud_topic"].value.c_str()));
-      depth_max_update_rate_field_->setText(QString(sensors_vec_map[i]["max_update_rate"].value.c_str()));
+      image_topic_field_->setText(QString(sensors_vec_map[i]["image_topic"].getValue().c_str()));
+      queue_size_field_->setText(QString(sensors_vec_map[i]["queue_size"].getValue().c_str()));
+      near_clipping_field_->setText(QString(sensors_vec_map[i]["near_clipping_plane_distance"].getValue().c_str()));
+      far_clipping_field_->setText(QString(sensors_vec_map[i]["far_clipping_plane_distance"].getValue().c_str()));
+      shadow_threshold_field_->setText(QString(sensors_vec_map[i]["shadow_threshold"].getValue().c_str()));
+      depth_padding_scale_field_->setText(QString(sensors_vec_map[i]["padding_scale"].getValue().c_str()));
+      depth_padding_offset_field_->setText(QString(sensors_vec_map[i]["padding_offset"].getValue().c_str()));
+      depth_filtered_cloud_topic_field_->setText(
+          QString(sensors_vec_map[i]["filtered_cloud_topic"].getValue().c_str()));
+      depth_max_update_rate_field_->setText(QString(sensors_vec_map[i]["max_update_rate"].getValue().c_str()));
     }
   }
 

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -1,0 +1,344 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Mohamad Ayman.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mohamad Ayman */
+
+// SA
+#include "perception_widget.h"
+
+// Qt
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QApplication>
+
+namespace moveit_setup_assistant
+{
+// ******************************************************************************************
+// Constructor
+// ******************************************************************************************
+PerceptionWidget::PerceptionWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data)
+  : SetupScreenWidget(parent), config_data_(config_data)
+{
+  // Basic widget container
+  QVBoxLayout* layout = new QVBoxLayout();
+  layout->setAlignment(Qt::AlignTop);
+
+  // Top Header Area ------------------------------------------------
+
+  HeaderWidget* header =
+      new HeaderWidget("3D Perception Sensor Configuration", "Configure your 3D sensors to work with Moveit! ", this);
+  layout->addWidget(header);
+
+  // Perception documentation page
+  QLabel* perception_documentation_hyperlink = new QLabel(this);
+  perception_documentation_hyperlink->setText("Look at <a "
+                                              "href='http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/"
+                                              "perception_configuration/"
+                                              "perception_configuration_tutorial.html'>Perception Documentation</a> "
+                                              "for more details");
+  perception_documentation_hyperlink->setTextFormat(Qt::RichText);
+  perception_documentation_hyperlink->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  perception_documentation_hyperlink->setOpenExternalLinks(true);
+  layout->addWidget(perception_documentation_hyperlink);
+
+  // Add spacing
+  QSpacerItem* blank_space = new QSpacerItem(1, 6);
+  layout->addSpacerItem(blank_space);
+
+  // Plugin type combo box
+  QLabel* plugin_field_title = new QLabel(this);
+  plugin_field_title->setText("Optionally choose a type of 3D sensor plugin to configure:");
+  layout->addWidget(plugin_field_title);
+
+  sensor_plugin_field_ = new QComboBox(this);
+  sensor_plugin_field_->setEditable(false);
+  sensor_plugin_field_->setMaximumWidth(600);
+  connect(sensor_plugin_field_, SIGNAL(currentIndexChanged(int)), this, SLOT(sensorPluginChanged(int)));
+  layout->addWidget(sensor_plugin_field_);
+
+  // Point Cloud group -------------------------------------------
+  point_cloud_group_ = new QGroupBox("Point Cloud");
+
+  QFormLayout* point_cloud_form_layout = new QFormLayout();
+  point_cloud_form_layout->setContentsMargins(0, 15, 0, 15);
+
+  // Point Cloud Topic
+  point_cloud_topic_field_ = new QLineEdit(this);
+  point_cloud_topic_field_->setMaximumWidth(400);
+  // point_cloud_topic_field_->setText(QString("/clud topic"));
+  point_cloud_form_layout->addRow("Point Cloud Topic:", point_cloud_topic_field_);
+
+  // Max Range
+  max_range_field_ = new QLineEdit(this);
+  max_range_field_->setMaximumWidth(400);
+  point_cloud_form_layout->addRow("Max Range:", max_range_field_);
+
+  // Point Subsample
+  point_subsample_field_ = new QLineEdit(this);
+  point_subsample_field_->setMaximumWidth(400);
+  point_cloud_form_layout->addRow("Point Subsample:", point_subsample_field_);
+
+  // Padding Offset
+  padding_offset_field_ = new QLineEdit(this);
+  padding_offset_field_->setMaximumWidth(400);
+  point_cloud_form_layout->addRow("Padding Offset:", padding_offset_field_);
+
+  // Padding Scale
+  padding_scale_field_ = new QLineEdit(this);
+  padding_scale_field_->setMaximumWidth(400);
+  point_cloud_form_layout->addRow("Padding Scale:", padding_scale_field_);
+
+  // Filtered Cloud Topic
+  filtered_cloud_topic_field_ = new QLineEdit(this);
+  filtered_cloud_topic_field_->setMaximumWidth(400);
+  point_cloud_form_layout->addRow("Filtered Cloud Topic:", filtered_cloud_topic_field_);
+
+  // Max Update Rate
+  max_update_rate_field_ = new QLineEdit(this);
+  max_update_rate_field_->setMaximumWidth(400);
+  point_cloud_form_layout->addRow("Max Update Rate:", max_update_rate_field_);
+
+  // Piont Cloud form layout
+  point_cloud_group_->setLayout(point_cloud_form_layout);
+  layout->addWidget(point_cloud_group_);
+
+  // Depth map group --------------------------------------------
+  depth_map_group_ = new QGroupBox("Depth Map");
+
+  // Depth Map form layout
+  QFormLayout* depth_map_form_layout = new QFormLayout();
+  depth_map_form_layout->setContentsMargins(0, 15, 0, 15);
+
+  // Image Topic
+  image_topic_field_ = new QLineEdit(this);
+  image_topic_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Image Topic:", image_topic_field_);
+
+  // Queue Size
+  queue_size_field_ = new QLineEdit(this);
+  queue_size_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Queue Size:", queue_size_field_);
+
+  // Near Clipping Plane Distance
+  near_clipping_field_ = new QLineEdit(this);
+  near_clipping_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Near Clipping Plane Distance:", near_clipping_field_);
+
+  // Far Clipping Plane Distance
+  far_clipping_field_ = new QLineEdit(this);
+  far_clipping_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Far Clipping Plane Distance:", far_clipping_field_);
+
+  // Shadow Threshold
+  shadow_threshold_field_ = new QLineEdit(this);
+  shadow_threshold_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Shadow Threshold:", shadow_threshold_field_);
+
+  // Padding Offset
+  depth_padding_offset_field_ = new QLineEdit(this);
+  depth_padding_offset_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Padding Offset:", depth_padding_offset_field_);
+
+  // Padding Scale
+  depth_padding_scale_field_ = new QLineEdit(this);
+  depth_padding_scale_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Padding Scale:", depth_padding_scale_field_);
+
+  // Filtered Cloud Topic
+  depth_filtered_cloud_topic_field_ = new QLineEdit(this);
+  depth_filtered_cloud_topic_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Filtered Cloud Topic:", depth_filtered_cloud_topic_field_);
+
+  // Filtered Cloud Topic
+  depth_max_update_rate_field_ = new QLineEdit(this);
+  depth_max_update_rate_field_->setMaximumWidth(400);
+  depth_map_form_layout->addRow("Max Update Rate:", depth_max_update_rate_field_);
+
+  depth_map_group_->setLayout(depth_map_form_layout);
+  layout->addWidget(depth_map_group_);
+
+  layout->setAlignment(Qt::AlignTop);
+
+  // Finish Layout --------------------------------------------------
+  this->setLayout(layout);
+}
+
+// ******************************************************************************************
+// Recieved when this widget is chosen from the navigation menu
+// ******************************************************************************************
+void PerceptionWidget::focusGiven()
+{
+  loadSensorPluginsComboBox();
+}
+
+// ******************************************************************************************
+// Recieved when another widget is chosen from the navigation menu
+// ******************************************************************************************
+bool PerceptionWidget::focusLost()
+{
+  // Save the sensor plugin configuration to sensors_plugin_config data structure
+  if (sensor_plugin_field_->currentIndex() == 1)
+  {
+    // Point Cloud plugin feilds
+    config_data_->addGenericParameterToSensorPluginConfig("sensor_plugin", "occupancy_map_monitor/"
+                                                                           "PointCloudOctomapUpdater");
+    config_data_->addGenericParameterToSensorPluginConfig("point_cloud_topic",
+                                                          point_cloud_topic_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("max_range",
+                                                          max_range_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("point_subsample",
+                                                          point_subsample_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("padding_offset",
+                                                          padding_offset_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("padding_scale",
+                                                          padding_scale_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("max_update_rate",
+                                                          max_update_rate_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("filtered_cloud_topic",
+                                                          filtered_cloud_topic_field_->text().trimmed().toStdString());
+
+    config_data_->changes |= MoveItConfigData::SENSORS_CONFIG;
+  }
+  else if (sensor_plugin_field_->currentIndex() == 2)
+  {
+    // Depth Map plugin feilds
+    config_data_->addGenericParameterToSensorPluginConfig("sensor_plugin", "occupancy_map_monitor/"
+                                                                           "DepthImageOctomapUpdater");
+    config_data_->addGenericParameterToSensorPluginConfig("image_topic",
+                                                          image_topic_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("queue_size",
+                                                          queue_size_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("near_clipping_plane_distance",
+                                                          near_clipping_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("far_clipping_plane_distance",
+                                                          far_clipping_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("shadow_threshold",
+                                                          shadow_threshold_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("padding_scale",
+                                                          depth_padding_scale_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("padding_offset",
+                                                          depth_padding_offset_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig(
+        "filtered_cloud_topic", depth_filtered_cloud_topic_field_->text().trimmed().toStdString());
+    config_data_->addGenericParameterToSensorPluginConfig("max_update_rate",
+                                                          depth_max_update_rate_field_->text().trimmed().toStdString());
+
+    config_data_->changes |= MoveItConfigData::SENSORS_CONFIG;
+  }
+  else
+  {
+    // Clear the sensors_plugin_config data structure
+    config_data_->clearSensorPluginConfig();
+    config_data_->changes ^= MoveItConfigData::SENSORS_CONFIG;
+  }
+}
+
+void PerceptionWidget::sensorPluginChanged(int index)
+{
+  if (index == 1)
+  {
+    // Point cloud form visible, depth map form invisible
+    point_cloud_group_->setVisible(true);
+    depth_map_group_->setVisible(false);
+  }
+  else if (index == 2)
+  {
+    // Depth map form visible, point cloud form invisible
+    point_cloud_group_->setVisible(false);
+    depth_map_group_->setVisible(true);
+  }
+  else
+  {
+    // All forms invisible
+    point_cloud_group_->setVisible(false);
+    depth_map_group_->setVisible(false);
+  }
+}
+
+void PerceptionWidget::loadSensorPluginsComboBox()
+{
+  // Only load this combo box once
+  static bool hasLoaded = false;
+  if (hasLoaded)
+    return;
+  hasLoaded = true;
+
+  // Remove all old items
+  sensor_plugin_field_->clear();
+
+  // Add None option, the default
+  sensor_plugin_field_->addItem("None");
+
+  // Add the two avilable plugins to combo box
+  sensor_plugin_field_->addItem("Point Cloud");
+  sensor_plugin_field_->addItem("Depth Map");
+
+  // Load deafult config, or use the one in the config package if exists
+  std::vector<std::map<std::string, GenericParameter> > sensors_vec_map = config_data_->getSensorPluginConfig();
+  for (std::size_t i = 0; i < sensors_vec_map.size(); ++i)
+  {
+    if (sensors_vec_map[i]["sensor_plugin"].value == std::string("occupancy_map_monitor/PointCloudOctomapUpdater"))
+    {
+      sensor_plugin_field_->setCurrentIndex(1);
+      point_cloud_topic_field_->setText(QString(sensors_vec_map[i]["point_cloud_topic"].value.c_str()));
+      max_range_field_->setText(QString(sensors_vec_map[i]["max_range"].value.c_str()));
+      point_subsample_field_->setText(QString(sensors_vec_map[i]["point_subsample"].value.c_str()));
+      padding_offset_field_->setText(QString(sensors_vec_map[i]["padding_offset"].value.c_str()));
+      padding_scale_field_->setText(QString(sensors_vec_map[i]["padding_scale"].value.c_str()));
+      max_update_rate_field_->setText(QString(sensors_vec_map[i]["max_update_rate"].value.c_str()));
+      filtered_cloud_topic_field_->setText(QString(sensors_vec_map[i]["filtered_cloud_topic"].value.c_str()));
+    }
+    else if (sensors_vec_map[i]["sensor_plugin"].value == std::string("occupancy_map_monitor/DepthImageOctomapUpdater"))
+    {
+      sensor_plugin_field_->setCurrentIndex(2);
+      image_topic_field_->setText(QString(sensors_vec_map[i]["image_topic"].value.c_str()));
+      queue_size_field_->setText(QString(sensors_vec_map[i]["queue_size"].value.c_str()));
+      near_clipping_field_->setText(QString(sensors_vec_map[i]["near_clipping_plane_distance"].value.c_str()));
+      far_clipping_field_->setText(QString(sensors_vec_map[i]["far_clipping_plane_distance"].value.c_str()));
+      shadow_threshold_field_->setText(QString(sensors_vec_map[i]["shadow_threshold"].value.c_str()));
+      depth_padding_scale_field_->setText(QString(sensors_vec_map[i]["padding_scale"].value.c_str()));
+      depth_padding_offset_field_->setText(QString(sensors_vec_map[i]["padding_offset"].value.c_str()));
+      depth_filtered_cloud_topic_field_->setText(QString(sensors_vec_map[i]["filtered_cloud_topic"].value.c_str()));
+      depth_max_update_rate_field_->setText(QString(sensors_vec_map[i]["max_update_rate"].value.c_str()));
+    }
+  }
+
+  // If no sensor config exists, default to None
+  if (sensors_vec_map.size() == 2)
+  {
+    sensor_plugin_field_->setCurrentIndex(0);
+  }
+}
+
+}  // namespace

--- a/moveit_setup_assistant/src/widgets/perception_widget.h
+++ b/moveit_setup_assistant/src/widgets/perception_widget.h
@@ -1,0 +1,130 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Mohamad Ayman.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mohamad Ayman */
+
+#ifndef MOVEIT_MOVEIT_SETUP_ASSISTANT_WIDGETS_PERCEPTION_WIDGET_
+#define MOVEIT_MOVEIT_SETUP_ASSISTANT_WIDGETS_PERCEPTION_WIDGET_
+
+// Qt
+#include <QWidget>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QString>
+#include <QLineEdit>
+
+// SA
+#ifndef Q_MOC_RUN
+#include <moveit/setup_assistant/tools/moveit_config_data.h>
+#endif
+
+#include "header_widget.h"
+#include "setup_screen_widget.h"  // a base class for screens in the setup assistant
+
+namespace moveit_setup_assistant
+{
+// ******************************************************************************************
+// User Interface for setting up 3D sensor config
+// ******************************************************************************************
+class PerceptionWidget : public SetupScreenWidget
+{
+  Q_OBJECT
+
+public:
+  // ******************************************************************************************
+  // Public Functions
+  // ******************************************************************************************
+
+  PerceptionWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
+
+  /// Recieved when this widget is chosen from the navigation menu
+  virtual void focusGiven();
+
+  /// Recieved when another widget is chosen from the navigation menu
+  virtual bool focusLost();
+
+  /// Populate the combo dropdown box with sensor plugins
+  void loadSensorPluginsComboBox();
+
+  // ******************************************************************************************
+  // Qt Components
+  // ******************************************************************************************
+
+  QComboBox* sensor_plugin_field_;
+
+  // Group form for each plugin option
+  QGroupBox* point_cloud_group_;
+  QGroupBox* depth_map_group_;
+
+  // Point Cloud plugin feilds
+  QLineEdit* point_cloud_topic_field_;
+  QLineEdit* max_range_field_;
+  QLineEdit* point_subsample_field_;
+  QLineEdit* padding_offset_field_;
+  QLineEdit* padding_scale_field_;
+  QLineEdit* max_update_rate_field_;
+  QLineEdit* filtered_cloud_topic_field_;
+
+  // Depth Map plugin feilds
+  QLineEdit* image_topic_field_;
+  QLineEdit* queue_size_field_;
+  QLineEdit* near_clipping_field_;
+  QLineEdit* far_clipping_field_;
+  QLineEdit* shadow_threshold_field_;
+  QLineEdit* depth_padding_scale_field_;
+  QLineEdit* depth_padding_offset_field_;
+  QLineEdit* depth_filtered_cloud_topic_field_;
+  QLineEdit* depth_max_update_rate_field_;
+
+private Q_SLOTS:
+
+  // ******************************************************************************************
+  // Slot Event Functions
+  // ******************************************************************************************
+
+  /// Called when the selected item in the sensor_plugin_field_ combobox is changed
+  void sensorPluginChanged(int index);
+
+private:
+  // ******************************************************************************************
+  // Variables
+  // ******************************************************************************************
+
+  /// Contains all the configuration data for the setup assistant
+  moveit_setup_assistant::MoveItConfigDataPtr config_data_;
+};
+
+}  // namespace moveit_setup_assistant
+
+#endif

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -126,6 +126,7 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
   nav_name_list_ << "Robot Poses";
   nav_name_list_ << "End Effectors";
   nav_name_list_ << "Passive Joints";
+  nav_name_list_ << "Perception";
   nav_name_list_ << "Author Information";
   nav_name_list_ << "Configuration Files";
 
@@ -288,6 +289,16 @@ void SetupAssistantWidget::progressPastStartScreen()
           SLOT(highlightLink(const std::string&, const QColor&)));
   connect(pjw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
   connect(pjw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+
+  // Perception
+  perception_widget_ = new PerceptionWidget(this, config_data_);
+  main_content_->addWidget(perception_widget_);
+  connect(perception_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(perception_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+          SLOT(highlightLink(const std::string&, const QColor&)));
+  connect(perception_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(perception_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Author Information
   aiw_ = new AuthorInformationWidget(this, config_data_);

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
@@ -60,6 +60,7 @@
 #include "passive_joints_widget.h"
 #include "author_information_widget.h"
 #include "configuration_files_widget.h"
+#include "perception_widget.h"
 
 #ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
@@ -222,6 +223,7 @@ private:
   PassiveJointsWidget* pjw_;
   AuthorInformationWidget* aiw_;
   ConfigurationFilesWidget* cfw_;
+  PerceptionWidget* perception_widget_;
 
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -421,6 +421,23 @@ bool StartScreenWidget::loadExistingFiles()
   fs::path kinematics_yaml_path = config_data_->config_pkg_path_;
   kinematics_yaml_path /= "config/kinematics.yaml";
 
+  // Load sensors_3d yaml file if available --------------------------------------------------
+  fs::path sensors_3d_yaml_path = config_data_->config_pkg_path_;
+  sensors_3d_yaml_path /= "config/sensors_3d.yaml";
+
+  // If config was not available, load default configuration
+  if (!fs::is_regular_file(sensors_3d_yaml_path))
+  {
+    sensors_3d_yaml_path = "resources/default_config/sensors_3d.yaml";
+    config_data_->input3DSensorsYAML(sensors_3d_yaml_path.make_preferred().native().c_str());
+  }
+  else
+  {
+    fs::path default_sensors_3d_yaml_path = "resources/default_config/sensors_3d.yaml";
+    config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().native().c_str(),
+                                     sensors_3d_yaml_path.make_preferred().native().c_str());
+  }
+
   if (!config_data_->inputKinematicsYAML(kinematics_yaml_path.make_preferred().native().c_str()))
   {
     QMessageBox::warning(this, "No Kinematic YAML File",

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/sensor_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/sensor_manager.launch.xml
@@ -2,6 +2,9 @@
 
   <!-- This file makes it easy to include the settings for sensor managers -->
 
+  <!-- Params for 3D sensors config -->
+  <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/sensors_3d.yaml" />
+
   <!-- Params for the octomap monitor -->
   <!--  <param name="octomap_frame" type="string" value="some frame in which the robot moves" /> -->
   <param name="octomap_resolution" type="double" value="0.025" />

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -119,6 +119,32 @@ TEST_F(MoveItConfigData, ReadingControllers)
   boost::filesystem::remove((res_path / "ros_controller.yaml").string());
 }
 
+// This tests parsing of sensors_rgbd.yaml
+TEST_F(MoveItConfigData, ReadingSensorsConfig)
+{
+  // Contains all the config data for the setup assistant
+  moveit_setup_assistant::MoveItConfigDataPtr config_data_;
+  config_data_.reset(new moveit_setup_assistant::MoveItConfigData());
+
+  boost::filesystem::path setup_assistant_path(config_data_->setup_assistant_path_);
+
+  // Before parsing, no config available
+  EXPECT_EQ(config_data_->getSensorPluginConfig().size(), 0);
+
+  // Read the file containing the default config parameters
+  config_data_->input3DSensorsYAML((setup_assistant_path / "resources/default_config/sensors_3d.yaml").string());
+
+  // Default config for the two available sensor plugins
+  // Make sure both are parsed correctly
+  EXPECT_EQ(config_data_->getSensorPluginConfig().size(), 2);
+
+  EXPECT_EQ(config_data_->getSensorPluginConfig()[0]["sensor_plugin"].value,
+            std::string("occupancy_map_monitor/PointCloudOctomapUpdater"));
+
+  EXPECT_EQ(config_data_->getSensorPluginConfig()[1]["sensor_plugin"].value,
+            std::string("occupancy_map_monitor/DepthImageOctomapUpdater"));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -138,10 +138,10 @@ TEST_F(MoveItConfigData, ReadingSensorsConfig)
   // Make sure both are parsed correctly
   EXPECT_EQ(config_data_->getSensorPluginConfig().size(), 2);
 
-  EXPECT_EQ(config_data_->getSensorPluginConfig()[0]["sensor_plugin"].value,
+  EXPECT_EQ(config_data_->getSensorPluginConfig()[0]["sensor_plugin"].getValue(),
             std::string("occupancy_map_monitor/PointCloudOctomapUpdater"));
 
-  EXPECT_EQ(config_data_->getSensorPluginConfig()[1]["sensor_plugin"].value,
+  EXPECT_EQ(config_data_->getSensorPluginConfig()[1]["sensor_plugin"].getValue(),
             std::string("occupancy_map_monitor/DepthImageOctomapUpdater"));
 }
 


### PR DESCRIPTION
### Description

This perception screen works as the following:
if (package has a 3d sensors config file) loads it into the screen
else load the default values from `moveit_setup_assistanat/resources/config/sensors_rgbd.yaml` -name is not final-.
when the user leaves the screen, saves the new config values to the `sensors_rgbd.yaml` to the package, if the user selected `none` from the plugin type drop down then no config file is saved.

![](https://raw.githubusercontent.com/MohmadAyman/school/3dbd3c7e8a5dbcbc3a8298ed688aab7fe03a25c1/perception.gif)

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [x] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
