### PR TITLE
chomp tests: add moveit includes before [version of #958]

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -56,17 +56,17 @@ install(TARGETS ${PROJECT_NAME} chomp_planner_plugin
 )
 
 if(CATKIN_ENABLE_TESTING)
-  # additional packages needed for testing
-  find_package(rostest REQUIRED)
+  # additional test dependencies
   find_package(moveit_ros_planning_interface REQUIRED)
-  include_directories(
-    ${rostest_INCLUDE_DIRS}
-    ${moveit_ros_planning_interface_INCLUDE_DIRS})
+  find_package(rostest REQUIRED)
+  # add moveit includes *before* the rest for better overlay compliance
+  include_directories(BEFORE ${moveit_ros_planning_interface})
+  include_directories(AFTER ${rostest_INCLUDE_DIRS})
   add_rostest_gtest(chomp_moveit_test
     test/chomp_moveit.test
     test/chomp_moveit_test.cpp)
   target_link_libraries(chomp_moveit_test
+    ${moveit_ros_planning_interface_LIBRARIES}
     ${catkin_LIBRARIES}
-    ${rostest_LIBRARIES}
-    ${moveit_ros_planning_interface_LIBRARIES})
+    ${rostest_LIBRARIES})
 endif()


### PR DESCRIPTION
This resolves problems when a system version of moveit is overlayed.
It could still trigger new bugs when `moveit_ros_planning_interface`
is installed in a workspace other than the current one where chomp_interface
is compiled, but this is not a big issue here because both packages
are part of the same repository and are usually compiled together.

See [my comment in the other request](https://github.com/ros-planning/moveit/pull/958#issuecomment-402118210)
about why this is worse than the other request,
but does not require any other change.

It would be nice to see overlays working again.