### PR TITLE
Enable gcc warnings, remove unused variables

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -3,6 +3,13 @@ project(moveit_core)
 
 add_compile_options(-std=c++11)
 
+# Warnings
+add_definitions(-W -Wall -Wextra
+  -Wwrite-strings -Wunreachable-code -Wpointer-arith
+  -Winit-self -Wredundant-decls
+  -Wno-unused-parameter -Wno-unused-function)
+#TODO(davetcoleman) enable -Wcast-qual
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -365,7 +365,6 @@ struct FCLShapeCache
     if (clean_count_ > MAX_CLEAN_COUNT || force)
     {
       clean_count_ = 0;
-      unsigned int from = map_.size();
       for (auto it = map_.begin(); it != map_.end();)
       {
         auto nit = it;
@@ -542,7 +541,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       {
         double max_dist = 0;
         int max_index = 0;
-        for (int i = 0; i < contacts; ++i)
+        for (std::size_t i = 0; i < contacts; ++i)
         {
           const fcl::Contact& contact = coll_res.getContact(i);
           if (contact.penetration_depth > max_dist)

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -133,7 +133,6 @@ bool KinematicsBase::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_po
   std::vector<double> solution;
   result.solution_percentage = 0.0;
 
-  bool supported = false;
   if (std::find(supported_methods_.begin(), supported_methods_.end(), options.discretization_method) ==
       supported_methods_.end())
   {


### PR DESCRIPTION
To reduce potential bugs, I am enabling stricter warnings.

This PR also removed some unused variables that it found. There is still one warning this uncovers of potentially uninitialized variables, but debugging that is more complex and left as an exercise for the reader.