### PR TITLE
shallow workspace checkout

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -16,10 +16,8 @@ RUN \
     mkdir src && \
     cd src && \
     #
-    # Download moveit source so that we can get necessary dependencies
-    wstool init . && \
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
-    wstool update && \
+    # Download moveit source, so that we can get necessary dependencies
+    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
     #
     # Update apt package list as previous containers clear the cache
     apt-get -qq update && \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -11,9 +11,7 @@ RUN \
     cd src && \
     #
     # Download moveit source so that we can get necessary dependencies
-    wstool init . && \
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
-    wstool update && \
+    wstool init . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
     #
     # Update apt package list as cache is cleared in previous container
     # Usually upgrading involves a few packages only (if container builds became out-of-sync)


### PR DESCRIPTION
Merging `wstool init + merge + update` into a single `wstool init` command, allows to use the new `--shallow` option to enforce shallow git clone.
However, the `source` container shouldn't use shallow clone.