### PR TITLE
Chomp needs to depend on cmake_modules.

### DIFF
--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -12,6 +12,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <depend>roscpp</depend>
   <depend>moveit_core</depend>


### PR DESCRIPTION
### Description

Fix the chomp package.xml to depend on cmake_modules, which is necessary to fix binary builds for it on the Melodic buildfarm.  An example problem is here: http://build.ros.org/view/Mbin_ds_dS64/job/Mbin_ds_dS64__moveit_planners_chomp__debian_stretch_amd64__binary/56/consoleFull

### Checklist
- [ N/A ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ N/A ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ N/A ] Include a screenshot if changing a GUI
- [ N/A ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic) - shouldn't be necessary, as chomp is only released in Melodic.

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
