### PR TITLE
Chomp needs to depend on cmake_modules. (#976)

### DIFF
--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -12,6 +12,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <depend>roscpp</depend>
   <depend>moveit_core</depend>


### PR DESCRIPTION
Otherwise, the binary builds on the buildfarm fail.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Bence:
Regardless of buildfarm on Kinetic, `cmake_modules` is `find_package`-d, therefore it should be in the `package.xml` too.