### PR TITLE
Allow chains to have only one active joint

### DIFF
--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -244,7 +244,7 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
     updated_link_model_with_geometry_name_vector_.push_back(updated_link_model_with_geometry_vector_[i]->getName());
 
   // check if this group should actually be a chain
-  if (joint_roots_.size() == 1 && active_joint_model_vector_.size() > 1)
+  if (joint_roots_.size() == 1 && active_joint_model_vector_.size() >= 1)
   {
     bool chain = true;
     // due to our sorting, the joints are sorted in a DF fashion, so looking at them in reverse,


### PR DESCRIPTION
### Description

I was getting an error using a two-link chain (base link and moving link); this check currently requires more than one active joint, but one active joint still should be a valid (though very short) chain.

### Checklist
- [x ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [n/a ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ n/a] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

Rebased version that supersedes https://github.com/ros-planning/moveit/pull/981 