### PR TITLE
Fix CurrentStateMonitor update callback for floating joints with non-identity joint origin

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -590,55 +590,32 @@ void RobotState::updateLinkTransforms()
 
 void RobotState::updateLinkTransformsInternal(const JointModel* start)
 {
-  const std::vector<const LinkModel*>& links = start->getDescendantLinkModels();
-  if (!links.empty())
-  {
-    const LinkModel* parent = links[0]->getParentLinkModel();
+  for(const LinkModel* link : start->getDescendantLinkModels()) {
+    const LinkModel* parent = link->getParentLinkModel();
     if (parent)
     {
-      if (links[0]->parentJointIsFixed())
-        global_link_transforms_[links[0]->getLinkIndex()].matrix().noalias() =
-            global_link_transforms_[parent->getLinkIndex()].matrix() * links[0]->getJointOriginTransform().matrix();
+      if (link->parentJointIsFixed())
+        global_link_transforms_[link->getLinkIndex()].matrix().noalias() =
+            global_link_transforms_[parent->getLinkIndex()].matrix() * link->getJointOriginTransform().matrix();
       else
       {
-        if (links[0]->jointOriginTransformIsIdentity())
-          global_link_transforms_[links[0]->getLinkIndex()].matrix().noalias() =
+        if (link->jointOriginTransformIsIdentity())
+          global_link_transforms_[link->getLinkIndex()].matrix().noalias() =
               global_link_transforms_[parent->getLinkIndex()].matrix() *
-              getJointTransform(links[0]->getParentJointModel()).matrix();
+              getJointTransform(link->getParentJointModel()).matrix();
         else
-          global_link_transforms_[links[0]->getLinkIndex()].matrix().noalias() =
-              global_link_transforms_[parent->getLinkIndex()].matrix() * links[0]->getJointOriginTransform().matrix() *
-              getJointTransform(links[0]->getParentJointModel()).matrix();
+          global_link_transforms_[link->getLinkIndex()].matrix().noalias() =
+              global_link_transforms_[parent->getLinkIndex()].matrix() *
+              link->getJointOriginTransform().matrix() * getJointTransform(link->getParentJointModel()).matrix();
       }
     }
     else
     {
-      if (links[0]->jointOriginTransformIsIdentity())
-        global_link_transforms_[links[0]->getLinkIndex()] = getJointTransform(links[0]->getParentJointModel());
+      if (link->jointOriginTransformIsIdentity())
+        global_link_transforms_[link->getLinkIndex()] = getJointTransform(link->getParentJointModel());
       else
-        global_link_transforms_[links[0]->getLinkIndex()].matrix().noalias() =
-            links[0]->getJointOriginTransform().matrix() * getJointTransform(links[0]->getParentJointModel()).matrix();
-    }
-
-    // we know the rest of the links have parents
-    for (std::size_t i = 1; i < links.size(); ++i)
-    {
-      if (links[i]->parentJointIsFixed())
-        global_link_transforms_[links[i]->getLinkIndex()].matrix().noalias() =
-            global_link_transforms_[links[i]->getParentLinkModel()->getLinkIndex()].matrix() *
-            links[i]->getJointOriginTransform().matrix();
-      else
-      {
-        if (links[i]->jointOriginTransformIsIdentity())
-          global_link_transforms_[links[i]->getLinkIndex()].matrix().noalias() =
-              global_link_transforms_[links[i]->getParentLinkModel()->getLinkIndex()].matrix() *
-              getJointTransform(links[i]->getParentJointModel()).matrix();
-        else
-          global_link_transforms_[links[i]->getLinkIndex()].matrix().noalias() =
-              global_link_transforms_[links[i]->getParentLinkModel()->getLinkIndex()].matrix() *
-              links[i]->getJointOriginTransform().matrix() *
-              getJointTransform(links[i]->getParentJointModel()).matrix();
-      }
+        global_link_transforms_[link->getLinkIndex()].matrix().noalias() =
+            link->getJointOriginTransform().matrix() * getJointTransform(link->getParentJointModel()).matrix();
     }
   }
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -593,7 +593,7 @@ void RobotState::updateLinkTransformsInternal(const JointModel* start)
   for (const LinkModel* link : start->getDescendantLinkModels())
   {
     const LinkModel* parent = link->getParentLinkModel();
-    if (parent)
+    if (parent)  // root JointModel will not have a parent
     {
       if (link->parentJointIsFixed())
         global_link_transforms_[link->getLinkIndex()].matrix().noalias() =

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -590,7 +590,8 @@ void RobotState::updateLinkTransforms()
 
 void RobotState::updateLinkTransformsInternal(const JointModel* start)
 {
-  for(const LinkModel* link : start->getDescendantLinkModels()) {
+  for (const LinkModel* link : start->getDescendantLinkModels())
+  {
     const LinkModel* parent = link->getParentLinkModel();
     if (parent)
     {
@@ -605,8 +606,8 @@ void RobotState::updateLinkTransformsInternal(const JointModel* start)
               getJointTransform(link->getParentJointModel()).matrix();
         else
           global_link_transforms_[link->getLinkIndex()].matrix().noalias() =
-              global_link_transforms_[parent->getLinkIndex()].matrix() *
-              link->getJointOriginTransform().matrix() * getJointTransform(link->getParentJointModel()).matrix();
+              global_link_transforms_[parent->getLinkIndex()].matrix() * link->getJointOriginTransform().matrix() *
+              getJointTransform(link->getParentJointModel()).matrix();
       }
     }
     else

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -462,8 +462,11 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       Eigen::Affine3d eigen_transf;
       tf::transformTFToEigen(transf, eigen_transf);
 
+      const Eigen::Affine3d& joint_origin = joint->getChildLinkModel()->getJointOriginTransform();
+      const Eigen::Affine3d joint_transform = joint_origin.inverse(Eigen::Isometry) * eigen_transf;
+
       double new_values[joint->getStateSpaceDimension()];
-      joint->computeVariablePositions(eigen_transf, new_values);
+      joint->computeVariablePositions(joint_transform, new_values);
 
       if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
       {

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -465,9 +465,10 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       double new_values[joint->getStateSpaceDimension()];
       const robot_model::LinkModel* link = joint->getChildLinkModel();
       if (link->jointOriginTransformIsIdentity())
-          joint->computeVariablePositions(eigen_transf, new_values);
+        joint->computeVariablePositions(eigen_transf, new_values);
       else
-          joint->computeVariablePositions(link->getJointOriginTransform().inverse(Eigen::Isometry) * eigen_transf, new_values);
+        joint->computeVariablePositions(link->getJointOriginTransform().inverse(Eigen::Isometry) * eigen_transf,
+                                        new_values);
 
       if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
       {

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -462,11 +462,12 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       Eigen::Affine3d eigen_transf;
       tf::transformTFToEigen(transf, eigen_transf);
 
-      const Eigen::Affine3d& joint_origin = joint->getChildLinkModel()->getJointOriginTransform();
-      const Eigen::Affine3d joint_transform = joint_origin.inverse(Eigen::Isometry) * eigen_transf;
-
       double new_values[joint->getStateSpaceDimension()];
-      joint->computeVariablePositions(joint_transform, new_values);
+      const robot_model::LinkModel* link = joint->getChildLinkModel();
+      if (link->jointOriginTransformIsIdentity())
+          joint->computeVariablePositions(eigen_transf, new_values);
+      else
+          joint->computeVariablePositions(link->getJointOriginTransform().inverse(Eigen::Isometry) * eigen_transf, new_values);
 
       if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
       {


### PR DESCRIPTION
### Description

This PR fixes a bug in the CurrentStateMonitor::tfCallback() method. The old implementation does not take the joint's origin into account. This leads to wrong transformations in the PlanningScene of a PlanningSceneMonitor if the transformation to a floating joint's origin is not the identity.

A demo of the bug can be found here: https://github.com/xaver-k/floating_joint_test

#### A more in-depth explanation of the bug and the fix:

We calculate the pose of a child link relative to its parent as the concatenation of the transformations `parent -> joint origin` and `joint origin -> child`, where `joint origin -> child` is dependent on the joint variable(s). With 1D-joint (rotational, prismatic) we can update the joint variable directly from the `/joint_states` topic.

In contrast, we update the joint variables of floating joints from TF. The data in TF is already the transform `child -> parent`. The old implementation saves this transformation as the joint's variables. This means that we practically apply the `child -> joint origin`-transform twice when calculating the link poses internally. This does not show as long as your floating joint's origin is just the identity, but leads to problems otherwise.

The code in the PR corrects this by applying the inverse of the `child -> joint origin`-transformation before storing the transform in the joint variables.

#### Thoughts on the implementation:
* Calculating the inverse during each update cycle should not be too bad, since practically we transpose and multiply (no numeric inverse). I did not experience any performance issues.
* If more performance is required, we could store the inverse of the joint origin in the ` moveit::core::LinkModel` and provide a new method `getJointOriginTransformInverse()`.

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
 **Note:** There are some changes that clang-format makes but none are related to the code-changes in the PR.
- [X] Extended the tutorials / documentation, if necessary (not applicable)
- [X] Include a screenshot if changing a GUI (not applicable)
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
