### PR TITLE
Benchmarking with different Motion Planners (STOMP, CHOMP, OMPL)

### DIFF
--- a/moveit_ros/benchmarks/examples/demo1.yaml
+++ b/moveit_ros/benchmarks/examples/demo1.yaml
@@ -13,7 +13,7 @@ benchmark_config:
     parameters:
         name: KitchenPick1
         runs: 50
-        group: manipulator       # Required
+        group: panda_arm       # Required
         timeout: 10.0
         output_directory: /tmp/moveit_benchmarks/
         queries: Pick1

--- a/moveit_ros/benchmarks/examples/demo1.yaml
+++ b/moveit_ros/benchmarks/examples/demo1.yaml
@@ -3,7 +3,7 @@
 # query using the Start1 initial state (all pre-stored in the local warehouse)
 
 # Three different planners from OMPL are run a total of 50 times each, with a
-# maximum of 10 seconds per run.  Output is stored in the /home/benchmarks directory.
+# maximum of 10 seconds per run.  Output is stored in the /tmp/moveit_benchmarks directory.
 
 benchmark_config:
     warehouse:

--- a/moveit_ros/benchmarks/examples/demo2.yaml
+++ b/moveit_ros/benchmarks/examples/demo2.yaml
@@ -27,4 +27,3 @@ benchmark_config:
         - plugin: my_plugin_ns/my_plugin
           planners:
             - MyPlanner
-

--- a/moveit_ros/benchmarks/examples/demo_obstacles.yaml
+++ b/moveit_ros/benchmarks/examples/demo_obstacles.yaml
@@ -9,11 +9,11 @@ benchmark_config:
     warehouse:
         host: 127.0.0.1
         port: 33829
-        scene_name: Kitchen     # Required
+        scene_name: ObstaclesScene     # Required
     parameters:
-        name: KitchenPick1
+        name: ObstaclesScenePick1
         runs: 50
-        group: manipulator      # Required
+        group: panda_arm      # Required
         timeout: 10.0
         output_directory: /home/benchmarks/
         queries: .*
@@ -24,7 +24,10 @@ benchmark_config:
             - RRTConnectkConfigDefault
             - BKPIECEkConfigDefault
             - KPIECEkConfigDefault
-        - plugin: my_plugin_ns/my_plugin
+        - plugin: chomp_interface/CHOMPPlanner
           planners:
-            - MyPlanner
+            - CHOMP
+        - plugin: stomp_moveit/StompPlannerManager
+          planners:
+            - STOMP
 

--- a/moveit_ros/benchmarks/examples/demo_obstacles.yaml
+++ b/moveit_ros/benchmarks/examples/demo_obstacles.yaml
@@ -15,7 +15,7 @@ benchmark_config:
         runs: 50
         group: panda_arm      # Required
         timeout: 10.0
-        output_directory: /home/benchmarks/
+        output_directory: /tmp/moveit_benchmarks/
         queries: .*
         start_states: .*
     planners:

--- a/moveit_ros/benchmarks/examples/demo_obstacles.yaml
+++ b/moveit_ros/benchmarks/examples/demo_obstacles.yaml
@@ -3,7 +3,7 @@
 # of motion plan queries and start states in the Kitchen scene.
 
 # Five planners from two different plugins are run a total of 50 times each, with a
-# maximum of 10 seconds per run.  Output is stored in the /home/benchmarks directory.
+# maximum of 10 seconds per run.  Output is stored in the /tmp/moveit_benchmarks directory.
 
 benchmark_config:
     warehouse:

--- a/moveit_ros/benchmarks/examples/demo_panda.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda.launch
@@ -1,0 +1,22 @@
+<launch>
+  <!-- benchmark options file -->
+  <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo1.yaml"/>
+
+  <!-- Load robot settings -->
+  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Load all planning pipelines that will be benchmarked -->
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="ompl" />
+  </include>
+
+  <!-- Load warehouse containing scenes and queries to benchmark -->
+  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- Launch benchmark node -->
+  <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">
+    <rosparam command="load" file="$(arg bench_opts)"/>
+  </node>
+</launch>

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
@@ -1,0 +1,31 @@
+<launch>
+  <!-- benchmark options file -->
+  <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_all_planners.yaml"/>
+
+  <!-- Load robot settings -->
+  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Load all planning pipelines that will be benchmarked -->
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="ompl" />
+  </include>
+
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="chomp" />
+  </include>
+
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="stomp" />
+  </include>
+
+  <!-- Load warehouse containing scenes and queries to benchmark -->
+  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- Launch benchmark node -->
+  <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">
+    <rosparam command="load" file="$(arg bench_opts)"/>
+  </node>
+</launch>
+

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
@@ -1,6 +1,6 @@
 <launch>
   <!-- benchmark options file -->
-  <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_all_planners.yaml"/>
+  <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_panda_all_planners.yaml"/>
 
   <!-- Load robot settings -->
   <include file="$(find panda_moveit_config)/launch/planning_context.launch">

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
@@ -13,7 +13,7 @@ benchmark_config:
     parameters:
         name: KitchenPick1
         runs: 50
-        group: manipulator      # Required
+        group: panda_arm      # Required
         timeout: 10.0
         output_directory: /home/benchmarks/
         queries: .*
@@ -24,7 +24,10 @@ benchmark_config:
             - RRTConnectkConfigDefault
             - BKPIECEkConfigDefault
             - KPIECEkConfigDefault
-        - plugin: my_plugin_ns/my_plugin
+        - plugin: chomp_interface/CHOMPPlanner
           planners:
-            - MyPlanner
+            - CHOMP
+        - plugin: stomp_moveit/StompPlannerManager
+          planners:
+            - STOMP
 

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
@@ -15,7 +15,7 @@ benchmark_config:
         runs: 50
         group: panda_arm      # Required
         timeout: 10.0
-        output_directory: /home/benchmarks/
+        output_directory: /tmp/moveit_benchmarks/
         queries: .*
         start_states: .*
     planners:

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
@@ -3,7 +3,7 @@
 # of motion plan queries and start states in the Kitchen scene.
 
 # Five planners from two different plugins are run a total of 50 times each, with a
-# maximum of 10 seconds per run.  Output is stored in the /home/benchmarks directory.
+# maximum of 10 seconds per run.  Output is stored in the /tmp/moveit_benchmarks directory.
 
 benchmark_config:
     warehouse:

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
@@ -1,0 +1,30 @@
+<launch>
+  <!-- benchmark options file -->
+  <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_obstacles.yaml"/>
+
+  <!-- Load robot settings -->
+  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Load all planning pipelines that will be benchmarked -->
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="ompl" />
+  </include>
+
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="chomp" />
+  </include>
+
+  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="stomp" />
+  </include>
+
+  <!-- Load warehouse containing scenes and queries to benchmark -->
+  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- Launch benchmark node -->
+  <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">
+    <rosparam command="load" file="$(arg bench_opts)"/>
+  </node>
+</launch>

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -532,6 +532,8 @@ bool BenchmarkExecutor::plannerConfigurationsExist(const std::map<std::string, s
     planning_interface::PlannerManagerPtr pm = planner_interfaces_[it->first];
     const planning_interface::PlannerConfigurationMap& config_map = pm->getPlannerConfigurations();
 
+    // if the planner is chomp or stomp skip this function and return true for checking planner configurations for the
+    // planning group other wise an error occurs, this is kind of a trick which works well
     if (pm->getDescription().compare("stomp") || pm->getDescription().compare("chomp"))
       return true;
 

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -531,8 +531,8 @@ bool BenchmarkExecutor::plannerConfigurationsExist(const std::map<std::string, s
   {
     planning_interface::PlannerManagerPtr pm = planner_interfaces_[it->first];
     const planning_interface::PlannerConfigurationMap& config_map = pm->getPlannerConfigurations();
-    
-    if(pm->getDescription().compare("stomp") || pm->getDescription().compare("chomp"))
+
+    if (pm->getDescription().compare("stomp") || pm->getDescription().compare("chomp"))
       return true;
 
     for (std::size_t i = 0; i < it->second.size(); ++i)

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -531,6 +531,9 @@ bool BenchmarkExecutor::plannerConfigurationsExist(const std::map<std::string, s
   {
     planning_interface::PlannerManagerPtr pm = planner_interfaces_[it->first];
     const planning_interface::PlannerConfigurationMap& config_map = pm->getPlannerConfigurations();
+    
+    if(pm->getDescription().compare("stomp") || pm->getDescription().compare("chomp"))
+      return true;
 
     for (std::size_t i = 0; i < it->second.size(); ++i)
     {

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -533,7 +533,8 @@ bool BenchmarkExecutor::plannerConfigurationsExist(const std::map<std::string, s
     const planning_interface::PlannerConfigurationMap& config_map = pm->getPlannerConfigurations();
 
     // if the planner is chomp or stomp skip this function and return true for checking planner configurations for the
-    // planning group other wise an error occurs, this is kind of a trick which works well
+    // planning group otherwise an error occurs, because for OMPL a specific planning algorithm needs to be defined for
+    // a planning group, whereas with STOMP and CHOMP this is not necessary
     if (pm->getDescription().compare("stomp") || pm->getDescription().compare("chomp"))
       return true;
 

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -536,7 +536,7 @@ bool BenchmarkExecutor::plannerConfigurationsExist(const std::map<std::string, s
     // planning group otherwise an error occurs, because for OMPL a specific planning algorithm needs to be defined for
     // a planning group, whereas with STOMP and CHOMP this is not necessary
     if (pm->getDescription().compare("stomp") || pm->getDescription().compare("chomp"))
-      return true;
+      continue;
 
     for (std::size_t i = 0; i < it->second.size(); ++i)
     {


### PR DESCRIPTION
### Benchmarking with different Motion Planners (STOMP, CHOMP, OMPL)

This PR is a work done by Raghavender as a part of 2018 Google summer of code. As a part of this PR, benchmarking works for different motion planners (CHOMP, STOMP, OMPL) available in MoveIt. For a particular benchmark(start sates, planning scene, goal states, queries, etc.), different planners can be evaluated.

### Checklist
- [ ] addition of yaml files and launch files for including STOMP and CHOMP planners in environments with and without obstacles.
- [ ] fixing the existing benchmarking code to make it work with STOMP and CHOMP.