### PR TITLE
Renamed variable names in setup assistant widget to follow naming convention

### DIFF
--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -90,22 +90,22 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
   // Screens --------------------------------------------------------
 
   // Start Screen
-  ssw_ = new StartScreenWidget(this, config_data_);
-  ssw_->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-  connect(ssw_, SIGNAL(readyToProgress()), this, SLOT(progressPastStartScreen()));
-  connect(ssw_, SIGNAL(loadRviz()), this, SLOT(loadRviz()));
-  main_content_->addWidget(ssw_);
+  start_screen_widget_ = new StartScreenWidget(this, config_data_);
+  start_screen_widget_->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  connect(start_screen_widget_, SIGNAL(readyToProgress()), this, SLOT(progressPastStartScreen()));
+  connect(start_screen_widget_, SIGNAL(loadRviz()), this, SLOT(loadRviz()));
+  main_content_->addWidget(start_screen_widget_);
 
   // Pass command arg values to start screen and show appropriate part of screen
   if (args.count("urdf_path"))
   {
-    ssw_->urdf_file_->setPath(args["urdf_path"].as<std::string>());
-    ssw_->select_mode_->btn_new_->click();
+    start_screen_widget_->urdf_file_->setPath(args["urdf_path"].as<std::string>());
+    start_screen_widget_->select_mode_->btn_new_->click();
   }
   if (args.count("config_pkg"))
   {
-    ssw_->stack_path_->setPath(args["config_pkg"].as<std::string>());
-    ssw_->select_mode_->btn_exist_->click();
+    start_screen_widget_->stack_path_->setPath(args["config_pkg"].as<std::string>());
+    start_screen_widget_->select_mode_->btn_exist_->click();
   }
   else
   {
@@ -115,7 +115,7 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
     char* pwd;
     pwd = getenv("PWD");
     pwdir.append(pwd);
-    ssw_->stack_path_->setPath(pwdir);
+    start_screen_widget_->stack_path_->setPath(pwdir);
   }
 
   // Add Navigation Buttons (but do not load widgets yet except start screen)
@@ -236,71 +236,78 @@ void SetupAssistantWidget::progressPastStartScreen()
   // Load all widgets ------------------------------------------------
 
   // Self-Collisions
-  dcw_ = new DefaultCollisionsWidget(this, config_data_);
-  main_content_->addWidget(dcw_);
-  connect(dcw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  default_collisions_widget_ = new DefaultCollisionsWidget(this, config_data_);
+  main_content_->addWidget(default_collisions_widget_);
+  connect(default_collisions_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(dcw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(dcw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(default_collisions_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(default_collisions_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Virtual Joints
-  vjw_ = new VirtualJointsWidget(this, config_data_);
-  main_content_->addWidget(vjw_);
-  connect(vjw_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
-  connect(vjw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  virtual_joints_widget_ = new VirtualJointsWidget(this, config_data_);
+  main_content_->addWidget(virtual_joints_widget_);
+  connect(virtual_joints_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(virtual_joints_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(vjw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(vjw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
-  connect(vjw_, SIGNAL(referenceFrameChanged()), this, SLOT(virtualJointReferenceFrameChanged()));
+  connect(virtual_joints_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(virtual_joints_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(virtual_joints_widget_, SIGNAL(referenceFrameChanged()), this, SLOT(virtualJointReferenceFrameChanged()));
 
   // Planning Groups
-  pgw_ = new PlanningGroupsWidget(this, config_data_);
-  main_content_->addWidget(pgw_);
-  connect(pgw_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
-  connect(pgw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  planning_groups_widget = new PlanningGroupsWidget(this, config_data_);
+  main_content_->addWidget(planning_groups_widget);
+  connect(planning_groups_widget, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(planning_groups_widget, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(pgw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(pgw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(planning_groups_widget, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(planning_groups_widget, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Robot Poses
-  rpw_ = new RobotPosesWidget(this, config_data_);
-  main_content_->addWidget(rpw_);
-  connect(rpw_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
-  connect(rpw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  robot_poses_widget_ = new RobotPosesWidget(this, config_data_);
+  main_content_->addWidget(robot_poses_widget_);
+  connect(robot_poses_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(robot_poses_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(rpw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(rpw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(robot_poses_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(robot_poses_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // End Effectors
-  efw_ = new EndEffectorsWidget(this, config_data_);
-  main_content_->addWidget(efw_);
-  connect(efw_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
-  connect(efw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  end_effectors_widget_ = new EndEffectorsWidget(this, config_data_);
+  main_content_->addWidget(end_effectors_widget_);
+  connect(end_effectors_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(end_effectors_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(efw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(efw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(end_effectors_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(end_effectors_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Virtual Joints
-  pjw_ = new PassiveJointsWidget(this, config_data_);
-  main_content_->addWidget(pjw_);
-  connect(pjw_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
-  connect(pjw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  passive_joints_widget_ = new PassiveJointsWidget(this, config_data_);
+  main_content_->addWidget(passive_joints_widget_);
+  connect(passive_joints_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(passive_joints_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(pjw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(pjw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(passive_joints_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(passive_joints_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Author Information
-  aiw_ = new AuthorInformationWidget(this, config_data_);
-  main_content_->addWidget(aiw_);
-  connect(aiw_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
-  connect(aiw_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
+  author_information_widget_ = new AuthorInformationWidget(this, config_data_);
+  main_content_->addWidget(author_information_widget_);
+  connect(author_information_widget_, SIGNAL(isModal(bool)), this, SLOT(setModalMode(bool)));
+  connect(author_information_widget_, SIGNAL(highlightLink(const std::string&, const QColor&)), this,
           SLOT(highlightLink(const std::string&, const QColor&)));
-  connect(aiw_, SIGNAL(highlightGroup(const std::string&)), this, SLOT(highlightGroup(const std::string&)));
-  connect(aiw_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
+  connect(author_information_widget_, SIGNAL(highlightGroup(const std::string&)), this,
+          SLOT(highlightGroup(const std::string&)));
+  connect(author_information_widget_, SIGNAL(unhighlightAll()), this, SLOT(unhighlightAll()));
 
   // Configuration Files
-  cfw_ = new ConfigurationFilesWidget(this, config_data_);
-  main_content_->addWidget(cfw_);
+  configuration_files_widget_ = new ConfigurationFilesWidget(this, config_data_);
+  main_content_->addWidget(configuration_files_widget_);
 
   // Enable all nav buttons -------------------------------------------
   for (int i = 0; i < nav_name_list_.count(); ++i)

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.h
@@ -213,15 +213,15 @@ private:
   moveit_rviz_plugin::RobotStateDisplay* robot_state_display_;
 
   // Screen Widgets
-  StartScreenWidget* ssw_;
-  DefaultCollisionsWidget* dcw_;
-  PlanningGroupsWidget* pgw_;
-  RobotPosesWidget* rpw_;
-  EndEffectorsWidget* efw_;
-  VirtualJointsWidget* vjw_;
-  PassiveJointsWidget* pjw_;
-  AuthorInformationWidget* aiw_;
-  ConfigurationFilesWidget* cfw_;
+  StartScreenWidget* start_screen_widget_;
+  DefaultCollisionsWidget* default_collisions_widget_;
+  PlanningGroupsWidget* planning_groups_widget;
+  RobotPosesWidget* robot_poses_widget_;
+  EndEffectorsWidget* end_effectors_widget_;
+  VirtualJointsWidget* virtual_joints_widget_;
+  PassiveJointsWidget* passive_joints_widget_;
+  AuthorInformationWidget* author_information_widget_;
+  ConfigurationFilesWidget* configuration_files_widget_;
 
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;


### PR DESCRIPTION
### Description
Renamed widgets in setup assistant widget to follow naming convention

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
