### PR TITLE
Add info messages to pick and place routine

### DIFF
--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -173,7 +173,7 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
     {  // Do what was done before
       ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION
                                                     << " seconds to the grasp closure time. Assign time_from_start to "
-                                                       "your trajectory to avoid this.");
+                                                    << "your trajectory to avoid this.");
       ee_closed_traj->addPrefixWayPoint(ee_closed_state, PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION);
     }
 

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -171,8 +171,9 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
     }
     else
     {  // Do what was done before
-      ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION << 
-                      " seconds to the grasp closure time. Assign time_from_start to your trajectory to avoid this.");
+      ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION
+                                                    << " seconds to the grasp closure time. Assign time_from_start to "
+                                                       "your trajectory to avoid this.");
       ee_closed_traj->addPrefixWayPoint(ee_closed_state, PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION);
     }
 

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -171,6 +171,8 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
     }
     else
     {  // Do what was done before
+      ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION << 
+                      " seconds to the grasp closure time. Assign time_from_start to your trajectory to avoid this.");
       ee_closed_traj->addPrefixWayPoint(ee_closed_state, PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION);
     }
 

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -94,7 +94,7 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
         {  // Do what was done before
           ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION
                                                         << " seconds to the grasp closure time. Assign time_from_start "
-                                                           "to your trajectory to avoid this.");
+                                                        << "to your trajectory to avoid this.");
           pre_approach_traj->addPrefixWayPoint(pre_approach_state,
                                                PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION);
         }

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -92,6 +92,8 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
         }
         else
         {  // Do what was done before
+          ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION << 
+                          " seconds to the grasp closure time. Assign time_from_start to your trajectory to avoid this.");
           pre_approach_traj->addPrefixWayPoint(pre_approach_state,
                                                PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION);
         }

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -92,8 +92,9 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
         }
         else
         {  // Do what was done before
-          ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION << 
-                          " seconds to the grasp closure time. Assign time_from_start to your trajectory to avoid this.");
+          ROS_INFO_STREAM("Adding default duration of " << PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION
+                                                        << " seconds to the grasp closure time. Assign time_from_start "
+                                                           "to your trajectory to avoid this.");
           pre_approach_traj->addPrefixWayPoint(pre_approach_state,
                                                PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION);
         }


### PR DESCRIPTION
### Description

The current pick and place pipeline silently assigns a default duration of an arbitrary (and long) 7 seconds to each action of the gripper. This PR adds a message alerting the user to this behavior, and prompts them to define an appropriate wait time for their own gripper. This helps them identify a problem which is otherwise not trivial to debug, due to the structure of the planning stages. Case in point: it was [an issue](https://github.com/ros-planning/moveit_tutorials/pull/200) in the official pick and place tutorial.

I suppose this should have been a PR on melodic-devel and cherry-picked to Kinetic. Let me know if anything needs changing.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
