### PR TITLE
publish all joints into fake_controller_joint_states, instad of joint…

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/include/moveit_fake_controller_manager/follow_joint_trajectory_server_handle.h
+++ b/moveit_plugins/moveit_fake_controller_manager/include/moveit_fake_controller_manager/follow_joint_trajectory_server_handle.h
@@ -49,13 +49,12 @@ namespace moveit_fake_controller_manager
  */
 class FollowJointTrajectoryServerHandle
 {
-
 public:
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
 
-  FollowJointTrajectoryServerHandle(const ros::NodeHandle node_handle,
-                                    const std::string& name, const std::vector<std::string>& joints) :
-    follow_joint_trajectory_server(node_handle, name, false)
+  FollowJointTrajectoryServerHandle(const ros::NodeHandle node_handle, const std::string& name,
+                                    const std::vector<std::string>& joints)
+    : follow_joint_trajectory_server(node_handle, name, false)
   {
     follow_joint_trajectory_server.start();
   }
@@ -64,8 +63,8 @@ public:
   {
     follow_joint_trajectory_server.shutdown();
   }
-  
-  //virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory);
+
+// virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory);
 #if 0  
   {
     ROS_ERROR("sendTrajectory on FollowJointTrajectoryServerHandle");
@@ -143,7 +142,7 @@ protected:
   void controllerFeedbackCallback(const control_msgs::FollowJointTrajectoryFeedbackConstPtr& feedback)
   {
   }
-#endif  
+#endif
 };
 
 MOVEIT_CLASS_FORWARD(FollowJointTrajectoryServerHandle);

--- a/moveit_plugins/moveit_fake_controller_manager/include/moveit_fake_controller_manager/follow_joint_trajectory_server_handle.h
+++ b/moveit_plugins/moveit_fake_controller_manager/include/moveit_fake_controller_manager/follow_joint_trajectory_server_handle.h
@@ -1,0 +1,153 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Unbounded Robotics Inc.
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Ferguson, Ioan Sucan, E. Gil Jones */
+
+#ifndef MOVEIT_PLUGINS_FOLLOW_TRAJECTORY_SERVER_HANDLE
+#define MOVEIT_PLUGINS_FOLLOW_TRAJECTORY_SERVER_HANDLE
+
+#include <actionlib/server/simple_action_server.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+namespace moveit_fake_controller_manager
+{
+/*
+ * This is generally used for arms, but could also be used for multi-dof hands,
+ *   or anything using a control_mgs/FollowJointTrajectoryAction.
+ */
+class FollowJointTrajectoryServerHandle
+{
+
+public:
+  actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
+
+  FollowJointTrajectoryServerHandle(const ros::NodeHandle node_handle,
+                                    const std::string& name, const std::vector<std::string>& joints) :
+    follow_joint_trajectory_server(node_handle, name, false)
+  {
+    follow_joint_trajectory_server.start();
+  }
+
+  ~FollowJointTrajectoryServerHandle()
+  {
+    follow_joint_trajectory_server.shutdown();
+  }
+  
+  //virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory);
+#if 0  
+  {
+    ROS_ERROR("sendTrajectory on FollowJointTrajectoryServerHandle");
+  }
+#endif
+#if 0
+  virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)
+  {
+    ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryServer", "new trajectory to " << name_);
+
+    if (!controller_action_client_)
+      return false;
+
+    if (!trajectory.multi_dof_joint_trajectory.points.empty())
+    {
+      ROS_WARN_NAMED("FollowJointTrajectoryServer", "%s cannot execute multi-dof trajectories.", name_.c_str());
+    }
+
+    if (done_)
+      ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryServer", "sending trajectory to " << name_);
+    else
+      ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryServer",
+                             "sending continuation for the currently executed trajectory to " << name_);
+
+    control_msgs::FollowJointTrajectoryGoal goal;
+    goal.trajectory = trajectory.joint_trajectory;
+    controller_action_client_->sendGoal(
+        goal, boost::bind(&FollowJointTrajectoryServerHandle::controllerDoneCallback, this, _1, _2),
+        boost::bind(&FollowJointTrajectoryServerHandle::controllerActiveCallback, this),
+        boost::bind(&FollowJointTrajectoryServerHandle::controllerFeedbackCallback, this, _1));
+    done_ = false;
+    last_exec_ = moveit_controller_manager::ExecutionStatus::RUNNING;
+    return true;
+  }
+
+protected:
+  void controllerDoneCallback(const actionlib::SimpleClientGoalState& state,
+                              const control_msgs::FollowJointTrajectoryResultConstPtr& result)
+  {
+    // Output custom error message for FollowJointTrajectoryResult if necessary
+    if (result)
+    {
+      switch (result->error_code)
+      {
+        case control_msgs::FollowJointTrajectoryResult::INVALID_GOAL:
+          ROS_WARN_STREAM("Server " << name_ << " failed with error code INVALID_GOAL");
+          break;
+        case control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS:
+          ROS_WARN_STREAM("Server " << name_ << " failed with error code INVALID_JOINTS");
+          break;
+        case control_msgs::FollowJointTrajectoryResult::OLD_HEADER_TIMESTAMP:
+          ROS_WARN_STREAM("Server " << name_ << " failed with error code OLD_HEADER_TIMESTAMP");
+          break;
+        case control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED:
+          ROS_WARN_STREAM("Server " << name_ << " failed with error code PATH_TOLERANCE_VIOLATED");
+          break;
+        case control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED:
+          ROS_WARN_STREAM("Server " << name_ << " failed with error code GOAL_TOLERANCE_VIOLATED");
+          break;
+      }
+    }
+    else
+    {
+      ROS_WARN_STREAM("Server " << name_ << ": no result returned");
+    }
+
+    finishServerExecution(state);
+  }
+
+  void controllerActiveCallback()
+  {
+    ROS_DEBUG_STREAM_NAMED("FollowJointTrajectoryServer", name_ << " started execution");
+  }
+
+  void controllerFeedbackCallback(const control_msgs::FollowJointTrajectoryFeedbackConstPtr& feedback)
+  {
+  }
+#endif  
+};
+
+MOVEIT_CLASS_FORWARD(FollowJointTrajectoryServerHandle);
+
+}  // end namespace moveit_simple_controller_manager
+
+#endif  // MOVEIT_PLUGINS_FOLLOW_TRAJECTORY_SERVER_HANDLE

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -109,11 +109,14 @@ public:
         const std::string& type =
             controller_list[i].hasMember("type") ? std::string(controller_list[i]["type"]) : DEFAULT_TYPE;
         if (type == "last point")
-          controllers_[name].reset(new LastPointController(name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
+          controllers_[name].reset(new LastPointController(
+              name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
         else if (type == "via points")
-          controllers_[name].reset(new ViaPointController(name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
+          controllers_[name].reset(new ViaPointController(
+              name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
         else if (type == "interpolate")
-          controllers_[name].reset(new InterpolatingController(name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
+          controllers_[name].reset(new InterpolatingController(
+              name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
         else
           ROS_ERROR_STREAM("Unknown fake controller type: " << type);
       }
@@ -209,30 +212,29 @@ public:
    */
   void updateJointState(const sensor_msgs::JointState js)
   {
-    //pub_js_ = js;
+    // pub_js_ = js;
     int i = 0;
-    for (std::vector<std::string>::const_iterator name = js.name.begin(); name != js.name.end();
-         ++name, i++)
+    for (std::vector<std::string>::const_iterator name = js.name.begin(); name != js.name.end(); ++name, i++)
     {
       std::vector<std::string>::iterator it = std::find(pub_js_.name.begin(), pub_js_.name.end(), *name);
       if (it != pub_js_.name.end())
       {
         size_t j = std::distance(pub_js_.name.begin(), it);
-        if ( i < js.position.size() && j < pub_js_.position.size() )
+        if (i < js.position.size() && j < pub_js_.position.size())
           pub_js_.position[j] = js.position[i];
-        if ( i < js.velocity.size() && j < pub_js_.velocity.size() )
+        if (i < js.velocity.size() && j < pub_js_.velocity.size())
           pub_js_.velocity[j] = js.velocity[i];
-        if ( i < js.effort.size() && j < pub_js_.effort.size() )
+        if (i < js.effort.size() && j < pub_js_.effort.size())
           pub_js_.effort[j] = js.effort[i];
       }
       else
       {
         pub_js_.name.push_back(js.name[i]);
-        if ( i < js.position.size())
+        if (i < js.position.size())
           pub_js_.position.push_back(js.position[i]);
-        if ( i < js.velocity.size())
+        if (i < js.velocity.size())
           pub_js_.velocity.push_back(js.velocity[i]);
-        if ( i < js.effort.size())
+        if (i < js.effort.size())
           pub_js_.effort.push_back(js.effort[i]);
       }
     }
@@ -248,11 +250,13 @@ public:
     if (ros::param::get("~fake_interpolating_joint_state_rate", r))
       pub_js_rate_ = ros::WallRate(r);
 
-    while ( pub_js_thread_running() && ros::ok() )
+    while (pub_js_thread_running() && ros::ok())
     {
       pub_js_.header.stamp = ros::Time::now();
-      // add virtual noise for waitForCurrentState, which consider 'Didn't received robot state (joint angles) with recent timestamp within 1 sec'
-      for (size_t i = 0; i < pub_js_.position.size(); i++) {
+      // add virtual noise for waitForCurrentState, which consider 'Didn't received robot state (joint angles) with
+      // recent timestamp within 1 sec'
+      for (size_t i = 0; i < pub_js_.position.size(); i++)
+      {
         pub_js_.position[i] += dist(gen);
       }
       pub.publish(pub_js_);

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -44,6 +44,9 @@
 #include <map>
 #include <iterator>
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+
 namespace moveit_fake_controller_manager
 {
 static const std::string DEFAULT_TYPE = "interpolate";
@@ -52,7 +55,7 @@ static const std::string ROBOT_DESCRIPTION = "robot_description";
 class MoveItFakeControllerManager : public moveit_controller_manager::MoveItControllerManager
 {
 public:
-  MoveItFakeControllerManager() : node_handle_("~")
+  MoveItFakeControllerManager() : node_handle_("~"), pub_js_rate_(10)
   {
     if (!node_handle_.hasParam("controller_list"))
     {
@@ -68,7 +71,8 @@ public:
       return;
     }
 
-    pub_ = node_handle_.advertise<sensor_msgs::JointState>("fake_controller_joint_states", 100, false);
+    pub_js_thread_running_ = true;
+    pub_js_thread_ = boost::thread(boost::bind(&MoveItFakeControllerManager::publishJointState, this));
 
     /* publish initial pose */
     XmlRpc::XmlRpcValue initial;
@@ -76,7 +80,7 @@ public:
     {
       sensor_msgs::JointState js = loadInitialJointValues(initial);
       js.header.stamp = ros::Time::now();
-      pub_.publish(js);
+      updateJointState(js);
     }
 
     /* actually create each controller */
@@ -105,11 +109,11 @@ public:
         const std::string& type =
             controller_list[i].hasMember("type") ? std::string(controller_list[i]["type"]) : DEFAULT_TYPE;
         if (type == "last point")
-          controllers_[name].reset(new LastPointController(name, joints, pub_));
+          controllers_[name].reset(new LastPointController(name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
         else if (type == "via points")
-          controllers_[name].reset(new ViaPointController(name, joints, pub_));
+          controllers_[name].reset(new ViaPointController(name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
         else if (type == "interpolate")
-          controllers_[name].reset(new InterpolatingController(name, joints, pub_));
+          controllers_[name].reset(new InterpolatingController(name, joints, boost::bind(&MoveItFakeControllerManager::updateJointState, this, _1)));
         else
           ROS_ERROR_STREAM("Unknown fake controller type: " << type);
       }
@@ -196,6 +200,64 @@ public:
 
   virtual ~MoveItFakeControllerManager()
   {
+    pub_js_thread_running_ = false;
+    pub_js_thread_.join();
+  }
+
+  /*
+   * Update by joint name
+   */
+  void updateJointState(const sensor_msgs::JointState js)
+  {
+    //pub_js_ = js;
+    int i = 0;
+    for (std::vector<std::string>::const_iterator name = js.name.begin(); name != js.name.end();
+         ++name, i++)
+    {
+      std::vector<std::string>::iterator it = std::find(pub_js_.name.begin(), pub_js_.name.end(), *name);
+      if (it != pub_js_.name.end())
+      {
+        size_t j = std::distance(pub_js_.name.begin(), it);
+        if ( i < js.position.size() && j < pub_js_.position.size() )
+          pub_js_.position[j] = js.position[i];
+        if ( i < js.velocity.size() && j < pub_js_.velocity.size() )
+          pub_js_.velocity[j] = js.velocity[i];
+        if ( i < js.effort.size() && j < pub_js_.effort.size() )
+          pub_js_.effort[j] = js.effort[i];
+      }
+      else
+      {
+        pub_js_.name.push_back(js.name[i]);
+        if ( i < js.position.size())
+          pub_js_.position.push_back(js.position[i]);
+        if ( i < js.velocity.size())
+          pub_js_.velocity.push_back(js.velocity[i]);
+        if ( i < js.effort.size())
+          pub_js_.effort.push_back(js.effort[i]);
+      }
+    }
+  }
+
+  void publishJointState()
+  {
+    boost::random::mt19937 gen;
+    boost::random::uniform_real_distribution<> dist(0.0, 0.0001);
+
+    ros::Publisher pub = node_handle_.advertise<sensor_msgs::JointState>("fake_controller_joint_states", 100, false);
+    double r;
+    if (ros::param::get("~fake_interpolating_joint_state_rate", r))
+      pub_js_rate_ = ros::WallRate(r);
+
+    while ( pub_js_thread_running() && ros::ok() )
+    {
+      pub_js_.header.stamp = ros::Time::now();
+      // add virtual noise for waitForCurrentState, which consider 'Didn't received robot state (joint angles) with recent timestamp within 1 sec'
+      for (size_t i = 0; i < pub_js_.position.size(); i++) {
+        pub_js_.position[i] += dist(gen);
+      }
+      pub.publish(pub_js_);
+      pub_js_rate_.sleep();
+    }
   }
 
   /*
@@ -276,9 +338,18 @@ public:
   }
 
 protected:
+  bool pub_js_thread_running()
+  {
+    return pub_js_thread_running_;
+  }
+
   ros::NodeHandle node_handle_;
-  ros::Publisher pub_;
   std::map<std::string, BaseFakeControllerPtr> controllers_;
+
+  sensor_msgs::JointState pub_js_;
+  boost::thread pub_js_thread_;
+  ros::WallRate pub_js_rate_;
+  bool pub_js_thread_running_;
 };
 
 }  // end namespace moveit_fake_controller_manager

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -44,7 +44,7 @@
 namespace moveit_fake_controller_manager
 {
 BaseFakeController::BaseFakeController(const std::string& name, const std::vector<std::string>& joints,
-                                       boost::function<void (const sensor_msgs::JointState)> update_js)
+                                       boost::function<void(const sensor_msgs::JointState)> update_js)
   : moveit_controller_manager::MoveItControllerHandle(name), joints_(joints), update_js_(update_js)
 {
   std::stringstream ss;
@@ -65,7 +65,7 @@ moveit_controller_manager::ExecutionStatus BaseFakeController::getLastExecutionS
 }
 
 LastPointController::LastPointController(const std::string& name, const std::vector<std::string>& joints,
-                                         boost::function<void (const sensor_msgs::JointState)> update_js)
+                                         boost::function<void(const sensor_msgs::JointState)> update_js)
   : BaseFakeController(name, joints, update_js)
 {
 }
@@ -105,7 +105,7 @@ bool LastPointController::waitForExecution(const ros::Duration&)
 }
 
 ThreadedController::ThreadedController(const std::string& name, const std::vector<std::string>& joints,
-                                       boost::function<void (const sensor_msgs::JointState)> update_js)
+                                       boost::function<void(const sensor_msgs::JointState)> update_js)
   : BaseFakeController(name, joints, update_js)
 {
 }
@@ -151,7 +151,7 @@ moveit_controller_manager::ExecutionStatus ThreadedController::getLastExecutionS
 }
 
 ViaPointController::ViaPointController(const std::string& name, const std::vector<std::string>& joints,
-                                       boost::function<void (const sensor_msgs::JointState)> update_js)
+                                       boost::function<void(const sensor_msgs::JointState)> update_js)
   : ThreadedController(name, joints, update_js)
 {
 }
@@ -191,7 +191,7 @@ void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
 }
 
 InterpolatingController::InterpolatingController(const std::string& name, const std::vector<std::string>& joints,
-                                                 boost::function<void (const sensor_msgs::JointState)> update_js)
+                                                 boost::function<void(const sensor_msgs::JointState)> update_js)
   : ThreadedController(name, joints, update_js), rate_(10)
 {
   double r;

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -44,8 +44,8 @@
 namespace moveit_fake_controller_manager
 {
 BaseFakeController::BaseFakeController(const std::string& name, const std::vector<std::string>& joints,
-                                       const ros::Publisher& pub)
-  : moveit_controller_manager::MoveItControllerHandle(name), joints_(joints), pub_(pub)
+                                       boost::function<void (const sensor_msgs::JointState)> update_js)
+  : moveit_controller_manager::MoveItControllerHandle(name), joints_(joints), update_js_(update_js)
 {
   std::stringstream ss;
   ss << "Fake controller '" << name << "' with joints [ ";
@@ -65,8 +65,8 @@ moveit_controller_manager::ExecutionStatus BaseFakeController::getLastExecutionS
 }
 
 LastPointController::LastPointController(const std::string& name, const std::vector<std::string>& joints,
-                                         const ros::Publisher& pub)
-  : BaseFakeController(name, joints, pub)
+                                         boost::function<void (const sensor_msgs::JointState)> update_js)
+  : BaseFakeController(name, joints, update_js)
 {
 }
 
@@ -88,7 +88,7 @@ bool LastPointController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
   js.position = last.positions;
   js.velocity = last.velocities;
   js.effort = last.effort;
-  pub_.publish(js);
+  update_js_(js);
 
   return true;
 }
@@ -105,8 +105,8 @@ bool LastPointController::waitForExecution(const ros::Duration&)
 }
 
 ThreadedController::ThreadedController(const std::string& name, const std::vector<std::string>& joints,
-                                       const ros::Publisher& pub)
-  : BaseFakeController(name, joints, pub)
+                                       boost::function<void (const sensor_msgs::JointState)> update_js)
+  : BaseFakeController(name, joints, update_js)
 {
 }
 
@@ -151,8 +151,8 @@ moveit_controller_manager::ExecutionStatus ThreadedController::getLastExecutionS
 }
 
 ViaPointController::ViaPointController(const std::string& name, const std::vector<std::string>& joints,
-                                       const ros::Publisher& pub)
-  : ThreadedController(name, joints, pub)
+                                       boost::function<void (const sensor_msgs::JointState)> update_js)
+  : ThreadedController(name, joints, update_js)
 {
 }
 
@@ -185,14 +185,14 @@ void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
       waitTime.sleep();
     }
     js.header.stamp = ros::Time::now();
-    pub_.publish(js);
+    update_js_(js);
   }
   ROS_DEBUG("Fake execution of trajectory: done");
 }
 
 InterpolatingController::InterpolatingController(const std::string& name, const std::vector<std::string>& joints,
-                                                 const ros::Publisher& pub)
-  : ThreadedController(name, joints, pub), rate_(10)
+                                                 boost::function<void (const sensor_msgs::JointState)> update_js)
+  : ThreadedController(name, joints, update_js), rate_(10)
 {
   double r;
   if (ros::param::get("~fake_interpolating_controller_rate", r))
@@ -256,7 +256,7 @@ void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory&
                                                                   1.0);
     interpolate(js, *prev, *next, elapsed);
     js.header.stamp = ros::Time::now();
-    pub_.publish(js);
+    update_js_(js);
     rate_.sleep();
   }
   if (cancelled())
@@ -269,7 +269,7 @@ void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory&
   // publish last point
   interpolate(js, *prev, *prev, prev->time_from_start);
   js.header.stamp = ros::Time::now();
-  pub_.publish(js);
+  update_js_(js);
 
   ROS_DEBUG("Fake execution of trajectory: done");
 }

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -40,6 +40,8 @@
 #include <ros/publisher.h>
 #include <ros/rate.h>
 #include <boost/thread/thread.hpp>
+#include <boost/function.hpp>
+#include <sensor_msgs/JointState.h>
 
 #ifndef MOVEIT_FAKE_CONTROLLERS
 #define MOVEIT_FAKE_CONTROLLERS
@@ -52,20 +54,20 @@ MOVEIT_CLASS_FORWARD(BaseFakeController);
 class BaseFakeController : public moveit_controller_manager::MoveItControllerHandle
 {
 public:
-  BaseFakeController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
+  BaseFakeController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
 
   virtual moveit_controller_manager::ExecutionStatus getLastExecutionStatus();
   void getJoints(std::vector<std::string>& joints) const;
 
 protected:
   std::vector<std::string> joints_;
-  const ros::Publisher& pub_;
+  boost::function<void (const sensor_msgs::JointState)> update_js_;
 };
 
 class LastPointController : public BaseFakeController
 {
 public:
-  LastPointController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
+  LastPointController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
   ~LastPointController();
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& t);
@@ -76,7 +78,7 @@ public:
 class ThreadedController : public BaseFakeController
 {
 public:
-  ThreadedController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
+  ThreadedController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
   ~ThreadedController();
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& t);
@@ -103,7 +105,7 @@ private:
 class ViaPointController : public ThreadedController
 {
 public:
-  ViaPointController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
+  ViaPointController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
   ~ViaPointController();
 
 protected:
@@ -113,7 +115,7 @@ protected:
 class InterpolatingController : public ThreadedController
 {
 public:
-  InterpolatingController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
+  InterpolatingController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
   ~InterpolatingController();
 
 protected:

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -54,20 +54,22 @@ MOVEIT_CLASS_FORWARD(BaseFakeController);
 class BaseFakeController : public moveit_controller_manager::MoveItControllerHandle
 {
 public:
-  BaseFakeController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
+  BaseFakeController(const std::string& name, const std::vector<std::string>& joints,
+                     boost::function<void(const sensor_msgs::JointState)> update_js);
 
   virtual moveit_controller_manager::ExecutionStatus getLastExecutionStatus();
   void getJoints(std::vector<std::string>& joints) const;
 
 protected:
   std::vector<std::string> joints_;
-  boost::function<void (const sensor_msgs::JointState)> update_js_;
+  boost::function<void(const sensor_msgs::JointState)> update_js_;
 };
 
 class LastPointController : public BaseFakeController
 {
 public:
-  LastPointController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
+  LastPointController(const std::string& name, const std::vector<std::string>& joints,
+                      boost::function<void(const sensor_msgs::JointState)> update_js);
   ~LastPointController();
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& t);
@@ -78,7 +80,8 @@ public:
 class ThreadedController : public BaseFakeController
 {
 public:
-  ThreadedController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
+  ThreadedController(const std::string& name, const std::vector<std::string>& joints,
+                     boost::function<void(const sensor_msgs::JointState)> update_js);
   ~ThreadedController();
 
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& t);
@@ -105,7 +108,8 @@ private:
 class ViaPointController : public ThreadedController
 {
 public:
-  ViaPointController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
+  ViaPointController(const std::string& name, const std::vector<std::string>& joints,
+                     boost::function<void(const sensor_msgs::JointState)> update_js);
   ~ViaPointController();
 
 protected:
@@ -115,7 +119,8 @@ protected:
 class InterpolatingController : public ThreadedController
 {
 public:
-  InterpolatingController(const std::string& name, const std::vector<std::string>& joints, boost::function<void (const sensor_msgs::JointState)> update_js);
+  InterpolatingController(const std::string& name, const std::vector<std::string>& joints,
+                          boost::function<void(const sensor_msgs::JointState)> update_js);
   ~InterpolatingController();
 
 protected:


### PR DESCRIPTION
…s incldued in current controller

### Description

FakeTrajectoryExecutionController publishes '/joint_states' only when the trajectory is interpolated, this PR changes publish the 'joint_state' all the time and also publishes all joints, instead of joint within the controllers.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
