### PR TITLE
Addition of CHOMP planning adapter for optimizing result of other planners

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -979,11 +979,10 @@ public:
   /** \brief Clone a planning scene. Even if the scene \e scene depends on a parent, the cloned scene will not. */
   static PlanningScenePtr clone(const PlanningSceneConstPtr& scene);
 
-public:
+private:
   /* Private constructor used by the diff() methods. */
   PlanningScene(const PlanningSceneConstPtr& parent);
 
-private:
   /* Initialize the scene.  This should only be called by the constructors.
    * Requires a valid robot_model_ */
   void initialize();

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -245,6 +245,7 @@ public:
    *
    * */
   void addCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator);
+  const void addCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const;
 
   /** \brief Set the type of collision detector to use.
    * Calls addCollisionDetector() to add it if it has not already been added.
@@ -257,6 +258,8 @@ public:
    */
   void setActiveCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
                                   bool exclusive = false);
+  const void setActiveCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+                                    bool exclusive = false) const;
 
   /** \brief Set the type of collision detector to use.
    * This type must have already been added with addCollisionDetector().
@@ -265,6 +268,7 @@ public:
    * name of a collision detector that has been previously added with
    * addCollisionDetector(). */
   bool setActiveCollisionDetector(const std::string& collision_detector_name);
+  const bool setActiveCollisionDetector_ConstVersion(const std::string& collision_detector_name) const;
 
   const std::string& getActiveCollisionDetectorName() const
   {
@@ -949,10 +953,11 @@ public:
   /** \brief Clone a planning scene. Even if the scene \e scene depends on a parent, the cloned scene will not. */
   static PlanningScenePtr clone(const PlanningSceneConstPtr& scene);
 
-private:
+public:
   /* Private constructor used by the diff() methods. */
   PlanningScene(const PlanningSceneConstPtr& parent);
 
+private:
   /* Initialize the scene.  This should only be called by the constructors.
    * Requires a valid robot_model_ */
   void initialize();
@@ -1008,14 +1013,17 @@ private:
 
   robot_state::TransformsPtr ftf_;  // if NULL use parent's
 
-  collision_detection::WorldPtr world_;             // never NULL, never shared with parent/child
+public:
+  collision_detection::WorldPtr world_;  // never NULL, never shared with parent/child
+public:
   collision_detection::WorldConstPtr world_const_;  // copy of world_
   collision_detection::WorldDiffPtr world_diff_;    // NULL unless this is a diff scene
   collision_detection::World::ObserverCallbackFn current_world_object_update_callback_;
   collision_detection::World::ObserverHandle current_world_object_update_observer_handle_;
 
-  std::map<std::string, CollisionDetectorPtr> collision_;  // never empty
-  CollisionDetectorPtr active_collision_;                  // copy of one of the entries in collision_.  Never NULL.
+  mutable std::map<std::string, CollisionDetectorPtr> collision_;  // never empty
+  mutable CollisionDetectorPtr active_collision_;  // copy of one of the entries in collision_.  Never NULL.
+  // const bool setActiveCollisionDetector(); const
 
   collision_detection::AllowedCollisionMatrixPtr acm_;  // if NULL use parent's
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -245,7 +245,14 @@ public:
    *
    * */
   void addCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator);
-  const void addCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const;
+
+  /** \brief Add a new collision detector type.
+   *
+   * this is the constant version of the function addCollisionDetector(), it is added here for changing the collision
+   * checker for a constant planning scene whenever required, e.g., for some planners like CHOMP
+   */
+  const void
+  addCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const;
 
   /** \brief Set the type of collision detector to use.
    * Calls addCollisionDetector() to add it if it has not already been added.
@@ -258,8 +265,16 @@ public:
    */
   void setActiveCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
                                   bool exclusive = false);
-  const void setActiveCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
-                                    bool exclusive = false) const;
+
+  /** \brief Set the type of collision detector to use.
+  * Calls addCollisionDetector_ConstVersion() to add it if it
+  * has not already been added.
+  *
+  * this is the constant version of the function setActiveCollisionDetector(), it is added here for setting the
+  * collision checker for a constant planning scene whenever required, e.g., for some planners like CHOMP
+  */
+  const void setActiveCollisionDetector_ConstVersion(
+      const collision_detection::CollisionDetectorAllocatorPtr& allocator, bool exclusive = false) const;
 
   /** \brief Set the type of collision detector to use.
    * This type must have already been added with addCollisionDetector().
@@ -268,6 +283,17 @@ public:
    * name of a collision detector that has been previously added with
    * addCollisionDetector(). */
   bool setActiveCollisionDetector(const std::string& collision_detector_name);
+
+  /** \brief Set the type of collision detector to use.
+   * This type must have already been added with addCollisionDetector_ConstVersion().
+   *
+   * this is the constant version of the function setActiveCollisionDetector() and is added here to change the collision
+   * checkers for a constant planning scene whenever required, e.g., for some planners like CHOMP
+   *
+   * Returns true on success, false if \e collision_detector_name is not the
+   * name of a collision detector that has been previously added with
+   * addCollisionDetector_ConstVersion().
+   */
   const bool setActiveCollisionDetector_ConstVersion(const std::string& collision_detector_name) const;
 
   const std::string& getActiveCollisionDetectorName() const
@@ -1013,17 +1039,18 @@ private:
 
   robot_state::TransformsPtr ftf_;  // if NULL use parent's
 
-public:
-  collision_detection::WorldPtr world_;  // never NULL, never shared with parent/child
-public:
+  collision_detection::WorldPtr world_;             // never NULL, never shared with parent/child
   collision_detection::WorldConstPtr world_const_;  // copy of world_
   collision_detection::WorldDiffPtr world_diff_;    // NULL unless this is a diff scene
   collision_detection::World::ObserverCallbackFn current_world_object_update_callback_;
   collision_detection::World::ObserverHandle current_world_object_update_observer_handle_;
 
-  mutable std::map<std::string, CollisionDetectorPtr> collision_;  // never empty
-  mutable CollisionDetectorPtr active_collision_;  // copy of one of the entries in collision_.  Never NULL.
-  // const bool setActiveCollisionDetector(); const
+  mutable std::map<std::string, CollisionDetectorPtr> collision_;  // never empty, marked as mutable as for some
+                                                                   // planners like CHOMP, this needs to be changed for
+                                                                   // a constant PlanningScene
+  mutable CollisionDetectorPtr active_collision_;  // copy of one of the entries in collision_.  Never NULL. marked as
+                                                   // mutable as for some planners like CHOMP, this needs to be changed
+                                                   // for a constant PlanningScene
 
   collision_detection::AllowedCollisionMatrixPtr acm_;  // if NULL use parent's
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -248,7 +248,7 @@ public:
 
   /** \brief Add a new collision detector type.
    *
-   * this is the constant version of the function addCollisionDetector(), it is added here for changing the collision
+   * This is the constant version of the function addCollisionDetector(), it is added here for changing the collision
    * checker for a constant planning scene whenever required, e.g., for some planners like CHOMP
    */
   const void addCollisionDetectorConst(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const;

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -251,8 +251,7 @@ public:
    * this is the constant version of the function addCollisionDetector(), it is added here for changing the collision
    * checker for a constant planning scene whenever required, e.g., for some planners like CHOMP
    */
-  const void
-  addCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const;
+  const void addCollisionDetectorConst(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const;
 
   /** \brief Set the type of collision detector to use.
    * Calls addCollisionDetector() to add it if it has not already been added.
@@ -270,11 +269,11 @@ public:
   * Calls addCollisionDetector_ConstVersion() to add it if it
   * has not already been added.
   *
-  * this is the constant version of the function setActiveCollisionDetector(), it is added here for setting the
+  * This is the constant version of the function setActiveCollisionDetector(), it is added here for setting the
   * collision checker for a constant planning scene whenever required, e.g., for some planners like CHOMP
   */
-  const void setActiveCollisionDetector_ConstVersion(
-      const collision_detection::CollisionDetectorAllocatorPtr& allocator, bool exclusive = false) const;
+  const void setActiveCollisionDetectorConst(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+                                             bool exclusive = false) const;
 
   /** \brief Set the type of collision detector to use.
    * This type must have already been added with addCollisionDetector().
@@ -287,14 +286,14 @@ public:
   /** \brief Set the type of collision detector to use.
    * This type must have already been added with addCollisionDetector_ConstVersion().
    *
-   * this is the constant version of the function setActiveCollisionDetector() and is added here to change the collision
+   * This is the constant version of the function setActiveCollisionDetector() and is added here to change the collision
    * checkers for a constant planning scene whenever required, e.g., for some planners like CHOMP
    *
    * Returns true on success, false if \e collision_detector_name is not the
    * name of a collision detector that has been previously added with
    * addCollisionDetector_ConstVersion().
    */
-  const bool setActiveCollisionDetector_ConstVersion(const std::string& collision_detector_name) const;
+  const bool setActiveCollisionDetectorConst(const std::string& collision_detector_name) const;
 
   const std::string& getActiveCollisionDetectorName() const
   {
@@ -1044,12 +1043,13 @@ private:
   collision_detection::World::ObserverCallbackFn current_world_object_update_callback_;
   collision_detection::World::ObserverHandle current_world_object_update_observer_handle_;
 
-  mutable std::map<std::string, CollisionDetectorPtr> collision_;  // never empty, marked as mutable as for some
-                                                                   // planners like CHOMP, this needs to be changed for
-                                                                   // a constant PlanningScene
-  mutable CollisionDetectorPtr active_collision_;  // copy of one of the entries in collision_.  Never NULL. marked as
-                                                   // mutable as for some planners like CHOMP, this needs to be changed
-                                                   // for a constant PlanningScene
+  // never empty, marked as mutable as for some planners like CHOMP, this needs to be changed for a constant
+  // PlanningScene
+  mutable std::map<std::string, CollisionDetectorPtr> collision_;
+
+  // copy of one of the entries in collision_.  Never NULL. marked as mutable as for some planners like CHOMP, this
+  // needs to be changed for a constant PlanningScene
+  mutable CollisionDetectorPtr active_collision_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;  // if NULL use parent's
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -358,7 +358,8 @@ bool PlanningScene::setActiveCollisionDetector(const std::string& collision_dete
   }
 }
 
-const void PlanningScene::addCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const
+const void PlanningScene::addCollisionDetector_ConstVersion(
+    const collision_detection::CollisionDetectorAllocatorPtr& allocator) const
 {
   const std::string& name = allocator->getName();
   CollisionDetectorPtr& detector = collision_[name];
@@ -397,8 +398,8 @@ const void PlanningScene::addCollisionDetector_ConstVersion(const collision_dete
   }
 }
 
-const void PlanningScene::setActiveCollisionDetector_ConstVersion(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
-                                       bool exclusive) const
+const void PlanningScene::setActiveCollisionDetector_ConstVersion(
+    const collision_detection::CollisionDetectorAllocatorPtr& allocator, bool exclusive) const
 {
   if (exclusive)
   {
@@ -435,12 +436,11 @@ const bool PlanningScene::setActiveCollisionDetector_ConstVersion(const std::str
   {
     ROS_ERROR_NAMED("planning_scene",
                     "Cannot setActiveCollisionDetector to '%s' -- it has been added to PlanningScene. "
-                            "Keeping existing active collision detector '%s'",
+                    "Keeping existing active collision detector '%s'",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return false;
   }
 }
-
 
 void PlanningScene::getCollisionDetectorNames(std::vector<std::string>& names) const
 {

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -358,73 +358,73 @@ bool PlanningScene::setActiveCollisionDetector(const std::string& collision_dete
   }
 }
 
-const void PlanningScene::addCollisionDetector_ConstVersion(
-    const collision_detection::CollisionDetectorAllocatorPtr& allocator) const
+const void
+PlanningScene::addCollisionDetectorConst(const collision_detection::CollisionDetectorAllocatorPtr& allocator) const
 {
   const std::string& name = allocator->getName();
-  CollisionDetectorPtr& detector = collision_[name];
+  CollisionDetectorPtr& collision_detector = collision_[name];
 
-  if (detector)  // already added this one
+  if (collision_detector)  // already added this one
     return;
 
-  detector.reset(new CollisionDetector());
+  collision_detector.reset(new CollisionDetector());
 
-  detector->alloc_ = allocator;
+  collision_detector->alloc_ = allocator;
 
   if (!active_collision_)
-    active_collision_ = detector;
+    active_collision_ = collision_detector;
 
-  detector->findParent(*this);
+  collision_detector->findParent(*this);
 
-  detector->cworld_ = detector->alloc_->allocateWorld(world_);
-  detector->cworld_const_ = detector->cworld_;
+  collision_detector->cworld_ = collision_detector->alloc_->allocateWorld(world_);
+  collision_detector->cworld_const_ = collision_detector->cworld_;
 
   // Allocate CollisionRobot unless we can use the parent's crobot_.
   // If active_collision_->crobot_ is non-NULL there is local padding and we cannot use the parent's crobot_.
-  if (!detector->parent_ || active_collision_->crobot_)
+  if (!collision_detector->parent_ || active_collision_->crobot_)
   {
-    detector->crobot_ = detector->alloc_->allocateRobot(getRobotModel());
-    detector->crobot_const_ = detector->crobot_;
+    collision_detector->crobot_ = collision_detector->alloc_->allocateRobot(getRobotModel());
+    collision_detector->crobot_const_ = collision_detector->crobot_;
 
-    if (detector != active_collision_)
-      detector->copyPadding(*active_collision_);
+    if (collision_detector != active_collision_)
+      collision_detector->copyPadding(*active_collision_);
   }
 
   // Allocate CollisionRobot unless we can use the parent's crobot_unpadded_.
-  if (!detector->parent_)
+  if (!collision_detector->parent_)
   {
-    detector->crobot_unpadded_ = detector->alloc_->allocateRobot(getRobotModel());
-    detector->crobot_unpadded_const_ = detector->crobot_unpadded_;
+    collision_detector->crobot_unpadded_ = collision_detector->alloc_->allocateRobot(getRobotModel());
+    collision_detector->crobot_unpadded_const_ = collision_detector->crobot_unpadded_;
   }
 }
 
-const void PlanningScene::setActiveCollisionDetector_ConstVersion(
+const void PlanningScene::setActiveCollisionDetectorConst(
     const collision_detection::CollisionDetectorAllocatorPtr& allocator, bool exclusive) const
 {
   if (exclusive)
   {
-    CollisionDetectorPtr p;
+    CollisionDetectorPtr collision_detector_ptr;
     CollisionDetectorIterator it = collision_.find(allocator->getName());
 
     if (it != collision_.end())
-      p = it->second;
+      collision_detector_ptr = it->second;
 
     collision_.clear();
     active_collision_.reset();
 
-    if (p)
+    if (collision_detector_ptr)
     {
-      collision_[allocator->getName()] = p;
-      active_collision_ = p;
+      collision_[allocator->getName()] = collision_detector_ptr;
+      active_collision_ = collision_detector_ptr;
       return;
     }
   }
 
-  addCollisionDetector_ConstVersion(allocator);
-  setActiveCollisionDetector_ConstVersion(allocator->getName());
+  addCollisionDetectorConst(allocator);
+  setActiveCollisionDetectorConst(allocator->getName());
 }
 
-const bool PlanningScene::setActiveCollisionDetector_ConstVersion(const std::string& collision_detector_name) const
+const bool PlanningScene::setActiveCollisionDetectorConst(const std::string& collision_detector_name) const
 {
   CollisionDetectorIterator it = collision_.find(collision_detector_name);
   if (it != collision_.end())

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -129,6 +129,7 @@ public:
    */
   void fillInCubicInterpolation();
 
+  void fillInFromOMPL();
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
    *

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -41,6 +41,9 @@
 #include <moveit/robot_model/robot_model.h>
 #include <chomp_motion_planner/chomp_utils.h>
 
+#include <moveit_msgs/MotionPlanDetailedResponse.h>
+#include <moveit_msgs/MotionPlanRequest.h>
+
 #include <vector>
 #include <eigen3/Eigen/Core>
 
@@ -129,7 +132,11 @@ public:
    */
   void fillInCubicInterpolation();
 
-  void fillInFromOMPL();
+  /**
+   * \brief receives the path obtained from OMPL and puts it into the appropriate trajectory format required for CHOMP
+   * @param res
+   */
+  void fillInFromOMPL(moveit_msgs::MotionPlanDetailedResponse& res);
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
    *

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -133,10 +133,11 @@ public:
   void fillInCubicInterpolation();
 
   /**
-   * \brief receives the path obtained from OMPL and puts it into the appropriate trajectory format required for CHOMP
+   * \brief receives the path obtained from a given MotionPlanDetailedResponse res object's trajectory (e.g., trajectory
+   * produced by OMPL) and puts it into the appropriate trajectory format required for CHOMP
    * @param res
    */
-  void fillInFromOMPL(moveit_msgs::MotionPlanDetailedResponse& res);
+  void fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res);
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
    *

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -138,6 +138,19 @@ public:
    * @param res
    */
   bool fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res);
+
+  /**
+   * This function assigns the chomp_trajectory row / robot pose at index 'chomp_trajectory_point' obtained from input
+   * trajectory_msgs at index 'trajectory_msgs_point'
+   * @param trajectory_msg the input trajectory_msg
+   * @param num_joints_trajectory number of joints in the given robot trajectory
+   * @param trajectory_msgs_point index of the input trajectory_msg's point to get joint values from
+   * @param chomp_trajectory_point index of the chomp_trajectory's point to get joint values from
+   */
+  void assignCHOMPTrajectoryPointFromInputTrajectoryPoint(moveit_msgs::RobotTrajectory trajectory_msg,
+                                                          int num_joints_trajectory, int trajectory_msgs_point,
+                                                          int chomp_trajectory_point);
+
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
    *

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -133,11 +133,11 @@ public:
   void fillInCubicInterpolation();
 
   /**
-   * \brief receives the path obtained from a given MotionPlanDetailedResponse res object's trajectory (e.g., trajectory
+   * \brief Receives the path obtained from a given MotionPlanDetailedResponse res object's trajectory (e.g., trajectory
    * produced by OMPL) and puts it into the appropriate trajectory format required for CHOMP
    * @param res
    */
-  void fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res);
+  bool fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res);
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
    *

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -125,8 +125,6 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
       }
     }
   }
-  std::cout << trajectory.getTrajectory() << " 1. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
-  std::cout << trajectory.getTrajectory().size() << " 1. size_trajectory" << std::endl;
 
   const std::vector<std::string>& active_joint_names = model_group->getActiveJointModelNames();
   const Eigen::MatrixXd goal_state = trajectory.getTrajectoryPoint(goal_index);
@@ -152,6 +150,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     trajectory.fillInFromOMPL(res);
   else
     ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
+
+  ROS_INFO("CHOMP trajectory initialized using method: %s ", (params.trajectory_initialization_method_).c_str());
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());
@@ -231,14 +231,10 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   // resetting the CHOMP Parameters to the original values after a successful plan
   params_nonconst.setRecoveryParams(org_learning_rate, org_ridge_factor, org_planning_time_limit, org_max_iterations);
 
-
   ROS_DEBUG_NAMED("chomp_planner", "Optimization actually took %f sec to run",
                   (ros::WallTime::now() - create_time).toSec());
   create_time = ros::WallTime::now();
   // assume that the trajectory is now optimized, fill in the output structure:
-
-  std::cout << trajectory.getTrajectory() << " 4. complete optimized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
-  std::cout << trajectory.getTrajectory().size() << " 4. size_trajectory" << std::endl;
 
   ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -147,7 +147,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   else if (params.trajectory_initialization_method_.compare("cubic") == 0)
     trajectory.fillInCubicInterpolation();
   else if (params.trajectory_initialization_method_.compare("OMPL") == 0)
-    trajectory.fillInFromOMPL(res);
+    trajectory.fillInFromTrajectory(res);
   else
     ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -147,11 +147,18 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   else if (params.trajectory_initialization_method_.compare("cubic") == 0)
     trajectory.fillInCubicInterpolation();
   else if (params.trajectory_initialization_method_.compare("OMPL") == 0)
-    trajectory.fillInFromTrajectory(res);
+  {
+    if (!(trajectory.fillInFromTrajectory(res)))
+    {
+      ROS_ERROR_STREAM_NAMED("chomp_planner", "Input trajectory has less than 2 points, trajectory must contain "
+                                              "atleast start and goal state");
+      return false;
+    }
+  }
   else
     ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
 
-  ROS_INFO("CHOMP trajectory initialized using method: %s ", (params.trajectory_initialization_method_).c_str());
+  ROS_INFO_NAMED("CHOMP trajectory initialized using method: %s ", (params.trajectory_initialization_method_).c_str());
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -146,7 +146,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     trajectory.fillInLinearInterpolation();
   else if (params.trajectory_initialization_method_.compare("cubic") == 0)
     trajectory.fillInCubicInterpolation();
-  else if (params.trajectory_initialization_method_.compare("OMPL") == 0)
+  else if (params.trajectory_initialization_method_.compare("fillTrajectory") == 0)
   {
     if (!(trajectory.fillInFromTrajectory(res)))
     {

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -73,10 +73,6 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
 
   ros::WallTime start_time = ros::WallTime::now();
-
-  // add a new trajectory initialization with a new constructor for getting path from OMPL, also have a new CHOMP
-  // parameter indicating its usage
-
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
 
   jointStateToArray(planning_scene->getRobotModel(), req.start_state.joint_state, req.group_name,
@@ -153,93 +149,9 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   else if (params.trajectory_initialization_method_.compare("cubic") == 0)
     trajectory.fillInCubicInterpolation();
   else if (params.trajectory_initialization_method_.compare("OMPL") == 0)
-  {
-    //////
-
-    moveit_msgs::RobotTrajectory trajectory_msgs = res.trajectory[0];  // = new moveit_msgs::MotionPlanResponse();
-    std::cout << "got it e$@#$@#@%$@%GFSgfds#$@" << std::endl;
-    // res.trajectory->getRobotTrajectoryMsg(trajectory_msgs); //.joint_trajectory.points.size();
-    std::cout << trajectory_msgs.joint_trajectory.points[3].positions.size() << " Points size #$@#@ " << std::endl;
-    // change the getNumPoints to points in the response trajectory
-
-    std::cout << "Robot trajectory num points:: " << trajectory_msgs.joint_trajectory.points.size() << std::endl;
-
-    int num_chomp_trajectory_points = trajectory.getNumPoints();  // getTrajectory().size();
-    int num_response_points = trajectory_msgs.joint_trajectory.points.size();
-    int num_joints_trajectory = trajectory_msgs.joint_trajectory.points[0].positions.size();
-
-    for (int i = 0; i < num_response_points; i++)
-    {
-      for (size_t j = 0; j < num_joints_trajectory; j++)
-      {
-        std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " rr ";
-        (trajectory)(i, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-      }
-      std::cout << std::endl;
-    }
-
-    int repeated_factor = num_chomp_trajectory_points / num_response_points;
-    int repeated_goal_state = num_chomp_trajectory_points % num_response_points;
-
-    std::cout << repeated_factor << " repeated factor= REPEATITION OF EACH ROW " << std::endl;
-    std::cout << repeated_goal_state << " repeated goal_state= REPEATITION OF EACH ROW " << std::endl;
-
-    int count_new_traj_points = 0;
-    int trajectory_row_index = 0;
-    for (int i = 0; i < num_response_points; i++)
-    {
-      for (int k = 0; k < repeated_factor; k++)
-      {
-        for (size_t j = 0; j < num_joints_trajectory; j++)
-        {
-          std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " t ";
-          //(trajectory)(i*repeated_factor+k, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-          (trajectory)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-        }
-
-        std::cout << std::endl
-                  << trajectory_row_index << "   ,   row: " << i << "  , i*repeat+k" << i * repeated_factor + k
-                  << std::endl;
-        count_new_traj_points++;
-        trajectory_row_index++;
-      }
-
-      // if (i == num_response_points - 1)
-      if (i < repeated_goal_state)
-      {
-        // for (int l = 0; l < repeated_goal_state; l++)
-        //{
-        for (size_t j = 0; j < num_joints_trajectory; j++)
-        {
-          std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " t ";
-          //(trajectory)(i*repeated_factor+l, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-          (trajectory)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-        }
-        std::cout << std::endl;
-        std::cout << std::endl << trajectory_row_index << "   ,   row: " << i << std::endl;
-
-        count_new_traj_points++;
-        trajectory_row_index++;
-        //}
-      }
-      std::cout << std::endl;
-      // break; //for()
-    }
-
-    std::cout << " New trajectory points " << count_new_traj_points << std::endl;
-
-    std::cout << trajectory.getTrajectory()
-              << " 2. ^&(*^$(*&#^$(&^##*(#@ complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
-    std::cout << trajectory.getTrajectory().size() << " 2. size_trajectory" << std::endl;
-
-    /////
-  }
+    trajectory.fillInFromOMPL(res);
   else
     ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
-
-  // std::cout << trajectory.getTrajectory() << " 3. complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" <<
-  // std::endl;
-  // std::cout << trajectory.getTrajectory().size() << " 3. size_trajectory" << std::endl;
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());
@@ -319,10 +231,14 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   // resetting the CHOMP Parameters to the original values after a successful plan
   params_nonconst.setRecoveryParams(org_learning_rate, org_ridge_factor, org_planning_time_limit, org_max_iterations);
 
+
   ROS_DEBUG_NAMED("chomp_planner", "Optimization actually took %f sec to run",
                   (ros::WallTime::now() - create_time).toSec());
   create_time = ros::WallTime::now();
   // assume that the trajectory is now optimized, fill in the output structure:
+
+  std::cout << trajectory.getTrajectory() << " 4. complete optimized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  std::cout << trajectory.getTrajectory().size() << " 4. size_trajectory" << std::endl;
 
   ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -158,7 +158,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   else
     ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
 
-  ROS_INFO_NAMED("CHOMP trajectory initialized using method: %s ", (params.trajectory_initialization_method_).c_str());
+  ROS_INFO_NAMED("chomp_planner", "CHOMP trajectory initialized using method: %s ",
+                 (params.trajectory_initialization_method_).c_str());
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -252,4 +252,8 @@ void ChompTrajectory::fillInMinJerk()
   }
 }
 
+void ChompTrajectory::fillInFromOMPL()
+{
+}
+
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -252,45 +252,50 @@ void ChompTrajectory::fillInMinJerk()
   }
 }
 
-void ChompTrajectory::fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res)
+bool ChompTrajectory::fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res)
 {
   // create a RobotTrajectory msg to obtain the trajectory from the MotionPlanDetailedResponse object
-  moveit_msgs::RobotTrajectory trajectory_msgs = res.trajectory[0];  // = new moveit_msgs::MotionPlanResponse();
+  moveit_msgs::RobotTrajectory trajectory_msg = res.trajectory[0];  // = new moveit_msgs::MotionPlanResponse();
 
   // get the default number of points in the CHOMP trajectory
   int num_chomp_trajectory_points = (*this).getNumPoints();
   // get the number of points in the response trajectory obtained from OMPL
-  int num_response_points = trajectory_msgs.joint_trajectory.points.size();
+  int num_response_points = trajectory_msg.joint_trajectory.points.size();
+
+  // check if input trajectory has less than two states (start and goal), return false if true
+  if (num_response_points < 2)
+    return false;
+
   // get the number of joints for each robot state
-  int num_joints_trajectory = trajectory_msgs.joint_trajectory.points[0].positions.size();
+  int num_joints_trajectory = trajectory_msg.joint_trajectory.points[0].positions.size();
 
   // variables for populating the CHOMP trajectory with correct number of trajectory points
   int repeated_factor = num_chomp_trajectory_points / num_response_points;
   int repeated_balance_factor = num_chomp_trajectory_points % num_response_points;
 
-  int trajectory_row_index = 0;
+  // response_point_id stores the point at the stored index location.
+  int response_point_id = 0;
   if (num_chomp_trajectory_points >= num_response_points)
   {
     for (int i = 0; i < num_response_points; i++)
     {
       // following for loop repeats each OMPL trajectory pose/row 'repeated_factor' times; alternatively, there could
-      // also
-      // be a linear interpolation between these points later if required
+      // also be a linear interpolation between these points later if required
       for (int k = 0; k < repeated_factor; k++)
       {
         for (size_t j = 0; j < num_joints_trajectory; j++)
-          (*this)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
+          (*this)(response_point_id, j) = trajectory_msg.joint_trajectory.points[i].positions[j];
 
-        trajectory_row_index++;
+        response_point_id++;
       }
 
       // this populates the CHOMP trajectory row  for the remainder number of rows.
       if (i < repeated_balance_factor)
       {
         for (size_t j = 0; j < num_joints_trajectory; j++)
-          (*this)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
+          (*this)(response_point_id, j) = trajectory_msg.joint_trajectory.points[i].positions[j];
 
-        trajectory_row_index++;
+        response_point_id++;
       }  // end of if
     }    // end of for loop for loading in the trajectory poses/rows
   }
@@ -306,9 +311,10 @@ void ChompTrajectory::fillInFromTrajectory(moveit_msgs::MotionPlanDetailedRespon
 
       // following loop iterates over all joints for a single robot pose
       for (size_t j = 0; j < num_joints_trajectory; j++)
-        (*this)(i, j) = trajectory_msgs.joint_trajectory.points[sampled_point].positions[j];
+        (*this)(i, j) = trajectory_msg.joint_trajectory.points[sampled_point].positions[j];
     }
   }  // end of else
+  return true;
 }
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -252,8 +252,78 @@ void ChompTrajectory::fillInMinJerk()
   }
 }
 
-void ChompTrajectory::fillInFromOMPL()
+void ChompTrajectory::fillInFromOMPL(moveit_msgs::MotionPlanDetailedResponse& res)
 {
+  // create a RobotTrajectory msg to obtain the trajectory from the MotionPlanDetailedResponse object
+  moveit_msgs::RobotTrajectory trajectory_msgs = res.trajectory[0];  // = new moveit_msgs::MotionPlanResponse();
+  // std::cout << "got it e$@#$@#@%$@%GFSgfds#$@" << std::endl;
+  // std::cout << trajectory_msgs.joint_trajectory.points[3].positions.size() << " Points size #$@#@ " << std::endl;
+  // change the getNumPoints to points in the response trajectory
+
+  // std::cout << "Robot trajectory num points:: " << trajectory_msgs.joint_trajectory.points.size() << std::endl;
+
+  // get the default number of points in the CHOMP trajectory
+  int num_chomp_trajectory_points = (*this).getNumPoints();
+  // get the number of points in the response trajectory obtained from OMPL
+  int num_response_points = trajectory_msgs.joint_trajectory.points.size();
+  // get the number of joints for each robot state
+  int num_joints_trajectory = trajectory_msgs.joint_trajectory.points[0].positions.size();
+
+  // following comment is for debuging purposes only, needs to be removed later
+  /*
+  for (int i = 0; i < num_response_points; i++)
+    for (size_t j = 0; j < num_joints_trajectory; j++)
+      //std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " rr ";
+      (*this)(i, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
+    //std::cout << std::endl;
+  */
+
+  // variables for populating the CHOMP trajectory with correct number of trajectory points
+  int repeated_factor = num_chomp_trajectory_points / num_response_points;
+  int repeated_balance_factor = num_chomp_trajectory_points % num_response_points;
+
+  // std::cout << repeated_factor << " repeated factor= REPEATITION OF EACH ROW " << std::endl;
+  // std::cout << repeated_balance_factor << " repeated goal_state= REPEATITION OF EACH ROW " << std::endl;
+
+  // int count_new_traj_points = 0;
+  int trajectory_row_index = 0;
+  for (int i = 0; i < num_response_points; i++)
+  {
+    for (int k = 0; k < repeated_factor; k++)
+    {
+      for (size_t j = 0; j < num_joints_trajectory; j++)
+      {
+        // std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " t ";
+        (*this)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
+      }
+
+      // std::cout << std::endl << trajectory_row_index << "   ,   row: " << i << "  , i*repeat+k" << i *
+      // repeated_factor + k << std::endl;
+      // count_new_traj_points++;
+      trajectory_row_index++;
+    }
+
+    if (i < repeated_balance_factor)
+    {
+      for (size_t j = 0; j < num_joints_trajectory; j++)
+      {
+        // std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " t ";
+        (*this)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
+      }
+      // std::cout << std::endl;
+      // std::cout << std::endl << trajectory_row_index << "   ,   row: " << i << std::endl;
+
+      // count_new_traj_points++;
+      trajectory_row_index++;
+    }
+    // std::cout << std::endl;
+  }
+
+  // std::cout << " New trajectory points " << count_new_traj_points << std::endl;
+
+  // std::cout << (*this).getTrajectory()
+  //          << " 2. ^&(*^$(*&#^$(&^##*(#@ complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
+  // std::cout << (*this).getTrajectory().size() << " 2. size_trajectory" << std::endl;
 }
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -256,11 +256,6 @@ void ChompTrajectory::fillInFromOMPL(moveit_msgs::MotionPlanDetailedResponse& re
 {
   // create a RobotTrajectory msg to obtain the trajectory from the MotionPlanDetailedResponse object
   moveit_msgs::RobotTrajectory trajectory_msgs = res.trajectory[0];  // = new moveit_msgs::MotionPlanResponse();
-  // std::cout << "got it e$@#$@#@%$@%GFSgfds#$@" << std::endl;
-  // std::cout << trajectory_msgs.joint_trajectory.points[3].positions.size() << " Points size #$@#@ " << std::endl;
-  // change the getNumPoints to points in the response trajectory
-
-  // std::cout << "Robot trajectory num points:: " << trajectory_msgs.joint_trajectory.points.size() << std::endl;
 
   // get the default number of points in the CHOMP trajectory
   int num_chomp_trajectory_points = (*this).getNumPoints();
@@ -269,61 +264,32 @@ void ChompTrajectory::fillInFromOMPL(moveit_msgs::MotionPlanDetailedResponse& re
   // get the number of joints for each robot state
   int num_joints_trajectory = trajectory_msgs.joint_trajectory.points[0].positions.size();
 
-  // following comment is for debuging purposes only, needs to be removed later
-  /*
-  for (int i = 0; i < num_response_points; i++)
-    for (size_t j = 0; j < num_joints_trajectory; j++)
-      //std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " rr ";
-      (*this)(i, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-    //std::cout << std::endl;
-  */
-
   // variables for populating the CHOMP trajectory with correct number of trajectory points
   int repeated_factor = num_chomp_trajectory_points / num_response_points;
   int repeated_balance_factor = num_chomp_trajectory_points % num_response_points;
 
-  // std::cout << repeated_factor << " repeated factor= REPEATITION OF EACH ROW " << std::endl;
-  // std::cout << repeated_balance_factor << " repeated goal_state= REPEATITION OF EACH ROW " << std::endl;
-
-  // int count_new_traj_points = 0;
   int trajectory_row_index = 0;
   for (int i = 0; i < num_response_points; i++)
   {
+    // following for loop repeats each OMPL trajectory pose/row 'repeated_factor' times; alternatively, there could also
+    // be a linear interpolation between these points later if required
     for (int k = 0; k < repeated_factor; k++)
     {
       for (size_t j = 0; j < num_joints_trajectory; j++)
-      {
-        // std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " t ";
         (*this)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-      }
 
-      // std::cout << std::endl << trajectory_row_index << "   ,   row: " << i << "  , i*repeat+k" << i *
-      // repeated_factor + k << std::endl;
-      // count_new_traj_points++;
       trajectory_row_index++;
     }
 
+    // this populates the CHOMP trajectory row  for the remainder number of rows.
     if (i < repeated_balance_factor)
     {
       for (size_t j = 0; j < num_joints_trajectory; j++)
-      {
-        // std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " t ";
         (*this)(trajectory_row_index, j) = trajectory_msgs.joint_trajectory.points[i].positions[j];
-      }
-      // std::cout << std::endl;
-      // std::cout << std::endl << trajectory_row_index << "   ,   row: " << i << std::endl;
 
-      // count_new_traj_points++;
       trajectory_row_index++;
-    }
-    // std::cout << std::endl;
-  }
-
-  // std::cout << " New trajectory points " << count_new_traj_points << std::endl;
-
-  // std::cout << (*this).getTrajectory()
-  //          << " 2. ^&(*^$(*&#^$(&^##*(#@ complete initialized TRAJECTORY in CHOMP_PLANNER..!!!!!" << std::endl;
-  // std::cout << (*this).getTrajectory().size() << " 2. size_trajectory" << std::endl;
+    }  // end of if
+  }    // end of for loop for loading in the trajectory poses/rows
 }
 
 }  // namespace chomp

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   tf_conversions
   eigen_conversions
+  chomp_motion_planner
 )
 
 find_package(Eigen3 REQUIRED)

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -1,13 +1,34 @@
 set(MOVEIT_LIB_NAME moveit_default_planning_request_adapter_plugins)
 
 set(SOURCE_FILES
-  src/empty.cpp
-  src/fix_start_state_bounds.cpp
-  src/fix_start_state_collision.cpp
-  src/fix_start_state_path_constraints.cpp
-  src/fix_workspace_bounds.cpp
-  src/add_time_parameterization.cpp
-  src/add_iterative_spline_parameterization.cpp)
+        src/empty.cpp
+        src/fix_start_state_bounds.cpp
+        src/fix_start_state_collision.cpp
+        src/fix_start_state_path_constraints.cpp
+        src/fix_workspace_bounds.cpp
+        src/add_time_parameterization.cpp
+        src/add_iterative_spline_parameterization.cpp
+        src/chomp_optimizer_adapter.cpp)
+
+find_package(catkin REQUIRED COMPONENTS
+        cmake_modules
+        roscpp
+        moveit_core
+        pluginlib
+        chomp_motion_planner
+        moveit_experimental
+        )
+
+find_package(Eigen3 REQUIRED)
+
+
+include_directories(../../../moveit_planners
+        ../../../moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner
+        ../../../moveit_planners/chomp/chomp_motion_planner/include/
+        ../../../moveit_planners/chomp/chomp_motion_planner/
+        ../../../moveit_experimental/collision_distance_field/include/moveit/collision_distance_field
+        ../../../moveit_experimental/collision_distance_field/include/
+        ../../../moveit_experimental/collision_distance_field/)
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
@@ -17,6 +38,5 @@ add_executable(moveit_list_request_adapter_plugins src/list.cpp)
 target_link_libraries(moveit_list_request_adapter_plugins ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} moveit_list_request_adapter_plugins
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
         cmake_modules
         roscpp
         moveit_core
+        moveit_msgs
         pluginlib
         chomp_motion_planner
         moveit_experimental

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -17,19 +17,15 @@ find_package(catkin REQUIRED COMPONENTS
         moveit_msgs
         pluginlib
         chomp_motion_planner
-        moveit_experimental
         )
 
 find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
 
-
-include_directories(../../../moveit_planners
-        ../../../moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner
+include_directories(
         ../../../moveit_planners/chomp/chomp_motion_planner/include/
-        ../../../moveit_planners/chomp/chomp_motion_planner/
-        ../../../moveit_experimental/collision_distance_field/include/moveit/collision_distance_field
-        ../../../moveit_experimental/collision_distance_field/include/
-        ../../../moveit_experimental/collision_distance_field/)
+        ../../../moveit_experimental/collision_distance_field/include/)
+
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -1,0 +1,224 @@
+//
+// Created by deepthought on 24/07/18.
+//
+
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan */
+
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit/trajectory_processing/trajectory_tools.h>
+#include <class_loader/class_loader.hpp>
+#include <ros/ros.h>
+
+#include <chomp_motion_planner/chomp_planner.h>
+#include <chomp_motion_planner/chomp_parameters.h>
+#include <moveit/planning_interface/planning_interface.h>
+#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+
+#include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
+
+#include <tf/transform_listener.h>
+
+#include <moveit/robot_state/conversions.h>
+#include <yaml-cpp/yaml.h>
+
+using namespace chomp;
+
+namespace default_planner_request_adapters
+{
+class CHOMPOptimizerAdapter : public planning_request_adapter::PlanningRequestAdapter
+{
+public:
+
+  ChompPlanner chomp_interface_;
+  moveit::core::RobotModelConstPtr robot_model_;
+
+  chomp::ChompParameters params_;
+  boost::shared_ptr<tf::TransformListener> tf_;
+  CHOMPOptimizerAdapter() : planning_request_adapter::PlanningRequestAdapter(), nh_("~")
+  {
+      if (!nh_.getParam("planning_time_limit", params_.planning_time_limit_))
+      {
+          params_.planning_time_limit_ = 10.0;
+          ROS_INFO_STREAM("Param planning_time_limit was not set. Using default value: " << params_.planning_time_limit_ );
+      }
+      if (!nh_.getParam("max_iterations", params_.max_iterations_))
+      {
+          params_.max_iterations_ = 200;
+          ROS_INFO_STREAM("Param max_iterations was not set. Using default value: " << params_.max_iterations_ );
+      }
+      if (!nh_.getParam("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
+      {
+          params_.max_iterations_after_collision_free_ = 5;
+          ROS_INFO_STREAM("Param max_iterations_after_collision_free was not set. Using default value: " << params_.max_iterations_after_collision_free_ );
+      }
+      if (!nh_.getParam("smoothness_cost_weight", params_.smoothness_cost_weight_))
+      {
+          params_.smoothness_cost_weight_ = 0.1;
+          ROS_INFO_STREAM("Param smoothness_cost_weight was not set. Using default value: " << params_.smoothness_cost_weight_ );
+      }
+      if (!nh_.getParam("obstacle_cost_weight", params_.obstacle_cost_weight_))
+      {
+          params_.obstacle_cost_weight_ = 1.0;
+          ROS_INFO_STREAM("Param obstacle_cost_weight was not set. Using default value: " << params_.obstacle_cost_weight_ );
+      }
+      if (!nh_.getParam("learning_rate", params_.learning_rate_))
+      {
+          params_.learning_rate_ = 0.01;
+          ROS_INFO_STREAM("Param learning_rate was not set. Using default value: " << params_.learning_rate_ );
+      }
+      if (!nh_.getParam("smoothness_cost_velocity", params_.smoothness_cost_velocity_))
+      {
+          params_.smoothness_cost_velocity_ = 0.0;
+          ROS_INFO_STREAM("Param smoothness_cost_velocity was not set. Using default value: " << params_.smoothness_cost_velocity_ );
+      }
+      if (!nh_.getParam("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
+      {
+          params_.smoothness_cost_acceleration_ = 1.0;
+          ROS_INFO_STREAM("Param smoothness_cost_acceleration was not set. Using default value: " << params_.smoothness_cost_acceleration_ );
+      }
+      if (!nh_.getParam("smoothness_cost_jerk", params_.smoothness_cost_jerk_))
+      {
+          params_.smoothness_cost_jerk_ = 0.0;
+          ROS_INFO_STREAM("Param smoothness_cost_jerk_ was not set. Using default value: " << params_.smoothness_cost_jerk_ );
+      }
+      if (!nh_.getParam("ridge_factor", params_.ridge_factor_))
+      {
+          params_.ridge_factor_ = 0.0;
+          ROS_INFO_STREAM("Param ridge_factor_ was not set. Using default value: " << params_.ridge_factor_ );
+      }
+      if (!nh_.getParam("use_pseudo_inverse", params_.use_pseudo_inverse_))
+      {
+          params_.use_pseudo_inverse_ = 0.0;
+          ROS_INFO_STREAM("Param use_pseudo_inverse_ was not set. Using default value: " << params_.use_pseudo_inverse_ );
+      }
+      if (!nh_.getParam("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_))
+      {
+          params_.pseudo_inverse_ridge_factor_ = 1e-4;
+          ROS_INFO_STREAM("Param pseudo_inverse_ridge_factor was not set. Using default value: " << params_.pseudo_inverse_ridge_factor_ );
+      }
+      if (!nh_.getParam("joint_update_limit", params_.joint_update_limit_))
+      {
+          params_.joint_update_limit_ = 0.1;
+          ROS_INFO_STREAM("Param joint_update_limit was not set. Using default value: " << params_.joint_update_limit_ );
+      }
+      if (!nh_.getParam("min_clearence", params_.min_clearence_))
+      {
+          params_.min_clearence_ = 0.2;
+          ROS_INFO_STREAM("Param min_clearence was not set. Using default value: " << params_.min_clearence_ );
+      }
+      if (!nh_.getParam("collision_threshold", params_.collision_threshold_))
+      {
+          params_.collision_threshold_ = 0.07;
+          ROS_INFO_STREAM("Param collision_threshold_ was not set. Using default value: " << params_.collision_threshold_ );
+      }
+      if (!nh_.getParam("use_stochastic_descent", params_.use_stochastic_descent_))
+      {
+          params_.use_stochastic_descent_ = true;
+          ROS_INFO_STREAM("Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_ );
+      }
+  }
+
+  virtual std::string getDescription() const
+  {
+    return "CHOMP Optimizer !!@$@#$@%$@#!!";
+  }
+
+  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                            const planning_interface::MotionPlanRequest& req,
+                            planning_interface::MotionPlanResponse& res,
+                            std::vector<std::size_t>& added_path_index) const
+  {
+    // this call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res variable which is then used by CHOMP for optimization of the computed trajectory
+    bool solved = planner(planning_scene, req, res);
+
+    collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
+        collision_detection::CollisionDetectorAllocatorHybrid::create());
+
+    ROS_INFO_STREAM("Configuring Planning Scene for CHOMP ....");
+    planning_scene->setActiveCollisionDetector_ConstVersion(hybrid_cd, true);
+
+
+    chomp::ChompPlanner chompPlanner;
+    planning_interface::MotionPlanDetailedResponse res_detailed;
+    moveit_msgs::MotionPlanDetailedResponse res2;
+    moveit_msgs::MotionPlanRequest req_moveit_msgs;
+
+    bool planning_success;
+
+    bool temp = chompPlanner.solve(planning_scene, req, params_, res2);
+
+    std::cout << temp << "chomp_solver STATUS" << std::endl;
+    if (temp)
+    {
+      res_detailed.trajectory_.resize(1);
+      res_detailed.trajectory_[0] = robot_trajectory::RobotTrajectoryPtr(
+          new robot_trajectory::RobotTrajectory(planning_scene->getRobotModel(), "panda_arm"));
+
+      moveit::core::RobotState start_state(planning_scene->getRobotModel());
+      robot_state::robotStateMsgToRobotState(res2.trajectory_start, start_state);
+      res_detailed.trajectory_[0]->setRobotTrajectoryMsg(start_state, res2.trajectory[0]);
+      res_detailed.description_.push_back("plan");
+      res_detailed.processing_time_ = res2.processing_time;
+      res_detailed.error_code_ = res2.error_code;
+      planning_success = true;
+    }
+    else
+    {
+      res_detailed.error_code_ = res2.error_code;
+      planning_success = false;
+    }
+
+    res.error_code_ = res_detailed.error_code_;
+
+    if (planning_success)
+    {
+      res.trajectory_ = res_detailed.trajectory_[0];
+      res.planning_time_ = res_detailed.processing_time_[0];
+    }
+
+    return solved;
+
+  }
+
+private:
+  ros::NodeHandle nh_;
+};
+}
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::CHOMPOptimizerAdapter,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -63,7 +63,6 @@ namespace default_planner_request_adapters
 class CHOMPOptimizerAdapter : public planning_request_adapter::PlanningRequestAdapter
 {
 public:
-
   ChompPlanner chomp_interface_;
   moveit::core::RobotModelConstPtr robot_model_;
 
@@ -71,91 +70,98 @@ public:
   boost::shared_ptr<tf::TransformListener> tf_;
   CHOMPOptimizerAdapter() : planning_request_adapter::PlanningRequestAdapter(), nh_("~")
   {
-      if (!nh_.getParam("planning_time_limit", params_.planning_time_limit_))
-      {
-          params_.planning_time_limit_ = 10.0;
-          ROS_INFO_STREAM("Param planning_time_limit was not set. Using default value: " << params_.planning_time_limit_ );
-      }
-      if (!nh_.getParam("max_iterations", params_.max_iterations_))
-      {
-          params_.max_iterations_ = 200;
-          ROS_INFO_STREAM("Param max_iterations was not set. Using default value: " << params_.max_iterations_ );
-      }
-      if (!nh_.getParam("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
-      {
-          params_.max_iterations_after_collision_free_ = 5;
-          ROS_INFO_STREAM("Param max_iterations_after_collision_free was not set. Using default value: " << params_.max_iterations_after_collision_free_ );
-      }
-      if (!nh_.getParam("smoothness_cost_weight", params_.smoothness_cost_weight_))
-      {
-          params_.smoothness_cost_weight_ = 0.1;
-          ROS_INFO_STREAM("Param smoothness_cost_weight was not set. Using default value: " << params_.smoothness_cost_weight_ );
-      }
-      if (!nh_.getParam("obstacle_cost_weight", params_.obstacle_cost_weight_))
-      {
-          params_.obstacle_cost_weight_ = 1.0;
-          ROS_INFO_STREAM("Param obstacle_cost_weight was not set. Using default value: " << params_.obstacle_cost_weight_ );
-      }
-      if (!nh_.getParam("learning_rate", params_.learning_rate_))
-      {
-          params_.learning_rate_ = 0.01;
-          ROS_INFO_STREAM("Param learning_rate was not set. Using default value: " << params_.learning_rate_ );
-      }
-      if (!nh_.getParam("smoothness_cost_velocity", params_.smoothness_cost_velocity_))
-      {
-          params_.smoothness_cost_velocity_ = 0.0;
-          ROS_INFO_STREAM("Param smoothness_cost_velocity was not set. Using default value: " << params_.smoothness_cost_velocity_ );
-      }
-      if (!nh_.getParam("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
-      {
-          params_.smoothness_cost_acceleration_ = 1.0;
-          ROS_INFO_STREAM("Param smoothness_cost_acceleration was not set. Using default value: " << params_.smoothness_cost_acceleration_ );
-      }
-      if (!nh_.getParam("smoothness_cost_jerk", params_.smoothness_cost_jerk_))
-      {
-          params_.smoothness_cost_jerk_ = 0.0;
-          ROS_INFO_STREAM("Param smoothness_cost_jerk_ was not set. Using default value: " << params_.smoothness_cost_jerk_ );
-      }
-      if (!nh_.getParam("ridge_factor", params_.ridge_factor_))
-      {
-          params_.ridge_factor_ = 0.0;
-          ROS_INFO_STREAM("Param ridge_factor_ was not set. Using default value: " << params_.ridge_factor_ );
-      }
-      if (!nh_.getParam("use_pseudo_inverse", params_.use_pseudo_inverse_))
-      {
-          params_.use_pseudo_inverse_ = 0.0;
-          ROS_INFO_STREAM("Param use_pseudo_inverse_ was not set. Using default value: " << params_.use_pseudo_inverse_ );
-      }
-      if (!nh_.getParam("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_))
-      {
-          params_.pseudo_inverse_ridge_factor_ = 1e-4;
-          ROS_INFO_STREAM("Param pseudo_inverse_ridge_factor was not set. Using default value: " << params_.pseudo_inverse_ridge_factor_ );
-      }
-      if (!nh_.getParam("joint_update_limit", params_.joint_update_limit_))
-      {
-          params_.joint_update_limit_ = 0.1;
-          ROS_INFO_STREAM("Param joint_update_limit was not set. Using default value: " << params_.joint_update_limit_ );
-      }
-      if (!nh_.getParam("min_clearence", params_.min_clearence_))
-      {
-          params_.min_clearence_ = 0.2;
-          ROS_INFO_STREAM("Param min_clearence was not set. Using default value: " << params_.min_clearence_ );
-      }
-      if (!nh_.getParam("collision_threshold", params_.collision_threshold_))
-      {
-          params_.collision_threshold_ = 0.07;
-          ROS_INFO_STREAM("Param collision_threshold_ was not set. Using default value: " << params_.collision_threshold_ );
-      }
-      if (!nh_.getParam("use_stochastic_descent", params_.use_stochastic_descent_))
-      {
-          params_.use_stochastic_descent_ = true;
-          ROS_INFO_STREAM("Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_ );
-      }
+    if (!nh_.getParam("planning_time_limit", params_.planning_time_limit_))
+    {
+      params_.planning_time_limit_ = 10.0;
+      ROS_INFO_STREAM("Param planning_time_limit was not set. Using default value: " << params_.planning_time_limit_);
+    }
+    if (!nh_.getParam("max_iterations", params_.max_iterations_))
+    {
+      params_.max_iterations_ = 200;
+      ROS_INFO_STREAM("Param max_iterations was not set. Using default value: " << params_.max_iterations_);
+    }
+    if (!nh_.getParam("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
+    {
+      params_.max_iterations_after_collision_free_ = 5;
+      ROS_INFO_STREAM("Param max_iterations_after_collision_free was not set. Using default value: "
+                      << params_.max_iterations_after_collision_free_);
+    }
+    if (!nh_.getParam("smoothness_cost_weight", params_.smoothness_cost_weight_))
+    {
+      params_.smoothness_cost_weight_ = 0.1;
+      ROS_INFO_STREAM(
+          "Param smoothness_cost_weight was not set. Using default value: " << params_.smoothness_cost_weight_);
+    }
+    if (!nh_.getParam("obstacle_cost_weight", params_.obstacle_cost_weight_))
+    {
+      params_.obstacle_cost_weight_ = 1.0;
+      ROS_INFO_STREAM("Param obstacle_cost_weight was not set. Using default value: " << params_.obstacle_cost_weight_);
+    }
+    if (!nh_.getParam("learning_rate", params_.learning_rate_))
+    {
+      params_.learning_rate_ = 0.01;
+      ROS_INFO_STREAM("Param learning_rate was not set. Using default value: " << params_.learning_rate_);
+    }
+    if (!nh_.getParam("smoothness_cost_velocity", params_.smoothness_cost_velocity_))
+    {
+      params_.smoothness_cost_velocity_ = 0.0;
+      ROS_INFO_STREAM(
+          "Param smoothness_cost_velocity was not set. Using default value: " << params_.smoothness_cost_velocity_);
+    }
+    if (!nh_.getParam("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
+    {
+      params_.smoothness_cost_acceleration_ = 1.0;
+      ROS_INFO_STREAM("Param smoothness_cost_acceleration was not set. Using default value: "
+                      << params_.smoothness_cost_acceleration_);
+    }
+    if (!nh_.getParam("smoothness_cost_jerk", params_.smoothness_cost_jerk_))
+    {
+      params_.smoothness_cost_jerk_ = 0.0;
+      ROS_INFO_STREAM(
+          "Param smoothness_cost_jerk_ was not set. Using default value: " << params_.smoothness_cost_jerk_);
+    }
+    if (!nh_.getParam("ridge_factor", params_.ridge_factor_))
+    {
+      params_.ridge_factor_ = 0.0;
+      ROS_INFO_STREAM("Param ridge_factor_ was not set. Using default value: " << params_.ridge_factor_);
+    }
+    if (!nh_.getParam("use_pseudo_inverse", params_.use_pseudo_inverse_))
+    {
+      params_.use_pseudo_inverse_ = 0.0;
+      ROS_INFO_STREAM("Param use_pseudo_inverse_ was not set. Using default value: " << params_.use_pseudo_inverse_);
+    }
+    if (!nh_.getParam("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_))
+    {
+      params_.pseudo_inverse_ridge_factor_ = 1e-4;
+      ROS_INFO_STREAM("Param pseudo_inverse_ridge_factor was not set. Using default value: "
+                      << params_.pseudo_inverse_ridge_factor_);
+    }
+    if (!nh_.getParam("joint_update_limit", params_.joint_update_limit_))
+    {
+      params_.joint_update_limit_ = 0.1;
+      ROS_INFO_STREAM("Param joint_update_limit was not set. Using default value: " << params_.joint_update_limit_);
+    }
+    if (!nh_.getParam("min_clearence", params_.min_clearence_))
+    {
+      params_.min_clearence_ = 0.2;
+      ROS_INFO_STREAM("Param min_clearence was not set. Using default value: " << params_.min_clearence_);
+    }
+    if (!nh_.getParam("collision_threshold", params_.collision_threshold_))
+    {
+      params_.collision_threshold_ = 0.07;
+      ROS_INFO_STREAM("Param collision_threshold_ was not set. Using default value: " << params_.collision_threshold_);
+    }
+    if (!nh_.getParam("use_stochastic_descent", params_.use_stochastic_descent_))
+    {
+      params_.use_stochastic_descent_ = true;
+      ROS_INFO_STREAM(
+          "Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_);
+    }
   }
 
   virtual std::string getDescription() const
   {
-    return "CHOMP Optimizer !!@$@#$@%$@#!!";
+    return "CHOMP Optimizer !!!!";
   }
 
   virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
@@ -163,15 +169,16 @@ public:
                             planning_interface::MotionPlanResponse& res,
                             std::vector<std::size_t>& added_path_index) const
   {
-    // this call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res variable which is then used by CHOMP for optimization of the computed trajectory
+    // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
+    // variable which is then used by CHOMP for optimization of the computed trajectory
     bool solved = planner(planning_scene, req, res);
 
+    // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
         collision_detection::CollisionDetectorAllocatorHybrid::create());
 
     ROS_INFO_STREAM("Configuring Planning Scene for CHOMP ....");
     planning_scene->setActiveCollisionDetector_ConstVersion(hybrid_cd, true);
-
 
     chomp::ChompPlanner chompPlanner;
     planning_interface::MotionPlanDetailedResponse res_detailed;
@@ -182,7 +189,6 @@ public:
 
     bool temp = chompPlanner.solve(planning_scene, req, params_, res2);
 
-    std::cout << temp << "chomp_solver STATUS" << std::endl;
     if (temp)
     {
       res_detailed.trajectory_.resize(1);
@@ -212,7 +218,6 @@ public:
     }
 
     return solved;
-
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -41,6 +41,7 @@
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
+#include <moveit_msgs/RobotTrajectory.h>
 #include <class_loader/class_loader.hpp>
 #include <ros/ros.h>
 
@@ -54,7 +55,9 @@
 #include <tf/transform_listener.h>
 
 #include <moveit/robot_state/conversions.h>
-#include <yaml-cpp/yaml.h>
+
+#include <vector>
+#include <eigen3/Eigen/Core>
 
 using namespace chomp;
 
@@ -173,6 +176,32 @@ public:
     // variable which is then used by CHOMP for optimization of the computed trajectory
     bool solved = planner(planning_scene, req, res);
 
+    int num_WayPoints = res.trajectory_->getWayPointCount();
+    // int num_joints = res.trajectory_->getJoints();
+    std::cout << num_WayPoints << " joint trajectory" << std::endl;
+
+    res.trajectory_->getWayPoint(2).printStateInfo();
+
+    // convert the response trajectory into  EigenXd format suitable for chomp trajectory initialization and pass it
+    // into the solve method for initialization of the CHOMP trajectory
+    // Eigen::MatrxXd response_trajectory = Eigen::MatrixXd(num_WayPoints, num_joints);
+
+    moveit_msgs::RobotTrajectory trajectory_msgs;             // = new moveit_msgs::MotionPlanResponse();
+    res.trajectory_->getRobotTrajectoryMsg(trajectory_msgs);  //.joint_trajectory.points.size();
+
+    for (int i = 0; i < num_WayPoints; i++)
+    {
+      // res.trajectory[0].joint_trajectory.points[i].positions.resize(trajectory.getNumJoints());
+      for (size_t j = 0; j < trajectory_msgs.joint_trajectory.points[i].positions.size(); j++)
+      {
+        std::cout << trajectory_msgs.joint_trajectory.points[i].positions[j] << " ";
+      }
+      std::cout << std::endl;
+      // Setting invalid timestamps.
+      // Further filtering is required to set valid timestamps accounting for velocity and acceleration constraints.
+      // res.trajectory[0].joint_trajectory.points[i].time_from_start = ros::Duration(0.0);
+    }
+
     // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
         collision_detection::CollisionDetectorAllocatorHybrid::create());
@@ -185,6 +214,11 @@ public:
     moveit_msgs::MotionPlanDetailedResponse res2;
     moveit_msgs::MotionPlanRequest req_moveit_msgs;
 
+    moveit_msgs::RobotTrajectory trajectory_msgs2;
+    res.trajectory_->getRobotTrajectoryMsg(trajectory_msgs2);
+    res2.trajectory.resize(1);
+    res2.trajectory[0] = trajectory_msgs2;
+    ;
     bool planning_success;
 
     bool temp = chompPlanner.solve(planning_scene, req, params_, res2);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -213,7 +213,7 @@ public:
 
     res.error_code_ = res_detailed.error_code_;
 
-    // populate the original response object 'res' with the CHOMP's optimized trajectory
+    // populate the original response object 'res' with the CHOMP's optimized trajectory.
     if (planning_success)
     {
       res.trajectory_ = res_detailed.trajectory_[0];

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -1,7 +1,3 @@
-//
-// Created by deepthought on 24/07/18.
-//
-
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -36,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Raghavender Sahdev */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/robot_state/conversions.h>

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -153,7 +153,7 @@ public:
     }
     if (!nh_.getParam("trajectory_initialization_method", params_.use_stochastic_descent_))
     {
-      params_.trajectory_initialization_method_ = std::string("OMPL");
+      params_.trajectory_initialization_method_ = std::string("fillTrajectory");
       ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using New value as: "
                       << params_.trajectory_initialization_method_);
     }

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -160,7 +160,7 @@ public:
       ROS_INFO_STREAM(
           "Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_);
     }
-    if (!nh_.getParam("interpolation_method", params_.use_stochastic_descent_))
+    if (!nh_.getParam("trajectory_initialization_method", params_.use_stochastic_descent_))
     {
       params_.trajectory_initialization_method_ = std::string("OMPL");
       ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using New value as: "

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -34,5 +34,10 @@
     <description>
     </description>
   </class>
+  
+  <class name="default_planner_request_adapters/CHOMPOptimizerAdapter" type="default_planner_request_adapters::CHOMPOptimizerAdapter" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+    </description>
+  </class>
 
 </library>


### PR DESCRIPTION
### Addition of CHOMP planning adapter to act as an additional optimizer for other planners like OMPL

This PR is a work done by Raghavender as a part of 2018 Google summer of code. As a part of this PR, CHOMP planning adapter works and can be used as an additional optimization technique in combination with other motion planners like OMPL. 

With this PR, CHOMP can act as a post-processor for other planners. one simply needs to add a line in their[ ompl_planning_pipeline.yaml ](https://github.com/ros-planning/panda_moveit_config/blob/master/launch/ompl_planning_pipeline.launch.xml)file if they want to use this. Just add this line in your planning_adapter= > `default_planner_request_adapters/CHOMPOptimizerAdapter` to add CHOMP a an additional post-processing optimizer.
Corresponding Tutorials PR available [here](https://github.com/ros-planning/moveit_tutorials/pull/204/)!

### Checklist
- [ ] addition of CHOMP planning adapter in the [planning_request_adapter folder](https://github.com/ros-planning/moveit/tree/kinetic-devel/moveit_ros/planning/planning_request_adapter_plugins/src).
- [ ] added code in[ chomp planner folder](https://github.com/ros-planning/moveit/tree/kinetic-devel/moveit_planners/chomp/chomp_motion_planner). Addition of functionality in CHOMP to receive input paths obtained from OMPL and act as an optimizer.
- [ ] updated planning_scene.h and planning_scene.cpp; Added code in the [planning_scene folder](https://github.com/ros-planning/moveit/tree/kinetic-devel/moveit_core/planning_scene) to make certain variables mutable and addition of constant version of certain functions.