### PR TITLE
IKFast improvements

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -8,8 +8,7 @@ kinematics service, from within the moveit planning environment, or in
 your own ROS node.
 
 Author: Michael Lautman, PickNik Robotics
-        Dave Coleman PickNik Robotics
-
+        Dave Coleman, PickNik Robotics
         Based heavily on the arm_kinematic_tools package by Jeremy Zoss, SwRI
         and the arm_navigation plugin generator by David Butterworth, KAIST
 
@@ -55,25 +54,41 @@ from lxml import etree
 import shutil
 import argparse
 
-plugin_gen_pkg = 'moveit_kinematics'  # package containing this file
-plugin_sub_dir = 'ikfast_kinematics_plugin' # sub directory which contains the template directory
+# Package containing this file
+plugin_gen_pkg = 'moveit_kinematics'
+# Sub directory which contains the template directory
+plugin_sub_dir = 'ikfast_kinematics_plugin'
 # Allowed search modes, see SEARCH_MODE enum in template file
-search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT' ]
+search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT']
 
 
 def create_parser():
-  parser = argparse.ArgumentParser(description="Generate an IKFast MoveIt! kinematic plugin")
-  parser.add_argument("robot_name", help="The name of your robot")
-  parser.add_argument("planning_group_name", help="The name of the planning group for which your IKFast solution was generated")
-  parser.add_argument("kinematic_plugin_pkg", help="The name of the MoveIt! IKFast Kinematics Plugin to be updated")
-  parser.add_argument("base_link_name", help="The name of the base link that was used when generating your IKFast solution")
-  parser.add_argument("eef_link_name", help="The name of the end effector link that was used when generating your IKFast solution")
-  parser.add_argument("ikfast_output_path", help="The full path to the analytic IK solution output by IKFast")
-  parser.add_argument("--search_mode", default=search_modes[0], help="The search mode used to solve IK for robots with more than 6DOF")
-  parser.add_argument("--srdf_filename", help="The name of your robot. If your robot's srdf is not <robot_name>.srdf, then set this value with the correct filename. Defaults to <robot_name>.srdf")
-  parser.add_argument("--robot_name_in_srdf", help="The name of your robot as defined in the srdf. Defaults to <robot_name>")
-  parser.add_argument("--moveit_config_pkg", help="The robot moveit_config pagkacge. Defaults to <robot_name>_moveit_config")
+  parser = argparse.ArgumentParser(
+      description="Generate an IKFast MoveIt! kinematic plugin")
+  parser.add_argument("robot_name",
+                      help="The name of your robot")
+  parser.add_argument("planning_group_name",
+                      help="The name of the planning group for which your IKFast solution was generated")
+  parser.add_argument("kinematic_plugin_pkg",
+                      help="The name of the MoveIt! IKFast Kinematics Plugin to be updated")
+  parser.add_argument("base_link_name",
+                      help="The name of the base link that was used when generating your IKFast solution")
+  parser.add_argument("eef_link_name",
+                      help="The name of the end effector link that was used when generating your IKFast solution")
+  parser.add_argument("ikfast_output_path",
+                      help="The full path to the analytic IK solution output by IKFast")
+  parser.add_argument("--search_mode",
+                      default=search_modes[0],
+                      help="The search mode used to solve IK for robots with more than 6DOF")
+  parser.add_argument("--srdf_filename",
+                      help="The name of your robot. If your robot's srdf is not <robot_name>.srdf, then set this value \
+                            with the correct filename. Defaults to <robot_name>.srdf")
+  parser.add_argument("--robot_name_in_srdf",
+                      help="The name of your robot as defined in the srdf. Defaults to <robot_name>")
+  parser.add_argument("--moveit_config_pkg",
+                      help="The robot moveit_config package. Defaults to <robot_name>_moveit_config")
   return parser
+
 
 def populate_optional(args):
   if args.srdf_filename is None:
@@ -83,17 +98,21 @@ def populate_optional(args):
   if args.moveit_config_pkg is None:
     args.moveit_config_pkg = args.robot_name + "_moveit_config"
 
+
 def print_args(args):
-  print "robot_name:", args.robot_name
-  print "base_link_name:", args.base_link_name
-  print "eef_link_name:", args.eef_link_name
-  print "planning_group_name:", args.planning_group_name
-  print "kinematic_plugin_pkg:", args.kinematic_plugin_pkg
-  print "ikfast_output_path:", args.ikfast_output_path
-  print "search_mode:", args.search_mode
-  print "srdf_filename:", args.srdf_filename
-  print "robot_name_in_srdf:", args.robot_name_in_srdf
-  print "moveit_config_pkg:", args.moveit_config_pkg
+  print("Creating IKFastKinematicsPlugin with parameters: ")
+  print(" robot_name:           %s" % args.robot_name)
+  print(" base_link_name:       %s" % args.base_link_name)
+  print(" eef_link_name:        %s" % args.eef_link_name)
+  print(" planning_group_name:  %s" % args.planning_group_name)
+  print(" kinematic_plugin_pkg: %s" % args.kinematic_plugin_pkg)
+  print(" ikfast_output_path:   %s" % args.ikfast_output_path)
+  print(" search_mode:          %s" % args.search_mode)
+  print(" srdf_filename:        %s" % args.srdf_filename)
+  print(" robot_name_in_srdf:   %s" % args.robot_name_in_srdf)
+  print(" moveit_config_pkg:    %s" % args.moveit_config_pkg)
+  print("")
+
 
 def update_deps(reqd_deps, req_type, e_parent):
   curr_deps = [e.text for e in e_parent.findall(req_type)]
@@ -101,35 +120,44 @@ def update_deps(reqd_deps, req_type, e_parent):
   for dep in missing_deps:
      etree.SubElement(e_parent, req_type).text = dep
 
+
 def update_package(args):
   try:
-    moveit_config_pkg_path = roslib.packages.get_pkg_dir(args.moveit_config_pkg)
-  except:
-    print "Failed to find package: %s" % args.moveit_config_pkg
+    moveit_config_pkg_path = roslib.packages.get_pkg_dir(
+        args.moveit_config_pkg)
+  except roslib.packages.InvalidROSPkgException:
+    print("Failed to find package: %s", args.moveit_config_pkg)
     sys.exit(-1)
 
   try:
-    kinematic_plugin_pkg_path = roslib.packages.get_pkg_dir(args.kinematic_plugin_pkg)
-  except:
-    print "Failed to find package: %s" % args.kinematic_plugin_pkg
+    kinematic_plugin_pkg_path = roslib.packages.get_pkg_dir(
+        args.kinematic_plugin_pkg)
+  except roslib.packages.InvalidROSPkgException:
+    print("Failed to find package: %s" % args.kinematic_plugin_pkg)
     sys.exit(-1)
 
   try:
     srdf_file_name = moveit_config_pkg_path + '/config/' + args.srdf_filename
     srdf = etree.parse(srdf_file_name).getroot()
-  except:
-    print "Failed to find srdf file: %s" % srdf_file_name
+    raise IOError
+  except IOError:
+    print("Failed to find SRDF file: %s" % srdf_file_name)
+    sys.exit(-1)
+  except etree.XMLSyntaxError as err:
+    print("Failed to parse xml in file %s" % srdf_file_name)
+    print(err.msg)
     sys.exit(-1)
 
   if args.robot_name_in_srdf != srdf.get('name'):
-    print "\nERROR: non-matching robot name found in '%s'. Expected '%s' but found '%s'" % (srdf_file_name,
-                                                                                            args.robot_name_in_srdf,
-                                                                                            srdf.get('name'))
+    print("\nERROR: non-matching robot name found in '%s'. Expected '%s' "
+          "but found '%s'" % (srdf_file_name,
+                              args.robot_name_in_srdf,
+                              srdf.get('name')))
     sys.exit(-1)
 
   groups = srdf.findall('group')
   if len(groups) < 1:
-    print "Failed to load planning group since no planning groups are defined in the SRDF"
+    print("Failed to load planning group since no planning groups are defined in the SRDF")
     sys.exit(-1)
 
   planning_group = None
@@ -138,9 +166,9 @@ def update_package(args):
       planning_group = group
 
   if planning_group is None:
-    print "Failed to load planning group '%s' since it is not defined in the SRDF. "\
-          "Available groups: \n%s" % (args.planning_group_name,
-                                      "".join([group_name.get('name') for group_name in groups]))
+    print("Failed to load planning group '%s' since it is not defined in the SRDF. Available groups: \n%s" % (
+        args.planning_group_name,
+        "".join([group_name.get('name') for group_name in groups])))
 
   kinematic_plugin_pkg_src_path = kinematic_plugin_pkg_path + '/src/'
   if not os.path.exists(kinematic_plugin_pkg_src_path):
@@ -150,19 +178,23 @@ def update_package(args):
   if not os.path.exists(kinematic_plugin_pkg_include_path):
      os.makedirs(kinematic_plugin_pkg_include_path)
 
-
   if not os.path.exists(args.ikfast_output_path):
-    print "\nERROR: can't find IKFast source code at '%s'\n" % args.ikfast_output_path
+    print("\nERROR: can't find IKFast source code at '%s'\n" % args.ikfast_output_path)
     sys.exit(-1)
 
   # Copy the source code generated by IKFast into our src folder
-  solver_file_path = kinematic_plugin_pkg_src_path + args.robot_name + '_' + args.planning_group_name + '_ikfast_solver.cpp'
+  solver_file_path = \
+      kinematic_plugin_pkg_src_path + \
+      args.robot_name + \
+      '_' + \
+      args.planning_group_name + \
+      '_ikfast_solver.cpp'
 
   # Check if they are the same file - if so, skip
   skip = False
   if os.path.exists(args.ikfast_output_path) and os.path.exists(solver_file_path):
     if os.path.samefile(args.ikfast_output_path, solver_file_path):
-       print 'Skipping copying ' + solver_file_path + ' since it is already in the correct location'
+       print("Skipping copying %s since it is already in the correct location" % solver_file_path)
        skip = True
 
   if not skip:
@@ -170,52 +202,52 @@ def update_package(args):
 
   # Error check
   if not os.path.exists(solver_file_path):
-    print "\nERROR: Unable to copy IKFast source code from '%s' to '%s'" % (args.ikfast_output_path, solver_file_path)
-    print 'Manually copy the source file generated by IKFast to this location and re-run'
+    print("\nERROR: Unable to copy IKFast source code from '%s' to '%s'" % (args.ikfast_output_path, solver_file_path))
+    print('Manually copy the source file generated by IKFast to this location and re-run\n')
     sys.exit(-1)
 
   # Detect version of IKFast used to generate solver code
   solver_version = 0
-  with open(solver_file_path,'r') as src:
+  with open(solver_file_path, 'r') as src:
     for line in src:
        if line.startswith('/// ikfast version'):
           line_search = re.search('ikfast version (.*) generated', line)
           if line_search:
              solver_version = int(line_search.group(1), 0)
           break
-  print 'Found source code generated by IKFast version %s' % str(solver_version)
+  print('Found source code generated by IKFast version %s' % str(solver_version))
 
   # Chose template depending on IKFast version
   if solver_version >= 56:
     template_version = 61
   else:
-    print 'ERROR this converter is not made for IKFast 54 or anything but 61'
+    print('ERROR this converter is not made for IKFast 54 or anything but 61')
     sys.exit(-1)
 
   # Get template folder location
   try:
     plugin_gen_dir = os.path.join(roslib.packages.get_pkg_dir(plugin_gen_pkg), plugin_sub_dir)
-  except:
-    print "ERROR: can't find package " + plugin_gen_pkg
+  except roslib.packages.InvalidROSPkgException:
+    print("ERROR: can't find package %s" % plugin_gen_pkg)
     sys.exit(-1)
 
   # Check if IKFast header file exists
   template_header_path = plugin_gen_dir + '/templates/ikfast.h'
   if not os.path.exists(template_header_path):
-    print "ERROR: can't find ikfast header file at '%s'" % template_header_path
+    print("ERROR: can't find ikfast header file at '%s'" % template_header_path)
     sys.exit(-1)
 
   # Copy the IKFast header file into the include directory
   output_header_path = kinematic_plugin_pkg_include_path + "ikfast.h"
   shutil.copy2(template_header_path, output_header_path)
   if not os.path.exists(output_header_path):
-    print "ERROR: Unable to copy IKFast header file from '%s' to '%s'" % (template_header_path, output_header_path)
+    print("ERROR: Unable to copy IKFast header file from '%s' to '%s'" % (template_header_path, output_header_path))
     sys.exit(-1)
 
   # Check if template exists
   template_src_path = plugin_gen_dir + '/templates/ikfast' + str(template_version) + '_moveit_plugin_template.cpp'
   if not os.path.exists(template_src_path):
-    print "ERROR: can't find template file at '%s' " % template_src_path
+    print("ERROR: can't find template file at '%s' " % template_src_path)
     sys.exit(-1)
 
   # Create plugin source from template
@@ -227,37 +259,43 @@ def update_package(args):
   template_text = re.sub('_EEF_LINK_', args.eef_link_name, template_text)
   template_text = re.sub('_BASE_LINK_', args.base_link_name, template_text)
 
-  output_src_path = kinematic_plugin_pkg_src_path + args.robot_name + '_' + args.planning_group_name + "_ikfast_moveit_plugin.cpp"
+  output_src_path = \
+      kinematic_plugin_pkg_src_path + \
+      args.robot_name + \
+      '_' + \
+      args.planning_group_name + \
+      "_ikfast_moveit_plugin.cpp"
+
   with open(output_src_path, 'w') as f:
     f.write(template_text)
-  print "Created plugin file at '%s'" % output_src_path
+  print("Created plugin file at '%s'" % output_src_path)
 
   # Create plugin definition .xml file
   ik_library_name = args.robot_name + "_" + args.planning_group_name + "_moveit_ikfast_plugin"
   plugin_name = args.robot_name + '_' + args.planning_group_name + '_kinematics/IKFastKinematicsPlugin'
-  plugin_def = etree.Element("library", path="lib/lib"+ik_library_name)
+  plugin_def = etree.Element("library", path="lib/lib" + ik_library_name)
   cl = etree.SubElement(plugin_def, "class")
   cl.set("name", plugin_name)
   cl.set("type", 'ikfast_kinematics_plugin::IKFastKinematicsPlugin')
   cl.set("base_class_type", "kinematics::KinematicsBase")
   desc = etree.SubElement(cl, "description")
-  desc.text = 'IKFast'+str(template_version)+' plugin for closed-form kinematics'
+  desc.text = 'IKFast' + str(template_version) + ' plugin for closed-form kinematics'
 
   # Write plugin definition to file
   plugin_file_name = ik_library_name + "_description.xml"
   plugin_file_path = kinematic_plugin_pkg_path + "/" + plugin_file_name
-  with open(plugin_file_path,'w') as f:
+  with open(plugin_file_path, 'w') as f:
     etree.ElementTree(plugin_def).write(f, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-  print "Created plugin definition at: '%s'" % plugin_file_path
+  print("Created plugin definition at: '%s'" % plugin_file_path)
 
   # Check if CMakeLists file exists
   cmake_template_file = plugin_gen_dir + "/templates/CMakeLists.txt"
   if not os.path.exists(cmake_template_file):
-    print "ERROR: can't find CMakeLists template file at '%s'" % cmake_template_file
+    print("ERROR: can't find CMakeLists template file at '%s'" % cmake_template_file)
     sys.exit(-1)
 
   # Create new CMakeLists file
-  cmake_file = kinematic_plugin_pkg_path+'/CMakeLists.txt'
+  cmake_file = kinematic_plugin_pkg_path + '/CMakeLists.txt'
 
   # Create plugin source from template
   template_file_data = open(cmake_template_file, 'r')
@@ -269,16 +307,16 @@ def update_package(args):
 
   with open(cmake_file, 'w') as f:
     f.write(template_text)
-  print "Overwrote CMakeLists file at '%s'" % cmake_file
+  print("Overwrote CMakeLists file at '%s'" % cmake_file)
 
   # Add plugin export to package manifest
   parser = etree.XMLParser(remove_blank_text=True)
-  package_file_name = kinematic_plugin_pkg_path+"/package.xml"
+  package_file_name = kinematic_plugin_pkg_path + "/package.xml"
   package_xml = etree.parse(package_file_name, parser)
 
   # Make sure at least all required dependencies are in the depends lists
   build_deps = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
-  run_deps   = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
+  run_deps = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
 
   update_deps(build_deps, "build_depend", package_xml.getroot())
   update_deps(run_deps, "exec_depend", package_xml.getroot())
@@ -288,13 +326,14 @@ def update_package(args):
                              plugin="${prefix}/" + plugin_file_name)
 
   export_element = package_xml.getroot().find("export")
-  if export_element == None:
+  if export_element is None:
     export_element = etree.SubElement(package_xml.getroot(), "export")
 
   found = False
   for el in export_element.findall("moveit_core"):
     found = (etree.tostring(new_export) == etree.tostring(el))
-    if found: break
+    if found:
+      break
 
   if not found:
     export_element.append(new_export)
@@ -303,39 +342,43 @@ def update_package(args):
   # proper encodings are used in the future (UTF-8)
   with open(package_file_name, "w") as f:
     package_xml.write(f, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-  print "Modified package.xml at '%s'" % package_file_name
+  print("Modified package.xml at '%s'" % package_file_name)
 
   # Modify kinematics.yaml file
-  kin_yaml_file_name = moveit_config_pkg_path+"/config/kinematics.yaml"
+  kin_yaml_file_name = moveit_config_pkg_path + "/config/kinematics.yaml"
   with open(kin_yaml_file_name, 'r') as f:
     kin_yaml_data = yaml.safe_load(f)
+
   kin_yaml_data[args.planning_group_name]["kinematics_solver"] = plugin_name
   with open(kin_yaml_file_name, 'w') as f:
     yaml.dump(kin_yaml_data, f, default_flow_style=False)
-  print "Modified kinematics.yaml at '%s'" % kin_yaml_file_name
+
+  print("Modified kinematics.yaml at '%s'" % kin_yaml_file_name)
 
   # Create a script for easily updating the plugin in the future in case the plugin needs to be updated
   easy_script_file_name = "update_ikfast_plugin.sh"
   easy_script_file_path = kinematic_plugin_pkg_path + "/" + easy_script_file_name
-  with open(easy_script_file_path,'w') as f:
-    f.write("rosrun moveit_kinematics create_ikfast_moveit_plugin.py"
-            + " --search_mode=" + args.search_mode
-            + " --srdf_filename=" + args.srdf_filename
-            + " --robot_name_in_srdf=" + args.robot_name_in_srdf
-            + " --moveit_config_pkg=" + args.moveit_config_pkg
-            + " " + args.robot_name
-            + " " + args.planning_group_name
-            + " " + args.kinematic_plugin_pkg
-            + " " + args.base_link_name
-            + " " + args.eef_link_name
-            + " " + solver_file_path )
+  with open(easy_script_file_path, 'w') as f:
+    f.write("rosrun moveit_kinematics create_ikfast_moveit_plugin.py" +
+            " --search_mode=" + args.search_mode +
+            " --srdf_filename=" + args.srdf_filename +
+            " --robot_name_in_srdf=" + args.robot_name_in_srdf +
+            " --moveit_config_pkg=" + args.moveit_config_pkg +
+            " " + args.robot_name +
+            " " + args.planning_group_name +
+            " " + args.kinematic_plugin_pkg +
+            " " + args.base_link_name +
+            " " + args.eef_link_name +
+            " " + solver_file_path)
 
-  print "Created update plugin script at '%s'" % easy_script_file_path
+  print("Created update plugin script at '%s'" % easy_script_file_path)
+
 
 def main(args):
   populate_optional(args)
   print_args(args)
   update_package(args)
+
 
 if __name__ == '__main__':
   parser = create_parser()

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -7,8 +7,8 @@ This plugin and the move_group node can be used as a general
 kinematics service, from within the moveit planning environment, or in
 your own ROS node.
 
-Author: Michael Lautman, PickNik Robotics
-        Dave Coleman, PickNik Robotics
+Author: Dave Coleman, PickNik Robotics
+        Michael Lautman, PickNik Robotics
         Based heavily on the arm_kinematic_tools package by Jeremy Zoss, SwRI
         and the arm_navigation plugin generator by David Butterworth, KAIST
 

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -7,8 +7,8 @@ This plugin and the move_group node can be used as a general
 kinematics service, from within the moveit planning environment, or in
 your own ROS node.
 
-Author: Michael Lautman PickNik Robotics
-        Dave Coleman, CU Boulder
+Author: Michael Lautman, PickNik Robotics
+        Dave Coleman PickNik Robotics
 
         Based heavily on the arm_kinematic_tools package by Jeremy Zoss, SwRI
         and the arm_navigation plugin generator by David Butterworth, KAIST
@@ -61,7 +61,7 @@ plugin_sub_dir = 'ikfast_kinematics_plugin' # sub directory which contains the t
 search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT' ]
 
 
-def createParser():
+def create_parser():
   parser = argparse.ArgumentParser(description="Generate an IKFast MoveIt! kinematic plugin")
   parser.add_argument("robot_name", help="The name of your robot")
   parser.add_argument("planning_group_name", help="The name of the planning group for which your IKFast solution was generated")
@@ -95,13 +95,11 @@ def print_args(args):
   print "robot_name_in_srdf:", args.robot_name_in_srdf
   print "moveit_config_pkg:", args.moveit_config_pkg
 
-
 def update_deps(reqd_deps, req_type, e_parent):
   curr_deps = [e.text for e in e_parent.findall(req_type)]
   missing_deps = set(reqd_deps) - set(curr_deps)
-  for d in missing_deps:
-     etree.SubElement(e_parent, req_type).text = d
-  # return missing_deps
+  for dep in missing_deps:
+     etree.SubElement(e_parent, req_type).text = dep
 
 def update_package(args):
   try:
@@ -338,9 +336,8 @@ def main(args):
   populate_optional(args)
   print_args(args)
   update_package(args)
-  pass
 
 if __name__ == '__main__':
-  parser = createParser()
+  parser = create_parser()
   args = parser.parse_args()
   main(args)

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -7,9 +7,12 @@ This plugin and the move_group node can be used as a general
 kinematics service, from within the moveit planning environment, or in
 your own ROS node.
 
-Author: Dave Coleman, CU Boulder
+Author: Michael Lautman PickNik Robotics
+        Dave Coleman, CU Boulder
+
         Based heavily on the arm_kinematic_tools package by Jeremy Zoss, SwRI
         and the arm_navigation plugin generator by David Butterworth, KAIST
+
 Date: March 2013
 
 '''
@@ -50,296 +53,294 @@ import os
 import yaml
 from lxml import etree
 import shutil
+import argparse
 
 plugin_gen_pkg = 'moveit_kinematics'  # package containing this file
 plugin_sub_dir = 'ikfast_kinematics_plugin' # sub directory which contains the template directory
 # Allowed search modes, see SEARCH_MODE enum in template file
 search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT' ]
 
+
+def createParser():
+  parser = argparse.ArgumentParser(description="Generate an IKFast MoveIt! kinematic plugin")
+  parser.add_argument("robot_name", help="The name of your robot")
+  parser.add_argument("planning_group_name", help="The name of the planning group for which your IKFast solution was generated")
+  parser.add_argument("kinematic_plugin_pkg", help="The name of the MoveIt! IKFast Kinematics Plugin to be updated")
+  parser.add_argument("base_link_name", help="The name of the base link that was used when generating your IKFast solution")
+  parser.add_argument("eef_link_name", help="The name of the end effector link that was used when generating your IKFast solution")
+  parser.add_argument("ikfast_output_path", help="The full path to the analytic IK solution output by IKFast")
+  parser.add_argument("--search_mode", default=search_modes[0], help="The search mode used to solve IK for robots with more than 6DOF")
+  parser.add_argument("--srdf_filename", help="The name of your robot. If your robot's srdf is not <robot_name>.srdf, then set this value with the correct filename. Defaults to <robot_name>.srdf")
+  parser.add_argument("--robot_name_in_srdf", help="The name of your robot as defined in the srdf. Defaults to <robot_name>")
+  parser.add_argument("--moveit_config_pkg", help="The robot moveit_config pagkacge. Defaults to <robot_name>_moveit_config")
+  return parser
+
+def populate_optional(args):
+  if args.srdf_filename is None:
+    args.srdf_filename = args.robot_name + ".srdf"
+  if args.robot_name_in_srdf is None:
+    args.robot_name_in_srdf = args.robot_name
+  if args.moveit_config_pkg is None:
+    args.moveit_config_pkg = args.robot_name + "_moveit_config"
+
+def print_args(args):
+  print "robot_name:", args.robot_name
+  print "base_link_name:", args.base_link_name
+  print "eef_link_name:", args.eef_link_name
+  print "planning_group_name:", args.planning_group_name
+  print "kinematic_plugin_pkg:", args.kinematic_plugin_pkg
+  print "ikfast_output_path:", args.ikfast_output_path
+  print "search_mode:", args.search_mode
+  print "srdf_filename:", args.srdf_filename
+  print "robot_name_in_srdf:", args.robot_name_in_srdf
+  print "moveit_config_pkg:", args.moveit_config_pkg
+
+
+def update_deps(reqd_deps, req_type, e_parent):
+  curr_deps = [e.text for e in e_parent.findall(req_type)]
+  missing_deps = set(reqd_deps) - set(curr_deps)
+  for d in missing_deps:
+     etree.SubElement(e_parent, req_type).text = d
+  # return missing_deps
+
+def update_package(args):
+  try:
+    moveit_config_pkg_path = roslib.packages.get_pkg_dir(args.moveit_config_pkg)
+  except:
+    print "Failed to find package: %s" % args.moveit_config_pkg
+    sys.exit(-1)
+
+  try:
+    kinematic_plugin_pkg_path = roslib.packages.get_pkg_dir(args.kinematic_plugin_pkg)
+  except:
+    print "Failed to find package: %s" % args.kinematic_plugin_pkg
+    sys.exit(-1)
+
+  try:
+    srdf_file_name = moveit_config_pkg_path + '/config/' + args.srdf_filename
+    srdf = etree.parse(srdf_file_name).getroot()
+  except:
+    print "Failed to find srdf file: %s" % srdf_file_name
+    sys.exit(-1)
+
+  if args.robot_name_in_srdf != srdf.get('name'):
+    print "\nERROR: non-matching robot name found in '%s'. Expected '%s' but found '%s'" % (srdf_file_name,
+                                                                                            args.robot_name_in_srdf,
+                                                                                            srdf.get('name'))
+    sys.exit(-1)
+
+  groups = srdf.findall('group')
+  if len(groups) < 1:
+    print "Failed to load planning group since no planning groups are defined in the SRDF"
+    sys.exit(-1)
+
+  planning_group = None
+  for group in groups:
+    if group.get('name').lower() == args.planning_group_name.lower():
+      planning_group = group
+
+  if planning_group is None:
+    print "Failed to load planning group '%s' since it is not defined in the SRDF. "\
+          "Available groups: \n%s" % (args.planning_group_name,
+                                      "".join([group_name.get('name') for group_name in groups]))
+
+  kinematic_plugin_pkg_src_path = kinematic_plugin_pkg_path + '/src/'
+  if not os.path.exists(kinematic_plugin_pkg_src_path):
+     os.makedirs(kinematic_plugin_pkg_src_path)
+
+  kinematic_plugin_pkg_include_path = kinematic_plugin_pkg_path + '/include/'
+  if not os.path.exists(kinematic_plugin_pkg_include_path):
+     os.makedirs(kinematic_plugin_pkg_include_path)
+
+
+  if not os.path.exists(args.ikfast_output_path):
+    print "\nERROR: can't find IKFast source code at '%s'\n" % args.ikfast_output_path
+    sys.exit(-1)
+
+  # Copy the source code generated by IKFast into our src folder
+  solver_file_path = kinematic_plugin_pkg_src_path + args.robot_name + '_' + args.planning_group_name + '_ikfast_solver.cpp'
+
+  # Check if they are the same file - if so, skip
+  skip = False
+  if os.path.exists(args.ikfast_output_path) and os.path.exists(solver_file_path):
+    if os.path.samefile(args.ikfast_output_path, solver_file_path):
+       print 'Skipping copying ' + solver_file_path + ' since it is already in the correct location'
+       skip = True
+
+  if not skip:
+    shutil.copy2(args.ikfast_output_path, solver_file_path)
+
+  # Error check
+  if not os.path.exists(solver_file_path):
+    print "\nERROR: Unable to copy IKFast source code from '%s' to '%s'" % (args.ikfast_output_path, solver_file_path)
+    print 'Manually copy the source file generated by IKFast to this location and re-run'
+    sys.exit(-1)
+
+  # Detect version of IKFast used to generate solver code
+  solver_version = 0
+  with open(solver_file_path,'r') as src:
+    for line in src:
+       if line.startswith('/// ikfast version'):
+          line_search = re.search('ikfast version (.*) generated', line)
+          if line_search:
+             solver_version = int(line_search.group(1), 0)
+          break
+  print 'Found source code generated by IKFast version %s' % str(solver_version)
+
+  # Chose template depending on IKFast version
+  if solver_version >= 56:
+    template_version = 61
+  else:
+    print 'ERROR this converter is not made for IKFast 54 or anything but 61'
+    sys.exit(-1)
+
+  # Get template folder location
+  try:
+    plugin_gen_dir = os.path.join(roslib.packages.get_pkg_dir(plugin_gen_pkg), plugin_sub_dir)
+  except:
+    print "ERROR: can't find package " + plugin_gen_pkg
+    sys.exit(-1)
+
+  # Check if IKFast header file exists
+  template_header_path = plugin_gen_dir + '/templates/ikfast.h'
+  if not os.path.exists(template_header_path):
+    print "ERROR: can't find ikfast header file at '%s'" % template_header_path
+    sys.exit(-1)
+
+  # Copy the IKFast header file into the include directory
+  output_header_path = kinematic_plugin_pkg_include_path + "ikfast.h"
+  shutil.copy2(template_header_path, output_header_path)
+  if not os.path.exists(output_header_path):
+    print "ERROR: Unable to copy IKFast header file from '%s' to '%s'" % (template_header_path, output_header_path)
+    sys.exit(-1)
+
+  # Check if template exists
+  template_src_path = plugin_gen_dir + '/templates/ikfast' + str(template_version) + '_moveit_plugin_template.cpp'
+  if not os.path.exists(template_src_path):
+    print "ERROR: can't find template file at '%s' " % template_src_path
+    sys.exit(-1)
+
+  # Create plugin source from template
+  template_file_data = open(template_src_path, 'r')
+  template_text = template_file_data.read()
+  template_text = re.sub('_ROBOT_NAME_', args.robot_name, template_text)
+  template_text = re.sub('_GROUP_NAME_', args.planning_group_name, template_text)
+  template_text = re.sub('_SEARCH_MODE_', args.search_mode, template_text)
+  template_text = re.sub('_EEF_LINK_', args.eef_link_name, template_text)
+  template_text = re.sub('_BASE_LINK_', args.base_link_name, template_text)
+
+  output_src_path = kinematic_plugin_pkg_src_path + args.robot_name + '_' + args.planning_group_name + "_ikfast_moveit_plugin.cpp"
+  with open(output_src_path, 'w') as f:
+    f.write(template_text)
+  print "Created plugin file at '%s'" % output_src_path
+
+  # Create plugin definition .xml file
+  ik_library_name = args.robot_name + "_" + args.planning_group_name + "_moveit_ikfast_plugin"
+  plugin_name = args.robot_name + '_' + args.planning_group_name + '_kinematics/IKFastKinematicsPlugin'
+  plugin_def = etree.Element("library", path="lib/lib"+ik_library_name)
+  cl = etree.SubElement(plugin_def, "class")
+  cl.set("name", plugin_name)
+  cl.set("type", 'ikfast_kinematics_plugin::IKFastKinematicsPlugin')
+  cl.set("base_class_type", "kinematics::KinematicsBase")
+  desc = etree.SubElement(cl, "description")
+  desc.text = 'IKFast'+str(template_version)+' plugin for closed-form kinematics'
+
+  # Write plugin definition to file
+  plugin_file_name = ik_library_name + "_description.xml"
+  plugin_file_path = kinematic_plugin_pkg_path + "/" + plugin_file_name
+  with open(plugin_file_path,'w') as f:
+    etree.ElementTree(plugin_def).write(f, xml_declaration=True, pretty_print=True, encoding="UTF-8")
+  print "Created plugin definition at: '%s'" % plugin_file_path
+
+  # Check if CMakeLists file exists
+  cmake_template_file = plugin_gen_dir + "/templates/CMakeLists.txt"
+  if not os.path.exists(cmake_template_file):
+    print "ERROR: can't find CMakeLists template file at '%s'" % cmake_template_file
+    sys.exit(-1)
+
+  # Create new CMakeLists file
+  cmake_file = kinematic_plugin_pkg_path+'/CMakeLists.txt'
+
+  # Create plugin source from template
+  template_file_data = open(cmake_template_file, 'r')
+  template_text = template_file_data.read()
+  template_text = re.sub('_ROBOT_NAME_', args.robot_name, template_text)
+  template_text = re.sub('_GROUP_NAME_', args.planning_group_name, template_text)
+  template_text = re.sub('_PACKAGE_NAME_', args.kinematic_plugin_pkg, template_text)
+  template_text = re.sub('_LIBRARY_NAME_', ik_library_name, template_text)
+
+  with open(cmake_file, 'w') as f:
+    f.write(template_text)
+  print "Overwrote CMakeLists file at '%s'" % cmake_file
+
+  # Add plugin export to package manifest
+  parser = etree.XMLParser(remove_blank_text=True)
+  package_file_name = kinematic_plugin_pkg_path+"/package.xml"
+  package_xml = etree.parse(package_file_name, parser)
+
+  # Make sure at least all required dependencies are in the depends lists
+  build_deps = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
+  run_deps   = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
+
+  update_deps(build_deps, "build_depend", package_xml.getroot())
+  update_deps(run_deps, "exec_depend", package_xml.getroot())
+
+  # Check that plugin definition file is in the export list
+  new_export = etree.Element("moveit_core",
+                             plugin="${prefix}/" + plugin_file_name)
+
+  export_element = package_xml.getroot().find("export")
+  if export_element == None:
+    export_element = etree.SubElement(package_xml.getroot(), "export")
+
+  found = False
+  for el in export_element.findall("moveit_core"):
+    found = (etree.tostring(new_export) == etree.tostring(el))
+    if found: break
+
+  if not found:
+    export_element.append(new_export)
+
+  # Always write the package xml file, even if there are no changes, to ensure
+  # proper encodings are used in the future (UTF-8)
+  with open(package_file_name, "w") as f:
+    package_xml.write(f, xml_declaration=True, pretty_print=True, encoding="UTF-8")
+  print "Modified package.xml at '%s'" % package_file_name
+
+  # Modify kinematics.yaml file
+  kin_yaml_file_name = moveit_config_pkg_path+"/config/kinematics.yaml"
+  with open(kin_yaml_file_name, 'r') as f:
+    kin_yaml_data = yaml.safe_load(f)
+  kin_yaml_data[args.planning_group_name]["kinematics_solver"] = plugin_name
+  with open(kin_yaml_file_name, 'w') as f:
+    yaml.dump(kin_yaml_data, f, default_flow_style=False)
+  print "Modified kinematics.yaml at '%s'" % kin_yaml_file_name
+
+  # Create a script for easily updating the plugin in the future in case the plugin needs to be updated
+  easy_script_file_name = "update_ikfast_plugin.sh"
+  easy_script_file_path = kinematic_plugin_pkg_path + "/" + easy_script_file_name
+  with open(easy_script_file_path,'w') as f:
+    f.write("rosrun moveit_kinematics create_ikfast_moveit_plugin.py"
+            + " --search_mode=" + args.search_mode
+            + " --srdf_filename=" + args.srdf_filename
+            + " --robot_name_in_srdf=" + args.robot_name_in_srdf
+            + " --moveit_config_pkg=" + args.moveit_config_pkg
+            + " " + args.robot_name
+            + " " + args.planning_group_name
+            + " " + args.kinematic_plugin_pkg
+            + " " + args.base_link_name
+            + " " + args.eef_link_name
+            + " " + solver_file_path )
+
+  print "Created update plugin script at '%s'" % easy_script_file_path
+
+def main(args):
+  populate_optional(args)
+  print_args(args)
+  update_package(args)
+  pass
+
 if __name__ == '__main__':
-   # Check input arguments
-   try:
-      robot_name = sys.argv[1]
-      planning_group_name = sys.argv[2]
-      moveit_plugin_pkg = sys.argv[3]
-      base_link_name = sys.argv[4]
-      eef_link_name = sys.argv[5]
-      if len(sys.argv) == 8:
-         ikfast_output_file = sys.argv[7]
-         search_mode = sys.argv[6]
-         if search_mode not in search_modes:
-            print 'Invalid search mode. Allowed values: ', search_modes
-            raise Exception()
-      elif len(sys.argv) == 7:
-         search_mode = search_modes[0];
-         print "Warning: The default search has changed from OPTIMIZE_FREE_JOINT to now %s!" % (search_mode)
-         ikfast_output_file = sys.argv[6]
-      else:
-         raise Exception()
-   except:
-      print("\nUsage: create_ikfast_plugin.py <yourrobot_name> <planning_group_name> <moveit_plugin_pkg> <base_link_name> <eef_link_name> [<search_mode>] <ikfast_output_path>\n")
-      sys.exit(-1)
-   print '\nIKFast Plugin Generator'
-
-   # Setup key package directories
-   try:
-      plan_pkg = robot_name + '_moveit_config'
-      plan_pkg_dir = roslib.packages.get_pkg_dir(plan_pkg)
-      print 'Loading robot from \''+plan_pkg+'\' package ... '
-   except:
-      print '\nERROR: can\'t find package '+plan_pkg+'\n'
-      try:
-         plan_pkg = robot_name + '_moveit'
-         plan_pkg_dir = roslib.packages.get_pkg_dir(plan_pkg)
-         print 'Loading robot from \''+plan_pkg+'\' package ... '
-      except:
-         print '\nERROR: can\'t find package '+plan_pkg+'\n'
-         sys.exit(-1)
-   try:
-      plugin_pkg = moveit_plugin_pkg
-      plugin_pkg_dir = roslib.packages.get_pkg_dir(plugin_pkg)
-      print 'Creating plugin in \''+plugin_pkg+'\' package ... '
-   except:
-      print '\nERROR: can\'t find package '+plugin_pkg+'\n'
-      sys.exit(-1)
-
-   # Check for at least 1 planning group
-   try:
-      srdf_files = glob.glob(plan_pkg_dir+'/config/*.srdf')
-      if (len(srdf_files) == 1):
-         srdf_file_name = srdf_files[0]
-      else:
-         srdf_file_name = plan_pkg_dir + '/config/' + robot_name + '.srdf'
-      srdf = etree.parse(srdf_file_name).getroot()
-   except:
-      print("\nERROR: unable to parse robot configuration file\n" + srdf_file_name + "\n")
-      sys.exit(-1)
-   try:
-      if (robot_name != srdf.get('name')):
-         print '\nERROR: non-matching robot name found in ' + srdf_file_name + '.' \
-             + '  Expected \'' + robot_name + '\',' + ' found \''+srdf.get('name')+'\''
-         raise
-
-      groups = srdf.findall('group')
-      if(len(groups) < 1) : # No groups
-         raise
-      if groups[0].get('name') == None: # Group name is blank
-         raise
-   except:
-      print("\nERROR: need at least 1 planning group in robot planning description ")
-      print srdf_file_name + '\n'
-      sys.exit(-1)
-   print '  found ' + str(len(groups)) + ' planning groups: ' \
-       + ", ".join([g.get('name') for g in groups])
-
-   # Select manipulator arm group
-   planning_group = None
-   for g in groups:
-      foundName  = (g.get('name').lower() == planning_group_name.lower())
-
-      if (foundName):
-         planning_group = g
-         break
-   if planning_group is None:
-      print '\nERROR: could not find planning group ' + planning_group_name + ' in SRDF.\n'
-      sys.exit(-1)
-   print '  found group \'' + planning_group_name + '\''
-
-   # Create src and include folders in target package
-   plugin_pkg_src_dir = plugin_pkg_dir+'/src/'
-   plugin_pkg_include_dir = plugin_pkg_dir+'/include/'
-
-   if not os.path.exists(plugin_pkg_src_dir):
-      os.makedirs(plugin_pkg_src_dir)
-   if not os.path.exists(plugin_pkg_include_dir):
-      os.makedirs(plugin_pkg_include_dir)
-
-   # Check for source code generated by IKFast
-   if not os.path.exists(ikfast_output_file):
-      print '\nERROR: can\'t find IKFast source code at \'' + \
-          ikfast_output_file + '\'\n'
-      print 'Make sure this input argument is correct \n'
-      sys.exit(-1)
-
-   # Copy the source code generated by IKFast into our src folder
-   solver_file_name = plugin_pkg_dir+'/src/'+robot_name+'_'+planning_group_name+'_ikfast_solver.cpp'
-   # Check if they are the same file - if so, skip
-   skip = False
-   if os.path.exists(ikfast_output_file) & os.path.exists(solver_file_name):
-      if os.path.samefile(ikfast_output_file, solver_file_name):
-         print 'Skipping copying ' + solver_file_name + ' since it is already in the correct location'
-         skip = True
-   if not skip:
-      shutil.copy2(ikfast_output_file,solver_file_name)
-   # Error check
-   if not os.path.exists(solver_file_name):
-      print '\nERROR: Unable to copy IKFast source code from \'' + ikfast_output_file + '\'' + ' to \'' + solver_file_name + '\''
-      print 'Manually copy the source file generated by IKFast to this location \n'
-      sys.exit(-1)
-
-   # Detect version of IKFast used to generate solver code
-   solver_version = 0
-   with open(solver_file_name,'r') as src:
-      for line in src:
-         if line.startswith('/// ikfast version'):
-            line_search = re.search('ikfast version (.*) generated', line)
-            if line_search:
-               solver_version = int(line_search.group(1), 0)
-            break
-   print '  found source code generated by IKFast version ' + str(solver_version)
-
-   # Get template folder location
-   try:
-      plugin_gen_dir = os.path.join(roslib.packages.get_pkg_dir(plugin_gen_pkg), plugin_sub_dir)
-   except:
-      print '\nERROR: can\'t find package '+plugin_gen_pkg+' \n'
-      sys.exit(-1)
-
-   # Chose template depending on IKFast version
-   if solver_version >= 56:
-      template_version = 61
-   else:
-      print '\nERROR this converter is not made for IKFast 54 or anything but 61'
-      sys.exit(-1)
-
-   # Check if IKFast header file exists
-   template_header_file = plugin_gen_dir + '/templates/ikfast.h'
-   if not os.path.exists(template_header_file):
-      print '\nERROR: can\'t find ikfast header file at \'' + template_header_file + '\'\n'
-      sys.exit(-1)
-
-   # Copy the IKFast header file into the include directory
-   header_file_name = plugin_pkg_dir+'/include/ikfast.h'
-   shutil.copy2(template_header_file,header_file_name)
-   if not os.path.exists(header_file_name):
-      print '\nERROR: Unable to copy IKFast header file from \'' + \
-          template_header_file + '\'' + ' to \'' + header_file_name + '\' \n'
-      print 'Manually copy ikfast.h to this location \n'
-      sys.exit(-1)
-
-   # Check if template exists
-   template_file_name = plugin_gen_dir + '/templates/ikfast' + str(template_version) + '_moveit_plugin_template.cpp'
-
-   if not os.path.exists(template_file_name):
-      print '\nERROR: can\'t find template file at \'' + template_file_name + '\'\n'
-      sys.exit(-1)
-
-   # Create plugin source from template
-   template_file_data = open(template_file_name, 'r')
-   template_text = template_file_data.read()
-   template_text = re.sub('_ROBOT_NAME_', robot_name, template_text)
-   template_text = re.sub('_GROUP_NAME_', planning_group_name, template_text)
-   template_text = re.sub('_SEARCH_MODE_', search_mode, template_text)
-   template_text = re.sub('_EEF_LINK_', eef_link_name, template_text)
-   template_text = re.sub('_BASE_LINK_', base_link_name, template_text)
-   plugin_file_base = robot_name + '_' + planning_group_name + '_ikfast_moveit_plugin.cpp'
-
-   plugin_file_name = plugin_pkg_dir + '/src/' + plugin_file_base
-   with open(plugin_file_name,'w') as f:
-      f.write(template_text)
-   print '\nCreated plugin file at \'' + plugin_file_name + '\''
-
-   # Create plugin definition .xml file
-   ik_library_name = robot_name + "_" + planning_group_name + "_moveit_ikfast_plugin"
-   plugin_name = robot_name + '_' + planning_group_name + \
-       '_kinematics/IKFastKinematicsPlugin'
-   plugin_def = etree.Element("library", path="lib/lib"+ik_library_name)
-   cl = etree.SubElement(plugin_def, "class")
-   cl.set("name", plugin_name)
-   cl.set("type", 'ikfast_kinematics_plugin::IKFastKinematicsPlugin')
-   cl.set("base_class_type", "kinematics::KinematicsBase")
-   desc = etree.SubElement(cl, "description")
-   desc.text = 'IKFast'+str(template_version)+' plugin for closed-form kinematics'
-
-   # Write plugin definition to file
-   def_file_base = ik_library_name + "_description.xml"
-   def_file_name = plugin_pkg_dir + "/" + def_file_base
-   with open(def_file_name,'w') as f:
-      etree.ElementTree(plugin_def).write(f, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-   print '\nCreated plugin definition at: \''+def_file_name+'\''
-
-
-
-
-   # Check if CMakeLists file exists
-   cmake_template_file = plugin_gen_dir+"/templates/CMakeLists.txt"
-   if not os.path.exists(cmake_template_file):
-      print '\nERROR: can\'t find CMakeLists template file at \'' + cmake_template_file + '\'\n'
-      sys.exit(-1)
-
-   # Create new CMakeLists file
-   cmake_file = plugin_pkg_dir+'/CMakeLists.txt'
-
-   # Create plugin source from template
-   template_file_data = open(cmake_template_file, 'r')
-   template_text = template_file_data.read()
-   template_text = re.sub('_ROBOT_NAME_', robot_name, template_text)
-   template_text = re.sub('_GROUP_NAME_', planning_group_name, template_text)
-   template_text = re.sub('_PACKAGE_NAME_', moveit_plugin_pkg, template_text)
-   template_text = re.sub('_LIBRARY_NAME_', ik_library_name, template_text)
-
-   with open(cmake_file,'w') as f:
-      f.write(template_text)
-   print '\nOverwrote CMakeLists file at \'' + cmake_file + '\''
-
-   # Add plugin export to package manifest
-   parser = etree.XMLParser(remove_blank_text=True)
-   package_file_name = plugin_pkg_dir+"/package.xml"
-   package_xml = etree.parse(package_file_name, parser)
-
-   # Make sure at least all required dependencies are in the depends lists
-   build_deps = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
-   run_deps   = ["liblapack-dev", "moveit_core", "pluginlib", "roscpp", "tf_conversions", "moveit_ros_planning"]
-
-   def update_deps(reqd_deps, req_type, e_parent):
-      curr_deps = [e.text for e in e_parent.findall(req_type)]
-      missing_deps = set(reqd_deps) - set(curr_deps)
-      for d in missing_deps:
-         etree.SubElement(e_parent, req_type).text = d
-      return missing_deps
-
-   update_deps(build_deps, "build_depend", package_xml.getroot())
-   update_deps(run_deps, "exec_depend", package_xml.getroot())
-
-   # Check that plugin definition file is in the export list
-   new_export = etree.Element("moveit_core", \
-                                 plugin="${prefix}/"+def_file_base)
-   export_element = package_xml.getroot().find("export")
-   if export_element == None:
-      export_element = etree.SubElement(package_xml.getroot(), "export")
-   found = False
-   for el in export_element.findall("moveit_core"):
-      found = (etree.tostring(new_export) == etree.tostring(el))
-      if found: break
-
-   if not found:
-      export_element.append(new_export)
-
-   # Always write the package xml file, even if there are no changes, to ensure
-   # proper encodings are used in the future (UTF-8)
-   with open(package_file_name,"w") as f:
-      package_xml.write(f, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-   print '\nModified package.xml at \''+package_file_name+'\''
-
-   # Modify kinematics.yaml file
-   kin_yaml_file_name = plan_pkg_dir+"/config/kinematics.yaml"
-   with open(kin_yaml_file_name, 'r') as f:
-      kin_yaml_data = yaml.safe_load(f)
-   kin_yaml_data[planning_group_name]["kinematics_solver"] = plugin_name
-   with open(kin_yaml_file_name, 'w') as f:
-      yaml.dump(kin_yaml_data, f,default_flow_style=False)
-   print '\nModified kinematics.yaml at ' + kin_yaml_file_name
-
-   # Create a script for easily updating the plugin in the future in case the plugin needs to be updated
-   easy_script_file_name = "update_ikfast_plugin.sh"
-   easy_script_file_path = plugin_pkg_dir + "/" + easy_script_file_name
-   with open(easy_script_file_path,'w') as f:
-      f.write("rosrun moveit_kinematics create_ikfast_moveit_plugin.py"
-              + " " + robot_name
-              + " " + planning_group_name
-              + " " + plugin_pkg
-              + " " + base_link_name
-              + " " + eef_link_name
-              + " " + solver_file_name )
-
-   print '\nCreated update plugin script at '+easy_script_file_path
+  parser = createParser()
+  args = parser.parse_args()
+  main(args)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
   roscpp
   tf_conversions
+  moveit_ros_planning
 )
 
 include_directories(${catkin_INCLUDE_DIRS})
@@ -19,6 +20,7 @@ catkin_package(
     pluginlib
     roscpp
     tf_conversions
+    moveit_ros_planning
 )
 
 include_directories(include)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -371,7 +371,6 @@ private:
   */
   bool sampleRedundantJoint(kinematics::DiscretizationMethod method, std::vector<double>& sampled_joint_vals) const;
 
-
   /**
   * @brief  Transforms the input pose to the correct frame for the solver. This assumes that the group includes the
   * entire solver chain and that any joints outside of the solver chain within the group are are fixed.

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -405,7 +405,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, co
 
   if (!urdf_model || !srdf)
   {
-    ROS_ERROR_NAMED("kdl", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
+    ROS_ERROR_NAMED(name_, "URDF and SRDF must be loaded for KDL kinematics solver to work.");
     return false;
   }
 
@@ -419,20 +419,22 @@ bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, co
   // TODO: Check for non-fixed joints between the ikfast tip and base frames and the group tip
   //       and base frames. If any are found, we should throw an error and return.
   if (tip_frame_ != ikfast_tip_frame_)
-    ROS_DEBUG_NAMED("ikfast", "This IKFastKinematicsPlugin was generated with a tip frame of %s, but is being "
-                              "initialized with tip frame %s",
-                    ikfast_tip_frame_.c_str(), tip_frame_.c_str());
+    ROS_INFO_NAMED(name_, "This IKFastKinematicsPlugin was generated with a tip frame of %s, but is being "
+                          "initialized with tip frame %s. There must not be any active joints between these "
+                          "links",
+                   ikfast_tip_frame_.c_str(), tip_frame_.c_str());
 
   if (base_frame_ != ikfast_base_frame_)
-    ROS_DEBUG_NAMED("ikfast", "This IKFastKinematicsPlugin was generated with a base frame of %s, but is being "
-                              "initialized with base frame %s",
-                    ikfast_base_frame_.c_str(), base_name.c_str());
+    ROS_INFO_NAMED(name_, "This IKFastKinematicsPlugin was generated with a base frame of %s, but is being "
+                          "initialized with base frame %s. There must not be any active joints between these "
+                          "links",
+                   ikfast_base_frame_.c_str(), base_name.c_str());
 
   if (transform_base_)
   {
     if (!robot_state_->knowsFrameTransform(base_frame_) || !robot_state_->knowsFrameTransform(ikfast_base_frame_))
     {
-      ROS_ERROR_NAMED("ikfast", "could not find base frame");
+      ROS_ERROR_NAMED(name_, "could not find base frame");
       return false;
     }
     else
@@ -446,7 +448,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, co
   {
     if (!robot_state_->knowsFrameTransform(tip_frame_) || !robot_state_->knowsFrameTransform(ikfast_tip_frame_))
     {
-      ROS_ERROR_NAMED("ikfast", "could not find tip frame");
+      ROS_ERROR_NAMED(name_, "could not find tip frame");
       return false;
     }
     else


### PR DESCRIPTION
### Description
This PR increases the functionality of the IKFastKinematicsPlugin by enabling the solver to solve for end effector poses in the base link frame. This makes it so that kinematic solvers generated with the IKFast template behave exactly like KDL and removes the need for shim layers like the one used in the [Descartes package](https://github.com/ros-industrial-consortium/descartes/tree/kinetic-devel/descartes_moveit/include/descartes_moveit)) or the one provided as part of the [ur_kinematics package](https://github.com/ros-industrial/universal_robot/blob/2af9088dfa2671c8184900c0710e85ea54f2413f/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h#L275). 

These improvements are the result of a collaboration between [Carbon Robotics](http://www.carbon.ai/) and [PickNik Robotics](picknik.ai)

The tutorials have been updated in this pr: https://github.com/ros-planning/moveit_tutorials/pull/206

Additionally, this PR implements a number of small features:

- Adding argparse to the `create_ikfast_moveit_plugin.py` making it a lot more flexible and removing a lot of the (often incorrect) assumptions that were made
- Checking the joint limits of the robot and returning solutions that are within those limits if possible

 

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
