### PR TITLE
Add joint state controller config by default

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -482,6 +482,16 @@ public:
   std::vector<std::map<std::string, GenericParameter> > getSensorPluginConfig();
 
   /**
+   * \brief Helper function to get the default start state group for moveit_sim_hw_interface
+   */
+  std::string getDefaultStartStateGroup();
+
+  /**
+   * \brief Helper function to get the default start pose for moveit_sim_hw_interface
+   */
+  std::string getDefaultStartPose();
+
+  /**
    * \brief Custom std::set comparator, used for sorting the joint_limits.yaml file into alphabetical order
    * \param jm1 - a pointer to the first joint model to compare
    * \param jm2 - a pointer to the second joint model to compare

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -725,6 +725,26 @@ void MoveItConfigData::outputFollowJointTrajectoryYAML(YAML::Emitter& emitter,
 }
 
 // ******************************************************************************************
+// Helper function to get the default start state group for moveit_sim_hw_interface
+// ******************************************************************************************
+std::string MoveItConfigData::getDefaultStartStateGroup()
+{
+  if (!srdf_->srdf_model_->getGroups().empty())
+    return srdf_->srdf_model_->getGroups()[0].name_;
+  return "todo_no_group_selected";
+}
+
+// ******************************************************************************************
+// Helper function to get the default start pose for moveit_sim_hw_interface
+// ******************************************************************************************
+std::string MoveItConfigData::getDefaultStartPose()
+{
+  if (!srdf_->group_states_.empty())
+    return srdf_->group_states_[0].name_;
+  return "todo_no_pose_selected";
+}
+
+// ******************************************************************************************
 // Output controllers config files
 // ******************************************************************************************
 bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
@@ -771,17 +791,11 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
     {
       // Use the first planning group if initial joint_model_group was not set, else write a default value
       emitter << YAML::Key << "joint_model_group";
-      if (!srdf_->srdf_model_->getGroups().empty())
-        emitter << YAML::Value << srdf_->srdf_model_->getGroups()[0].name_;
-      else
-        emitter << YAML::Value << "todo_no_group_selected";
+      emitter << YAML::Value << getDefaultStartStateGroup();
 
       // Use the first robot pose if initial joint_model_group_pose was not set, else write a default value
       emitter << YAML::Key << "joint_model_group_pose";
-      if (!srdf_->group_states_.empty())
-        emitter << YAML::Value << srdf_->group_states_[0].name_;
-      else
-        emitter << YAML::Value << "todo_no_pose_selected";
+      emitter << YAML::Value << getDefaultStartPose();
 
       emitter << YAML::EndMap;
     }

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
@@ -195,12 +195,11 @@ void ControllerEditWidget::loadControllersTypesComboBox()
     return;
   has_loaded_ = true;
 
-  const std::array<std::string, 9> default_types = {
+  const std::array<std::string, 8> default_types = {
     "effort_controllers/JointTrajectoryController",   "effort_controllers/JointPositionController",
     "effort_controllers/JointVelocityController",     "effort_controllers/JointEffortController",
-    "joint_state_controller/JointStateController",    "position_controllers/JointPositionController",
-    "position_controllers/JointTrajectoryController", "velocity_controllers/JointTrajectoryController",
-    "velocity_controllers/JointvelocityController"
+    "position_controllers/JointPositionController",   "position_controllers/JointTrajectoryController",
+    "velocity_controllers/JointTrajectoryController", "velocity_controllers/JointvelocityController"
   };
 
   // Remove all old items

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
@@ -199,7 +199,7 @@ void ControllerEditWidget::loadControllersTypesComboBox()
     "effort_controllers/JointTrajectoryController",   "effort_controllers/JointPositionController",
     "effort_controllers/JointVelocityController",     "effort_controllers/JointEffortController",
     "position_controllers/JointPositionController",   "position_controllers/JointTrajectoryController",
-    "velocity_controllers/JointTrajectoryController", "velocity_controllers/JointvelocityController"
+    "velocity_controllers/JointTrajectoryController", "velocity_controllers/JointVelocityController"
   };
 
   // Remove all old items


### PR DESCRIPTION
### Description
This PR improves the controllers screen by hiding not useful controller options, and renaming `moveit_sim_controllers` to more appropriate names.

- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

