### PR TITLE
PR template: Suggest contributors review other PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,11 @@
 Please explain the changes you made, including a reference to the related issue if applicable
 
 ### Checklist
-- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
+- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
 - [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
 - [ ] Include a screenshot if changing a GUI
-- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
-- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
+- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
+- [ ] Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
+- [ ] While waiting for review, please help by reviewing [another pull request](https://github.com/ros-planning/moveit/pulls)
 
 [//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Please explain the changes you made, including a reference to the related issue 
 - [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
 - [ ] Include a screenshot if changing a GUI
 - [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
-- [ ] Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)
-- [ ] While waiting for review, please help by reviewing [another pull request](https://github.com/ros-planning/moveit/pulls)
+- [ ] Decide if this should be cherry-picked to other current ROS branches
+- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
 
 [//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


### PR DESCRIPTION
### Description

From: Ridhwan Luthra via email:

> I am a part of the ROS quality assurance group and we were discussing a way to promote pull request reviewing. As a part of the discussions, we came up with a plan that whenever a contributor would submit a pull request they are supposed to review another pull request before their's is merged.
> In, the discussions that I had with mike and Michael yesterday they hinted that we need a lot of help in reviewing pull requests, so I suggested that we could pick MoveIt! as a pilot repository.

I was requested to make this change so I added a new line item to the pull request guidelines. I also:

- Clarified meaning of "Required"... its enforced by the continuous integration
- Removed "optional" since that is assumed when the first item is the only one bold and "required"

@v4hn @mlautman 