### PR TITLE
added a setup assistant window icon

### DIFF
--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -74,6 +74,11 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
   if (args.count("debug"))
     config_data_->debug_ = true;
 
+  // Setting the window icon
+  std::string moveit_ros_visualization_package_path = ros::package::getPath("moveit_ros_visualization");
+  moveit_ros_visualization_package_path += "/icons/classes/MotionPlanning.png";
+  this->setWindowIcon(QIcon(moveit_ros_visualization_package_path.c_str()));
+
   // Basic widget container -----------------------------------------
   QHBoxLayout* layout = new QHBoxLayout();
   layout->setAlignment(Qt::AlignTop);


### PR DESCRIPTION
### Description

Added the setup_assistant window icon to appear on the launcher

![pr](https://user-images.githubusercontent.com/28768115/44349393-7e5cda00-a4cf-11e8-9a17-d3c90c8d6c9e.png)


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
