### PR TITLE
Add moveit_setup_assistant as depenency of all *_moveit_config pkgs

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -21,6 +21,7 @@
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>moveit_setup_assistant</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
Allows usage of setup_assistant.launch that is auto-generated by MSA

cherry-pick to Melodic