### PR TITLE
fix various compiler warnings

### DIFF
--- a/moveit_experimental/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_common_distance_field.cpp
@@ -191,7 +191,6 @@ void getBodySphereVisualizationMarkers(GroupStateRepresentationConstPtr& gsr, st
   sphere_marker.color = attached_color;
   for (unsigned int i = 0; i < gsr->dfce_->attached_body_names_.size(); i++)
   {
-    int link_index = gsr->dfce_->attached_body_link_state_indices_[i];
     const moveit::core::AttachedBody* att = state.getAttachedBody(gsr->dfce_->attached_body_names_[i]);
     if (!att)
     {

--- a/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
@@ -289,7 +289,6 @@ void collision_detection::BodyDecomposition::init(const std::vector<shapes::Shap
   relative_collision_points_.clear();
   std::vector<CollisionSphere> body_spheres;
   EigenSTL::vector_Vector3d body_collision_points;
-  double radius = RESOLUTION_SCALE * resolution;
   for (unsigned int i = 0; i < bodies_.getCount(); i++)
   {
     body_spheres.clear();

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -330,9 +330,6 @@ bool CollisionRobotDistanceField::getSelfProximityGradients(GroupStateRepresenta
 {
   bool in_collision = false;
 
-  // creating distance field for each link at the current position
-  ros::Time start_time = ros::Time::now();
-
   for (unsigned int i = 0; i < gsr->dfce_->link_names_.size(); i++)
   {
     const std::string& link_name = gsr->dfce_->link_names_[i];
@@ -703,7 +700,6 @@ DistanceFieldCacheEntryPtr CollisionRobotDistanceField::generateDistanceFieldCac
     const std::string& group_name, const moveit::core::RobotState& state,
     const collision_detection::AllowedCollisionMatrix* acm, bool generate_distance_field) const
 {
-  ros::WallTime n = ros::WallTime::now();
   DistanceFieldCacheEntryPtr dfce(new DistanceFieldCacheEntry());
 
   if (robot_model_->getJointModelGroup(group_name) == NULL)
@@ -1004,7 +1000,6 @@ void CollisionRobotDistanceField::createCollisionModelMarker(const moveit::core:
   sphere_marker.lifetime = ros::Duration(0);
 
   unsigned int id = 0;
-  const std::vector<const moveit::core::LinkModel*>& link_models = robot_model_->getLinkModelsWithCollisionGeometry();
   const moveit::core::JointModelGroup* joint_group = state.getJointModelGroup(distance_field_cache_entry_->group_name_);
   const std::vector<std::string>& group_link_names = joint_group->getUpdatedLinkModelNames();
 
@@ -1116,7 +1111,6 @@ void CollisionRobotDistanceField::updateGroupStateRepresentationState(const move
 
   for (unsigned int i = 0; i < gsr->dfce_->attached_body_names_.size(); i++)
   {
-    int link_index = gsr->dfce_->attached_body_link_state_indices_[i];
     const moveit::core::AttachedBody* att = state.getAttachedBody(gsr->dfce_->attached_body_names_[i]);
     if (!att)
     {
@@ -1158,7 +1152,6 @@ void CollisionRobotDistanceField::getGroupStateRepresentation(const DistanceFiel
     ROS_DEBUG_STREAM("Creating GroupStateRepresentation");
 
     // unsigned int count = 0;
-    ros::WallTime b = ros::WallTime::now();
     gsr.reset(new GroupStateRepresentation());
     gsr->dfce_ = dfce;
     gsr->gradients_.resize(dfce->link_names_.size() + dfce->attached_body_names_.size());

--- a/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_world_distance_field.cpp
@@ -71,8 +71,8 @@ CollisionWorldDistanceField::CollisionWorldDistanceField(const WorldPtr& world, 
                                                          double resolution, double collision_tolerance,
                                                          double max_propogation_distance)
   : CollisionWorld(world)
-  , size_(size_)
-  , origin_(origin_)
+  , size_(size)
+  , origin_(origin)
   , use_signed_distance_field_(use_signed_distance_field)
   , resolution_(resolution)
   , collision_tolerance_(collision_tolerance)

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -560,7 +560,6 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
                                         const std::vector<double>& joint_angles,
                                         std::vector<geometry_msgs::Pose>& poses) const
 {
-  ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
     ROS_ERROR_NAMED("kdl", "kinematics not active");

--- a/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -185,7 +185,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJntRedundant(const JntArray& q_in, const 
   // Using the svd decomposition this becomes(jac_pinv=V*S_pinv*Ut):
   // qdot_out = V*S_pinv*Ut*v_in
 
-  unsigned int columns, rows;
+  unsigned int rows;
   if (!position_ik)
     rows = jac_locked.rows();
   else
@@ -287,7 +287,7 @@ int ChainIkSolverVel_pinv_mimic::CartToJnt(const JntArray& q_in, const Twist& v_
   // Using the svd decomposition this becomes(jac_pinv=V*S_pinv*Ut):
   // qdot_out = V*S_pinv*Ut*v_in
 
-  unsigned int columns, rows;
+  unsigned int rows;
   if (!position_ik)
     rows = jac_reduced.rows();
   else

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -220,7 +220,6 @@ bool LMAKinematicsPlugin::initialize(const std::string& robot_description, const
       kdl_chain_.getNrOfJoints() - joint_model_group->getMimicJointModels().size() - (position_ik ? 3 : 6);
 
   // Check for mimic joints
-  bool has_mimic_joints = joint_model_group->getMimicJointModels().size() > 0;
   std::vector<unsigned int> redundant_joints_map_index;
 
   std::vector<JointMimic> mimic_joints;
@@ -569,7 +568,6 @@ bool LMAKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
                                         const std::vector<double>& joint_angles,
                                         std::vector<geometry_msgs::Pose>& poses) const
 {
-  ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
     ROS_ERROR_NAMED("lma", "kinematics not active");

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -292,7 +292,7 @@ bool LMAKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
     ROS_ERROR_NAMED("lma", "This group cannot have redundant joints");
     return false;
   }
-  if (redundant_joints.size() > num_possible_redundant_joints_)
+  if (int(redundant_joints.size()) > num_possible_redundant_joints_)
   {
     ROS_ERROR_NAMED("lma", "This group can only have %d redundant joints", num_possible_redundant_joints_);
     return false;

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -327,10 +327,9 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
     error_code.val = ik_srv.response.error_code.val;
     if (error_code.val != error_code.SUCCESS)
     {
-      ROS_DEBUG_NAMED("srv", "An IK that satisifes the constraints and is collision free could not be found.");
-      // Debug mode for failure:
-      ROS_DEBUG_STREAM("Request was: \n" << ik_srv.request.ik_request);
-      ROS_DEBUG_STREAM("Response was: \n" << ik_srv.response.solution);
+      ROS_DEBUG_STREAM_NAMED("srv", "An IK that satisifes the constraints and is collision free could not be found."
+                             << "\nRequest was: \n" << ik_srv.request.ik_request
+                             << "\nResponse was: \n" << ik_srv.response.solution);
       switch (error_code.val)
       {
         case moveit_msgs::MoveItErrorCodes::FAILURE:

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -399,7 +399,6 @@ bool SrvKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
                                         const std::vector<double>& joint_angles,
                                         std::vector<geometry_msgs::Pose>& poses) const
 {
-  ros::WallTime n1 = ros::WallTime::now();
   if (!active_)
   {
     ROS_ERROR_NAMED("srv", "kinematics not active");

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -154,7 +154,7 @@ bool SrvKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& re
     ROS_ERROR_NAMED("srv", "This group cannot have redundant joints");
     return false;
   }
-  if (redundant_joints.size() > num_possible_redundant_joints_)
+  if (int(redundant_joints.size()) > num_possible_redundant_joints_)
   {
     ROS_ERROR_NAMED("srv", "This group can only have %d redundant joints", num_possible_redundant_joints_);
     return false;

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -328,8 +328,9 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
     if (error_code.val != error_code.SUCCESS)
     {
       ROS_DEBUG_STREAM_NAMED("srv", "An IK that satisifes the constraints and is collision free could not be found."
-                             << "\nRequest was: \n" << ik_srv.request.ik_request
-                             << "\nResponse was: \n" << ik_srv.response.solution);
+                                        << "\nRequest was: \n"
+                                        << ik_srv.request.ik_request << "\nResponse was: \n"
+                                        << ik_srv.response.solution);
       switch (error_code.val)
       {
         case moveit_msgs::MoveItErrorCodes::FAILURE:

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -355,7 +355,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Convert the robot state message to our robot_state representation
   if (!moveit::core::robotStateMsgToRobotState(ik_srv.response.solution, *robot_state_))
   {
-    ROS_ERROR_STREAM_NAMED("srv", "An error occured converting recieved robot state message into internal robot "
+    ROS_ERROR_STREAM_NAMED("srv", "An error occured converting received robot state message into internal robot "
                                   "state.");
     error_code.val = error_code.FAILURE;
     return false;

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -328,12 +328,11 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
     if (error_code.val != error_code.SUCCESS)
     {
       ROS_DEBUG_NAMED("srv", "An IK that satisifes the constraints and is collision free could not be found.");
+      // Debug mode for failure:
+      ROS_DEBUG_STREAM("Request was: \n" << ik_srv.request.ik_request);
+      ROS_DEBUG_STREAM("Response was: \n" << ik_srv.response.solution);
       switch (error_code.val)
       {
-        // Debug mode for failure:
-        ROS_DEBUG_STREAM("Request was: \n" << ik_srv.request.ik_request);
-        ROS_DEBUG_STREAM("Response was: \n" << ik_srv.response.solution);
-
         case moveit_msgs::MoveItErrorCodes::FAILURE:
           ROS_ERROR_STREAM_NAMED("srv", "Service failed with with error code: FAILURE");
           break;

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -54,7 +54,7 @@ public:
     // model->printModelInfo(std::cout);
     std::vector<std::string> groups = model->getJointModelGroupNames();
     ROS_INFO_STREAM("Following groups exist:");
-    for (int i = 0; i < groups.size(); i++)
+    for (std::size_t i = 0; i < groups.size(); i++)
     {
       ROS_INFO("%s", groups[i].c_str());
       planning_contexts_[groups[i]] =

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -319,11 +319,11 @@ bool ChompOptimizer::optimize()
 {
   bool optimization_result = 0;
   ros::WallTime start_time = ros::WallTime::now();
-  double averageCostVelocity = 0.0;
-  int currentCostIter = 0;
+  // double averageCostVelocity = 0.0;
+  // int currentCostIter = 0;
   int costWindow = 10;
   std::vector<double> costs(costWindow, 0.0);
-  double minimaThreshold = 0.05;
+  // double minimaThreshold = 0.05;
   bool should_break_out = false;
 
   // iterate
@@ -373,9 +373,7 @@ bool ChompOptimizer::optimize()
       }
     }
     calculateSmoothnessIncrements();
-    ros::WallTime coll_time = ros::WallTime::now();
     calculateCollisionIncrements();
-    // ROS_INFO_STREAM("Collision increments took " << (ros::WallTime::now()-coll_time));
     calculateTotalIncrements();
 
     /// TODO: HMC BASED COMMENTED CODE BELOW, Need to uncomment and perform extensive testing by varying the HMC

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -68,7 +68,7 @@ ChompOptimizer::ChompOptimizer(ChompTrajectory* trajectory, const planning_scene
   planning_scene->getCollisionDetectorNames(cd_names);
 
   ROS_INFO_STREAM("The following collision detectors are active in the planning scene.");
-  for (int i = 0; i < cd_names.size(); i++)
+  for (std::size_t i = 0; i < cd_names.size(); i++)
   {
     ROS_INFO_STREAM(cd_names[i]);
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -174,7 +174,6 @@ void ChompTrajectory::fillInLinearInterpolation()
 {
   double start_index = start_index_ - 1;
   double end_index = end_index_ + 1;
-  int time_steps = end_index - start_index;
   for (int i = 0; i < num_joints_; i++)
   {
     double theta = ((*this)(end_index, i) - (*this)(start_index, i)) / (end_index - 1);

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -560,7 +560,6 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
         unsigned int isteps =
             std::min<unsigned int>(options.max_explicit_points, d / options.explicit_points_resolution);
         double step = 1.0 / (double)isteps;
-        double remain = 1.0;
         bool ok = true;
         space->interpolate(sstor->getState(i), sj, step, int_states[0]);
         for (unsigned int k = 1; k < isteps; ++k)

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -605,4 +605,5 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
     return sstor;
   }
+#warning "else case not yet handled: missing return value!"
 }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -126,7 +126,7 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
         if (vc > 0)
         {
           int idx = getJointModelGroup()->getVariableGroupIndex(v);
-          for (int q = 0; q < vc; ++q)
+          for (unsigned int q = 0; q < vc; ++q)
             j.push_back(idx + q);
         }
         else
@@ -369,7 +369,7 @@ void ompl_interface::ModelBasedPlanningContext::interpolateSolution()
 
     // Find the number of states that will be in the interpolated solution.
     // This is what interpolate() does internally.
-    int eventual_states = 1;
+    unsigned int eventual_states = 1;
     std::vector<ompl::base::State*> states = pg.getStates();
     for (size_t i = 0; i < states.size() - 1; i++)
     {

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -245,7 +245,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         int value_i;
-        if (nh_.getParam(group_name + "/" + k, value_d))
+        if (nh_.getParam(group_name + "/" + k, value_i))
         {
           specific_group_params[k] = std::to_string(value_i);
           continue;

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -291,7 +291,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         continue;
       }
 
-      for (std::size_t j = 0; j < config_names.size(); ++j)
+      for (int j = 0; j < config_names.size(); ++j)
       {
         if (config_names[j].getType() != XmlRpc::XmlRpcValue::TypeString)
         {

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -69,7 +69,7 @@ class ActionBasedControllerHandle : public ActionBasedControllerHandleBase
 {
 public:
   ActionBasedControllerHandle(const std::string& name, const std::string& ns)
-    : ActionBasedControllerHandleBase(name), namespace_(ns), done_(true), nh_("~")
+    : ActionBasedControllerHandleBase(name), nh_("~"), done_(true), namespace_(ns)
   {
     controller_action_client_.reset(new actionlib::SimpleActionClient<T>(getActionName(), true));
     unsigned int attempts = 0;

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -89,7 +89,7 @@ public:
       return false;
     }
 
-    std::vector<int> gripper_joint_indexes;
+    std::vector<std::size_t> gripper_joint_indexes;
     for (std::size_t i = 0; i < trajectory.joint_trajectory.joint_names.size(); ++i)
     {
       if (command_joints_.find(trajectory.joint_trajectory.joint_names[i]) != command_joints_.end())
@@ -120,7 +120,7 @@ public:
     // fill in goal from last point
     for (std::size_t i = 0; i < gripper_joint_indexes.size(); ++i)
     {
-      int idx = gripper_joint_indexes[i];
+      std::size_t idx = gripper_joint_indexes[i];
 
       if (trajectory.joint_trajectory.points[tpoint].positions.size() <= idx)
       {

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -593,7 +593,7 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string& filen
 
       if (strings.size() != 6)
       {
-        ROS_WARN_STREAM("Invalid number of workspace parameters. Expected 6, recieved " << strings.size());
+        ROS_WARN_STREAM("Invalid number of workspace parameters. Expected 6, received " << strings.size());
       }
       else if (declared_options["scene.workspace_frame"].empty())
       {
@@ -719,7 +719,7 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string& filen
         if (strings.size() != 3)
         {
           ROS_WARN_STREAM("Invalid sweep parameter for key "
-                          << sweep_var << ". Expected 3 values (start, iterator, end) but only recieved "
+                          << sweep_var << ". Expected 3 values (start, iterator, end) but only received "
                           << strings.size());
           continue;
         }

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -119,8 +119,7 @@ void BenchmarkExecutor::initialize(const std::vector<std::string>& plugin_classe
       planning_interface::PlannerManagerPtr p = planner_plugin_loader_->createUniqueInstance(plugin_classes[i]);
       p->initialize(planning_scene_->getRobotModel(), "");
 
-      const planning_interface::PlannerConfigurationMap& config_map = p->getPlannerConfigurations();
-
+      p->getPlannerConfigurations();
       planner_interfaces_[plugin_classes[i]] = p;
     }
     catch (pluginlib::PluginlibException& ex)
@@ -316,8 +315,6 @@ bool BenchmarkExecutor::initializeBenchmarks(const BenchmarkOptions& opts, movei
   std::vector<PathConstraints> goal_constraints;
   std::vector<TrajectoryConstraints> traj_constraints;
   std::vector<BenchmarkRequest> queries;
-
-  const std::string& group_name = opts.getGroupName();
 
   bool ok = loadPlanningScene(opts.getSceneName(), scene_msg) && loadStates(opts.getStartStateRegex(), start_states) &&
             loadPathConstraints(opts.getGoalConstraintRegex(), goal_constraints) &&

--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -251,7 +251,7 @@ void BenchmarkOptions::readPlannerConfigs(ros::NodeHandle& nh)
       return;
     }
 
-    for (std::size_t i = 0; i < planner_configs.size(); ++i)
+    for (int i = 0; i < planner_configs.size(); ++i)
     {
       if (planner_configs[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
       {
@@ -274,7 +274,7 @@ void BenchmarkOptions::readPlannerConfigs(ros::NodeHandle& nh)
       ROS_INFO("Reading in planner names for plugin '%s'", plugin.c_str());
 
       std::vector<std::string> planners;
-      for (std::size_t j = 0; j < planner_configs[i]["planners"].size(); ++j)
+      for (int j = 0; j < planner_configs[i]["planners"].size(); ++j)
         planners.push_back(planner_configs[i]["planners"][j]);
 
       for (std::size_t j = 0; j < planners.size(); ++j)

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -41,22 +41,6 @@
 
 namespace move_group
 {
-// These capabilities are loaded unless listed in disable_capabilities
-// clang-format off
-static const char* DEFAULT_CAPABILITIES[] = {
-   "move_group/MoveGroupCartesianPathService",
-   "move_group/MoveGroupKinematicsService",
-   "move_group/MoveGroupExecuteTrajectoryAction",
-   "move_group/MoveGroupMoveAction",
-   "move_group/MoveGroupPickPlaceAction",
-   "move_group/MoveGroupPlanService",
-   "move_group/MoveGroupQueryPlannersService",
-   "move_group/MoveGroupStateValidationService",
-   "move_group/MoveGroupGetPlanningSceneService",
-   "move_group/ApplyPlanningSceneService",
-   "move_group/ClearOctomapService",
-};
-// clang-format on
 
 static const std::string PLANNER_SERVICE_NAME =
     "plan_kinematic_path";  // name of the advertised service (within the ~ namespace)

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -41,7 +41,6 @@
 
 namespace move_group
 {
-
 static const std::string PLANNER_SERVICE_NAME =
     "plan_kinematic_path";  // name of the advertised service (within the ~ namespace)
 static const std::string EXECUTE_ACTION_NAME = "execute_trajectory";  // name of 'execute' action

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -57,7 +57,6 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
   // context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
-  bool solved = false;
   planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);
   try
   {

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -50,6 +50,24 @@ static const std::string ROBOT_DESCRIPTION =
 
 namespace move_group
 {
+
+// These capabilities are loaded unless listed in disable_capabilities
+// clang-format off
+static const char* DEFAULT_CAPABILITIES[] = {
+   "move_group/MoveGroupCartesianPathService",
+   "move_group/MoveGroupKinematicsService",
+   "move_group/MoveGroupExecuteTrajectoryAction",
+   "move_group/MoveGroupMoveAction",
+   "move_group/MoveGroupPickPlaceAction",
+   "move_group/MoveGroupPlanService",
+   "move_group/MoveGroupQueryPlannersService",
+   "move_group/MoveGroupStateValidationService",
+   "move_group/MoveGroupGetPlanningSceneService",
+   "move_group/ApplyPlanningSceneService",
+   "move_group/ClearOctomapService",
+};
+// clang-format on
+
 class MoveGroupExe
 {
 public:

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -50,7 +50,6 @@ static const std::string ROBOT_DESCRIPTION =
 
 namespace move_group
 {
-
 // These capabilities are loaded unless listed in disable_capabilities
 // clang-format off
 static const char* DEFAULT_CAPABILITIES[] = {

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -385,7 +385,6 @@ void mesh_filter::GLRenderer::createGLContext()
   if (contextIt == context_.end())
   {
     context_[threadID] = std::pair<unsigned, GLuint>(1, 0);
-    map<boost::thread::id, pair<unsigned, GLuint> >::iterator contextIt = context_.find(threadID);
 
     glutInitWindowPosition(glutGet(GLUT_SCREEN_WIDTH) + 30000, 0);
     glutInitWindowSize(1, 1);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -328,7 +328,7 @@ void MotionPlanningDisplay::updateBackgroundJobProgressBar()
   if (!frame_)
     return;
   QProgressBar* p = frame_->ui_->background_job_progress;
-  std::size_t n = background_process_.getJobCount();
+  int n = background_process_.getJobCount();
 
   if (n == 0)
   {
@@ -1105,7 +1105,7 @@ void MotionPlanningDisplay::populateMenuHandler(std::shared_ptr<interactive_mark
   // Commands for changing the state
   immh::EntryHandle menu_states =
       mh->insert(is_start ? "Set start state to" : "Set goal state to", immh::FeedbackCallback());
-  for (int i = 0; i < state_names.size(); ++i)
+  for (std::size_t i = 0; i < state_names.size(); ++i)
   {
     // Don't add "same as start" to the start state handler, and vice versa.
     if ((state_names[i] == "same as start" && is_start) || (state_names[i] == "same as goal" && !is_start))

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -207,7 +207,7 @@ void MotionPlanningFrame::approximateIKChanged(int state)
 void MotionPlanningFrame::setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list)
 {
   QList<QListWidgetItem*> found_items = list->findItems(QString(item_name.c_str()), Qt::MatchExactly);
-  for (std::size_t i = 0; i < found_items.size(); ++i)
+  for (int i = 0; i < found_items.size(); ++i)
     found_items[i]->setSelected(selection);
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -290,7 +290,8 @@ void MotionPlanningFrame::populatePlannersList(const moveit_msgs::PlannerInterfa
 
   bool found_group = false;
   // the name of a planner is either "GROUP[planner_id]" or "planner_id"
-  if (!group.empty()) {
+  if (!group.empty())
+  {
     for (std::size_t i = 0; i < desc.planner_ids.size(); ++i)
       if (desc.planner_ids[i] == group)
         found_group = true;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -290,7 +290,7 @@ void MotionPlanningFrame::populatePlannersList(const moveit_msgs::PlannerInterfa
 
   bool found_group = false;
   // the name of a planner is either "GROUP[planner_id]" or "planner_id"
-  if (!group.empty())
+  if (!group.empty()) {
     for (std::size_t i = 0; i < desc.planner_ids.size(); ++i)
       if (desc.planner_ids[i] == group)
         found_group = true;
@@ -306,6 +306,7 @@ void MotionPlanningFrame::populatePlannersList(const moveit_msgs::PlannerInterfa
           }
         }
       }
+  }
   if (ui_->planning_algorithm_combo_box->count() == 0 && !found_group)
     for (std::size_t i = 0; i < desc.planner_ids.size(); ++i)
       ui_->planning_algorithm_combo_box->addItem(QString::fromStdString(desc.planner_ids[i]));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -223,7 +223,7 @@ void MotionPlanningFrame::removeStateButtonClicked()
       case QMessageBox::Yes:
       {
         QList<QListWidgetItem*> found_items = ui_->list_states->selectedItems();
-        for (std::size_t i = 0; i < found_items.size(); ++i)
+        for (int i = 0; i < found_items.size(); ++i)
         {
           const std::string& name = found_items[i]->text().toStdString();
           try

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -384,7 +384,7 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       }
       else if (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible())
       {
-        if (trajectory_slider_panel_->getSliderPosition() >= displaying_trajectory_message_->getWayPointCount() - 1)
+        if (static_cast<unsigned int>(trajectory_slider_panel_->getSliderPosition()) >= displaying_trajectory_message_->getWayPointCount() - 1)
           return;  // nothing more to do
         else
           animating_path_ = true;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -59,11 +59,11 @@
 namespace moveit_rviz_plugin
 {
 TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::Display* display)
-  : display_(display)
-  , widget_(widget)
-  , animating_path_(false)
+  : animating_path_(false)
   , drop_displaying_trajectory_(false)
   , current_state_(-1)
+  , display_(display)
+  , widget_(widget)
   , trajectory_slider_panel_(NULL)
   , trajectory_slider_dock_panel_(NULL)
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -384,7 +384,8 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       }
       else if (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible())
       {
-        if (static_cast<unsigned int>(trajectory_slider_panel_->getSliderPosition()) >= displaying_trajectory_message_->getWayPointCount() - 1)
+        if (static_cast<unsigned int>(trajectory_slider_panel_->getSliderPosition()) >=
+            displaying_trajectory_message_->getWayPointCount() - 1)
           return;  // nothing more to do
         else
           animating_path_ = true;

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -48,7 +48,6 @@ static const std::string ROBOT_DESCRIPTION = "robot_description";
 bool storeState(moveit_msgs::SaveRobotStateToWarehouse::Request& request,
                 moveit_msgs::SaveRobotStateToWarehouse::Response& response, moveit_warehouse::RobotStateStorage* rs)
 {
-  const moveit_msgs::RobotState& state = request.state;
   if (request.name.empty())
   {
     ROS_ERROR("You must specify a name to store a state");

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -51,10 +51,10 @@ bool storeState(moveit_msgs::SaveRobotStateToWarehouse::Request& request,
   if (request.name.empty())
   {
     ROS_ERROR("You must specify a name to store a state");
-    return response.success = false;
+    return (response.success = false);
   }
   rs->addRobotState(request.state, request.name, request.robot);
-  return response.success = true;
+  return (response.success = true);
 }
 
 bool listStates(moveit_msgs::ListRobotStatesInWarehouse::Request& request,

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1164,7 +1164,7 @@ bool MoveItConfigData::inputOMPLYAML(const std::string& file_path)
       {
         std::string planner;
         parse(group_it->second, "default_planner_config", planner);
-        int pos = planner.find_last_not_of("kConfigDefault");
+        std::size_t pos = planner.find_last_not_of("kConfigDefault");
         if (pos != std::string::npos)
         {
           planner = planner.substr(0, pos + 1);

--- a/moveit_setup_assistant/src/widgets/author_information_widget.h
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.h
@@ -61,7 +61,7 @@ public:
 
   AuthorInformationWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -741,7 +741,7 @@ bool ConfigurationFilesWidget::checkGenFiles()
 
   // Check all old file's modification time
   bool found_modified = false;
-  for (int i = 0; i < gen_files_.size(); ++i)
+  for (std::size_t i = 0; i < gen_files_.size(); ++i)
   {
     GenerateFile* file = &gen_files_[i];
 
@@ -932,7 +932,7 @@ bool ConfigurationFilesWidget::generatePackage()
   // Begin to create files and folders ----------------------------------------------------------------------
   std::string absolute_path;
 
-  for (int i = 0; i < gen_files_.size(); ++i)
+  for (std::size_t i = 0; i < gen_files_.size(); ++i)
   {
     GenerateFile* file = &gen_files_[i];
 
@@ -1151,7 +1151,7 @@ bool ConfigurationFilesWidget::copyTemplate(const std::string& template_path, co
   template_stream.close();
 
   // Replace keywords in string ------------------------------------------------------------
-  for (int i = 0; i < template_strings_.size(); ++i)
+  for (std::size_t i = 0; i < template_strings_.size(); ++i)
   {
     boost::replace_all(template_string, template_strings_[i].first, template_strings_[i].second);
   }

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.h
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.h
@@ -84,7 +84,7 @@ public:
 
   ConfigurationFilesWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -57,7 +57,7 @@ namespace moveit_setup_assistant
 // User interface for editing the default collision matrix list in an SRDF
 // ******************************************************************************************
 DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, MoveItConfigDataPtr config_data)
-  : SetupScreenWidget(parent), worker_(NULL), config_data_(config_data), model_(NULL), selection_model_(NULL)
+  : SetupScreenWidget(parent), model_(NULL), selection_model_(NULL), worker_(NULL), config_data_(config_data)
 {
   // Basic widget container
   layout_ = new QVBoxLayout(this);

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.h
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.h
@@ -71,7 +71,7 @@ public:
 
   EndEffectorsWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -114,7 +114,6 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, moveit_setup_assistant::MoveIt
   layout->setAlignment(Qt::AlignTop);
 
   // New Group Options  ---------------------------------------------------------
-  QWidget* labels_widget = new QWidget();
   new_buttons_widget_ = new QWidget();
 
   QVBoxLayout* new_buttons_layout_container = new QVBoxLayout();

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -345,7 +345,7 @@ void GroupEditWidget::loadKinematicPlannersComboBox()
   }
 
   std::vector<OMPLPlannerDescription> planners = config_data_->getOMPLPlanners();
-  for (int i = 0; i < planners.size(); ++i)
+  for (std::size_t i = 0; i < planners.size(); ++i)
   {
     std::string planner_name = planners[i].name_;
     default_planner_field_->addItem(planner_name.c_str());

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
@@ -130,7 +130,7 @@ void PassiveJointsWidget::previewSelectedJoints(std::vector<std::string> joints)
   // Unhighlight all links
   Q_EMIT unhighlightAll();
 
-  for (int i = 0; i < joints.size(); ++i)
+  for (std::size_t i = 0; i < joints.size(); ++i)
   {
     const robot_model::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joints[i]);
 

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.h
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.h
@@ -70,7 +70,7 @@ public:
 
   PassiveJointsWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -188,7 +188,7 @@ PerceptionWidget::PerceptionWidget(QWidget* parent, moveit_setup_assistant::Move
 }
 
 // ******************************************************************************************
-// Recieved when this widget is chosen from the navigation menu
+// Received when this widget is chosen from the navigation menu
 // ******************************************************************************************
 void PerceptionWidget::focusGiven()
 {
@@ -196,7 +196,7 @@ void PerceptionWidget::focusGiven()
 }
 
 // ******************************************************************************************
-// Recieved when another widget is chosen from the navigation menu
+// Received when another widget is chosen from the navigation menu
 // ******************************************************************************************
 bool PerceptionWidget::focusLost()
 {

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -255,6 +255,7 @@ bool PerceptionWidget::focusLost()
     config_data_->clearSensorPluginConfig();
     config_data_->changes ^= MoveItConfigData::SENSORS_CONFIG;
   }
+  return true;
 }
 
 void PerceptionWidget::sensorPluginChanged(int index)

--- a/moveit_setup_assistant/src/widgets/perception_widget.h
+++ b/moveit_setup_assistant/src/widgets/perception_widget.h
@@ -67,10 +67,10 @@ public:
 
   PerceptionWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
-  /// Recieved when another widget is chosen from the navigation menu
+  /// Received when another widget is chosen from the navigation menu
   virtual bool focusLost();
 
   /// Populate the combo dropdown box with sensor plugins

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1437,7 +1437,7 @@ void PlanningGroupsWidget::previewSelectedLink(std::vector<std::string> links)
   // Unhighlight all links
   Q_EMIT unhighlightAll();
 
-  for (int i = 0; i < links.size(); ++i)
+  for (std::size_t i = 0; i < links.size(); ++i)
   {
     if (links[i].empty())
     {
@@ -1457,7 +1457,7 @@ void PlanningGroupsWidget::previewSelectedJoints(std::vector<std::string> joints
   // Unhighlight all links
   Q_EMIT unhighlightAll();
 
-  for (int i = 0; i < joints.size(); ++i)
+  for (std::size_t i = 0; i < joints.size(); ++i)
   {
     const robot_model::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joints[i]);
 
@@ -1488,7 +1488,7 @@ void PlanningGroupsWidget::previewSelectedSubgroup(std::vector<std::string> grou
   // Unhighlight all links
   Q_EMIT unhighlightAll();
 
-  for (int i = 0; i < groups.size(); ++i)
+  for (std::size_t i = 0; i < groups.size(); ++i)
   {
     // Highlight group
     Q_EMIT highlightGroup(groups[i]);

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1010,7 +1010,6 @@ void PlanningGroupsWidget::saveSubgroupsScreen()
 
   // Create the empty graph
   typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS> Graph;
-  typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
   Graph g(group_nodes.size());
 
   // Traverse the group list again, this time inserting subgroups into graph

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.h
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.h
@@ -86,7 +86,7 @@ public:
 
   void changeScreen(int index);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
 private Q_SLOTS:

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.h
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.h
@@ -73,7 +73,7 @@ public:
 
   RobotPosesWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.h
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.h
@@ -71,7 +71,7 @@ public:
 
   void changeScreen(int index);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
 private Q_SLOTS:

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -398,7 +398,7 @@ void SetupAssistantWidget::loadRviz()
 
   rviz_manager_->addDisplay(robot_state_display_, true);
 
-  // Set the topic on which the moveit_msgs::PlanningScene messages are recieved
+  // Set the topic on which the moveit_msgs::PlanningScene messages are received
   robot_state_display_->subProp("Robot State Topic")->setValue(QString::fromStdString(MOVEIT_ROBOT_STATE));
 
   // Set robot description

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.h
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.h
@@ -69,7 +69,7 @@ public:
 
   VirtualJointsWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
-  /// Recieved when this widget is chosen from the navigation menu
+  /// Received when this widget is chosen from the navigation menu
   virtual void focusGiven();
 
   // ******************************************************************************************


### PR DESCRIPTION
This PR attempt to fix most compiler warnings in the current melodic-devel branch - there are too many now. I grouped the commits according to types of compiler warnings:
- unused variables / names
- comparison between signed and unsigned
- fix member initialization (typically order)

Fixing those warnings also revealed some errors in the code ;-)
