### PR TITLE
Fix some alignment issuses due to missing aligned allocation

### DIFF
--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -448,8 +448,8 @@ public:
   }
 
 private:
+  /** Typedef for set of integer indices */
   typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> VoxelSet;
-  /**< \brief Typedef for set of integer indices */
   /**
    * \brief Initializes the field, resetting the voxel grid and
    * building a sqrt lookup table for efficiency based on

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -53,7 +53,7 @@ namespace distance_field
  */
 struct compareEigen_Vector3i
 {
-  bool operator()(Eigen::Vector3i loc_1, Eigen::Vector3i loc_2) const
+  bool operator()(const Eigen::Vector3i& loc_1, const Eigen::Vector3i& loc_2) const
   {
     if (loc_1.z() != loc_2.z())
       return (loc_1.z() < loc_2.z());
@@ -102,6 +102,7 @@ struct PropDistanceFieldVoxel
                                      propagation*/
 
   static const int UNINITIALIZED = -1; /**< \brief Value that represents an unitialized voxel */
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 /**
@@ -441,9 +442,9 @@ public:
     return max_distance_sq_;
   }
 
+  typedef std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> StlVectorEigenVector3i;
 private:
-  typedef std::set<Eigen::Vector3i, compareEigen_Vector3i> VoxelSet; /**< \brief Typedef for set of integer indices */
-
+  typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> VoxelSet; /**< \brief Typedef for set of integer indices */
   /**
    * \brief Initializes the field, resetting the voxel grid and
    * building a sqrt lookup table for efficiency based on
@@ -457,14 +458,14 @@ private:
    *
    * @param voxel_points Valid set of voxel points for addition
    */
-  void addNewObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points);
+  void addNewObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
 
   /**
    * \brief Removes a valid set of integer points from the voxel grid
    *
    * @param voxel_points Valid set of voxel points for removal
    */
-  void removeObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points);
+  void removeObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
 
   /**
    * \brief Propagates outward to the maximum distance given the
@@ -549,12 +550,12 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<std::vector<Eigen::Vector3i> > bucket_queue_; /**< \brief Data member that holds points from which to
+  std::vector<StlVectorEigenVector3i > bucket_queue_; /**< \brief Data member that holds points from which to
                                                                propagate, where each vector holds points that are a
                                                                particular integer distance from the closest obstacle
                                                                points*/
 
-  std::vector<std::vector<Eigen::Vector3i> > negative_bucket_queue_; /**< \brief Data member that holds points from
+  std::vector<StlVectorEigenVector3i > negative_bucket_queue_; /**< \brief Data member that holds points from
                                                                         which to propagate in the negative, where each
                                                                         vector holds points that are a particular
                                                                         integer distance from the closest unoccupied
@@ -577,9 +578,9 @@ private:
    *
    */
 
-  std::vector<std::vector<std::vector<Eigen::Vector3i> > > neighborhoods_;
+  std::vector<std::vector<StlVectorEigenVector3i > > neighborhoods_;
 
-  std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
+ StlVectorEigenVector3i direction_number_to_direction_; /**< \brief Holds conversion from direction number to
                                                                   integer changes */
 };
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -551,16 +551,16 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<std::vector<Eigen::Vector3i> > bucket_queue_; /**< \brief Data member that holds points from which to
-                                                               propagate, where each vector holds points that are a
-                                                               particular integer distance from the closest obstacle
-                                                               points*/
+  std::vector<std::vector<Eigen::Vector3i>> bucket_queue_; /**< \brief Data member that holds points from which to
+                                                              propagate, where each vector holds points that are a
+                                                              particular integer distance from the closest obstacle
+                                                              points*/
 
-  std::vector<std::vector<Eigen::Vector3i> > negative_bucket_queue_; /**< \brief Data member that holds points from
-                                                                        which to propagate in the negative, where each
-                                                                        vector holds points that are a particular
-                                                                        integer distance from the closest unoccupied
-                                                                        points*/
+  std::vector<std::vector<Eigen::Vector3i>> negative_bucket_queue_; /**< \brief Data member that holds points from
+                                                                       which to propagate in the negative, where each
+                                                                       vector holds points that are a particular
+                                                                       integer distance from the closest unoccupied
+                                                                       points*/
 
   double max_distance_; /**< \brief Holds maximum distance  */
   int max_distance_sq_; /**< \brief Holds maximum distance squared in cells */
@@ -579,10 +579,10 @@ private:
    *
    */
 
-  std::vector<std::vector<std::vector<Eigen::Vector3i> > > neighborhoods_;
+  std::vector<std::vector<std::vector<Eigen::Vector3i>>> neighborhoods_;
 
- std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
-                                                                  integer changes */
+  std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
+                                                                   integer changes */
 };
 
 ////////////////////////// inline functions follow ////////////////////////////////////////

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -42,11 +42,8 @@
 #include <vector>
 #include <list>
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 #include <set>
 #include <octomap/octomap.h>
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::Vector3i)
-
 namespace distance_field
 {
 /**
@@ -443,15 +440,17 @@ public:
   {
     return max_distance_sq_;
   }
+  typedef std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> StlVectorEigenVector3i;
 
 private:
-  typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> VoxelSet; /**< \brief Typedef for set of integer indices */
-  /**
-   * \brief Initializes the field, resetting the voxel grid and
-   * building a sqrt lookup table for efficiency based on
-   * max_distance_.
-   *
-   */
+  typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>>
+      VoxelSet; /**< \brief Typedef for set of integer indices */
+                /**
+                 * \brief Initializes the field, resetting the voxel grid and
+                 * building a sqrt lookup table for efficiency based on
+                 * max_distance_.
+                 *
+                 */
   void initialize();
 
   /**
@@ -459,14 +458,14 @@ private:
    *
    * @param voxel_points Valid set of voxel points for addition
    */
-  void addNewObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points);
+  void addNewObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
 
   /**
    * \brief Removes a valid set of integer points from the voxel grid
    *
    * @param voxel_points Valid set of voxel points for removal
    */
-  void removeObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points);
+  void removeObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
 
   /**
    * \brief Propagates outward to the maximum distance given the
@@ -551,12 +550,12 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<std::vector<Eigen::Vector3i>> bucket_queue_; /**< \brief Data member that holds points from which to
+  std::vector<StlVectorEigenVector3i> bucket_queue_; /**< \brief Data member that holds points from which to
                                                               propagate, where each vector holds points that are a
                                                               particular integer distance from the closest obstacle
                                                               points*/
 
-  std::vector<std::vector<Eigen::Vector3i>> negative_bucket_queue_; /**< \brief Data member that holds points from
+  std::vector<StlVectorEigenVector3i> negative_bucket_queue_; /**< \brief Data member that holds points from
                                                                        which to propagate in the negative, where each
                                                                        vector holds points that are a particular
                                                                        integer distance from the closest unoccupied
@@ -579,9 +578,9 @@ private:
    *
    */
 
-  std::vector<std::vector<std::vector<Eigen::Vector3i>>> neighborhoods_;
+  std::vector<std::vector<StlVectorEigenVector3i>> neighborhoods_;
 
-  std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
+  StlVectorEigenVector3i direction_number_to_direction_; /**< \brief Holds conversion from direction number to
                                                                   integer changes */
 };
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -551,16 +551,16 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<std::vector<Eigen::Vector3i> > bucket_queue_; /**< \brief Data member that holds points from which to
-                                                               propagate, where each vector holds points that are a
-                                                               particular integer distance from the closest obstacle
-                                                               points*/
+  std::vector<std::vector<Eigen::Vector3i>> bucket_queue_; /**< \brief Data member that holds points from which to
+                                                              propagate, where each vector holds points that are a
+                                                              particular integer distance from the closest obstacle
+                                                              points*/
 
-  std::vector<std::vector<Eigen::Vector3i> > negative_bucket_queue_; /**< \brief Data member that holds points from
-                                                                        which to propagate in the negative, where each
-                                                                        vector holds points that are a particular
-                                                                        integer distance from the closest unoccupied
-                                                                        points*/
+  std::vector<std::vector<Eigen::Vector3i>> negative_bucket_queue_; /**< \brief Data member that holds points from
+                                                                       which to propagate in the negative, where each
+                                                                       vector holds points that are a particular
+                                                                       integer distance from the closest unoccupied
+                                                                       points*/
 
   double max_distance_; /**< \brief Holds maximum distance  */
   int max_distance_sq_; /**< \brief Holds maximum distance squared in cells */
@@ -579,7 +579,7 @@ private:
    *
    */
 
-  std::vector<std::vector<std::vector<Eigen::Vector3i> > > neighborhoods_;
+  std::vector<std::vector<std::vector<Eigen::Vector3i>>> neighborhoods_;
 
   std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
                                                                   integer changes */

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -42,8 +42,10 @@
 #include <vector>
 #include <list>
 #include <Eigen/Core>
+#include <Eigen/StdVector>
 #include <set>
 #include <octomap/octomap.h>
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::Vector3i)
 
 namespace distance_field
 {
@@ -442,7 +444,6 @@ public:
     return max_distance_sq_;
   }
 
-  typedef std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> StlVectorEigenVector3i;
 private:
   typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> VoxelSet; /**< \brief Typedef for set of integer indices */
   /**
@@ -458,14 +459,14 @@ private:
    *
    * @param voxel_points Valid set of voxel points for addition
    */
-  void addNewObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
+  void addNewObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points);
 
   /**
    * \brief Removes a valid set of integer points from the voxel grid
    *
    * @param voxel_points Valid set of voxel points for removal
    */
-  void removeObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
+  void removeObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points);
 
   /**
    * \brief Propagates outward to the maximum distance given the
@@ -550,12 +551,12 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<StlVectorEigenVector3i > bucket_queue_; /**< \brief Data member that holds points from which to
+  std::vector<std::vector<Eigen::Vector3i> > bucket_queue_; /**< \brief Data member that holds points from which to
                                                                propagate, where each vector holds points that are a
                                                                particular integer distance from the closest obstacle
                                                                points*/
 
-  std::vector<StlVectorEigenVector3i > negative_bucket_queue_; /**< \brief Data member that holds points from
+  std::vector<std::vector<Eigen::Vector3i> > negative_bucket_queue_; /**< \brief Data member that holds points from
                                                                         which to propagate in the negative, where each
                                                                         vector holds points that are a particular
                                                                         integer distance from the closest unoccupied
@@ -578,9 +579,9 @@ private:
    *
    */
 
-  std::vector<std::vector<StlVectorEigenVector3i > > neighborhoods_;
+  std::vector<std::vector<std::vector<Eigen::Vector3i> > > neighborhoods_;
 
- StlVectorEigenVector3i direction_number_to_direction_; /**< \brief Holds conversion from direction number to
+ std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
                                                                   integer changes */
 };
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -44,6 +44,12 @@
 #include <Eigen/Core>
 #include <set>
 #include <octomap/octomap.h>
+
+namespace EigenSTL
+{
+typedef std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> vector_Vector3i;
+}
+
 namespace distance_field
 {
 /**
@@ -440,17 +446,16 @@ public:
   {
     return max_distance_sq_;
   }
-  typedef std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> StlVectorEigenVector3i;
 
 private:
-  typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>>
-      VoxelSet; /**< \brief Typedef for set of integer indices */
-                /**
-                 * \brief Initializes the field, resetting the voxel grid and
-                 * building a sqrt lookup table for efficiency based on
-                 * max_distance_.
-                 *
-                 */
+  typedef std::set<Eigen::Vector3i, compareEigen_Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> VoxelSet;
+  /**< \brief Typedef for set of integer indices */
+  /**
+   * \brief Initializes the field, resetting the voxel grid and
+   * building a sqrt lookup table for efficiency based on
+   * max_distance_.
+   *
+   */
   void initialize();
 
   /**
@@ -458,14 +463,14 @@ private:
    *
    * @param voxel_points Valid set of voxel points for addition
    */
-  void addNewObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
+  void addNewObstacleVoxels(const EigenSTL::vector_Vector3i& voxel_points);
 
   /**
    * \brief Removes a valid set of integer points from the voxel grid
    *
    * @param voxel_points Valid set of voxel points for removal
    */
-  void removeObstacleVoxels(const StlVectorEigenVector3i& voxel_points);
+  void removeObstacleVoxels(const EigenSTL::vector_Vector3i& voxel_points);
 
   /**
    * \brief Propagates outward to the maximum distance given the
@@ -550,12 +555,12 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<StlVectorEigenVector3i> bucket_queue_; /**< \brief Data member that holds points from which to
+  std::vector<EigenSTL::vector_Vector3i> bucket_queue_; /**< \brief Data member that holds points from which to
                                                               propagate, where each vector holds points that are a
                                                               particular integer distance from the closest obstacle
                                                               points*/
 
-  std::vector<StlVectorEigenVector3i> negative_bucket_queue_; /**< \brief Data member that holds points from
+  std::vector<EigenSTL::vector_Vector3i> negative_bucket_queue_; /**< \brief Data member that holds points from
                                                                        which to propagate in the negative, where each
                                                                        vector holds points that are a particular
                                                                        integer distance from the closest unoccupied
@@ -578,9 +583,9 @@ private:
    *
    */
 
-  std::vector<std::vector<StlVectorEigenVector3i>> neighborhoods_;
+  std::vector<std::vector<EigenSTL::vector_Vector3i>> neighborhoods_;
 
-  StlVectorEigenVector3i direction_number_to_direction_; /**< \brief Holds conversion from direction number to
+  EigenSTL::vector_Vector3i direction_number_to_direction_; /**< \brief Holds conversion from direction number to
                                                                   integer changes */
 };
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -551,16 +551,16 @@ private:
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */
 
   /// \brief Structure used to hold propagation frontier
-  std::vector<std::vector<Eigen::Vector3i>> bucket_queue_; /**< \brief Data member that holds points from which to
-                                                              propagate, where each vector holds points that are a
-                                                              particular integer distance from the closest obstacle
-                                                              points*/
+  std::vector<std::vector<Eigen::Vector3i> > bucket_queue_; /**< \brief Data member that holds points from which to
+                                                               propagate, where each vector holds points that are a
+                                                               particular integer distance from the closest obstacle
+                                                               points*/
 
-  std::vector<std::vector<Eigen::Vector3i>> negative_bucket_queue_; /**< \brief Data member that holds points from
-                                                                       which to propagate in the negative, where each
-                                                                       vector holds points that are a particular
-                                                                       integer distance from the closest unoccupied
-                                                                       points*/
+  std::vector<std::vector<Eigen::Vector3i> > negative_bucket_queue_; /**< \brief Data member that holds points from
+                                                                        which to propagate in the negative, where each
+                                                                        vector holds points that are a particular
+                                                                        integer distance from the closest unoccupied
+                                                                        points*/
 
   double max_distance_; /**< \brief Holds maximum distance  */
   int max_distance_sq_; /**< \brief Holds maximum distance squared in cells */
@@ -579,10 +579,10 @@ private:
    *
    */
 
-  std::vector<std::vector<std::vector<Eigen::Vector3i>>> neighborhoods_;
+  std::vector<std::vector<std::vector<Eigen::Vector3i> > > neighborhoods_;
 
   std::vector<Eigen::Vector3i> direction_number_to_direction_; /**< \brief Holds conversion from direction number to
-                                                                   integer changes */
+                                                                  integer changes */
 };
 
 ////////////////////////// inline functions follow ////////////////////////////////////////

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -152,15 +152,15 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
   }
   compareEigen_Vector3i comp;
 
-  std::vector<Eigen::Vector3i> old_not_new;
+  StlVectorEigenVector3i old_not_new;
   std::set_difference(old_point_set.begin(), old_point_set.end(), new_point_set.begin(), new_point_set.end(),
                       std::inserter(old_not_new, old_not_new.end()), comp);
 
-  std::vector<Eigen::Vector3i> new_not_old;
+  StlVectorEigenVector3i new_not_old;
   std::set_difference(new_point_set.begin(), new_point_set.end(), old_point_set.begin(), old_point_set.end(),
                       std::inserter(new_not_old, new_not_old.end()), comp);
 
-  std::vector<Eigen::Vector3i> new_not_in_current;
+  StlVectorEigenVector3i new_not_in_current;
   for (unsigned int i = 0; i < new_not_old.size(); i++)
   {
     if (voxel_grid_->getCell(new_not_old[i].x(), new_not_old[i].y(), new_not_old[i].z()).distance_square_ != 0)
@@ -184,7 +184,7 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
 
 void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d& points)
 {
-  std::vector<Eigen::Vector3i> voxel_points;
+  StlVectorEigenVector3i voxel_points;
 
   for (unsigned int i = 0; i < points.size(); i++)
   {
@@ -205,7 +205,7 @@ void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d&
 
 void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vector3d& points)
 {
-  std::vector<Eigen::Vector3i> voxel_points;
+  StlVectorEigenVector3i voxel_points;
   // VoxelSet voxel_locs;
 
   for (unsigned int i = 0; i < points.size(); i++)
@@ -226,11 +226,11 @@ void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vect
   removeObstacleVoxels(voxel_points);
 }
 
-void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points)
+void PropagationDistanceField::addNewObstacleVoxels(const StlVectorEigenVector3i& voxel_points)
 {
   int initial_update_direction = getDirectionNumber(0, 0, 0);
   bucket_queue_[0].reserve(voxel_points.size());
-  std::vector<Eigen::Vector3i> negative_stack;
+  StlVectorEigenVector3i negative_stack;
   if (propagate_negative_)
   {
     negative_stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -308,11 +308,11 @@ void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vec
   }
 }
 
-void PropagationDistanceField::removeObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points)
+void PropagationDistanceField::removeObstacleVoxels(const StlVectorEigenVector3i& voxel_points)
 // const VoxelSet& locations )
 {
-  std::vector<Eigen::Vector3i> stack;
-  std::vector<Eigen::Vector3i> negative_stack;
+  StlVectorEigenVector3i stack;
+  StlVectorEigenVector3i negative_stack;
   int initial_update_direction = getDirectionNumber(0, 0, 0);
 
   stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -400,15 +400,15 @@ void PropagationDistanceField::propagatePositive()
   // now process the queue:
   for (unsigned int i = 0; i < bucket_queue_.size(); ++i)
   {
-    std::vector<Eigen::Vector3i>::iterator list_it = bucket_queue_[i].begin();
-    std::vector<Eigen::Vector3i>::iterator list_end = bucket_queue_[i].end();
+    StlVectorEigenVector3i::iterator list_it = bucket_queue_[i].begin();
+    StlVectorEigenVector3i::iterator list_end = bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-      std::vector<Eigen::Vector3i>* neighborhood;
+      StlVectorEigenVector3i* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -458,15 +458,15 @@ void PropagationDistanceField::propagateNegative()
   // now process the queue:
   for (unsigned int i = 0; i < negative_bucket_queue_.size(); ++i)
   {
-    std::vector<Eigen::Vector3i>::iterator list_it = negative_bucket_queue_[i].begin();
-    std::vector<Eigen::Vector3i>::iterator list_end = negative_bucket_queue_[i].end();
+    StlVectorEigenVector3i::iterator list_it = negative_bucket_queue_[i].begin();
+    StlVectorEigenVector3i::iterator list_end = negative_bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-      std::vector<Eigen::Vector3i>* neighborhood;
+      StlVectorEigenVector3i* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -741,7 +741,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
 
   // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
 
-  std::vector<Eigen::Vector3i> obs_points;
+  StlVectorEigenVector3i obs_points;
   for (unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++)
   {
     for (unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++)

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -152,15 +152,15 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
   }
   compareEigen_Vector3i comp;
 
-  std::vector<Eigen::Vector3i> old_not_new;
+ StlVectorEigenVector3i old_not_new;
   std::set_difference(old_point_set.begin(), old_point_set.end(), new_point_set.begin(), new_point_set.end(),
                       std::inserter(old_not_new, old_not_new.end()), comp);
 
-  std::vector<Eigen::Vector3i> new_not_old;
+ StlVectorEigenVector3i new_not_old;
   std::set_difference(new_point_set.begin(), new_point_set.end(), old_point_set.begin(), old_point_set.end(),
                       std::inserter(new_not_old, new_not_old.end()), comp);
 
-  std::vector<Eigen::Vector3i> new_not_in_current;
+ StlVectorEigenVector3i new_not_in_current;
   for (unsigned int i = 0; i < new_not_old.size(); i++)
   {
     if (voxel_grid_->getCell(new_not_old[i].x(), new_not_old[i].y(), new_not_old[i].z()).distance_square_ != 0)
@@ -184,7 +184,7 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
 
 void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d& points)
 {
-  std::vector<Eigen::Vector3i> voxel_points;
+ StlVectorEigenVector3i voxel_points;
 
   for (unsigned int i = 0; i < points.size(); i++)
   {
@@ -205,7 +205,7 @@ void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d&
 
 void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vector3d& points)
 {
-  std::vector<Eigen::Vector3i> voxel_points;
+ StlVectorEigenVector3i voxel_points;
   // VoxelSet voxel_locs;
 
   for (unsigned int i = 0; i < points.size(); i++)
@@ -226,11 +226,11 @@ void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vect
   removeObstacleVoxels(voxel_points);
 }
 
-void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points)
+void PropagationDistanceField::addNewObstacleVoxels(const StlVectorEigenVector3i &voxel_points)
 {
   int initial_update_direction = getDirectionNumber(0, 0, 0);
   bucket_queue_[0].reserve(voxel_points.size());
-  std::vector<Eigen::Vector3i> negative_stack;
+ StlVectorEigenVector3i negative_stack;
   if (propagate_negative_)
   {
     negative_stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -308,11 +308,11 @@ void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vec
   }
 }
 
-void PropagationDistanceField::removeObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points)
+void PropagationDistanceField::removeObstacleVoxels(const StlVectorEigenVector3i &voxel_points)
 // const VoxelSet& locations )
 {
-  std::vector<Eigen::Vector3i> stack;
-  std::vector<Eigen::Vector3i> negative_stack;
+ StlVectorEigenVector3i stack;
+ StlVectorEigenVector3i negative_stack;
   int initial_update_direction = getDirectionNumber(0, 0, 0);
 
   stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -400,15 +400,15 @@ void PropagationDistanceField::propagatePositive()
   // now process the queue:
   for (unsigned int i = 0; i < bucket_queue_.size(); ++i)
   {
-    std::vector<Eigen::Vector3i>::iterator list_it = bucket_queue_[i].begin();
-    std::vector<Eigen::Vector3i>::iterator list_end = bucket_queue_[i].end();
+   StlVectorEigenVector3i::iterator list_it = bucket_queue_[i].begin();
+   StlVectorEigenVector3i::iterator list_end = bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-      std::vector<Eigen::Vector3i>* neighborhood;
+     StlVectorEigenVector3i* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -458,15 +458,15 @@ void PropagationDistanceField::propagateNegative()
   // now process the queue:
   for (unsigned int i = 0; i < negative_bucket_queue_.size(); ++i)
   {
-    std::vector<Eigen::Vector3i>::iterator list_it = negative_bucket_queue_[i].begin();
-    std::vector<Eigen::Vector3i>::iterator list_end = negative_bucket_queue_[i].end();
+   StlVectorEigenVector3i::iterator list_it = negative_bucket_queue_[i].begin();
+   StlVectorEigenVector3i::iterator list_end = negative_bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-      std::vector<Eigen::Vector3i>* neighborhood;
+     StlVectorEigenVector3i* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -741,7 +741,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
 
   // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
 
-  std::vector<Eigen::Vector3i> obs_points;
+ StlVectorEigenVector3i obs_points;
   for (unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++)
   {
     for (unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++)

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -152,15 +152,15 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
   }
   compareEigen_Vector3i comp;
 
-  StlVectorEigenVector3i old_not_new;
+  EigenSTL::vector_Vector3i old_not_new;
   std::set_difference(old_point_set.begin(), old_point_set.end(), new_point_set.begin(), new_point_set.end(),
                       std::inserter(old_not_new, old_not_new.end()), comp);
 
-  StlVectorEigenVector3i new_not_old;
+  EigenSTL::vector_Vector3i new_not_old;
   std::set_difference(new_point_set.begin(), new_point_set.end(), old_point_set.begin(), old_point_set.end(),
                       std::inserter(new_not_old, new_not_old.end()), comp);
 
-  StlVectorEigenVector3i new_not_in_current;
+  EigenSTL::vector_Vector3i new_not_in_current;
   for (unsigned int i = 0; i < new_not_old.size(); i++)
   {
     if (voxel_grid_->getCell(new_not_old[i].x(), new_not_old[i].y(), new_not_old[i].z()).distance_square_ != 0)
@@ -184,7 +184,7 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
 
 void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d& points)
 {
-  StlVectorEigenVector3i voxel_points;
+  EigenSTL::vector_Vector3i voxel_points;
 
   for (unsigned int i = 0; i < points.size(); i++)
   {
@@ -205,7 +205,7 @@ void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d&
 
 void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vector3d& points)
 {
-  StlVectorEigenVector3i voxel_points;
+  EigenSTL::vector_Vector3i voxel_points;
   // VoxelSet voxel_locs;
 
   for (unsigned int i = 0; i < points.size(); i++)
@@ -226,11 +226,11 @@ void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vect
   removeObstacleVoxels(voxel_points);
 }
 
-void PropagationDistanceField::addNewObstacleVoxels(const StlVectorEigenVector3i& voxel_points)
+void PropagationDistanceField::addNewObstacleVoxels(const EigenSTL::vector_Vector3i& voxel_points)
 {
   int initial_update_direction = getDirectionNumber(0, 0, 0);
   bucket_queue_[0].reserve(voxel_points.size());
-  StlVectorEigenVector3i negative_stack;
+  EigenSTL::vector_Vector3i negative_stack;
   if (propagate_negative_)
   {
     negative_stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -308,11 +308,11 @@ void PropagationDistanceField::addNewObstacleVoxels(const StlVectorEigenVector3i
   }
 }
 
-void PropagationDistanceField::removeObstacleVoxels(const StlVectorEigenVector3i& voxel_points)
+void PropagationDistanceField::removeObstacleVoxels(const EigenSTL::vector_Vector3i& voxel_points)
 // const VoxelSet& locations )
 {
-  StlVectorEigenVector3i stack;
-  StlVectorEigenVector3i negative_stack;
+  EigenSTL::vector_Vector3i stack;
+  EigenSTL::vector_Vector3i negative_stack;
   int initial_update_direction = getDirectionNumber(0, 0, 0);
 
   stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -400,15 +400,15 @@ void PropagationDistanceField::propagatePositive()
   // now process the queue:
   for (unsigned int i = 0; i < bucket_queue_.size(); ++i)
   {
-    StlVectorEigenVector3i::iterator list_it = bucket_queue_[i].begin();
-    StlVectorEigenVector3i::iterator list_end = bucket_queue_[i].end();
+    EigenSTL::vector_Vector3i::iterator list_it = bucket_queue_[i].begin();
+    EigenSTL::vector_Vector3i::iterator list_end = bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-      StlVectorEigenVector3i* neighborhood;
+      EigenSTL::vector_Vector3i* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -458,15 +458,15 @@ void PropagationDistanceField::propagateNegative()
   // now process the queue:
   for (unsigned int i = 0; i < negative_bucket_queue_.size(); ++i)
   {
-    StlVectorEigenVector3i::iterator list_it = negative_bucket_queue_[i].begin();
-    StlVectorEigenVector3i::iterator list_end = negative_bucket_queue_[i].end();
+    EigenSTL::vector_Vector3i::iterator list_it = negative_bucket_queue_[i].begin();
+    EigenSTL::vector_Vector3i::iterator list_end = negative_bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-      StlVectorEigenVector3i* neighborhood;
+      EigenSTL::vector_Vector3i* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -741,7 +741,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
 
   // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
 
-  StlVectorEigenVector3i obs_points;
+  EigenSTL::vector_Vector3i obs_points;
   for (unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++)
   {
     for (unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++)

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -152,15 +152,15 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
   }
   compareEigen_Vector3i comp;
 
- std::vector<Eigen::Vector3i> old_not_new;
+  std::vector<Eigen::Vector3i> old_not_new;
   std::set_difference(old_point_set.begin(), old_point_set.end(), new_point_set.begin(), new_point_set.end(),
                       std::inserter(old_not_new, old_not_new.end()), comp);
 
- std::vector<Eigen::Vector3i> new_not_old;
+  std::vector<Eigen::Vector3i> new_not_old;
   std::set_difference(new_point_set.begin(), new_point_set.end(), old_point_set.begin(), old_point_set.end(),
                       std::inserter(new_not_old, new_not_old.end()), comp);
 
- std::vector<Eigen::Vector3i> new_not_in_current;
+  std::vector<Eigen::Vector3i> new_not_in_current;
   for (unsigned int i = 0; i < new_not_old.size(); i++)
   {
     if (voxel_grid_->getCell(new_not_old[i].x(), new_not_old[i].y(), new_not_old[i].z()).distance_square_ != 0)
@@ -184,7 +184,7 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
 
 void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d& points)
 {
- std::vector<Eigen::Vector3i> voxel_points;
+  std::vector<Eigen::Vector3i> voxel_points;
 
   for (unsigned int i = 0; i < points.size(); i++)
   {
@@ -205,7 +205,7 @@ void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d&
 
 void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vector3d& points)
 {
- std::vector<Eigen::Vector3i> voxel_points;
+  std::vector<Eigen::Vector3i> voxel_points;
   // VoxelSet voxel_locs;
 
   for (unsigned int i = 0; i < points.size(); i++)
@@ -226,11 +226,11 @@ void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vect
   removeObstacleVoxels(voxel_points);
 }
 
-void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vector3i> &voxel_points)
+void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points)
 {
   int initial_update_direction = getDirectionNumber(0, 0, 0);
   bucket_queue_[0].reserve(voxel_points.size());
- std::vector<Eigen::Vector3i> negative_stack;
+  std::vector<Eigen::Vector3i> negative_stack;
   if (propagate_negative_)
   {
     negative_stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -308,11 +308,11 @@ void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vec
   }
 }
 
-void PropagationDistanceField::removeObstacleVoxels(const std::vector<Eigen::Vector3i> &voxel_points)
+void PropagationDistanceField::removeObstacleVoxels(const std::vector<Eigen::Vector3i>& voxel_points)
 // const VoxelSet& locations )
 {
- std::vector<Eigen::Vector3i> stack;
- std::vector<Eigen::Vector3i> negative_stack;
+  std::vector<Eigen::Vector3i> stack;
+  std::vector<Eigen::Vector3i> negative_stack;
   int initial_update_direction = getDirectionNumber(0, 0, 0);
 
   stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -400,15 +400,15 @@ void PropagationDistanceField::propagatePositive()
   // now process the queue:
   for (unsigned int i = 0; i < bucket_queue_.size(); ++i)
   {
-   std::vector<Eigen::Vector3i>::iterator list_it = bucket_queue_[i].begin();
-   std::vector<Eigen::Vector3i>::iterator list_end = bucket_queue_[i].end();
+    std::vector<Eigen::Vector3i>::iterator list_it = bucket_queue_[i].begin();
+    std::vector<Eigen::Vector3i>::iterator list_end = bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-     std::vector<Eigen::Vector3i>* neighborhood;
+      std::vector<Eigen::Vector3i>* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -458,15 +458,15 @@ void PropagationDistanceField::propagateNegative()
   // now process the queue:
   for (unsigned int i = 0; i < negative_bucket_queue_.size(); ++i)
   {
-   std::vector<Eigen::Vector3i>::iterator list_it = negative_bucket_queue_[i].begin();
-   std::vector<Eigen::Vector3i>::iterator list_end = negative_bucket_queue_[i].end();
+    std::vector<Eigen::Vector3i>::iterator list_it = negative_bucket_queue_[i].begin();
+    std::vector<Eigen::Vector3i>::iterator list_end = negative_bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-     std::vector<Eigen::Vector3i>* neighborhood;
+      std::vector<Eigen::Vector3i>* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -741,7 +741,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
 
   // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
 
- std::vector<Eigen::Vector3i> obs_points;
+  std::vector<Eigen::Vector3i> obs_points;
   for (unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++)
   {
     for (unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++)

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -152,15 +152,15 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
   }
   compareEigen_Vector3i comp;
 
- StlVectorEigenVector3i old_not_new;
+ std::vector<Eigen::Vector3i> old_not_new;
   std::set_difference(old_point_set.begin(), old_point_set.end(), new_point_set.begin(), new_point_set.end(),
                       std::inserter(old_not_new, old_not_new.end()), comp);
 
- StlVectorEigenVector3i new_not_old;
+ std::vector<Eigen::Vector3i> new_not_old;
   std::set_difference(new_point_set.begin(), new_point_set.end(), old_point_set.begin(), old_point_set.end(),
                       std::inserter(new_not_old, new_not_old.end()), comp);
 
- StlVectorEigenVector3i new_not_in_current;
+ std::vector<Eigen::Vector3i> new_not_in_current;
   for (unsigned int i = 0; i < new_not_old.size(); i++)
   {
     if (voxel_grid_->getCell(new_not_old[i].x(), new_not_old[i].y(), new_not_old[i].z()).distance_square_ != 0)
@@ -184,7 +184,7 @@ void PropagationDistanceField::updatePointsInField(const EigenSTL::vector_Vector
 
 void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d& points)
 {
- StlVectorEigenVector3i voxel_points;
+ std::vector<Eigen::Vector3i> voxel_points;
 
   for (unsigned int i = 0; i < points.size(); i++)
   {
@@ -205,7 +205,7 @@ void PropagationDistanceField::addPointsToField(const EigenSTL::vector_Vector3d&
 
 void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vector3d& points)
 {
- StlVectorEigenVector3i voxel_points;
+ std::vector<Eigen::Vector3i> voxel_points;
   // VoxelSet voxel_locs;
 
   for (unsigned int i = 0; i < points.size(); i++)
@@ -226,11 +226,11 @@ void PropagationDistanceField::removePointsFromField(const EigenSTL::vector_Vect
   removeObstacleVoxels(voxel_points);
 }
 
-void PropagationDistanceField::addNewObstacleVoxels(const StlVectorEigenVector3i &voxel_points)
+void PropagationDistanceField::addNewObstacleVoxels(const std::vector<Eigen::Vector3i> &voxel_points)
 {
   int initial_update_direction = getDirectionNumber(0, 0, 0);
   bucket_queue_[0].reserve(voxel_points.size());
- StlVectorEigenVector3i negative_stack;
+ std::vector<Eigen::Vector3i> negative_stack;
   if (propagate_negative_)
   {
     negative_stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -308,11 +308,11 @@ void PropagationDistanceField::addNewObstacleVoxels(const StlVectorEigenVector3i
   }
 }
 
-void PropagationDistanceField::removeObstacleVoxels(const StlVectorEigenVector3i &voxel_points)
+void PropagationDistanceField::removeObstacleVoxels(const std::vector<Eigen::Vector3i> &voxel_points)
 // const VoxelSet& locations )
 {
- StlVectorEigenVector3i stack;
- StlVectorEigenVector3i negative_stack;
+ std::vector<Eigen::Vector3i> stack;
+ std::vector<Eigen::Vector3i> negative_stack;
   int initial_update_direction = getDirectionNumber(0, 0, 0);
 
   stack.reserve(getXNumCells() * getYNumCells() * getZNumCells());
@@ -400,15 +400,15 @@ void PropagationDistanceField::propagatePositive()
   // now process the queue:
   for (unsigned int i = 0; i < bucket_queue_.size(); ++i)
   {
-   StlVectorEigenVector3i::iterator list_it = bucket_queue_[i].begin();
-   StlVectorEigenVector3i::iterator list_end = bucket_queue_[i].end();
+   std::vector<Eigen::Vector3i>::iterator list_it = bucket_queue_[i].begin();
+   std::vector<Eigen::Vector3i>::iterator list_end = bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-     StlVectorEigenVector3i* neighborhood;
+     std::vector<Eigen::Vector3i>* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -458,15 +458,15 @@ void PropagationDistanceField::propagateNegative()
   // now process the queue:
   for (unsigned int i = 0; i < negative_bucket_queue_.size(); ++i)
   {
-   StlVectorEigenVector3i::iterator list_it = negative_bucket_queue_[i].begin();
-   StlVectorEigenVector3i::iterator list_end = negative_bucket_queue_[i].end();
+   std::vector<Eigen::Vector3i>::iterator list_it = negative_bucket_queue_[i].begin();
+   std::vector<Eigen::Vector3i>::iterator list_end = negative_bucket_queue_[i].end();
     for (; list_it != list_end; ++list_it)
     {
       const Eigen::Vector3i& loc = *list_it;
       PropDistanceFieldVoxel* vptr = &voxel_grid_->getCell(loc.x(), loc.y(), loc.z());
 
       // select the neighborhood list based on the update direction:
-     StlVectorEigenVector3i* neighborhood;
+     std::vector<Eigen::Vector3i>* neighborhood;
       int D = i;
       if (D > 1)
         D = 1;
@@ -741,7 +741,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
 
   // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
 
- StlVectorEigenVector3i obs_points;
+ std::vector<Eigen::Vector3i> obs_points;
   for (unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++)
   {
     for (unsigned int y = 0; y < static_cast<unsigned int>(getYNumCells()); y++)

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -291,8 +291,7 @@ unsigned int countLeafNodes(const octomap::OcTree& octree)
 void check_distance_field(const PropagationDistanceField& df, const EigenSTL::vector_Vector3d& points, int numX,
                           int numY, int numZ, bool do_negs)
 {
-
-  PropagationDistanceField::StlVectorEigenVector3i points_ind(points.size());
+  std::vector<Eigen::Vector3i> points_ind(points.size());
   for (unsigned int i = 0; i < points.size(); i++)
   {
     Eigen::Vector3i loc;

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -291,7 +291,7 @@ unsigned int countLeafNodes(const octomap::OcTree& octree)
 void check_distance_field(const PropagationDistanceField& df, const EigenSTL::vector_Vector3d& points, int numX,
                           int numY, int numZ, bool do_negs)
 {
-  PropagationDistanceField::StlVectorEigenVector3i points_ind(points.size());
+  EigenSTL::vector_Vector3i points_ind(points.size());
   for (unsigned int i = 0; i < points.size(); i++)
   {
     Eigen::Vector3i loc;

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -291,7 +291,8 @@ unsigned int countLeafNodes(const octomap::OcTree& octree)
 void check_distance_field(const PropagationDistanceField& df, const EigenSTL::vector_Vector3d& points, int numX,
                           int numY, int numZ, bool do_negs)
 {
-  std::vector<Eigen::Vector3i> points_ind(points.size());
+
+  PropagationDistanceField::StlVectorEigenVector3i points_ind(points.size());
   for (unsigned int i = 0; i < points.size(); i++)
   {
     Eigen::Vector3i loc;

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -291,7 +291,7 @@ unsigned int countLeafNodes(const octomap::OcTree& octree)
 void check_distance_field(const PropagationDistanceField& df, const EigenSTL::vector_Vector3d& points, int numX,
                           int numY, int numZ, bool do_negs)
 {
-  std::vector<Eigen::Vector3i> points_ind(points.size());
+  PropagationDistanceField::StlVectorEigenVector3i points_ind(points.size());
   for (unsigned int i = 0; i < points.size(); i++)
   {
     Eigen::Vector3i loc;

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -35,6 +35,7 @@
 /* Author: Sachin Chitta */
 
 #include <moveit/kinematics_metrics/kinematics_metrics.h>
+#include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <boost/math/constants/constants.hpp>
 

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -47,7 +47,7 @@
 #include <moveit/collision_distance_field/collision_world_hybrid.h>
 
 #include <Eigen/Core>
-
+#include <Eigen/StdVector>
 #include <vector>
 
 namespace chomp
@@ -81,7 +81,6 @@ public:
   {
     return is_collision_free_;
   }
-  typedef std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>> StlVectorEigenVector3d;
 
 private:
   inline double getPotential(double field_distance, double radius, double clearence)
@@ -145,14 +144,14 @@ private:
   bool initialized_;
 
   std::vector<std::vector<std::string> > collision_point_joint_names_;
-  std::vector<StlVectorEigenVector3d> collision_point_pos_eigen_;
-  std::vector<StlVectorEigenVector3d> collision_point_vel_eigen_;
-  std::vector<StlVectorEigenVector3d> collision_point_acc_eigen_;
+  std::vector<EigenSTL::vector_Vector3d> collision_point_pos_eigen_;
+  std::vector<EigenSTL::vector_Vector3d> collision_point_vel_eigen_;
+  std::vector<EigenSTL::vector_Vector3d> collision_point_acc_eigen_;
   std::vector<std::vector<double> > collision_point_potential_;
   std::vector<std::vector<double> > collision_point_vel_mag_;
-  std::vector<StlVectorEigenVector3d> collision_point_potential_gradient_;
-  std::vector<StlVectorEigenVector3d> joint_axes_;
-  std::vector<StlVectorEigenVector3d> joint_positions_;
+  std::vector<EigenSTL::vector_Vector3d> collision_point_potential_gradient_;
+  std::vector<EigenSTL::vector_Vector3d> joint_axes_;
+  std::vector<EigenSTL::vector_Vector3d> joint_positions_;
   Eigen::MatrixXd group_trajectory_backup_;
   Eigen::MatrixXd best_group_trajectory_;
   double best_group_trajectory_cost_;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -81,6 +81,7 @@ public:
   {
     return is_collision_free_;
   }
+  typedef std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>> StlVectorEigenVector3d;
 
 private:
   inline double getPotential(double field_distance, double radius, double clearence)
@@ -144,14 +145,14 @@ private:
   bool initialized_;
 
   std::vector<std::vector<std::string> > collision_point_joint_names_;
-  std::vector<std::vector<Eigen::Vector3d> > collision_point_pos_eigen_;
-  std::vector<std::vector<Eigen::Vector3d> > collision_point_vel_eigen_;
-  std::vector<std::vector<Eigen::Vector3d> > collision_point_acc_eigen_;
+  std::vector<StlVectorEigenVector3d> collision_point_pos_eigen_;
+  std::vector<StlVectorEigenVector3d> collision_point_vel_eigen_;
+  std::vector<StlVectorEigenVector3d> collision_point_acc_eigen_;
   std::vector<std::vector<double> > collision_point_potential_;
   std::vector<std::vector<double> > collision_point_vel_mag_;
-  std::vector<std::vector<Eigen::Vector3d> > collision_point_potential_gradient_;
-  std::vector<std::vector<Eigen::Vector3d> > joint_axes_;
-  std::vector<std::vector<Eigen::Vector3d> > joint_positions_;
+  std::vector<StlVectorEigenVector3d> collision_point_potential_gradient_;
+  std::vector<StlVectorEigenVector3d> joint_axes_;
+  std::vector<StlVectorEigenVector3d> joint_positions_;
   Eigen::MatrixXd group_trajectory_backup_;
   Eigen::MatrixXd best_group_trajectory_;
   double best_group_trajectory_cost_;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -163,15 +163,15 @@ void ChompOptimizer::initialize()
   best_group_trajectory_ = group_trajectory_.getTrajectory();
 
   collision_point_joint_names_.resize(num_vars_all_, std::vector<std::string>(num_collision_points_));
-  collision_point_pos_eigen_.resize(num_vars_all_, std::vector<Eigen::Vector3d>(num_collision_points_));
-  collision_point_vel_eigen_.resize(num_vars_all_, std::vector<Eigen::Vector3d>(num_collision_points_));
-  collision_point_acc_eigen_.resize(num_vars_all_, std::vector<Eigen::Vector3d>(num_collision_points_));
-  joint_axes_.resize(num_vars_all_, std::vector<Eigen::Vector3d>(num_joints_));
-  joint_positions_.resize(num_vars_all_, std::vector<Eigen::Vector3d>(num_joints_));
+  collision_point_pos_eigen_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
+  collision_point_vel_eigen_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
+  collision_point_acc_eigen_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
+  joint_axes_.resize(num_vars_all_, StlVectorEigenVector3d(num_joints_));
+  joint_positions_.resize(num_vars_all_, StlVectorEigenVector3d(num_joints_));
 
   collision_point_potential_.resize(num_vars_all_, std::vector<double>(num_collision_points_));
   collision_point_vel_mag_.resize(num_vars_all_, std::vector<double>(num_collision_points_));
-  collision_point_potential_gradient_.resize(num_vars_all_, std::vector<Eigen::Vector3d>(num_collision_points_));
+  collision_point_potential_gradient_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
 
   collision_free_iteration_ = 0;
   is_collision_free_ = false;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -163,15 +163,15 @@ void ChompOptimizer::initialize()
   best_group_trajectory_ = group_trajectory_.getTrajectory();
 
   collision_point_joint_names_.resize(num_vars_all_, std::vector<std::string>(num_collision_points_));
-  collision_point_pos_eigen_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
-  collision_point_vel_eigen_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
-  collision_point_acc_eigen_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
-  joint_axes_.resize(num_vars_all_, StlVectorEigenVector3d(num_joints_));
-  joint_positions_.resize(num_vars_all_, StlVectorEigenVector3d(num_joints_));
+  collision_point_pos_eigen_.resize(num_vars_all_, EigenSTL::vector_Vector3d(num_collision_points_));
+  collision_point_vel_eigen_.resize(num_vars_all_, EigenSTL::vector_Vector3d(num_collision_points_));
+  collision_point_acc_eigen_.resize(num_vars_all_, EigenSTL::vector_Vector3d(num_collision_points_));
+  joint_axes_.resize(num_vars_all_, EigenSTL::vector_Vector3d(num_joints_));
+  joint_positions_.resize(num_vars_all_, EigenSTL::vector_Vector3d(num_joints_));
 
   collision_point_potential_.resize(num_vars_all_, std::vector<double>(num_collision_points_));
   collision_point_vel_mag_.resize(num_vars_all_, std::vector<double>(num_collision_points_));
-  collision_point_potential_gradient_.resize(num_vars_all_, StlVectorEigenVector3d(num_collision_points_));
+  collision_point_potential_gradient_.resize(num_vars_all_, EigenSTL::vector_Vector3d(num_collision_points_));
 
   collision_free_iteration_ = 0;
   is_collision_free_ = false;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -85,6 +85,8 @@ MOVEIT_CLASS_FORWARD(ManipulationPlan);
 
 struct ManipulationPlan
 {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   ManipulationPlan(const ManipulationPlanSharedDataConstPtr& shared_data)
     : shared_data_(shared_data), processing_stage_(0)
   {

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -85,7 +85,7 @@ MOVEIT_CLASS_FORWARD(ManipulationPlan);
 
 struct ManipulationPlan
 {
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   ManipulationPlan(const ManipulationPlanSharedDataConstPtr& shared_data)
     : shared_data_(shared_data), processing_stage_(0)

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/stereo_camera_model.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/stereo_camera_model.h
@@ -120,6 +120,8 @@ public:
      */
     const Eigen::Vector3f& getPaddingCoefficients() const;
 
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   private:
     /** \brief focal length in x-direction*/
     float fx_;

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -133,6 +133,7 @@ private:
     {
       transformation_.matrix().setZero();
     }
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     std::string frame_id_;
     Eigen::Affine3d transformation_;
     boost::mutex mutex_;

--- a/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
 
     Eigen::Affine3d t;
     t.setIdentity();
-    std::vector<Eigen::Vector3d> points;
+    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>> points;
     std::size_t published = 0;
     random_numbers::RandomNumberGenerator rng;
     collision_detection::CollisionRequest req;


### PR DESCRIPTION
### Description
I had some Eigen struct alignment issues on my system, thus I had to check all the used source code for alignment issues. However, I also had some in moveit.
These aligment issues caused segmentation faults, e.g. in kinematics_metrics.cpp, getManipulability, line 228 while creating the Eigen::JacobiSVD to calculate the manipulability index:
```

    Eigen::MatrixXd jacobian = state.getJacobian(joint_model_group);
    Eigen::JacobiSVD<Eigen::MatrixXd> svdsolver(jacobian);
    Eigen::MatrixXd singular_values = svdsolver.singularValues();
    for (int i = 0; i < singular_values.rows(); ++i)
      ROS_DEBUG_NAMED("kinematics_metrics", "Singular value: %d %f", i, singular_values(i, 0));
    manipulability = penalty * singular_values.minCoeff() / singular_values.maxCoeff();
```
However, after adding missing aligned operators  EIGEN_MAKE_ALIGNED_OPERATOR_NEW and properly aligning some stl containers, everything seems to work well again.

### My environment
* ROS Distro: Kinetic
* OS Version: Ubuntu 16.04
* parent commit: 1d203a953f3b5f4b4e51d98351dfc7d89519014e
*  Eigen Version: 3.3.5

Thank you for considering this.
