### PR TITLE
removing regression introduced in #658

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -243,11 +243,11 @@ bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)
     emitter << YAML::Value << YAML::BeginMap;
     // Output associated planners
     emitter << YAML::Key << "default_planner_config" << YAML::Value
-            << group_meta_data_[group_it->name_].default_planner_ + "kConfigDefault";
+            << group_meta_data_[group_it->name_].default_planner_;
     emitter << YAML::Key << "planner_configs";
     emitter << YAML::Value << YAML::BeginSeq;
     for (std::size_t i = 0; i < pconfigs.size(); ++i)
-      emitter << pconfigs[i] + "kConfigDefault";
+      emitter << pconfigs[i];
     emitter << YAML::EndSeq;
 
     // Output projection_evaluator
@@ -1164,10 +1164,10 @@ bool MoveItConfigData::inputOMPLYAML(const std::string& file_path)
       {
         std::string planner;
         parse(group_it->second, "default_planner_config", planner);
-        std::size_t pos = planner.find_last_not_of("kConfigDefault");
+        std::size_t pos = planner.find("kConfigDefault");
         if (pos != std::string::npos)
         {
-          planner = planner.substr(0, pos + 1);
+          planner = planner.substr(0, pos);
         }
         group_meta_data_[group_name].default_planner_ = planner;
       }

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="paused" default="false"/>
   <arg name="gui" default="true"/>
-  
+
   <!-- startup simulated world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" default="worlds/empty.world"/>


### PR DESCRIPTION
### Description

Thisa regressions introduced in #658 which was raised in issue https://github.com/ros-planning/moveit/issues/955

This stops the setup assistant from appending ``kConfigDefault`` to planner names and correctly trims  ``kConfigDefault`` from existing ompl_planning.yaml files.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
