### PR TITLE
Use panda robot in testing instead or pr2

### DIFF
--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -31,4 +31,5 @@
   <run_depend>xacro</run_depend>
   <run_depend version_gt="0.3.1">srdfdom</run_depend>
 
+  <test_depend>moveit_resources</test_depend>
 </package>

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -55,7 +55,7 @@ protected:
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "panda_description/urdf/panda.urdf").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -67,7 +67,7 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
+    srdf_model->initFile(*urdf_model, (res_path / "panda_moveit_config/config/panda.srdf").string());
     robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   };
 
@@ -100,8 +100,11 @@ TEST_F(MoveItConfigData, ReadingControllers)
   // Test that addDefaultControllers() did accually add a controller for the new_group
   EXPECT_EQ(config_data_->getROSControllers().size(), group_count);
 
+  // Temporary file used during the test and is deleted when the test is finished
+  char test_file[] = "/tmp/msa_unittest_ros_controller.yaml";
+
   // ros_controller.yaml written correctly
-  EXPECT_EQ(config_data_->outputROSControllersYAML((res_path / "ros_controller.yaml").string()), true);
+  EXPECT_EQ(config_data_->outputROSControllersYAML(test_file), true);
 
   // Reset moveit config MoveItConfigData
   config_data_.reset(new moveit_setup_assistant::MoveItConfigData());
@@ -110,13 +113,13 @@ TEST_F(MoveItConfigData, ReadingControllers)
   EXPECT_EQ(config_data_->getROSControllers().size(), 0);
 
   // ros_controllers.yaml read correctly
-  EXPECT_EQ(config_data_->inputROSControllersYAML((res_path / "ros_controller.yaml").string()), true);
+  EXPECT_EQ(config_data_->inputROSControllersYAML(test_file), true);
 
   // ros_controllers.yaml parsed correctly
   EXPECT_EQ(config_data_->getROSControllers().size(), group_count);
 
   // Remove ros_controllers.yaml temp file which was used in testing
-  boost::filesystem::remove((res_path / "ros_controller.yaml").string());
+  boost::filesystem::remove(test_file);
 }
 
 // This tests parsing of sensors_rgbd.yaml


### PR DESCRIPTION
### Description

* Use panda robot in testing of `moveit_config_data` instead or pr2.
* Write test temp file to `/tmp` instead of `moveit_resources` package.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
(http://moveit.ros.org/documentation/contributing/)
- [x] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
