### PR TITLE
update perception tutorial link in SA

### DIFF
--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -55,14 +55,14 @@ PerceptionWidget::PerceptionWidget(QWidget* parent, moveit_setup_assistant::Move
 
   // Top Header Area ------------------------------------------------
 
-  HeaderWidget* header = new HeaderWidget("3D Perception Sensor Configuration",
-                                          "Configure your 3D sensors to work with Moveit! "
-                                          "Please see <a "
-                                          "href='http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/"
-                                          "perception_configuration/"
-                                          "perception_configuration_tutorial.html'>Perception Documentation</a> "
-                                          "for more details.",
-                                          this);
+  HeaderWidget* header =
+      new HeaderWidget("3D Perception Sensor Configuration",
+                       "Configure your 3D sensors to work with Moveit! "
+                       "Please see <a "
+                       "href='http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/perception_pipeline/"
+                       "perception_pipeline_tutorial.html'>Perception Documentation</a> "
+                       "for more details.",
+                       this);
   layout->addWidget(header);
 
   // Add spacing


### PR DESCRIPTION
### Description
Updating perception tutorial link in the perception widget.
it has been changed from http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/perception_configuration_tutorial.html
to http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/perception_pipeline/perception_pipeline_tutorial.html

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
