### PR TITLE
Added an option to generate gazebo launch file to SA simulation screen

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -278,6 +278,9 @@ public:
   /// Email of the author of this config
   std::string author_email_;
 
+  /// Optional generation of gazebo launch file
+  bool generate_gazebo_launch_ = false;
+
   // ******************************************************************************************
   // Public Functions
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -64,7 +64,7 @@ const std::string SETUP_ASSISTANT_FILE = ".setup_assistant";
 // ******************************************************************************************
 ConfigurationFilesWidget::ConfigurationFilesWidget(QWidget* parent,
                                                    moveit_setup_assistant::MoveItConfigDataPtr config_data)
-  : SetupScreenWidget(parent), config_data_(config_data), has_generated_pkg_(false), first_focusGiven_(true)
+  : SetupScreenWidget(parent), config_data_(config_data), has_generated_pkg_(false)
 {
   // Basic widget container
   QVBoxLayout* layout = new QVBoxLayout();
@@ -518,6 +518,17 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
+  // gazebo.launch ------------------------------------------------------------------
+  file.file_name_ = "gazebo.launch";
+  file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
+  template_path = config_data_->appendPaths(template_launch_path, "gazebo.launch");
+  file.description_ = "Gazebo launch file which also launches ros_controllers and sends robot urdf to param server, "
+                      "then using gazebo_ros pkg the robot is spawned to Gazebo";
+  file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, _1);
+  file.generate_ = config_data_->generate_gazebo_launch_;
+  file.write_on_changes = -1;
+  gen_files_.push_back(file);
+
   // moveit.rviz ------------------------------------------------------------------
   file.file_name_ = "moveit.rviz";
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
@@ -684,14 +695,8 @@ void ConfigurationFilesWidget::changeCheckedState(QListWidgetItem* item)
 // ******************************************************************************************
 void ConfigurationFilesWidget::focusGiven()
 {
-  if (first_focusGiven_)
-  {
-    // only generate list once
-    first_focusGiven_ = false;
-
-    // Load this list of all files to be generated
-    loadGenFiles();
-  }
+  // Load this list of all files to be generated
+  loadGenFiles();
 
   // Which files have been modified outside the Setup Assistant?
   bool files_already_modified = checkGenFiles();

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.h
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.h
@@ -136,9 +136,6 @@ private:
   /// Has the package been generated yet this program execution? Used for popping up exit warning
   bool has_generated_pkg_;
 
-  /// Populate the 'Files to be Generated' list just once
-  bool first_focusGiven_;
-
   /// Vector of all files to be generated
   std::vector<GenerateFile> gen_files_;
 

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -94,6 +94,11 @@ SimulationWidget::SimulationWidget(QWidget* parent, moveit_setup_assistant::Move
   layout->setAlignment(btn_generate, Qt::AlignLeft);
   connect(btn_generate, SIGNAL(clicked()), this, SLOT(generateURDFClick()));
 
+  // Optional generation of gazebo launch file
+  gazebo_generate_option_ = new QCheckBox("&Generate Gazebo launch file", this);
+  layout->addWidget(gazebo_generate_option_);
+  layout->setAlignment(gazebo_generate_option_, Qt::AlignRight);
+
   // When there wa no change to be made
   no_changes_label_ = new QLabel(this);
   no_changes_label_->setText("No Changes To Be Made");
@@ -197,6 +202,18 @@ void SimulationWidget::copyURDF(const QString& link)
 {
   simulation_text_->selectAll();
   simulation_text_->copy();
+}
+
+// ******************************************************************************************
+// Received when another widget is chosen from the navigation menu
+// ******************************************************************************************
+bool SimulationWidget::focusLost()
+{
+  // If we the user chose to generate a gazebo launch file
+  if (gazebo_generate_option_->isChecked())
+    config_data_->generate_gazebo_launch_ = true;
+  else
+    config_data_->generate_gazebo_launch_ = false;
 }
 
 }  // namespace

--- a/moveit_setup_assistant/src/widgets/simulation_widget.h
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.h
@@ -39,6 +39,7 @@
 // Qt
 #include <QScrollArea>
 #include <QTextEdit>
+#include <QCheckBox>
 #include <QString>
 
 // SA
@@ -67,6 +68,9 @@ public:
 
   SimulationWidget(QWidget* parent, moveit_setup_assistant::MoveItConfigDataPtr config_data);
 
+  /// Received when another widget is chosen from the navigation menu
+  virtual bool focusLost();
+
 private Q_SLOTS:
 
   // ******************************************************************************************
@@ -87,6 +91,7 @@ private:
   QTextEdit* simulation_text_;
   QLabel* no_changes_label_;
   QLabel* copy_urdf_;
+  QCheckBox* gazebo_generate_option_;
 
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;


### PR DESCRIPTION
### Description
Added an option to generate gazebo launch file to setup assistant `simulation screen`.

![](https://github.com/MohmadAyman/school/blob/a875e81978202f298f9dee87a680342cad611611/gen_gazebo.png?raw=true)

For this to work correctly -e.g.if the user decides to go back to any screen after navigating to the configuration screen for the first time- , I had the `loadGenFiles()` [get called every time we navigate to the `configuration_files` screen](https://github.com/ros-planning/moveit/compare/kinetic-devel...MohmadAyman:option_gazebo_launch_generation?expand=1#diff-82144bb4cd694a06a3f4ac970a305343L687). 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
