### PR TITLE
backport (#903) to kinetic

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
@@ -37,8 +37,15 @@
 #ifndef MOVEIT_OMPL_INTERFACE_DETAIL_PROJECTION_EVALUATORS_
 #define MOVEIT_OMPL_INTERFACE_DETAIL_PROJECTION_EVALUATORS_
 
+#include <ompl/config.h>
 #include <ompl/base/ProjectionEvaluator.h>
 #include <moveit/ompl_interface/detail/threadsafe_state_storage.h>
+
+#if OMPL_VERSION_VALUE >= 1004000  // Version greater than 1.4.0
+typedef Eigen::Ref<Eigen::VectorXd> OMPLProjection;
+#else  // All other versions
+typedef ompl::base::EuclideanProjection& OMPLProjection;
+#endif
 
 namespace ompl_interface
 {
@@ -53,7 +60,7 @@ public:
 
   virtual unsigned int getDimension() const;
   virtual void defaultCellSizes();
-  virtual void project(const ompl::base::State* state, ompl::base::EuclideanProjection& projection) const;
+  virtual void project(const ompl::base::State* state, OMPLProjection projection) const override;
 
 private:
   const ModelBasedPlanningContext* planning_context_;
@@ -70,7 +77,7 @@ public:
 
   virtual unsigned int getDimension() const;
   virtual void defaultCellSizes();
-  virtual void project(const ompl::base::State* state, ompl::base::EuclideanProjection& projection) const;
+  virtual void project(const ompl::base::State* state, OMPLProjection projection) const;
 
 private:
   const ModelBasedPlanningContext* planning_context_;

--- a/moveit_planners/ompl/ompl_interface/src/detail/projection_evaluators.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/projection_evaluators.cpp
@@ -61,7 +61,7 @@ void ompl_interface::ProjectionEvaluatorLinkPose::defaultCellSizes()
 }
 
 void ompl_interface::ProjectionEvaluatorLinkPose::project(const ompl::base::State* state,
-                                                          ompl::base::EuclideanProjection& projection) const
+                                                          OMPLProjection projection) const
 {
   robot_state::RobotState* s = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*s, state);
@@ -90,7 +90,7 @@ void ompl_interface::ProjectionEvaluatorJointValue::defaultCellSizes()
 }
 
 void ompl_interface::ProjectionEvaluatorJointValue::project(const ompl::base::State* state,
-                                                            ompl::base::EuclideanProjection& projection) const
+                                                            OMPLProjection projection) const
 {
   for (std::size_t i = 0; i < variables_.size(); ++i)
     projection(i) = state->as<ModelBasedStateSpace::StateType>()->values[variables_[i]];


### PR DESCRIPTION
Defined an OMPLProjection that is typedef'd to work with versions <= 1.4 of OMPL

It's not strictly necessary for most setups, but I believe there is no harm in having it in kinetic too.