### PR TITLE
Check errors when loading scene geometry from files

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -670,7 +670,7 @@ public:
   void saveGeometryToStream(std::ostream& out) const;
 
   /** \brief Load the geometry of the planning scene from a stream */
-  bool loadGeometryFromStream(std::istream &in);
+  bool loadGeometryFromStream(std::istream& in);
 
   /** \brief Load the geometry of the planning scene from a stream at a certain location using offset*/
   bool loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset);

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -670,10 +670,10 @@ public:
   void saveGeometryToStream(std::ostream& out) const;
 
   /** \brief Load the geometry of the planning scene from a stream */
-  void loadGeometryFromStream(std::istream& in);
+  bool loadGeometryFromStream(std::istream &in);
 
   /** \brief Load the geometry of the planning scene from a stream at a certain location using offset*/
-  void loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset);
+  bool loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset);
 
   /** \brief Fill the message \e scene with the differences between this instance of PlanningScene with respect to the
      parent.

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1031,39 +1031,65 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
   out << "." << std::endl;
 }
 
-void PlanningScene::loadGeometryFromStream(std::istream& in)
+bool PlanningScene::loadGeometryFromStream(std::istream &in)
 {
-  loadGeometryFromStream(in, Eigen::Affine3d::Identity());  // Use no offset
+  return loadGeometryFromStream(in, Eigen::Affine3d::Identity());  // Use no offset
 }
 
-void PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset)
+bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset)
 {
   if (!in.good() || in.eof())
-    return;
+  {
+      ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading scene geometry");
+      return false;
+  }
   std::getline(in, name_);
   do
   {
     std::string marker;
     in >> marker;
     if (!in.good() || in.eof())
-      return;
+    {
+        ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading marker in scene geometry");
+        return false;
+    }
     if (marker == "*")
     {
       std::string ns;
       std::getline(in, ns);
       if (!in.good() || in.eof())
-        return;
+      {
+          ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading ns in scene geometry");
+          return false;
+      }
       boost::algorithm::trim(ns);
       unsigned int shape_count;
       in >> shape_count;
       for (std::size_t i = 0; i < shape_count && in.good() && !in.eof(); ++i)
       {
         shapes::Shape* s = shapes::constructShapeFromText(in);
+        if(!s)
+        {
+            ROS_ERROR_NAMED("planning_scene", "Failed to load shape from scene file");
+            return false;
+        }
         double x, y, z, rx, ry, rz, rw;
-        in >> x >> y >> z;
-        in >> rx >> ry >> rz >> rw;
+        if(! (in >> x >> y >> z) )
+        {
+            ROS_ERROR_NAMED("planning_scene", "Improperly formatted translation in scene geometry file");
+            return false;
+        }
+        if(! (in >> rx >> ry >> rz >> rw) )
+        {
+            ROS_ERROR_NAMED("planning_scene", "Improperly formatted rotation in scene geometry file");
+            return false;
+        }
         float r, g, b, a;
-        in >> r >> g >> b >> a;
+        if(! (in >> r >> g >> b >> a) )
+        {
+            ROS_ERROR_NAMED("planning_scene", "Improperly formatted color in scene geometry file");
+            return false;
+        }
         if (s)
         {
           Eigen::Affine3d pose = Eigen::Translation3d(x, y, z) * Eigen::Quaterniond(rw, rx, ry, rz);
@@ -1082,8 +1108,16 @@ void PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
         }
       }
     }
+    else if(marker == ".")
+    {
+      // Marks the end of the scene geometry;
+      return true;
+    }
     else
-      break;
+    {
+      ROS_ERROR_STREAM_NAMED("planning_scene", "Unknown marker in scene geometry file: " << marker);
+      return false;
+    }
   } while (true);
 }
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1031,7 +1031,7 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
   out << "." << std::endl;
 }
 
-bool PlanningScene::loadGeometryFromStream(std::istream &in)
+bool PlanningScene::loadGeometryFromStream(std::istream& in)
 {
   return loadGeometryFromStream(in, Eigen::Affine3d::Identity());  // Use no offset
 }
@@ -1040,8 +1040,8 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
 {
   if (!in.good() || in.eof())
   {
-      ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading scene geometry");
-      return false;
+    ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading scene geometry");
+    return false;
   }
   std::getline(in, name_);
   do
@@ -1050,8 +1050,8 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
     in >> marker;
     if (!in.good() || in.eof())
     {
-        ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading marker in scene geometry");
-        return false;
+      ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading marker in scene geometry");
+      return false;
     }
     if (marker == "*")
     {
@@ -1059,8 +1059,8 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
       std::getline(in, ns);
       if (!in.good() || in.eof())
       {
-          ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading ns in scene geometry");
-          return false;
+        ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading ns in scene geometry");
+        return false;
       }
       boost::algorithm::trim(ns);
       unsigned int shape_count;
@@ -1068,27 +1068,27 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
       for (std::size_t i = 0; i < shape_count && in.good() && !in.eof(); ++i)
       {
         shapes::Shape* s = shapes::constructShapeFromText(in);
-        if(!s)
+        if (!s)
         {
-            ROS_ERROR_NAMED("planning_scene", "Failed to load shape from scene file");
-            return false;
+          ROS_ERROR_NAMED("planning_scene", "Failed to load shape from scene file");
+          return false;
         }
         double x, y, z, rx, ry, rz, rw;
-        if(! (in >> x >> y >> z) )
+        if (!(in >> x >> y >> z))
         {
-            ROS_ERROR_NAMED("planning_scene", "Improperly formatted translation in scene geometry file");
-            return false;
+          ROS_ERROR_NAMED("planning_scene", "Improperly formatted translation in scene geometry file");
+          return false;
         }
-        if(! (in >> rx >> ry >> rz >> rw) )
+        if (!(in >> rx >> ry >> rz >> rw))
         {
-            ROS_ERROR_NAMED("planning_scene", "Improperly formatted rotation in scene geometry file");
-            return false;
+          ROS_ERROR_NAMED("planning_scene", "Improperly formatted rotation in scene geometry file");
+          return false;
         }
         float r, g, b, a;
-        if(! (in >> r >> g >> b >> a) )
+        if (!(in >> r >> g >> b >> a))
         {
-            ROS_ERROR_NAMED("planning_scene", "Improperly formatted color in scene geometry file");
-            return false;
+          ROS_ERROR_NAMED("planning_scene", "Improperly formatted color in scene geometry file");
+          return false;
         }
         if (s)
         {
@@ -1108,7 +1108,7 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
         }
       }
     }
-    else if(marker == ".")
+    else if (marker == ".")
     {
       // Marks the end of the scene geometry;
       return true;

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -177,26 +177,26 @@ TEST(PlanningScene, loadGoodSceneGeometry)
 
   std::istringstream good_scene_geometry;
   good_scene_geometry.str("foobar_scene\n"
-                         "* foo\n"
-                         "1\n"
-                         "box\n"
-                         "2.58 1.36 0.31\n"
-                         "1.49257 1.00222 0.170051\n"
-                         "0 0 4.16377e-05 1\n"
-                         "0 0 1 0.3\n"
-                         "* bar\n"
-                         "1\n"
-                         "cylinder\n"
-                         "0.02 0.0001\n"
-                         "0.453709 0.499136 0.355051\n"
-                         "0 0 4.16377e-05 1\n"
-                         "1 0 0 1\n"
-                         ".\n");
+                          "* foo\n"
+                          "1\n"
+                          "box\n"
+                          "2.58 1.36 0.31\n"
+                          "1.49257 1.00222 0.170051\n"
+                          "0 0 4.16377e-05 1\n"
+                          "0 0 1 0.3\n"
+                          "* bar\n"
+                          "1\n"
+                          "cylinder\n"
+                          "0.02 0.0001\n"
+                          "0.453709 0.499136 0.355051\n"
+                          "0 0 4.16377e-05 1\n"
+                          "1 0 0 1\n"
+                          ".\n");
   EXPECT_TRUE(ps->loadGeometryFromStream(good_scene_geometry));
   EXPECT_EQ(ps->getName(), "foobar_scene");
   EXPECT_TRUE(ps->getWorld()->hasObject("foo"));
   EXPECT_TRUE(ps->getWorld()->hasObject("bar"));
-  EXPECT_FALSE(ps->getWorld()->hasObject("baz")); // Sanity check.
+  EXPECT_FALSE(ps->getWorld()->hasObject("baz"));  // Sanity check.
 }
 
 TEST(PlanningScene, loadBadSceneGeometry)
@@ -212,14 +212,14 @@ TEST(PlanningScene, loadBadSceneGeometry)
 
   std::istringstream malformed_scene_geometry;
   malformed_scene_geometry.str("malformed_scene_geometry\n"
-                          "* foo\n"
-                          "1\n"
-                          "box\n"
-                          "2.58 1.36\n" /* Only two tokens; should be 3 */
-                          "1.49257 1.00222 0.170051\n"
-                          "0 0 4.16377e-05 1\n"
-                          "0 0 1 0.3\n"
-                          ".\n");
+                               "* foo\n"
+                               "1\n"
+                               "box\n"
+                               "2.58 1.36\n" /* Only two tokens; should be 3 */
+                               "1.49257 1.00222 0.170051\n"
+                               "0 0 4.16377e-05 1\n"
+                               "0 0 1 0.3\n"
+                               ".\n");
   EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry));
 }
 

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -38,6 +38,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <boost/filesystem/path.hpp>
 #include <moveit_resources/config.h>
@@ -165,6 +166,61 @@ TEST(PlanningScene, isStateValid)
   {
     EXPECT_FALSE(ps->isStateValid(current_state, "left_arm"));
   }
+}
+
+TEST(PlanningScene, loadGoodSceneGeometry)
+{
+  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  urdf::ModelInterfaceSharedPtr urdf_model;
+  loadRobotModels(urdf_model, srdf_model);
+  planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
+
+  std::istringstream good_scene_geometry;
+  good_scene_geometry.str("foobar_scene\n"
+                         "* foo\n"
+                         "1\n"
+                         "box\n"
+                         "2.58 1.36 0.31\n"
+                         "1.49257 1.00222 0.170051\n"
+                         "0 0 4.16377e-05 1\n"
+                         "0 0 1 0.3\n"
+                         "* bar\n"
+                         "1\n"
+                         "cylinder\n"
+                         "0.02 0.0001\n"
+                         "0.453709 0.499136 0.355051\n"
+                         "0 0 4.16377e-05 1\n"
+                         "1 0 0 1\n"
+                         ".\n");
+  EXPECT_TRUE(ps->loadGeometryFromStream(good_scene_geometry));
+  EXPECT_EQ(ps->getName(), "foobar_scene");
+  EXPECT_TRUE(ps->getWorld()->hasObject("foo"));
+  EXPECT_TRUE(ps->getWorld()->hasObject("bar"));
+  EXPECT_FALSE(ps->getWorld()->hasObject("baz")); // Sanity check.
+}
+
+TEST(PlanningScene, loadBadSceneGeometry)
+{
+  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  urdf::ModelInterfaceSharedPtr urdf_model;
+  loadRobotModels(urdf_model, srdf_model);
+  planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
+  std::istringstream empty_scene_geometry;
+
+  // This should fail since there is no planning scene name and no end of geometry marker.
+  EXPECT_FALSE(ps->loadGeometryFromStream(empty_scene_geometry));
+
+  std::istringstream malformed_scene_geometry;
+  malformed_scene_geometry.str("malformed_scene_geometry\n"
+                          "* foo\n"
+                          "1\n"
+                          "box\n"
+                          "2.58 1.36\n" /* Only two tokens; should be 3 */
+                          "1.49257 1.00222 0.170051\n"
+                          "0 0 4.16377e-05 1\n"
+                          "0 0 1 0.3\n"
+                          ".\n");
+  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry));
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
@@ -73,10 +73,8 @@ int main(int argc, char** argv)
     planning_scene::PlanningScene ps(rml->getModel());
 
     std::ifstream f(argv[filename_index]);
-    if (f.good() && !f.eof())
-    {
+    if (ps.loadGeometryFromStream(f)) {
       ROS_INFO("Publishing geometry from '%s' ...", argv[filename_index]);
-      ps.loadGeometryFromStream(f);
       moveit_msgs::PlanningScene ps_msg;
       ps.getPlanningSceneMsg(ps_msg);
       ps_msg.is_diff = true;
@@ -93,8 +91,6 @@ int main(int argc, char** argv)
 
       sleep(1);
     }
-    else
-      ROS_WARN("Unable to load '%s'.", argv[filename_index]);
   }
   else
     ROS_WARN("A filename was expected as argument. That file should be a text representation of the geometry in a "

--- a/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
@@ -73,7 +73,8 @@ int main(int argc, char** argv)
     planning_scene::PlanningScene ps(rml->getModel());
 
     std::ifstream f(argv[filename_index]);
-    if (ps.loadGeometryFromStream(f)) {
+    if (ps.loadGeometryFromStream(f))
+    {
       ROS_INFO("Publishing geometry from '%s' ...", argv[filename_index]);
       moveit_msgs::PlanningScene ps_msg;
       ps.getPlanningSceneMsg(ps_msg);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -933,16 +933,17 @@ void MotionPlanningFrame::computeImportFromText(const std::string& path)
   if (ps)
   {
     std::ifstream fin(path.c_str());
-    if (fin.good())
+    if (ps->loadGeometryFromStream(fin))
     {
-      ps->loadGeometryFromStream(fin);
-      fin.close();
       ROS_INFO("Loaded scene geometry from '%s'", path.c_str());
       planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
       planning_display_->queueRenderSceneGeometry();
     }
     else
-      ROS_WARN("Unable to load scene geometry from '%s'", path.c_str());
+    {
+      QMessageBox::warning(nullptr, "Loading scene geometry", "Failed to load scene geometry.\n"
+                           "See console output for more details.");
+    }
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -942,7 +942,7 @@ void MotionPlanningFrame::computeImportFromText(const std::string& path)
     else
     {
       QMessageBox::warning(nullptr, "Loading scene geometry", "Failed to load scene geometry.\n"
-                           "See console output for more details.");
+                                                              "See console output for more details.");
     }
   }
 }


### PR DESCRIPTION
### Description

Before this PR, there was no error checking when loading planning scene geometry from a text file. This meant the caller couldn't tell whether the planning scene had been successfully loaded.

Not sure if this should be cherry-picked. It changes the return type of two PlanningScene member functions, so I think it would require people to re-compile their code.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [x] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
