### PR TITLE
Add named frames to CollisionObjects

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -151,7 +151,7 @@ public:
   bool knowsTransform(const std::string& id) const;
 
   /** \brief Get the transform to a frame or object with name id*/
-  Eigen::Affine3d getTransform(const std::string& id) const;
+  const Eigen::Affine3d& getTransform(const std::string& id) const;
 
   /** \brief Get the object id that owns the named frame with name id*/
   std::string getParent(const std::string& id) const;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -107,9 +107,8 @@ public:
      * @copydetails shapes_ */
     EigenSTL::vector_Affine3d shape_poses_;
 
-
     /** \brief Transforms to named frames on the object. Transforms are applied to the link.
-     *  Use these to define points of interest on the object to plan with 
+     *  Use these to define points of interest on the object to plan with
      *  (e.g. screwdriver_tip, kettle_spout, mug_base).
      * */
     std::map<std::string, Eigen::Affine3d> named_frames_;
@@ -182,7 +181,7 @@ public:
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
   bool replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                   const EigenSTL::vector_Affine3d& poses);
+                             const EigenSTL::vector_Affine3d& poses);
 
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the
@@ -301,6 +300,6 @@ private:
   };
   std::vector<Observer*> observers_;
 };
-}
+}  // namespace collision_detection
 
 #endif

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -107,8 +107,9 @@ public:
      * @copydetails shapes_ */
     EigenSTL::vector_Affine3d shape_poses_;
 
+
     /** \brief Transforms to named frames on the object. Transforms are applied to the link.
-     *  Use these to define points of interest on the object to plan with
+     *  Use these to define points of interest on the object to plan with 
      *  (e.g. screwdriver_tip, kettle_spout, mug_base).
      * */
     std::map<std::string, Eigen::Affine3d> named_frames_;
@@ -181,7 +182,7 @@ public:
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
   bool replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                             const EigenSTL::vector_Affine3d& poses);
+                   const EigenSTL::vector_Affine3d& poses);
 
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the
@@ -300,6 +301,6 @@ private:
   };
   std::vector<Observer*> observers_;
 };
-}  // namespace collision_detection
+}
 
 #endif

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -41,6 +41,7 @@
 
 #include <string>
 #include <vector>
+#include <set>
 #include <map>
 #include <memory>
 #include <boost/function.hpp>
@@ -105,6 +106,13 @@ public:
      *
      * @copydetails shapes_ */
     EigenSTL::vector_Affine3d shape_poses_;
+
+
+    /** \brief Transforms to named frames on the object. Transforms are applied to the link.
+     *  Use these to define points of interest on the object to plan with 
+     *  (e.g. screwdriver_tip, kettle_spout, mug_base).
+     * */
+    std::map<std::string, Eigen::Affine3d> named_frames_;
   };
 
   /** \brief Get the list of Object ids */
@@ -139,6 +147,15 @@ public:
   /** \brief Check if a particular object exists in the collision world*/
   bool hasObject(const std::string& id) const;
 
+  /** \brief Check if a frame or object with name id exists in the collision world*/
+  bool knowsTransform(const std::string& id) const;
+
+  /** \brief Get the transform to a frame or object with name id*/
+  Eigen::Affine3d getTransform(const std::string& id) const;
+
+  /** \brief Get the object id that owns the named frame with name id*/
+  std::string getParent(const std::string& id) const;
+
   /** \brief Add shapes to an object in the map.
    * This function makes repeated calls to addToObjectInternal() to add the
    * shapes one by one.
@@ -160,6 +177,13 @@ public:
   /** \brief Move all shapes in an object according to the given transform specified in world frame */
   bool moveObject(const std::string& id, const Eigen::Affine3d& transform);
 
+  /** \brief Replaces all shapes in an existing object.
+   * If the object already exists, this call will add the shape to the object
+   * at the specified pose. Otherwise, the object is created and the
+   * specified shape is added. This calls addToObjectInternal(). */
+  bool replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+                   const EigenSTL::vector_Affine3d& poses);
+
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the
    * object is renounced (i.e. object is deleted if no external references
@@ -173,6 +197,9 @@ public:
    * Object, the memory is freed.
    * Returns true on success and false if no such object was found. */
   bool removeObject(const std::string& id);
+
+  /** \brief Set named frames on an object. */
+  bool setNamedFramesOfObject(const std::string& id, const std::map<std::string, Eigen::Affine3d>& named_frames);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -198,7 +198,8 @@ public:
   bool removeObject(const std::string& object_id);
 
   /** \brief Set named frames on an object. */
-  bool setNamedFramesOfObject(const std::string& object_id, const std::map<std::string, Eigen::Affine3d>& named_frame_poses);
+  bool setNamedFramesOfObject(const std::string& object_id,
+                              const std::map<std::string, Eigen::Affine3d>& named_frame_poses);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -80,13 +80,13 @@ public:
   /** \brief A representation of an object */
   struct Object
   {
-    Object(const std::string& id) : id_(id)
+    Object(const std::string& object_id) : id_(object_id)
     {
     }
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    /** \brief The id for this object */
+    /** \brief The object_id for this object */
     std::string id_;
 
     /** \brief All the shapes making up this object.
@@ -111,14 +111,14 @@ public:
      *  Use these to define points of interest on the object to plan with
      *  (e.g. screwdriver_tip, kettle_spout, mug_base).
      * */
-    std::map<std::string, Eigen::Affine3d> named_frames_;
+    std::map<std::string, Eigen::Affine3d> named_frame_poses_;
   };
 
   /** \brief Get the list of Object ids */
   std::vector<std::string> getObjectIds() const;
 
   /** \brief Get a particular object */
-  ObjectConstPtr getObject(const std::string& id) const;
+  ObjectConstPtr getObject(const std::string& object_id) const;
 
   /** iterator over the objects in the world. */
   typedef std::map<std::string, ObjectPtr>::const_iterator const_iterator;
@@ -138,22 +138,22 @@ public:
     return objects_.size();
   }
   /** find changes for a named object */
-  const_iterator find(const std::string& id) const
+  const_iterator find(const std::string& object_id) const
   {
-    return objects_.find(id);
+    return objects_.find(object_id);
   }
 
   /** \brief Check if a particular object exists in the collision world*/
-  bool hasObject(const std::string& id) const;
+  bool hasObject(const std::string& object_id) const;
 
-  /** \brief Check if a frame or object with name id exists in the collision world*/
-  bool knowsTransform(const std::string& id) const;
+  /** \brief Check if a frame or object with name object_id exists in the collision world*/
+  bool knowsTransform(const std::string& object_id) const;
 
-  /** \brief Get the transform to a frame or object with name id*/
-  const Eigen::Affine3d& getTransform(const std::string& id) const;
+  /** \brief Get the transform to a frame or object with name object_id*/
+  const Eigen::Affine3d& getTransform(const std::string& object_id) const;
 
-  /** \brief Get the object id that owns the named frame with name id*/
-  std::string getParent(const std::string& id) const;
+  /** \brief Get the object id that owns the named frame with name object_id*/
+  std::string getObjectOwningFrame(const std::string& frame_name) const;
 
   /** \brief Add shapes to an object in the map.
    * This function makes repeated calls to addToObjectInternal() to add the
@@ -167,20 +167,20 @@ public:
    * If the object already exists, this call will add the shape to the object
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
-  void addToObject(const std::string& id, const shapes::ShapeConstPtr& shape, const Eigen::Affine3d& pose);
+  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Affine3d& pose);
 
   /** \brief Update the pose of a shape in an object. Shape equality is
    * verified by comparing pointers. Returns true on success. */
-  bool moveShapeInObject(const std::string& id, const shapes::ShapeConstPtr& shape, const Eigen::Affine3d& pose);
+  bool moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Affine3d& pose);
 
   /** \brief Move all shapes in an object according to the given transform specified in world frame */
-  bool moveObject(const std::string& id, const Eigen::Affine3d& transform);
+  bool moveObject(const std::string& object_id, const Eigen::Affine3d& transform);
 
   /** \brief Replaces all shapes in an existing object.
-   * If the object already exists, this call will add the shape to the object
+   * If the object already exists, this call will assign the new shapes to the object
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
-  bool replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+  bool replaceShapesInObject(const std::string& object_id, const std::vector<shapes::ShapeConstPtr>& shapes,
                              const EigenSTL::vector_Affine3d& poses);
 
   /** \brief Remove shape from object.
@@ -189,16 +189,16 @@ public:
    * exist) if this was the last shape in the object.
    * Returns true on success and false if the object did not exist or did not
    * contain the shape. */
-  bool removeShapeFromObject(const std::string& id, const shapes::ShapeConstPtr& shape);
+  bool removeShapeFromObject(const std::string& object_id, const shapes::ShapeConstPtr& shape);
 
   /** \brief Remove a particular object.
    * If there are no external pointers to the corresponding instance of
    * Object, the memory is freed.
    * Returns true on success and false if no such object was found. */
-  bool removeObject(const std::string& id);
+  bool removeObject(const std::string& object_id);
 
   /** \brief Set named frames on an object. */
-  bool setNamedFramesOfObject(const std::string& id, const std::map<std::string, Eigen::Affine3d>& named_frames);
+  bool setNamedFramesOfObject(const std::string& object_id, const std::map<std::string, Eigen::Affine3d>& named_frame_poses);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,
@@ -277,7 +277,7 @@ private:
   /** send notification of change to all objects. */
   void notifyAll(Action action);
 
-  /** \brief Make sure that the object named \e id is known only to this
+  /** \brief Make sure that the object named \e object_id is known only to this
    * instance of the World. If the object is known outside of it, a
    * clone is made so that it can be safely modified later on. */
   void ensureUnique(ObjectPtr& obj);

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -107,9 +107,8 @@ public:
      * @copydetails shapes_ */
     EigenSTL::vector_Affine3d shape_poses_;
 
-
     /** \brief Transforms to named frames on the object. Transforms are applied to the link.
-     *  Use these to define points of interest on the object to plan with 
+     *  Use these to define points of interest on the object to plan with
      *  (e.g. screwdriver_tip, kettle_spout, mug_base).
      * */
     std::map<std::string, Eigen::Affine3d> named_frames_;
@@ -182,7 +181,7 @@ public:
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
   bool replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                   const EigenSTL::vector_Affine3d& poses);
+                             const EigenSTL::vector_Affine3d& poses);
 
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -152,7 +152,7 @@ bool World::knowsTransform(const std::string& id) const
   return false;
 }
 
-Eigen::Affine3d World::getTransform(const std::string& id) const
+const Eigen::Affine3d& World::getTransform(const std::string& id) const
 {
   auto it = objects_.find(id);
   if (it != objects_.end())

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -141,7 +141,7 @@ bool World::knowsTransform(const std::string& id) const
   // Check object names first
   if (objects_.find(id) != objects_.end())
     return true;
-  else  // Then objects' named frames
+  else // Then objects' named frames
   {
     for (auto o : objects_)
     {
@@ -157,7 +157,7 @@ const Eigen::Affine3d& World::getTransform(const std::string& id) const
   auto it = objects_.find(id);
   if (it != objects_.end())
     return it->second->shape_poses_[0];
-  else  // Find within named frames
+  else // Find within named frames
   {
     for (auto o : objects_)
     {
@@ -215,7 +215,7 @@ bool World::moveObject(const std::string& id, const Eigen::Affine3d& transform)
 }
 
 bool World::replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                                  const EigenSTL::vector_Affine3d& poses)
+                   const EigenSTL::vector_Affine3d& poses)
 {
   auto it = objects_.find(id);
   if (it == objects_.end())

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -173,7 +173,7 @@ std::string World::getObjectOwningFrame(const std::string& frame_name) const
   auto it = objects_.find(frame_name);
   if (it != objects_.end())
     return it->second->id_;
-  
+
   // Return the object owning the frame
   for (const auto& object : objects_)
   {
@@ -183,7 +183,8 @@ std::string World::getObjectOwningFrame(const std::string& frame_name) const
   return "";
 }
 
-bool World::moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Affine3d& pose)
+bool World::moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
+                              const Eigen::Affine3d& pose)
 {
   auto it = objects_.find(object_id);
   if (it != objects_.end())
@@ -274,7 +275,8 @@ void World::clearObjects()
   objects_.clear();
 }
 
-bool World::setNamedFramesOfObject(const std::string& object_id, const std::map<std::string, Eigen::Affine3d>& named_frame_poses)
+bool World::setNamedFramesOfObject(const std::string& object_id,
+                                   const std::map<std::string, Eigen::Affine3d>& named_frame_poses)
 {
   auto obj_pair = objects_.find(object_id);
   if (obj_pair == objects_.end())

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -141,7 +141,7 @@ bool World::knowsTransform(const std::string& id) const
   // Check object names first
   if (objects_.find(id) != objects_.end())
     return true;
-  else // Then objects' named frames
+  else  // Then objects' named frames
   {
     for (auto o : objects_)
     {
@@ -157,7 +157,7 @@ const Eigen::Affine3d& World::getTransform(const std::string& id) const
   auto it = objects_.find(id);
   if (it != objects_.end())
     return it->second->shape_poses_[0];
-  else // Find within named frames
+  else  // Find within named frames
   {
     for (auto o : objects_)
     {
@@ -215,7 +215,7 @@ bool World::moveObject(const std::string& id, const Eigen::Affine3d& transform)
 }
 
 bool World::replaceShapesInObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                   const EigenSTL::vector_Affine3d& poses)
+                                  const EigenSTL::vector_Affine3d& poses)
 {
   auto it = objects_.find(id);
   if (it == objects_.end())

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -187,39 +187,35 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to. 
+ * field if changed to the link the AttachedBody object is attached to.
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validatePositionConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c);
+bool validatePositionConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to. 
+ * field if changed to the link the AttachedBody object is attached to.
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validateOrientationConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c);
-
+bool validateOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to. 
+ * field if changed to the link the AttachedBody object is attached to.
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validatePositionOrientationConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c);
+bool validatePositionOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 }
 
 #endif

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -187,39 +187,35 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to. 
+ * field if changed to the link the AttachedBody object is attached to.
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validatePositionConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c);
+bool validatePositionConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to. 
+ * field if changed to the link the AttachedBody object is attached to.
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validateOrientationConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c);
-
+bool validateOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to. 
+ * field if changed to the link the AttachedBody object is attached to.
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validatePositionOrientationConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c);
-}
+bool validatePositionOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
+}  // namespace kinematic_constraints
 
 #endif

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -185,10 +185,12 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
                                                   double tolerance = 1e-3);
 
 /**
- * \brief Attempts to make a constraint message valid which in its link_name field
- * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to.
- * This function is to be used when constructing goals.
+ * \brief Converts constraints that refer to frames of AttachedBody objects 
+ * to frames that exist on the robot. This is required to construct a valid
+ * planning request. The link_name field of the constraint is changed from
+ * the name of the object frame to the name of the robot link that the 
+ * AttachedBody object is attached to.
+ * This function is used when constructing goals. 
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
@@ -196,10 +198,12 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
 bool validatePositionConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
- * \brief Attempts to make a constraint message valid which in its link_name field
- * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to.
- * This function is to be used when constructing goals.
+ * \brief Converts constraints that refer to frames of AttachedBody objects 
+ * to frames that exist on the robot. This is required to construct a valid
+ * planning request. The link_name field of the constraint is changed from
+ * the name of the object frame to the name of the robot link that the 
+ * AttachedBody object is attached to.
+ * This function is used when constructing goals. 
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
@@ -207,10 +211,12 @@ bool validatePositionConstraints(const robot_state::RobotState& state, moveit_ms
 bool validateOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
- * \brief Attempts to make a constraint message valid which in its link_name field
- * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to.
- * This function is to be used when constructing goals.
+ * \brief Converts constraints that refer to frames of AttachedBody objects 
+ * to frames that exist on the robot. This is required to construct a valid
+ * planning request. The link_name field of the constraint is changed from
+ * the name of the object frame to the name of the robot link that the 
+ * AttachedBody object is attached to.
+ * This function is used when constructing goals. 
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -187,35 +187,39 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to.
+ * field if changed to the link the AttachedBody object is attached to. 
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validatePositionConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
+bool validatePositionConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c);
 
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to.
+ * field if changed to the link the AttachedBody object is attached to. 
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validateOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
+bool validateOrientationConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c);
+
 
 /**
  * \brief Attempts to make a constraint message valid which in its link_name field
  * has the name of an AttachedBody object that exists in the RobotState. The link_name
- * field if changed to the link the AttachedBody object is attached to.
+ * field if changed to the link the AttachedBody object is attached to. 
  * This function is to be used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
  */
-bool validatePositionOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
-}  // namespace kinematic_constraints
+bool validatePositionOrientationConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c);
+}
 
 #endif

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -185,12 +185,12 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
                                                   double tolerance = 1e-3);
 
 /**
- * \brief Converts constraints that refer to frames of AttachedBody objects 
+ * \brief Converts constraints that refer to frames of AttachedBody objects
  * to frames that exist on the robot. This is required to construct a valid
  * planning request. The link_name field of the constraint is changed from
- * the name of the object frame to the name of the robot link that the 
+ * the name of the object frame to the name of the robot link that the
  * AttachedBody object is attached to.
- * This function is used when constructing goals. 
+ * This function is used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
@@ -198,12 +198,12 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
 bool validatePositionConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
- * \brief Converts constraints that refer to frames of AttachedBody objects 
+ * \brief Converts constraints that refer to frames of AttachedBody objects
  * to frames that exist on the robot. This is required to construct a valid
  * planning request. The link_name field of the constraint is changed from
- * the name of the object frame to the name of the robot link that the 
+ * the name of the object frame to the name of the robot link that the
  * AttachedBody object is attached to.
- * This function is used when constructing goals. 
+ * This function is used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).
@@ -211,12 +211,12 @@ bool validatePositionConstraints(const robot_state::RobotState& state, moveit_ms
 bool validateOrientationConstraints(const robot_state::RobotState& state, moveit_msgs::Constraints& c);
 
 /**
- * \brief Converts constraints that refer to frames of AttachedBody objects 
+ * \brief Converts constraints that refer to frames of AttachedBody objects
  * to frames that exist on the robot. This is required to construct a valid
  * planning request. The link_name field of the constraint is changed from
- * the name of the object frame to the name of the robot link that the 
+ * the name of the object frame to the name of the robot link that the
  * AttachedBody object is attached to.
- * This function is used when constructing goals. 
+ * This function is used when constructing goals.
  *
  * @param [in] state The pointer to the state from which to generate goal joint constraints
  * @param [in] c The message to be validated (modified directly).

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -183,6 +183,43 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
 moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
                                                   const geometry_msgs::PointStamped& goal_point,
                                                   double tolerance = 1e-3);
+
+/**
+ * \brief Attempts to make a constraint message valid which in its link_name field
+ * has the name of an AttachedBody object that exists in the RobotState. The link_name
+ * field if changed to the link the AttachedBody object is attached to. 
+ * This function is to be used when constructing goals.
+ *
+ * @param [in] state The pointer to the state from which to generate goal joint constraints
+ * @param [in] c The message to be validated (modified directly).
+ */
+bool validatePositionConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c);
+
+/**
+ * \brief Attempts to make a constraint message valid which in its link_name field
+ * has the name of an AttachedBody object that exists in the RobotState. The link_name
+ * field if changed to the link the AttachedBody object is attached to. 
+ * This function is to be used when constructing goals.
+ *
+ * @param [in] state The pointer to the state from which to generate goal joint constraints
+ * @param [in] c The message to be validated (modified directly).
+ */
+bool validateOrientationConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c);
+
+
+/**
+ * \brief Attempts to make a constraint message valid which in its link_name field
+ * has the name of an AttachedBody object that exists in the RobotState. The link_name
+ * field if changed to the link the AttachedBody object is attached to. 
+ * This function is to be used when constructing goals.
+ *
+ * @param [in] state The pointer to the state from which to generate goal joint constraints
+ * @param [in] c The message to be validated (modified directly).
+ */
+bool validatePositionOrientationConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c);
 }
 
 #endif

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -275,24 +275,21 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
 }
 
 bool kinematic_constraints::validatePositionConstraints(const robot_state::RobotState& state,
-                                                        moveit_msgs::Constraints& c)
+                                          moveit_msgs::Constraints& c)
 {
   ROS_INFO("Validating position constraints.");
-
+  
   for (auto pos_con_it = c.position_constraints.begin(); pos_con_it != c.position_constraints.end(); ++pos_con_it)
   {
     ROS_INFO("Cycling through position constraint.");
-    ROS_INFO_STREAM("Current position constraint: link_name "
-                    << pos_con_it->link_name << ", offset " << pos_con_it->target_point_offset.x << " "
-                    << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z
-                    << ". header/frame_id: " << pos_con_it->header.frame_id);
+    ROS_INFO_STREAM("Current position constraint: link_name " << pos_con_it->link_name << ", offset " << pos_con_it->target_point_offset.x << 
+                                            " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z << 
+                                            ". header/frame_id: " << pos_con_it->header.frame_id);
     // If the link is not found in the robot model
     if (!state.hasLinkModel(pos_con_it->link_name))
     {
-      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the
-      // link_frame of the robot,
-      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform
-      //       and std::string link_name.
+      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the link_frame of the robot,
+      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform and std::string link_name.
       std::vector<const robot_state::AttachedBody*> bodies;
       state.getAttachedBodies(bodies);
       Eigen::Affine3d t;
@@ -318,9 +315,7 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
           {
             t = ab->getNamedTransform(pos_con_it->link_name);
             robot_link_name = ab->getAttachedLinkName();
-            ROS_INFO_STREAM("State has "
-                            << " named frame called " << pos_con_it->link_name << " on attached body "
-                            << ab->getName());
+            ROS_INFO_STREAM("State has " << " named frame called " << pos_con_it->link_name << " on attached body " << ab->getName());
             transform_found = true;
           }
         }
@@ -328,44 +323,35 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
 
       if (transform_found)
       {
-        Eigen::Vector3d pos_in_link_frame,
-            pos_in_original_frame(pos_con_it->target_point_offset.x, pos_con_it->target_point_offset.y,
-                                  pos_con_it->target_point_offset.z);
-
-        ROS_INFO_STREAM("Original position constraint in frame "
-                        << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " "
-                        << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
+        Eigen::Vector3d pos_in_link_frame, pos_in_original_frame(pos_con_it->target_point_offset.x, pos_con_it->target_point_offset.y, pos_con_it->target_point_offset.z);
+          
+        ROS_INFO_STREAM("Original position constraint in frame " << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
         pos_in_link_frame = t * pos_in_original_frame;
         pos_con_it->link_name = robot_link_name;
         pos_con_it->target_point_offset.x = pos_in_link_frame[0];
         pos_con_it->target_point_offset.y = pos_in_link_frame[1];
         pos_con_it->target_point_offset.z = pos_in_link_frame[2];
-        ROS_INFO_STREAM("New position constraint in frame "
-                        << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " "
-                        << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
+        ROS_INFO_STREAM("New position constraint in frame " << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
       }
-      else
-        return false;
+      else return false;
     }
   }
   return true;
 }
 
 bool kinematic_constraints::validateOrientationConstraints(const robot_state::RobotState& state,
-                                                           moveit_msgs::Constraints& c)
+                                          moveit_msgs::Constraints& c)
 {
   ROS_INFO("Validating orientation constraints.");
-
+  
   for (auto ori_con_it = c.orientation_constraints.begin(); ori_con_it != c.orientation_constraints.end(); ++ori_con_it)
   {
     ROS_INFO("Cycling through orientation constraints.");
     // If the link is not found in the robot model
     if (!state.hasLinkModel(ori_con_it->link_name))
     {
-      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the
-      // link_frame of the robot,
-      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform
-      //       and std::string link_name.
+      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the link_frame of the robot,
+      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform and std::string link_name.
       std::vector<const robot_state::AttachedBody*> bodies;
       state.getAttachedBodies(bodies);
       Eigen::Quaterniond q_i;
@@ -388,9 +374,7 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
           {
             q_i = ab->getNamedTransform(ori_con_it->link_name).inverse().rotation();
             robot_link_name = ab->getAttachedLinkName();
-            ROS_INFO_STREAM("State has "
-                            << " named frame called " << ori_con_it->link_name << " on attached body "
-                            << ab->getName());
+            ROS_INFO_STREAM("State has " << " named frame called " << ori_con_it->link_name << " on attached body " << ab->getName());
             transform_found = true;
           }
         }
@@ -398,31 +382,25 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
 
       if (transform_found)
       {
-        Eigen::Quaterniond q_target(ori_con_it->orientation.w, ori_con_it->orientation.x, ori_con_it->orientation.y,
-                                    ori_con_it->orientation.z);
+        Eigen::Quaterniond q_target(ori_con_it->orientation.w, ori_con_it->orientation.x, ori_con_it->orientation.y, ori_con_it->orientation.z);
         Eigen::Quaterniond q_in_link = q_i * q_target;
-
-        ROS_INFO_STREAM("Original orientation constraint in frame "
-                        << ori_con_it->link_name << " is (xyz) " << ori_con_it->orientation.x << " "
-                        << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
+        
+        ROS_INFO_STREAM("Original orientation constraint in frame " << ori_con_it->link_name << " is (xyz) " << ori_con_it->orientation.x << " " << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
         ori_con_it->link_name = robot_link_name;
         ori_con_it->orientation.x = q_in_link.x();
         ori_con_it->orientation.y = q_in_link.y();
         ori_con_it->orientation.z = q_in_link.z();
         ori_con_it->orientation.w = q_in_link.w();
-        ROS_INFO_STREAM("New orientation constraint in frame "
-                        << ori_con_it->link_name << " is (xyz)  " << ori_con_it->orientation.x << " "
-                        << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
+        ROS_INFO_STREAM("New orientation constraint in frame " << ori_con_it->link_name << " is (xyz)  " << ori_con_it->orientation.x << " " << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
       }
-      else
-        return false;
+      else return false;
     }
   }
   return true;
 }
 
 bool kinematic_constraints::validatePositionOrientationConstraints(const robot_state::RobotState& state,
-                                                                   moveit_msgs::Constraints& c)
+                                        moveit_msgs::Constraints& c)
 {
   return (validatePositionConstraints(state, c) && validateOrientationConstraints(state, c));
 }

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -282,15 +282,16 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
   for (auto& pos_con_it : c.position_constraints)
   {
     ROS_DEBUG_NAMED("kinematic_constraints_utils", "Cycling through position constraint.");
-    ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "Current position constraint: link_name "
-                    << pos_con_it.link_name << ", offset " << pos_con_it.target_point_offset.x << " "
-                    << pos_con_it.target_point_offset.y << " " << pos_con_it.target_point_offset.z
-                    << ". header/frame_id: " << pos_con_it.header.frame_id);
+    ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils",
+                           "Current position constraint: link_name "
+                               << pos_con_it.link_name << ", offset " << pos_con_it.target_point_offset.x << " "
+                               << pos_con_it.target_point_offset.y << " " << pos_con_it.target_point_offset.z
+                               << ". header/frame_id: " << pos_con_it.header.frame_id);
     // If the link is not found in the robot model
     if (!state.hasLinkModel(pos_con_it.link_name))
     {
       // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the
-      // link_frame of the robot, and I can't think of a good name for a function that returns bool frame_exists, 
+      // link_frame of the robot, and I can't think of a good name for a function that returns bool frame_exists,
       // Eigen::Affine3d transform and std::string link_name.
       // TODO(felixvd): Make this comment understandable.
       std::vector<const robot_state::AttachedBody*> bodies;
@@ -301,7 +302,8 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
       // Try finding it in attached bodies
       if (state.hasAttachedBody(pos_con_it.link_name))
       {
-        ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has attached body with name " << pos_con_it.link_name);
+        ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has attached body with name "
+                                                                  << pos_con_it.link_name);
         const robot_state::AttachedBody* body = state.getAttachedBody(pos_con_it.link_name);
         transform = body->getFixedTransforms()[0];
         robot_link_name = body->getAttachedLinkName();
@@ -309,18 +311,21 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
       }
       else  // Try finding it in attached bodies' named frames
       {
-        ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has no attached body with name " << pos_con_it.link_name << ". Checking named frames.");
+        ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has no attached body with name "
+                                                                  << pos_con_it.link_name
+                                                                  << ". Checking named frames.");
         for (auto body : bodies)
         {
           ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "Checking attached body " << body->getName());
-          ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", body->getName() << " has " << body->getNamedTransforms().size() << " named frames.");
+          ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils",
+                                 body->getName() << " has " << body->getNamedTransforms().size() << " named frames.");
           if (body->hasNamedTransform(pos_con_it.link_name))
           {
             transform = body->getNamedTransform(pos_con_it.link_name);
             robot_link_name = body->getAttachedLinkName();
             ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has "
-                            << " named frame called " << pos_con_it.link_name << " on attached body "
-                            << body->getName());
+                                                                      << " named frame called " << pos_con_it.link_name
+                                                                      << " on attached body " << body->getName());
             transform_found = true;
           }
         }
@@ -332,17 +337,19 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
           pos_in_original_frame(pos_con_it.target_point_offset.x, pos_con_it.target_point_offset.y,
                                 pos_con_it.target_point_offset.z);
 
-      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "Original position constraint in frame "
-                      << pos_con_it.link_name << " is " << pos_con_it.target_point_offset.x << " "
-                      << pos_con_it.target_point_offset.y << " " << pos_con_it.target_point_offset.z);
+      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils",
+                             "Original position constraint in frame "
+                                 << pos_con_it.link_name << " is " << pos_con_it.target_point_offset.x << " "
+                                 << pos_con_it.target_point_offset.y << " " << pos_con_it.target_point_offset.z);
       pos_in_link_frame = transform * pos_in_original_frame;
       pos_con_it.link_name = robot_link_name;
       pos_con_it.target_point_offset.x = pos_in_link_frame[0];
       pos_con_it.target_point_offset.y = pos_in_link_frame[1];
       pos_con_it.target_point_offset.z = pos_in_link_frame[2];
-      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "New position constraint in frame "
-                      << pos_con_it.link_name << " is " << pos_con_it.target_point_offset.x << " "
-                      << pos_con_it.target_point_offset.y << " " << pos_con_it.target_point_offset.z);
+      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils",
+                             "New position constraint in frame "
+                                 << pos_con_it.link_name << " is " << pos_con_it.target_point_offset.x << " "
+                                 << pos_con_it.target_point_offset.y << " " << pos_con_it.target_point_offset.z);
     }
   }
   return true;
@@ -360,7 +367,7 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
     if (!state.hasLinkModel(ori_con_it.link_name))
     {
       // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the
-      // link_frame of the robot, and I can't think of a good name for a function that returns bool frame_exists, 
+      // link_frame of the robot, and I can't think of a good name for a function that returns bool frame_exists,
       // Eigen::Affine3d transform and std::string link_name.
       // TODO(felixvd): Make this comment understandable.
       std::vector<const robot_state::AttachedBody*> bodies;
@@ -371,7 +378,8 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
       // Try finding it in attached bodies
       if (state.hasAttachedBody(ori_con_it.link_name))
       {
-        ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has attached body with name " << ori_con_it.link_name);
+        ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has attached body with name "
+                                                                  << ori_con_it.link_name);
         const robot_state::AttachedBody* body = state.getAttachedBody(ori_con_it.link_name);
         q_body_to_link = body->getFixedTransforms()[0].inverse().rotation();
         robot_link_name = body->getAttachedLinkName();
@@ -386,8 +394,8 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
             q_body_to_link = body->getNamedTransform(ori_con_it.link_name).inverse().rotation();
             robot_link_name = body->getAttachedLinkName();
             ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "State has "
-                            << " named frame called " << ori_con_it.link_name << " on attached body "
-                            << body->getName());
+                                                                      << " named frame called " << ori_con_it.link_name
+                                                                      << " on attached body " << body->getName());
             transform_found = true;
           }
         }
@@ -399,17 +407,19 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
                                   ori_con_it.orientation.z);
       Eigen::Quaterniond q_in_link = q_body_to_link * q_target;
 
-      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "Original orientation constraint in frame "
-                      << ori_con_it.link_name << " is (xyz) " << ori_con_it.orientation.x << " "
-                      << ori_con_it.orientation.y << " " << ori_con_it.orientation.z);
+      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils",
+                             "Original orientation constraint in frame "
+                                 << ori_con_it.link_name << " is (xyz) " << ori_con_it.orientation.x << " "
+                                 << ori_con_it.orientation.y << " " << ori_con_it.orientation.z);
       ori_con_it.link_name = robot_link_name;
       ori_con_it.orientation.x = q_in_link.x();
       ori_con_it.orientation.y = q_in_link.y();
       ori_con_it.orientation.z = q_in_link.z();
       ori_con_it.orientation.w = q_in_link.w();
-      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils", "New orientation constraint in frame "
-                      << ori_con_it.link_name << " is (xyz)  " << ori_con_it.orientation.x << " "
-                      << ori_con_it.orientation.y << " " << ori_con_it.orientation.z);
+      ROS_DEBUG_STREAM_NAMED("kinematic_constraints_utils",
+                             "New orientation constraint in frame "
+                                 << ori_con_it.link_name << " is (xyz)  " << ori_con_it.orientation.x << " "
+                                 << ori_con_it.orientation.y << " " << ori_con_it.orientation.z);
     }
   }
   return true;

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -275,21 +275,24 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
 }
 
 bool kinematic_constraints::validatePositionConstraints(const robot_state::RobotState& state,
-                                          moveit_msgs::Constraints& c)
+                                                        moveit_msgs::Constraints& c)
 {
   ROS_INFO("Validating position constraints.");
-  
+
   for (auto pos_con_it = c.position_constraints.begin(); pos_con_it != c.position_constraints.end(); ++pos_con_it)
   {
     ROS_INFO("Cycling through position constraint.");
-    ROS_INFO_STREAM("Current position constraint: link_name " << pos_con_it->link_name << ", offset " << pos_con_it->target_point_offset.x << 
-                                            " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z << 
-                                            ". header/frame_id: " << pos_con_it->header.frame_id);
+    ROS_INFO_STREAM("Current position constraint: link_name "
+                    << pos_con_it->link_name << ", offset " << pos_con_it->target_point_offset.x << " "
+                    << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z
+                    << ". header/frame_id: " << pos_con_it->header.frame_id);
     // If the link is not found in the robot model
     if (!state.hasLinkModel(pos_con_it->link_name))
     {
-      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the link_frame of the robot,
-      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform and std::string link_name.
+      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the
+      // link_frame of the robot,
+      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform
+      //       and std::string link_name.
       std::vector<const robot_state::AttachedBody*> bodies;
       state.getAttachedBodies(bodies);
       Eigen::Affine3d t;
@@ -315,7 +318,9 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
           {
             t = ab->getNamedTransform(pos_con_it->link_name);
             robot_link_name = ab->getAttachedLinkName();
-            ROS_INFO_STREAM("State has " << " named frame called " << pos_con_it->link_name << " on attached body " << ab->getName());
+            ROS_INFO_STREAM("State has "
+                            << " named frame called " << pos_con_it->link_name << " on attached body "
+                            << ab->getName());
             transform_found = true;
           }
         }
@@ -323,35 +328,44 @@ bool kinematic_constraints::validatePositionConstraints(const robot_state::Robot
 
       if (transform_found)
       {
-        Eigen::Vector3d pos_in_link_frame, pos_in_original_frame(pos_con_it->target_point_offset.x, pos_con_it->target_point_offset.y, pos_con_it->target_point_offset.z);
-          
-        ROS_INFO_STREAM("Original position constraint in frame " << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
+        Eigen::Vector3d pos_in_link_frame,
+            pos_in_original_frame(pos_con_it->target_point_offset.x, pos_con_it->target_point_offset.y,
+                                  pos_con_it->target_point_offset.z);
+
+        ROS_INFO_STREAM("Original position constraint in frame "
+                        << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " "
+                        << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
         pos_in_link_frame = t * pos_in_original_frame;
         pos_con_it->link_name = robot_link_name;
         pos_con_it->target_point_offset.x = pos_in_link_frame[0];
         pos_con_it->target_point_offset.y = pos_in_link_frame[1];
         pos_con_it->target_point_offset.z = pos_in_link_frame[2];
-        ROS_INFO_STREAM("New position constraint in frame " << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
+        ROS_INFO_STREAM("New position constraint in frame "
+                        << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " "
+                        << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
       }
-      else return false;
+      else
+        return false;
     }
   }
   return true;
 }
 
 bool kinematic_constraints::validateOrientationConstraints(const robot_state::RobotState& state,
-                                          moveit_msgs::Constraints& c)
+                                                           moveit_msgs::Constraints& c)
 {
   ROS_INFO("Validating orientation constraints.");
-  
+
   for (auto ori_con_it = c.orientation_constraints.begin(); ori_con_it != c.orientation_constraints.end(); ++ori_con_it)
   {
     ROS_INFO("Cycling through orientation constraints.");
     // If the link is not found in the robot model
     if (!state.hasLinkModel(ori_con_it->link_name))
     {
-      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the link_frame of the robot,
-      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform and std::string link_name.
+      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the
+      // link_frame of the robot,
+      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform
+      //       and std::string link_name.
       std::vector<const robot_state::AttachedBody*> bodies;
       state.getAttachedBodies(bodies);
       Eigen::Quaterniond q_i;
@@ -374,7 +388,9 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
           {
             q_i = ab->getNamedTransform(ori_con_it->link_name).inverse().rotation();
             robot_link_name = ab->getAttachedLinkName();
-            ROS_INFO_STREAM("State has " << " named frame called " << ori_con_it->link_name << " on attached body " << ab->getName());
+            ROS_INFO_STREAM("State has "
+                            << " named frame called " << ori_con_it->link_name << " on attached body "
+                            << ab->getName());
             transform_found = true;
           }
         }
@@ -382,25 +398,31 @@ bool kinematic_constraints::validateOrientationConstraints(const robot_state::Ro
 
       if (transform_found)
       {
-        Eigen::Quaterniond q_target(ori_con_it->orientation.w, ori_con_it->orientation.x, ori_con_it->orientation.y, ori_con_it->orientation.z);
+        Eigen::Quaterniond q_target(ori_con_it->orientation.w, ori_con_it->orientation.x, ori_con_it->orientation.y,
+                                    ori_con_it->orientation.z);
         Eigen::Quaterniond q_in_link = q_i * q_target;
-        
-        ROS_INFO_STREAM("Original orientation constraint in frame " << ori_con_it->link_name << " is (xyz) " << ori_con_it->orientation.x << " " << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
+
+        ROS_INFO_STREAM("Original orientation constraint in frame "
+                        << ori_con_it->link_name << " is (xyz) " << ori_con_it->orientation.x << " "
+                        << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
         ori_con_it->link_name = robot_link_name;
         ori_con_it->orientation.x = q_in_link.x();
         ori_con_it->orientation.y = q_in_link.y();
         ori_con_it->orientation.z = q_in_link.z();
         ori_con_it->orientation.w = q_in_link.w();
-        ROS_INFO_STREAM("New orientation constraint in frame " << ori_con_it->link_name << " is (xyz)  " << ori_con_it->orientation.x << " " << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
+        ROS_INFO_STREAM("New orientation constraint in frame "
+                        << ori_con_it->link_name << " is (xyz)  " << ori_con_it->orientation.x << " "
+                        << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
       }
-      else return false;
+      else
+        return false;
     }
   }
   return true;
 }
 
 bool kinematic_constraints::validatePositionOrientationConstraints(const robot_state::RobotState& state,
-                                        moveit_msgs::Constraints& c)
+                                                                   moveit_msgs::Constraints& c)
 {
   return (validatePositionConstraints(state, c) && validateOrientationConstraints(state, c));
 }

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -273,3 +273,134 @@ moveit_msgs::Constraints kinematic_constraints::constructGoalConstraints(const s
 
   return goal;
 }
+
+bool kinematic_constraints::validatePositionConstraints(const robot_state::RobotState& state,
+                                          moveit_msgs::Constraints& c)
+{
+  ROS_INFO("Validating position constraints.");
+  
+  for (auto pos_con_it = c.position_constraints.begin(); pos_con_it != c.position_constraints.end(); ++pos_con_it)
+  {
+    ROS_INFO("Cycling through position constraint.");
+    ROS_INFO_STREAM("Current position constraint: link_name " << pos_con_it->link_name << ", offset " << pos_con_it->target_point_offset.x << 
+                                            " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z << 
+                                            ". header/frame_id: " << pos_con_it->header.frame_id);
+    // If the link is not found in the robot model
+    if (!state.hasLinkModel(pos_con_it->link_name))
+    {
+      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the link_frame of the robot,
+      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform and std::string link_name.
+      std::vector<const robot_state::AttachedBody*> bodies;
+      state.getAttachedBodies(bodies);
+      Eigen::Affine3d t;
+      bool transform_found = false;
+      std::string robot_link_name;
+      // Try finding it in attached bodies
+      if (state.hasAttachedBody(pos_con_it->link_name))
+      {
+        ROS_INFO_STREAM("State has attached body with name " << pos_con_it->link_name);
+        auto ab = state.getAttachedBody(pos_con_it->link_name);
+        t = ab->getFixedTransforms()[0];
+        robot_link_name = ab->getAttachedLinkName();
+        transform_found = true;
+      }
+      else  // Try finding it in attached bodies' named frames
+      {
+        ROS_INFO_STREAM("State has no attached body with name " << pos_con_it->link_name << ". Checking named frames.");
+        for (auto ab : bodies)
+        {
+          ROS_INFO_STREAM("Checking attached body " << ab->getName());
+          ROS_INFO_STREAM(ab->getName() << " has " << ab->getNamedTransforms().size() << " named frames.");
+          if (ab->hasNamedTransform(pos_con_it->link_name))
+          {
+            t = ab->getNamedTransform(pos_con_it->link_name);
+            robot_link_name = ab->getAttachedLinkName();
+            ROS_INFO_STREAM("State has " << " named frame called " << pos_con_it->link_name << " on attached body " << ab->getName());
+            transform_found = true;
+          }
+        }
+      }
+
+      if (transform_found)
+      {
+        Eigen::Vector3d pos_in_link_frame, pos_in_original_frame(pos_con_it->target_point_offset.x, pos_con_it->target_point_offset.y, pos_con_it->target_point_offset.z);
+          
+        ROS_INFO_STREAM("Original position constraint in frame " << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
+        pos_in_link_frame = t * pos_in_original_frame;
+        pos_con_it->link_name = robot_link_name;
+        pos_con_it->target_point_offset.x = pos_in_link_frame[0];
+        pos_con_it->target_point_offset.y = pos_in_link_frame[1];
+        pos_con_it->target_point_offset.z = pos_in_link_frame[2];
+        ROS_INFO_STREAM("New position constraint in frame " << pos_con_it->link_name << " is " << pos_con_it->target_point_offset.x << " " << pos_con_it->target_point_offset.y << " " << pos_con_it->target_point_offset.z);
+      }
+      else return false;
+    }
+  }
+  return true;
+}
+
+bool kinematic_constraints::validateOrientationConstraints(const robot_state::RobotState& state,
+                                          moveit_msgs::Constraints& c)
+{
+  ROS_INFO("Validating orientation constraints.");
+  
+  for (auto ori_con_it = c.orientation_constraints.begin(); ori_con_it != c.orientation_constraints.end(); ++ori_con_it)
+  {
+    ROS_INFO("Cycling through orientation constraints.");
+    // If the link is not found in the robot model
+    if (!state.hasLinkModel(ori_con_it->link_name))
+    {
+      // NOTE: This could use state.knowsFrameTransform() and state.getFrameTransform(), but those don't return the link_frame of the robot,
+      //       and I can't think of a good name for a function that returns bool frame_exists, Eigen::Affine3d transform and std::string link_name.
+      std::vector<const robot_state::AttachedBody*> bodies;
+      state.getAttachedBodies(bodies);
+      Eigen::Quaterniond q_i;
+      bool transform_found = false;
+      std::string robot_link_name;
+      // Try finding it in attached bodies
+      if (state.hasAttachedBody(ori_con_it->link_name))
+      {
+        ROS_INFO_STREAM("State has attached body with name " << ori_con_it->link_name);
+        auto ab = state.getAttachedBody(ori_con_it->link_name);
+        q_i = ab->getFixedTransforms()[0].inverse().rotation();
+        robot_link_name = ab->getAttachedLinkName();
+        transform_found = true;
+      }
+      else  // Try finding it in attached bodies' named frames
+      {
+        for (auto ab : bodies)
+        {
+          if (ab->hasNamedTransform(ori_con_it->link_name))
+          {
+            q_i = ab->getNamedTransform(ori_con_it->link_name).inverse().rotation();
+            robot_link_name = ab->getAttachedLinkName();
+            ROS_INFO_STREAM("State has " << " named frame called " << ori_con_it->link_name << " on attached body " << ab->getName());
+            transform_found = true;
+          }
+        }
+      }
+
+      if (transform_found)
+      {
+        Eigen::Quaterniond q_target(ori_con_it->orientation.w, ori_con_it->orientation.x, ori_con_it->orientation.y, ori_con_it->orientation.z);
+        Eigen::Quaterniond q_in_link = q_i * q_target;
+        
+        ROS_INFO_STREAM("Original orientation constraint in frame " << ori_con_it->link_name << " is (xyz) " << ori_con_it->orientation.x << " " << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
+        ori_con_it->link_name = robot_link_name;
+        ori_con_it->orientation.x = q_in_link.x();
+        ori_con_it->orientation.y = q_in_link.y();
+        ori_con_it->orientation.z = q_in_link.z();
+        ori_con_it->orientation.w = q_in_link.w();
+        ROS_INFO_STREAM("New orientation constraint in frame " << ori_con_it->link_name << " is (xyz)  " << ori_con_it->orientation.x << " " << ori_con_it->orientation.y << " " << ori_con_it->orientation.z);
+      }
+      else return false;
+    }
+  }
+  return true;
+}
+
+bool kinematic_constraints::validatePositionOrientationConstraints(const robot_state::RobotState& state,
+                                        moveit_msgs::Constraints& c)
+{
+  return (validatePositionConstraints(state, c) && validateOrientationConstraints(state, c));
+}

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -72,9 +72,9 @@ public:
     if (Transforms::isFixedFrame(frame))
       return true;
     if (frame[0] == '/')
-      return knowsObject(frame.substr(1));
+      return knowsFrame(frame.substr(1));
     else
-      return knowsObject(frame);
+      return knowsFrame(frame);
   }
 
   const Eigen::Affine3d& getTransform(const std::string& from_frame) const override
@@ -83,14 +83,9 @@ public:
   }
 
 private:
-  bool knowsObject(const std::string& id) const
+  bool knowsFrame(const std::string& id) const
   {
-    if (scene_->getWorld()->hasObject(id))
-    {
-      collision_detection::World::ObjectConstPtr obj = scene_->getWorld()->getObject(id);
-      return obj->shape_poses_.size() == 1;
-    }
-    return false;
+    return scene_->getWorld()->knowsTransform(id);
   }
 
   const PlanningScene* scene_;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1543,7 +1543,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& transform = kstate_->getGlobalLinkTransform(link_model).inverse() *
-                                     getTransforms().getTransform(object.object.header.frame_id);
+                                             getTransforms().getTransform(object.object.header.frame_id);
           for (std::size_t i = 0; i < object_to_attach.shape_poses_.size(); ++i)
             object_to_attach.shape_poses_[i] = transform * object_to_attach.shape_poses_[i];
         }
@@ -1565,7 +1565,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         object_to_attach.named_frame_poses_ = obj_in_world->named_frame_poses_;
         // Transform named frames to the link frame
         const Eigen::Affine3d& inv_transform = kstate_->getGlobalLinkTransform(link_model).inverse();
-        for (auto it = object_to_attach.named_frame_poses_.begin(); it != object_to_attach.named_frame_poses_.end(); it++)
+        for (auto it = object_to_attach.named_frame_poses_.begin(); it != object_to_attach.named_frame_poses_.end();
+             it++)
           it->second = inv_transform * it->second;
       }
       else  // Populate named frames from message
@@ -1582,8 +1583,9 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& transform = kstate_->getGlobalLinkTransform(link_model).inverse() *
-                                     getTransforms().getTransform(object.object.header.frame_id);
-          for (auto frame_pair = object_to_attach.named_frame_poses_.begin(); frame_pair != object_to_attach.named_frame_poses_.end(); frame_pair++)
+                                             getTransforms().getTransform(object.object.header.frame_id);
+          for (auto frame_pair = object_to_attach.named_frame_poses_.begin();
+               frame_pair != object_to_attach.named_frame_poses_.end(); frame_pair++)
             frame_pair->second = transform * frame_pair->second;
         }
       }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -841,7 +841,7 @@ bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collisio
     tf::poseEigenToMsg(it.second, p);
     collision_obj.named_frames.push_back(p);
   }
-  
+
   return true;
 }
 
@@ -1461,13 +1461,14 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
 
     if (object.object.frame_names.size() != object.object.named_frames.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object "
+                                        "message");
       return false;
     }
 
     const robot_model::LinkModel* lm = getRobotModel()->getLinkModel(object.link_name);
     if (lm)
-    {      
+    {
       collision_detection::World::Object object_to_attach(object.object.id);
       // This is a copy because we need access to transform the poses inside
 
@@ -1498,7 +1499,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           return false;
         }
       }
-      else // If first object is not in the world, fill it with the message contents
+      else  // If first object is not in the world, fill it with the message contents
       {
         for (std::size_t i = 0; i < object.object.primitives.size(); ++i)
         {
@@ -1538,7 +1539,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
-                                    getTransforms().getTransform(object.object.header.frame_id);
+                                     getTransforms().getTransform(object.object.header.frame_id);
           for (std::size_t i = 0; i < object_to_attach.shape_poses_.size(); ++i)
             object_to_attach.shape_poses_[i] = t * object_to_attach.shape_poses_[i];
         }
@@ -1554,15 +1555,16 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       if (!object.object.type.db.empty() || !object.object.type.key.empty())
         setObjectType(object.object.id, object.object.type);
 
-      if (object.object.operation == moveit_msgs::CollisionObject::ADD && object.object.named_frames.empty() && obj_in_world)
+      if (object.object.operation == moveit_msgs::CollisionObject::ADD && object.object.named_frames.empty() &&
+          obj_in_world)
       {
         object_to_attach.named_frames_ = obj_in_world->named_frames_;
         // Transform named frames to the link frame
         const Eigen::Affine3d& i_t = kstate_->getGlobalLinkTransform(lm).inverse();
-        for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++ )
+        for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++)
           it->second = i_t * it->second;
       }
-      else // Populate named frames from message
+      else  // Populate named frames from message
       {
         Eigen::Affine3d p;
         for (std::size_t i = 0; i < object.object.named_frames.size(); ++i)
@@ -1576,8 +1578,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
-                                    getTransforms().getTransform(object.object.header.frame_id);
-          for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++ )
+                                     getTransforms().getTransform(object.object.header.frame_id);
+          for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++)
             it->second = t * it->second;
         }
       }
@@ -1590,9 +1592,9 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
                           object.object.id.c_str());
         else
           ROS_WARN_NAMED("planning_scene",
-                          "You tried to append geometry to an attached object that is actually a world object ('%s'). "
-                          "World geometry is ignored.",
-                          object.object.id.c_str());
+                         "You tried to append geometry to an attached object that is actually a world object ('%s'). "
+                         "World geometry is ignored.",
+                         object.object.id.c_str());
       }
 
       // STEP 3: Attach the object to the robot
@@ -1602,10 +1604,10 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           ROS_DEBUG_NAMED("planning_scene", "The robot state already had an object named '%s' attached to link '%s'. "
                                             "The object was replaced.",
                           object_to_attach.id_.c_str(), object.link_name.c_str());
-        
-        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, 
-                          object.touch_links, object.link_name, object.detach_posture, 
-                          object_to_attach.named_frames_);
+
+        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_,
+                            object.touch_links, object.link_name, object.detach_posture,
+                            object_to_attach.named_frames_);
         ROS_DEBUG_NAMED("planning_scene", "Attached object '%s' to link '%s'", object_to_attach.id_.c_str(),
                         object.link_name.c_str());
       }
@@ -1614,30 +1616,34 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       {
         const robot_state::AttachedBody* ab = kstate_->getAttachedBody(object_to_attach.id_);
         object_to_attach.shapes_.insert(object_to_attach.shapes_.end(), ab->getShapes().begin(), ab->getShapes().end());
-        object_to_attach.shape_poses_.insert(object_to_attach.shape_poses_.end(), ab->getFixedTransforms().begin(), ab->getFixedTransforms().end());
+        object_to_attach.shape_poses_.insert(object_to_attach.shape_poses_.end(), ab->getFixedTransforms().begin(),
+                                             ab->getFixedTransforms().end());
         trajectory_msgs::JointTrajectory detach_posture =
             object.detach_posture.joint_names.empty() ? ab->getDetachPosture() : object.detach_posture;
         std::set<std::string> touch_links;
-        if (object.touch_links.empty()) {touch_links = ab->getTouchLinks();}
-        else 
+        if (object.touch_links.empty())
         {
-          touch_links = std::set<std::string>(
-                  std::make_move_iterator(object.touch_links.begin()), std::make_move_iterator(object.touch_links.end())); 
+          touch_links = ab->getTouchLinks();
+        }
+        else
+        {
+          touch_links = std::set<std::string>(std::make_move_iterator(object.touch_links.begin()),
+                                              std::make_move_iterator(object.touch_links.end()));
         }
         object_to_attach.named_frames_.insert(ab->getNamedTransforms().begin(), ab->getNamedTransforms().end());
-        
+
         kstate_->clearAttachedBody(object_to_attach.id_);
-        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, 
-                            touch_links, object.link_name, detach_posture, object_to_attach.named_frames_);
-        ROS_DEBUG_NAMED("planning_scene", "Appended things to object '%s' attached to link '%s'", object_to_attach.id_.c_str(),
-                        object.link_name.c_str());
+        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, touch_links,
+                            object.link_name, detach_posture, object_to_attach.named_frames_);
+        ROS_DEBUG_NAMED("planning_scene", "Appended things to object '%s' attached to link '%s'",
+                        object_to_attach.id_.c_str(), object.link_name.c_str());
       }
       return true;
     }
     else
       ROS_ERROR_NAMED("planning_scene", "Robot state is not compatible with robot model. This could be fatal.");
   }
-  else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE) // == DETACH
+  else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE)  // == DETACH
   {
     // STEP 1: Get info about the object from the RobotState
     std::vector<const robot_state::AttachedBody*> attached_bodies;
@@ -1746,7 +1752,8 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
 
     if (object.frame_names.size() != object.named_frames.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object "
+                                        "message");
       return false;
     }
 
@@ -1900,7 +1907,7 @@ const Eigen::Affine3d& PlanningScene::getFrameTransform(const robot_state::Robot
       if (obj->shape_poses_.size() > 1)
       {
         ROS_WARN_NAMED("planning_scene", "More than one shapes in object '%s'. Using first one to decide transform",
-                      id.c_str());
+                       id.c_str());
         return obj->shape_poses_[0];
       }
       else if (obj->shape_poses_.size() == 1)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -396,8 +396,9 @@ PlanningScene::getCollisionRobotUnpadded(const std::string& collision_detector_n
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    ROS_ERROR_NAMED("planning_scene", "Could not get CollisionRobotUnpadded named '%s'. "
-                                      "Returning active CollisionRobotUnpadded '%s' instead",
+    ROS_ERROR_NAMED("planning_scene",
+                    "Could not get CollisionRobotUnpadded named '%s'. "
+                    "Returning active CollisionRobotUnpadded '%s' instead",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->getCollisionRobotUnpadded();
   }
@@ -805,7 +806,7 @@ private:
   moveit_msgs::CollisionObject* obj_;
   const geometry_msgs::Pose* pose_;
 };
-}
+}  // namespace
 
 bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collision_obj, const std::string& ns) const
 {
@@ -841,7 +842,7 @@ bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collisio
     tf::poseEigenToMsg(it.second, p);
     collision_obj.named_frames.push_back(p);
   }
-  
+
   return true;
 }
 
@@ -1117,8 +1118,9 @@ void PlanningScene::setCurrentState(const moveit_msgs::RobotState& state)
   {
     if (!state.is_diff && state.attached_collision_objects[i].object.operation != moveit_msgs::CollisionObject::ADD)
     {
-      ROS_ERROR_NAMED("planning_scene", "The specified RobotState is not marked as is_diff. "
-                                        "The request to modify the object '%s' is not supported. Object is ignored.",
+      ROS_ERROR_NAMED("planning_scene",
+                      "The specified RobotState is not marked as is_diff. "
+                      "The request to modify the object '%s' is not supported. Object is ignored.",
                       state.attached_collision_objects[i].object.id.c_str());
       continue;
     }
@@ -1461,13 +1463,14 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
 
     if (object.object.frame_names.size() != object.object.named_frames.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object "
+                                        "message");
       return false;
     }
 
     const robot_model::LinkModel* lm = getRobotModel()->getLinkModel(object.link_name);
     if (lm)
-    {      
+    {
       collision_detection::World::Object object_to_attach(object.object.id);
       // This is a copy because we need access to transform the poses inside
 
@@ -1492,13 +1495,14 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         }
         else
         {
-          ROS_ERROR_NAMED("planning_scene", "Attempting to attach object '%s' to link '%s' but no geometry specified "
-                                            "and such an object does not exist in the collision world",
+          ROS_ERROR_NAMED("planning_scene",
+                          "Attempting to attach object '%s' to link '%s' but no geometry specified "
+                          "and such an object does not exist in the collision world",
                           object.object.id.c_str(), object.link_name.c_str());
           return false;
         }
       }
-      else // If first object is not in the world, fill it with the message contents
+      else  // If first object is not in the world, fill it with the message contents
       {
         for (std::size_t i = 0; i < object.object.primitives.size(); ++i)
         {
@@ -1538,7 +1542,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
-                                    getTransforms().getTransform(object.object.header.frame_id);
+                                     getTransforms().getTransform(object.object.header.frame_id);
           for (std::size_t i = 0; i < object_to_attach.shape_poses_.size(); ++i)
             object_to_attach.shape_poses_[i] = t * object_to_attach.shape_poses_[i];
         }
@@ -1554,15 +1558,16 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       if (!object.object.type.db.empty() || !object.object.type.key.empty())
         setObjectType(object.object.id, object.object.type);
 
-      if (object.object.operation == moveit_msgs::CollisionObject::ADD && object.object.named_frames.empty() && obj_in_world)
+      if (object.object.operation == moveit_msgs::CollisionObject::ADD && object.object.named_frames.empty() &&
+          obj_in_world)
       {
         object_to_attach.named_frames_ = obj_in_world->named_frames_;
         // Transform named frames to the link frame
         const Eigen::Affine3d& i_t = kstate_->getGlobalLinkTransform(lm).inverse();
-        for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++ )
+        for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++)
           it->second = i_t * it->second;
       }
-      else // Populate named frames from message
+      else  // Populate named frames from message
       {
         Eigen::Affine3d p;
         for (std::size_t i = 0; i < object.object.named_frames.size(); ++i)
@@ -1576,8 +1581,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
-                                    getTransforms().getTransform(object.object.header.frame_id);
-          for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++ )
+                                     getTransforms().getTransform(object.object.header.frame_id);
+          for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++)
             it->second = t * it->second;
         }
       }
@@ -1590,22 +1595,23 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
                           object.object.id.c_str());
         else
           ROS_WARN_NAMED("planning_scene",
-                          "You tried to append geometry to an attached object that is actually a world object ('%s'). "
-                          "World geometry is ignored.",
-                          object.object.id.c_str());
+                         "You tried to append geometry to an attached object that is actually a world object ('%s'). "
+                         "World geometry is ignored.",
+                         object.object.id.c_str());
       }
 
       // STEP 3: Attach the object to the robot
       if (object.object.operation == moveit_msgs::CollisionObject::ADD || !kstate_->hasAttachedBody(object.object.id))
       {
         if (kstate_->clearAttachedBody(object_to_attach.id_))
-          ROS_DEBUG_NAMED("planning_scene", "The robot state already had an object named '%s' attached to link '%s'. "
-                                            "The object was replaced.",
+          ROS_DEBUG_NAMED("planning_scene",
+                          "The robot state already had an object named '%s' attached to link '%s'. "
+                          "The object was replaced.",
                           object_to_attach.id_.c_str(), object.link_name.c_str());
-        
-        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, 
-                          object.touch_links, object.link_name, object.detach_posture, 
-                          object_to_attach.named_frames_);
+
+        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_,
+                            object.touch_links, object.link_name, object.detach_posture,
+                            object_to_attach.named_frames_);
         ROS_DEBUG_NAMED("planning_scene", "Attached object '%s' to link '%s'", object_to_attach.id_.c_str(),
                         object.link_name.c_str());
       }
@@ -1614,30 +1620,34 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       {
         const robot_state::AttachedBody* ab = kstate_->getAttachedBody(object_to_attach.id_);
         object_to_attach.shapes_.insert(object_to_attach.shapes_.end(), ab->getShapes().begin(), ab->getShapes().end());
-        object_to_attach.shape_poses_.insert(object_to_attach.shape_poses_.end(), ab->getFixedTransforms().begin(), ab->getFixedTransforms().end());
+        object_to_attach.shape_poses_.insert(object_to_attach.shape_poses_.end(), ab->getFixedTransforms().begin(),
+                                             ab->getFixedTransforms().end());
         trajectory_msgs::JointTrajectory detach_posture =
             object.detach_posture.joint_names.empty() ? ab->getDetachPosture() : object.detach_posture;
         std::set<std::string> touch_links;
-        if (object.touch_links.empty()) {touch_links = ab->getTouchLinks();}
-        else 
+        if (object.touch_links.empty())
         {
-          touch_links = std::set<std::string>(
-                  std::make_move_iterator(object.touch_links.begin()), std::make_move_iterator(object.touch_links.end())); 
+          touch_links = ab->getTouchLinks();
+        }
+        else
+        {
+          touch_links = std::set<std::string>(std::make_move_iterator(object.touch_links.begin()),
+                                              std::make_move_iterator(object.touch_links.end()));
         }
         object_to_attach.named_frames_.insert(ab->getNamedTransforms().begin(), ab->getNamedTransforms().end());
-        
+
         kstate_->clearAttachedBody(object_to_attach.id_);
-        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, 
-                            touch_links, object.link_name, detach_posture, object_to_attach.named_frames_);
-        ROS_DEBUG_NAMED("planning_scene", "Appended things to object '%s' attached to link '%s'", object_to_attach.id_.c_str(),
-                        object.link_name.c_str());
+        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, touch_links,
+                            object.link_name, detach_posture, object_to_attach.named_frames_);
+        ROS_DEBUG_NAMED("planning_scene", "Appended things to object '%s' attached to link '%s'",
+                        object_to_attach.id_.c_str(), object.link_name.c_str());
       }
       return true;
     }
     else
       ROS_ERROR_NAMED("planning_scene", "Robot state is not compatible with robot model. This could be fatal.");
   }
-  else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE) // == DETACH
+  else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE)  // == DETACH
   {
     // STEP 1: Get info about the object from the RobotState
     std::vector<const robot_state::AttachedBody*> attached_bodies;
@@ -1746,7 +1756,8 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
 
     if (object.frame_names.size() != object.named_frames.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object message");
+      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object "
+                                        "message");
       return false;
     }
 
@@ -1900,7 +1911,7 @@ const Eigen::Affine3d& PlanningScene::getFrameTransform(const robot_state::Robot
       if (obj->shape_poses_.size() > 1)
       {
         ROS_WARN_NAMED("planning_scene", "More than one shapes in object '%s'. Using first one to decide transform",
-                      id.c_str());
+                       id.c_str());
         return obj->shape_poses_[0];
       }
       else if (obj->shape_poses_.size() == 1)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -396,9 +396,8 @@ PlanningScene::getCollisionRobotUnpadded(const std::string& collision_detector_n
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    ROS_ERROR_NAMED("planning_scene",
-                    "Could not get CollisionRobotUnpadded named '%s'. "
-                    "Returning active CollisionRobotUnpadded '%s' instead",
+    ROS_ERROR_NAMED("planning_scene", "Could not get CollisionRobotUnpadded named '%s'. "
+                                      "Returning active CollisionRobotUnpadded '%s' instead",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->getCollisionRobotUnpadded();
   }
@@ -806,7 +805,7 @@ private:
   moveit_msgs::CollisionObject* obj_;
   const geometry_msgs::Pose* pose_;
 };
-}  // namespace
+}
 
 bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collision_obj, const std::string& ns) const
 {
@@ -842,7 +841,7 @@ bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collisio
     tf::poseEigenToMsg(it.second, p);
     collision_obj.named_frames.push_back(p);
   }
-
+  
   return true;
 }
 
@@ -1118,9 +1117,8 @@ void PlanningScene::setCurrentState(const moveit_msgs::RobotState& state)
   {
     if (!state.is_diff && state.attached_collision_objects[i].object.operation != moveit_msgs::CollisionObject::ADD)
     {
-      ROS_ERROR_NAMED("planning_scene",
-                      "The specified RobotState is not marked as is_diff. "
-                      "The request to modify the object '%s' is not supported. Object is ignored.",
+      ROS_ERROR_NAMED("planning_scene", "The specified RobotState is not marked as is_diff. "
+                                        "The request to modify the object '%s' is not supported. Object is ignored.",
                       state.attached_collision_objects[i].object.id.c_str());
       continue;
     }
@@ -1463,14 +1461,13 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
 
     if (object.object.frame_names.size() != object.object.named_frames.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object "
-                                        "message");
+      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object message");
       return false;
     }
 
     const robot_model::LinkModel* lm = getRobotModel()->getLinkModel(object.link_name);
     if (lm)
-    {
+    {      
       collision_detection::World::Object object_to_attach(object.object.id);
       // This is a copy because we need access to transform the poses inside
 
@@ -1495,14 +1492,13 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         }
         else
         {
-          ROS_ERROR_NAMED("planning_scene",
-                          "Attempting to attach object '%s' to link '%s' but no geometry specified "
-                          "and such an object does not exist in the collision world",
+          ROS_ERROR_NAMED("planning_scene", "Attempting to attach object '%s' to link '%s' but no geometry specified "
+                                            "and such an object does not exist in the collision world",
                           object.object.id.c_str(), object.link_name.c_str());
           return false;
         }
       }
-      else  // If first object is not in the world, fill it with the message contents
+      else // If first object is not in the world, fill it with the message contents
       {
         for (std::size_t i = 0; i < object.object.primitives.size(); ++i)
         {
@@ -1542,7 +1538,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
-                                     getTransforms().getTransform(object.object.header.frame_id);
+                                    getTransforms().getTransform(object.object.header.frame_id);
           for (std::size_t i = 0; i < object_to_attach.shape_poses_.size(); ++i)
             object_to_attach.shape_poses_[i] = t * object_to_attach.shape_poses_[i];
         }
@@ -1558,16 +1554,15 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       if (!object.object.type.db.empty() || !object.object.type.key.empty())
         setObjectType(object.object.id, object.object.type);
 
-      if (object.object.operation == moveit_msgs::CollisionObject::ADD && object.object.named_frames.empty() &&
-          obj_in_world)
+      if (object.object.operation == moveit_msgs::CollisionObject::ADD && object.object.named_frames.empty() && obj_in_world)
       {
         object_to_attach.named_frames_ = obj_in_world->named_frames_;
         // Transform named frames to the link frame
         const Eigen::Affine3d& i_t = kstate_->getGlobalLinkTransform(lm).inverse();
-        for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++)
+        for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++ )
           it->second = i_t * it->second;
       }
-      else  // Populate named frames from message
+      else // Populate named frames from message
       {
         Eigen::Affine3d p;
         for (std::size_t i = 0; i < object.object.named_frames.size(); ++i)
@@ -1581,8 +1576,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (object.object.header.frame_id != object.link_name)
         {
           const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
-                                     getTransforms().getTransform(object.object.header.frame_id);
-          for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++)
+                                    getTransforms().getTransform(object.object.header.frame_id);
+          for (auto it = object_to_attach.named_frames_.begin(); it != object_to_attach.named_frames_.end(); it++ )
             it->second = t * it->second;
         }
       }
@@ -1595,23 +1590,22 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
                           object.object.id.c_str());
         else
           ROS_WARN_NAMED("planning_scene",
-                         "You tried to append geometry to an attached object that is actually a world object ('%s'). "
-                         "World geometry is ignored.",
-                         object.object.id.c_str());
+                          "You tried to append geometry to an attached object that is actually a world object ('%s'). "
+                          "World geometry is ignored.",
+                          object.object.id.c_str());
       }
 
       // STEP 3: Attach the object to the robot
       if (object.object.operation == moveit_msgs::CollisionObject::ADD || !kstate_->hasAttachedBody(object.object.id))
       {
         if (kstate_->clearAttachedBody(object_to_attach.id_))
-          ROS_DEBUG_NAMED("planning_scene",
-                          "The robot state already had an object named '%s' attached to link '%s'. "
-                          "The object was replaced.",
+          ROS_DEBUG_NAMED("planning_scene", "The robot state already had an object named '%s' attached to link '%s'. "
+                                            "The object was replaced.",
                           object_to_attach.id_.c_str(), object.link_name.c_str());
-
-        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_,
-                            object.touch_links, object.link_name, object.detach_posture,
-                            object_to_attach.named_frames_);
+        
+        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, 
+                          object.touch_links, object.link_name, object.detach_posture, 
+                          object_to_attach.named_frames_);
         ROS_DEBUG_NAMED("planning_scene", "Attached object '%s' to link '%s'", object_to_attach.id_.c_str(),
                         object.link_name.c_str());
       }
@@ -1620,34 +1614,30 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       {
         const robot_state::AttachedBody* ab = kstate_->getAttachedBody(object_to_attach.id_);
         object_to_attach.shapes_.insert(object_to_attach.shapes_.end(), ab->getShapes().begin(), ab->getShapes().end());
-        object_to_attach.shape_poses_.insert(object_to_attach.shape_poses_.end(), ab->getFixedTransforms().begin(),
-                                             ab->getFixedTransforms().end());
+        object_to_attach.shape_poses_.insert(object_to_attach.shape_poses_.end(), ab->getFixedTransforms().begin(), ab->getFixedTransforms().end());
         trajectory_msgs::JointTrajectory detach_posture =
             object.detach_posture.joint_names.empty() ? ab->getDetachPosture() : object.detach_posture;
         std::set<std::string> touch_links;
-        if (object.touch_links.empty())
+        if (object.touch_links.empty()) {touch_links = ab->getTouchLinks();}
+        else 
         {
-          touch_links = ab->getTouchLinks();
-        }
-        else
-        {
-          touch_links = std::set<std::string>(std::make_move_iterator(object.touch_links.begin()),
-                                              std::make_move_iterator(object.touch_links.end()));
+          touch_links = std::set<std::string>(
+                  std::make_move_iterator(object.touch_links.begin()), std::make_move_iterator(object.touch_links.end())); 
         }
         object_to_attach.named_frames_.insert(ab->getNamedTransforms().begin(), ab->getNamedTransforms().end());
-
+        
         kstate_->clearAttachedBody(object_to_attach.id_);
-        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, touch_links,
-                            object.link_name, detach_posture, object_to_attach.named_frames_);
-        ROS_DEBUG_NAMED("planning_scene", "Appended things to object '%s' attached to link '%s'",
-                        object_to_attach.id_.c_str(), object.link_name.c_str());
+        kstate_->attachBody(object_to_attach.id_, object_to_attach.shapes_, object_to_attach.shape_poses_, 
+                            touch_links, object.link_name, detach_posture, object_to_attach.named_frames_);
+        ROS_DEBUG_NAMED("planning_scene", "Appended things to object '%s' attached to link '%s'", object_to_attach.id_.c_str(),
+                        object.link_name.c_str());
       }
       return true;
     }
     else
       ROS_ERROR_NAMED("planning_scene", "Robot state is not compatible with robot model. This could be fatal.");
   }
-  else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE)  // == DETACH
+  else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE) // == DETACH
   {
     // STEP 1: Get info about the object from the RobotState
     std::vector<const robot_state::AttachedBody*> attached_bodies;
@@ -1756,8 +1746,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
 
     if (object.frame_names.size() != object.named_frames.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object "
-                                        "message");
+      ROS_ERROR_NAMED("planning_scene", "Number of frame names does not match number of frames in collision object message");
       return false;
     }
 
@@ -1911,7 +1900,7 @@ const Eigen::Affine3d& PlanningScene::getFrameTransform(const robot_state::Robot
       if (obj->shape_poses_.size() > 1)
       {
         ROS_WARN_NAMED("planning_scene", "More than one shapes in object '%s'. Using first one to decide transform",
-                       id.c_str());
+                      id.c_str());
         return obj->shape_poses_[0];
       }
       else if (obj->shape_poses_.size() == 1)

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -1,36 +1,36 @@
 /*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2012, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of Willow Garage, Inc. nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2012, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
 
 /* Author: Ioan Sucan */
 
@@ -123,7 +123,7 @@ public:
     return named_frames_.find(frame_name)->second;
   }
 
-  /** \brief Returns true if the named
+  /** \brief Returns true if the named 
    */
   bool hasNamedTransform(const std::string& frame_name) const
   {
@@ -195,12 +195,12 @@ private:
   EigenSTL::vector_Affine3d global_collision_body_transforms_;
 
   /** \brief Transforms to named frames on the object. Transforms are applied to the link.
-   *  Use these to define points of interest on the object to plan with
+   *  Use these to define points of interest on the object to plan with 
    *  (e.g. screwdriver_tip, kettle_spout, mug_base).
    * */
   std::map<std::string, Eigen::Affine3d> named_frames_;
 };
-}  // namespace core
-}  // namespace moveit
+}
+}
 
 #endif

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -63,7 +63,7 @@ public:
   AttachedBody(const LinkModel* link, const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
                const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
                const trajectory_msgs::JointTrajectory& attach_posture,
-               const std::map<std::string, Eigen::Affine3d>& named_frames);
+               const std::map<std::string, Eigen::Affine3d>& named_frame_poses);
 
   ~AttachedBody();
 
@@ -120,14 +120,15 @@ public:
   /** \brief Get the fixed transform to a named frame on this body (not a transform to a visual or collision shape) */
   const Eigen::Affine3d& getNamedTransform(const std::string& frame_name) const
   {
-    return named_frames_.find(frame_name)->second;
+    return named_frame_poses_.find(frame_name)->second;
   }
 
-  /** \brief Returns true if the named
+  /** \brief Returns true if the named frames contain the frame_name
    */
   bool hasNamedTransform(const std::string& frame_name) const
   {
-    return (named_frames_.count(frame_name) > 0);
+    
+    return (named_frame_poses_.find(frame_name) != named_frame_poses_.end());
   }
 
   /** \brief Get all named transforms (not the ones associated to visual or collision shapes)
@@ -135,21 +136,21 @@ public:
    */
   const std::map<std::string, Eigen::Affine3d>& getNamedTransforms() const
   {
-    return named_frames_;
+    return named_frame_poses_;
   }
 
   /** \brief Get all named transforms (not the ones associated to visual or collision shapes)
    * These are also technically "FixedTransforms", but changing the other function would be bad.
    */
-  void getNamedTransforms(std::map<std::string, Eigen::Affine3d>& named_frames) const
+  void getNamedTransforms(std::map<std::string, Eigen::Affine3d>& named_frame_poses) const
   {
-    named_frames = named_frames_;
+    named_frame_poses = named_frame_poses_;
   }
 
   /** \brief Set the map of named frames. */
-  void setNamedTransforms(const std::map<std::string, Eigen::Affine3d>& named_frames)
+  void setNamedTransforms(const std::map<std::string, Eigen::Affine3d>& named_frame_poses)
   {
-    named_frames_ = named_frames;
+    named_frame_poses_ = named_frame_poses;
   }
 
   /** \brief Get the global transforms for the collision bodies */
@@ -198,7 +199,7 @@ private:
    *  Use these to define points of interest on the object to plan with
    *  (e.g. screwdriver_tip, kettle_spout, mug_base).
    * */
-  std::map<std::string, Eigen::Affine3d> named_frames_;
+  std::map<std::string, Eigen::Affine3d> named_frame_poses_;
 };
 }
 }

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -123,7 +123,7 @@ public:
     return named_frames_.find(frame_name)->second;
   }
 
-  /** \brief Returns true if the named 
+  /** \brief Returns true if the named
    */
   bool hasNamedTransform(const std::string& frame_name) const
   {
@@ -195,7 +195,7 @@ private:
   EigenSTL::vector_Affine3d global_collision_body_transforms_;
 
   /** \brief Transforms to named frames on the object. Transforms are applied to the link.
-   *  Use these to define points of interest on the object to plan with 
+   *  Use these to define points of interest on the object to plan with
    *  (e.g. screwdriver_tip, kettle_spout, mug_base).
    * */
   std::map<std::string, Eigen::Affine3d> named_frames_;

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -62,7 +62,8 @@ public:
      object is specified by \e touch_links. */
   AttachedBody(const LinkModel* link, const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
                const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
-               const trajectory_msgs::JointTrajectory& attach_posture);
+               const trajectory_msgs::JointTrajectory& attach_posture,
+               const std::map<std::string, Eigen::Affine3d>& named_frames);
 
   ~AttachedBody();
 
@@ -110,6 +111,47 @@ public:
     return attach_trans_;
   }
 
+  /** \brief Get the fixed transform to a named frame on this body (not a transform to a visual or collision shape) */
+  const Eigen::Affine3d& getFixedTransform(const std::string& frame_name) const
+  {
+    return getNamedTransform(frame_name);
+  }
+
+  /** \brief Get the fixed transform to a named frame on this body (not a transform to a visual or collision shape) */
+  const Eigen::Affine3d& getNamedTransform(const std::string& frame_name) const
+  {
+    return named_frames_.find(frame_name)->second;
+  }
+
+  /** \brief Returns true if the named 
+   */
+  bool hasNamedTransform(const std::string& frame_name) const
+  {
+    return (named_frames_.count(frame_name) > 0);
+  }
+
+  /** \brief Get all named transforms (not the ones associated to visual or collision shapes)
+   * These are also technically "FixedTransforms", but changing the other function would be bad.
+   */
+  const std::map<std::string, Eigen::Affine3d>& getNamedTransforms() const
+  {
+    return named_frames_;
+  }
+
+  /** \brief Get all named transforms (not the ones associated to visual or collision shapes)
+   * These are also technically "FixedTransforms", but changing the other function would be bad.
+   */
+  void getNamedTransforms(std::map<std::string, Eigen::Affine3d>& named_frames) const
+  {
+    named_frames = named_frames_;
+  }
+
+  /** \brief Set the map of named frames. */
+  void setNamedTransforms(const std::map<std::string, Eigen::Affine3d>& named_frames)
+  {
+    named_frames_ = named_frames;
+  }
+
   /** \brief Get the global transforms for the collision bodies */
   const EigenSTL::vector_Affine3d& getGlobalCollisionBodyTransforms() const
   {
@@ -151,6 +193,12 @@ private:
 
   /** \brief The global transforms for these attached bodies (computed by forward kinematics) */
   EigenSTL::vector_Affine3d global_collision_body_transforms_;
+
+  /** \brief Transforms to named frames on the object. Transforms are applied to the link.
+   *  Use these to define points of interest on the object to plan with 
+   *  (e.g. screwdriver_tip, kettle_spout, mug_base).
+   * */
+  std::map<std::string, Eigen::Affine3d> named_frames_;
 };
 }
 }

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2012, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of Willow Garage, Inc. nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 
@@ -123,7 +123,7 @@ public:
     return named_frames_.find(frame_name)->second;
   }
 
-  /** \brief Returns true if the named 
+  /** \brief Returns true if the named
    */
   bool hasNamedTransform(const std::string& frame_name) const
   {
@@ -195,12 +195,12 @@ private:
   EigenSTL::vector_Affine3d global_collision_body_transforms_;
 
   /** \brief Transforms to named frames on the object. Transforms are applied to the link.
-   *  Use these to define points of interest on the object to plan with 
+   *  Use these to define points of interest on the object to plan with
    *  (e.g. screwdriver_tip, kettle_spout, mug_base).
    * */
   std::map<std::string, Eigen::Affine3d> named_frames_;
 };
-}
-}
+}  // namespace core
+}  // namespace moveit
 
 #endif

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -127,7 +127,6 @@ public:
    */
   bool hasNamedTransform(const std::string& frame_name) const
   {
-    
     return (named_frame_poses_.find(frame_name) != named_frame_poses_.end());
   }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1601,7 +1601,7 @@ as the new values that correspond to the group */
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
-   * @param named_frames Transforms to points of interest on the object (can be used as end effector link)
+   * @param named_frame_poses Transforms to points of interest on the object (can be used as end effector link)
    *
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
@@ -1615,7 +1615,7 @@ as the new values that correspond to the group */
              const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
              const std::string& link_name,
              const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
-             const std::map<std::string, Eigen::Affine3d>& named_frames = std::map<std::string, Eigen::Affine3d>());
+             const std::map<std::string, Eigen::Affine3d>& named_frame_poses = std::map<std::string, Eigen::Affine3d>());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
@@ -1624,7 +1624,7 @@ as the new values that correspond to the group */
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
-   * @param named_frames Transforms to points of interest on the object (can be used as end effector link)
+   * @param named_frame_poses Transforms to points of interest on the object (can be used as end effector link)
    *
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
@@ -1637,10 +1637,10 @@ as the new values that correspond to the group */
                   const EigenSTL::vector_Affine3d& attach_trans, const std::vector<std::string>& touch_links,
                   const std::string& link_name,
                   const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
-                  const std::map<std::string, Eigen::Affine3d>& named_frames = std::map<std::string, Eigen::Affine3d>())
+                  const std::map<std::string, Eigen::Affine3d>& named_frame_poses = std::map<std::string, Eigen::Affine3d>())
   {
     std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
-    attachBody(id, shapes, attach_trans, touch_links_set, link_name, detach_posture, named_frames);
+    attachBody(id, shapes, attach_trans, touch_links_set, link_name, detach_posture, named_frame_poses);
   }
 
   /** \brief Get all bodies attached to the model corresponding to this state */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1602,7 +1602,7 @@ as the new values that correspond to the group */
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
    * @param named_frames Transforms to points of interest on the object (can be used as end effector link)
-   * 
+   *
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
    * representations of the object elsewhere in the system.  So if the
@@ -1610,11 +1610,12 @@ as the new values that correspond to the group */
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
-                  const std::string& link_name,
-                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
-                  const std::map<std::string, Eigen::Affine3d>& named_frames = std::map<std::string, Eigen::Affine3d>());
+  void
+  attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+             const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
+             const std::string& link_name,
+             const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+             const std::map<std::string, Eigen::Affine3d>& named_frames = std::map<std::string, Eigen::Affine3d>());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1610,12 +1610,12 @@ as the new values that correspond to the group */
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void
-  attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-             const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
-             const std::string& link_name,
-             const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
-             const std::map<std::string, Eigen::Affine3d>& named_frame_poses = std::map<std::string, Eigen::Affine3d>());
+  void attachBody(
+      const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+      const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
+      const std::string& link_name,
+      const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+      const std::map<std::string, Eigen::Affine3d>& named_frame_poses = std::map<std::string, Eigen::Affine3d>());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
@@ -1633,11 +1633,12 @@ as the new values that correspond to the group */
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Affine3d& attach_trans, const std::vector<std::string>& touch_links,
-                  const std::string& link_name,
-                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
-                  const std::map<std::string, Eigen::Affine3d>& named_frame_poses = std::map<std::string, Eigen::Affine3d>())
+  void
+  attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+             const EigenSTL::vector_Affine3d& attach_trans, const std::vector<std::string>& touch_links,
+             const std::string& link_name,
+             const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+             const std::map<std::string, Eigen::Affine3d>& named_frame_poses = std::map<std::string, Eigen::Affine3d>())
   {
     std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
     attachBody(id, shapes, attach_trans, touch_links_set, link_name, detach_posture, named_frame_poses);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -152,6 +152,11 @@ public:
     return robot_model_->getVariableNames();
   }
 
+  bool hasLinkModel(const std::string& link) const
+  {
+    return robot_model_->hasLinkModel(link);
+  }
+
   /** \brief Get the model of a particular link */
   const LinkModel* getLinkModel(const std::string& link) const
   {
@@ -1595,7 +1600,9 @@ as the new values that correspond to the group */
    * @param attach_trans The desired transform between this link and the attached body
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
-   *
+   * @param detach_posture The posture of the gripper when placing the object
+   * @param named_frames Transforms to points of interest on the object (can be used as end effector link)
+   * 
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
    * representations of the object elsewhere in the system.  So if the
@@ -1606,7 +1613,8 @@ as the new values that correspond to the group */
   void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
                   const EigenSTL::vector_Affine3d& attach_trans, const std::set<std::string>& touch_links,
                   const std::string& link_name,
-                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory());
+                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+                  const std::map<std::string, Eigen::Affine3d>& named_frames = std::map<std::string, Eigen::Affine3d>());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
@@ -1614,6 +1622,8 @@ as the new values that correspond to the group */
    * @param attach_trans The desired transform between this link and the attached body
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
+   * @param detach_posture The posture of the gripper when placing the object
+   * @param named_frames Transforms to points of interest on the object (can be used as end effector link)
    *
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
@@ -1625,10 +1635,11 @@ as the new values that correspond to the group */
   void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
                   const EigenSTL::vector_Affine3d& attach_trans, const std::vector<std::string>& touch_links,
                   const std::string& link_name,
-                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory())
+                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+                  const std::map<std::string, Eigen::Affine3d>& named_frames = std::map<std::string, Eigen::Affine3d>())
   {
     std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
-    attachBody(id, shapes, attach_trans, touch_links_set, link_name, detach_posture);
+    attachBody(id, shapes, attach_trans, touch_links_set, link_name, detach_posture, named_frames);
   }
 
   /** \brief Get all bodies attached to the model corresponding to this state */

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2013, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -42,14 +42,14 @@ moveit::core::AttachedBody::AttachedBody(const LinkModel* parent_link_model, con
                                          const EigenSTL::vector_Affine3d& attach_trans,
                                          const std::set<std::string>& touch_links,
                                          const trajectory_msgs::JointTrajectory& detach_posture,
-                                         const std::map<std::string, Eigen::Affine3d>& named_frames)
+                                         const std::map<std::string, Eigen::Affine3d>& named_frame_poses)
   : parent_link_model_(parent_link_model)
   , id_(id)
   , shapes_(shapes)
   , attach_trans_(attach_trans)
   , touch_links_(touch_links)
   , detach_posture_(detach_posture)
-  , named_frames_(named_frames)
+  , named_frame_poses_(named_frame_poses)
 {
   global_collision_body_transforms_.resize(attach_trans.size());
   for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -41,13 +41,15 @@ moveit::core::AttachedBody::AttachedBody(const LinkModel* parent_link_model, con
                                          const std::vector<shapes::ShapeConstPtr>& shapes,
                                          const EigenSTL::vector_Affine3d& attach_trans,
                                          const std::set<std::string>& touch_links,
-                                         const trajectory_msgs::JointTrajectory& detach_posture)
+                                         const trajectory_msgs::JointTrajectory& detach_posture,
+                                         const std::map<std::string, Eigen::Affine3d>& named_frames)
   : parent_link_model_(parent_link_model)
   , id_(id)
   , shapes_(shapes)
   , attach_trans_(attach_trans)
   , touch_links_(touch_links)
   , detach_posture_(detach_posture)
+  , named_frames_(named_frames)
 {
   global_collision_body_transforms_.resize(attach_trans.size());
   for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2013, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2013, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
 
 /* Author: Ioan Sucan */
 

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -1,37 +1,37 @@
 /*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2013, Ioan A. Sucan
- *  Copyright (c) 2011-2013, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2013, Ioan A. Sucan
+*  Copyright (c) 2011-2013, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
 
 /* Author: Ioan Sucan, Dave Coleman */
 
@@ -99,9 +99,8 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
       error = true;
 
     if (error)
-      ROS_WARN_NAMED("robot_state",
-                     "The transform for multi-dof joints was specified in frame '%s' "
-                     "but it was not possible to transform that to frame '%s'",
+      ROS_WARN_NAMED("robot_state", "The transform for multi-dof joints was specified in frame '%s' "
+                                    "but it was not possible to transform that to frame '%s'",
                      mjs.header.frame_id.c_str(), state.getRobotModel()->getModelFrame().c_str());
   }
 
@@ -302,7 +301,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           named_frames[name] = p;
         }
 
-        // Transform shape poses and named frames to link frame
+        // Transform shape poses and named frames to link frame        
         if (!Transforms::sameFrame(aco.object.header.frame_id, aco.link_name))
         {
           Eigen::Affine3d t0;
@@ -313,15 +312,14 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           else
           {
             t0.setIdentity();
-            ROS_ERROR_NAMED("robot_state",
-                            "Cannot properly transform from frame '%s'. "
-                            "The pose of the attached body may be incorrect",
+            ROS_ERROR_NAMED("robot_state", "Cannot properly transform from frame '%s'. "
+                                           "The pose of the attached body may be incorrect",
                             aco.object.header.frame_id.c_str());
           }
           Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
           for (std::size_t i = 0; i < poses.size(); ++i)
             poses[i] = t * poses[i];
-          for (auto it = named_frames.begin(); it != named_frames.end(); it++)
+          for (auto it = named_frames.begin(); it != named_frames.end(); it++ )
             it->second = t * it->second;
         }
 
@@ -331,12 +329,11 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
         else
         {
           if (state.clearAttachedBody(aco.object.id))
-            ROS_DEBUG_NAMED("robot_state",
-                            "The robot state already had an object named '%s' attached to link '%s'. "
-                            "The object was replaced.",
+            ROS_DEBUG_NAMED("robot_state", "The robot state already had an object named '%s' attached to link '%s'. "
+                                           "The object was replaced.",
                             aco.object.id.c_str(), aco.link_name.c_str());
           state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture,
-                           named_frames);
+                            named_frames);
           ROS_DEBUG_NAMED("robot_state", "Attached object '%s' to link '%s'", aco.object.id.c_str(),
                           aco.link_name.c_str());
         }
@@ -381,7 +378,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
 
   return valid;
 }
-}  // namespace
+}
 
 // ********************************************
 

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -301,7 +301,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           named_frames[name] = p;
         }
 
-        // Transform shape poses and named frames to link frame        
+        // Transform shape poses and named frames to link frame
         if (!Transforms::sameFrame(aco.object.header.frame_id, aco.link_name))
         {
           Eigen::Affine3d t0;
@@ -319,7 +319,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
           for (std::size_t i = 0; i < poses.size(); ++i)
             poses[i] = t * poses[i];
-          for (auto it = named_frames.begin(); it != named_frames.end(); it++ )
+          for (auto it = named_frames.begin(); it != named_frames.end(); it++)
             it->second = t * it->second;
         }
 
@@ -333,7 +333,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
                                            "The object was replaced.",
                             aco.object.id.c_str(), aco.link_name.c_str());
           state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture,
-                            named_frames);
+                           named_frames);
           ROS_DEBUG_NAMED("robot_state", "Attached object '%s' to link '%s'", aco.object.id.c_str(),
                           aco.link_name.c_str());
         }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -1,37 +1,37 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2013, Ioan A. Sucan
-*  Copyright (c) 2011-2013, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ioan A. Sucan
+ *  Copyright (c) 2011-2013, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan, Dave Coleman */
 
@@ -99,8 +99,9 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
       error = true;
 
     if (error)
-      ROS_WARN_NAMED("robot_state", "The transform for multi-dof joints was specified in frame '%s' "
-                                    "but it was not possible to transform that to frame '%s'",
+      ROS_WARN_NAMED("robot_state",
+                     "The transform for multi-dof joints was specified in frame '%s' "
+                     "but it was not possible to transform that to frame '%s'",
                      mjs.header.frame_id.c_str(), state.getRobotModel()->getModelFrame().c_str());
   }
 
@@ -301,7 +302,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           named_frames[name] = p;
         }
 
-        // Transform shape poses and named frames to link frame        
+        // Transform shape poses and named frames to link frame
         if (!Transforms::sameFrame(aco.object.header.frame_id, aco.link_name))
         {
           Eigen::Affine3d t0;
@@ -312,14 +313,15 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           else
           {
             t0.setIdentity();
-            ROS_ERROR_NAMED("robot_state", "Cannot properly transform from frame '%s'. "
-                                           "The pose of the attached body may be incorrect",
+            ROS_ERROR_NAMED("robot_state",
+                            "Cannot properly transform from frame '%s'. "
+                            "The pose of the attached body may be incorrect",
                             aco.object.header.frame_id.c_str());
           }
           Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
           for (std::size_t i = 0; i < poses.size(); ++i)
             poses[i] = t * poses[i];
-          for (auto it = named_frames.begin(); it != named_frames.end(); it++ )
+          for (auto it = named_frames.begin(); it != named_frames.end(); it++)
             it->second = t * it->second;
         }
 
@@ -329,11 +331,12 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
         else
         {
           if (state.clearAttachedBody(aco.object.id))
-            ROS_DEBUG_NAMED("robot_state", "The robot state already had an object named '%s' attached to link '%s'. "
-                                           "The object was replaced.",
+            ROS_DEBUG_NAMED("robot_state",
+                            "The robot state already had an object named '%s' attached to link '%s'. "
+                            "The object was replaced.",
                             aco.object.id.c_str(), aco.link_name.c_str());
           state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture,
-                            named_frames);
+                           named_frames);
           ROS_DEBUG_NAMED("robot_state", "Attached object '%s' to link '%s'", aco.object.id.c_str(),
                           aco.link_name.c_str());
         }
@@ -378,7 +381,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
 
   return valid;
 }
-}
+}  // namespace
 
 // ********************************************
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1,37 +1,37 @@
 /*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2013, Ioan A. Sucan
- *  Copyright (c) 2013, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2013, Ioan A. Sucan
+*  Copyright (c) 2013, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
 
 /* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman */
 
@@ -128,10 +128,9 @@ void RobotState::copyFrom(const RobotState& other)
   if (dirty_link_transforms_ == robot_model_->getRootJoint())
   {
     // everything is dirty; no point in copying transforms; copy positions, potentially velocity & acceleration
-    memcpy(position_, other.position_,
-           robot_model_->getVariableCount() * sizeof(double) *
-               (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
-                ((has_acceleration_ || has_effort_) ? 1 : 0)));
+    memcpy(position_, other.position_, robot_model_->getVariableCount() * sizeof(double) *
+                                           (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
+                                            ((has_acceleration_ || has_effort_) ? 1 : 0)));
 
     // mark all transforms as dirty
     const int nr_doubles_for_dirty_joint_transforms =
@@ -973,35 +972,31 @@ const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) cons
     if (ab.second->hasNamedTransform(id))
       return ab.second->getNamedTransform(id);
   }
-  // TODO: Is this efficient? Probably not, should be a find() + iterator comparison instead of two loops.
+    // TODO: Is this efficient? Probably not, should be a find() + iterator comparison instead of two loops.
 
   // Check names of the AttachedBody objects themselves
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    ROS_ERROR_NAMED("robot_state",
-                    "Transform from frame '%s' to frame '%s' is not known "
-                    "('%s' should be a link name, an attached body id, or the id of an attached body's named frame).",
+    ROS_ERROR_NAMED("robot_state", "Transform from frame '%s' to frame '%s' is not known "
+                                   "('%s' should be a link name, an attached body id, or the id of an attached body's named frame).",
                     id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
   }
-
+  
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   const std::map<std::string, Eigen::Affine3d>& nf = jt->second->getNamedTransforms();
   if (!nf.empty())
-    ROS_ERROR_NAMED("robot_state", "The AttachedBody has named frames. Use their names directly to access them.");
+      ROS_ERROR_NAMED("robot_state", "The AttachedBody has named frames. Use their names directly to access them.");
   if (tf.empty())
   {
-    ROS_ERROR_NAMED("robot_state",
-                    "'%s' is the name of an AttachedBody, but it has no geometry associated to it. No transform to "
-                    "return.",
+    ROS_ERROR_NAMED("robot_state", "'%s' is the name of an AttachedBody, but it has no geometry associated to it. No transform to return.",
                     id.c_str());
     return identity_transform;
   }
   if (tf.size() > 1)
-    ROS_DEBUG_NAMED("robot_state",
-                    "There are multiple geometries associated to attached body '%s'. "
-                    "Returning the transform for the first one.",
+    ROS_DEBUG_NAMED("robot_state", "There are multiple geometries associated to attached body '%s'. "
+                                   "Returning the transform for the first one.",
                     id.c_str());
   return tf[0];
 }
@@ -1012,7 +1007,7 @@ bool RobotState::knowsFrameTransform(const std::string& id) const
     return knowsFrameTransform(id.substr(1));
   if (robot_model_->hasLinkModel(id))
     return true;
-
+  
   for (auto ab : attached_body_map_)  // Check if an AttachedBody has a child frame with name id
   {
     if (ab.second->hasNamedTransform(id))
@@ -1362,7 +1357,7 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return true;
 }
-}  // namespace
+}
 
 bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const kinematics::KinematicsBaseConstPtr& solver)
 {
@@ -1462,9 +1457,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    ROS_ERROR_NAMED("robot_state",
-                    "Invalid number (%zu) of sets of consistency limits for a setFromIK request "
-                    "that is being solved by a single IK solver",
+    ROS_ERROR_NAMED("robot_state", "Invalid number (%zu) of sets of consistency limits for a setFromIK request "
+                                   "that is being solved by a single IK solver",
                     consistency_limit_sets.size());
     return false;
   }
@@ -1922,11 +1916,10 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
   if (max_step.translation <= 0.0 && max_step.rotation <= 0.0)
   {
-    ROS_ERROR_NAMED("robot_state", "Invalid MaxEEFStep passed into computeCartesianPath. Both the MaxEEFStep.rotation "
-                                   "and "
-                                   "MaxEEFStep.translation components must be non-negative and at least one component "
-                                   "must be "
-                                   "greater than zero");
+    ROS_ERROR_NAMED("robot_state",
+                    "Invalid MaxEEFStep passed into computeCartesianPath. Both the MaxEEFStep.rotation and "
+                    "MaxEEFStep.translation components must be non-negative and at least one component must be "
+                    "greater than zero");
     return 0.0;
   }
 
@@ -2031,9 +2024,8 @@ double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std:
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
-    ROS_WARN_NAMED("robot_state",
-                   "The computed trajectory is too short to detect jumps in joint-space "
-                   "Need at least %zu steps, only got %zu. Try a lower max_step.",
+    ROS_WARN_NAMED("robot_state", "The computed trajectory is too short to detect jumps in joint-space "
+                                  "Need at least %zu steps, only got %zu. Try a lower max_step.",
                    MIN_STEPS_FOR_JUMP_THRESH, traj.size());
   }
 
@@ -2088,9 +2080,8 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
           type_index = 1;
           break;
         default:
-          ROS_WARN_NAMED("robot_state",
-                         "Joint %s has not supported type %s. \n"
-                         "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
+          ROS_WARN_NAMED("robot_state", "Joint %s has not supported type %s. \n"
+                                        "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
                          joint->getName().c_str(), joint->getTypeName().c_str());
           continue;
       }
@@ -2276,7 +2267,7 @@ void getPoseString(std::ostream& ss, const Eigen::Affine3d& pose, const std::str
     ss << std::endl;
   }
 }
-}  // namespace
+}
 
 void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0,
                                          bool last) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -972,25 +972,27 @@ const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) cons
     if (ab.second->hasNamedTransform(id))
       return ab.second->getNamedTransform(id);
   }
-    // TODO: Is this efficient? Probably not, should be a find() + iterator comparison instead of two loops.
+  // TODO: Is this efficient? Probably not, should be a find() + iterator comparison instead of two loops.
 
   // Check names of the AttachedBody objects themselves
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    ROS_ERROR_NAMED("robot_state", "Transform from frame '%s' to frame '%s' is not known "
-                                   "('%s' should be a link name, an attached body id, or the id of an attached body's named frame).",
+    ROS_ERROR_NAMED("robot_state",
+                    "Transform from frame '%s' to frame '%s' is not known "
+                    "('%s' should be a link name, an attached body id, or the id of an attached body's named frame).",
                     id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
   }
-  
+
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   const std::map<std::string, Eigen::Affine3d>& nf = jt->second->getNamedTransforms();
   if (!nf.empty())
-      ROS_ERROR_NAMED("robot_state", "The AttachedBody has named frames. Use their names directly to access them.");
+    ROS_ERROR_NAMED("robot_state", "The AttachedBody has named frames. Use their names directly to access them.");
   if (tf.empty())
   {
-    ROS_ERROR_NAMED("robot_state", "'%s' is the name of an AttachedBody, but it has no geometry associated to it. No transform to return.",
+    ROS_ERROR_NAMED("robot_state", "'%s' is the name of an AttachedBody, but it has no geometry associated to it. No "
+                                   "transform to return.",
                     id.c_str());
     return identity_transform;
   }
@@ -1007,7 +1009,7 @@ bool RobotState::knowsFrameTransform(const std::string& id) const
     return knowsFrameTransform(id.substr(1));
   if (robot_model_->hasLinkModel(id))
     return true;
-  
+
   for (auto ab : attached_body_map_)  // Check if an AttachedBody has a child frame with name id
   {
     if (ab.second->hasNamedTransform(id))

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1,37 +1,37 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2013, Ioan A. Sucan
-*  Copyright (c) 2013, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ioan A. Sucan
+ *  Copyright (c) 2013, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan, Sachin Chitta, Acorn Pooley, Mario Prats, Dave Coleman */
 
@@ -128,9 +128,10 @@ void RobotState::copyFrom(const RobotState& other)
   if (dirty_link_transforms_ == robot_model_->getRootJoint())
   {
     // everything is dirty; no point in copying transforms; copy positions, potentially velocity & acceleration
-    memcpy(position_, other.position_, robot_model_->getVariableCount() * sizeof(double) *
-                                           (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
-                                            ((has_acceleration_ || has_effort_) ? 1 : 0)));
+    memcpy(position_, other.position_,
+           robot_model_->getVariableCount() * sizeof(double) *
+               (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
+                ((has_acceleration_ || has_effort_) ? 1 : 0)));
 
     // mark all transforms as dirty
     const int nr_doubles_for_dirty_joint_transforms =
@@ -972,31 +973,35 @@ const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) cons
     if (ab.second->hasNamedTransform(id))
       return ab.second->getNamedTransform(id);
   }
-    // TODO: Is this efficient? Probably not, should be a find() + iterator comparison instead of two loops.
+  // TODO: Is this efficient? Probably not, should be a find() + iterator comparison instead of two loops.
 
   // Check names of the AttachedBody objects themselves
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    ROS_ERROR_NAMED("robot_state", "Transform from frame '%s' to frame '%s' is not known "
-                                   "('%s' should be a link name, an attached body id, or the id of an attached body's named frame).",
+    ROS_ERROR_NAMED("robot_state",
+                    "Transform from frame '%s' to frame '%s' is not known "
+                    "('%s' should be a link name, an attached body id, or the id of an attached body's named frame).",
                     id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
   }
-  
+
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   const std::map<std::string, Eigen::Affine3d>& nf = jt->second->getNamedTransforms();
   if (!nf.empty())
-      ROS_ERROR_NAMED("robot_state", "The AttachedBody has named frames. Use their names directly to access them.");
+    ROS_ERROR_NAMED("robot_state", "The AttachedBody has named frames. Use their names directly to access them.");
   if (tf.empty())
   {
-    ROS_ERROR_NAMED("robot_state", "'%s' is the name of an AttachedBody, but it has no geometry associated to it. No transform to return.",
+    ROS_ERROR_NAMED("robot_state",
+                    "'%s' is the name of an AttachedBody, but it has no geometry associated to it. No transform to "
+                    "return.",
                     id.c_str());
     return identity_transform;
   }
   if (tf.size() > 1)
-    ROS_DEBUG_NAMED("robot_state", "There are multiple geometries associated to attached body '%s'. "
-                                   "Returning the transform for the first one.",
+    ROS_DEBUG_NAMED("robot_state",
+                    "There are multiple geometries associated to attached body '%s'. "
+                    "Returning the transform for the first one.",
                     id.c_str());
   return tf[0];
 }
@@ -1007,7 +1012,7 @@ bool RobotState::knowsFrameTransform(const std::string& id) const
     return knowsFrameTransform(id.substr(1));
   if (robot_model_->hasLinkModel(id))
     return true;
-  
+
   for (auto ab : attached_body_map_)  // Check if an AttachedBody has a child frame with name id
   {
     if (ab.second->hasNamedTransform(id))
@@ -1357,7 +1362,7 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return true;
 }
-}
+}  // namespace
 
 bool RobotState::setToIKSolverFrame(Eigen::Affine3d& pose, const kinematics::KinematicsBaseConstPtr& solver)
 {
@@ -1457,8 +1462,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    ROS_ERROR_NAMED("robot_state", "Invalid number (%zu) of sets of consistency limits for a setFromIK request "
-                                   "that is being solved by a single IK solver",
+    ROS_ERROR_NAMED("robot_state",
+                    "Invalid number (%zu) of sets of consistency limits for a setFromIK request "
+                    "that is being solved by a single IK solver",
                     consistency_limit_sets.size());
     return false;
   }
@@ -1916,10 +1922,11 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
   if (max_step.translation <= 0.0 && max_step.rotation <= 0.0)
   {
-    ROS_ERROR_NAMED("robot_state",
-                    "Invalid MaxEEFStep passed into computeCartesianPath. Both the MaxEEFStep.rotation and "
-                    "MaxEEFStep.translation components must be non-negative and at least one component must be "
-                    "greater than zero");
+    ROS_ERROR_NAMED("robot_state", "Invalid MaxEEFStep passed into computeCartesianPath. Both the MaxEEFStep.rotation "
+                                   "and "
+                                   "MaxEEFStep.translation components must be non-negative and at least one component "
+                                   "must be "
+                                   "greater than zero");
     return 0.0;
   }
 
@@ -2024,8 +2031,9 @@ double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std:
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
-    ROS_WARN_NAMED("robot_state", "The computed trajectory is too short to detect jumps in joint-space "
-                                  "Need at least %zu steps, only got %zu. Try a lower max_step.",
+    ROS_WARN_NAMED("robot_state",
+                   "The computed trajectory is too short to detect jumps in joint-space "
+                   "Need at least %zu steps, only got %zu. Try a lower max_step.",
                    MIN_STEPS_FOR_JUMP_THRESH, traj.size());
   }
 
@@ -2080,8 +2088,9 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
           type_index = 1;
           break;
         default:
-          ROS_WARN_NAMED("robot_state", "Joint %s has not supported type %s. \n"
-                                        "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
+          ROS_WARN_NAMED("robot_state",
+                         "Joint %s has not supported type %s. \n"
+                         "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
                          joint->getName().c_str(), joint->getTypeName().c_str());
           continue;
       }
@@ -2267,7 +2276,7 @@ void getPoseString(std::ostream& ss, const Eigen::Affine3d& pose, const std::str
     ss << std::endl;
   }
 }
-}
+}  // namespace
 
 void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0,
                                          bool last) const

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/query_planners_service_capability.cpp
   src/default_capabilities/kinematics_service_capability.cpp
   src/default_capabilities/state_validation_service_capability.cpp
+  src/default_capabilities/constraint_validation_service_capability.cpp
   src/default_capabilities/cartesian_path_service_capability.cpp
   src/default_capabilities/get_planning_scene_service_capability.cpp
   src/default_capabilities/apply_planning_scene_service_capability.cpp

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -48,6 +48,12 @@
     </description>
   </class>
 
+  <class name="move_group/MoveGroupConstraintValidationService" type="move_group::MoveGroupConstraintValidationService" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      Provide a ROS service that checks if a set of constraints is valid for the current RobotState and fixes them if possible
+    </description>
+  </class>
+
   <class name="move_group/MoveGroupGetPlanningSceneService" type="move_group::MoveGroupGetPlanningSceneService" base_class_type="move_group::MoveGroupCapability">
     <description>
       Provide a ROS service that allows for querying the planning scene

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -67,6 +67,6 @@ static const std::string APPLY_PLANNING_SCENE_SERVICE_NAME =
     "apply_planning_scene";  // name of the service that applies a given planning scene
 static const std::string CLEAR_OCTOMAP_SERVICE_NAME =
     "clear_octomap";  // name of the service that can be used to clear the octomap
-}  // namespace move_group
+}
 
 #endif

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -57,6 +57,8 @@ static const std::string IK_SERVICE_NAME = "compute_ik";  // name of ik service
 static const std::string FK_SERVICE_NAME = "compute_fk";  // name of fk service
 static const std::string STATE_VALIDITY_SERVICE_NAME =
     "check_state_validity";  // name of the service that validates states
+static const std::string CONSTRAINT_VALIDITY_SERVICE_NAME =
+    "check_constraint_validity";  // name of the service that validates constraints
 static const std::string CARTESIAN_PATH_SERVICE_NAME =
     "compute_cartesian_path";  // name of the service that computes cartesian paths
 static const std::string GET_PLANNING_SCENE_SERVICE_NAME =

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -67,6 +67,6 @@ static const std::string APPLY_PLANNING_SCENE_SERVICE_NAME =
     "apply_planning_scene";  // name of the service that applies a given planning scene
 static const std::string CLEAR_OCTOMAP_SERVICE_NAME =
     "clear_octomap";  // name of the service that can be used to clear the octomap
-}
+}  // namespace move_group
 
 #endif

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.cpp
@@ -1,0 +1,77 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Felix von Drigalski */
+
+#include "constraint_validation_service_capability.h"
+#include <moveit/robot_state/conversions.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/collision_detection/collision_tools.h>
+#include <eigen_conversions/eigen_msg.h>
+#include <moveit/move_group/capability_names.h>
+
+move_group::MoveGroupConstraintValidationService::MoveGroupConstraintValidationService()
+  : MoveGroupCapability("ConstraintValidationService")
+{
+}
+
+void move_group::MoveGroupConstraintValidationService::initialize()
+{
+  constraint_validity_service_ = root_node_handle_.advertiseService(CONSTRAINT_VALIDITY_SERVICE_NAME,
+                                                         &MoveGroupConstraintValidationService::computeService, this);
+}
+
+bool move_group::MoveGroupConstraintValidationService::computeService(moveit_msgs::GetConstraintValidity::Request& req,
+                                                                 moveit_msgs::GetConstraintValidity::Response& res)
+{
+  planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
+  robot_state::RobotState rs = ls->getCurrentState();
+
+  ROS_INFO("Validating constraints inside capability");
+  // Checks if the goal is defined either for existing link_names or the names of AttachedBody objects
+  // that are attached to the robot. The latter are transformed to link_names so the planner can deal with them.
+  res.constraints = req.constraints;
+  bool v = true;
+  // for (std::size_t i = 0; i < res.constraints.size(); ++i)
+  // {
+    // v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints[i]);
+  // }
+  v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints);
+
+  res.valid = v;
+  return true;
+}
+
+#include <class_loader/class_loader.hpp>
+CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupConstraintValidationService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.cpp
@@ -48,12 +48,12 @@ move_group::MoveGroupConstraintValidationService::MoveGroupConstraintValidationS
 
 void move_group::MoveGroupConstraintValidationService::initialize()
 {
-  constraint_validity_service_ = root_node_handle_.advertiseService(CONSTRAINT_VALIDITY_SERVICE_NAME,
-                                                         &MoveGroupConstraintValidationService::computeService, this);
+  constraint_validity_service_ = root_node_handle_.advertiseService(
+      CONSTRAINT_VALIDITY_SERVICE_NAME, &MoveGroupConstraintValidationService::computeService, this);
 }
 
 bool move_group::MoveGroupConstraintValidationService::computeService(moveit_msgs::GetConstraintValidity::Request& req,
-                                                                 moveit_msgs::GetConstraintValidity::Response& res)
+                                                                      moveit_msgs::GetConstraintValidity::Response& res)
 {
   planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
   robot_state::RobotState rs = ls->getCurrentState();
@@ -65,7 +65,7 @@ bool move_group::MoveGroupConstraintValidationService::computeService(moveit_msg
   bool v = true;
   // for (std::size_t i = 0; i < res.constraints.size(); ++i)
   // {
-    // v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints[i]);
+  // v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints[i]);
   // }
   v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints);
 

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2018, OMRON SINIC X Corporation
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of OMRON SINIC X Corp. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
@@ -58,18 +58,14 @@ bool move_group::MoveGroupConstraintValidationService::computeService(moveit_msg
   planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
   robot_state::RobotState rs = ls->getCurrentState();
 
-  ROS_INFO("Validating constraints inside capability");
+  ROS_INFO_NAMED("constraint_validation_service_capability", "Validating constraints inside capability");
   // Checks if the goal is defined either for existing link_names or the names of AttachedBody objects
   // that are attached to the robot. The latter are transformed to link_names so the planner can deal with them.
   res.constraints = req.constraints;
-  bool v = true;
-  // for (std::size_t i = 0; i < res.constraints.size(); ++i)
-  // {
-  // v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints[i]);
-  // }
-  v = v * kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints);
+  bool valid = true;
+  valid = valid && kinematic_constraints::validatePositionOrientationConstraints(rs, res.constraints);
 
-  res.valid = v;
+  res.valid = valid;
   return true;
 }
 

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
@@ -50,11 +50,10 @@ public:
   virtual void initialize();
 
 private:
-  bool computeService(moveit_msgs::GetConstraintValidity::Request& req,
-                      moveit_msgs::GetConstraintValidity::Response& res);
+  bool computeService(moveit_msgs::GetConstraintValidity::Request& req, moveit_msgs::GetConstraintValidity::Response& res);
 
   ros::ServiceServer constraint_validity_service_;
 };
-}  // namespace move_group
+}
 
 #endif

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
@@ -33,14 +33,14 @@
  *********************************************************************/
 
 /* This service is used for constraints that are applied to frames on
- * objects attached to the robot (e.g. "tip of screw driver"). 
+ * objects attached to the robot (e.g. "tip of screw driver").
  * It makes these constraints valid by transforming them from the frame
  * on the object to a frame on the robot. The planning request is not
  * valid unless the constraints are applied to a robot link.
  *
  * This service might become a PlanningRequestAdapter in the near future.
- * 
- * Author: Felix von Drigalski 
+ *
+ * Author: Felix von Drigalski
  */
 
 #ifndef MOVEIT_MOVE_GROUP_CONSTRAINT_VALIDATION_SERVICE_CAPABILITY_

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
@@ -1,0 +1,59 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Felix von Drigalski */
+
+#ifndef MOVEIT_MOVE_GROUP_CONSTRAINT_VALIDATION_SERVICE_CAPABILITY_
+#define MOVEIT_MOVE_GROUP_CONSTRAINT_VALIDATION_SERVICE_CAPABILITY_
+
+#include <moveit/move_group/move_group_capability.h>
+#include <moveit_msgs/GetConstraintValidity.h>
+
+namespace move_group
+{
+class MoveGroupConstraintValidationService : public MoveGroupCapability
+{
+public:
+  MoveGroupConstraintValidationService();
+
+  virtual void initialize();
+
+private:
+  bool computeService(moveit_msgs::GetConstraintValidity::Request& req, moveit_msgs::GetConstraintValidity::Response& res);
+
+  ros::ServiceServer constraint_validity_service_;
+};
+}
+
+#endif

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2018, OMRON SINIC X Corporation
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of OMRON SINIC X Corp. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
@@ -32,7 +32,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Felix von Drigalski */
+/* This service is used for constraints that are applied to frames on
+ * objects attached to the robot (e.g. "tip of screw driver"). 
+ * It makes these constraints valid by transforming them from the frame
+ * on the object to a frame on the robot. The planning request is not
+ * valid unless the constraints are applied to a robot link.
+ *
+ * This service might become a PlanningRequestAdapter in the near future.
+ * 
+ * Author: Felix von Drigalski 
+ */
 
 #ifndef MOVEIT_MOVE_GROUP_CONSTRAINT_VALIDATION_SERVICE_CAPABILITY_
 #define MOVEIT_MOVE_GROUP_CONSTRAINT_VALIDATION_SERVICE_CAPABILITY_

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
@@ -50,7 +50,8 @@ public:
   virtual void initialize();
 
 private:
-  bool computeService(moveit_msgs::GetConstraintValidity::Request& req, moveit_msgs::GetConstraintValidity::Response& res);
+  bool computeService(moveit_msgs::GetConstraintValidity::Request& req,
+                      moveit_msgs::GetConstraintValidity::Response& res);
 
   ros::ServiceServer constraint_validity_service_;
 };

--- a/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/constraint_validation_service_capability.h
@@ -50,10 +50,11 @@ public:
   virtual void initialize();
 
 private:
-  bool computeService(moveit_msgs::GetConstraintValidity::Request& req, moveit_msgs::GetConstraintValidity::Response& res);
+  bool computeService(moveit_msgs::GetConstraintValidity::Request& req,
+                      moveit_msgs::GetConstraintValidity::Response& res);
 
   ros::ServiceServer constraint_validity_service_;
 };
-}
+}  // namespace move_group
 
 #endif

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -60,6 +60,7 @@ static const char* DEFAULT_CAPABILITIES[] = {
    "move_group/MoveGroupPickPlaceAction",
    "move_group/MoveGroupPlanService",
    "move_group/MoveGroupQueryPlannersService",
+   "move_group/MoveGroupConstraintValidationService",
    "move_group/MoveGroupStateValidationService",
    "move_group/MoveGroupGetPlanningSceneService",
    "move_group/ApplyPlanningSceneService",

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -113,12 +113,8 @@ private:
   {
     try
     {
-      capability_plugin_loader_.reset(new pluginlib::ClassLoader<MoveGroupCapability>("moveit_ros_move_group", "move_"
-                                                                                                               "group::"
-                                                                                                               "MoveGro"
-                                                                                                               "upCapab"
-                                                                                                               "ilit"
-                                                                                                               "y"));
+      capability_plugin_loader_.reset(
+          new pluginlib::ClassLoader<MoveGroupCapability>("moveit_ros_move_group", "move_group::MoveGroupCapability"));
     }
     catch (pluginlib::PluginlibException& ex)
     {
@@ -186,7 +182,7 @@ private:
   std::shared_ptr<pluginlib::ClassLoader<MoveGroupCapability> > capability_plugin_loader_;
   std::vector<MoveGroupCapabilityPtr> capabilities_;
 };
-}  // namespace move_group
+}
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -113,8 +113,12 @@ private:
   {
     try
     {
-      capability_plugin_loader_.reset(
-          new pluginlib::ClassLoader<MoveGroupCapability>("moveit_ros_move_group", "move_group::MoveGroupCapability"));
+      capability_plugin_loader_.reset(new pluginlib::ClassLoader<MoveGroupCapability>("moveit_ros_move_group", "move_"
+                                                                                                               "group::"
+                                                                                                               "MoveGro"
+                                                                                                               "upCapab"
+                                                                                                               "ilit"
+                                                                                                               "y"));
     }
     catch (pluginlib::PluginlibException& ex)
     {
@@ -182,7 +186,7 @@ private:
   std::shared_ptr<pluginlib::ClassLoader<MoveGroupCapability> > capability_plugin_loader_;
   std::vector<MoveGroupCapabilityPtr> capabilities_;
 };
-}
+}  // namespace move_group
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -914,7 +914,7 @@ public:
   void clearTrajectoryConstraints();
 
   /** \brief Make constraints valid for the current robot state if possible.
-      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */    
+      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */
   bool validateConstraints(moveit_msgs::Constraints& constraints);
 
   /**@}*/
@@ -924,7 +924,7 @@ private:
   class MoveGroupInterfaceImpl;
   MoveGroupInterfaceImpl* impl_;
 };
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit
 
 #endif

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -914,7 +914,7 @@ public:
   void clearTrajectoryConstraints();
 
   /** \brief Make constraints valid for the current robot state if possible.
-      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */    
+      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */
   bool validateConstraints(moveit_msgs::Constraints& constraints);
 
   /**@}*/

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -914,7 +914,7 @@ public:
   void clearTrajectoryConstraints();
 
   /** \brief Make constraints valid for the current robot state if possible.
-      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */
+      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */    
   bool validateConstraints(moveit_msgs::Constraints& constraints);
 
   /**@}*/
@@ -924,7 +924,7 @@ private:
   class MoveGroupInterfaceImpl;
   MoveGroupInterfaceImpl* impl_;
 };
-}  // namespace planning_interface
-}  // namespace moveit
+}
+}
 
 #endif

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -913,6 +913,10 @@ public:
   void setTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints& constraint);
   void clearTrajectoryConstraints();
 
+  /** \brief Make constraints valid for the current robot state if possible.
+      Returns false if the constraints do not refer to valid link_names or AttachedBody objects. */    
+  bool validateConstraints(moveit_msgs::Constraints& constraints);
+
   /**@}*/
 
 private:

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -291,11 +291,10 @@ public:
     {
       if (execute_service_.exists())
       {
-        ROS_WARN_NAMED("move_group_interface", "\nDeprecation warning: Trajectory execution service is deprecated (was "
-                                               "replaced by an action)."
-                                               "\nReplace 'MoveGroupExecuteService' with "
-                                               "'MoveGroupExecuteTrajectoryAction' in "
-                                               "move_group.launch");
+        ROS_WARN_NAMED("move_group_interface",
+                       "\nDeprecation warning: Trajectory execution service is deprecated (was replaced by an action)."
+                       "\nReplace 'MoveGroupExecuteService' with 'MoveGroupExecuteTrajectoryAction' in "
+                       "move_group.launch");
       }
       else
       {
@@ -777,10 +776,10 @@ public:
   {
     if (!plan_grasps_service_)
     {
-      ROS_ERROR_STREAM_NAMED("move_group_interface", "Grasp planning service '" << GRASP_PLANNING_SERVICE_NAME
-                                                                                << "' is not available."
-                                                                                   " This has to be implemented and "
-                                                                                   "started separately.");
+      ROS_ERROR_STREAM_NAMED("move_group_interface", "Grasp planning service '"
+                                                         << GRASP_PLANNING_SERVICE_NAME
+                                                         << "' is not available."
+                                                            " This has to be implemented and started separately.");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
 
@@ -1166,6 +1165,7 @@ public:
         validateConstraints(constraint);
       }
     }
+      
   }
 
   void constructGoal(moveit_msgs::MoveGroupGoal& goal)
@@ -1388,8 +1388,8 @@ private:
   std::unique_ptr<boost::thread> constraints_init_thread_;
   bool initializing_constraints_;
 };
-}  // namespace planning_interface
-}  // namespace moveit
+}
+}
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const std::string& group_name,
                                                                    const boost::shared_ptr<tf::Transformer>& tf,
@@ -1946,7 +1946,7 @@ inline void transformPose(const tf::Transformer& tf, const std::string& desired_
     tf::poseTFToMsg(stamped_target_out, target.pose);
   }
 }
-}  // namespace
+}
 
 bool moveit::planning_interface::MoveGroupInterface::setPositionTarget(double x, double y, double z,
                                                                        const std::string& end_effector_link)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1165,7 +1165,6 @@ public:
         validateConstraints(constraint);
       }
     }
-      
   }
 
   void constructGoal(moveit_msgs::MoveGroupGoal& goal)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -291,10 +291,11 @@ public:
     {
       if (execute_service_.exists())
       {
-        ROS_WARN_NAMED("move_group_interface",
-                       "\nDeprecation warning: Trajectory execution service is deprecated (was replaced by an action)."
-                       "\nReplace 'MoveGroupExecuteService' with 'MoveGroupExecuteTrajectoryAction' in "
-                       "move_group.launch");
+        ROS_WARN_NAMED("move_group_interface", "\nDeprecation warning: Trajectory execution service is deprecated (was "
+                                               "replaced by an action)."
+                                               "\nReplace 'MoveGroupExecuteService' with "
+                                               "'MoveGroupExecuteTrajectoryAction' in "
+                                               "move_group.launch");
       }
       else
       {
@@ -776,10 +777,10 @@ public:
   {
     if (!plan_grasps_service_)
     {
-      ROS_ERROR_STREAM_NAMED("move_group_interface", "Grasp planning service '"
-                                                         << GRASP_PLANNING_SERVICE_NAME
-                                                         << "' is not available."
-                                                            " This has to be implemented and started separately.");
+      ROS_ERROR_STREAM_NAMED("move_group_interface", "Grasp planning service '" << GRASP_PLANNING_SERVICE_NAME
+                                                                                << "' is not available."
+                                                                                   " This has to be implemented and "
+                                                                                   "started separately.");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
 
@@ -1165,7 +1166,6 @@ public:
         validateConstraints(constraint);
       }
     }
-      
   }
 
   void constructGoal(moveit_msgs::MoveGroupGoal& goal)
@@ -1388,8 +1388,8 @@ private:
   std::unique_ptr<boost::thread> constraints_init_thread_;
   bool initializing_constraints_;
 };
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const std::string& group_name,
                                                                    const boost::shared_ptr<tf::Transformer>& tf,
@@ -1946,7 +1946,7 @@ inline void transformPose(const tf::Transformer& tf, const std::string& desired_
     tf::poseTFToMsg(stamped_target_out, target.pose);
   }
 }
-}
+}  // namespace
 
 bool moveit::planning_interface::MoveGroupInterface::setPositionTarget(double x, double y, double z,
                                                                        const std::string& end_effector_link)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -975,4 +975,4 @@ void MotionPlanningFrame::importFromTextButtonClicked()
     planning_display_->addBackgroundJob(
         boost::bind(&MotionPlanningFrame::computeImportFromText, this, path.toStdString()), "import from text");
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -975,4 +975,4 @@ void MotionPlanningFrame::importFromTextButtonClicked()
     planning_display_->addBackgroundJob(
         boost::bind(&MotionPlanningFrame::computeImportFromText, this, path.toStdString()), "import from text");
 }
-}  // namespace moveit_rviz_plugin
+}

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -160,7 +160,7 @@ static QString decideStatusText(const collision_detection::CollisionWorld::Objec
 {
   QString status_text = "'" + QString::fromStdString(obj->id_) + "' is a collision object with ";
   if (obj->shapes_.empty())
-    status_text += "no geometry";
+    status_text += "no geometry.\n";
   else
   {
     std::vector<QString> shape_names;
@@ -174,6 +174,17 @@ static QString decideStatusText(const collision_detection::CollisionWorld::Objec
       for (std::size_t i = 0; i < shape_names.size(); ++i)
         status_text += " " + shape_names[i];
     }
+    status_text += ".";
+  }
+  if (obj->named_frames_.size() > 0)
+  {
+    status_text += "\nIt has the named frames '";
+    for (auto frame : obj->named_frames_)
+    {
+      status_text += QString::fromStdString(frame.first) + "', '";
+    }
+    status_text.chop(3);
+    status_text += ".";
   }
   return status_text;
 }
@@ -181,7 +192,17 @@ static QString decideStatusText(const collision_detection::CollisionWorld::Objec
 static QString decideStatusText(const robot_state::AttachedBody* attached_body)
 {
   QString status_text = "'" + QString::fromStdString(attached_body->getName()) + "' is attached to '" +
-                        QString::fromStdString(attached_body->getAttachedLinkName()) + "'";
+                        QString::fromStdString(attached_body->getAttachedLinkName()) + "'.";
+  if (attached_body->getNamedTransforms().size() > 0)
+  {
+    status_text += "\nIt has the named frames '";
+    for (auto ab : attached_body->getNamedTransforms())
+    {
+      status_text += QString::fromStdString(ab.first) + "', '";
+    }
+    status_text.chop(3);
+    status_text += ".";
+  }
   return status_text;
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -176,10 +176,10 @@ static QString decideStatusText(const collision_detection::CollisionWorld::Objec
     }
     status_text += ".";
   }
-  if (obj->named_frames_.size() > 0)
+  if (obj->named_frame_poses_.size() > 0)
   {
     status_text += "\nIt has the named frames '";
-    for (auto frame : obj->named_frames_)
+    for (auto frame : obj->named_frame_poses_)
     {
       status_text += QString::fromStdString(frame.first) + "', '";
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -782,7 +782,7 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       known_collision_objects_[item->type()].first = item_text;
       robot_state::AttachedBody* new_ab = new robot_state::AttachedBody(
           ab->getAttachedLink(), known_collision_objects_[item->type()].first, ab->getShapes(),
-          ab->getFixedTransforms(), ab->getTouchLinks(), ab->getDetachPosture());
+          ab->getFixedTransforms(), ab->getTouchLinks(), ab->getDetachPosture(), ab->getNamedTransforms());
       cs.clearAttachedBody(ab->getName());
       cs.attachBody(new_ab);
     }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -104,16 +104,16 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     for (std::size_t j = 0; j < o->shapes_.size(); ++j)
       render_shapes_->renderShape(planning_scene_geometry_node_, o->shapes_[j].get(), o->shape_poses_[j],
                                   octree_voxel_rendering, octree_color_mode, color, alpha);
-    
+
     // Insert the named frames as red spheres of radius 2 mm
     // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     for (auto nf_pair : o->named_frames_)
     {
-      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, 
-                                  octree_voxel_rendering, octree_color_mode, red, 1.0);
+      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, octree_voxel_rendering,
+                                  octree_color_mode, red, 1.0);
     }
   }
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -104,16 +104,16 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     for (std::size_t j = 0; j < o->shapes_.size(); ++j)
       render_shapes_->renderShape(planning_scene_geometry_node_, o->shapes_[j].get(), o->shape_poses_[j],
                                   octree_voxel_rendering, octree_color_mode, color, alpha);
-
+    
     // Insert the named frames as red spheres of radius 2 mm
     // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     for (auto nf_pair : o->named_frames_)
     {
-      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, octree_voxel_rendering,
-                                  octree_color_mode, red, 1.0);
+      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, 
+                                  octree_voxel_rendering, octree_color_mode, red, 1.0);
     }
   }
 }
-}  // namespace moveit_rviz_plugin
+}

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -109,7 +109,7 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
-    for (auto nf_pair : o->named_frames_)
+    for (auto nf_pair : o->named_frame_poses_)
     {
       render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, octree_voxel_rendering,
                                   octree_color_mode, red, 1.0);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -104,15 +104,15 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     for (std::size_t j = 0; j < o->shapes_.size(); ++j)
       render_shapes_->renderShape(planning_scene_geometry_node_, o->shapes_[j].get(), o->shape_poses_[j],
                                   octree_voxel_rendering, octree_color_mode, color, alpha);
-    
+
     // Insert the named frames as red spheres of radius 2 mm
     // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     for (auto nf_pair : o->named_frames_)
     {
-      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, 
-                                  octree_voxel_rendering, octree_color_mode, red, 1.0);
+      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, octree_voxel_rendering,
+                                  octree_color_mode, red, 1.0);
     }
   }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -104,6 +104,16 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     for (std::size_t j = 0; j < o->shapes_.size(); ++j)
       render_shapes_->renderShape(planning_scene_geometry_node_, o->shapes_[j].get(), o->shape_poses_[j],
                                   octree_voxel_rendering, octree_color_mode, color, alpha);
+    
+    // Insert the named frames as red spheres of radius 2 mm
+    // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
+    auto s = shapes::Sphere(.002);
+    rviz::Color red(1.0, 0.0, 0.0);
+    for (auto nf_pair : o->named_frames_)
+    {
+      render_shapes_->renderShape(planning_scene_geometry_node_, &s, nf_pair.second, 
+                                  octree_voxel_rendering, octree_color_mode, red, 1.0);
+    }
   }
 }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -138,8 +138,8 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     Eigen::Affine3d t = kinematic_state->getGlobalLinkTransform(attached_bodies[i]->getAttachedLinkName());
-    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin(); 
-          it != attached_bodies[i]->getNamedTransforms().end(); it++ )
+    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin();
+         it != attached_bodies[i]->getNamedTransforms().end(); it++)
     {
       render_shapes_->renderShape(robot_.getVisualNode(), &s, t * it->second, octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, red, 1.0);
@@ -172,4 +172,4 @@ void RobotStateVisualization::setAlpha(float alpha)
 {
   robot_.setAlpha(alpha);
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -138,8 +138,8 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     Eigen::Affine3d t = kinematic_state->getGlobalLinkTransform(attached_bodies[i]->getAttachedLinkName());
-    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin(); 
-          it != attached_bodies[i]->getNamedTransforms().end(); it++ )
+    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin();
+         it != attached_bodies[i]->getNamedTransforms().end(); it++)
     {
       render_shapes_->renderShape(robot_.getVisualNode(), &s, t * it->second, octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, red, 1.0);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -132,6 +132,18 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
       render_shapes_->renderShape(robot_.getCollisionNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, rcolor, alpha);
     }
+
+    // Insert the named frames as red spheres of radius 2 mm
+    // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
+    auto s = shapes::Sphere(.002);
+    rviz::Color red(1.0, 0.0, 0.0);
+    Eigen::Affine3d t = kinematic_state->getGlobalLinkTransform(attached_bodies[i]->getAttachedLinkName());
+    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin(); 
+          it != attached_bodies[i]->getNamedTransforms().end(); it++ )
+    {
+      render_shapes_->renderShape(robot_.getVisualNode(), &s, t * it->second, octree_voxel_render_mode_,
+                                  octree_voxel_color_mode_, red, 1.0);
+    }
   }
   robot_.setVisualVisible(visual_visible_);
   robot_.setCollisionVisible(collision_visible_);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -138,8 +138,8 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
     auto s = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     Eigen::Affine3d t = kinematic_state->getGlobalLinkTransform(attached_bodies[i]->getAttachedLinkName());
-    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin();
-         it != attached_bodies[i]->getNamedTransforms().end(); it++)
+    for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin(); 
+          it != attached_bodies[i]->getNamedTransforms().end(); it++ )
     {
       render_shapes_->renderShape(robot_.getVisualNode(), &s, t * it->second, octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, red, 1.0);
@@ -172,4 +172,4 @@ void RobotStateVisualization::setAlpha(float alpha)
 {
   robot_.setAlpha(alpha);
 }
-}  // namespace moveit_rviz_plugin
+}

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -134,14 +134,14 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
     }
 
     // Insert the named frames as red spheres of radius 2 mm
-    // TODO: Integrate this properly (either by publishing to TF, or frames that can be toggled)
-    auto s = shapes::Sphere(.002);
+    // TODO(felixvd): Integrate this properly (either by publishing to TF, or frames that can be toggled)
+    auto frame_marker = shapes::Sphere(.002);
     rviz::Color red(1.0, 0.0, 0.0);
     Eigen::Affine3d t = kinematic_state->getGlobalLinkTransform(attached_bodies[i]->getAttachedLinkName());
     for (std::map<std::string, Eigen::Affine3d>::const_iterator it = attached_bodies[i]->getNamedTransforms().begin();
          it != attached_bodies[i]->getNamedTransforms().end(); it++)
     {
-      render_shapes_->renderShape(robot_.getVisualNode(), &s, t * it->second, octree_voxel_render_mode_,
+      render_shapes_->renderShape(robot_.getVisualNode(), &frame_marker, t * it->second, octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, red, 1.0);
     }
   }


### PR DESCRIPTION
### Description

This PR implements #1041. It adds named frames to collision objects so that they can be used for planning, both as targets in the planning scene, as well as end effector links when the objects are attached to the robot. This allows writing commands like "Move the tip of the screwdriver to the head of the screw" or "Move the spout of the teapot to the top of the mug". It also opens up avenues for using in-hand pose estimation to update the pose of an object in the gripper (e.g. grasp a tool, confirm the object pose with a camera, then use the updated tool tip pose on the object).

Currently, the named frames are displayed in Rviz in the Scene Objects tab and as red dots on the `AttachedBodies`. I also made a header file that converts URDF files to `collision_object` messages in C++, but it's not part of this PR. I didn't test it a lot yet, so there are surely some bugs, but it should be good enough to try out.

[Here](https://gist.github.com/felixvd/9b79be2bd10cc615e980f389bab2096d) is a gist that you can use to create the following example images. These run for a UR5, but you have to adjust everything to your system and fill in some variables. I didn't have time to prepare a whole test package.

![2018-9-11-ps-extension](https://user-images.githubusercontent.com/4535737/45336934-a9af8200-b5c0-11e8-85be-31d180b2a07c.png)

The result of "Move the cylinder tip to the bottom of the box":

![2018-09-11-ps-extension-2](https://user-images.githubusercontent.com/4535737/45336938-ac11dc00-b5c0-11e8-8e5d-71c56015c264.png)

Open ToDos:

* Test the path and trajectory constraints (I only checked that it works on goal constraints)
* Integrate the frames' visualization into Rviz (should they be published to TF? Should there be a checkbox?)
* Implement MOVE for CollisionObjects and AttachedBodies (would be great for updating the object pose in the gripper)
* Check effect on performance

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
