### PR TITLE
Chomp trajectory seed

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -130,11 +130,11 @@ public:
    */
   void fillInCubicInterpolation();
 
-   /**
-   * \brief Fill the trajectory from a trajectory seed
-   *
-   * Only modifies points from start_index_ to end_index_, inclusive
-   */
+  /**
+  * \brief Fill the trajectory from a trajectory seed
+  *
+  * Only modifies points from start_index_ to end_index_, inclusive
+  */
   void fillInSeed(const moveit_msgs::MotionPlanRequest& req);
 
   /**

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -40,6 +40,7 @@
 #include <trajectory_msgs/JointTrajectory.h>
 #include <moveit/robot_model/robot_model.h>
 #include <chomp_motion_planner/chomp_utils.h>
+#include <moveit_msgs/MotionPlanRequest.h>
 
 #include <vector>
 #include <eigen3/Eigen/Core>
@@ -128,6 +129,13 @@ public:
    * Only modifies points from start_index_ to end_index_, inclusive
    */
   void fillInCubicInterpolation();
+
+   /**
+   * \brief Fill the trajectory from a trajectory seed
+   *
+   * Only modifies points from start_index_ to end_index_, inclusive
+   */
+  void fillInSeed(const moveit_msgs::MotionPlanRequest& req);
 
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -140,14 +140,18 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
 
   // fill in an initial trajectory based on user choice from the chomp_config.yaml file
-  if (params.trajectory_initialization_method_.compare("quintic-spline") == 0)
-    trajectory.fillInMinJerk();
-  else if (params.trajectory_initialization_method_.compare("linear") == 0)
-    trajectory.fillInLinearInterpolation();
-  else if (params.trajectory_initialization_method_.compare("cubic") == 0)
-    trajectory.fillInCubicInterpolation();
-  else
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
+  // if a trajectory seed is given, use it
+  if (req.trajectory_constraints.constraints.empty()) {
+    if (params.trajectory_initialization_method_.compare("quintic-spline") == 0)
+      trajectory.fillInMinJerk();
+    else if (params.trajectory_initialization_method_.compare("linear") == 0)
+      trajectory.fillInLinearInterpolation();
+    else if (params.trajectory_initialization_method_.compare("cubic") == 0)
+      trajectory.fillInCubicInterpolation();
+    else
+      ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
+  }
+  else {trajectory.fillInSeed(req);}
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -141,7 +141,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   // fill in an initial trajectory based on user choice from the chomp_config.yaml file
   // if a trajectory seed is given, use it
-  if (req.trajectory_constraints.constraints.empty()) {
+  if (req.trajectory_constraints.constraints.empty())
+  {
     if (params.trajectory_initialization_method_.compare("quintic-spline") == 0)
       trajectory.fillInMinJerk();
     else if (params.trajectory_initialization_method_.compare("linear") == 0)
@@ -151,7 +152,10 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     else
       ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
   }
-  else {trajectory.fillInSeed(req);}
+  else
+  {
+    trajectory.fillInSeed(req);
+  }
 
   // optimize!
   moveit::core::RobotState start_state(planning_scene->getCurrentState());

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -37,6 +37,7 @@
 #include <ros/ros.h>
 #include <chomp_motion_planner/chomp_trajectory.h>
 #include <iostream>
+#include <moveit_msgs/MotionPlanRequest.h>
 
 namespace chomp
 {
@@ -248,6 +249,19 @@ void ChompTrajectory::fillInMinJerk()
       {
         (*this)(i, j) += t[k] * coeff[j][k];
       }
+    }
+  }
+}
+
+void ChompTrajectory::fillInSeed(const moveit_msgs::MotionPlanRequest& req)
+{
+  double start_index = start_index_ - 1;
+  double end_index = end_index_ + 1; 
+  for (int i = 0; i < num_joints_; i++)
+  {
+    for (int j = start_index + 1; j < end_index; j++)
+    {
+      (*this)(j, i) = req.trajectory_constraints.constraints[j].joint_constraints[i].position;
     }
   }
 }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -256,7 +256,7 @@ void ChompTrajectory::fillInMinJerk()
 void ChompTrajectory::fillInSeed(const moveit_msgs::MotionPlanRequest& req)
 {
   double start_index = start_index_ - 1;
-  double end_index = end_index_ + 1; 
+  double end_index = end_index_ + 1;
   for (int i = 0; i < num_joints_; i++)
   {
     for (int j = start_index + 1; j < end_index; j++)


### PR DESCRIPTION
### Description

In the moveit message MotionPlanRequest the member trajectory_constraints is used by the STOMP planner to provide an initial seed trajectory. I implemented the same functionality in the CHOMP planner. 

If one wants to use an initial trajectory for the CHOMP planner, one should only do : 

```
moveit_msgs::TrajectoryConstraints initial_traj;
/*
Filling of initial_traj
*/
my_group.setTrajectoryConstraints(initial_traj);
```
Before the commit, CHOMP did not care about the trajectory constraints, now it automatically detects if there is one and if yes use it.
