### PR TITLE
Documenting why setFromIK in computeCartesianPath does not use random restarts

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1919,6 +1919,9 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
   traj.clear();
   traj.push_back(RobotStatePtr(new RobotState(*this)));
 
+  // For each waypoint we do not use random restarts since they would very likely result in IK jumps
+  std::size_t ik_attempts = 1;
+
   double last_valid_percentage = 0.0;
   for (std::size_t i = 1; i <= steps; ++i)
   {
@@ -1927,7 +1930,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
     Eigen::Affine3d pose(start_quaternion.slerp(percentage, target_quaternion));
     pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
 
-    if (setFromIK(group, pose, link->getName(), 1, 0.0, validCallback, options))
+    if (setFromIK(group, pose, link->getName(), ik_attempts, 0.0, validCallback, options))
       traj.push_back(RobotStatePtr(new RobotState(*this)));
     else
       break;


### PR DESCRIPTION
Documenting why the setFromIK call in computeCartesianPath uses a single attempt rather than the default.  

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
