### PR TITLE
Check errors when loading scene geometry from text file (#1056)

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -670,10 +670,10 @@ public:
   void saveGeometryToStream(std::ostream& out) const;
 
   /** \brief Load the geometry of the planning scene from a stream */
-  void loadGeometryFromStream(std::istream& in);
+  bool loadGeometryFromStream(std::istream& in);
 
   /** \brief Load the geometry of the planning scene from a stream at a certain location using offset*/
-  void loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset);
+  bool loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset);
 
   /** \brief Fill the message \e scene with the differences between this instance of PlanningScene with respect to the
      parent.

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1033,39 +1033,65 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
   out << "." << std::endl;
 }
 
-void PlanningScene::loadGeometryFromStream(std::istream& in)
+bool PlanningScene::loadGeometryFromStream(std::istream& in)
 {
-  loadGeometryFromStream(in, Eigen::Affine3d::Identity());  // Use no offset
+  return loadGeometryFromStream(in, Eigen::Affine3d::Identity());  // Use no offset
 }
 
-void PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset)
+bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine3d& offset)
 {
   if (!in.good() || in.eof())
-    return;
+  {
+    ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading scene geometry");
+    return false;
+  }
   std::getline(in, name_);
   do
   {
     std::string marker;
     in >> marker;
     if (!in.good() || in.eof())
-      return;
+    {
+      ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading marker in scene geometry");
+      return false;
+    }
     if (marker == "*")
     {
       std::string ns;
       std::getline(in, ns);
       if (!in.good() || in.eof())
-        return;
+      {
+        ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading ns in scene geometry");
+        return false;
+      }
       boost::algorithm::trim(ns);
       unsigned int shape_count;
       in >> shape_count;
       for (std::size_t i = 0; i < shape_count && in.good() && !in.eof(); ++i)
       {
         shapes::Shape* s = shapes::constructShapeFromText(in);
+        if (!s)
+        {
+          ROS_ERROR_NAMED("planning_scene", "Failed to load shape from scene file");
+          return false;
+        }
         double x, y, z, rx, ry, rz, rw;
-        in >> x >> y >> z;
-        in >> rx >> ry >> rz >> rw;
+        if (!(in >> x >> y >> z))
+        {
+          ROS_ERROR_NAMED("planning_scene", "Improperly formatted translation in scene geometry file");
+          return false;
+        }
+        if (!(in >> rx >> ry >> rz >> rw))
+        {
+          ROS_ERROR_NAMED("planning_scene", "Improperly formatted rotation in scene geometry file");
+          return false;
+        }
         float r, g, b, a;
-        in >> r >> g >> b >> a;
+        if (!(in >> r >> g >> b >> a))
+        {
+          ROS_ERROR_NAMED("planning_scene", "Improperly formatted color in scene geometry file");
+          return false;
+        }
         if (s)
         {
           Eigen::Affine3d pose = Eigen::Translation3d(x, y, z) * Eigen::Quaterniond(rw, rx, ry, rz);
@@ -1084,8 +1110,16 @@ void PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
         }
       }
     }
+    else if (marker == ".")
+    {
+      // Marks the end of the scene geometry;
+      return true;
+    }
     else
-      break;
+    {
+      ROS_ERROR_STREAM_NAMED("planning_scene", "Unknown marker in scene geometry file: " << marker);
+      return false;
+    }
   } while (true);
 }
 

--- a/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
@@ -73,10 +73,9 @@ int main(int argc, char** argv)
     planning_scene::PlanningScene ps(rml->getModel());
 
     std::ifstream f(argv[filename_index]);
-    if (f.good() && !f.eof())
+    if (ps.loadGeometryFromStream(f))
     {
       ROS_INFO("Publishing geometry from '%s' ...", argv[filename_index]);
-      ps.loadGeometryFromStream(f);
       moveit_msgs::PlanningScene ps_msg;
       ps.getPlanningSceneMsg(ps_msg);
       ps_msg.is_diff = true;
@@ -93,8 +92,6 @@ int main(int argc, char** argv)
 
       sleep(1);
     }
-    else
-      ROS_WARN("Unable to load '%s'.", argv[filename_index]);
   }
   else
     ROS_WARN("A filename was expected as argument. That file should be a text representation of the geometry in a "

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -933,16 +933,17 @@ void MotionPlanningFrame::computeImportFromText(const std::string& path)
   if (ps)
   {
     std::ifstream fin(path.c_str());
-    if (fin.good())
+    if (ps->loadGeometryFromStream(fin))
     {
-      ps->loadGeometryFromStream(fin);
-      fin.close();
       ROS_INFO("Loaded scene geometry from '%s'", path.c_str());
       planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
       planning_display_->queueRenderSceneGeometry();
     }
     else
-      ROS_WARN("Unable to load scene geometry from '%s'", path.c_str());
+    {
+      QMessageBox::warning(nullptr, "Loading scene geometry", "Failed to load scene geometry.\n"
+                                                              "See console output for more details.");
+    }
   }
 }
 


### PR DESCRIPTION
Backport of #1056 into Kinetic. Do we want to accept the API change, returning bool instead of void in the functions `loadGeometryFromStream()`?

I don't consider this patch essential and personally would prefer API stability over backporting this.
However, I'm open to other opinions.