### PR TITLE
using LOGNAME variable rather than strings for logging

### DIFF
--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -50,6 +50,8 @@ namespace moveit
 {
 namespace core
 {
+const std::string LOGNAME = "robot_model";
+
 RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model, const srdf::ModelConstSharedPtr& srdf_model)
 {
   root_joint_ = nullptr;
@@ -88,39 +90,39 @@ void RobotModel::buildModel(const urdf::ModelInterface& urdf_model, const srdf::
   link_geometry_count_ = 0;
   variable_count_ = 0;
   model_name_ = urdf_model.getName();
-  ROS_INFO_NAMED("robot_model", "Loading robot model '%s'...", model_name_.c_str());
+  ROS_INFO_NAMED(LOGNAME, "Loading robot model '%s'...", model_name_.c_str());
 
   if (urdf_model.getRoot())
   {
     const urdf::Link* root_link_ptr = urdf_model.getRoot().get();
     model_frame_ = '/' + root_link_ptr->name;
 
-    ROS_DEBUG_NAMED("robot_model", "... building kinematic chain");
+    ROS_DEBUG_NAMED(LOGNAME, "... building kinematic chain");
     root_joint_ = buildRecursive(nullptr, root_link_ptr, srdf_model);
     if (root_joint_)
       root_link_ = root_joint_->getChildLinkModel();
-    ROS_DEBUG_NAMED("robot_model", "... building mimic joints");
+    ROS_DEBUG_NAMED(LOGNAME, "... building mimic joints");
     buildMimic(urdf_model);
 
-    ROS_DEBUG_NAMED("robot_model", "... computing joint indexing");
+    ROS_DEBUG_NAMED(LOGNAME, "... computing joint indexing");
     buildJointInfo();
 
     if (link_models_with_collision_geometry_vector_.empty())
-      ROS_WARN_NAMED("robot_model", "No geometry is associated to any robot links");
+      ROS_WARN_NAMED(LOGNAME, "No geometry is associated to any robot links");
 
     // build groups
 
-    ROS_DEBUG_NAMED("robot_model", "... constructing joint groups");
+    ROS_DEBUG_NAMED(LOGNAME, "... constructing joint groups");
     buildGroups(srdf_model);
 
-    ROS_DEBUG_NAMED("robot_model", "... constructing joint group states");
+    ROS_DEBUG_NAMED(LOGNAME, "... constructing joint group states");
     buildGroupStates(srdf_model);
 
     // For debugging entire model
     // printModelInfo(std::cout);
   }
   else
-    ROS_WARN_NAMED("robot_model", "No root link found");
+    ROS_WARN_NAMED(LOGNAME, "No root link found");
 }
 
 namespace
@@ -334,21 +336,21 @@ void RobotModel::buildGroupStates(const srdf::Model& srdf_model)
             for (std::size_t j = 0; j < vn.size(); ++j)
               state[vn[j]] = jt->second[j];
           else
-            ROS_ERROR_NAMED(
-                "robot_model", "The model for joint '%s' requires %d variable values, "
-                               "but only %d variable values were supplied in default state '%s' for group '%s'",
-                jt->first.c_str(), (int)vn.size(), (int)jt->second.size(), ds[i].name_.c_str(), jmg->getName().c_str());
+            ROS_ERROR_NAMED(LOGNAME, "The model for joint '%s' requires %d variable values, "
+                                     "but only %d variable values were supplied in default state '%s' for group '%s'",
+                            jt->first.c_str(), (int)vn.size(), (int)jt->second.size(), ds[i].name_.c_str(),
+                            jmg->getName().c_str());
         }
         else
-          ROS_ERROR_NAMED("robot_model", "Group state '%s' specifies value for joint '%s', "
-                                         "but that joint is not part of group '%s'",
+          ROS_ERROR_NAMED(LOGNAME, "Group state '%s' specifies value for joint '%s', "
+                                   "but that joint is not part of group '%s'",
                           ds[i].name_.c_str(), jt->first.c_str(), jmg->getName().c_str());
       }
       if (!state.empty())
         jmg->addDefaultState(ds[i].name_, state);
     }
     else
-      ROS_ERROR_NAMED("robot_model", "Group state '%s' specified for group '%s', but that group does not exist",
+      ROS_ERROR_NAMED(LOGNAME, "Group state '%s' specified for group '%s', but that group does not exist",
                       ds[i].name_.c_str(), ds[i].group_.c_str());
   }
 }
@@ -368,12 +370,11 @@ void RobotModel::buildMimic(const urdf::ModelInterface& urdf_model)
           if (joint_model_vector_[i]->getVariableCount() == jit->second->getVariableCount())
             joint_model_vector_[i]->setMimic(jit->second, jm->mimic->multiplier, jm->mimic->offset);
           else
-            ROS_ERROR_NAMED("robot_model",
-                            "Join '%s' cannot mimic joint '%s' because they have different number of DOF",
+            ROS_ERROR_NAMED(LOGNAME, "Join '%s' cannot mimic joint '%s' because they have different number of DOF",
                             joint_model_vector_[i]->getName().c_str(), jm->mimic->joint_name.c_str());
         }
         else
-          ROS_ERROR_NAMED("robot_model", "Joint '%s' cannot mimic unknown joint '%s'",
+          ROS_ERROR_NAMED(LOGNAME, "Joint '%s' cannot mimic unknown joint '%s'",
                           joint_model_vector_[i]->getName().c_str(), jm->mimic->joint_name.c_str());
       }
   }
@@ -397,7 +398,7 @@ void RobotModel::buildMimic(const urdf::ModelInterface& urdf_model)
         }
         if (joint_model_vector_[i] == joint_model_vector_[i]->getMimic())
         {
-          ROS_ERROR_NAMED("robot_model", "Cycle found in joint that mimic each other. Ignoring all mimic joints.");
+          ROS_ERROR_NAMED(LOGNAME, "Cycle found in joint that mimic each other. Ignoring all mimic joints.");
           for (std::size_t i = 0; i < joint_model_vector_.size(); ++i)
             joint_model_vector_[i]->setMimic(nullptr, 0.0, 0.0);
           change = false;
@@ -427,7 +428,7 @@ const JointModelGroup* RobotModel::getEndEffector(const std::string& name) const
     it = joint_model_group_map_.find(name);
     if (it != joint_model_group_map_.end() && it->second->isEndEffector())
       return it->second;
-    ROS_ERROR_NAMED("robot_model", "End-effector '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "End-effector '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
     return nullptr;
   }
   return it->second;
@@ -441,7 +442,7 @@ JointModelGroup* RobotModel::getEndEffector(const std::string& name)
     it = joint_model_group_map_.find(name);
     if (it != joint_model_group_map_.end() && it->second->isEndEffector())
       return it->second;
-    ROS_ERROR_NAMED("robot_model", "End-effector '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "End-effector '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
     return nullptr;
   }
   return it->second;
@@ -457,7 +458,7 @@ const JointModelGroup* RobotModel::getJointModelGroup(const std::string& name) c
   JointModelGroupMap::const_iterator it = joint_model_group_map_.find(name);
   if (it == joint_model_group_map_.end())
   {
-    ROS_ERROR_NAMED("robot_model", "Group '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Group '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
     return nullptr;
   }
   return it->second;
@@ -468,7 +469,7 @@ JointModelGroup* RobotModel::getJointModelGroup(const std::string& name)
   JointModelGroupMap::const_iterator it = joint_model_group_map_.find(name);
   if (it == joint_model_group_map_.end())
   {
-    ROS_ERROR_NAMED("robot_model", "Group '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Group '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
     return nullptr;
   }
   return it->second;
@@ -503,14 +504,14 @@ void RobotModel::buildGroups(const srdf::Model& srdf_model)
           added = true;
           processed[i] = true;
           if (!addJointModelGroup(group_configs[i]))
-            ROS_WARN_NAMED("robot_model", "Failed to add group '%s'", group_configs[i].name_.c_str());
+            ROS_WARN_NAMED(LOGNAME, "Failed to add group '%s'", group_configs[i].name_.c_str());
         }
       }
   }
 
   for (std::size_t i = 0; i < processed.size(); ++i)
     if (!processed[i])
-      ROS_WARN_NAMED("robot_model", "Could not process group '%s' due to unmet subgroup dependencies",
+      ROS_WARN_NAMED(LOGNAME, "Could not process group '%s' due to unmet subgroup dependencies",
                      group_configs[i].name_.c_str());
 
   for (JointModelGroupMap::const_iterator it = joint_model_group_map_.begin(); it != joint_model_group_map_.end(); ++it)
@@ -596,17 +597,16 @@ void RobotModel::buildGroupsInfo_EndEffectors(const srdf::Model& srdf_model)
               if (jt->second != it->second)
                 eef_parent_group = jt->second;
               else
-                ROS_ERROR_NAMED("robot_model", "Group '%s' for end-effector '%s' cannot be its own parent",
+                ROS_ERROR_NAMED(LOGNAME, "Group '%s' for end-effector '%s' cannot be its own parent",
                                 eefs[k].parent_group_.c_str(), eefs[k].name_.c_str());
             }
             else
-              ROS_ERROR_NAMED("robot_model", "Group '%s' was specified as parent group for end-effector '%s' "
-                                             "but it does not include the parent link '%s'",
+              ROS_ERROR_NAMED(LOGNAME, "Group '%s' was specified as parent group for end-effector '%s' "
+                                       "but it does not include the parent link '%s'",
                               eefs[k].parent_group_.c_str(), eefs[k].name_.c_str(), eefs[k].parent_link_.c_str());
           }
           else
-            ROS_ERROR_NAMED("robot_model",
-                            "Group name '%s' not found (specified as parent group for end-effector '%s')",
+            ROS_ERROR_NAMED(LOGNAME, "Group name '%s' not found (specified as parent group for end-effector '%s')",
                             eefs[k].parent_group_.c_str(), eefs[k].name_.c_str());
         }
 
@@ -630,7 +630,7 @@ void RobotModel::buildGroupsInfo_EndEffectors(const srdf::Model& srdf_model)
         }
         else
         {
-          ROS_WARN_NAMED("robot_model", "Could not identify parent group for end-effector '%s'", eefs[k].name_.c_str());
+          ROS_WARN_NAMED(LOGNAME, "Could not identify parent group for end-effector '%s'", eefs[k].name_.c_str());
           it->second->setEndEffectorParent("", eefs[k].parent_link_);
         }
         break;
@@ -643,7 +643,7 @@ bool RobotModel::addJointModelGroup(const srdf::Model::Group& gc)
 {
   if (joint_model_group_map_.find(gc.name_) != joint_model_group_map_.end())
   {
-    ROS_WARN_NAMED("robot_model", "A group named '%s' already exists. Not adding.", gc.name_.c_str());
+    ROS_WARN_NAMED(LOGNAME, "A group named '%s' already exists. Not adding.", gc.name_.c_str());
     return false;
   }
 
@@ -740,7 +740,7 @@ bool RobotModel::addJointModelGroup(const srdf::Model::Group& gc)
 
   if (jset.empty())
   {
-    ROS_WARN_NAMED("robot_model", "Group '%s' must have at least one valid joint", gc.name_.c_str());
+    ROS_WARN_NAMED(LOGNAME, "Group '%s' must have at least one valid joint", gc.name_.c_str());
     return false;
   }
 
@@ -885,7 +885,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
         result = new FixedJointModel(urdf_joint->name);
         break;
       default:
-        ROS_ERROR_NAMED("robot_model", "Unknown joint type: %d", (int)urdf_joint->type);
+        ROS_ERROR_NAMED(LOGNAME, "Unknown joint type: %d", (int)urdf_joint->type);
         break;
     }
   }
@@ -896,13 +896,13 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
     {
       if (vjoints[i].child_link_ != child_link->name)
       {
-        ROS_WARN_NAMED("robot_model", "Skipping virtual joint '%s' because its child frame '%s' "
-                                      "does not match the URDF frame '%s'",
+        ROS_WARN_NAMED(LOGNAME, "Skipping virtual joint '%s' because its child frame '%s' "
+                                "does not match the URDF frame '%s'",
                        vjoints[i].name_.c_str(), vjoints[i].child_link_.c_str(), child_link->name.c_str());
       }
       else if (vjoints[i].parent_frame_.empty())
       {
-        ROS_WARN_NAMED("robot_model", "Skipping virtual joint '%s' because its parent frame is empty",
+        ROS_WARN_NAMED(LOGNAME, "Skipping virtual joint '%s' because its parent frame is empty",
                        vjoints[i].name_.c_str());
       }
       else
@@ -928,7 +928,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
     }
     if (!result)
     {
-      ROS_INFO_NAMED("robot_model", "No root/virtual joint specified in SRDF. Assuming fixed joint");
+      ROS_INFO_NAMED(LOGNAME, "No root/virtual joint specified in SRDF. Assuming fixed joint");
       result = new FixedJointModel("ASSUMED_FIXED_ROOT_JOINT");
     }
   }
@@ -1060,7 +1060,7 @@ shapes::ShapePtr RobotModel::constructShape(const urdf::Geometry* geom)
     }
     break;
     default:
-      ROS_ERROR_NAMED("robot_model", "Unknown geometry type: %d", (int)geom->type);
+      ROS_ERROR_NAMED(LOGNAME, "Unknown geometry type: %d", (int)geom->type);
       break;
   }
 
@@ -1082,7 +1082,7 @@ const JointModel* RobotModel::getJointModel(const std::string& name) const
   JointModelMap::const_iterator it = joint_model_map_.find(name);
   if (it != joint_model_map_.end())
     return it->second;
-  ROS_ERROR_NAMED("robot_model", "Joint '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+  ROS_ERROR_NAMED(LOGNAME, "Joint '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
   return nullptr;
 }
 
@@ -1090,8 +1090,7 @@ const JointModel* RobotModel::getJointModel(int index) const
 {
   if (index < 0 || index >= static_cast<int>(joint_model_vector_.size()))
   {
-    ROS_ERROR_NAMED("robot_model", "Joint index '%i' out of bounds of joints in model '%s'", index,
-                    model_name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Joint index '%i' out of bounds of joints in model '%s'", index, model_name_.c_str());
     return nullptr;
   }
   assert(joint_model_vector_[index]->getJointIndex() == index);
@@ -1103,7 +1102,7 @@ JointModel* RobotModel::getJointModel(const std::string& name)
   JointModelMap::const_iterator it = joint_model_map_.find(name);
   if (it != joint_model_map_.end())
     return it->second;
-  ROS_ERROR_NAMED("robot_model", "Joint '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+  ROS_ERROR_NAMED(LOGNAME, "Joint '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
   return nullptr;
 }
 
@@ -1116,7 +1115,7 @@ const LinkModel* RobotModel::getLinkModel(int index) const
 {
   if (index < 0 || index >= static_cast<int>(link_model_vector_.size()))
   {
-    ROS_ERROR_NAMED("robot_model", "Link index '%i' out of bounds of links in model '%s'", index, model_name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Link index '%i' out of bounds of links in model '%s'", index, model_name_.c_str());
     return nullptr;
   }
   assert(link_model_vector_[index]->getLinkIndex() == index);
@@ -1128,7 +1127,7 @@ LinkModel* RobotModel::getLinkModel(const std::string& name)
   LinkModelMap::const_iterator it = link_model_map_.find(name);
   if (it != link_model_map_.end())
     return it->second;
-  ROS_ERROR_NAMED("robot_model", "Link '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+  ROS_ERROR_NAMED(LOGNAME, "Link '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
   return nullptr;
 }
 
@@ -1329,7 +1328,7 @@ void RobotModel::setKinematicsAllocators(const std::map<std::string, SolverAlloc
           ss << subs[i]->getName() << " ";
           result.second[subs[i]] = allocators.find(subs[i]->getName())->second;
         }
-        ROS_DEBUG_NAMED("robot_model", "Added sub-group IK allocators for group '%s': [ %s]", jmg->getName().c_str(),
+        ROS_DEBUG_NAMED(LOGNAME, "Added sub-group IK allocators for group '%s': [ %s]", jmg->getName().c_str(),
                         ss.str().c_str());
       }
       jmg->setSolverAllocators(result);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -561,17 +561,7 @@ public:
     memcpy(velocity_ + joint->getFirstVariableIndex(), velocity, joint->getVariableCount() * sizeof(double));
   }
 
-  void setJointEfforts(const JointModel* joint, const double* effort)
-  {
-    if (has_acceleration_)
-    {
-      ROS_ERROR_NAMED("robot_state", "Unable to set joint efforts because array is being used for accelerations");
-      return;
-    }
-    has_effort_ = true;
-
-    memcpy(effort_ + joint->getFirstVariableIndex(), effort, joint->getVariableCount() * sizeof(double));
-  }
+  void setJointEfforts(const JointModel* joint, const double* effort);
 
   const double* getJointPositions(const std::string& joint_name) const
   {

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -44,6 +44,8 @@ namespace moveit
 {
 namespace core
 {
+const std::string LOGNAME = "robot_state";
+
 // ********************************************
 // * Internal (hidden) functions
 // ********************************************
@@ -54,7 +56,7 @@ static bool _jointStateToRobotState(const sensor_msgs::JointState& joint_state, 
 {
   if (joint_state.name.size() != joint_state.position.size())
   {
-    ROS_ERROR_NAMED("robot_state", "Different number of names and positions in JointState message: %zu, %zu",
+    ROS_ERROR_NAMED(LOGNAME, "Different number of names and positions in JointState message: %zu, %zu",
                     joint_state.name.size(), joint_state.position.size());
     return false;
   }
@@ -70,7 +72,7 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
   std::size_t nj = mjs.joint_names.size();
   if (nj != mjs.transforms.size())
   {
-    ROS_ERROR_NAMED("robot_state", "Different number of names, values or frames in MultiDOFJointState message.");
+    ROS_ERROR_NAMED(LOGNAME, "Different number of names, values or frames in MultiDOFJointState message.");
     return false;
   }
 
@@ -92,15 +94,15 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
       }
       catch (std::exception& ex)
       {
-        ROS_ERROR_NAMED("robot_state", "Caught %s", ex.what());
+        ROS_ERROR_NAMED(LOGNAME, "Caught %s", ex.what());
         error = true;
       }
     else
       error = true;
 
     if (error)
-      ROS_WARN_NAMED("robot_state", "The transform for multi-dof joints was specified in frame '%s' "
-                                    "but it was not possible to transform that to frame '%s'",
+      ROS_WARN_NAMED(LOGNAME, "The transform for multi-dof joints was specified in frame '%s' "
+                              "but it was not possible to transform that to frame '%s'",
                      mjs.header.frame_id.c_str(), state.getRobotModel()->getModelFrame().c_str());
   }
 
@@ -109,7 +111,7 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
     const std::string& joint_name = mjs.joint_names[i];
     if (!state.getRobotModel()->hasJointModel(joint_name))
     {
-      ROS_WARN_NAMED("robot_state", "No joint matching multi-dof joint '%s'", joint_name.c_str());
+      ROS_WARN_NAMED(LOGNAME, "No joint matching multi-dof joint '%s'", joint_name.c_str());
       error = true;
       continue;
     }
@@ -225,20 +227,20 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
     {
       if (aco.object.primitives.size() != aco.object.primitive_poses.size())
       {
-        ROS_ERROR_NAMED("robot_state", "Number of primitive shapes does not match "
-                                       "number of poses in collision object message");
+        ROS_ERROR_NAMED(LOGNAME, "Number of primitive shapes does not match "
+                                 "number of poses in collision object message");
         return;
       }
 
       if (aco.object.meshes.size() != aco.object.mesh_poses.size())
       {
-        ROS_ERROR_NAMED("robot_state", "Number of meshes does not match number of poses in collision object message");
+        ROS_ERROR_NAMED(LOGNAME, "Number of meshes does not match number of poses in collision object message");
         return;
       }
 
       if (aco.object.planes.size() != aco.object.plane_poses.size())
       {
-        ROS_ERROR_NAMED("robot_state", "Number of planes does not match number of poses in collision object message");
+        ROS_ERROR_NAMED(LOGNAME, "Number of planes does not match number of poses in collision object message");
         return;
       }
 
@@ -294,8 +296,8 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           else
           {
             t0.setIdentity();
-            ROS_ERROR_NAMED("robot_state", "Cannot properly transform from frame '%s'. "
-                                           "The pose of the attached body may be incorrect",
+            ROS_ERROR_NAMED(LOGNAME, "Cannot properly transform from frame '%s'. "
+                                     "The pose of the attached body may be incorrect",
                             aco.object.header.frame_id.c_str());
           }
           Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
@@ -304,31 +306,30 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
         }
 
         if (shapes.empty())
-          ROS_ERROR_NAMED("robot_state", "There is no geometry to attach to link '%s' as part of attached body '%s'",
+          ROS_ERROR_NAMED(LOGNAME, "There is no geometry to attach to link '%s' as part of attached body '%s'",
                           aco.link_name.c_str(), aco.object.id.c_str());
         else
         {
           if (state.clearAttachedBody(aco.object.id))
-            ROS_DEBUG_NAMED("robot_state", "The robot state already had an object named '%s' attached to link '%s'. "
-                                           "The object was replaced.",
+            ROS_DEBUG_NAMED(LOGNAME, "The robot state already had an object named '%s' attached to link '%s'. "
+                                     "The object was replaced.",
                             aco.object.id.c_str(), aco.link_name.c_str());
           state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture);
-          ROS_DEBUG_NAMED("robot_state", "Attached object '%s' to link '%s'", aco.object.id.c_str(),
-                          aco.link_name.c_str());
+          ROS_DEBUG_NAMED(LOGNAME, "Attached object '%s' to link '%s'", aco.object.id.c_str(), aco.link_name.c_str());
         }
       }
     }
     else
-      ROS_ERROR_NAMED("robot_state", "The attached body for link '%s' has no geometry", aco.link_name.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "The attached body for link '%s' has no geometry", aco.link_name.c_str());
   }
   else if (aco.object.operation == moveit_msgs::CollisionObject::REMOVE)
   {
     if (!state.clearAttachedBody(aco.object.id))
-      ROS_ERROR_NAMED("robot_state", "The attached body '%s' can not be removed because it does not exist",
+      ROS_ERROR_NAMED(LOGNAME, "The attached body '%s' can not be removed because it does not exist",
                       aco.link_name.c_str());
   }
   else
-    ROS_ERROR_NAMED("robot_state", "Unknown collision object operation: %d", aco.object.operation);
+    ROS_ERROR_NAMED(LOGNAME, "Unknown collision object operation: %d", aco.object.operation);
 }
 
 static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_msgs::RobotState& robot_state,
@@ -339,7 +340,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
 
   if (!rs.is_diff && rs.joint_state.name.empty() && rs.multi_dof_joint_state.joint_names.empty())
   {
-    ROS_ERROR_NAMED("robot_state", "Found empty JointState message");
+    ROS_ERROR_NAMED(LOGNAME, "Found empty JointState message");
     return false;
   }
 
@@ -435,12 +436,12 @@ bool jointTrajPointToRobotState(const trajectory_msgs::JointTrajectory& trajecto
 {
   if (trajectory.points.empty() || point_id > trajectory.points.size() - 1)
   {
-    ROS_ERROR_NAMED("robot_state", "Invalid point_id");
+    ROS_ERROR_NAMED(LOGNAME, "Invalid point_id");
     return false;
   }
   if (trajectory.joint_names.empty())
   {
-    ROS_ERROR_NAMED("robot_state", "No joint names specified");
+    ROS_ERROR_NAMED(LOGNAME, "No joint names specified");
     return false;
   }
 
@@ -530,7 +531,7 @@ void streamToRobotState(RobotState& state, const std::string& line, const std::s
   {
     // Get a variable
     if (!std::getline(lineStream, cell, separator[0]))
-      ROS_ERROR_STREAM_NAMED("robot_state", "Missing variable " << state.getVariableNames()[i]);
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Missing variable " << state.getVariableNames()[i]);
 
     state.getVariablePositions()[i] = boost::lexical_cast<double>(cell.c_str());
   }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -54,6 +54,8 @@ namespace core
  * valid paths from paths with large joint space jumps. */
 static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
 
+const std::string LOGNAME = "robot_state";
+
 RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)
   , has_velocity_(false)
@@ -164,7 +166,7 @@ bool RobotState::checkJointTransforms(const JointModel* joint) const
 {
   if (dirtyJointTransform(joint))
   {
-    ROS_WARN_NAMED("robot_state", "Returning dirty joint transforms for joint '%s'", joint->getName().c_str());
+    ROS_WARN_NAMED(LOGNAME, "Returning dirty joint transforms for joint '%s'", joint->getName().c_str());
     return false;
   }
   return true;
@@ -174,7 +176,7 @@ bool RobotState::checkLinkTransforms() const
 {
   if (dirtyLinkTransforms())
   {
-    ROS_WARN_NAMED("robot_state", "Returning dirty link transforms");
+    ROS_WARN_NAMED(LOGNAME, "Returning dirty link transforms");
     return false;
   }
   return true;
@@ -184,7 +186,7 @@ bool RobotState::checkCollisionTransforms() const
 {
   if (dirtyCollisionBodyTransforms())
   {
-    ROS_WARN_NAMED("robot_state", "Returning dirty collision body transforms");
+    ROS_WARN_NAMED(LOGNAME, "Returning dirty collision body transforms");
     return false;
   }
   return true;
@@ -418,6 +420,18 @@ void RobotState::setVariableEffort(const std::vector<std::string>& variable_name
   assert(variable_names.size() == variable_effort.size());
   for (std::size_t i = 0; i < variable_names.size(); ++i)
     effort_[robot_model_->getVariableIndex(variable_names[i])] = variable_effort[i];
+}
+
+void RobotState::setJointEfforts(const JointModel* joint, const double* effort)
+{
+  if (has_acceleration_)
+  {
+    ROS_ERROR_NAMED(LOGNAME, "Unable to set joint efforts because array is being used for accelerations");
+    return;
+  }
+  has_effort_ = true;
+
+  memcpy(effort_ + joint->getFirstVariableIndex(), effort, joint->getVariableCount() * sizeof(double));
 }
 
 void RobotState::setJointGroupPositions(const JointModelGroup* group, const double* gstate)
@@ -825,7 +839,7 @@ const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
   std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
   {
-    ROS_ERROR_NAMED("robot_state", "Attached body '%s' not found", id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' not found", id.c_str());
     return nullptr;
   }
   else
@@ -966,21 +980,21 @@ const Eigen::Affine3d& RobotState::getFrameTransform(const std::string& id) cons
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
   if (jt == attached_body_map_.end())
   {
-    ROS_ERROR_NAMED("robot_state", "Transform from frame '%s' to frame '%s' is not known "
-                                   "('%s' should be a link name or an attached body id).",
+    ROS_ERROR_NAMED(LOGNAME, "Transform from frame '%s' to frame '%s' is not known "
+                             "('%s' should be a link name or an attached body id).",
                     id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
     return identity_transform;
   }
   const EigenSTL::vector_Affine3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   if (tf.empty())
   {
-    ROS_ERROR_NAMED("robot_state", "Attached body '%s' has no geometry associated to it. No transform to return.",
+    ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' has no geometry associated to it. No transform to return.",
                     id.c_str());
     return identity_transform;
   }
   if (tf.size() > 1)
-    ROS_DEBUG_NAMED("robot_state", "There are multiple geometries associated to attached body '%s'. "
-                                   "Returning the transform for the first one.",
+    ROS_DEBUG_NAMED(LOGNAME, "There are multiple geometries associated to attached body '%s'. "
+                             "Returning the transform for the first one.",
                     id.c_str());
   return tf[0];
 }
@@ -1017,7 +1031,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std
   ros::Time tm = ros::Time::now();
   for (std::size_t i = 0; i < link_names.size(); ++i)
   {
-    ROS_DEBUG_NAMED("robot_state", "Trying to get marker for link '%s'", link_names[i].c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "Trying to get marker for link '%s'", link_names[i].c_str());
     const LinkModel* lm = robot_model_->getLinkModel(link_names[i]);
     if (!lm)
       continue;
@@ -1097,13 +1111,13 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
 
   if (!group->isChain())
   {
-    ROS_ERROR_NAMED("robot_state", "The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
+    ROS_ERROR_NAMED(LOGNAME, "The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
     return false;
   }
 
   if (!group->isLinkUpdated(link->getName()))
   {
-    ROS_ERROR_NAMED("robot_state", "Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
+    ROS_ERROR_NAMED(LOGNAME, "Link name '%s' does not exist in the chain '%s' or is not a child for this chain",
                     link->getName().c_str(), group->getName().c_str());
     return false;
   }
@@ -1120,7 +1134,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   Eigen::Vector3d point_transform = link_transform * reference_point_position;
 
   /*
-  ROS_DEBUG_NAMED("robot_state", "Point from reference origin expressed in world coordinates: %f %f %f",
+  ROS_DEBUG_NAMED(LOGNAME, "Point from reference origin expressed in world coordinates: %f %f %f",
            point_transform.x(),
            point_transform.y(),
            point_transform.z());
@@ -1132,11 +1146,11 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   while (link)
   {
     /*
-    ROS_DEBUG_NAMED("robot_state", "Link: %s, %f %f %f",link_state->getName().c_str(),
+    ROS_DEBUG_NAMED(LOGNAME, "Link: %s, %f %f %f",link_state->getName().c_str(),
              link_state->getGlobalLinkTransform().translation().x(),
              link_state->getGlobalLinkTransform().translation().y(),
              link_state->getGlobalLinkTransform().translation().z());
-    ROS_DEBUG_NAMED("robot_state", "Joint: %s",link_state->getParentJointState()->getName().c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "Joint: %s",link_state->getParentJointState()->getName().c_str());
     */
     const JointModel* pjm = link->getParentJointModel();
     if (pjm->getVariableCount() > 0)
@@ -1174,7 +1188,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
         jacobian.block<3, 1>(3, joint_index + 2) = jacobian.block<3, 1>(3, joint_index + 2) + joint_axis;
       }
       else
-        ROS_ERROR_NAMED("robot_state", "Unknown type of joint in Jacobian computation");
+        ROS_ERROR_NAMED(LOGNAME, "Unknown type of joint in Jacobian computation");
     }
     if (pjm == root_joint_model)
       break;
@@ -1279,7 +1293,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
   {
-    ROS_ERROR_NAMED("robot_state", "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+    ROS_ERROR_NAMED(LOGNAME, "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
   return setFromIK(jmg, pose, solver->getTipFrame(), attempts, timeout, constraint, options);
@@ -1302,7 +1316,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Affine3d& po
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
   {
-    ROS_ERROR_NAMED("robot_state", "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+    ROS_ERROR_NAMED(LOGNAME, "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
   static std::vector<double> consistency_limits;
@@ -1389,7 +1403,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   // Error check
   if (poses_in.size() != tips_in.size())
   {
-    ROS_ERROR_NAMED("robot_state", "Number of poses must be the same as number of tips");
+    ROS_ERROR_NAMED(LOGNAME, "Number of poses must be the same as number of tips");
     return false;
   }
 
@@ -1408,7 +1422,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     std::string error_msg;
     if (!solver->supportsGroup(jmg, &error_msg))
     {
-      ROS_ERROR_NAMED("robot_state", "Kinematics solver %s does not support joint group %s.  Error: %s",
+      ROS_ERROR_NAMED(LOGNAME, "Kinematics solver %s does not support joint group %s.  Error: %s",
                       typeid(*solver).name(), jmg->getName().c_str(), error_msg.c_str());
       valid_solver = false;
     }
@@ -1424,7 +1438,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     }
     else
     {
-      ROS_ERROR_NAMED("robot_state", "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
+      ROS_ERROR_NAMED(LOGNAME, "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
       return false;
     }
   }
@@ -1433,8 +1447,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {
-    ROS_ERROR_NAMED("robot_state", "Invalid number (%zu) of sets of consistency limits for a setFromIK request "
-                                   "that is being solved by a single IK solver",
+    ROS_ERROR_NAMED(LOGNAME, "Invalid number (%zu) of sets of consistency limits for a setFromIK request "
+                             "that is being solved by a single IK solver",
                     consistency_limit_sets.size());
     return false;
   }
@@ -1490,8 +1504,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
           const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
-            ROS_ERROR_NAMED("robot_state", "Cannot use an attached body "
-                                           "with multiple geometries as a reference frame.");
+            ROS_ERROR_NAMED(LOGNAME, "Cannot use an attached body "
+                                     "with multiple geometries as a reference frame.");
             return false;
           }
           pose_frame = ab->getAttachedLinkName();
@@ -1526,13 +1540,12 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     // Make sure one of the tip frames worked
     if (!found_valid_frame)
     {
-      ROS_ERROR_NAMED("robot_state", "Cannot compute IK for query %zu pose reference frame '%s'", i,
-                      pose_frame.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "Cannot compute IK for query %zu pose reference frame '%s'", i, pose_frame.c_str());
       // Debug available tip frames
       std::stringstream ss;
       for (solver_tip_id = 0; solver_tip_id < solver_tip_frames.size(); ++solver_tip_id)
         ss << solver_tip_frames[solver_tip_id] << ", ";
-      ROS_ERROR_NAMED("robot_state", "Available tip frames: [%s]", ss.str().c_str());
+      ROS_ERROR_NAMED(LOGNAME, "Available tip frames: [%s]", ss.str().c_str());
       return false;
     }
 
@@ -1611,7 +1624,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Af
     }
     else
     {
-      ROS_DEBUG_NAMED("robot_state", "Rerunning IK solver with random joint positions");
+      ROS_DEBUG_NAMED(LOGNAME, "Rerunning IK solver with random joint positions");
 
       // sample a random seed
       random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
@@ -1662,21 +1675,21 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   // Error check
   if (poses_in.size() != sub_groups.size())
   {
-    ROS_ERROR_NAMED("robot_state", "Number of poses (%zu) must be the same as number of sub-groups (%zu)",
-                    poses_in.size(), sub_groups.size());
+    ROS_ERROR_NAMED(LOGNAME, "Number of poses (%zu) must be the same as number of sub-groups (%zu)", poses_in.size(),
+                    sub_groups.size());
     return false;
   }
 
   if (tips_in.size() != sub_groups.size())
   {
-    ROS_ERROR_NAMED("robot_state", "Number of tip names (%zu) must be same as number of sub-groups (%zu)",
-                    tips_in.size(), sub_groups.size());
+    ROS_ERROR_NAMED(LOGNAME, "Number of tip names (%zu) must be same as number of sub-groups (%zu)", tips_in.size(),
+                    sub_groups.size());
     return false;
   }
 
   if (!consistency_limits.empty() && consistency_limits.size() != sub_groups.size())
   {
-    ROS_ERROR_NAMED("robot_state", "Number of consistency limit vectors must be the same as number of sub-groups");
+    ROS_ERROR_NAMED(LOGNAME, "Number of consistency limit vectors must be the same as number of sub-groups");
     return false;
   }
 
@@ -1684,7 +1697,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      ROS_ERROR_NAMED("robot_state", "Number of joints in consistency_limits is %zu but it should be should be %u", i,
+      ROS_ERROR_NAMED(LOGNAME, "Number of joints in consistency_limits is %zu but it should be should be %u", i,
                       sub_groups[i]->getVariableCount());
       return false;
     }
@@ -1697,7 +1710,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
     kinematics::KinematicsBaseConstPtr solver = sub_groups[i]->getSolverInstance();
     if (!solver)
     {
-      ROS_ERROR_NAMED("robot_state", "Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
+      ROS_ERROR_NAMED(LOGNAME, "Could not find solver for group '%s'", sub_groups[i]->getName().c_str());
       return false;
     }
     solvers.push_back(solver);
@@ -1733,7 +1746,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
         const EigenSTL::vector_Affine3d& ab_trans = ab->getFixedTransforms();
         if (ab_trans.size() != 1)
         {
-          ROS_ERROR_NAMED("robot_state", "Cannot use an attached body with multiple geometries as a reference frame.");
+          ROS_ERROR_NAMED(LOGNAME, "Cannot use an attached body with multiple geometries as a reference frame.");
           return false;
         }
         pose_frame = ab->getAttachedLinkName();
@@ -1757,7 +1770,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 
     if (pose_frame != solver_tip_frame)
     {
-      ROS_ERROR_NAMED("robot_state", "Cannot compute IK for query pose reference frame '%s', desired: '%s'",
+      ROS_ERROR_NAMED(LOGNAME, "Cannot compute IK for query pose reference frame '%s', desired: '%s'",
                       pose_frame.c_str(), solver_tip_frame.c_str());
       return false;
     }
@@ -1831,7 +1844,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
         found_solution = false;
         break;
       }
-      ROS_DEBUG_NAMED("robot_state", "IK attempt: %d of %d", st, attempts);
+      ROS_DEBUG_NAMED(LOGNAME, "IK attempt: %d of %d", st, attempts);
     }
     if (found_solution)
     {
@@ -1839,7 +1852,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
       copyJointGroupPositions(jmg, full_solution);
       if (constraint ? constraint(this, jmg, &full_solution[0]) : true)
       {
-        ROS_DEBUG_NAMED("robot_state", "Found IK solution");
+        ROS_DEBUG_NAMED(LOGNAME, "Found IK solution");
         return true;
       }
     }
@@ -1892,7 +1905,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
   if (max_step.translation <= 0.0 && max_step.rotation <= 0.0)
   {
-    ROS_ERROR_NAMED("robot_state",
+    ROS_ERROR_NAMED(LOGNAME,
                     "Invalid MaxEEFStep passed into computeCartesianPath. Both the MaxEEFStep.rotation and "
                     "MaxEEFStep.translation components must be non-negative and at least one component must be "
                     "greater than zero");
@@ -2000,8 +2013,8 @@ double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std:
 {
   if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
   {
-    ROS_WARN_NAMED("robot_state", "The computed trajectory is too short to detect jumps in joint-space "
-                                  "Need at least %zu steps, only got %zu. Try a lower max_step.",
+    ROS_WARN_NAMED(LOGNAME, "The computed trajectory is too short to detect jumps in joint-space "
+                            "Need at least %zu steps, only got %zu. Try a lower max_step.",
                    MIN_STEPS_FOR_JUMP_THRESH, traj.size());
   }
 
@@ -2021,7 +2034,7 @@ double RobotState::testRelativeJointSpaceJump(const JointModelGroup* group, std:
   for (std::size_t i = 0; i < dist_vector.size(); ++i)
     if (dist_vector[i] > thres)
     {
-      ROS_DEBUG_NAMED("robot_state", "Truncating Cartesian path due to detected jump in joint-space distance");
+      ROS_DEBUG_NAMED(LOGNAME, "Truncating Cartesian path due to detected jump in joint-space distance");
       percentage = (double)(i + 1) / (double)(traj.size());
       traj.resize(i + 1);
       break;
@@ -2056,8 +2069,8 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
           type_index = 1;
           break;
         default:
-          ROS_WARN_NAMED("robot_state", "Joint %s has not supported type %s. \n"
-                                        "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
+          ROS_WARN_NAMED(LOGNAME, "Joint %s has not supported type %s. \n"
+                                  "testAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
                          joint->getName().c_str(), joint->getTypeName().c_str());
           continue;
       }
@@ -2067,8 +2080,8 @@ double RobotState::testAbsoluteJointSpaceJump(const JointModelGroup* group, std:
       double distance = traj[traj_ix]->distance(*traj[traj_ix + 1], joint);
       if (distance > data[type_index].limit)
       {
-        ROS_DEBUG_NAMED("robot_state", "Truncating Cartesian path due to detected jump of %.4f > %.4f in joint %s",
-                        distance, data[type_index].limit, joint->getName().c_str());
+        ROS_DEBUG_NAMED(LOGNAME, "Truncating Cartesian path due to detected jump of %.4f > %.4f in joint %s", distance,
+                        data[type_index].limit, joint->getName().c_str());
         still_valid = false;
         break;
       }


### PR DESCRIPTION
### Description
Using `name_` variable for logging rather than `"robot_state"`

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
