### PR TITLE
Building melodic-devel on ROS Kinetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format
     - ROS_DISTRO=melodic ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. REMOVE when Kinetic support is dropped
+if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. TODO: Remove when Kinetic support is dropped
   add_definitions(-DROS_KINETIC)
 endif()
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. REMOVE when Kinetic support is dropped
+  add_definitions(-DROS_KINETIC)
+endif()
+
 set(HEADERS
   include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
   include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -55,10 +55,6 @@
 #include <actionlib/client/simple_action_client.h>
 #include <object_recognition_msgs/ObjectRecognitionAction.h>
 
-#ifdef ROS_KINETIC
-#include <tf2_ros/transform_listener.h>
-#endif
-
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
 #endif
@@ -313,10 +309,6 @@ private:
   ros::NodeHandle nh_;
   ros::Publisher planning_scene_publisher_;
   ros::Publisher planning_scene_world_publisher_;
-#ifdef ROS_KINETIC
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-#endif
 
   collision_detection::CollisionWorld::ObjectConstPtr scaled_object_;
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -313,10 +313,10 @@ private:
   ros::NodeHandle nh_;
   ros::Publisher planning_scene_publisher_;
   ros::Publisher planning_scene_world_publisher_;
-  #ifdef ROS_KINETIC
+#ifdef ROS_KINETIC
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-  #endif
+#endif
 
   collision_detection::CollisionWorld::ObjectConstPtr scaled_object_;
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -55,6 +55,10 @@
 #include <actionlib/client/simple_action_client.h>
 #include <object_recognition_msgs/ObjectRecognitionAction.h>
 
+#ifdef ROS_KINETIC
+#include <tf2_ros/transform_listener.h>
+#endif
+
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
 #endif
@@ -309,6 +313,10 @@ private:
   ros::NodeHandle nh_;
   ros::Publisher planning_scene_publisher_;
   ros::Publisher planning_scene_world_publisher_;
+  #ifdef ROS_KINETIC
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  #endif
 
   collision_detection::CollisionWorld::ObjectConstPtr scaled_object_;
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -59,8 +59,6 @@
 #include <OgreSceneNode.h>
 #include <rviz/ogre_helpers/shape.h>
 
-#include <tf/transform_listener.h>
-
 #include <moveit/robot_state/conversions.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -313,11 +313,11 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     try
     {
 #ifdef ROS_KINETIC
-      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(opt, planning_display_->getTF2BufferPtr(), ros::WallDuration(30, 0)));
+      std::shared_ptr<tf2_ros::Buffer> tf_buffer = getTF2BufferPtr();
 #else
-      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
-          opt, context_->getFrameManager()->getTF2BufferPtr(), ros::WallDuration(30, 0)));
+      std::shared_ptr<tf2_ros::Buffer> tf_buffer = context_->getFrameManager()->getTF2BufferPtr();
 #endif
+      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(opt, tf_buffer, ros::WallDuration(30, 0)));
 
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -145,10 +145,10 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
 
   known_collision_objects_version_ = 0;
 
-  #ifdef ROS_KINETIC
+#ifdef ROS_KINETIC
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, nh_);
-  #endif
+#endif
 
   planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
   planning_scene_world_publisher_ = nh_.advertise<moveit_msgs::PlanningSceneWorld>("planning_scene_world", 1);
@@ -319,13 +319,12 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     opt.node_handle_ = ros::NodeHandle(planning_display_->getMoveGroupNS());
     try
     {
-      #ifdef ROS_KINETIC
-      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
-          opt, tf_buffer_, ros::WallDuration(30, 0)));
-      #else
+#ifdef ROS_KINETIC
+      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(opt, tf_buffer_, ros::WallDuration(30, 0)));
+#else
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
           opt, context_->getFrameManager()->getTF2BufferPtr(), ros::WallDuration(30, 0)));
-      #endif
+#endif
 
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -51,8 +51,6 @@
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
-#include <tf2_ros/buffer.h>
-
 namespace moveit_rviz_plugin
 {
 MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::DisplayContext* context,
@@ -144,11 +142,6 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   ui_->tabWidget->setCurrentIndex(0);
 
   known_collision_objects_version_ = 0;
-
-#ifdef ROS_KINETIC
-  tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
-  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, nh_);
-#endif
 
   planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
   planning_scene_world_publisher_ = nh_.advertise<moveit_msgs::PlanningSceneWorld>("planning_scene_world", 1);
@@ -320,7 +313,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     try
     {
 #ifdef ROS_KINETIC
-      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(opt, tf_buffer_, ros::WallDuration(30, 0)));
+      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(opt, planning_display_->getTF2BufferPtr(), ros::WallDuration(30, 0)));
 #else
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
           opt, context_->getFrameManager()->getTF2BufferPtr(), ros::WallDuration(30, 0)));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -42,6 +42,7 @@
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
+#include <tf2_ros/buffer.h>
 
 #include <std_srvs/Empty.h>
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -313,7 +313,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     try
     {
 #ifdef ROS_KINETIC
-      std::shared_ptr<tf2_ros::Buffer> tf_buffer = getTF2BufferPtr();
+      std::shared_ptr<tf2_ros::Buffer> tf_buffer = PlanningSceneDisplay::getTF2BufferPtr();
 #else
       std::shared_ptr<tf2_ros::Buffer> tf_buffer = context_->getFrameManager()->getTF2BufferPtr();
 #endif

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -145,6 +145,11 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
 
   known_collision_objects_version_ = 0;
 
+  #ifdef ROS_KINETIC
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, nh_);
+  #endif
+
   planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
   planning_scene_world_publisher_ = nh_.advertise<moveit_msgs::PlanningSceneWorld>("planning_scene_world", 1);
 
@@ -314,8 +319,14 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     opt.node_handle_ = ros::NodeHandle(planning_display_->getMoveGroupNS());
     try
     {
+      #ifdef ROS_KINETIC
+      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
+          opt, tf_buffer_, ros::WallDuration(30, 0)));
+      #else
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(
           opt, context_->getFrameManager()->getTF2BufferPtr(), ros::WallDuration(30, 0)));
+      #endif
+
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -1,5 +1,10 @@
 
 set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
+
+if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. REMOVE when Kinetic support is dropped
+  add_definitions(-DROS_KINETIC)
+endif()
+
 add_library(${MOVEIT_LIB_NAME}_core
   src/planning_scene_display.cpp
   include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
 
-if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. TODO: remove when Kinetic support is dropped
+if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. TODO: Remove when Kinetic support is dropped
   add_definitions(-DROS_KINETIC)
 endif()
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
 
-if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. REMOVE when Kinetic support is dropped
+if(roscpp_VERSION VERSION_LESS 1.14) # Pre-Melodic release. TODO: remove when Kinetic support is dropped
   add_definitions(-DROS_KINETIC)
 endif()
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -46,6 +46,10 @@
 #include <ros/ros.h>
 #endif
 
+#ifdef ROS_KINETIC
+#include <tf2_ros/transform_listener.h>
+#endif
+
 namespace Ogre
 {
 class SceneNode;
@@ -208,6 +212,11 @@ protected:
   rviz::FloatProperty* scene_display_time_property_;
   rviz::EnumProperty* octree_render_property_;
   rviz::EnumProperty* octree_coloring_property_;
+
+  #ifdef ROS_KINETIC
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  #endif
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -118,12 +118,9 @@ public:
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 
 #ifdef ROS_KINETIC
-  // Grant Access to tf2 Transform Buffer
-  inline std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr(){
-    return tf_buffer_;
-  }
+  // Return (singleton) tf2 Transform Buffer shared between all MoveIt display instances
+  static std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr();
 #endif
-
 
 private Q_SLOTS:
 
@@ -220,10 +217,6 @@ protected:
   rviz::FloatProperty* scene_display_time_property_;
   rviz::EnumProperty* octree_render_property_;
   rviz::EnumProperty* octree_coloring_property_;
-#ifdef ROS_KINETIC
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-#endif
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -213,10 +213,10 @@ protected:
   rviz::EnumProperty* octree_render_property_;
   rviz::EnumProperty* octree_coloring_property_;
 
-  #ifdef ROS_KINETIC
+#ifdef ROS_KINETIC
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-  #endif
+#endif
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -117,6 +117,14 @@ public:
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 
+#ifdef ROS_KINETIC
+  // Grant Access to tf2 Transform Buffer
+  inline std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr(){
+    return tf_buffer_;
+  }
+#endif
+
+
 private Q_SLOTS:
 
   // ******************************************************************************************
@@ -212,7 +220,6 @@ protected:
   rviz::FloatProperty* scene_display_time_property_;
   rviz::EnumProperty* octree_render_property_;
   rviz::EnumProperty* octree_coloring_property_;
-
 #ifdef ROS_KINETIC
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -47,7 +47,7 @@
 #endif
 
 #ifdef ROS_KINETIC
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
 #endif
 
 namespace Ogre

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -179,11 +179,11 @@ void PlanningSceneDisplay::clearJobs()
 void PlanningSceneDisplay::onInitialize()
 {
   Display::onInitialize();
-  #ifdef ROS_KINETIC
+#ifdef ROS_KINETIC
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, threaded_nh_);
-  // QUESTION: threaded_nh_ or update_nh_ ? http://docs.ros.org/kinetic/api/rviz/html/c++/classrviz_1_1Display.html
-  #endif
+// QUESTION: threaded_nh_ or update_nh_ ? http://docs.ros.org/kinetic/api/rviz/html/c++/classrviz_1_1Display.html
+#endif
 
   // the scene node that contains everything
   planning_scene_node_ = scene_node_->createChildSceneNode();
@@ -491,15 +491,14 @@ void PlanningSceneDisplay::unsetLinkColor(rviz::Robot* robot, const std::string&
 // ******************************************************************************************
 planning_scene_monitor::PlanningSceneMonitorPtr PlanningSceneDisplay::createPlanningSceneMonitor()
 {
-  #ifdef ROS_KINETIC
+#ifdef ROS_KINETIC
   return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
-      robot_description_property_->getStdString(), tf_buffer_,
-      getNameStd() + "_planning_scene_monitor"));
-  #else
+      robot_description_property_->getStdString(), tf_buffer_, getNameStd() + "_planning_scene_monitor"));
+#else
   return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
       robot_description_property_->getStdString(), context_->getFrameManager()->getTF2BufferPtr(),
       getNameStd() + "_planning_scene_monitor"));
-  #endif
+#endif
 }
 
 void PlanningSceneDisplay::clearRobotModel()

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -179,11 +179,6 @@ void PlanningSceneDisplay::clearJobs()
 void PlanningSceneDisplay::onInitialize()
 {
   Display::onInitialize();
-#ifdef ROS_KINETIC
-  tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
-  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, threaded_nh_);
-// QUESTION: threaded_nh_ or update_nh_ ? http://docs.ros.org/kinetic/api/rviz/html/c++/classrviz_1_1Display.html
-#endif
 
   // the scene node that contains everything
   planning_scene_node_ = scene_node_->createChildSceneNode();
@@ -492,13 +487,12 @@ void PlanningSceneDisplay::unsetLinkColor(rviz::Robot* robot, const std::string&
 planning_scene_monitor::PlanningSceneMonitorPtr PlanningSceneDisplay::createPlanningSceneMonitor()
 {
 #ifdef ROS_KINETIC
-  return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
-      robot_description_property_->getStdString(), tf_buffer_, getNameStd() + "_planning_scene_monitor"));
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = getTF2BufferPtr();
 #else
-  return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
-      robot_description_property_->getStdString(), context_->getFrameManager()->getTF2BufferPtr(),
-      getNameStd() + "_planning_scene_monitor"));
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = context_->getFrameManager()->getTF2BufferPtr();
 #endif
+  return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
+      robot_description_property_->getStdString(), tf_buffer, getNameStd() + "_planning_scene_monitor"));
 }
 
 void PlanningSceneDisplay::clearRobotModel()
@@ -670,5 +664,29 @@ void PlanningSceneDisplay::fixedFrameChanged()
   Display::fixedFrameChanged();
   calculateOffsetPosition();
 }
+
+#ifdef ROS_KINETIC
+#include <boost/thread/mutex.hpp>
+
+/* Unfortunately, in Kinetic rviz doesn't provide access to its tf2 buffer.
+   Hence, we maintain single other tf2 buffer to be use by all MoveIt rviz plugin instances */
+
+// Return (singleton) tf2 Transform Buffer shared between all MoveIt display instances
+std::shared_ptr<tf2_ros::Buffer> PlanningSceneDisplay::getTF2BufferPtr()
+{
+  static boost::mutex m;
+  static std::shared_ptr<tf2_ros::Buffer> tf_buffer;
+  static std::shared_ptr<tf2_ros::TransformListener> tf_listener;
+  static ros::NodeHandle nh;
+
+  boost::mutex::scoped_lock lock(m);
+  if (!tf_buffer)
+  {
+    tf_buffer = std::make_shared<tf2_ros::Buffer>();
+    tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh);
+  }
+  return tf_buffer;
+}
+#endif
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -179,6 +179,11 @@ void PlanningSceneDisplay::clearJobs()
 void PlanningSceneDisplay::onInitialize()
 {
   Display::onInitialize();
+  #ifdef ROS_KINETIC
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, threaded_nh_);
+  // QUESTION: threaded_nh_ or update_nh_ ? http://docs.ros.org/kinetic/api/rviz/html/c++/classrviz_1_1Display.html
+  #endif
 
   // the scene node that contains everything
   planning_scene_node_ = scene_node_->createChildSceneNode();
@@ -486,9 +491,15 @@ void PlanningSceneDisplay::unsetLinkColor(rviz::Robot* robot, const std::string&
 // ******************************************************************************************
 planning_scene_monitor::PlanningSceneMonitorPtr PlanningSceneDisplay::createPlanningSceneMonitor()
 {
+  #ifdef ROS_KINETIC
+  return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
+      robot_description_property_->getStdString(), tf_buffer_,
+      getNameStd() + "_planning_scene_monitor"));
+  #else
   return planning_scene_monitor::PlanningSceneMonitorPtr(new planning_scene_monitor::PlanningSceneMonitor(
       robot_description_property_->getStdString(), context_->getFrameManager()->getTF2BufferPtr(),
       getNameStd() + "_planning_scene_monitor"));
+  #endif
 }
 
 void PlanningSceneDisplay::clearRobotModel()

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -49,7 +49,6 @@
 #include <rviz/properties/color_property.h>
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
-#include <tf/transform_listener.h>
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>


### PR DESCRIPTION
### Background
As part of MoveIt's tf2 migration for `melodic` in https://github.com/ros-planning/moveit/pull/830, there were upstream changes required to RViz, `tf1`, and `tf2`. The changes to RViz and `tf1` were not backwards compatible with Kinetic. 

 The moveit maintainers have a desire to have MoveIt compile on both ROS Kinetic and Melodic with the same branch, summed up in this ticket:  https://github.com/ros-planning/moveit/issues/925 . The final step in #925 is to find an acceptable way to maintain tf2 buffers for interacting with RViz. In Kinetic, RViz doesn't easily expose its internal and protected tf2 buffers. I tried several ways to get at these buffers in Kinetic as described https://github.com/ros-visualization/rviz/issues/1215, without any success. 

### Description
In the end, for Kinetic, it is simplest to have MoveIt's RViz plugin to just spin up a new `tf2_ros::TransformListener` and `tf2_ros::Buffer` when it would normally depend on RViz' internal TF Buffer. This is not necessary in ROS Melodic, as the buffers are properly exposed from RViz' API. That brings us to the conditional compile. As @davetcoleman mentioned, it might be acceptable to [use ugly compile defs ](https://github.com/ros-planning/moveit/issues/925#issuecomment-429578337) to build Kinetic and Melodic on the same branch. Despite them being ugly, that was the simplest and most run-time efficient solution: `melodic-devel` would not use extra tf2 listeners/buffers when built in a Melodic environment, and would compile and run in a Kinetic environment. I am using [`roscpp`'s release versioning](https://github.com/ros/ros_comm/releases) to check for a "pre-Melodic" environment. Anything prior to release `1.14.x` should fall into this category.

This code needs more testing in a Kinetic environment, but I figured I'd get it out there now to have eyeballs on it sooner rather than later. Everything builds on Melodic & Kinetic I think I had MoveIt/RViz running in a Kinetic docker container last night, but I didn't see any interactive markers. I'll continue to investigate and update this PR accordingly.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [x] (?) Decide if this should be cherry-picked to other current ROS branches