### PR TITLE
fix Eigen::Affine3d for Kinetic

### DIFF
--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -247,7 +247,7 @@ void cleanCollisionGeometryCache();
 
 inline void transform2fcl(const Eigen::Affine3d& b, fcl::Transform3f& f)
 {
-  Eigen::Quaterniond q(b.rotation());
+  Eigen::Quaterniond q(b.linear());
   f.setTranslation(fcl::Vec3f(b.translation().x(), b.translation().y(), b.translation().z()));
   f.setQuatRotation(fcl::Quaternion3f(q.w(), q.x(), q.y(), q.z()));
 }

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -561,7 +561,7 @@ bool IKConstraintSampler::sampleHelper(robot_state::RobotState& state, const rob
       // we need to convert this transform to the frame expected by the IK solver
       // both the planning frame and the frame for the IK are assumed to be robot links
       Eigen::Affine3d ikq(Eigen::Translation3d(point) * quat.toRotationMatrix());
-      ikq = reference_state.getFrameTransform(ik_frame_).inverse() * ikq;
+      ikq = reference_state.getFrameTransform(ik_frame_).inverse(Eigen::Isometry) * ikq;
       point = ikq.translation();
       quat = Eigen::Quaterniond(ikq.linear());
     }

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -477,16 +477,16 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
     Eigen::Affine3d diff(Eigen::AngleAxisd(angle_x, Eigen::Vector3d::UnitX()) *
                          Eigen::AngleAxisd(angle_y, Eigen::Vector3d::UnitY()) *
                          Eigen::AngleAxisd(angle_z, Eigen::Vector3d::UnitZ()));
-    Eigen::Affine3d reqr(sampling_pose_.orientation_constraint_->getDesiredRotationMatrix() * diff.rotation());
-    quat = Eigen::Quaterniond(reqr.rotation());
+    Eigen::Affine3d reqr(sampling_pose_.orientation_constraint_->getDesiredRotationMatrix() * diff.linear());
+    quat = Eigen::Quaterniond(reqr.linear());
 
     // if this constraint is with respect a mobile frame, we need to convert this rotation to the root frame of the
     // model
     if (sampling_pose_.orientation_constraint_->mobileReferenceFrame())
     {
       const Eigen::Affine3d& t = ks.getFrameTransform(sampling_pose_.orientation_constraint_->getReferenceFrame());
-      Eigen::Affine3d rt(t.rotation() * quat.toRotationMatrix());
-      quat = Eigen::Quaterniond(rt.rotation());
+      Eigen::Affine3d rt(t.linear() * quat.toRotationMatrix());
+      quat = Eigen::Quaterniond(rt.linear());
     }
   }
   else
@@ -563,7 +563,7 @@ bool IKConstraintSampler::sampleHelper(robot_state::RobotState& state, const rob
       Eigen::Affine3d ikq(Eigen::Translation3d(point) * quat.toRotationMatrix());
       ikq = reference_state.getFrameTransform(ik_frame_).inverse() * ikq;
       point = ikq.translation();
-      quat = Eigen::Quaterniond(ikq.rotation());
+      quat = Eigen::Quaterniond(ikq.linear());
     }
 
     if (need_eef_to_ik_tip_transform_)
@@ -572,7 +572,7 @@ bool IKConstraintSampler::sampleHelper(robot_state::RobotState& state, const rob
       Eigen::Affine3d ikq(Eigen::Translation3d(point) * quat.toRotationMatrix());
       ikq = ikq * eef_to_ik_tip_transform_;
       point = ikq.translation();
-      quat = Eigen::Quaterniond(ikq.rotation());
+      quat = Eigen::Quaterniond(ikq.linear());
     }
 
     geometry_msgs::Pose ik_query;

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -142,7 +142,7 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
   shoulder_elbow_offset_ = shoulder_upperarm_offset_ + upperarm_elbow_offset_;
   shoulder_wrist_offset_ = shoulder_upperarm_offset_ + upperarm_elbow_offset_ + elbow_wrist_offset_;
 
-  Eigen::Matrix4f home = Eigen::Matrix4f::Identity();
+  Eigen::Affine3f home = Eigen::Affine3f::Identity();
   home(0, 3) = shoulder_upperarm_offset_ + upperarm_elbow_offset_ + elbow_wrist_offset_;
   home_inv_ = home.inverse(Eigen::Isometry);
   grhs_ = home;
@@ -194,15 +194,15 @@ void PR2ArmIK::getSolverInfo(moveit_msgs::KinematicSolverInfo& info)
   info = solver_info_;
 }
 
-void PR2ArmIK::computeIKShoulderPan(const Eigen::Matrix4f& g_in, const double& t1_in,
+void PR2ArmIK::computeIKShoulderPan(const Eigen::Affine3f& g_in, const double& t1_in,
                                     std::vector<std::vector<double> >& solution) const
 {
   // t1 = shoulder/turret pan is specified
   //  solution_ik_.resize(0);
   std::vector<double> solution_ik(NUM_JOINTS_ARM7DOF, 0.0);
-  Eigen::Matrix4f g = g_in;
-  Eigen::Matrix4f gf_local = home_inv_;
-  Eigen::Matrix4f grhs_local = home_inv_;
+  Eigen::Affine3f g = g_in;
+  Eigen::Affine3f gf_local = home_inv_;
+  Eigen::Affine3f grhs_local = home_inv_;
   // First bring everything into the arm frame
   g(0, 3) = g_in(0, 3) - torso_shoulder_offset_x_;
   g(1, 3) = g_in(1, 3) - torso_shoulder_offset_y_;
@@ -461,7 +461,7 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Matrix4f& g_in, const double& t
   }
 }
 
-void PR2ArmIK::computeIKShoulderRoll(const Eigen::Matrix4f& g_in, const double& t3,
+void PR2ArmIK::computeIKShoulderRoll(const Eigen::Affine3f& g_in, const double& t3,
                                      std::vector<std::vector<double> >& solution) const
 {
   std::vector<double> solution_ik(NUM_JOINTS_ARM7DOF, 0.0);
@@ -475,9 +475,9 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Matrix4f& g_in, const double& 
   //  if(!solution_ik_.empty())
   //    solution_ik_.resize(0);
   // t3 = shoulder/turret roll is specified
-  Eigen::Matrix4f g = g_in;
-  Eigen::Matrix4f gf_local = home_inv_;
-  Eigen::Matrix4f grhs_local = home_inv_;
+  Eigen::Affine3f g = g_in;
+  Eigen::Affine3f gf_local = home_inv_;
+  Eigen::Affine3f grhs_local = home_inv_;
   // First bring everything into the arm frame
   g(0, 3) = g_in(0, 3) - torso_shoulder_offset_x_;
   g(1, 3) = g_in(1, 3) - torso_shoulder_offset_y_;

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -144,7 +144,7 @@ bool PR2ArmIK::init(const urdf::ModelInterface& robot_model, const std::string& 
 
   Eigen::Matrix4f home = Eigen::Matrix4f::Identity();
   home(0, 3) = shoulder_upperarm_offset_ + upperarm_elbow_offset_ + elbow_wrist_offset_;
-  home_inv_ = home.inverse();
+  home_inv_ = home.inverse(Eigen::Isometry);
   grhs_ = home;
   gf_ = home_inv_;
   solution_.resize(NUM_JOINTS_ARM7DOF);

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -39,7 +39,7 @@
 
 #include <urdf_model/model.h>
 #include <urdf/model.h>
-#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <Eigen/LU>  // provides LU decomposition
 #include <kdl/chainiksolver.hpp>
 #include <moveit_msgs/GetPositionFK.h>
@@ -140,7 +140,7 @@ public:
      @param Input pose for end-effector
      @param Initial guess for shoulder pan angle
   */
-  void computeIKShoulderPan(const Eigen::Matrix4f& g_in, const double& shoulder_pan_initial_guess,
+  void computeIKShoulderPan(const Eigen::Affine3f& g_in, const double& shoulder_pan_initial_guess,
                             std::vector<std::vector<double> >& solution) const;
 
   /**
@@ -148,7 +148,7 @@ public:
      h       @param Input pose for end-effector
      @param Initial guess for shoulder roll angle
   */
-  void computeIKShoulderRoll(const Eigen::Matrix4f& g_in, const double& shoulder_roll_initial_guess,
+  void computeIKShoulderRoll(const Eigen::Affine3f& g_in, const double& shoulder_roll_initial_guess,
                              std::vector<std::vector<double> >& solution) const;
 
   //  std::vector<std::vector<double> > solution_ik_;/// a vector of ik solutions
@@ -174,7 +174,7 @@ private:
 
   bool checkJointLimits(const double& joint_value, const int& joint_num) const;
 
-  Eigen::Matrix4f grhs_, gf_, home_inv_, home_;
+  Eigen::Affine3f grhs_, gf_, home_inv_;
 
   std::vector<double> angle_multipliers_;
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -101,7 +101,7 @@ PR2ArmIKSolver::PR2ArmIKSolver(const urdf::ModelInterface& robot_model, const st
 int PR2ArmIKSolver::CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_in, KDL::JntArray& q_out)
 {
   const bool verbose = false;
-  Eigen::Matrix4f b = KDLToEigenMatrix(p_in);
+  Eigen::Affine3f b = KDLToEigenMatrix(p_in);
   std::vector<std::vector<double> > solution_ik;
   if (free_angle_ == 0)
   {
@@ -216,9 +216,9 @@ bool getKDLChain(const urdf::ModelInterface& model, const std::string& root_name
   return true;
 }
 
-Eigen::Matrix4f KDLToEigenMatrix(const KDL::Frame& p)
+Eigen::Affine3f KDLToEigenMatrix(const KDL::Frame& p)
 {
-  Eigen::Matrix4f b = Eigen::Matrix4f::Identity();
+  Eigen::Affine3f b = Eigen::Affine3f::Identity();
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < 3; j++)

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -116,7 +116,7 @@ private:
   std::string root_frame_name_;
 };
 
-Eigen::Matrix4f KDLToEigenMatrix(const KDL::Frame& p);
+Eigen::Affine3f KDLToEigenMatrix(const KDL::Frame& p);
 double computeEuclideanDistance(const std::vector<double>& array_1, const KDL::JntArray& array_2);
 void getKDLChainInfo(const KDL::Chain& chain, moveit_msgs::KinematicSolverInfo& chain_info);
 

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -172,10 +172,10 @@ void DistanceField::getGradientMarkers(double min_distance, double max_distance,
           // double angle = -gradient.angle(unitX);
           // Eigen::AngleAxisd rotation(angle, axis);
 
-          // marker.pose.orientation.x = rotation.rotation().x();
-          // marker.pose.orientation.y = rotation.rotation().y();
-          // marker.pose.orientation.z = rotation.rotation().z();
-          // marker.pose.orientation.w = rotation.rotation().w();
+          // marker.pose.orientation.x = rotation.linear().x();
+          // marker.pose.orientation.y = rotation.linear().y();
+          // marker.pose.orientation.z = rotation.linear().z();
+          // marker.pose.orientation.w = rotation.linear().w();
 
           marker.scale.x = getResolution();
           marker.scale.y = getResolution();

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -245,7 +245,7 @@ bool DynamicsSolver::getMaxPayload(const std::vector<double>& joint_angles, doub
   state_->setJointGroupPositions(joint_model_group_, joint_angles);
   const Eigen::Affine3d& base_frame = state_->getFrameTransform(base_name_);
   const Eigen::Affine3d& tip_frame = state_->getFrameTransform(tip_name_);
-  Eigen::Affine3d transform = tip_frame.inverse() * base_frame;
+  Eigen::Affine3d transform = tip_frame.inverse(Eigen::Isometry) * base_frame;
   wrenches.back().force.z = 1.0;
   wrenches.back().force = transformVector(transform, wrenches.back().force);
   wrenches.back().torque = transformVector(transform, wrenches.back().torque);
@@ -301,7 +301,7 @@ bool DynamicsSolver::getPayloadTorques(const std::vector<double>& joint_angles, 
 
   const Eigen::Affine3d& base_frame = state_->getFrameTransform(base_name_);
   const Eigen::Affine3d& tip_frame = state_->getFrameTransform(tip_name_);
-  Eigen::Affine3d transform = tip_frame.inverse() * base_frame;
+  Eigen::Affine3d transform = tip_frame.inverse(Eigen::Isometry) * base_frame;
   wrenches.back().force.z = payload * gravity_;
   wrenches.back().force = transformVector(transform, wrenches.back().force);
   wrenches.back().torque = transformVector(transform, wrenches.back().torque);

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -53,7 +53,7 @@ inline geometry_msgs::Vector3 transformVector(const Eigen::Affine3d& transform, 
 {
   Eigen::Vector3d p;
   p = Eigen::Vector3d(vector.x, vector.y, vector.z);
-  p = transform.rotation() * p;
+  p = transform.linear() * p;
 
   geometry_msgs::Vector3 result;
   result.x = p.x();

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -520,7 +520,7 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
     tf.transformQuaternion(oc.header.frame_id, q, q);
     desired_rotation_frame_id_ = tf.getTargetFrame();
     desired_rotation_matrix_ = Eigen::Matrix3d(q);
-    desired_rotation_matrix_inv_ = desired_rotation_matrix_.inverse(Eigen::Isometry);
+    desired_rotation_matrix_inv_ = desired_rotation_matrix_.transpose();
     mobile_frame_ = false;
   }
   else
@@ -565,8 +565,7 @@ bool OrientationConstraint::equal(const KinematicConstraint& other, double margi
   if (o.link_model_ == link_model_ &&
       robot_state::Transforms::sameFrame(desired_rotation_frame_id_, o.desired_rotation_frame_id_))
   {
-    Eigen::Matrix3d diff = desired_rotation_matrix_.inverse(Eigen::Isometry) * o.desired_rotation_matrix_;
-    if (!diff.isIdentity(margin))
+    if (!desired_rotation_matrix_.isApprox(o.desired_rotation_matrix_))
       return false;
     return fabs(absolute_x_axis_tolerance_ - o.absolute_x_axis_tolerance_) <= margin &&
            fabs(absolute_y_axis_tolerance_ - o.absolute_y_axis_tolerance_) <= margin &&
@@ -599,7 +598,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const robot_state::Robo
   if (mobile_frame_)
   {
     Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).linear() * desired_rotation_matrix_;
-    Eigen::Affine3d diff(tmp.inverse(Eigen::Isometry) * state.getGlobalLinkTransform(link_model_).linear());
+    Eigen::Affine3d diff(tmp.transpose() * state.getGlobalLinkTransform(link_model_).linear());
     xyz = diff.linear().eulerAngles(0, 1, 2);
     // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   }

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -391,7 +391,7 @@ bool PositionConstraint::equal(const KinematicConstraint& other, double margin) 
       for (std::size_t j = 0; j < o.constraint_region_.size(); ++j)
       {
         Eigen::Affine3d diff = constraint_region_pose_[i].inverse() * o.constraint_region_pose_[j];
-        if (diff.translation().norm() < margin && diff.rotation().isIdentity(margin) &&
+        if (diff.translation().norm() < margin && diff.linear().isIdentity(margin) &&
             constraint_region_[i]->getType() == o.constraint_region_[j]->getType() &&
             fabs(constraint_region_[i]->computeVolume() - o.constraint_region_[j]->computeVolume()) < margin)
         {
@@ -598,16 +598,15 @@ ConstraintEvaluationResult OrientationConstraint::decide(const robot_state::Robo
   Eigen::Vector3d xyz;
   if (mobile_frame_)
   {
-    Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).rotation() * desired_rotation_matrix_;
-    Eigen::Affine3d diff(tmp.inverse() * state.getGlobalLinkTransform(link_model_).rotation());
-    xyz = diff.rotation().eulerAngles(0, 1, 2);
+    Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).linear() * desired_rotation_matrix_;
+    Eigen::Affine3d diff(tmp.inverse() * state.getGlobalLinkTransform(link_model_).linear());
+    xyz = diff.linear().eulerAngles(0, 1, 2);
     // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   }
   else
   {
-    Eigen::Affine3d diff(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).rotation());
-    xyz =
-        diff.rotation().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
+    Eigen::Affine3d diff(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).linear());
+    xyz = diff.linear().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   }
 
   xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::pi<double>() - fabs(xyz(0)));
@@ -619,7 +618,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const robot_state::Robo
 
   if (verbose)
   {
-    Eigen::Quaterniond q_act(state.getGlobalLinkTransform(link_model_).rotation());
+    Eigen::Quaterniond q_act(state.getGlobalLinkTransform(link_model_).linear());
     Eigen::Quaterniond q_des(desired_rotation_matrix_);
     ROS_INFO_NAMED("kinematic_constraints",
                    "Orientation constraint %s for link '%s'. Quaternion desired: %f %f %f %f, quaternion "
@@ -757,12 +756,12 @@ bool VisibilityConstraint::equal(const KinematicConstraint& other, double margin
     Eigen::Affine3d diff = sensor_pose_.inverse() * o.sensor_pose_;
     if (diff.translation().norm() > margin)
       return false;
-    if (!diff.rotation().isIdentity(margin))
+    if (!diff.linear().isIdentity(margin))
       return false;
     diff = target_pose_.inverse() * o.target_pose_;
     if (diff.translation().norm() > margin)
       return false;
-    if (!diff.rotation().isIdentity(margin))
+    if (!diff.linear().isIdentity(margin))
       return false;
     return true;
   }
@@ -896,7 +895,7 @@ void VisibilityConstraint::getMarkers(const robot_state::RobotState& state,
   mka.scale.y = .15;
   mka.scale.z = 0.0;
   mka.points.resize(2);
-  Eigen::Vector3d d = tp.translation() + tp.rotation().col(2) * 0.5;
+  Eigen::Vector3d d = tp.translation() + tp.linear().col(2) * 0.5;
   mka.points[0].x = tp.translation().x();
   mka.points[0].y = tp.translation().y();
   mka.points[0].z = tp.translation().z();
@@ -909,7 +908,7 @@ void VisibilityConstraint::getMarkers(const robot_state::RobotState& state,
   mka.color.b = 1.0;
   mka.color.r = 0.0;
 
-  d = sp.translation() + sp.rotation().col(2 - sensor_view_direction_) * 0.5;
+  d = sp.translation() + sp.linear().col(2 - sensor_view_direction_) * 0.5;
   mka.points[0].x = sp.translation().x();
   mka.points[0].y = sp.translation().y();
   mka.points[0].z = sp.translation().z();
@@ -933,11 +932,11 @@ ConstraintEvaluationResult VisibilityConstraint::decide(const robot_state::Robot
         mobile_target_frame_ ? state.getFrameTransform(target_frame_id_) * target_pose_ : target_pose_;
 
     // necessary to do subtraction as SENSOR_Z is 0 and SENSOR_X is 2
-    const Eigen::Vector3d& normal2 = sp.rotation().col(2 - sensor_view_direction_);
+    const Eigen::Vector3d& normal2 = sp.linear().col(2 - sensor_view_direction_);
 
     if (max_view_angle_ > 0.0)
     {
-      const Eigen::Vector3d& normal1 = tp.rotation().col(2) * -1.0;  // along Z axis and inverted
+      const Eigen::Vector3d& normal1 = tp.linear().col(2) * -1.0;  // along Z axis and inverted
       double dp = normal2.dot(normal1);
       double ang = acos(dp);
       if (dp < 0.0)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1470,7 +1470,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           world_->removeObject(object.object.id);
 
           // need to transform poses to the link frame
-          const Eigen::Affine3d& i_t = kstate_->getGlobalLinkTransform(lm).inverse();
+          const Eigen::Affine3d& i_t = kstate_->getGlobalLinkTransform(lm).inverse(Eigen::Isometry);
           for (std::size_t i = 0; i < poses.size(); ++i)
             poses[i] = i_t * poses[i];
         }
@@ -1534,7 +1534,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         // transform poses to link frame
         if (object.object.header.frame_id != object.link_name)
         {
-          const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse() *
+          const Eigen::Affine3d& t = kstate_->getGlobalLinkTransform(lm).inverse(Eigen::Isometry) *
                                      getTransforms().getTransform(object.object.header.frame_id);
           for (std::size_t i = 0; i < poses.size(); ++i)
             poses[i] = t * poses[i];

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1018,7 +1018,7 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
           shapes::saveAsText(obj->shapes_[j].get(), out);
           out << obj->shape_poses_[j].translation().x() << " " << obj->shape_poses_[j].translation().y() << " "
               << obj->shape_poses_[j].translation().z() << std::endl;
-          Eigen::Quaterniond r(obj->shape_poses_[j].rotation());
+          Eigen::Quaterniond r(obj->shape_poses_[j].linear());
           out << r.x() << " " << r.y() << " " << r.z() << " " << r.w() << std::endl;
           if (hasObjectColor(ns[i]))
           {

--- a/moveit_core/robot_model/src/aabb.cpp
+++ b/moveit_core/robot_model/src/aabb.cpp
@@ -44,7 +44,7 @@ void moveit::core::AABB::extendWithTransformedBox(const Eigen::Affine3d& transfo
   //
   // Here's a nice explanation why it works: https://zeuxcg.org/2010/10/17/aabb-from-obb-with-component-wise-abs/
 
-  const Eigen::Matrix3d& R = transform.rotation();
+  const Eigen::Matrix3d& R = transform.linear();
   const Eigen::Vector3d& T = transform.translation();
 
   double x_range = 0.5 * (fabs(R(0, 0) * box[0]) + fabs(R(0, 1) * box[1]) + fabs(R(0, 2) * box[2]));

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -226,7 +226,7 @@ void FloatingJointModel::computeVariablePositions(const Eigen::Affine3d& transf,
   joint_values[0] = transf.translation().x();
   joint_values[1] = transf.translation().y();
   joint_values[2] = transf.translation().z();
-  Eigen::Quaterniond q(transf.rotation());
+  Eigen::Quaterniond q(transf.linear());
   joint_values[3] = q.x();
   joint_values[4] = q.y();
   joint_values[5] = q.z();

--- a/moveit_core/robot_model/src/link_model.cpp
+++ b/moveit_core/robot_model/src/link_model.cpp
@@ -61,7 +61,7 @@ void LinkModel::setJointOriginTransform(const Eigen::Affine3d& transform)
 {
   joint_origin_transform_ = transform;
   joint_origin_transform_is_identity_ =
-      joint_origin_transform_.rotation().isIdentity() &&
+      joint_origin_transform_.linear().isIdentity() &&
       joint_origin_transform_.translation().norm() < std::numeric_limits<double>::epsilon();
 }
 
@@ -82,7 +82,7 @@ void LinkModel::setGeometry(const std::vector<shapes::ShapeConstPtr>& shapes, co
   for (std::size_t i = 0; i < shapes_.size(); ++i)
   {
     collision_origin_transform_is_identity_[i] =
-        (collision_origin_transform_[i].rotation().isIdentity() &&
+        (collision_origin_transform_[i].linear().isIdentity() &&
          collision_origin_transform_[i].translation().norm() < std::numeric_limits<double>::epsilon()) ?
             1 :
             0;

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -224,7 +224,7 @@ void PlanarJointModel::computeVariablePositions(const Eigen::Affine3d& transf, d
   joint_values[0] = transf.translation().x();
   joint_values[1] = transf.translation().y();
 
-  Eigen::Quaterniond q(transf.rotation());
+  Eigen::Quaterniond q(transf.linear());
   // taken from Bullet
   double s_squared = 1.0 - (q.w() * q.w());
   if (s_squared < 10.0 * std::numeric_limits<double>::epsilon())

--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -246,7 +246,7 @@ void RevoluteJointModel::computeTransform(const double* joint_values, Eigen::Aff
 
 void RevoluteJointModel::computeVariablePositions(const Eigen::Affine3d& transf, double* joint_values) const
 {
-  Eigen::Quaterniond q(transf.rotation());
+  Eigen::Quaterniond q(transf.linear());
   q.normalize();
   size_t maxIdx;
   axis_.array().abs().maxCoeff(&maxIdx);

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -302,7 +302,7 @@ void RobotModel::buildJointInfo()
       continue;
 
     LinkTransformMap associated_transforms;
-    computeFixedTransforms(link, link->getJointOriginTransform().inverse(), associated_transforms);
+    computeFixedTransforms(link, link->getJointOriginTransform().inverse(Eigen::Isometry), associated_transforms);
     for (auto& tf_base : associated_transforms)
     {
       link_considered[tf_base.first->getLinkIndex()] = true;
@@ -310,7 +310,8 @@ void RobotModel::buildJointInfo()
       {
         if (&tf_base != &tf_target)
           const_cast<LinkModel*>(tf_base.first)  // regain write access to base LinkModel*
-              ->addAssociatedFixedTransform(tf_target.first, tf_base.second.inverse() * tf_target.second);
+              ->addAssociatedFixedTransform(tf_target.first,
+                                            tf_base.second.inverse(Eigen::Isometry) * tf_target.second);
       }
     }
   }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -89,7 +89,7 @@ static bool _multiDOFJointsToRobotState(const sensor_msgs::MultiDOFJointState& m
         const Eigen::Affine3d& t2fixed_frame = tf->getTransform(mjs.header.frame_id);
         // we update the value of the transform so that it transforms from the known fixed frame to the desired child
         // link
-        inv_t = t2fixed_frame.inverse();
+        inv_t = t2fixed_frame.inverse(Eigen::Isometry);
         use_inv_t = true;
       }
       catch (std::exception& ex)
@@ -300,7 +300,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
                                      "The pose of the attached body may be incorrect",
                             aco.object.header.frame_id.c_str());
           }
-          Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
+          Eigen::Affine3d t = state.getGlobalLinkTransform(lm).inverse(Eigen::Isometry) * t0;
           for (std::size_t i = 0; i < poses.size(); ++i)
             poses[i] = t * poses[i];
         }

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -489,28 +489,28 @@ TEST_F(OneRobot, FK)
   state.setVariablePositions(joint_values);
 
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("base_link").translation(), Eigen::Vector3d(1, 1, 0));
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").rotation()).x(), 1e-5);
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").rotation()).y(), 1e-5);
-  EXPECT_NEAR(0.247404, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").rotation()).z(), 1e-5);
-  EXPECT_NEAR(0.968912, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").rotation()).w(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").linear()).x(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").linear()).y(), 1e-5);
+  EXPECT_NEAR(0.247404, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").linear()).z(), 1e-5);
+  EXPECT_NEAR(0.968912, Eigen::Quaterniond(state.getGlobalLinkTransform("base_link").linear()).w(), 1e-5);
 
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_a").translation(), Eigen::Vector3d(1, 1, 0));
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").rotation()).x(), 1e-5);
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").rotation()).y(), 1e-5);
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").rotation()).z(), 1e-5);
-  EXPECT_NEAR(1.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").rotation()).w(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").linear()).x(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").linear()).y(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").linear()).z(), 1e-5);
+  EXPECT_NEAR(1.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_a").linear()).w(), 1e-5);
 
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_b").translation(), Eigen::Vector3d(1, 1.5, 0));
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").rotation()).x(), 1e-5);
-  EXPECT_NEAR(-0.2084598, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").rotation()).y(), 1e-5);
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").rotation()).z(), 1e-5);
-  EXPECT_NEAR(0.97803091, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").rotation()).w(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").linear()).x(), 1e-5);
+  EXPECT_NEAR(-0.2084598, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").linear()).y(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").linear()).z(), 1e-5);
+  EXPECT_NEAR(0.97803091, Eigen::Quaterniond(state.getGlobalLinkTransform("link_b").linear()).w(), 1e-5);
 
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("link_c").translation(), Eigen::Vector3d(1.08, 1.4, 0));
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").rotation()).x(), 1e-5);
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").rotation()).y(), 1e-5);
-  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").rotation()).z(), 1e-5);
-  EXPECT_NEAR(1.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").rotation()).w(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").linear()).x(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").linear()).y(), 1e-5);
+  EXPECT_NEAR(0.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").linear()).z(), 1e-5);
+  EXPECT_NEAR(1.0, Eigen::Quaterniond(state.getGlobalLinkTransform("link_c").linear()).w(), 1e-5);
 
   EXPECT_TRUE(state.satisfiesBounds());
 

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -234,7 +234,7 @@ TEST_F(TestAABB, TestPR2)
     msg.scale.z = extents[2];
     msg.color.r = 0;
     msg.color.b = 1;
-    Eigen::Quaterniond q(transform.rotation());
+    Eigen::Quaterniond q(transform.linear());
     msg.pose.orientation.x = q.x();
     msg.pose.orientation.y = q.y();
     msg.pose.orientation.z = q.z();
@@ -280,7 +280,7 @@ TEST_F(TestAABB, TestPR2)
       msg.scale.z = extents[2];
       msg.color.r = 0;
       msg.color.b = 1;
-      Eigen::Quaterniond q(transforms[i].rotation());
+      Eigen::Quaterniond q(transforms[i].linear());
       msg.pose.orientation.x = q.x();
       msg.pose.orientation.y = q.y();
       msg.pose.orientation.z = q.z();

--- a/moveit_core/robot_state/test/test_transforms.cpp
+++ b/moveit_core/robot_state/test/test_transforms.cpp
@@ -112,11 +112,11 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
   tf.transformPose(ks, "some_frame_2", x, x);
 
   EXPECT_TRUE(t2.translation() == x.translation());
-  EXPECT_TRUE(t2.rotation() == x.rotation());
+  EXPECT_TRUE(t2.linear() == x.linear());
 
   tf.transformPose(ks, kmodel->getModelFrame(), x, x);
   EXPECT_TRUE(t2.translation() == x.translation());
-  EXPECT_TRUE(t2.rotation() == x.rotation());
+  EXPECT_TRUE(t2.linear() == x.linear());
 
   x.setIdentity();
   tf.transformPose(ks, "r_wrist_roll_link", x, x);

--- a/moveit_core/transforms/include/moveit/transforms/transforms.h
+++ b/moveit_core/transforms/include/moveit/transforms/transforms.h
@@ -138,7 +138,7 @@ public:
    */
   void transformVector3(const std::string& from_frame, const Eigen::Vector3d& v_in, Eigen::Vector3d& v_out) const
   {
-    v_out = getTransform(from_frame).rotation() * v_in;
+    v_out = getTransform(from_frame).linear() * v_in;
   }
 
   /**
@@ -150,7 +150,7 @@ public:
   void transformQuaternion(const std::string& from_frame, const Eigen::Quaterniond& q_in,
                            Eigen::Quaterniond& q_out) const
   {
-    q_out = getTransform(from_frame).rotation() * q_in;
+    q_out = getTransform(from_frame).linear() * q_in;
   }
 
   /**
@@ -161,7 +161,7 @@ public:
    */
   void transformRotationMatrix(const std::string& from_frame, const Eigen::Matrix3d& m_in, Eigen::Matrix3d& m_out) const
   {
-    m_out = getTransform(from_frame).rotation() * m_in;
+    m_out = getTransform(from_frame).linear() * m_in;
   }
 
   /**

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -158,7 +158,7 @@ public:
   double getDistanceGradient(double x, double y, double z, double& gradient_x, double& gradient_y, double& gradient_z,
                              bool& in_bounds) const
   {
-    Eigen::Vector3d rel_pos = pose_.inverse() * Eigen::Vector3d(x, y, z);
+    Eigen::Vector3d rel_pos = pose_.inverse(Eigen::Isometry) * Eigen::Vector3d(x, y, z);
     double gx, gy, gz;
     double res = distance_field::PropagationDistanceField::getDistanceGradient(rel_pos.x(), rel_pos.y(), rel_pos.z(),
                                                                                gx, gy, gz, in_bounds);

--- a/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_distance_field_types.cpp
@@ -53,7 +53,7 @@ collision_detection::determineCollisionSpheres(const bodies::Body* body, Eigen::
   body->computeBoundingCylinder(cyl);
   unsigned int num_points = ceil(cyl.length / (cyl.radius / 2.0));
   double spacing = cyl.length / ((num_points * 1.0) - 1.0);
-  relative_transform = body->getPose().inverse() * cyl.pose;
+  relative_transform = body->getPose().inverse(Eigen::Isometry) * cyl.pose;
 
   for (unsigned int i = 1; i < num_points - 1; i++)
   {

--- a/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
+++ b/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
@@ -350,7 +350,7 @@ EigenSTL::vector_Affine3d KinematicsConstraintAware::transformPoses(
     if (!target_frame_is_root_frame)
     {
       eigen_pose_2 = planning_scene->getTransforms()->getTransform(kinematic_state, target_frame);
-      eigen_pose = eigen_pose_2.inverse() * eigen_pose;
+      eigen_pose = eigen_pose_2.inverse(Eigen::Isometry) * eigen_pose;
     }
     result[i] = eigen_pose;
   }
@@ -368,7 +368,7 @@ geometry_msgs::Pose KinematicsConstraintAware::getTipFramePose(
   tf::poseMsgToEigen(pose, eigen_pose_in);
   eigen_pose_link = planning_scene->getTransforms()->getTransform(kinematic_state, link_name);
   eigen_pose_tip = planning_scene->getTransforms()->getTransform(kinematic_state, tip_name);
-  eigen_pose_in = eigen_pose_in * (eigen_pose_link.inverse() * eigen_pose_tip);
+  eigen_pose_in = eigen_pose_in * (eigen_pose_link.inverse(Eigen::Isometry) * eigen_pose_tip);
   tf::poseEigenToMsg(eigen_pose_in, result);
   return result;
 }

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -215,10 +215,10 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
   // transform the input vectors in accordance to frame specified in the header;
   if (approach_direction_is_global_frame)
     approach_direction =
-        planning_scene_->getFrameTransform(plan->approach_.direction.header.frame_id).rotation() * approach_direction;
+        planning_scene_->getFrameTransform(plan->approach_.direction.header.frame_id).linear() * approach_direction;
   if (retreat_direction_is_global_frame)
     retreat_direction =
-        planning_scene_->getFrameTransform(plan->retreat_.direction.header.frame_id).rotation() * retreat_direction;
+        planning_scene_->getFrameTransform(plan->retreat_.direction.header.frame_id).linear() * retreat_direction;
 
   // state validity checking during the approach must ensure that the gripper posture is that for pre-grasping
   robot_state::GroupStateValidityCallbackFn approach_validCallback =

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -59,7 +59,7 @@ bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
 
   Eigen::Affine3d end_effector_transform;
   tf::poseMsgToEigen(goal_pose.pose, end_effector_transform);
-  end_effector_transform = end_effector_transform * fixed_transforms[0].inverse();
+  end_effector_transform = end_effector_transform * fixed_transforms[0].inverse(Eigen::Isometry);
   place_pose.header = goal_pose.header;
   tf::poseEigenToMsg(end_effector_transform, place_pose.pose);
   return true;

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -431,7 +431,7 @@ bool SemanticWorld::isInsideTableContour(const geometry_msgs::Pose& pose, const 
   tf::poseMsgToEigen(table.pose, pose_table);
 
   // Point in table frame
-  point = pose_table.inverse() * point;
+  point = pose_table.inverse(Eigen::Isometry) * point;
   // Assuming Z axis points upwards for the table
   if (point.z() < -fabs(min_vertical_offset))
   {

--- a/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
           state.setFromIK(jmg, pose);
           moveit::tools::Profiler::End("IK");
           const Eigen::Affine3d& pose_upd = state.getGlobalLinkTransform(tip);
-          Eigen::Affine3d diff = pose_upd * pose.inverse();
+          Eigen::Affine3d diff = pose_upd * pose.inverse(Eigen::Isometry);
           double rot_err = (diff.linear() - Eigen::Matrix3d::Identity()).norm();
           double trans_err = diff.translation().norm();
           moveit::tools::Profiler::Average("Rotation error", rot_err);

--- a/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
           moveit::tools::Profiler::End("IK");
           const Eigen::Affine3d& pose_upd = state.getGlobalLinkTransform(tip);
           Eigen::Affine3d diff = pose_upd * pose.inverse();
-          double rot_err = (diff.rotation() - Eigen::Matrix3d::Identity()).norm();
+          double rot_err = (diff.linear() - Eigen::Matrix3d::Identity()).norm();
           double trans_err = diff.translation().norm();
           moveit::tools::Profiler::Average("Rotation error", rot_err);
           moveit::tools::Profiler::Average("Translation error", trans_err);

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1022,7 +1022,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         tf::transformMsgToEigen(transforms[i], start_transform);
         Eigen::Vector3d offset = cur_transform.translation() - start_transform.translation();
         Eigen::AngleAxisd rotation;
-        rotation.fromRotationMatrix(cur_transform.linear().inverse(Eigen::Isometry) * start_transform.linear());
+        rotation.fromRotationMatrix(cur_transform.linear().transpose() * start_transform.linear());
         if ((offset.array() > allowed_start_tolerance_).any() || rotation.angle() > allowed_start_tolerance_)
         {
           ROS_ERROR_STREAM_NAMED(name_, "\nInvalid Trajectory: start point deviates from current robot state more than "

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1022,7 +1022,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         tf::transformMsgToEigen(transforms[i], start_transform);
         Eigen::Vector3d offset = cur_transform.translation() - start_transform.translation();
         Eigen::AngleAxisd rotation;
-        rotation.fromRotationMatrix(cur_transform.linear().inverse() * start_transform.linear());
+        rotation.fromRotationMatrix(cur_transform.linear().inverse(Eigen::Isometry) * start_transform.linear());
         if ((offset.array() > allowed_start_tolerance_).any() || rotation.angle() > allowed_start_tolerance_)
         {
           ROS_ERROR_STREAM_NAMED(name_, "\nInvalid Trajectory: start point deviates from current robot state more than "

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1022,7 +1022,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         tf::transformMsgToEigen(transforms[i], start_transform);
         Eigen::Vector3d offset = cur_transform.translation() - start_transform.translation();
         Eigen::AngleAxisd rotation;
-        rotation.fromRotationMatrix(cur_transform.rotation().inverse() * start_transform.rotation());
+        rotation.fromRotationMatrix(cur_transform.linear().inverse() * start_transform.linear());
         if ((offset.array() > allowed_start_tolerance_).any() || rotation.angle() > allowed_start_tolerance_)
         {
           ROS_ERROR_STREAM_NAMED(name_, "\nInvalid Trajectory: start point deviates from current robot state more than "

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -2133,7 +2133,7 @@ std::vector<double> moveit::planning_interface::MoveGroupInterface::getCurrentRP
       {
         result.resize(3);
         tf::Matrix3x3 ptf;
-        tf::matrixEigenToTF(current_state->getGlobalLinkTransform(lm).rotation(), ptf);
+        tf::matrixEigenToTF(current_state->getGlobalLinkTransform(lm).linear(), ptf);
         tfScalar pitch, roll, yaw;
         ptf.getRPY(roll, pitch, yaw);
         result[0] = roll;

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -153,7 +153,7 @@ public:
       v[0] = t.translation().x();
       v[1] = t.translation().y();
       v[2] = t.translation().z();
-      Eigen::Quaterniond q(t.rotation());
+      Eigen::Quaterniond q(t.linear());
       v[3] = q.x();
       v[4] = q.y();
       v[5] = q.z();

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -342,7 +342,7 @@ void InteractionHandler::updateStateJoint(robot_state::RobotState* state, const 
   tf::poseMsgToEigen(*feedback_pose, pose);
 
   if (!vj->parent_frame.empty() && !robot_state::Transforms::sameFrame(vj->parent_frame, planning_frame_))
-    pose = state->getGlobalLinkTransform(vj->parent_frame).inverse() * pose;
+    pose = state->getGlobalLinkTransform(vj->parent_frame).inverse(Eigen::Isometry) * pose;
 
   state->setJointPositions(vj->joint_name, pose);
   state->update();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -237,7 +237,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
           if (obj->shapes_.size() == 1)
           {
             obj_pose = obj->shape_poses_[0];
-            Eigen::Vector3d xyz = obj_pose.rotation().eulerAngles(0, 1, 2);
+            Eigen::Vector3d xyz = obj_pose.linear().eulerAngles(0, 1, 2);
             update_scene_marker = true;  // do the marker update outside locked scope to avoid deadlock
 
             bool oldState = ui_->object_x->blockSignals(true);
@@ -321,7 +321,7 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
       // Update the interactive marker pose to match the manually introduced one
       if (update_marker_position && scene_marker_)
       {
-        Eigen::Quaterniond eq(p.rotation());
+        Eigen::Quaterniond eq(p.linear());
         scene_marker_->setPose(Ogre::Vector3(ui_->object_x->value(), ui_->object_y->value(), ui_->object_z->value()),
                                Ogre::Quaternion(eq.w(), eq.x(), eq.y(), eq.z()), "");
       }
@@ -694,7 +694,7 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
       ps->getWorld()->getObject(sel[0]->text().toStdString());
   if (obj && obj->shapes_.size() == 1)
   {
-    Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
+    Eigen::Quaterniond eq(obj->shape_poses_[0].linear());
     geometry_msgs::PoseStamped shape_pose;
     shape_pose.pose.position.x = obj->shape_poses_[0].translation()[0];
     shape_pose.pose.position.y = obj->shape_poses_[0].translation()[1];

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
@@ -52,7 +52,7 @@ bool moveit_rviz_plugin::PlanningLinkUpdater::getLinkTransforms(const std::strin
   }
 
   const Eigen::Vector3d& robot_visual_position = kinematic_state_->getGlobalLinkTransform(link_model).translation();
-  Eigen::Quaterniond robot_visual_orientation(kinematic_state_->getGlobalLinkTransform(link_model).rotation());
+  Eigen::Quaterniond robot_visual_orientation(kinematic_state_->getGlobalLinkTransform(link_model).linear());
   visual_position = Ogre::Vector3(robot_visual_position.x(), robot_visual_position.y(), robot_visual_position.z());
   visual_orientation = Ogre::Quaternion(robot_visual_orientation.w(), robot_visual_orientation.x(),
                                         robot_visual_orientation.y(), robot_visual_orientation.z());

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -78,7 +78,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
   rviz::Shape* ogre_shape = NULL;
   Eigen::Vector3d translation = p.translation();
   Ogre::Vector3 position(translation.x(), translation.y(), translation.z());
-  Eigen::Quaterniond q(p.rotation());
+  Eigen::Quaterniond q(p.linear());
   Ogre::Quaternion orientation(q.w(), q.x(), q.y(), q.z());
 
   // we don't know how to render cones directly, but we can convert them to a mesh


### PR DESCRIPTION
This attempts to fix #1073, i.e. using Eigen::Affine3d while actually Eigen::Isometry3d is intended.
Instead of changing the actual type throughout the source, I followed @v4hn's suggestion and
- replaced `rotation()` -> `linear()`
- replaced `inverse()` -> `inverse(Eigen::Isometry)` or `transpose()` if applied to 3x3 rotation matrix only

This implicitly assumes that the linear part of all matrices is orthonormal and doesn't need an SVD to separate the rotation matrix from a (diagonal) scaling matrix.

Changing the type to Eigen::Isometry3d would do these simplifications automatically.
However, for Kinetic we don't want to break API that much.