### PR TITLE
fixing initial pose behavior when using the fake_controller_manager

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -68,7 +68,9 @@ public:
       return;
     }
 
-    pub_ = node_handle_.advertise<sensor_msgs::JointState>("fake_controller_joint_states", 100, false);
+    /* by setting latch to true we preserve the initial joint state while other nodes launch */
+    bool latch = true;
+    pub_ = node_handle_.advertise<sensor_msgs::JointState>("fake_controller_joint_states", 100, latch);
 
     /* publish initial pose */
     XmlRpc::XmlRpcValue initial;


### PR DESCRIPTION
This change handles a bug in the fake_controller_manager where the initial pose message was being missed some large percentage of the time. 

The relevant code was initially added by Ioan and updated by @rhaschke in https://github.com/ros-planning/moveit/commit/e1d91fec2587c7f13533ab3c140600685c87ca52

