### PR TITLE
Add tutorials to CI build to prevent breakages

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -17,6 +17,10 @@
     uri: https://github.com/ros-planning/moveit_visual_tools.git
     version: kinetic-devel
 - git:
+    local-name: moveit_tutorials
+    uri: https://github.com/ros-planning/moveit_tutorials.git
+    version: kinetic-devel
+- git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
     version: kinetic-devel


### PR DESCRIPTION
Also encourage community to contribute by auto-checking out sourcecode

This is in response to a breakage over a recent API change with TF: https://github.com/ros-planning/moveit_tutorials/pull/232#pullrequestreview-165233009