### PR TITLE
No longer support Lunar on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
-    - ROS_DISTRO=lunar   ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
-    - ROS_DISTRO=lunar   ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:


### PR DESCRIPTION
We do not have any plans to release another Lunar build and decided to our maintainer meetings to drop support for this a while back. This is reflected on our website, README.md, and elsewhere. Ergo, let's not test for it to avoid issues like this:
https://github.com/ros-planning/moveit/pull/1094