### PR TITLE
Minor fix of moveit_commander_cmdline.py

### DIFF
--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -14,7 +14,7 @@ from moveit_commander import MoveGroupCommandInterpreter, MoveGroupInfoLevel, ro
 
 # compatibility with python3
 # python2's input function is dangerous anyway
-if hasattr(__builtin__, 'raw_input'):
+if hasattr(__builtins__, 'raw_input'):
     input = raw_input
 
 class bcolors:


### PR DESCRIPTION

### Description

moveit_commander_cmdline.py fails to start due to "__builtin__". It was changed to "__builtins__".

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
