### PR TITLE
Fixed moveit_commander __builtin__ missing error

### DIFF
--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import __builtin__
 import roslib
 import rospy
 import readline


### PR DESCRIPTION
### Description
Fixes regression in **Kinetic** introduced by https://github.com/ros-planning/moveit/commit/8c62cf20c8c2200d098d55d0e506fbce57ee541d

Running:
`rosrun moveit_commander moveit_commander_cmdline.py`

Produces:
> Failed to import pyassimp, see https://github.com/ros-planning/moveit/issues/86 for more info
> Traceback (most recent call last):
>   File "~/ws/src/moveit/moveit_commander/bin/moveit_commander_cmdline.py", line 17, in <module>
>     if hasattr(__builtin__, 'raw_input'):



### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
