### PR TITLE
fix typo getCollisionBodyTransform(s)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,7 +7,7 @@ API changes in MoveIt! releases
 - Migration to ``tf2`` API.
 - The move_group capability ``ExecuteTrajectoryServiceCapability`` has been removed in favor of the improved ``ExecuteTrajectoryActionCapability`` capability. Since Indigo, both capabilities were supported. If you still load default capabilities in your ``config/launch/move_group.launch``, you can just remove them from the capabilities parameter. The correct default capabilities will be loaded automatically.
 - Deprecated method ``CurrentStateMonitor::waitForCurrentState(double wait_time)`` was finally removed.
-- Renamed ``RobotState::getCollisionBodyTransforms`` to ``getCollisionBodyTransforms`` as it returns a single transform only.
+- Renamed ``RobotState::getCollisionBodyTransforms`` to ``getCollisionBodyTransform`` as it returns a single transform only.
 
 ## ROS Kinetic
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,7 @@ API changes in MoveIt! releases
 - Migration to ``tf2`` API.
 - The move_group capability ``ExecuteTrajectoryServiceCapability`` has been removed in favor of the improved ``ExecuteTrajectoryActionCapability`` capability. Since Indigo, both capabilities were supported. If you still load default capabilities in your ``config/launch/move_group.launch``, you can just remove them from the capabilities parameter. The correct default capabilities will be loaded automatically.
 - Deprecated method ``CurrentStateMonitor::waitForCurrentState(double wait_time)`` was finally removed.
+- Renamed ``RobotState::getCollisionBodyTransforms`` to ``getCollisionBodyTransforms`` as it returns a single transform only.
 
 ## ROS Kinetic
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1373,7 +1373,7 @@ as the new values that correspond to the group */
     return global_link_transforms_[link->getLinkIndex()];
   }
 
-  const Eigen::Affine3d& getCollisionBodyTransforms(const std::string& link_name, std::size_t index)
+  const Eigen::Affine3d& getCollisionBodyTransform(const std::string& link_name, std::size_t index)
   {
     return getCollisionBodyTransform(robot_model_->getLinkModel(link_name), index);
   }


### PR DESCRIPTION
This method only returns a single transform, hence a singular form name should be used.
Interestingly this method was never used inside MoveIt.
