### PR TITLE
World::moveObject(): only apply changes if there is any non-zero motion

### DIFF
--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -160,6 +160,8 @@ bool World::moveObject(const std::string& id, const Eigen::Affine3d& transform)
   auto it = objects_.find(id);
   if (it == objects_.end())
     return false;
+  if (transform.isApprox(Eigen::Affine3d::Identity()))
+    return false;  // no movement
   ensureUnique(it->second);
   for (size_t i = 0, n = it->second->shapes_.size(); i < n; ++i)
   {

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -161,7 +161,7 @@ bool World::moveObject(const std::string& id, const Eigen::Affine3d& transform)
   if (it == objects_.end())
     return false;
   if (transform.isApprox(Eigen::Affine3d::Identity()))
-    return false;  // no movement
+    return true;  // object already at correct location
   ensureUnique(it->second);
   for (size_t i = 0, n = it->second->shapes_.size(); i < n; ++i)
   {


### PR DESCRIPTION
This is a follow up to #957, which introduced World::moveObject().
When transform is the identity matrix, i.e. there is no movement, the object shouldn't be touched.
This follows the rule, only to create a copy of the parent planning scene, when there are actual modifications.

- [ ] Cherry pick to Kinetic