### PR TITLE
Include chomp packages in a dependency chain starting from moveit metapkg

### DIFF
--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -16,6 +16,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>chomp_motion_planner</run_depend>
+  <run_depend>moveit_planners_chomp</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
 
   <export>


### PR DESCRIPTION
### Description

Per my suggestion https://github.com/ros-planning/moveit/issues/1083#issuecomment-432737000 that is based on the discussion at https://github.com/ros-gbp/moveit-release/pull/5#discussion_r227781794, `chomp` packages will be included in the list of released packages.

For the chomp packages to be easily installed by just installing `moveit` (e.g. `apt-get install ros-%DISTRO%-moveit`), those packages need to be included in the dependency chain that's rooted from `moveit`. The change in this PR realizes that.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Decide if this should be cherry-picked to other current ROS branches -> Should be ported to melodic. Not for older than Kinetic. See https://github.com/ros-gbp/moveit-release/pull/5#discussion_r227781794
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/) -> No need as this is not feature/enhancement change.
- [x] Include a screenshot if changing a GUI -> No GUI change.
- [x] Document API changes relevant to the user in the moveit/MIGRATION.md notes -> No API change. See more at https://github.com/ros-planning/moveit/issues/1083#issuecomment-432737000
- [x] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html) -> I can't think of anything to test for this particular change.

