### PR TITLE
remove dependency on moveit_experimental from chomp packages

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib
   chomp_motion_planner
-  moveit_experimental
 )
 
 find_package(Eigen3 REQUIRED)

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -19,7 +19,6 @@
   <depend version_gte="1.11.2">pluginlib</depend>
 
   <build_depend>chomp_motion_planner</build_depend>
-  <build_depend>moveit_experimental</build_depend>
 
   <test_depend>moveit_ros_planning_interface</test_depend>
   <test_depend>rostest</test_depend>
@@ -27,5 +26,4 @@
   <export>
     <moveit_core plugin="${prefix}/chomp_interface_plugin_description.xml"/>
   </export>
-
 </package>

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -3,7 +3,7 @@ project(chomp_motion_planner)
 
 add_definitions(-std=c++11)
 
-find_package(catkin REQUIRED COMPONENTS roscpp moveit_experimental moveit_core)
+find_package(catkin REQUIRED COMPONENTS roscpp moveit_core)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -15,9 +15,5 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
-  <build_depend>moveit_experimental</build_depend>
   <build_depend>moveit_core</build_depend>
-
 </package>
-
-


### PR DESCRIPTION
A local test build, removing moveit_experimental, approved that this is actually not needed.