### PR TITLE
PR template: Add ROS code review guide (#1027)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ Please explain the changes you made, including a reference to the related issue 
 - [ ] Include a screenshot if changing a GUI
 - [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
 - [ ] Decide if this should be cherry-picked to other current ROS branches
-- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
+- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers. You can refer to our [ROS code review guide](https://github.com/rosin-project/ros_code_review_guide/blob/master/README.md) for direction
 
 [//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


### PR DESCRIPTION
### Description
As promised in the following comment https://github.com/ros-planning/moveit/pull/1027#issuecomment-414323201, the ROS code review guidelines are ready and added a link to the pull request template.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
