### PR TITLE
Add coverage analysis for moveit_core

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -138,6 +138,18 @@ catkin_package(
     urdfdom_headers
     )
 
+
+# to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
+if(ENABLE_COVERAGE_TESTING)
+  find_package(code_coverage REQUIRED)   # catkin package ros-*-code-coverage
+  include(CodeCoverage)
+  APPEND_COVERAGE_COMPILER_FLAGS()
+  set(COVERAGE_EXCLUDES "*/test/*")
+  add_code_coverage(
+    NAME ${PROJECT_NAME}_coverage
+  )
+endif()
+
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
                            ${LIBFCL_INCLUDE_DIRS}
                            )


### PR DESCRIPTION
Originated from: https://github.com/ros-planning/moveit/issues/1

Provides a CMake target to generate a coverage analysis of moveit_core.

Usage: `catkin_make -DENABLE_COVERAGE_TESTING=ON moveit_core_coverage`
