### PR TITLE
replaced obsolete cmake_modules with Eigen

### DIFF
--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -23,7 +23,6 @@ COMPONENTS
   rostime
   rosconsole
   pluginlib
-  cmake_modules
 )
 find_package(Eigen3 REQUIRED)
 

--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -40,7 +40,7 @@
   <build_depend>roslib</build_depend>
   <build_depend>rostime</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>moveit_core</build_depend>
 
   <run_depend version_gte="1.11.2">pluginlib</run_depend>

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -4,7 +4,6 @@ project(moveit_planners_chomp)
 add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  cmake_modules
   roscpp
   moveit_core
   pluginlib

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -12,7 +12,6 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>cmake_modules</build_depend>
 
   <depend>roscpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -11,7 +11,6 @@ set(SOURCE_FILES
   src/chomp_optimizer_adapter.cpp)
 
 find_package(catkin REQUIRED COMPONENTS
-  cmake_modules
   roscpp
   moveit_core
   moveit_msgs


### PR DESCRIPTION
[Kinetic release build fails](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__moveit_ros_planning__ubuntu_xenial_amd64__binary/86/consoleFull#console-section-15) missing `cmake_modules`. While we removed it from package.xml, it's still present in some CMakeLists. Running a pre-release test to verify.