### PR TITLE
Update link to chomp documentation

### DIFF
--- a/moveit_planners/chomp/README.md
+++ b/moveit_planners/chomp/README.md
@@ -1,3 +1,3 @@
 ## CHOMP Motion Planner
 
-See [Chomp Interface Tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/chomp_interface_tutorial.html)
+See [Chomp Interface Tutorial](https://ros-planning.github.io/moveit_tutorials/doc/chomp_planner/chomp_planner_tutorial.html)


### PR DESCRIPTION
### Description

Fixes the link to the chomp planning plugin documentation. Old link 404'd. Now links to the chomp tutorial on moveit.ros.org

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
