### PR TITLE
Attached object visualization fix

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -124,6 +124,7 @@ private Q_SLOTS:
   void changedSceneEnabled();
   void changedSceneRobotVisualEnabled();
   void changedSceneRobotCollisionEnabled();
+  void changedSceneRobotAttachedBodyEnabled();
   void changedRobotSceneAlpha();
   void changedSceneAlpha();
   void changedSceneColor();
@@ -200,6 +201,7 @@ protected:
   rviz::BoolProperty* scene_enabled_property_;
   rviz::BoolProperty* scene_robot_visual_enabled_property_;
   rviz::BoolProperty* scene_robot_collision_enabled_property_;
+  rviz::BoolProperty* scene_robot_attached_body_enabled_property_;
   rviz::RosTopicProperty* planning_scene_topic_property_;
   rviz::FloatProperty* robot_alpha_property_;
   rviz::FloatProperty* scene_alpha_property_;

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -133,6 +133,10 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
                                        "displayed as defined for collision detection purposes.",
         robot_category_, SLOT(changedSceneRobotCollisionEnabled()), this);
 
+    scene_robot_attached_body_enabled_property_ = new rviz::BoolProperty(
+        "Show Attached Body", true, "Indicates whether the robot state's attached body should be displayed",
+        robot_category_, SLOT(changedSceneRobotAttachedBodyEnabled()), this);
+
     robot_alpha_property_ = new rviz::FloatProperty("Robot Alpha", 1.0f, "Specifies the alpha for the robot links",
                                                     robot_category_, SLOT(changedRobotSceneAlpha()), this);
     robot_alpha_property_->setMin(0.0);
@@ -144,11 +148,12 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   }
   else
   {
-    robot_category_ = NULL;
-    scene_robot_visual_enabled_property_ = NULL;
-    scene_robot_collision_enabled_property_ = NULL;
-    robot_alpha_property_ = NULL;
-    attached_body_color_property_ = NULL;
+    robot_category_ = nullptr;
+    scene_robot_visual_enabled_property_ = nullptr;
+    scene_robot_collision_enabled_property_ = nullptr;
+    scene_robot_attached_body_enabled_property_ = nullptr;
+    robot_alpha_property_ = nullptr;
+    attached_body_color_property_ = nullptr;
   }
 }
 
@@ -190,6 +195,7 @@ void PlanningSceneDisplay::onInitialize()
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setVisualVisible(scene_robot_visual_enabled_property_->getBool());
     planning_scene_robot_->setCollisionVisible(scene_robot_collision_enabled_property_->getBool());
+    planning_scene_robot_->setAttachedBodyVisible(scene_robot_attached_body_enabled_property_->getBool());
     changedRobotSceneAlpha();
     changedAttachedBodyColor();
   }
@@ -209,6 +215,7 @@ void PlanningSceneDisplay::reset()
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setVisualVisible(scene_robot_visual_enabled_property_->getBool());
     planning_scene_robot_->setCollisionVisible(scene_robot_collision_enabled_property_->getBool());
+    planning_scene_robot_->setAttachedBodyVisible(scene_robot_attached_body_enabled_property_->getBool());
   }
 }
 
@@ -395,6 +402,7 @@ void PlanningSceneDisplay::changedSceneRobotVisualEnabled()
   {
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setVisualVisible(scene_robot_visual_enabled_property_->getBool());
+    planning_scene_needs_render_ = true;
   }
 }
 
@@ -404,6 +412,16 @@ void PlanningSceneDisplay::changedSceneRobotCollisionEnabled()
   {
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setCollisionVisible(scene_robot_collision_enabled_property_->getBool());
+    planning_scene_needs_render_ = true;
+  }
+}
+
+void PlanningSceneDisplay::changedSceneRobotAttachedBodyEnabled()
+{
+  if (isEnabled() && planning_scene_robot_)
+  {
+    planning_scene_robot_->setAttachedBodyVisible(scene_robot_attached_body_enabled_property_->getBool());
+    planning_scene_needs_render_ = true;
   }
 }
 
@@ -579,6 +597,7 @@ void PlanningSceneDisplay::onEnable()
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setVisualVisible(scene_robot_visual_enabled_property_->getBool());
     planning_scene_robot_->setCollisionVisible(scene_robot_collision_enabled_property_->getBool());
+    planning_scene_robot_->setAttachedBodyVisible(scene_robot_attached_body_enabled_property_->getBool());
   }
   if (planning_scene_render_)
     planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -97,6 +97,7 @@ private Q_SLOTS:
   void changedEnableLinkHighlight();
   void changedEnableVisualVisible();
   void changedEnableCollisionVisible();
+  void changedEnableAttachedBodyVisible();
   void changedAllLinks();
 
 protected:
@@ -142,6 +143,7 @@ protected:
   rviz::BoolProperty* enable_link_highlight_;
   rviz::BoolProperty* enable_visual_visible_;
   rviz::BoolProperty* enable_collision_visible_;
+  rviz::BoolProperty* enable_attached_body_visible_;
   rviz::BoolProperty* show_all_links_;
 };
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -95,9 +95,9 @@ RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false), load_r
                                                      "Whether to display the collision representation of the robot.",
                                                      this, SLOT(changedEnableCollisionVisible()), this);
 
-  enable_attached_body_visible_ = new rviz::BoolProperty("Attached Body Visible", true,
-                                                         "Whether to display the attached body.",
-                                                         this, SLOT(changedEnableAttachedBodyVisible()), this);
+  enable_attached_body_visible_ =
+      new rviz::BoolProperty("Attached Body Visible", true, "Whether to display the attached body.", this,
+                             SLOT(changedEnableAttachedBodyVisible()), this);
 
   show_all_links_ = new rviz::BoolProperty("Show All Links", true, "Toggle all links visibility on or off.", this,
                                            SLOT(changedAllLinks()), this);

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -95,6 +95,10 @@ RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false), load_r
                                                      "Whether to display the collision representation of the robot.",
                                                      this, SLOT(changedEnableCollisionVisible()), this);
 
+  enable_attached_body_visible_ = new rviz::BoolProperty("Attached Body Visible", true,
+                                                         "Whether to display the attached body.",
+                                                         this, SLOT(changedEnableAttachedBodyVisible()), this);
+
   show_all_links_ = new rviz::BoolProperty("Show All Links", true, "Toggle all links visibility on or off.", this,
                                            SLOT(changedAllLinks()), this);
 }
@@ -182,6 +186,12 @@ void RobotStateDisplay::changedEnableVisualVisible()
 void RobotStateDisplay::changedEnableCollisionVisible()
 {
   robot_->setCollisionVisible(enable_collision_visible_->getBool());
+}
+
+void RobotStateDisplay::changedEnableAttachedBodyVisible()
+{
+  robot_->setAttachedBodyVisible(enable_attached_body_visible_->getBool());
+  update_state_ = true;
 }
 
 static bool operator!=(const std_msgs::ColorRGBA& a, const std_msgs::ColorRGBA& b)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -88,6 +88,12 @@ public:
    */
   void setCollisionVisible(bool visible);
 
+  /**
+   * \brief Set whether the attached body of the robot should be visible
+   * @param visible Whether the attached body should be visible
+   */
+  void setAttachedBodyVisible(bool visible);
+
   void setAlpha(float alpha);
 
 private:
@@ -103,6 +109,7 @@ private:
   bool visible_;
   bool visual_visible_;
   bool collision_visible_;
+  bool attached_body_visible_;
 };
 }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -49,6 +49,7 @@ RobotStateVisualization::RobotStateVisualization(Ogre::SceneNode* root_node, rvi
   , visible_(true)
   , visual_visible_(true)
   , collision_visible_(false)
+  , attached_body_visible_(true)
 {
   default_attached_object_color_.r = 0.0f;
   default_attached_object_color_.g = 0.7f;
@@ -105,6 +106,12 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
   robot_.update(PlanningLinkUpdater(kinematic_state));
   render_shapes_->clear();
 
+  robot_.setVisualVisible(visual_visible_);
+  robot_.setCollisionVisible(collision_visible_);
+  robot_.setVisible(visible_);
+  if (!attached_body_visible_)
+      return;
+
   std::vector<const robot_state::AttachedBody*> attached_bodies;
   kinematic_state->getAttachedBodies(attached_bodies);
   for (std::size_t i = 0; i < attached_bodies.size(); ++i)
@@ -133,9 +140,6 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
                                   octree_voxel_color_mode_, rcolor, alpha);
     }
   }
-  robot_.setVisualVisible(visual_visible_);
-  robot_.setCollisionVisible(collision_visible_);
-  robot_.setVisible(visible_);
 }
 
 void RobotStateVisualization::setVisible(bool visible)
@@ -154,6 +158,15 @@ void RobotStateVisualization::setCollisionVisible(bool visible)
 {
   collision_visible_ = visible;
   robot_.setCollisionVisible(visible);
+}
+
+void RobotStateVisualization::setAttachedBodyVisible(bool visible)
+{
+  attached_body_visible_ = visible;
+  // currently rviz::Shape does not provide a setVisible-method, so
+  // the best we can do here is to clear the shapes-vector in the not-visible-case
+  if (!attached_body_visible_)
+      render_shapes_->clear();
 }
 
 void RobotStateVisualization::setAlpha(float alpha)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -110,7 +110,7 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
   robot_.setCollisionVisible(collision_visible_);
   robot_.setVisible(visible_);
   if (!attached_body_visible_)
-      return;
+    return;
 
   std::vector<const robot_state::AttachedBody*> attached_bodies;
   kinematic_state->getAttachedBodies(attached_bodies);
@@ -166,7 +166,7 @@ void RobotStateVisualization::setAttachedBodyVisible(bool visible)
   // currently rviz::Shape does not provide a setVisible-method, so
   // the best we can do here is to clear the shapes-vector in the not-visible-case
   if (!attached_body_visible_)
-      render_shapes_->clear();
+    render_shapes_->clear();
 }
 
 void RobotStateVisualization::setAlpha(float alpha)


### PR DESCRIPTION
### Description

When deselecting "Visual Enabled"/"Collision Enabled" in
RobotStateDisplay or "Show Robot Visual"/"Show Robot Collision" in
PlanningSceneDisplay, the attached object was still shown.

Also, there was no way to not display the attached object individually.

--> added new BoolProperty "Attached Body Visible" / "Show Attached
Body" to both Displays and a corresponding field in the
RobotStateVisualization-class, which is then checked in its update-
function.

--> also, now require an update_state_ (RobotStateDisplay) /
planning_scene_needs_render_ (PlanningSceneDisplay), when either of the
three flags (Robot Visual / Robot Collision / Attached Body Visible) is
changed.

