### PR TITLE
[WIP] Pass RobotModel to ik plugins

### DIFF
--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -50,7 +50,9 @@ namespace moveit
 namespace core
 {
 class JointModelGroup;
+class RobotModel;
 class RobotState;
+MOVEIT_CLASS_FORWARD(RobotModel);
 }
 }
 
@@ -583,7 +585,19 @@ public:
     supported_methods_.push_back(DiscretizationMethods::NO_DISCRETIZATION);
   }
 
+  void setRobotModel(const moveit::core::RobotModelPtr& rm)
+  {
+    robot_model_ = rm;
+  }
+
+  moveit::core::RobotModelPtr getRobotModel() const
+  {
+    return robot_model_;
+  }
+
+
 protected:
+  moveit::core::RobotModelPtr robot_model_;
   std::string robot_description_;
   std::string group_name_;
   std::string base_frame_;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -611,7 +611,8 @@ void JointModelGroup::setSolverAllocators(const std::pair<SolverAllocatorFn, Sol
         ks.solver_instance_ = const_cast<JointModelGroup*>(it->first)->getSolverInstance();
         ks.default_ik_timeout_ = group_kinematics_.first.default_ik_timeout_;
         ks.default_ik_attempts_ = group_kinematics_.first.default_ik_attempts_;
-        if (!computeIKIndexBijection(ks.solver_instance_.lock()->getJointNames(), ks.bijection_))
+        kinematics::KinematicsBasePtr si = ks.solver_instance_.lock();
+        if (!si || !computeIKIndexBijection(si->getJointNames(), ks.bijection_))
         {
           group_kinematics_.second.clear();
           break;

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -188,8 +188,6 @@ private:
 
   mutable random_numbers::RandomNumberGenerator random_number_generator_;
 
-  robot_model::RobotModelPtr robot_model_;
-
   robot_state::RobotStatePtr state_, state_2_;
 
   int num_possible_redundant_joints_;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -131,17 +131,20 @@ bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const
 {
   setValues(robot_description, group_name, base_frame, tip_frame, search_discretization);
 
-  rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
-  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
+  if (!robot_model_)
+  {
+    ROS_ERROR_NAMED("kdl", "RobotModel must be set for KDL kinematics solver to work.");
+    return false;
+  }
+
+  const srdf::ModelConstSharedPtr& srdf = getRobotModel()->getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = getRobotModel()->getURDF();
 
   if (!urdf_model || !srdf)
   {
     ROS_ERROR_NAMED("kdl", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
     return false;
   }
-
-  robot_model_.reset(new robot_model::RobotModel(urdf_model, srdf));
 
   robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
   if (!joint_model_group)

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -55,9 +55,10 @@ public:
       ROS parameter under which the robot description can be
       found. This is passed to the kinematics solver initialization as
       well as used to read the SRDF document when needed. */
-  KinematicsPluginLoader(const std::string& robot_description = "robot_description",
+  KinematicsPluginLoader(const moveit::core::RobotModelPtr& model,
+                         const std::string& robot_description = "robot_description",
                          double default_search_resolution = 0.0)
-    : robot_description_(robot_description), default_search_resolution_(default_search_resolution)
+    : model_(model), robot_description_(robot_description), default_search_resolution_(default_search_resolution)
   {
   }
 
@@ -108,6 +109,8 @@ public:
   void status() const;
 
 private:
+  const moveit::core::RobotModelPtr model_;
+
   std::string robot_description_;
   double default_search_resolution_;
 

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -57,11 +57,13 @@ public:
    * \param search_res
    * \param iksolver_to_tip_links - a map between each ik solver and a vector of custom-specified tip link(s)
    */
-  KinematicsLoaderImpl(const std::string& robot_description,
+  KinematicsLoaderImpl(const moveit::core::RobotModelPtr& model,
+                       const std::string& robot_description,
                        const std::map<std::string, std::vector<std::string> >& possible_kinematics_solvers,
                        const std::map<std::string, std::vector<double> >& search_res,
                        const std::map<std::string, std::vector<std::string> >& iksolver_to_tip_links)
-    : robot_description_(robot_description)
+    : model_(model)
+    , robot_description_(robot_description)
     , possible_kinematics_solvers_(possible_kinematics_solvers)
     , search_res_(search_res)
     , iksolver_to_tip_links_(iksolver_to_tip_links)
@@ -163,6 +165,8 @@ public:
                 double search_res =
                     search_res_.find(jmg->getName())->second[i];  // we know this exists, by construction
 
+                result->setRobotModel(model_);
+
                 if (!result->initialize(robot_description_, jmg->getName(),
                                         (base.empty() || base[0] != '/') ? base : base.substr(1), tips, search_res))
                 {
@@ -233,6 +237,7 @@ public:
   }
 
 private:
+  moveit::core::RobotModelPtr model_;
   std::string robot_description_;
   std::map<std::string, std::vector<std::string> > possible_kinematics_solvers_;
   std::map<std::string, std::vector<double> > search_res_;
@@ -446,7 +451,7 @@ kinematics_plugin_loader::KinematicsPluginLoader::getLoaderFunction(const srdf::
     }
 
     loader_.reset(
-        new KinematicsLoaderImpl(robot_description_, possible_kinematics_solvers, search_res, iksolver_to_tip_links));
+        new KinematicsLoaderImpl(model_, robot_description_, possible_kinematics_solvers, search_res, iksolver_to_tip_links));
   }
 
   return boost::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(), _1);

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -178,7 +178,7 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(
       kinematics_loader_ = kloader;
     else
       kinematics_loader_.reset(
-          new kinematics_plugin_loader::KinematicsPluginLoader(rdf_loader_->getRobotDescription()));
+          new kinematics_plugin_loader::KinematicsPluginLoader(model_, rdf_loader_->getRobotDescription()));
     robot_model::SolverAllocatorFn kinematics_allocator = kinematics_loader_->getLoaderFunction(rdf_loader_->getSRDF());
     const std::vector<std::string>& groups = kinematics_loader_->getKnownGroups();
     std::stringstream ss;


### PR DESCRIPTION
This is a proof of concept for further discussion of a way to pass `RobotModel(Ptr)` to kinematics plugins. It is inspired by #150 and the recent and not so recent discussion therein

The main objective of this (and previous PRs (and previous 4y old PRs)) is to
1) save some parsing and loading time by reusing the `RobotModel`
2) use consistent joint limits in all parts of the code

Passing in `std::shared_ptr<RobotModel>` (aka `RobotModelPtr`) to `kinematics::KinematicsBase` derived plugins and storing it there or in a member variable `RobotState` will however create a cyclic shared pointer loop as
`RobotModel `-> `JointModelGroup` -> `KinematicsSolver`/`KinematicsBase` (plugin) -> `RobotModel`

This was discussed at length yesterday at  https://github.com/ros-planning/moveit/pull/150#issuecomment-433045509 and following

The solution sketched here is to turn the shared pointer from `JointModelGroup` -> `KinematicsSolver` into a weak pointer and have them owned by `RobotModelLoader` in its `KinematicPluginLoader`. `KinematicPluginLoader` already has the `KinematicSolvers` in a cache so changes there would only be needed for clarity. We could also move/copy the `KinematicSolvers` to a more explicit "storage" directly in `RobotModelLoader` (or elsewhere outside of `RobotModel`)

Further points open for discussion:
This PR adds a member variable of type  `RobotModelPtr` to `kinematics::KinematicsBase` for simple access. This breaks ABI. (but not API!) Still it means that e.g. ikFast plugins from ros-I packages need to be recompiled to be able to be loaded. This could be avoided by having a `virtual setRobotModel(RobotModelPtr)` be called right after the constructor and not storing the pointer in `KinematicsBase`. Plugins could then override this function to store the pointer themselves, thus preserving ABI as well.

This PR is made against kinetic-devel, mostly for convenience. Since it can change behavior it should probably only (eventually) be applied against melodic. I'm sure this can be handled by git ninjas

If during the discussion slight hints of approval emerge, I would port further plugins as well during this slightly extended World MoveIt! Week. They will continue working as is however for the time being.