### PR TITLE
add support for fcl 0.6

### DIFF
--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -40,9 +40,18 @@
 #include <moveit/collision_detection/world.h>
 #include <moveit/collision_detection/collision_world.h>
 #include <moveit/macros/class_forward.h>
+#include <moveit/collision_detection_fcl/fcl_compat.h>
+
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+#include <fcl/broadphase/broadphase_collision_manager.h>
+#include <fcl/narrowphase/collision.h>
+#include <fcl/narrowphase/distance.h>
+#else
 #include <fcl/broadphase/broadphase.h>
 #include <fcl/collision.h>
 #include <fcl/distance.h>
+#endif
+
 #include <memory>
 #include <set>
 
@@ -176,19 +185,19 @@ struct FCLGeometry
   {
   }
 
-  FCLGeometry(fcl::CollisionGeometry* collision_geometry, const robot_model::LinkModel* link, int shape_index)
+  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const robot_model::LinkModel* link, int shape_index)
     : collision_geometry_(collision_geometry), collision_geometry_data_(new CollisionGeometryData(link, shape_index))
   {
     collision_geometry_->setUserData(collision_geometry_data_.get());
   }
 
-  FCLGeometry(fcl::CollisionGeometry* collision_geometry, const robot_state::AttachedBody* ab, int shape_index)
+  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const robot_state::AttachedBody* ab, int shape_index)
     : collision_geometry_(collision_geometry), collision_geometry_data_(new CollisionGeometryData(ab, shape_index))
   {
     collision_geometry_->setUserData(collision_geometry_data_.get());
   }
 
-  FCLGeometry(fcl::CollisionGeometry* collision_geometry, const World::Object* obj, int shape_index)
+  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const World::Object* obj, int shape_index)
     : collision_geometry_(collision_geometry), collision_geometry_data_(new CollisionGeometryData(obj, shape_index))
   {
     collision_geometry_->setUserData(collision_geometry_data_.get());
@@ -204,17 +213,17 @@ struct FCLGeometry
     collision_geometry_->setUserData(collision_geometry_data_.get());
   }
 
-  std::shared_ptr<fcl::CollisionGeometry> collision_geometry_;
+  std::shared_ptr<fcl::CollisionGeometryd> collision_geometry_;
   CollisionGeometryDataPtr collision_geometry_data_;
 };
 
-typedef std::shared_ptr<fcl::CollisionObject> FCLCollisionObjectPtr;
-typedef std::shared_ptr<const fcl::CollisionObject> FCLCollisionObjectConstPtr;
+typedef std::shared_ptr<fcl::CollisionObjectd> FCLCollisionObjectPtr;
+typedef std::shared_ptr<const fcl::CollisionObjectd> FCLCollisionObjectConstPtr;
 
 struct FCLObject
 {
-  void registerTo(fcl::BroadPhaseCollisionManager* manager);
-  void unregisterFrom(fcl::BroadPhaseCollisionManager* manager);
+  void registerTo(fcl::BroadPhaseCollisionManagerd* manager);
+  void unregisterFrom(fcl::BroadPhaseCollisionManagerd* manager);
   void clear();
 
   std::vector<FCLCollisionObjectPtr> collision_objects_;
@@ -224,12 +233,12 @@ struct FCLObject
 struct FCLManager
 {
   FCLObject object_;
-  std::shared_ptr<fcl::BroadPhaseCollisionManager> manager_;
+  std::shared_ptr<fcl::BroadPhaseCollisionManagerd> manager_;
 };
 
-bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* data);
+bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data);
 
-bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* data, double& min_dist);
+bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist);
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_model::LinkModel* link,
                                             int shape_index);
@@ -245,21 +254,25 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
                                             const World::Object* obj);
 void cleanCollisionGeometryCache();
 
-inline void transform2fcl(const Eigen::Affine3d& b, fcl::Transform3f& f)
+inline void transform2fcl(const Eigen::Affine3d& b, fcl::Transform3d& f)
 {
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+  f = b.matrix();
+#else
   Eigen::Quaterniond q(b.rotation());
-  f.setTranslation(fcl::Vec3f(b.translation().x(), b.translation().y(), b.translation().z()));
+  f.setTranslation(fcl::Vector3d(b.translation().x(), b.translation().y(), b.translation().z()));
   f.setQuatRotation(fcl::Quaternion3f(q.w(), q.x(), q.y(), q.z()));
+#endif
 }
 
-inline fcl::Transform3f transform2fcl(const Eigen::Affine3d& b)
+inline fcl::Transform3d transform2fcl(const Eigen::Affine3d& b)
 {
-  fcl::Transform3f t;
+  fcl::Transform3d t;
   transform2fcl(b, t);
   return t;
 }
 
-inline void fcl2contact(const fcl::Contact& fc, Contact& c)
+inline void fcl2contact(const fcl::Contactd& fc, Contact& c)
 {
   c.pos = Eigen::Vector3d(fc.pos[0], fc.pos[1], fc.pos[2]);
   c.normal = Eigen::Vector3d(fc.normal[0], fc.normal[1], fc.normal[2]);
@@ -272,7 +285,7 @@ inline void fcl2contact(const fcl::Contact& fc, Contact& c)
   c.body_type_2 = cgd2->type;
 }
 
-inline void fcl2costsource(const fcl::CostSource& fcs, CostSource& cs)
+inline void fcl2costsource(const fcl::CostSourced& fcs, CostSource& cs)
 {
   cs.aabb_min[0] = fcs.aabb_min[0];
   cs.aabb_min[1] = fcs.aabb_min[1];

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_world_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_world_fcl.h
@@ -38,7 +38,14 @@
 #define MOVEIT_COLLISION_DETECTION_FCL_COLLISION_WORLD_FCL_
 
 #include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <moveit/collision_detection_fcl/fcl_compat.h>
+
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+#include <fcl/broadphase/broadphase_collision_manager.h>
+#else
 #include <fcl/broadphase/broadphase.h>
+#endif
+
 #include <memory>
 
 namespace collision_detection
@@ -82,7 +89,7 @@ protected:
   void constructFCLObject(const World::Object* obj, FCLObject& fcl_obj) const;
   void updateFCLObject(const std::string& id);
 
-  std::unique_ptr<fcl::BroadPhaseCollisionManager> manager_;
+  std::unique_ptr<fcl::BroadPhaseCollisionManagerd> manager_;
   std::map<std::string, FCLObject> fcl_objs_;
 
 private:

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/fcl_compat.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/fcl_compat.h
@@ -1,0 +1,101 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Hamburg University.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Benjamin Scholz */
+
+#ifndef MOVEIT_COLLISION_DETECTION_FCL_COMPAT_
+#define MOVEIT_COLLISION_DETECTION_FCL_COMPAT_
+
+#include <fcl/config.h>
+
+#define FCL_VERSION_CHECK(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
+#define MOVEIT_FCL_VERSION FCL_VERSION_CHECK(FCL_MAJOR_VERSION, FCL_MINOR_VERSION, FCL_PATCH_VERSION)
+
+#if (MOVEIT_FCL_VERSION < FCL_VERSION_CHECK(0, 6, 0))
+namespace fcl
+{
+class CollisionGeometry;
+using CollisionGeometryd = fcl::CollisionGeometry;
+class CollisionObject;
+using CollisionObjectd = fcl::CollisionObject;
+class BroadPhaseCollisionManager;
+using BroadPhaseCollisionManagerd = fcl::BroadPhaseCollisionManager;
+class Transform3f;
+using Transform3d = fcl::Transform3f;
+class Contact;
+using Contactd = fcl::Contact;
+class CostSource;
+using CostSourced = fcl::CostSource;
+class CollisionRequest;
+using CollisionRequestd = fcl::CollisionRequest;
+class CollisionResult;
+using CollisionResultd = fcl::CollisionResult;
+class DistanceRequest;
+using DistanceRequestd = fcl::DistanceRequest;
+class DistanceResult;
+using DistanceResultd = fcl::DistanceResult;
+class Plane;
+using Planed = fcl::Plane;
+class Sphere;
+using Sphered = fcl::Sphere;
+class Box;
+using Boxd = fcl::Box;
+class Cylinder;
+using Cylinderd = fcl::Cylinder;
+class Cone;
+using Coned = fcl::Cone;
+
+namespace details
+{
+struct sse_meta_f4;
+template <typename T>
+struct Vec3Data;
+}
+template <typename T>
+class Vec3fX;
+#if FCL_HAVE_SSE
+using Vector3d = Vec3fX<details::sse_meta_f4>;
+#else
+using Vector3d = Vec3fX<details::Vec3Data<double> >;
+#endif
+
+class OcTree;
+using OcTreed = fcl::OcTree;
+class OBBRSS;
+using OBBRSSd = fcl::OBBRSS;
+class DynamicAABBTreeCollisionManager;
+using DynamicAABBTreeCollisionManagerd = fcl::DynamicAABBTreeCollisionManager;
+}
+#endif
+#endif

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -36,15 +36,23 @@
 
 #include <moveit/collision_detection_fcl/collision_common.h>
 #include <geometric_shapes/shapes.h>
+#include <moveit/collision_detection_fcl/fcl_compat.h>
+
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+#include <fcl/geometry/bvh/BVH_model.h>
+#include <fcl/geometry/octree/octree.h>
+#else
 #include <fcl/BVH/BVH_model.h>
 #include <fcl/shape/geometric_shapes.h>
 #include <fcl/octree.h>
+#endif
+
 #include <boost/thread/mutex.hpp>
 #include <memory>
 
 namespace collision_detection
 {
-bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* data)
+bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)
 {
   CollisionData* cdata = reinterpret_cast<CollisionData*>(data);
   if (cdata->done_)
@@ -170,9 +178,9 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
     bool enable_cost = cdata->req_->cost;
     std::size_t num_max_cost_sources = cdata->req_->max_cost_sources;
     bool enable_contact = true;
-    fcl::CollisionResult col_result;
-    int num_contacts = fcl::collide(o1, o2, fcl::CollisionRequest(std::numeric_limits<size_t>::max(), enable_contact,
-                                                                  num_max_cost_sources, enable_cost),
+    fcl::CollisionResultd col_result;
+    int num_contacts = fcl::collide(o1, o2, fcl::CollisionRequestd(std::numeric_limits<size_t>::max(), enable_contact,
+                                                                   num_max_cost_sources, enable_cost),
                                     col_result);
     if (num_contacts > 0)
     {
@@ -216,7 +224,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
 
     if (enable_cost)
     {
-      std::vector<fcl::CostSource> cost_sources;
+      std::vector<fcl::CostSourced> cost_sources;
       col_result.getCostSources(cost_sources);
 
       CostSource cs;
@@ -238,9 +246,9 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       std::size_t num_max_cost_sources = cdata->req_->max_cost_sources;
       bool enable_contact = true;
 
-      fcl::CollisionResult col_result;
+      fcl::CollisionResultd col_result;
       int num_contacts = fcl::collide(
-          o1, o2, fcl::CollisionRequest(want_contact_count, enable_contact, num_max_cost_sources, enable_cost),
+          o1, o2, fcl::CollisionRequestd(want_contact_count, enable_contact, num_max_cost_sources, enable_cost),
           col_result);
       if (num_contacts > 0)
       {
@@ -276,7 +284,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
 
       if (enable_cost)
       {
-        std::vector<fcl::CostSource> cost_sources;
+        std::vector<fcl::CostSourced> cost_sources;
         col_result.getCostSources(cost_sources);
 
         CostSource cs;
@@ -294,9 +302,9 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
       bool enable_cost = cdata->req_->cost;
       std::size_t num_max_cost_sources = cdata->req_->max_cost_sources;
       bool enable_contact = false;
-      fcl::CollisionResult col_result;
-      int num_contacts =
-          fcl::collide(o1, o2, fcl::CollisionRequest(1, enable_contact, num_max_cost_sources, enable_cost), col_result);
+      fcl::CollisionResultd col_result;
+      int num_contacts = fcl::collide(
+          o1, o2, fcl::CollisionRequestd(1, enable_contact, num_max_cost_sources, enable_cost), col_result);
       if (num_contacts > 0)
       {
         cdata->res_->collision = true;
@@ -310,7 +318,7 @@ bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void*
 
       if (enable_cost)
       {
-        std::vector<fcl::CostSource> cost_sources;
+        std::vector<fcl::CostSourced> cost_sources;
         col_result.getCostSources(cost_sources);
 
         CostSource cs;
@@ -387,7 +395,7 @@ struct FCLShapeCache
   boost::mutex lock_;
 };
 
-bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* data, double& min_dist)
+bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist)
 {
   DistanceData* cdata = reinterpret_cast<DistanceData*>(data);
 
@@ -476,7 +484,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
     ROS_DEBUG_NAMED("collision_detection.fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
                     cd2->getID().c_str());
 
-  fcl::DistanceResult fcl_result;
+  fcl::DistanceResultd fcl_result;
   DistanceResultsData dist_result;
   double dist_threshold = cdata->req->distance_threshold;
 
@@ -507,7 +515,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
   }
 
   fcl_result.min_distance = dist_threshold;
-  double d = fcl::distance(o1, o2, fcl::DistanceRequest(cdata->req->enable_nearest_points), fcl_result);
+  double d = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
 
   // Check if either object is already in the map. If not add it or if present
   // check to see if the new distance is closer. If closer remove the existing
@@ -515,8 +523,13 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
   if (d < dist_threshold)
   {
     dist_result.distance = fcl_result.min_distance;
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+    dist_result.nearest_points[0] = fcl_result.nearest_points[0];
+    dist_result.nearest_points[1] = fcl_result.nearest_points[1];
+#else
     dist_result.nearest_points[0] = Eigen::Vector3d(fcl_result.nearest_points[0].data.vs);
     dist_result.nearest_points[1] = Eigen::Vector3d(fcl_result.nearest_points[1].data.vs);
+#endif
     dist_result.link_names[0] = cd1->getID();
     dist_result.link_names[1] = cd2->getID();
     dist_result.body_types[0] = cd1->type;
@@ -532,8 +545,8 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
       dist_result.nearest_points[1].setZero();
       dist_result.normal.setZero();
 
-      fcl::CollisionRequest coll_req;
-      fcl::CollisionResult coll_res;
+      fcl::CollisionRequestd coll_req;
+      fcl::CollisionResultd coll_res;
       coll_req.enable_contact = true;
       coll_req.num_max_contacts = 200;
       std::size_t contacts = fcl::collide(o1, o2, coll_req, coll_res);
@@ -543,7 +556,7 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
         int max_index = 0;
         for (std::size_t i = 0; i < contacts; ++i)
         {
-          const fcl::Contact& contact = coll_res.getContact(i);
+          const fcl::Contactd& contact = coll_res.getContact(i);
           if (contact.penetration_depth > max_dist)
           {
             max_dist = contact.penetration_depth;
@@ -551,11 +564,17 @@ bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* 
           }
         }
 
-        const fcl::Contact& contact = coll_res.getContact(max_index);
+        const fcl::Contactd& contact = coll_res.getContact(max_index);
         dist_result.distance = -contact.penetration_depth;
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+        dist_result.nearest_points[0] = contact.pos;
+        dist_result.nearest_points[1] = contact.pos;
+        dist_result.normal = contact.normal;
+#else
         dist_result.nearest_points[0] = Eigen::Vector3d(contact.pos.data.vs);
         dist_result.nearest_points[1] = Eigen::Vector3d(contact.pos.data.vs);
         dist_result.normal = Eigen::Vector3d(contact.normal.data.vs);
+#endif
       }
     }
 
@@ -742,7 +761,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
     othercache.lock_.unlock();
   }
 
-  fcl::CollisionGeometry* cg_g = nullptr;
+  fcl::CollisionGeometryd* cg_g = nullptr;
   if (shape->type == shapes::PLANE)  // shapes that directly produce CollisionGeometry
   {
     // handle cases individually
@@ -751,7 +770,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       case shapes::PLANE:
       {
         const shapes::Plane* p = static_cast<const shapes::Plane*>(shape.get());
-        cg_g = new fcl::Plane(p->a, p->b, p->c, p->d);
+        cg_g = new fcl::Planed(p->a, p->b, p->c, p->d);
       }
       break;
       default:
@@ -765,26 +784,26 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       case shapes::SPHERE:
       {
         const shapes::Sphere* s = static_cast<const shapes::Sphere*>(shape.get());
-        cg_g = new fcl::Sphere(s->radius);
+        cg_g = new fcl::Sphered(s->radius);
       }
       break;
       case shapes::BOX:
       {
         const shapes::Box* s = static_cast<const shapes::Box*>(shape.get());
         const double* size = s->size;
-        cg_g = new fcl::Box(size[0], size[1], size[2]);
+        cg_g = new fcl::Boxd(size[0], size[1], size[2]);
       }
       break;
       case shapes::CYLINDER:
       {
         const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
-        cg_g = new fcl::Cylinder(s->radius, s->length);
+        cg_g = new fcl::Cylinderd(s->radius, s->length);
       }
       break;
       case shapes::CONE:
       {
         const shapes::Cone* s = static_cast<const shapes::Cone*>(shape.get());
-        cg_g = new fcl::Cone(s->radius, s->length);
+        cg_g = new fcl::Coned(s->radius, s->length);
       }
       break;
       case shapes::MESH:
@@ -798,9 +817,9 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
             tri_indices[i] =
                 fcl::Triangle(mesh->triangles[3 * i], mesh->triangles[3 * i + 1], mesh->triangles[3 * i + 2]);
 
-          std::vector<fcl::Vec3f> points(mesh->vertex_count);
+          std::vector<fcl::Vector3d> points(mesh->vertex_count);
           for (unsigned int i = 0; i < mesh->vertex_count; ++i)
-            points[i] = fcl::Vec3f(mesh->vertices[3 * i], mesh->vertices[3 * i + 1], mesh->vertices[3 * i + 2]);
+            points[i] = fcl::Vector3d(mesh->vertices[3 * i], mesh->vertices[3 * i + 1], mesh->vertices[3 * i + 2]);
 
           g->beginModel();
           g->addSubModel(points, tri_indices);
@@ -812,7 +831,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       case shapes::OCTREE:
       {
         const shapes::OcTree* g = static_cast<const shapes::OcTree*>(shape.get());
-        cg_g = new fcl::OcTree(g->octree);
+        cg_g = new fcl::OcTreed(g->octree);
       }
       break;
       default:
@@ -837,18 +856,18 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_model::LinkModel* link,
                                             int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSS, robot_model::LinkModel>(shape, link, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, robot_model::LinkModel>(shape, link, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_state::AttachedBody* ab,
                                             int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSS, robot_state::AttachedBody>(shape, ab, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, robot_state::AttachedBody>(shape, ab, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const World::Object* obj)
 {
-  return createCollisionGeometry<fcl::OBBRSS, World::Object>(shape, obj, 0);
+  return createCollisionGeometry<fcl::OBBRSSd, World::Object>(shape, obj, 0);
 }
 
 template <typename BV, typename T>
@@ -869,29 +888,29 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
                                             const robot_model::LinkModel* link, int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSS, robot_model::LinkModel>(shape, scale, padding, link, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, robot_model::LinkModel>(shape, scale, padding, link, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
                                             const robot_state::AttachedBody* ab, int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSS, robot_state::AttachedBody>(shape, scale, padding, ab, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, robot_state::AttachedBody>(shape, scale, padding, ab, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
                                             const World::Object* obj)
 {
-  return createCollisionGeometry<fcl::OBBRSS, World::Object>(shape, scale, padding, obj, 0);
+  return createCollisionGeometry<fcl::OBBRSSd, World::Object>(shape, scale, padding, obj, 0);
 }
 
 void cleanCollisionGeometryCache()
 {
-  FCLShapeCache& cache1 = GetShapeCache<fcl::OBBRSS, World::Object>();
+  FCLShapeCache& cache1 = GetShapeCache<fcl::OBBRSSd, World::Object>();
   {
     boost::mutex::scoped_lock slock(cache1.lock_);
     cache1.bumpUseCount(true);
   }
-  FCLShapeCache& cache2 = GetShapeCache<fcl::OBBRSS, robot_state::AttachedBody>();
+  FCLShapeCache& cache2 = GetShapeCache<fcl::OBBRSSd, robot_state::AttachedBody>();
   {
     boost::mutex::scoped_lock slock(cache2.lock_);
     cache2.bumpUseCount(true);
@@ -907,16 +926,16 @@ void collision_detection::CollisionData::enableGroup(const robot_model::RobotMod
     active_components_only_ = nullptr;
 }
 
-void collision_detection::FCLObject::registerTo(fcl::BroadPhaseCollisionManager* manager)
+void collision_detection::FCLObject::registerTo(fcl::BroadPhaseCollisionManagerd* manager)
 {
-  std::vector<fcl::CollisionObject*> collision_objects(collision_objects_.size());
+  std::vector<fcl::CollisionObjectd*> collision_objects(collision_objects_.size());
   for (std::size_t i = 0; i < collision_objects_.size(); ++i)
     collision_objects[i] = collision_objects_[i].get();
   if (!collision_objects.empty())
     manager->registerObjects(collision_objects);
 }
 
-void collision_detection::FCLObject::unregisterFrom(fcl::BroadPhaseCollisionManager* manager)
+void collision_detection::FCLObject::unregisterFrom(fcl::BroadPhaseCollisionManagerd* manager)
 {
   for (auto& collision_object : collision_objects_)
     manager->unregisterObject(collision_object.get());

--- a/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_world_fcl.cpp
@@ -36,10 +36,20 @@
 
 #include <moveit/collision_detection_fcl/collision_world_fcl.h>
 #include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
+#include <moveit/collision_detection_fcl/fcl_compat.h>
+
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+#include <fcl/geometry/geometric_shape_to_BVH_model.h>
+#include <fcl/narrowphase/detail/traversal/collision/bvh_collision_traversal_node.h>
+#include <fcl/narrowphase/detail/traversal/collision_node.h>
+#include <fcl/broadphase/broadphase_dynamic_AABB_tree.h>
+#else
 #include <fcl/shape/geometric_shape_to_BVH_model.h>
 #include <fcl/traversal/traversal_node_bvhs.h>
 #include <fcl/traversal/traversal_node_setup.h>
 #include <fcl/collision_node.h>
+#endif
+
 #include <boost/bind.hpp>
 
 namespace collision_detection
@@ -48,7 +58,7 @@ const std::string CollisionDetectorAllocatorFCL::NAME_("FCL");
 
 CollisionWorldFCL::CollisionWorldFCL() : CollisionWorld()
 {
-  auto m = new fcl::DynamicAABBTreeCollisionManager();
+  auto m = new fcl::DynamicAABBTreeCollisionManagerd();
   // m->tree_init_level = 2;
   manager_.reset(m);
 
@@ -58,7 +68,7 @@ CollisionWorldFCL::CollisionWorldFCL() : CollisionWorld()
 
 CollisionWorldFCL::CollisionWorldFCL(const WorldPtr& world) : CollisionWorld(world)
 {
-  auto m = new fcl::DynamicAABBTreeCollisionManager();
+  auto m = new fcl::DynamicAABBTreeCollisionManagerd();
   // m->tree_init_level = 2;
   manager_.reset(m);
 
@@ -70,7 +80,7 @@ CollisionWorldFCL::CollisionWorldFCL(const WorldPtr& world) : CollisionWorld(wor
 CollisionWorldFCL::CollisionWorldFCL(const CollisionWorldFCL& other, const WorldPtr& world)
   : CollisionWorld(other, world)
 {
-  auto m = new fcl::DynamicAABBTreeCollisionManager();
+  auto m = new fcl::DynamicAABBTreeCollisionManagerd();
   // m->tree_init_level = 2;
   manager_.reset(m);
 
@@ -181,7 +191,7 @@ void CollisionWorldFCL::constructFCLObject(const World::Object* obj, FCLObject& 
     FCLGeometryConstPtr g = createCollisionGeometry(obj->shapes_[i], obj);
     if (g)
     {
-      auto co = new fcl::CollisionObject(g->collision_geometry_, transform2fcl(obj->shape_poses_[i]));
+      auto co = new fcl::CollisionObjectd(g->collision_geometry_, transform2fcl(obj->shape_poses_[i]));
       fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(co));
       fcl_obj.collision_geometry_.push_back(g);
     }


### PR DESCRIPTION
The (still unreleased) fcl 0.6 changed paths to relevant headers as well as the name of many types.
This patch adds support for fcl 0.6 without breaking support for fcl 0.5.

This patch adds the header fcl_compat.h to check for the fcl version and include fcl headers accordingly.
The old types are exchanged to the newer ones throughout the package.
Compability to fcl 0.5 is ensured by creating type aliases that map the old types to the new ones.

The other way around might be the better choice for now, but the old type names are still in use in the new versions (as templates), so the alias trick only works this way around.

For this a lot of code from @Levi-Armstrong was used, who already created a branch with support for fcl 0.6 but without support for fcl 0.5: https://github.com/Levi-Armstrong/moveit/tree/newFCL

@v4hn 