### PR TITLE
MoveItCommander: Ability to wait for collision object to be added

### DIFF
--- a/moveit_ros/planning_interface/test/python_move_group.test
+++ b/moveit_ros/planning_interface/test/python_move_group.test
@@ -1,4 +1,4 @@
-<!-- -*- mode: XML -*- -->
+<?xml version="1.0"?>
 <launch>
   <!-- Start joint_state_publisher, robot_state_publisher, and MoveGroup -->
   <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>


### PR DESCRIPTION
In the python move group tutorials there is a very clunky section recently added by @mlautman titled [Ensuring Collision Updates Are Receieved](https://ros-planning.github.io/moveit_tutorials/doc/move_group_python_interface/move_group_python_interface_tutorial.html#ensuring-collision-updates-are-receieved)

This should be a helper function in core moveit, and not something a beginner to moveit who is using python should see. This PR hides that functionality away. A future PR will be created to switch the tutorials to using this instead. I already tested that prototype but removed it for now so i could submit some other moveit_tutorial python cleanup PRs for now.

