### PR TITLE
Get available planning group names from MoveGroup C++

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -193,6 +193,9 @@ public:
   /** \brief Get the name of the frame in which the robot is planning */
   const std::string& getPlanningFrame() const;
 
+  /** \brief Get the available planning group names */
+  const std::vector<std::string>& getJointModelGroupNames() const;
+
   /** \brief Get vector of names of joints available in move group */
   const std::vector<std::string>& getJointNames();
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -2167,6 +2167,11 @@ const std::string& moveit::planning_interface::MoveGroupInterface::getPlanningFr
   return impl_->getRobotModel()->getModelFrame();
 }
 
+const std::vector<std::string>& moveit::planning_interface::MoveGroupInterface::getJointModelGroupNames() const
+{
+  return impl_->getRobotModel()->getJointModelGroupNames();
+}
+
 bool moveit::planning_interface::MoveGroupInterface::attachObject(const std::string& object, const std::string& link)
 {
   return attachObject(object, link, std::vector<std::string>());


### PR DESCRIPTION
- Will match the python MoveGroup API

The python tutorials have [this ability](https://github.com/ros-planning/moveit_tutorials/blob/melodic-devel/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py#L129) but the CPP one does not yet. This adds that.

Depended on by https://github.com/ros-planning/moveit_tutorials/pull/247