### PR TITLE
[CMake] add build depend on cmake_modules

### DIFF
--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -22,6 +22,7 @@
   <build_depend>moveit_ros_perception</build_depend>
   <build_depend version_gte="1.10.4">pluginlib</build_depend>
   <build_depend>actionlib</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>angles</build_depend>
   <build_depend>eigen</build_depend>


### PR DESCRIPTION
### Description

Backport #1161

Fix #1154. The only CMakeLists.txt which didn't have a build_depend
and used cmake_modules:

    planning/planning_request_adapter_plugins/CMakeLists.txt:  cmake_modules

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
