### PR TITLE
Pass RobotModel to kinematics plugins

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,10 @@ API changes in MoveIt! releases
 - Deprecated method ``CurrentStateMonitor::waitForCurrentState(double wait_time)`` was finally removed.
 - Renamed ``RobotState::getCollisionBodyTransforms`` to ``getCollisionBodyTransform`` as it returns a single transform only.
 - Removed deprecated class MoveGroup (was renamed to MoveGroupInterface).
-- KinematicsBase: Deprecate members tip_frame_, search_discretization_. Use tip_frames_ and redundant_joint_discretization_ instead.
+- KinematicsBase: Deprecated members `tip_frame_`, `search_discretization_`.
+  Use `tip_frames_` and `redundant_joint_discretization_` instead.
+- KinematicsBase: Deprecated `initialize(robot_description, ...)` in favour of `initialize(robot_model, ...)`.
+  Adapt your kinematics plugin to directly receive a `RobotModel`. See the [KDL plugin](https://github.com/ros-planning/moveit/tree/melodic-devel/moveit_kinematics/kdl_kinematics_plugin) for an example.
 
 ## ROS Kinetic
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,8 @@ API changes in MoveIt! releases
 - The move_group capability ``ExecuteTrajectoryServiceCapability`` has been removed in favor of the improved ``ExecuteTrajectoryActionCapability`` capability. Since Indigo, both capabilities were supported. If you still load default capabilities in your ``config/launch/move_group.launch``, you can just remove them from the capabilities parameter. The correct default capabilities will be loaded automatically.
 - Deprecated method ``CurrentStateMonitor::waitForCurrentState(double wait_time)`` was finally removed.
 - Renamed ``RobotState::getCollisionBodyTransforms`` to ``getCollisionBodyTransform`` as it returns a single transform only.
-- Remove deprecated class MoveGroup (was renamed to MoveGroupInterface).
+- Removed deprecated class MoveGroup (was renamed to MoveGroupInterface).
+- KinematicsBase: Deprecate members tip_frame_, search_discretization_. Use tip_frames_ and redundant_joint_discretization_ instead.
 
 ## ROS Kinetic
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -77,9 +77,9 @@ public:
    *  @brief ROS/KDL based interface for the inverse kinematics of the PR2 arm
    *  @author Sachin Chitta <sachinc@willowgarage.com>
    *
-   *  This class provides a KDL based interface to the inverse kinematics of the PR2 arm. It inherits from the
-   *KDL::ChainIkSolverPos class
-   *  but also exposes additional functionality to return multiple solutions from an inverse kinematics computation.
+   *  This class provides a KDL based interface to the inverse kinematics of the PR2 arm.
+   *  It inherits from the KDL::ChainIkSolverPos class but also exposes additional functionality
+   *  to return multiple solutions from an inverse kinematics computation.
    */
   PR2ArmIKSolver(const urdf::ModelInterface& robot_model, const std::string& root_frame_name,
                  const std::string& tip_frame_name, const double& search_discretization_angle, const int& free_angle);
@@ -134,8 +134,6 @@ public:
    *  @brief Plugin-able interface to the PR2 arm kinematics
    */
   PR2ArmKinematicsPlugin();
-
-  void setRobotModel(urdf::ModelInterfaceSharedPtr& robot_model);
 
   /**
    *  @brief Specifies if the node is active or not
@@ -225,8 +223,9 @@ public:
    * @brief  Initialization function for the kinematics
    * @return True if initialization was successful, false otherwise
    */
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
-                  const std::string& tip_name, double search_discretization) override;
+  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
+                  const std::string& base_frame, const std::vector<std::string>& tip_frames,
+                  double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally
@@ -241,7 +240,6 @@ public:
 protected:
   bool active_;
   int free_angle_;
-  urdf::ModelInterfaceSharedPtr robot_model_;
   pr2_arm_kinematics::PR2ArmIKSolverPtr pr2_arm_ik_solver_;
   std::string root_name_;
   int dimension_;

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -74,17 +74,14 @@ protected:
   void SetUp() override
   {
     robot_model_ = moveit::core::loadTestingRobotModel("pr2_description");
-    urdf::ModelInterfaceSharedPtr urdf = moveit::core::loadModelInterface("pr2_description");
 
     pr2_kinematics_plugin_right_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);
-
-    pr2_kinematics_plugin_right_arm_->setRobotModel(urdf);
-    pr2_kinematics_plugin_right_arm_->initialize("", "right_arm", "torso_lift_link", "r_wrist_roll_link", .01);
+    pr2_kinematics_plugin_right_arm_->initialize(*robot_model_, "right_arm", "torso_lift_link", { "r_wrist_roll_link" },
+                                                 .01);
 
     pr2_kinematics_plugin_left_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);
-
-    pr2_kinematics_plugin_left_arm_->setRobotModel(urdf);
-    pr2_kinematics_plugin_left_arm_->initialize("", "left_arm", "torso_lift_link", "l_wrist_roll_link", .01);
+    pr2_kinematics_plugin_left_arm_->initialize(*robot_model_, "left_arm", "torso_lift_link", { "l_wrist_roll_link" },
+                                                .01);
 
     func_right_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverRightArm, this, _1);
     func_left_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverLeftArm, this, _1);

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -2,6 +2,9 @@ set(MOVEIT_LIB_NAME moveit_kinematics_base)
 
 add_library(${MOVEIT_LIB_NAME} src/kinematics_base.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+# Avoid warnings about deprecated members of KinematicsBase when building KinematicsBase itself.
+# TODO: remove when deperecated variables (tip_frame_, search_discretization_) are finally removed.
+target_compile_options(${MOVEIT_LIB_NAME} PRIVATE -Wno-deprecated-declarations)
 
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -372,7 +372,7 @@ public:
    * @return True if initialization was successful, false otherwise
    *
    * Instead of this method, use the method passing in a RobotModel!
-   * Default implementation returns false, indicating that this API is not supported.
+   * Default implementation forwards to new API.
    */
   MOVEIT_DEPRECATED virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                                             const std::string& base_frame, const std::string& tip_frame,

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -40,7 +40,6 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <moveit_msgs/MoveItErrorCodes.h>
 #include <moveit/macros/class_forward.h>
-#include <moveit/macros/deprecation.h>
 #include <ros/node_handle.h>
 
 #include <boost/function.hpp>
@@ -371,7 +370,6 @@ public:
    *
    * Instead of this method, use the method passing in a RobotModel.
    */
-  MOVEIT_DEPRECATED
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& base_frame, const std::string& tip_frame,
                           double search_discretization) = 0;
@@ -389,7 +387,6 @@ public:
    *
    * Instead of this method, use the method passing in a RobotModel.
    */
-  MOVEIT_DEPRECATED
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& base_frame, const std::vector<std::string>& tip_frames,
                           double search_discretization);

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -372,7 +372,7 @@ public:
    * @return True if initialization was successful, false otherwise
    *
    * Instead of this method, use the method passing in a RobotModel!
-   * Default implementation forwards to new API.
+   * Default implementation returns false, indicating that this API is not supported.
    */
   MOVEIT_DEPRECATED virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                                             const std::string& base_frame, const std::string& tip_frame,

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -75,6 +75,21 @@ void KinematicsBase::setValues(const std::string& robot_description, const std::
     tip_frame_ = removeSlash(tip_frames[0]);
 }
 
+bool KinematicsBase::initialize(const std::string& robot_description, const std::string& group_name,
+                                const std::string& base_frame, const std::vector<std::string>& tip_frames,
+                                double search_discretization)
+{
+  // For IK solvers that do not support multiple tip frames, fall back to single pose call
+  if (tip_frames.size() == 1)
+  {
+    return initialize(robot_description, group_name, base_frame, tip_frames[0], search_discretization);
+  }
+
+  ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support initialization "
+                                     "with more than one tip frames");
+  return false;
+}
+
 bool KinematicsBase::setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices)
 {
   for (std::size_t i = 0; i < redundant_joint_indices.size(); ++i)
@@ -142,7 +157,7 @@ bool KinematicsBase::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_po
 
   if (ik_poses.size() != 1)
   {
-    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support getPositionIK for multiple poses");
+    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support getPositionIK for multiple tips");
     result.kinematic_error = KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -35,9 +35,7 @@
 /* Author: Sachin Chitta, Dave Coleman */
 
 #include <moveit/kinematics_base/kinematics_base.h>
-#include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model/joint_model_group.h>
-#include <moveit/rdf_loader/rdf_loader.h>
 
 static const std::string LOGNAME = "kinematics_base";
 
@@ -97,30 +95,11 @@ void KinematicsBase::setValues(const std::string& robot_description, const std::
   setValues(robot_description, group_name, base_frame, std::vector<std::string>({ tip_frame }), search_discretization);
 }
 
-// fallback implementation, redirecting to new API, passing RobotModel
 bool KinematicsBase::initialize(const std::string& robot_description, const std::string& group_name,
                                 const std::string& base_frame, const std::string& tip_frame,
                                 double search_discretization)
 {
-  ROS_WARN_NAMED(LOGNAME, "Called deprecated initialize() API. Forwarding to new API, passing a RobotModel.");
-
-  rdf_loader::RDFLoader rdf_loader(robot_description);
-  const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
-  const urdf::ModelInterfaceSharedPtr& urdf = rdf_loader.getURDF();
-
-  if (!urdf || !srdf)
-  {
-    ROS_ERROR_NAMED(LOGNAME, "Failed to load URDF or SRDF to initialize IK solver.");
-    return false;
-  }
-
-  moveit::core::RobotModelConstPtr robot_model(new moveit::core::RobotModel(urdf, srdf));
-  if (!initialize(*robot_model, group_name, base_frame, { tip_frame }, search_discretization))
-    return false;
-
-  robot_model_ = robot_model;  // store created robot_model (to free it later)
-  robot_description_ = robot_description;
-  return true;
+  return false;  // default implementation returns false
 }
 
 bool KinematicsBase::initialize(const std::string& robot_description, const std::string& group_name,

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -35,7 +35,9 @@
 /* Author: Sachin Chitta, Dave Coleman */
 
 #include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model/joint_model_group.h>
+#include <moveit/rdf_loader/rdf_loader.h>
 
 static const std::string LOGNAME = "kinematics_base";
 
@@ -95,11 +97,30 @@ void KinematicsBase::setValues(const std::string& robot_description, const std::
   setValues(robot_description, group_name, base_frame, std::vector<std::string>({ tip_frame }), search_discretization);
 }
 
+// fallback implementation, redirecting to new API, passing RobotModel
 bool KinematicsBase::initialize(const std::string& robot_description, const std::string& group_name,
                                 const std::string& base_frame, const std::string& tip_frame,
                                 double search_discretization)
 {
-  return false;  // default implementation returns false
+  ROS_WARN_NAMED(LOGNAME, "Called deprecated initialize() API. Forwarding to new API, passing a RobotModel.");
+
+  rdf_loader::RDFLoader rdf_loader(robot_description);
+  const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf = rdf_loader.getURDF();
+
+  if (!urdf || !srdf)
+  {
+    ROS_ERROR_NAMED(LOGNAME, "Failed to load URDF or SRDF to initialize IK solver.");
+    return false;
+  }
+
+  moveit::core::RobotModelConstPtr robot_model(new moveit::core::RobotModel(urdf, srdf));
+  if (!initialize(*robot_model, group_name, base_frame, { tip_frame }, search_discretization))
+    return false;
+
+  robot_model_ = robot_model;  // store created robot_model (to free it later)
+  robot_description_ = robot_description;
+  return true;
 }
 
 bool KinematicsBase::initialize(const std::string& robot_description, const std::string& group_name,

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -37,6 +37,8 @@
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/robot_model/joint_model_group.h>
 
+static const std::string LOGNAME = "kinematics_base";
+
 namespace kinematics
 {
 const double KinematicsBase::DEFAULT_SEARCH_DISCRETIZATION = 0.1;
@@ -85,8 +87,7 @@ bool KinematicsBase::initialize(const std::string& robot_description, const std:
     return initialize(robot_description, group_name, base_frame, tip_frames[0], search_discretization);
   }
 
-  ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support initialization "
-                                     "with more than one tip frames");
+  ROS_ERROR_NAMED(LOGNAME, "This solver does not support multiple tip frames");
   return false;
 }
 
@@ -157,14 +158,14 @@ bool KinematicsBase::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_po
 
   if (ik_poses.size() != 1)
   {
-    ROS_ERROR_NAMED("kinematics_base", "This kinematic solver does not support getPositionIK for multiple tips");
+    ROS_ERROR_NAMED(LOGNAME, "This kinematic solver does not support getPositionIK for multiple tips");
     result.kinematic_error = KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }
 
   if (ik_poses.empty())
   {
-    ROS_ERROR_NAMED("kinematics_base", "Input ik_poses array is empty");
+    ROS_ERROR_NAMED(LOGNAME, "Input ik_poses array is empty");
     result.kinematic_error = KinematicErrors::EMPTY_TIP_POSES;
     return false;
   }

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -120,7 +120,9 @@ bool KinematicsBase::initialize(const moveit::core::RobotModel& robot_model, con
                                 const std::string& base_frame, const std::vector<std::string>& tip_frames,
                                 double search_discretization)
 {
-  ROS_WARN_NAMED("kinematics_base", "Plugin uses a deprecated API. Please use initialize(RobotModel&).");
+  ROS_WARN_NAMED(LOGNAME, "IK plugin for group '%s' relies on deprecated API. "
+                          "Please implement initialize(RobotModel, ...).",
+                 group_name.c_str());
   return false;
 }
 

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -84,7 +84,6 @@ public:
     void reset()
     {
       solver_instance_.reset();
-      solver_instance_const_.reset();
       bijection_.clear();
     }
 
@@ -97,8 +96,6 @@ public:
        the variable at index
         i in the kinematic solver. */
     std::vector<unsigned int> bijection_;
-
-    kinematics::KinematicsBaseConstPtr solver_instance_const_;
 
     kinematics::KinematicsBasePtr solver_instance_;
 
@@ -526,9 +523,9 @@ public:
 
   void setSolverAllocators(const std::pair<SolverAllocatorFn, SolverAllocatorMapFn>& solvers);
 
-  const kinematics::KinematicsBaseConstPtr& getSolverInstance() const
+  const kinematics::KinematicsBaseConstPtr getSolverInstance() const
   {
-    return group_kinematics_.first.solver_instance_const_;
+    return group_kinematics_.first.solver_instance_;
   }
 
   const kinematics::KinematicsBasePtr& getSolverInstance()

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -594,7 +594,6 @@ void JointModelGroup::setSolverAllocators(const std::pair<SolverAllocatorFn, Sol
     if (group_kinematics_.first.solver_instance_)
     {
       group_kinematics_.first.solver_instance_->setDefaultTimeout(group_kinematics_.first.default_ik_timeout_);
-      group_kinematics_.first.solver_instance_const_ = group_kinematics_.first.solver_instance_;
       if (!computeIKIndexBijection(group_kinematics_.first.solver_instance_->getJointNames(),
                                    group_kinematics_.first.bijection_))
         group_kinematics_.first.reset();
@@ -608,7 +607,6 @@ void JointModelGroup::setSolverAllocators(const std::pair<SolverAllocatorFn, Sol
         KinematicsSolver& ks = group_kinematics_.second[it->first];
         ks.allocator_ = it->second;
         ks.solver_instance_ = const_cast<JointModelGroup*>(it->first)->getSolverInstance();
-        ks.solver_instance_const_ = ks.solver_instance_;
         ks.default_ik_timeout_ = group_kinematics_.first.default_ik_timeout_;
         ks.default_ik_attempts_ = group_kinematics_.first.default_ik_attempts_;
         if (!computeIKIndexBijection(ks.solver_instance_->getJointNames(), ks.bijection_))

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -50,18 +50,9 @@ CachedIKKinematicsPlugin<KinematicsPlugin>::~CachedIKKinematicsPlugin()
 }
 
 template <class KinematicsPlugin>
-bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& robot_description,
-                                                            const std::string& group_name,
-                                                            const std::string& base_frame, const std::string& tip_frame,
-                                                            double search_discretization)
+void CachedIKKinematicsPlugin<KinematicsPlugin>::initCache(const std::string& robot_id, const std::string& group_name,
+                                                           const std::string& cache_name)
 {
-  // call initialize method of wrapped class
-  if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
-  {
-    ROS_ERROR_NAMED("cached_ik", "failed to initialized caching plugin");
-    return false;
-  }
-
   IKCache::Options opts;
   int max_cache_size;  // rosparam can't handle unsigned int
   kinematics::KinematicsBase::lookupParam("max_cache_size", max_cache_size, static_cast<int>(opts.max_cache_size));
@@ -70,14 +61,29 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& r
   kinematics::KinematicsBase::lookupParam("min_joint_config_distance", opts.min_joint_config_distance, 1.0);
   kinematics::KinematicsBase::lookupParam<std::string>("cached_ik_path", opts.cached_ik_path, "");
 
-  cache_.initializeCache(robot_description, group_name, base_frame + tip_frame,
-                         KinematicsPlugin::getJointNames().size(), opts);
+  cache_.initializeCache(robot_id, group_name, cache_name, KinematicsPlugin::getJointNames().size(), opts);
 
   // for debugging purposes:
   // kdl_kinematics_plugin::KDLKinematicsPlugin fk;
   // fk.initialize(robot_description, group_name, base_frame, tip_frame, search_discretization);
   // cache_.verifyCache(fk);
+}
 
+template <class KinematicsPlugin>
+bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const moveit::core::RobotModel& robot_model,
+                                                                    const std::string& group_name,
+                                                                    const std::string& base_frame,
+                                                                    const std::vector<std::string>& tip_frames,
+                                                                    double search_discretization)
+{
+  // call initialize method of wrapped class
+  if (!KinematicsPlugin::initialize(robot_model, group_name, base_frame, tip_frames, search_discretization))
+    return false;
+
+  std::string cache_name = base_frame;
+  std::accumulate(tip_frames.begin(), tip_frames.end(), cache_name);
+  CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.initializeCache(robot_model.getName(), group_name, cache_name,
+                                                                     KinematicsPlugin::getJointNames().size());
   return true;
 }
 
@@ -90,10 +96,7 @@ bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::s
 {
   // call initialize method of wrapped class
   if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames, search_discretization))
-  {
-    ROS_ERROR_NAMED("cached_ik", "failed to initialized caching plugin");
     return false;
-  }
 
   std::string cache_name = base_frame;
   std::accumulate(tip_frames.begin(), tip_frames.end(), cache_name);

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -225,13 +225,13 @@ public:
                   const std::string& base_frame, const std::vector<std::string>& tip_frames,
                   double search_discretization) override
   {
-    return initImpl(robot_model, group_name, base_frame, tip_frames, search_discretization);
+    return initializeImpl(robot_model, group_name, base_frame, tip_frames, search_discretization);
   }
 
   bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
                   const std::string& tip_frame, double search_discretization) override
   {
-    return initImpl(robot_description, group_name, base_frame, tip_frame, search_discretization);
+    return initializeImpl(robot_description, group_name, base_frame, tip_frame, search_discretization);
   }
 
   bool getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
@@ -264,11 +264,12 @@ private:
 
   /* Using templates and SFINAE magic, we can selectively enable/disable methods depending on
      availability of API in wrapped KinematicsPlugin class.
-     However, as templates and virtual functions cannot be combined, we need helpers initImpl(). */
+     However, as templates and virtual functions cannot be combined, we need helpers initializeImpl(). */
   template <class T = KinematicsPlugin>
   typename std::enable_if<hasRobotModelAPI<T>::value, bool>::type
-  initImpl(const moveit::core::RobotModel& robot_model, const std::string& group_name, const std::string& base_frame,
-           const std::vector<std::string>& tip_frames, double search_discretization)
+  initializeImpl(const moveit::core::RobotModel& robot_model, const std::string& group_name,
+                 const std::string& base_frame, const std::vector<std::string>& tip_frames,
+                 double search_discretization)
   {
     if (tip_frames.size() != 1)
     {
@@ -284,17 +285,17 @@ private:
   }
 
   template <class T = KinematicsPlugin>
-  typename std::enable_if<!hasRobotModelAPI<T>::value, bool>::type initImpl(const moveit::core::RobotModel&,
-                                                                            const std::string&, const std::string&,
-                                                                            const std::vector<std::string>&, double)
+  typename std::enable_if<!hasRobotModelAPI<T>::value, bool>::type
+  initializeImpl(const moveit::core::RobotModel&, const std::string&, const std::string&,
+                 const std::vector<std::string>&, double)
   {
     return false;  // API not supported
   }
 
   template <class T = KinematicsPlugin>
   typename std::enable_if<hasRobotDescAPI<T>::value, bool>::type
-  initImpl(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
-           const std::string& tip_frame, double search_discretization)
+  initializeImpl(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
+                 const std::string& tip_frame, double search_discretization)
   {
     // call initialize method of wrapped class
     if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
@@ -304,9 +305,8 @@ private:
   }
 
   template <class T = KinematicsPlugin>
-  typename std::enable_if<!hasRobotDescAPI<T>::value, bool>::type initImpl(const std::string&, const std::string&,
-                                                                           const std::string&, const std::string&,
-                                                                           double)
+  typename std::enable_if<!hasRobotDescAPI<T>::value, bool>::type
+  initializeImpl(const std::string&, const std::string&, const std::string&, const std::string&, double)
   {
     return false;  // API not supported
   }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -60,8 +60,8 @@ IKCache::~IKCache()
     saveCache();
 }
 
-void IKCache::initializeCache(const std::string& robot_description, const std::string& group_name,
-                              const std::string& cache_name, const unsigned int num_joints, Options opts)
+void IKCache::initializeCache(const std::string& robot_id, const std::string& group_name, const std::string& cache_name,
+                              const unsigned int num_joints, Options opts)
 {
   // read ROS parameters
   max_cache_size_ = opts.max_cache_size;
@@ -78,8 +78,8 @@ void IKCache::initializeCache(const std::string& robot_description, const std::s
   // create cache directory if necessary
   boost::filesystem::create_directories(prefix);
 
-  cache_file_name_ = prefix / (robot_description + group_name + "_" + cache_name + "_" +
-                               std::to_string(max_cache_size_) + "_" + std::to_string(min_pose_distance_) + "_" +
+  cache_file_name_ = prefix / (robot_id + group_name + "_" + cache_name + "_" + std::to_string(max_cache_size_) + "_" +
+                               std::to_string(min_pose_distance_) + "_" +
                                std::to_string(std::sqrt(min_config_distance2_)) + ".ikcache");
 
   ik_cache_.clear();

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -105,8 +105,13 @@ public:
   bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
                      std::vector<geometry_msgs::Pose>& poses) const override;
 
+  MOVEIT_DEPRECATED
   bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
                   const std::string& tip_name, double search_discretization) override;
+
+  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
+                  const std::string& base_frame, const std::vector<std::string>& tip_frames,
+                  double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally
@@ -188,16 +193,14 @@ private:
 
   mutable random_numbers::RandomNumberGenerator random_number_generator_;
 
-  robot_model::RobotModelPtr robot_model_;
-
-  robot_state::RobotStatePtr state_, state_2_;
+  robot_state::RobotStatePtr state_;
 
   int num_possible_redundant_joints_;
   std::vector<unsigned int> redundant_joints_map_index_;
 
   // Storage required for when the set of redundant joints is reset
   bool position_ik_;  // whether this solver is only being used for position ik
-  robot_model::JointModelGroup* joint_model_group_;
+  const robot_model::JointModelGroup* joint_model_group_;
   double max_solver_iterations_;
   double epsilon_;
   std::vector<JointMimic> mimic_joints_;

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -105,10 +105,6 @@ public:
   bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
                      std::vector<geometry_msgs::Pose>& poses) const override;
 
-  MOVEIT_DEPRECATED
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
-                  const std::string& tip_name, double search_discretization) override;
-
   bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
                   const std::string& base_frame, const std::vector<std::string>& tip_frames,
                   double search_discretization) override;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -46,8 +46,6 @@
 #include <urdf_model/model.h>
 #include <srdfdom/model.h>
 
-#include <moveit/rdf_loader/rdf_loader.h>
-
 // register KDLKinematics as a KinematicsBase implementation
 CLASS_LOADER_REGISTER_CLASS(kdl_kinematics_plugin::KDLKinematicsPlugin, kinematics::KinematicsBase)
 
@@ -123,29 +121,6 @@ bool KDLKinematicsPlugin::checkConsistency(const KDL::JntArray& seed_state,
   for (std::size_t i = 0; i < dimension_; ++i)
     if (fabs(seed_state(i) - solution(i)) > consistency_limits[i])
       return false;
-  return true;
-}
-
-bool KDLKinematicsPlugin::initialize(const std::string& robot_description, const std::string& group_name,
-                                     const std::string& base_frame, const std::string& tip_frame,
-                                     double search_discretization)
-{
-  rdf_loader::RDFLoader rdf_loader(robot_description);
-  const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
-  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
-
-  if (!urdf_model || !srdf)
-  {
-    ROS_ERROR_NAMED("kdl", "URDF and SRDF must be loaded for KDL kinematics solver to work.");
-    return false;
-  }
-
-  robot_model::RobotModelConstPtr robot_model(new robot_model::RobotModel(urdf_model, srdf));
-  if (!initialize(*robot_model, group_name, base_frame, { tip_frame }, search_discretization))
-    return false;
-
-  robot_model_ = robot_model;  // store created robot_model (to free it later)
-  robot_description_ = robot_description;
   return true;
 }
 

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
@@ -59,7 +59,6 @@
 
 // MoveIt!
 #include <moveit/kinematics_base/kinematics_base.h>
-#include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 
 namespace lma_kinematics_plugin
@@ -106,8 +105,9 @@ public:
   bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
                      std::vector<geometry_msgs::Pose>& poses) const override;
 
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
-                  const std::string& tip_name, double search_discretization) override;
+  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
+                  const std::string& base_frame, const std::vector<std::string>& tip_frames,
+                  double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally
@@ -189,16 +189,14 @@ private:
 
   mutable random_numbers::RandomNumberGenerator random_number_generator_;
 
-  robot_model::RobotModelPtr robot_model_;
-
-  robot_state::RobotStatePtr state_, state_2_;
+  robot_state::RobotStatePtr state_;
 
   int num_possible_redundant_joints_;
   std::vector<unsigned int> redundant_joints_map_index_;
 
   // Storage required for when the set of redundant joints is reset
   bool position_ik_;  // whether this solver is only being used for position ik
-  robot_model::JointModelGroup* joint_model_group_;
+  const robot_model::JointModelGroup* joint_model_group_;
   double max_solver_iterations_;
   double epsilon_;
   std::vector<JointMimic> mimic_joints_;

--- a/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -57,7 +57,6 @@
 
 // MoveIt!
 #include <moveit/kinematics_base/kinematics_base.h>
-#include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 
 namespace srv_kinematics_plugin
@@ -104,16 +103,9 @@ public:
   bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
                      std::vector<geometry_msgs::Pose>& poses) const override;
 
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
-                  const std::string& tip_frame, double search_discretization) override
-  {
-    std::vector<std::string> tip_frames;
-    tip_frames.push_back(tip_frame);
-    return initialize(robot_description, group_name, base_name, tip_frames, search_discretization);
-  }
-
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
-                  const std::vector<std::string>& tip_frames, double search_discretization) override;
+  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
+                  const std::string& base_name, const std::vector<std::string>& tip_frames,
+                  double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally
@@ -158,8 +150,7 @@ private:
 
   unsigned int dimension_; /** Dimension of the group */
 
-  robot_model::RobotModelPtr robot_model_;
-  robot_model::JointModelGroup* joint_model_group_;
+  const robot_model::JointModelGroup* joint_model_group_;
 
   robot_state::RobotStatePtr robot_state_;
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -42,7 +42,6 @@
 #include <srdfdom/model.h>
 
 #include <moveit/robot_state/conversions.h>
-#include <moveit/rdf_loader/rdf_loader.h>
 
 // Eigen
 #include <Eigen/Core>
@@ -57,7 +56,7 @@ SrvKinematicsPlugin::SrvKinematicsPlugin() : active_(false)
 {
 }
 
-bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const std::string& group_name,
+bool SrvKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
                                      const std::string& base_frame, const std::vector<std::string>& tip_frames,
                                      double search_discretization)
 {
@@ -65,20 +64,7 @@ bool SrvKinematicsPlugin::initialize(const std::string& robot_description, const
 
   ROS_INFO_STREAM_NAMED("srv", "SrvKinematicsPlugin initializing");
 
-  setValues(robot_description, group_name, base_frame, tip_frames, search_discretization);
-
-  rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
-  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
-
-  if (!urdf_model || !srdf)
-  {
-    ROS_ERROR_NAMED("srv", "URDF and SRDF must be loaded for SRV kinematics solver to work.");  // TODO: is this true?
-    return false;
-  }
-
-  robot_model_.reset(new robot_model::RobotModel(urdf_model, srdf));
-
+  storeValues(robot_model, group_name, base_frame, tip_frames, search_discretization);
   joint_model_group_ = robot_model_->getJointModelGroup(group_name);
   if (!joint_model_group_)
     return false;

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -242,9 +242,8 @@ private:
   std::map<const robot_model::JointModelGroup*, std::vector<kinematics::KinematicsBasePtr> > instances_;
   boost::mutex lock_;
 };
-}
 
-void kinematics_plugin_loader::KinematicsPluginLoader::status() const
+void KinematicsPluginLoader::status() const
 {
   if (loader_)
     loader_->status();
@@ -252,7 +251,7 @@ void kinematics_plugin_loader::KinematicsPluginLoader::status() const
     ROS_INFO("Loader function was never required");
 }
 
-robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader::getLoaderFunction()
+robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction()
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction");
@@ -266,8 +265,7 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
   return getLoaderFunction(rml.getSRDF());
 }
 
-robot_model::SolverAllocatorFn
-kinematics_plugin_loader::KinematicsPluginLoader::getLoaderFunction(const srdf::ModelSharedPtr& srdf_model)
+robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const srdf::ModelSharedPtr& srdf_model)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction(SRDF)");
@@ -450,4 +448,5 @@ kinematics_plugin_loader::KinematicsPluginLoader::getLoaderFunction(const srdf::
   }
 
   return boost::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(), _1);
+}
 }

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -163,7 +163,10 @@ public:
                 double search_res =
                     search_res_.find(jmg->getName())->second[i];  // we know this exists, by construction
 
-                if (!result->initialize(robot_description_, jmg->getName(),
+                if (!result->initialize(jmg->getParentModel(), jmg->getName(),
+                                        (base.empty() || base[0] != '/') ? base : base.substr(1), tips, search_res) &&
+                    // on failure: fallback to old method (TODO: remove in future)
+                    !result->initialize(robot_description_, jmg->getName(),
                                         (base.empty() || base[0] != '/') ? base : base.substr(1), tips, search_res))
                 {
                   ROS_ERROR("Kinematics solver of type '%s' could not be initialized for group '%s'",
@@ -257,8 +260,7 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction()
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction");
 
   if (loader_)
-    return boost::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(),
-                       _1);
+    return boost::bind(&KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(), _1);
 
   rdf_loader::RDFLoader rml(robot_description_);
   robot_description_ = rml.getRobotDescription();


### PR DESCRIPTION
This is an alternative implemenation of #150 and #1153 to directly pass a RobotModel (RM) to kinematics plugins, thus
1) saving some loading time by reusing the `RobotModel` (particularly if there are dozens of groups)
2) ensuring a consistent RM (particularly, joint limits) is used throughout the code

#150 eventually got stuck due to circular reference of `RobotModelPtr` as detailed in https://github.com/ros-planning/moveit/pull/150#issuecomment-433106660.
To avoid/break this circular reference #1153 transferred ownership of KinematicSolvers (KS) from JointModelGroup (JMG) to KinematicsPluginLoader (KPL) / RobotModelLoader (RML). While this works, I think this is an evil hack. Ownership definitely belongs to JMG. This already becomes obvious from the fact that a RM with JMGs can (theoretically) exist without a KPL.

In this PR, ownership stays with JMGs. To break the circular reference, the RM is passed as reference to the KS. There, in contrast to #150, a new shared_ptr is created from the raw pointer, thus performing its own use counting. This way we decouple the use of the RM within the external KS from MoveIt. MoveIt just ensures that the RM is alive as long as the KS is. The KinematicsBase destructor could even check that the decoupled shared_ptr was correctly released by KS (and issue a warning if not).

To allow a smooth migration path, KS implementations should be able to choose which API for `initialize()` to implement. This is not (yet) considered in #1153. Here, KPL first tries the new API and - on failure - the old API. KinematicsBase provides default implementations for them, returning false, i.e. indicating failure.

Adaptation of CachedIK was a little bit tricky: This one wraps an arbitrary other KS. To relay `initialize()` calls of the wrapper to the available implementation(s) of the wrapped KS, I use SFINAE magic. This works for KDL IK, which already has the old API removed.

**Please, keep commit history when merging!**