### PR TITLE
Add tf dependency to package.xml

### DIFF
--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -25,6 +25,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>angles</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>tf</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_eigen</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
@@ -38,6 +39,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>angles</run_depend>
+  <run_depend>tf</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_eigen</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>


### PR DESCRIPTION
### Description

[chomp_optimizer_adapter.cpp](https://github.com/ros-planning/moveit/blob/melodic-devel/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp#L51) still requires tf, and will not compile on the build farm without it.

Here's a link to a failing binary build: http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__moveit_ros_planning__ubuntu_bionic_amd64__binary/20/consoleFull

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
