### PR TITLE
remove left-over tf artifacts

### DIFF
--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -28,7 +28,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>shape_msgs</run_depend>
-  <run_depend>tf2</run_depend>
+  <run_depend>tf</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>moveit_resources</test_depend>

--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -28,7 +28,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>shape_msgs</run_depend>
-  <run_depend>tf</run_depend>
+  <run_depend>tf2</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>moveit_resources</test_depend>

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -48,8 +48,6 @@
 
 #include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
 
-#include <tf/transform_listener.h>
-
 #include <moveit/robot_state/conversions.h>
 
 #include <vector>

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1068,7 +1068,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
   {
     const srdf::Model::VirtualJoint& vj = config_data_->srdf_->virtual_joints_[i];
     if (vj.type_ != "fixed")
-      vjb << "  <node pkg=\"tf\" type=\"static_transform_publisher\" name=\"virtual_joint_broadcaster_" << i
+      vjb << "  <node pkg=\"tf2_ros\" type=\"static_transform_publisher\" name=\"virtual_joint_broadcaster_" << i
           << "\" args=\"0 0 0 0 0 0 " << vj.parent_frame_ << " " << vj.child_link_ << " 100\" />" << std::endl;
   }
   addTemplateString("[VIRTUAL_JOINT_BROADCASTER]", vjb.str());

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -24,6 +24,7 @@
   <run_depend>moveit_setup_assistant</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>xacro</run_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->


### PR DESCRIPTION
Alternative fix of Melodic release build (instead of #1169).
Remove all left-over tf1 stuff:
```
$ grep -r "<tf/" .
./moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp:#include <tf/transform_listener.h>

$ grep -r ">tf[^2]" .
./moveit_commander/package.xml:  <run_depend>tf</run_depend>
```
