### PR TITLE
Remove --inorder default argument in setup assistant

### DIFF
--- a/moveit_planners/chomp/chomp_interface/test/rrbot_move_group.launch
+++ b/moveit_planners/chomp/chomp_interface/test/rrbot_move_group.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find moveit_planners_chomp)/test/rrbot.xacro'"/>
+  <param name="$(arg robot_description)" command="$(find xacro)/xacro '$(find moveit_planners_chomp)/test/rrbot.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find moveit_planners_chomp)/test/rrbot.srdf" />

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -127,7 +127,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
                              "optional xacro arguments:", this, true);  // directory
   // user needs to select option before this is shown
   stack_path_->hide();
-  stack_path_->setArgs("--inorder ");
+  stack_path_->setArgs("");
   connect(stack_path_, SIGNAL(pathChanged(QString)), this, SLOT(onPackagePathChanged(QString)));
   left_layout->addWidget(stack_path_);
 
@@ -138,7 +138,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, moveit_setup_assistant::Mo
                                       "optional xacro arguments:", this, false, true);  // no directory, load only
   // user needs to select option before this is shown
   urdf_file_->hide();
-  urdf_file_->setArgs("--inorder ");
+  urdf_file_->setArgs("");
   connect(urdf_file_, SIGNAL(pathChanged(QString)), this, SLOT(onUrdfPathChanged(QString)));
   left_layout->addWidget(urdf_file_);
 


### PR DESCRIPTION
### Description
The MoveIt setup assistant has the `optional xacro arguments` field set up to `--inorder` by default. As of Melodic specifying `--inorder` is not needed anymore and leads to warnings when reading the launch files.

This PR removes this default argument.
Do not cherry-pick this to any other branch.

![screenshot_20181030_101423](https://user-images.githubusercontent.com/5566160/47707636-9cac2800-dc2c-11e8-8afd-6eb304c4e339.png)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] ~~Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)~~
- [x] Include a screenshot if changing a GUI
- [x] ~~Document API changes relevant to the user in the moveit/MIGRATION.md notes~~
- [x] ~~Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)~~
- [x] Decide if this should be cherry-picked to other current ROS branches
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers