### PR TITLE
MSA: support dark themes

### DIFF
--- a/moveit_setup_assistant/src/tools/rotated_header_view.cpp
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.cpp
@@ -36,7 +36,6 @@
 
 #include "rotated_header_view.h"
 #include <QPainter>
-#include <QDebug>
 
 namespace moveit_setup_assistant
 {
@@ -125,7 +124,6 @@ int RotatedHeaderView::sectionSizeHint(int logicalIndex) const
   else
     size = sectionSizeFromContents(logicalIndex);
   int hint = size.height();
-  qDebug() << logicalIndex << size << hint;
   return qMax(minimumSectionSize(), hint);
 }
 }

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -150,8 +150,8 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
     painter->setPen(palette.color(QPalette::Button));
     painter->drawLine(option.rect.topLeft(), option.rect.topRight());
     painter->setPen(palette.color(QPalette::Light));
-    const QPoint offset(0,1);
-    painter->drawLine(option.rect.topLeft()+offset, option.rect.topRight()+offset);
+    const QPoint offset(0, 1);
+    painter->drawLine(option.rect.topLeft() + offset, option.rect.topRight() + offset);
   }
 
   QRect textRect(option.rect.x() + 10, option.rect.y(), option.rect.width() - 10, option.rect.height());

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -36,7 +36,6 @@
 
 #include "navigation_widget.h"
 #include <QApplication>
-#include <QDebug>
 #include <iostream>
 
 namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -35,6 +35,7 @@
 /* Author: Dave Coleman */
 
 #include "navigation_widget.h"
+#include <QApplication>
 #include <QDebug>
 #include <iostream>
 
@@ -134,54 +135,44 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
                                      QPoint(option.rect.x(), option.rect.y() + option.rect.height()));
   if (isSelected)
   {
-    backgroundGradient.setColorAt(0, QColor(109, 164, 219));
-    backgroundGradient.setColorAt(1, QColor(61, 138, 212));
+    backgroundGradient.setColorAt(0, QApplication::palette().color(QPalette::Highlight).lighter(125));
+    backgroundGradient.setColorAt(1, QApplication::palette().color(QPalette::Highlight));
     painter->fillRect(option.rect, QBrush(backgroundGradient));
   }
   else
   {
-    backgroundGradient.setColorAt(0, QColor(245, 245, 245));
-    backgroundGradient.setColorAt(1, QColor(240, 240, 240));
+    backgroundGradient.setColorAt(0, QApplication::palette().color(QPalette::Light));
+    backgroundGradient.setColorAt(1, QApplication::palette().color(QPalette::Button));
     painter->fillRect(option.rect, QBrush(backgroundGradient));
   }
 
-  painter->setPen(QColor(225, 225, 225));
+  painter->setPen(QApplication::palette().color(QPalette::Button));
   if (isSelected)
   {
-    painter->setPen(QColor(37, 105, 169));
+    painter->setPen(QApplication::palette().color(QPalette::Mid));
     painter->drawLine(option.rect.bottomLeft(), option.rect.bottomRight());
     painter->setPen(Qt::transparent);
   }
   painter->drawLine(option.rect.topLeft(), option.rect.topRight());
   if (!isSelected)
   {
-    painter->setPen(QColor(248, 248, 248));
+    painter->setPen(QApplication::palette().color(QPalette::Light));
     painter->drawLine(QPoint(option.rect.x(), option.rect.y() + 1),
                       QPoint(option.rect.x() + option.rect.width(), option.rect.y() + 1));
   }
 
   QRect textRect(option.rect.x() + 10, option.rect.y(), option.rect.width() - 10, option.rect.height());
-
   QFont textFont(painter->font());
   textFont.setPixelSize(14);  // Set font size
   painter->setFont(textFont);
 
   // Font color
   if (isSelected)
-  {
-    // Selected
-    painter->setPen(QColor(229, 229, 229));
-  }
-  else if (index.flags().testFlag(Qt::NoItemFlags))
-  {
-    // Disabled font color if disabled
-    painter->setPen(QColor(170, 170, 170));  // TODO: make this work
-  }
+    painter->setPen(QApplication::palette().color(QPalette::HighlightedText));
+  else if (!option.state.testFlag(QStyle::State_Enabled))
+    painter->setPen(QApplication::palette().color(QPalette::Dark));
   else
-  {
-    // Normal
-    painter->setPen(QColor(69, 69, 69));
-  }
+    painter->setPen(QApplication::palette().color(QPalette::ButtonText));
 
   painter->drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter, nav_name);
 

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -141,7 +141,7 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
   else
   {
     backgroundGradient.setColorAt(0, palette.color(QPalette::Light));
-    backgroundGradient.setColorAt(1, palette.color(QPalette::Light).darker(125));
+    backgroundGradient.setColorAt(1, palette.color(QPalette::Light).darker(105));
     painter->fillRect(option.rect, QBrush(backgroundGradient));
   }
 

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -142,7 +142,7 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
   else
   {
     backgroundGradient.setColorAt(0, palette.color(QPalette::Light));
-    backgroundGradient.setColorAt(1, palette.color(QPalette::Button));
+    backgroundGradient.setColorAt(1, palette.color(QPalette::Light).darker(125));
     painter->fillRect(option.rect, QBrush(backgroundGradient));
   }
 

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -125,40 +125,34 @@ QSize NavDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelInde
 void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
   const bool isSelected = option.state & QStyle::State_Selected;
+  const QPalette& palette = QApplication::palette();
 
-  // NavScreen tp = index.data().value<NavScreen>();
-  QString nav_name = index.data().value<QString>();
+  QString nav_name = displayText(index.data(), option.locale);
 
   painter->save();
 
-  QLinearGradient backgroundGradient(QPoint(option.rect.x(), option.rect.y()),
-                                     QPoint(option.rect.x(), option.rect.y() + option.rect.height()));
+  // draw background gradient
+  QLinearGradient backgroundGradient(option.rect.topLeft(), option.rect.bottomLeft());
   if (isSelected)
   {
-    backgroundGradient.setColorAt(0, QApplication::palette().color(QPalette::Highlight).lighter(125));
-    backgroundGradient.setColorAt(1, QApplication::palette().color(QPalette::Highlight));
+    backgroundGradient.setColorAt(0, palette.color(QPalette::Highlight).lighter(125));
+    backgroundGradient.setColorAt(1, palette.color(QPalette::Highlight));
     painter->fillRect(option.rect, QBrush(backgroundGradient));
   }
   else
   {
-    backgroundGradient.setColorAt(0, QApplication::palette().color(QPalette::Light));
-    backgroundGradient.setColorAt(1, QApplication::palette().color(QPalette::Button));
+    backgroundGradient.setColorAt(0, palette.color(QPalette::Light));
+    backgroundGradient.setColorAt(1, palette.color(QPalette::Button));
     painter->fillRect(option.rect, QBrush(backgroundGradient));
   }
 
-  painter->setPen(QApplication::palette().color(QPalette::Button));
-  if (isSelected)
+  if (!isSelected)  // draw shadow
   {
-    painter->setPen(QApplication::palette().color(QPalette::Mid));
-    painter->drawLine(option.rect.bottomLeft(), option.rect.bottomRight());
-    painter->setPen(Qt::transparent);
-  }
-  painter->drawLine(option.rect.topLeft(), option.rect.topRight());
-  if (!isSelected)
-  {
-    painter->setPen(QApplication::palette().color(QPalette::Light));
-    painter->drawLine(QPoint(option.rect.x(), option.rect.y() + 1),
-                      QPoint(option.rect.x() + option.rect.width(), option.rect.y() + 1));
+    painter->setPen(palette.color(QPalette::Button));
+    painter->drawLine(option.rect.topLeft(), option.rect.topRight());
+    painter->setPen(palette.color(QPalette::Light));
+    const QPoint offset(0,1);
+    painter->drawLine(option.rect.topLeft()+offset, option.rect.topRight()+offset);
   }
 
   QRect textRect(option.rect.x() + 10, option.rect.y(), option.rect.width() - 10, option.rect.height());
@@ -168,11 +162,11 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
 
   // Font color
   if (isSelected)
-    painter->setPen(QApplication::palette().color(QPalette::HighlightedText));
+    painter->setPen(palette.color(QPalette::HighlightedText));
   else if (!option.state.testFlag(QStyle::State_Enabled))
-    painter->setPen(QApplication::palette().color(QPalette::Dark));
+    painter->setPen(palette.color(QPalette::Dark));
   else
-    painter->setPen(QApplication::palette().color(QPalette::ButtonText));
+    painter->setPen(palette.color(QPalette::ButtonText));
 
   painter->drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter, nav_name);
 

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -943,7 +943,7 @@ void PlanningGroupsWidget::saveChainScreen()
 
     for (std::vector<std::string>::const_iterator link_it = links.begin(); link_it != links.end(); ++link_it)
     {
-      // Check if string matches either of user specefied links
+      // Check if string matches either of user specified links
       if (link_it->compare(tip) == 0)  // they are same
         found_tip = true;
       else if (link_it->compare(base) == 0)  // they are same

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -41,7 +41,6 @@
 #include <QStackedLayout>
 #include <QListWidget>
 #include <QListWidgetItem>
-#include <QDebug>
 #include <QFont>
 #include <QLabel>
 #include <QPushButton>

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -822,24 +822,15 @@ SelectModeWidget::SelectModeWidget(QWidget* parent) : QFrame(parent)
   layout->setAlignment(widget_title, Qt::AlignTop);
 
   // Widget Instructions
-  widget_instructions_ = new QTextEdit(this);
+  widget_instructions_ = new QLabel(this);
+  widget_instructions_->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+  widget_instructions_->setWordWrap(true);
+  widget_instructions_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   widget_instructions_->setText(
       "All settings for MoveIt! are stored in the MoveIt! configuration package. Here you have "
       "the option to create a new configuration package or load an existing one. Note: "
       "changes to a MoveIt! configuration package outside this Setup Assistant are likely to be "
       "overwritten by this tool.");
-
-  // Change color of TextEdit
-  QPalette p = widget_instructions_->palette();
-  p.setColor(QPalette::Active, QPalette::Base, this->palette().color(QWidget::backgroundRole()));
-  p.setColor(QPalette::Inactive, QPalette::Base, this->palette().color(QWidget::backgroundRole()));
-  widget_instructions_->setPalette(p);
-
-  // Make TextEdit behave like QLabel
-  widget_instructions_->setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
-  widget_instructions_->setReadOnly(true);
-  widget_instructions_->setFrameShape(QFrame::NoFrame);
-  widget_instructions_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
   layout->addWidget(widget_instructions_);
   layout->setAlignment(widget_instructions_, Qt::AlignTop);

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -455,7 +455,7 @@ bool StartScreenWidget::loadNewFiles()
   // Check that box is filled out
   if (config_data_->urdf_path_.empty())
   {
-    QMessageBox::warning(this, "Error Loading Files", "No robot model file specefied");
+    QMessageBox::warning(this, "Error Loading Files", "No robot model file specified");
     return false;
   }
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -187,7 +187,7 @@ public:
   // Load file button
   QPushButton* btn_new_;
   QPushButton* btn_exist_;
-  QTextEdit* widget_instructions_;
+  QLabel* widget_instructions_;
 };
 }
 


### PR DESCRIPTION
### Description

- GUI change only. This improves the `NavigationWidget` in the Setup Assistant for dark themes, ~~without changing anything when using a white theme~~.
- Can be cherry-picked but it is not necessary.
- Tested with Kubuntu 18.04.

~~The detection of a dark/white theme is done by comparing the luminance value of the widgets background color.~~ QPalette colors are used so that colors always match.

# Before
## White theme
![before_white](https://user-images.githubusercontent.com/5566160/47720715-d3933580-dc4e-11e8-8876-0fe2230bcf7b.png)

## Dark theme
![before_dark](https://user-images.githubusercontent.com/5566160/47720723-d8f08000-dc4e-11e8-90dc-8dd51768b14a.png)

# After (see updated images in the discussion)
## White theme
[after_white](https://user-images.githubusercontent.com/5566160/47720735-e0b02480-dc4e-11e8-8f8c-eb0739396d1c.png)

## Dark theme
[after_dark](https://user-images.githubusercontent.com/5566160/47720741-e443ab80-dc4e-11e8-919c-d9d35b293e0f.png)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] ~~Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)~~
- [x] Include a screenshot if changing a GUI
- [x] ~~Document API changes relevant to the user in the moveit/MIGRATION.md notes~~
- [x] ~~Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)~~
- [x] Decide if this should be cherry-picked to other current ROS branches
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
