### PR TITLE
A spurious dependency on eigen_msgs is causing OMPL to fail to build.

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -46,7 +46,6 @@
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/profiler/profiler.h>
 #include <moveit/utils/lexical_casts.h>
-#include <eigen_conversions/eigen_msg.h>
 
 #include <ompl/base/samplers/UniformValidStateSampler.h>
 #include <ompl/base/goals/GoalLazySamples.h>


### PR DESCRIPTION
### Description

Remove a spurious dependency on `eigen_conversions/eigen_msgs.h` in model_based_planning_context.cpp; as far as I can tell, it is not necessary, and is causing the build to fail on the Melodic build farm: http://build.ros.org/job/Mbin_uB64__moveit_planners_ompl__ubuntu_bionic_amd64__binary/17/console

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
