### PR TITLE
Cleanup Variable Names and Logging

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_robot_allvalid.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_robot_allvalid.h
@@ -44,7 +44,7 @@ namespace collision_detection
 class CollisionRobotAllValid : public CollisionRobot
 {
 public:
-  CollisionRobotAllValid(const robot_model::RobotModelConstPtr& kmodel, double padding = 0.0, double scale = 1.0);
+  CollisionRobotAllValid(const robot_model::RobotModelConstPtr& robot_model, double padding = 0.0, double scale = 1.0);
   CollisionRobotAllValid(const CollisionRobot& other);
 
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -248,10 +248,10 @@ struct DistanceRequest
   }
 
   /// Compute \e active_components_only_ based on \e req_
-  void enableGroup(const robot_model::RobotModelConstPtr& kmodel)
+  void enableGroup(const robot_model::RobotModelConstPtr& robot_model)
   {
-    if (kmodel->hasJointModelGroup(group_name))
-      active_components_only = &kmodel->getJointModelGroup(group_name)->getUpdatedLinkModelsSet();
+    if (robot_model->hasJointModelGroup(group_name))
+      active_components_only = &robot_model->getJointModelGroup(group_name)->getUpdatedLinkModelsSet();
     else
       active_components_only = nullptr;
   }

--- a/moveit_core/collision_detection/src/allvalid/collision_robot_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_robot_allvalid.cpp
@@ -36,9 +36,9 @@
 
 #include <moveit/collision_detection/allvalid/collision_robot_allvalid.h>
 
-collision_detection::CollisionRobotAllValid::CollisionRobotAllValid(const robot_model::RobotModelConstPtr& kmodel,
+collision_detection::CollisionRobotAllValid::CollisionRobotAllValid(const robot_model::RobotModelConstPtr& robot_model,
                                                                     double padding, double scale)
-  : CollisionRobot(kmodel, padding, scale)
+  : CollisionRobot(robot_model, padding, scale)
 {
 }
 

--- a/moveit_core/collision_detection/test/test_all_valid.cpp
+++ b/moveit_core/collision_detection/test/test_all_valid.cpp
@@ -49,9 +49,9 @@ TEST(AllValid, Instantiate)
   urdf_model.reset(new urdf::ModelInterface());
   srdf::ModelConstSharedPtr srdf_model;
   srdf_model.reset(new srdf::Model());
-  robot_model::RobotModelConstPtr kmodel;
-  kmodel.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  CollisionRobotAllValid robot(kmodel);
+  robot_model::RobotModelConstPtr robot_model;
+  robot_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
+  CollisionRobotAllValid robot(robot_model);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -129,7 +129,7 @@ struct CollisionData
   }
 
   /// Compute \e active_components_only_ based on \e req_
-  void enableGroup(const robot_model::RobotModelConstPtr& kmodel);
+  void enableGroup(const robot_model::RobotModelConstPtr& robot_model);
 
   /// The collision request passed by the user
   const CollisionRequest* req_;

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_robot_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_robot_fcl.h
@@ -46,7 +46,7 @@ class CollisionRobotFCL : public CollisionRobot
   friend class CollisionWorldFCL;
 
 public:
-  CollisionRobotFCL(const robot_model::RobotModelConstPtr& kmodel, double padding = 0.0, double scale = 1.0);
+  CollisionRobotFCL(const robot_model::RobotModelConstPtr& robot_model, double padding = 0.0, double scale = 1.0);
 
   CollisionRobotFCL(const CollisionRobotFCL& other);
 

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -899,10 +899,10 @@ void cleanCollisionGeometryCache()
 }
 }
 
-void collision_detection::CollisionData::enableGroup(const robot_model::RobotModelConstPtr& kmodel)
+void collision_detection::CollisionData::enableGroup(const robot_model::RobotModelConstPtr& robot_model)
 {
-  if (kmodel->hasJointModelGroup(req_->group_name))
-    active_components_only_ = &kmodel->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsSet();
+  if (robot_model->hasJointModelGroup(req_->group_name))
+    active_components_only_ = &robot_model->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsSet();
   else
     active_components_only_ = nullptr;
 }

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -87,11 +87,11 @@ protected:
     }
     srdf_ok_ = srdf_model_->initFile(*urdf_model_, srdf_file);
 
-    kmodel_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
+    robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
 
-    acm_.reset(new collision_detection::AllowedCollisionMatrix(kmodel_->getLinkModelNames(), true));
+    acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-    crobot_.reset(new DefaultCRobotType(kmodel_));
+    crobot_.reset(new DefaultCRobotType(robot_model_));
     cworld_.reset(new DefaultCWorldType());
   }
 
@@ -106,7 +106,7 @@ protected:
   urdf::ModelInterfaceSharedPtr urdf_model_;
   srdf::ModelSharedPtr srdf_model_;
 
-  robot_model::RobotModelPtr kmodel_;
+  robot_model::RobotModelPtr robot_model_;
 
   collision_detection::CollisionRobotPtr crobot_;
   collision_detection::CollisionWorldPtr cworld_;
@@ -124,7 +124,7 @@ TEST_F(FclCollisionDetectionTester, InitOK)
 
 TEST_F(FclCollisionDetectionTester, DefaultNotInCollision)
 {
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -143,7 +143,7 @@ TEST_F(FclCollisionDetectionTester, LinksInCollision)
   // req.contacts = true;
   // req.max_contacts = 100;
 
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -182,7 +182,7 @@ TEST_F(FclCollisionDetectionTester, ContactReporting)
   req.contacts = true;
   req.max_contacts = 1;
 
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -223,7 +223,7 @@ TEST_F(FclCollisionDetectionTester, ContactReporting)
 
   req.max_contacts = 10;
   req.max_contacts_per_pair = 2;
-  acm_.reset(new collision_detection::AllowedCollisionMatrix(kmodel_->getLinkModelNames(), false));
+  acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), false));
   crobot_->checkSelfCollision(req, res, kstate, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_LE(res.contacts.size(), 10u);
@@ -236,7 +236,7 @@ TEST_F(FclCollisionDetectionTester, ContactPositions)
   req.contacts = true;
   req.max_contacts = 1;
 
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -304,9 +304,9 @@ TEST_F(FclCollisionDetectionTester, AttachedBodyTester)
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
 
-  acm_.reset(new collision_detection::AllowedCollisionMatrix(kmodel_->getLinkModelNames(), true));
+  acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -369,7 +369,7 @@ TEST_F(FclCollisionDetectionTester, AttachedBodyTester)
 
 TEST_F(FclCollisionDetectionTester, DiffSceneTester)
 {
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -433,7 +433,7 @@ TEST_F(FclCollisionDetectionTester, ConvertObjectToAttached)
 
   cworld_->getWorld()->addToObject("kinect", shape, pos1);
 
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
   kstate.update();
 
@@ -449,8 +449,8 @@ TEST_F(FclCollisionDetectionTester, ConvertObjectToAttached)
   collision_detection::CollisionWorld::ObjectConstPtr object = cworld_->getWorld()->getObject("kinect");
   cworld_->getWorld()->removeObject("kinect");
 
-  robot_state::RobotState kstate1(kmodel_);
-  robot_state::RobotState kstate2(kmodel_);
+  robot_state::RobotState kstate1(robot_model_);
+  robot_state::RobotState kstate2(robot_model_);
   kstate1.setToDefaultValues();
   kstate2.setToDefaultValues();
   kstate1.update();
@@ -504,7 +504,7 @@ TEST_F(FclCollisionDetectionTester, TestCollisionMapAdditionSpeed)
 
 TEST_F(FclCollisionDetectionTester, MoveMesh)
 {
-  robot_state::RobotState kstate1(kmodel_);
+  robot_state::RobotState kstate1(robot_model_);
   kstate1.setToDefaultValues();
   kstate1.update();
 
@@ -528,7 +528,7 @@ TEST_F(FclCollisionDetectionTester, MoveMesh)
 
 TEST_F(FclCollisionDetectionTester, TestChangingShapeSize)
 {
-  robot_state::RobotState kstate1(kmodel_);
+  robot_state::RobotState kstate1(robot_model_);
   kstate1.setToDefaultValues();
   kstate1.update();
 

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -124,13 +124,13 @@ TEST_F(FclCollisionDetectionTester, InitOK)
 
 TEST_F(FclCollisionDetectionTester, DefaultNotInCollision)
 {
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_FALSE(res.collision);
 }
 
@@ -143,36 +143,36 @@ TEST_F(FclCollisionDetectionTester, LinksInCollision)
   // req.contacts = true;
   // req.max_contacts = 100;
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   Eigen::Affine3d offset = Eigen::Affine3d::Identity();
   offset.translation().x() = .01;
 
-  //  kstate.getLinkState("base_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
-  //  kstate.getLinkState("base_bellow_link")->updateGivenGlobalLinkTransform(offset);
-  kstate.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("base_bellow_link", offset);
-  kstate.update();
+  //  robot_state.getLinkState("base_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
+  //  robot_state.getLinkState("base_bellow_link")->updateGivenGlobalLinkTransform(offset);
+  robot_state.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("base_bellow_link", offset);
+  robot_state.update();
 
   acm_->setEntry("base_link", "base_bellow_link", false);
-  crobot_->checkSelfCollision(req, res1, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res1, robot_state, *acm_);
   ASSERT_TRUE(res1.collision);
 
   acm_->setEntry("base_link", "base_bellow_link", true);
-  crobot_->checkSelfCollision(req, res2, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res2, robot_state, *acm_);
   ASSERT_FALSE(res2.collision);
 
   //  req.verbose = true;
-  //  kstate.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
-  //  kstate.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(offset);
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", offset);
-  kstate.update();
+  //  robot_state.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
+  //  robot_state.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(offset);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", offset);
+  robot_state.update();
 
   acm_->setEntry("r_gripper_palm_link", "l_gripper_palm_link", false);
-  crobot_->checkSelfCollision(req, res3, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res3, robot_state, *acm_);
   ASSERT_TRUE(res3.collision);
 }
 
@@ -182,29 +182,29 @@ TEST_F(FclCollisionDetectionTester, ContactReporting)
   req.contacts = true;
   req.max_contacts = 1;
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   Eigen::Affine3d offset = Eigen::Affine3d::Identity();
   offset.translation().x() = .01;
 
-  //  kstate.getLinkState("base_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
-  //  kstate.getLinkState("base_bellow_link")->updateGivenGlobalLinkTransform(offset);
-  //  kstate.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
-  //  kstate.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(offset);
+  //  robot_state.getLinkState("base_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
+  //  robot_state.getLinkState("base_bellow_link")->updateGivenGlobalLinkTransform(offset);
+  //  robot_state.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(Eigen::Affine3d::Identity());
+  //  robot_state.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(offset);
 
-  kstate.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("base_bellow_link", offset);
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", offset);
-  kstate.update();
+  robot_state.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("base_bellow_link", offset);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", offset);
+  robot_state.update();
 
   acm_->setEntry("base_link", "base_bellow_link", false);
   acm_->setEntry("r_gripper_palm_link", "l_gripper_palm_link", false);
 
   collision_detection::CollisionResult res;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_EQ(res.contacts.size(), 1u);
   EXPECT_EQ(res.contacts.begin()->second.size(), 1u);
@@ -213,7 +213,7 @@ TEST_F(FclCollisionDetectionTester, ContactReporting)
   req.max_contacts = 2;
   req.max_contacts_per_pair = 1;
   //  req.verbose = true;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_EQ(res.contacts.size(), 2u);
   EXPECT_EQ(res.contacts.begin()->second.size(), 1u);
@@ -224,7 +224,7 @@ TEST_F(FclCollisionDetectionTester, ContactReporting)
   req.max_contacts = 10;
   req.max_contacts_per_pair = 2;
   acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), false));
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_LE(res.contacts.size(), 10u);
   EXPECT_LE(res.contact_count, 10u);
@@ -236,9 +236,9 @@ TEST_F(FclCollisionDetectionTester, ContactPositions)
   req.contacts = true;
   req.max_contacts = 1;
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   Eigen::Affine3d pos1 = Eigen::Affine3d::Identity();
   Eigen::Affine3d pos2 = Eigen::Affine3d::Identity();
@@ -246,16 +246,16 @@ TEST_F(FclCollisionDetectionTester, ContactPositions)
   pos1.translation().x() = 5.0;
   pos2.translation().x() = 5.01;
 
-  //  kstate.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
-  //  kstate.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(pos2);
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", pos2);
-  kstate.update();
+  //  robot_state.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
+  //  robot_state.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(pos2);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", pos2);
+  robot_state.update();
 
   acm_->setEntry("r_gripper_palm_link", "l_gripper_palm_link", false);
 
   collision_detection::CollisionResult res;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   ASSERT_EQ(res.contacts.size(), 1u);
   ASSERT_EQ(res.contacts.begin()->second.size(), 1u);
@@ -268,14 +268,14 @@ TEST_F(FclCollisionDetectionTester, ContactPositions)
 
   pos1 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond::Identity());
   pos2 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond(0.965, 0.0, 0.258, 0.0));
-  //  kstate.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
-  //  kstate.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(pos2);
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", pos2);
-  kstate.update();
+  //  robot_state.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
+  //  robot_state.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(pos2);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", pos2);
+  robot_state.update();
 
   collision_detection::CollisionResult res2;
-  crobot_->checkSelfCollision(req, res2, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res2, robot_state, *acm_);
   ASSERT_TRUE(res2.collision);
   ASSERT_EQ(res2.contacts.size(), 1u);
   ASSERT_EQ(res2.contacts.begin()->second.size(), 1u);
@@ -288,14 +288,14 @@ TEST_F(FclCollisionDetectionTester, ContactPositions)
 
   pos1 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond::Identity());
   pos2 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond(M_PI / 4.0, 0.0, M_PI / 4.0, 0.0));
-  //  kstate.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
-  //  kstate.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(pos2);
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", pos2);
-  kstate.update();
+  //  robot_state.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
+  //  robot_state.getLinkState("l_gripper_palm_link")->updateGivenGlobalLinkTransform(pos2);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", pos2);
+  robot_state.update();
 
   collision_detection::CollisionResult res3;
-  crobot_->checkSelfCollision(req, res2, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res2, robot_state, *acm_);
   ASSERT_FALSE(res3.collision);
 }
 
@@ -306,24 +306,24 @@ TEST_F(FclCollisionDetectionTester, AttachedBodyTester)
 
   acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   Eigen::Affine3d pos1 = Eigen::Affine3d::Identity();
   pos1.translation().x() = 5.0;
 
-  //  kstate.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.update();
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  //  robot_state.getLinkState("r_gripper_palm_link")->updateGivenGlobalLinkTransform(pos1);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.update();
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_FALSE(res.collision);
 
   shapes::Shape* shape = new shapes::Box(.1, .1, .1);
   cworld_->getWorld()->addToObject("box", shapes::ShapeConstPtr(shape), pos1);
 
   res = collision_detection::CollisionResult();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate, *acm_);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 
   // deletes shape
@@ -335,43 +335,43 @@ TEST_F(FclCollisionDetectionTester, AttachedBodyTester)
   shapes.push_back(shapes::ShapeConstPtr(shape));
   poses.push_back(Eigen::Affine3d::Identity());
   std::vector<std::string> touch_links;
-  kstate.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
 
   res = collision_detection::CollisionResult();
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 
   // deletes shape
-  kstate.clearAttachedBody("box");
+  robot_state.clearAttachedBody("box");
 
   touch_links.push_back("r_gripper_palm_link");
   touch_links.push_back("r_gripper_motor_accelerometer_link");
   shapes[0].reset(new shapes::Box(.1, .1, .1));
-  kstate.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
-  kstate.update();
+  robot_state.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.update();
 
   res = collision_detection::CollisionResult();
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_FALSE(res.collision);
 
   pos1.translation().x() = 5.01;
   shapes::Shape* coll = new shapes::Box(.1, .1, .1);
   cworld_->getWorld()->addToObject("coll", shapes::ShapeConstPtr(coll), pos1);
   res = collision_detection::CollisionResult();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate, *acm_);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 
   acm_->setEntry("coll", "r_gripper_palm_link", true);
   res = collision_detection::CollisionResult();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate, *acm_);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 }
 
 TEST_F(FclCollisionDetectionTester, DiffSceneTester)
 {
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
@@ -380,10 +380,10 @@ TEST_F(FclCollisionDetectionTester, DiffSceneTester)
       *(dynamic_cast<collision_detection::CollisionRobotFCL*>(crobot_.get())));
 
   ros::WallTime before = ros::WallTime::now();
-  new_crobot.checkSelfCollision(req, res, kstate);
+  new_crobot.checkSelfCollision(req, res, robot_state);
   double first_check = (ros::WallTime::now() - before).toSec();
   before = ros::WallTime::now();
-  new_crobot.checkSelfCollision(req, res, kstate);
+  new_crobot.checkSelfCollision(req, res, robot_state);
   double second_check = (ros::WallTime::now() - before).toSec();
 
   EXPECT_LT(fabs(first_check - second_check), .05);
@@ -397,13 +397,13 @@ TEST_F(FclCollisionDetectionTester, DiffSceneTester)
   poses.push_back(Eigen::Affine3d::Identity());
 
   std::vector<std::string> touch_links;
-  kstate.attachBody("kinect", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("kinect", shapes, poses, touch_links, "r_gripper_palm_link");
 
   before = ros::WallTime::now();
-  new_crobot.checkSelfCollision(req, res, kstate);
+  new_crobot.checkSelfCollision(req, res, robot_state);
   first_check = (ros::WallTime::now() - before).toSec();
   before = ros::WallTime::now();
-  new_crobot.checkSelfCollision(req, res, kstate);
+  new_crobot.checkSelfCollision(req, res, robot_state);
   second_check = (ros::WallTime::now() - before).toSec();
 
   // the first check is going to take a while, as data must be constructed
@@ -412,10 +412,10 @@ TEST_F(FclCollisionDetectionTester, DiffSceneTester)
   collision_detection::CollisionRobotFCL other_new_crobot(
       *(dynamic_cast<collision_detection::CollisionRobotFCL*>(crobot_.get())));
   before = ros::WallTime::now();
-  new_crobot.checkSelfCollision(req, res, kstate);
+  new_crobot.checkSelfCollision(req, res, robot_state);
   first_check = (ros::WallTime::now() - before).toSec();
   before = ros::WallTime::now();
-  new_crobot.checkSelfCollision(req, res, kstate);
+  new_crobot.checkSelfCollision(req, res, robot_state);
   second_check = (ros::WallTime::now() - before).toSec();
 
   EXPECT_LT(fabs(first_check - second_check), .05);
@@ -433,15 +433,15 @@ TEST_F(FclCollisionDetectionTester, ConvertObjectToAttached)
 
   cworld_->getWorld()->addToObject("kinect", shape, pos1);
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   ros::WallTime before = ros::WallTime::now();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state);
   double first_check = (ros::WallTime::now() - before).toSec();
   before = ros::WallTime::now();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state);
   double second_check = (ros::WallTime::now() - before).toSec();
 
   EXPECT_LT(second_check, .05);
@@ -449,35 +449,35 @@ TEST_F(FclCollisionDetectionTester, ConvertObjectToAttached)
   collision_detection::CollisionWorld::ObjectConstPtr object = cworld_->getWorld()->getObject("kinect");
   cworld_->getWorld()->removeObject("kinect");
 
-  robot_state::RobotState kstate1(robot_model_);
-  robot_state::RobotState kstate2(robot_model_);
-  kstate1.setToDefaultValues();
-  kstate2.setToDefaultValues();
-  kstate1.update();
-  kstate2.update();
+  robot_state::RobotState robot_state1(robot_model_);
+  robot_state::RobotState robot_state2(robot_model_);
+  robot_state1.setToDefaultValues();
+  robot_state2.setToDefaultValues();
+  robot_state1.update();
+  robot_state2.update();
 
   std::vector<std::string> touch_links;
-  kstate1.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
+  robot_state1.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
 
   EigenSTL::vector_Affine3d other_poses;
   other_poses.push_back(pos2);
 
   // This creates a new set of constant properties for the attached body, which happens to be the same as the one above;
-  kstate2.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
+  robot_state2.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
 
   // going to take a while, but that's fine
   res = collision_detection::CollisionResult();
-  crobot_->checkSelfCollision(req, res, kstate1);
+  crobot_->checkSelfCollision(req, res, robot_state1);
 
   EXPECT_TRUE(res.collision);
 
   before = ros::WallTime::now();
-  crobot_->checkSelfCollision(req, res, kstate1, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state1, *acm_);
   first_check = (ros::WallTime::now() - before).toSec();
   before = ros::WallTime::now();
   req.verbose = true;
   res = collision_detection::CollisionResult();
-  crobot_->checkSelfCollision(req, res, kstate2, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state2, *acm_);
   second_check = (ros::WallTime::now() - before).toSec();
 
   EXPECT_LT(first_check, .05);
@@ -504,9 +504,9 @@ TEST_F(FclCollisionDetectionTester, TestCollisionMapAdditionSpeed)
 
 TEST_F(FclCollisionDetectionTester, MoveMesh)
 {
-  robot_state::RobotState kstate1(robot_model_);
-  kstate1.setToDefaultValues();
-  kstate1.update();
+  robot_state::RobotState robot_state1(robot_model_);
+  robot_state1.setToDefaultValues();
+  robot_state1.update();
 
   Eigen::Affine3d kinect_pose;
   kinect_pose.setIdentity();
@@ -522,15 +522,15 @@ TEST_F(FclCollisionDetectionTester, MoveMesh)
     cworld_->getWorld()->moveShapeInObject("kinect", kinect_shape, np);
     collision_detection::CollisionRequest req;
     collision_detection::CollisionResult res;
-    cworld_->checkCollision(req, res, *crobot_, kstate1, *acm_);
+    cworld_->checkCollision(req, res, *crobot_, robot_state1, *acm_);
   }
 }
 
 TEST_F(FclCollisionDetectionTester, TestChangingShapeSize)
 {
-  robot_state::RobotState kstate1(robot_model_);
-  kstate1.setToDefaultValues();
-  kstate1.update();
+  robot_state::RobotState robot_state1(robot_model_);
+  robot_state1.setToDefaultValues();
+  robot_state1.update();
 
   collision_detection::CollisionRequest req1;
   collision_detection::CollisionResult res1;
@@ -549,7 +549,7 @@ TEST_F(FclCollisionDetectionTester, TestChangingShapeSize)
     cworld_->getWorld()->addToObject("shape", shapes, poses);
     collision_detection::CollisionRequest req;
     collision_detection::CollisionResult res;
-    cworld_->checkCollision(req, res, *crobot_, kstate1, *acm_);
+    cworld_->checkCollision(req, res, *crobot_, robot_state1, *acm_);
     ASSERT_TRUE(res.collision);
   }
 
@@ -559,7 +559,7 @@ TEST_F(FclCollisionDetectionTester, TestChangingShapeSize)
   cworld_->getWorld()->addToObject("kinect", kinect_shape, kinect_pose);
   collision_detection::CollisionRequest req2;
   collision_detection::CollisionResult res2;
-  cworld_->checkCollision(req2, res2, *crobot_, kstate1, *acm_);
+  cworld_->checkCollision(req2, res2, *crobot_, robot_state1, *acm_);
   ASSERT_TRUE(res2.collision);
   for (unsigned int i = 0; i < 5; i++)
   {
@@ -571,7 +571,7 @@ TEST_F(FclCollisionDetectionTester, TestChangingShapeSize)
     cworld_->getWorld()->addToObject("shape", shapes, poses);
     collision_detection::CollisionRequest req;
     collision_detection::CollisionResult res;
-    cworld_->checkCollision(req, res, *crobot_, kstate1, *acm_);
+    cworld_->checkCollision(req, res, *crobot_, robot_state1, *acm_);
     ASSERT_TRUE(res.collision);
   }
 }

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -68,7 +68,7 @@ protected:
       FAIL() << "Failed to find robot.xml";
     }
     srdf_model->initFile(*urdf_model, (res_path / "pr2_description/srdf/robot.xml").string());
-    kmodel.reset(new robot_model::RobotModel(urdf_model, srdf_model));
+    robot_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
   };
 
   void TearDown() override
@@ -78,16 +78,16 @@ protected:
 protected:
   urdf::ModelInterfaceSharedPtr urdf_model;
   srdf::ModelSharedPtr srdf_model;
-  robot_model::RobotModelPtr kmodel;
+  robot_model::RobotModelPtr robot_model;
 };
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsSimple)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::JointConstraint jc(kmodel);
+  kinematic_constraints::JointConstraint jc(robot_model);
   moveit_msgs::JointConstraint jcm;
   jcm.joint_name = "head_pan_joint";
   jcm.position = 0.4;
@@ -158,7 +158,7 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsSimple)
   EXPECT_FALSE(jc.decide(ks).satisfied);
 
   // testing equality
-  kinematic_constraints::JointConstraint jc2(kmodel);
+  kinematic_constraints::JointConstraint jc2(robot_model);
   EXPECT_TRUE(jc2.configure(jcm));
   EXPECT_TRUE(jc2.enabled());
   EXPECT_TRUE(jc.equal(jc2, 1e-12));
@@ -198,12 +198,12 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsSimple)
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsCont)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::JointConstraint jc(kmodel);
+  kinematic_constraints::JointConstraint jc(robot_model);
   moveit_msgs::JointConstraint jcm;
 
   jcm.joint_name = "l_wrist_roll_joint";
@@ -322,17 +322,17 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsCont)
   // should wrap to close and test to be near
   moveit_msgs::JointConstraint jcm2 = jcm;
   jcm2.position = -6.28;
-  kinematic_constraints::JointConstraint jc2(kmodel);
+  kinematic_constraints::JointConstraint jc2(robot_model);
   EXPECT_TRUE(jc.configure(jcm2));
   jc.equal(jc2, .02);
 }
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsMultiDOF)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
 
-  kinematic_constraints::JointConstraint jc(kmodel);
+  kinematic_constraints::JointConstraint jc(robot_model);
   moveit_msgs::JointConstraint jcm;
   jcm.joint_name = "world_joint";
   jcm.position = 3.14;
@@ -380,11 +380,11 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsMultiDOF)
 
 TEST_F(LoadPlanningModelsPr2, PositionConstraintsFixed)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
   ks.update(true);
-  robot_state::Transforms tf(kmodel->getModelFrame());
-  kinematic_constraints::PositionConstraint pc(kmodel);
+  robot_state::Transforms tf(robot_model->getModelFrame());
+  kinematic_constraints::PositionConstraint pc(robot_model);
   moveit_msgs::PositionConstraint pcm;
 
   // empty certainly means false
@@ -419,7 +419,7 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsFixed)
   // intentionally leaving header frame blank to test behavior
   EXPECT_FALSE(pc.configure(pcm, tf));
 
-  pcm.header.frame_id = kmodel->getModelFrame();
+  pcm.header.frame_id = robot_model->getModelFrame();
   EXPECT_TRUE(pc.configure(pcm, tf));
   EXPECT_FALSE(pc.mobileReferenceFrame());
 
@@ -456,12 +456,12 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsFixed)
 
 TEST_F(LoadPlanningModelsPr2, PositionConstraintsMobile)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
   ks.update();
 
-  kinematic_constraints::PositionConstraint pc(kmodel);
+  kinematic_constraints::PositionConstraint pc(robot_model);
   moveit_msgs::PositionConstraint pcm;
 
   pcm.link_name = "l_wrist_roll_link";
@@ -533,12 +533,12 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsMobile)
 
 TEST_F(LoadPlanningModelsPr2, PositionConstraintsEquality)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::PositionConstraint pc(kmodel);
-  kinematic_constraints::PositionConstraint pc2(kmodel);
+  kinematic_constraints::PositionConstraint pc(robot_model);
+  kinematic_constraints::PositionConstraint pc2(robot_model);
   moveit_msgs::PositionConstraint pcm;
 
   pcm.link_name = "l_wrist_roll_link";
@@ -619,12 +619,12 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsEquality)
 
 TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::OrientationConstraint oc(kmodel);
+  kinematic_constraints::OrientationConstraint oc(robot_model);
 
   moveit_msgs::OrientationConstraint ocm;
 
@@ -635,7 +635,7 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
   // all we currently have to specify is the link name to get a valid constraint
   EXPECT_TRUE(oc.configure(ocm, tf));
 
-  ocm.header.frame_id = kmodel->getModelFrame();
+  ocm.header.frame_id = robot_model->getModelFrame();
   ocm.orientation.x = 0.0;
   ocm.orientation.y = 0.0;
   ocm.orientation.z = 0.0;
@@ -662,7 +662,7 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
   geometry_msgs::Pose p = tf2::toMsg(ks.getGlobalLinkTransform(oc.getLinkModel()->getName()));
 
   ocm.orientation = p.orientation;
-  ocm.header.frame_id = kmodel->getModelFrame();
+  ocm.header.frame_id = robot_model->getModelFrame();
   EXPECT_TRUE(oc.configure(ocm, tf));
   EXPECT_TRUE(oc.decide(ks).satisfied);
 
@@ -680,12 +680,12 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
 
 TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsSimple)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::VisibilityConstraint vc(kmodel);
+  kinematic_constraints::VisibilityConstraint vc(robot_model);
   moveit_msgs::VisibilityConstraint vcm;
 
   EXPECT_FALSE(vc.configure(vcm, tf));
@@ -731,12 +731,12 @@ TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsSimple)
 
 TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsPR2)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::VisibilityConstraint vc(kmodel);
+  kinematic_constraints::VisibilityConstraint vc(robot_model);
   moveit_msgs::VisibilityConstraint vcm;
 
   vcm.sensor_pose.header.frame_id = "narrow_stereo_optical_frame";
@@ -805,11 +805,11 @@ TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsPR2)
 
 TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSet)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::KinematicConstraintSet kcs(kmodel);
+  kinematic_constraints::KinematicConstraintSet kcs(robot_model);
   EXPECT_TRUE(kcs.empty());
 
   moveit_msgs::JointConstraint jcm;
@@ -871,12 +871,12 @@ TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSet)
 
 TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSetEquality)
 {
-  robot_state::RobotState ks(kmodel);
+  robot_state::RobotState ks(robot_model);
   ks.setToDefaultValues();
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
-  kinematic_constraints::KinematicConstraintSet kcs(kmodel);
-  kinematic_constraints::KinematicConstraintSet kcs2(kmodel);
+  kinematic_constraints::KinematicConstraintSet kcs(robot_model);
+  kinematic_constraints::KinematicConstraintSet kcs2(robot_model);
 
   moveit_msgs::JointConstraint jcm;
   jcm.joint_name = "head_pan_joint";
@@ -905,7 +905,7 @@ TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSetEquality)
   pcm.constraint_region.primitive_poses[0].orientation.w = 1.0;
   pcm.weight = 1.0;
 
-  pcm.header.frame_id = kmodel->getModelFrame();
+  pcm.header.frame_id = robot_model->getModelFrame();
 
   // this is a valid constraint
   std::vector<moveit_msgs::JointConstraint> jcv;

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -118,7 +118,7 @@ public:
    *  The child scene has its own copy of the world. It maintains a list (in
    *  world_diff_) of changes made to the child world.
    *
-   *  The kmodel_, kstate_, ftf_, and acm_ are not copied.  They are shared
+   *  The robot_model_, robot_state_, ftf_, and acm_ are not copied.  They are shared
    *  with the parent.  So if changes to these are made in the parent they will
    *  be visible in the child.  But if any of these is modified (i.e. if the
    *  get*NonConst functions are called) in the child then a copy is made and
@@ -141,14 +141,14 @@ public:
   const robot_model::RobotModelConstPtr& getRobotModel() const
   {
     // the kinematic model does not change
-    return kmodel_;
+    return robot_model_;
   }
 
   /** \brief Get the state at which the robot is assumed to be. */
   const robot_state::RobotState& getCurrentState() const
   {
     // if we have an updated state, return it; otherwise, return the parent one
-    return kstate_ ? *kstate_ : parent_->getCurrentState();
+    return robot_state_ ? *robot_state_ : parent_->getCurrentState();
   }
   /** \brief Get the state at which the robot is assumed to be. */
   robot_state::RobotState& getCurrentStateNonConst();
@@ -1000,9 +1000,9 @@ private:
 
   PlanningSceneConstPtr parent_;  // Null unless this is a diff scene
 
-  robot_model::RobotModelConstPtr kmodel_;  // Never null (may point to same model as parent)
+  robot_model::RobotModelConstPtr robot_model_;  // Never null (may point to same model as parent)
 
-  robot_state::RobotStatePtr kstate_;                                       // if NULL use parent's
+  robot_state::RobotStatePtr robot_state_;                                  // if NULL use parent's
   robot_state::AttachedBodyCallback current_state_attached_body_callback_;  // called when changes are made to attached
                                                                             // bodies
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -391,34 +391,36 @@ public:
     checkCollision(req, res, getCurrentState());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision. This variant of the function takes
-      a non-const \e kstate and calls updateCollisionBodyTransforms() on it. */
+  /** \brief Check whether a specified state (\e robot_state) is in collision. This variant of the function takes
+      a non-const \e robot_state and calls updateCollisionBodyTransforms() on it. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      robot_state::RobotState& kstate) const
+                      robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    checkCollision(req, res, static_cast<const robot_state::RobotState&>(kstate));
+    robot_state.updateCollisionBodyTransforms();
+    checkCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state));
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision. The collision transforms of \e kstate are
+  /** \brief Check whether a specified state (\e robot_state) is in collision. The collision transforms of \e
+   * robot_state are
    * expected to be up to date. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      const robot_state::RobotState& kstate) const;
+                      const robot_state::RobotState& robot_state) const;
 
-  /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
+  /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm). This variant of the function takes
-      a non-const \e kstate and updates its link transforms if needed. */
+      a non-const \e robot_state and updates its link transforms if needed. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      robot_state::RobotState& kstate, const collision_detection::AllowedCollisionMatrix& acm) const
+                      robot_state::RobotState& robot_state,
+                      const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    checkCollision(req, res, static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    checkCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
+  /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm). */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      const robot_state::RobotState& kstate,
+                      const robot_state::RobotState& robot_state,
                       const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the current state is in collision,
@@ -435,39 +437,41 @@ public:
     checkCollisionUnpadded(req, res, getCurrentState(), getAllowedCollisionMatrix());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision,
+  /** \brief Check whether a specified state (\e robot_state) is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.  */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, const robot_state::RobotState& kstate) const
+                              collision_detection::CollisionResult& res,
+                              const robot_state::RobotState& robot_state) const
   {
-    checkCollisionUnpadded(req, res, kstate, getAllowedCollisionMatrix());
+    checkCollisionUnpadded(req, res, robot_state, getAllowedCollisionMatrix());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision,
+  /** \brief Check whether a specified state (\e robot_state) is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.
-      Update the link transforms of \e kstate if needed. */
+      Update the link transforms of \e robot_state if needed. */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, robot_state::RobotState& kstate) const
+                              collision_detection::CollisionResult& res, robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    robot_state.updateCollisionBodyTransforms();
+    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(robot_state),
+                           getAllowedCollisionMatrix());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
+  /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm), but use a collision_detection::CollisionRobot instance that has no padding.
-      This variant of the function takes a non-const \e kstate and calls updates the link transforms if needed. */
+      This variant of the function takes a non-const \e robot_state and calls updates the link transforms if needed. */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, robot_state::RobotState& kstate,
+                              collision_detection::CollisionResult& res, robot_state::RobotState& robot_state,
                               const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in collision, with respect to a given
+  /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm), but use a collision_detection::CollisionRobot instance that has no padding.  */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, const robot_state::RobotState& kstate,
+                              collision_detection::CollisionResult& res, const robot_state::RobotState& robot_state,
                               const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the current state is in self collision */
@@ -480,39 +484,40 @@ public:
     checkSelfCollision(req, res, getCurrentState());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in self collision */
+  /** \brief Check whether a specified state (\e robot_state) is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          robot_state::RobotState& kstate) const
+                          robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    robot_state.updateCollisionBodyTransforms();
+    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state), getAllowedCollisionMatrix());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in self collision */
+  /** \brief Check whether a specified state (\e robot_state) is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          const robot_state::RobotState& kstate) const
+                          const robot_state::RobotState& robot_state) const
   {
     // do self-collision checking with the unpadded version of the robot
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, getAllowedCollisionMatrix());
+    getCollisionRobotUnpadded()->checkSelfCollision(req, res, robot_state, getAllowedCollisionMatrix());
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in self collision, with respect to a given
-      allowed collision matrix (\e acm). The link transforms of \e kstate are updated if needed. */
+  /** \brief Check whether a specified state (\e robot_state) is in self collision, with respect to a given
+      allowed collision matrix (\e acm). The link transforms of \e robot_state are updated if needed. */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          robot_state::RobotState& kstate, const collision_detection::AllowedCollisionMatrix& acm) const
+                          robot_state::RobotState& robot_state,
+                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief Check whether a specified state (\e kstate) is in self collision, with respect to a given
+  /** \brief Check whether a specified state (\e robot_state) is in self collision, with respect to a given
       allowed collision matrix (\e acm) */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          const robot_state::RobotState& kstate,
+                          const robot_state::RobotState& robot_state,
                           const collision_detection::AllowedCollisionMatrix& acm) const
   {
     // do self-collision checking with the unpadded version of the robot
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, acm);
+    getCollisionRobotUnpadded()->checkSelfCollision(req, res, robot_state, acm);
   }
 
   /** \brief Get the names of the links that are involved in collisions for the current state */
@@ -524,32 +529,32 @@ public:
     getCollidingLinks(links, getCurrentState(), getAllowedCollisionMatrix());
   }
 
-  /** \brief Get the names of the links that are involved in collisions for the state \e kstate.
-      Update the link transforms for \e kstate if needed. */
-  void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& kstate) const
+  /** \brief Get the names of the links that are involved in collisions for the state \e robot_state.
+      Update the link transforms for \e robot_state if needed. */
+  void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    robot_state.updateCollisionBodyTransforms();
+    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(robot_state), getAllowedCollisionMatrix());
   }
 
-  /** \brief Get the names of the links that are involved in collisions for the state \e kstate */
-  void getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& kstate) const
+  /** \brief Get the names of the links that are involved in collisions for the state \e robot_state */
+  void getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& robot_state) const
   {
-    getCollidingLinks(links, kstate, getAllowedCollisionMatrix());
+    getCollidingLinks(links, robot_state, getAllowedCollisionMatrix());
   }
 
-  /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
+  /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm) */
-  void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& kstate,
+  void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
+  /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm) */
-  void getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& kstate,
+  void getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Get the names of the links that are involved in collisions for the current state.
@@ -562,35 +567,36 @@ public:
     getCollidingPairs(contacts, getCurrentState(), getAllowedCollisionMatrix());
   }
 
-  /** \brief Get the names of the links that are involved in collisions for the state \e kstate */
+  /** \brief Get the names of the links that are involved in collisions for the state \e robot_state */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         const robot_state::RobotState& kstate) const
+                         const robot_state::RobotState& robot_state) const
   {
-    getCollidingPairs(contacts, kstate, getAllowedCollisionMatrix());
+    getCollidingPairs(contacts, robot_state, getAllowedCollisionMatrix());
   }
 
-  /** \brief Get the names of the links that are involved in collisions for the state \e kstate.
-      Update the link transforms for \e kstate if needed. */
+  /** \brief Get the names of the links that are involved in collisions for the state \e robot_state.
+      Update the link transforms for \e robot_state if needed. */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         robot_state::RobotState& kstate) const
+                         robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(kstate), getAllowedCollisionMatrix());
+    robot_state.updateCollisionBodyTransforms();
+    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(robot_state), getAllowedCollisionMatrix());
   }
 
-  /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
-      allowed collision matrix (\e acm). Update the link transforms for \e kstate if needed. */
-  void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts, robot_state::RobotState& kstate,
+  /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
+      allowed collision matrix (\e acm). Update the link transforms for \e robot_state if needed. */
+  void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
+                         robot_state::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief  Get the names of the links that are involved in collisions for the state \e kstate given the
+  /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm) */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         const robot_state::RobotState& kstate,
+                         const robot_state::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /**@}*/
@@ -600,68 +606,74 @@ public:
    */
   /**@{*/
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions)
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
+   * self-collisions)
    */
-  double distanceToCollision(robot_state::RobotState& kstate) const
+  double distanceToCollision(robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    return distanceToCollision(static_cast<const robot_state::RobotState&>(kstate));
+    robot_state.updateCollisionBodyTransforms();
+    return distanceToCollision(static_cast<const robot_state::RobotState&>(robot_state));
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring self-collisions)
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
+   * self-collisions)
    */
-  double distanceToCollision(const robot_state::RobotState& kstate) const
+  double distanceToCollision(const robot_state::RobotState& robot_state) const
   {
-    return getCollisionWorld()->distanceRobot(*getCollisionRobot(), kstate, getAllowedCollisionMatrix());
+    return getCollisionWorld()->distanceRobot(*getCollisionRobot(), robot_state, getAllowedCollisionMatrix());
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
    * self-collisions), if the robot has no padding */
-  double distanceToCollisionUnpadded(robot_state::RobotState& kstate) const
+  double distanceToCollisionUnpadded(robot_state::RobotState& robot_state) const
   {
-    kstate.updateCollisionBodyTransforms();
-    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(kstate));
+    robot_state.updateCollisionBodyTransforms();
+    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(robot_state));
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision (ignoring
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
    * self-collisions), if the robot has no padding */
-  double distanceToCollisionUnpadded(const robot_state::RobotState& kstate) const
+  double distanceToCollisionUnpadded(const robot_state::RobotState& robot_state) const
   {
-    return getCollisionWorld()->distanceRobot(*getCollisionRobotUnpadded(), kstate, getAllowedCollisionMatrix());
+    return getCollisionWorld()->distanceRobot(*getCollisionRobotUnpadded(), robot_state, getAllowedCollisionMatrix());
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
+   * self-collisions
    * and elements that are allowed to collide. */
-  double distanceToCollision(robot_state::RobotState& kstate,
+  double distanceToCollision(robot_state::RobotState& robot_state,
                              const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    return distanceToCollision(static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    return distanceToCollision(static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
+   * self-collisions
    * and elements that are allowed to collide. */
-  double distanceToCollision(const robot_state::RobotState& kstate,
+  double distanceToCollision(const robot_state::RobotState& robot_state,
                              const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    return getCollisionWorld()->distanceRobot(*getCollisionRobot(), kstate, acm);
+    return getCollisionWorld()->distanceRobot(*getCollisionRobot(), robot_state, acm);
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
+   * self-collisions
    * and elements that are allowed to collide, if the robot has no padding. */
-  double distanceToCollisionUnpadded(robot_state::RobotState& kstate,
+  double distanceToCollisionUnpadded(robot_state::RobotState& robot_state,
                                      const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    kstate.updateCollisionBodyTransforms();
-    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(kstate), acm);
+    robot_state.updateCollisionBodyTransforms();
+    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(robot_state), acm);
   }
 
-  /** \brief The distance between the robot model at state \e kstate to the nearest collision, ignoring self-collisions
+  /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
+   * self-collisions
    * and elements that always allowed to collide, if the robot has no padding. */
-  double distanceToCollisionUnpadded(const robot_state::RobotState& kstate,
+  double distanceToCollisionUnpadded(const robot_state::RobotState& robot_state,
                                      const collision_detection::AllowedCollisionMatrix& acm) const
   {
-    return getCollisionWorld()->distanceRobot(*getCollisionRobotUnpadded(), kstate, acm);
+    return getCollisionWorld()->distanceRobot(*getCollisionRobotUnpadded(), robot_state, acm);
   }
 
   /**@}*/

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -524,15 +524,15 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
 
 void PlanningScene::checkCollision(const collision_detection::CollisionRequest& req,
                                    collision_detection::CollisionResult& res,
-                                   const robot_state::RobotState& kstate) const
+                                   const robot_state::RobotState& robot_state) const
 {
   // check collision with the world using the padded version
-  getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobot(), kstate, getAllowedCollisionMatrix());
+  getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobot(), robot_state, getAllowedCollisionMatrix());
 
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
   {
     // do self-collision checking with the unpadded version of the robot
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, getAllowedCollisionMatrix());
+    getCollisionRobotUnpadded()->checkSelfCollision(req, res, robot_state, getAllowedCollisionMatrix());
   }
 }
 
@@ -546,15 +546,16 @@ void PlanningScene::checkSelfCollision(const collision_detection::CollisionReque
 }
 
 void PlanningScene::checkCollision(const collision_detection::CollisionRequest& req,
-                                   collision_detection::CollisionResult& res, const robot_state::RobotState& kstate,
+                                   collision_detection::CollisionResult& res,
+                                   const robot_state::RobotState& robot_state,
                                    const collision_detection::AllowedCollisionMatrix& acm) const
 {
   // check collision with the world using the padded version
-  getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobot(), kstate, acm);
+  getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobot(), robot_state, acm);
 
   // do self-collision checking with the unpadded version of the robot
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, acm);
+    getCollisionRobotUnpadded()->checkSelfCollision(req, res, robot_state, acm);
 }
 
 void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
@@ -568,16 +569,16 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
 
 void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
                                            collision_detection::CollisionResult& res,
-                                           const robot_state::RobotState& kstate,
+                                           const robot_state::RobotState& robot_state,
                                            const collision_detection::AllowedCollisionMatrix& acm) const
 {
   // check collision with the world using the unpadded version
-  getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobotUnpadded(), kstate, acm);
+  getCollisionWorld()->checkRobotCollision(req, res, *getCollisionRobotUnpadded(), robot_state, acm);
 
   // do self-collision checking with the unpadded version of the robot
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
   {
-    getCollisionRobotUnpadded()->checkSelfCollision(req, res, kstate, acm);
+    getCollisionRobotUnpadded()->checkSelfCollision(req, res, robot_state, acm);
   }
 }
 
@@ -590,7 +591,7 @@ void PlanningScene::getCollidingPairs(collision_detection::CollisionResult::Cont
 }
 
 void PlanningScene::getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                                      const robot_state::RobotState& kstate,
+                                      const robot_state::RobotState& robot_state,
                                       const collision_detection::AllowedCollisionMatrix& acm) const
 {
   collision_detection::CollisionRequest req;
@@ -598,7 +599,7 @@ void PlanningScene::getCollidingPairs(collision_detection::CollisionResult::Cont
   req.max_contacts = getRobotModel()->getLinkModelsWithCollisionGeometry().size() + 1;
   req.max_contacts_per_pair = 1;
   collision_detection::CollisionResult res;
-  checkCollision(req, res, kstate, acm);
+  checkCollision(req, res, robot_state, acm);
   res.contacts.swap(contacts);
 }
 
@@ -610,11 +611,11 @@ void PlanningScene::getCollidingLinks(std::vector<std::string>& links)
     getCollidingLinks(links, getCurrentState(), getAllowedCollisionMatrix());
 }
 
-void PlanningScene::getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& kstate,
+void PlanningScene::getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& robot_state,
                                       const collision_detection::AllowedCollisionMatrix& acm) const
 {
   collision_detection::CollisionResult::ContactMap contacts;
-  getCollidingPairs(contacts, kstate, acm);
+  getCollidingPairs(contacts, robot_state, acm);
   links.clear();
   for (collision_detection::CollisionResult::ContactMap::const_iterator it = contacts.begin(); it != contacts.end();
        ++it)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -53,6 +53,8 @@ namespace planning_scene
 const std::string PlanningScene::OCTOMAP_NS = "<octomap>";
 const std::string PlanningScene::DEFAULT_SCENE_NAME = "(noname)";
 
+const std::string LOGNAME = "planning_scene";
+
 class SceneTransforms : public robot_state::Transforms
 {
 public:
@@ -349,9 +351,8 @@ bool PlanningScene::setActiveCollisionDetector(const std::string& collision_dete
   }
   else
   {
-    ROS_ERROR_NAMED("planning_scene",
-                    "Cannot setActiveCollisionDetector to '%s' -- it has been added to PlanningScene. "
-                    "Keeping existing active collision detector '%s'",
+    ROS_ERROR_NAMED(LOGNAME, "Cannot setActiveCollisionDetector to '%s' -- it has been added to PlanningScene. "
+                             "Keeping existing active collision detector '%s'",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return false;
   }
@@ -371,8 +372,7 @@ PlanningScene::getCollisionWorld(const std::string& collision_detector_name) con
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    ROS_ERROR_NAMED("planning_scene",
-                    "Could not get CollisionWorld named '%s'.  Returning active CollisionWorld '%s' instead",
+    ROS_ERROR_NAMED(LOGNAME, "Could not get CollisionWorld named '%s'.  Returning active CollisionWorld '%s' instead",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->cworld_const_;
   }
@@ -386,8 +386,7 @@ PlanningScene::getCollisionRobot(const std::string& collision_detector_name) con
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    ROS_ERROR_NAMED("planning_scene",
-                    "Could not get CollisionRobot named '%s'.  Returning active CollisionRobot '%s' instead",
+    ROS_ERROR_NAMED(LOGNAME, "Could not get CollisionRobot named '%s'.  Returning active CollisionRobot '%s' instead",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->getCollisionRobot();
   }
@@ -401,8 +400,8 @@ PlanningScene::getCollisionRobotUnpadded(const std::string& collision_detector_n
   CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
   if (it == collision_.end())
   {
-    ROS_ERROR_NAMED("planning_scene", "Could not get CollisionRobotUnpadded named '%s'. "
-                                      "Returning active CollisionRobotUnpadded '%s' instead",
+    ROS_ERROR_NAMED(LOGNAME, "Could not get CollisionRobotUnpadded named '%s'. "
+                             "Returning active CollisionRobotUnpadded '%s' instead",
                     collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
     return active_collision_->getCollisionRobotUnpadded();
   }
@@ -890,8 +889,7 @@ bool PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const
       octomap.origin = tf2::toMsg(map->shape_poses_[0]);
       return true;
     }
-    ROS_ERROR_NAMED("planning_scene",
-                    "Unexpected number of shapes in octomap collision object. Not including '%s' object",
+    ROS_ERROR_NAMED(LOGNAME, "Unexpected number of shapes in octomap collision object. Not including '%s' object",
                     OCTOMAP_NS.c_str());
   }
   return false;
@@ -1041,7 +1039,7 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
 {
   if (!in.good() || in.eof())
   {
-    ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading scene geometry");
+    ROS_ERROR_NAMED(LOGNAME, "Bad input stream when loading scene geometry");
     return false;
   }
   std::getline(in, name_);
@@ -1051,7 +1049,7 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
     in >> marker;
     if (!in.good() || in.eof())
     {
-      ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading marker in scene geometry");
+      ROS_ERROR_NAMED(LOGNAME, "Bad input stream when loading marker in scene geometry");
       return false;
     }
     if (marker == "*")
@@ -1060,7 +1058,7 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
       std::getline(in, ns);
       if (!in.good() || in.eof())
       {
-        ROS_ERROR_NAMED("planning_scene", "Bad input stream when loading ns in scene geometry");
+        ROS_ERROR_NAMED(LOGNAME, "Bad input stream when loading ns in scene geometry");
         return false;
       }
       boost::algorithm::trim(ns);
@@ -1071,24 +1069,24 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
         shapes::Shape* s = shapes::constructShapeFromText(in);
         if (!s)
         {
-          ROS_ERROR_NAMED("planning_scene", "Failed to load shape from scene file");
+          ROS_ERROR_NAMED(LOGNAME, "Failed to load shape from scene file");
           return false;
         }
         double x, y, z, rx, ry, rz, rw;
         if (!(in >> x >> y >> z))
         {
-          ROS_ERROR_NAMED("planning_scene", "Improperly formatted translation in scene geometry file");
+          ROS_ERROR_NAMED(LOGNAME, "Improperly formatted translation in scene geometry file");
           return false;
         }
         if (!(in >> rx >> ry >> rz >> rw))
         {
-          ROS_ERROR_NAMED("planning_scene", "Improperly formatted rotation in scene geometry file");
+          ROS_ERROR_NAMED(LOGNAME, "Improperly formatted rotation in scene geometry file");
           return false;
         }
         float r, g, b, a;
         if (!(in >> r >> g >> b >> a))
         {
-          ROS_ERROR_NAMED("planning_scene", "Improperly formatted color in scene geometry file");
+          ROS_ERROR_NAMED(LOGNAME, "Improperly formatted color in scene geometry file");
           return false;
         }
         if (s)
@@ -1116,7 +1114,7 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Affine
     }
     else
     {
-      ROS_ERROR_STREAM_NAMED("planning_scene", "Unknown marker in scene geometry file: " << marker);
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Unknown marker in scene geometry file: " << marker);
       return false;
     }
   } while (true);
@@ -1145,8 +1143,8 @@ void PlanningScene::setCurrentState(const moveit_msgs::RobotState& state)
   {
     if (!state.is_diff && state.attached_collision_objects[i].object.operation != moveit_msgs::CollisionObject::ADD)
     {
-      ROS_ERROR_NAMED("planning_scene", "The specified RobotState is not marked as is_diff. "
-                                        "The request to modify the object '%s' is not supported. Object is ignored.",
+      ROS_ERROR_NAMED(LOGNAME, "The specified RobotState is not marked as is_diff. "
+                               "The request to modify the object '%s' is not supported. Object is ignored.",
                       state.attached_collision_objects[i].object.id.c_str());
       continue;
     }
@@ -1233,12 +1231,12 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& sc
 {
   bool result = true;
 
-  ROS_DEBUG_NAMED("planning_scene", "Adding planning scene diff");
+  ROS_DEBUG_NAMED(LOGNAME, "Adding planning scene diff");
   if (!scene_msg.name.empty())
     name_ = scene_msg.name;
 
   if (!scene_msg.robot_model_name.empty() && scene_msg.robot_model_name != getRobotModel()->getName())
-    ROS_WARN_NAMED("planning_scene", "Setting the scene for model '%s' but model '%s' is loaded.",
+    ROS_WARN_NAMED(LOGNAME, "Setting the scene for model '%s' but model '%s' is loaded.",
                    scene_msg.robot_model_name.c_str(), getRobotModel()->getName().c_str());
 
   // there is at least one transform in the list of fixed transform: from model frame to itself;
@@ -1290,11 +1288,11 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& sc
 
 bool PlanningScene::setPlanningSceneMsg(const moveit_msgs::PlanningScene& scene_msg)
 {
-  ROS_DEBUG_NAMED("planning_scene", "Setting new planning scene: '%s'", scene_msg.name.c_str());
+  ROS_DEBUG_NAMED(LOGNAME, "Setting new planning scene: '%s'", scene_msg.name.c_str());
   name_ = scene_msg.name;
 
   if (!scene_msg.robot_model_name.empty() && scene_msg.robot_model_name != getRobotModel()->getName())
-    ROS_WARN_NAMED("planning_scene", "Setting the scene for model '%s' but model '%s' is loaded.",
+    ROS_WARN_NAMED(LOGNAME, "Setting the scene for model '%s' but model '%s' is loaded.",
                    scene_msg.robot_model_name.c_str(), getRobotModel()->getName().c_str());
 
   if (parent_)
@@ -1348,8 +1346,7 @@ void PlanningScene::processOctomapMsg(const octomap_msgs::Octomap& map)
 
   if (map.id != "OcTree")
   {
-    ROS_ERROR_NAMED("planning_scene", "Received octomap is of type '%s' but type 'OcTree' is expected.",
-                    map.id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Received octomap is of type '%s' but type 'OcTree' is expected.", map.id.c_str());
     return;
   }
 
@@ -1387,8 +1384,7 @@ void PlanningScene::processOctomapMsg(const octomap_msgs::OctomapWithPose& map)
 
   if (map.octomap.id != "OcTree")
   {
-    ROS_ERROR_NAMED("planning_scene", "Received octomap is of type '%s' but type 'OcTree' is expected.",
-                    map.octomap.id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Received octomap is of type '%s' but type 'OcTree' is expected.", map.octomap.id.c_str());
     return;
   }
 
@@ -1437,15 +1433,13 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
 {
   if (object.object.operation == moveit_msgs::CollisionObject::ADD && !getRobotModel()->hasLinkModel(object.link_name))
   {
-    ROS_ERROR_NAMED("planning_scene", "Unable to attach a body to link '%s' (link not found)",
-                    object.link_name.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unable to attach a body to link '%s' (link not found)", object.link_name.c_str());
     return false;
   }
 
   if (object.object.id == OCTOMAP_NS)
   {
-    ROS_ERROR_NAMED("planning_scene", "The ID '%s' cannot be used for collision objects (name reserved)",
-                    OCTOMAP_NS.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "The ID '%s' cannot be used for collision objects (name reserved)", OCTOMAP_NS.c_str());
     return false;
   }
 
@@ -1461,22 +1455,22 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
   {
     if (object.object.primitives.size() != object.object.primitive_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match number of poses "
-                                        "in attached collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "Number of primitive shapes does not match number of poses "
+                               "in attached collision object message");
       return false;
     }
 
     if (object.object.meshes.size() != object.object.mesh_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of meshes does not match number of poses "
-                                        "in attached collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "Number of meshes does not match number of poses "
+                               "in attached collision object message");
       return false;
     }
 
     if (object.object.planes.size() != object.object.plane_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of planes does not match number of poses "
-                                        "in attached collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "Number of planes does not match number of poses "
+                               "in attached collision object message");
       return false;
     }
 
@@ -1493,7 +1487,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         collision_detection::CollisionWorld::ObjectConstPtr obj = world_->getObject(object.object.id);
         if (obj)
         {
-          ROS_DEBUG_NAMED("planning_scene", "Attaching world object '%s' to link '%s'", object.object.id.c_str(),
+          ROS_DEBUG_NAMED(LOGNAME, "Attaching world object '%s' to link '%s'", object.object.id.c_str(),
                           object.link_name.c_str());
 
           // extract the shapes from the world
@@ -1509,8 +1503,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         }
         else
         {
-          ROS_ERROR_NAMED("planning_scene", "Attempting to attach object '%s' to link '%s' but no geometry specified "
-                                            "and such an object does not exist in the collision world",
+          ROS_ERROR_NAMED(LOGNAME, "Attempting to attach object '%s' to link '%s' but no geometry specified "
+                                   "and such an object does not exist in the collision world",
                           object.object.id.c_str(), object.link_name.c_str());
           return false;
         }
@@ -1521,10 +1515,10 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         if (world_->removeObject(object.object.id))
         {
           if (object.object.operation == moveit_msgs::CollisionObject::ADD)
-            ROS_DEBUG_NAMED("planning_scene", "Removing world object with the same name as newly attached object: '%s'",
+            ROS_DEBUG_NAMED(LOGNAME, "Removing world object with the same name as newly attached object: '%s'",
                             object.object.id.c_str());
           else
-            ROS_WARN_NAMED("planning_scene",
+            ROS_WARN_NAMED(LOGNAME,
                            "You tried to append geometry to an attached object that is actually a world object ('%s'). "
                            "World geometry is ignored.",
                            object.object.id.c_str());
@@ -1576,7 +1570,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
 
       if (shapes.empty())
       {
-        ROS_ERROR_NAMED("planning_scene", "There is no geometry to attach to link '%s' as part of attached body '%s'",
+        ROS_ERROR_NAMED(LOGNAME, "There is no geometry to attach to link '%s' as part of attached body '%s'",
                         object.link_name.c_str(), object.object.id.c_str());
         return false;
       }
@@ -1589,12 +1583,12 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       {
         // there should not exist an attached object with this name
         if (robot_state_->clearAttachedBody(object.object.id))
-          ROS_DEBUG_NAMED("planning_scene", "The robot state already had an object named '%s' attached to link '%s'. "
-                                            "The object was replaced.",
+          ROS_DEBUG_NAMED(LOGNAME, "The robot state already had an object named '%s' attached to link '%s'. "
+                                   "The object was replaced.",
                           object.object.id.c_str(), object.link_name.c_str());
         robot_state_->attachBody(object.object.id, shapes, poses, object.touch_links, object.link_name,
                                  object.detach_posture);
-        ROS_DEBUG_NAMED("planning_scene", "Attached object '%s' to link '%s'", object.object.id.c_str(),
+        ROS_DEBUG_NAMED(LOGNAME, "Attached object '%s' to link '%s'", object.object.id.c_str(),
                         object.link_name.c_str());
       }
       else
@@ -1611,14 +1605,14 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         else
           robot_state_->attachBody(object.object.id, shapes, poses, object.touch_links, object.link_name,
                                    detach_posture);
-        ROS_DEBUG_NAMED("planning_scene", "Added shapes to object '%s' attached to link '%s'", object.object.id.c_str(),
+        ROS_DEBUG_NAMED(LOGNAME, "Added shapes to object '%s' attached to link '%s'", object.object.id.c_str(),
                         object.link_name.c_str());
       }
 
       return true;
     }
     else
-      ROS_ERROR_NAMED("planning_scene", "Robot state is not compatible with robot model. This could be fatal.");
+      ROS_ERROR_NAMED(LOGNAME, "Robot state is not compatible with robot model. This could be fatal.");
   }
   else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE)
   {
@@ -1662,16 +1656,15 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       robot_state_->clearAttachedBody(name);
 
       if (world_->hasObject(name))
-        ROS_WARN_NAMED("planning_scene",
+        ROS_WARN_NAMED(LOGNAME,
                        "The collision world already has an object with the same name as the body about to be detached. "
                        "NOT adding the detached body '%s' to the collision world.",
                        object.object.id.c_str());
       else
       {
         world_->addToObject(name, shapes, poses);
-        ROS_DEBUG_NAMED("planning_scene",
-                        "Detached object '%s' from link '%s' and added it back in the collision world", name.c_str(),
-                        object.link_name.c_str());
+        ROS_DEBUG_NAMED(LOGNAME, "Detached object '%s' from link '%s' and added it back in the collision world",
+                        name.c_str(), object.link_name.c_str());
       }
     }
     if (!attached_bodies.empty() || object.object.id.empty())
@@ -1679,11 +1672,11 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
   }
   else if (object.object.operation == moveit_msgs::CollisionObject::MOVE)
   {
-    ROS_ERROR_NAMED("planning_scene", "Move for attached objects not yet implemented");
+    ROS_ERROR_NAMED(LOGNAME, "Move for attached objects not yet implemented");
   }
   else
   {
-    ROS_ERROR_NAMED("planning_scene", "Unknown collision object operation: %d", object.object.operation);
+    ROS_ERROR_NAMED(LOGNAME, "Unknown collision object operation: %d", object.object.operation);
   }
 
   return false;
@@ -1693,8 +1686,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
 {
   if (object.id == OCTOMAP_NS)
   {
-    ROS_ERROR_NAMED("planning_scene", "The ID '%s' cannot be used for collision objects (name reserved)",
-                    OCTOMAP_NS.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "The ID '%s' cannot be used for collision objects (name reserved)", OCTOMAP_NS.c_str());
     return false;
   }
 
@@ -1702,26 +1694,26 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
   {
     if (object.primitives.empty() && object.meshes.empty() && object.planes.empty())
     {
-      ROS_ERROR_NAMED("planning_scene", "There are no shapes specified in the collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "There are no shapes specified in the collision object message");
       return false;
     }
 
     if (object.primitives.size() != object.primitive_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of primitive shapes does not match number of poses "
-                                        "in collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "Number of primitive shapes does not match number of poses "
+                               "in collision object message");
       return false;
     }
 
     if (object.meshes.size() != object.mesh_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of meshes does not match number of poses in collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "Number of meshes does not match number of poses in collision object message");
       return false;
     }
 
     if (object.planes.size() != object.plane_poses.size())
     {
-      ROS_ERROR_NAMED("planning_scene", "Number of planes does not match number of poses in collision object message");
+      ROS_ERROR_NAMED(LOGNAME, "Number of planes does not match number of poses in collision object message");
       return false;
     }
 
@@ -1784,8 +1776,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
     if (world_->hasObject(object.id))
     {
       if (!object.primitives.empty() || !object.meshes.empty() || !object.planes.empty())
-        ROS_WARN_NAMED("planning_scene",
-                       "Move operation for object '%s' ignores the geometry specified in the message.",
+        ROS_WARN_NAMED(LOGNAME, "Move operation for object '%s' ignores the geometry specified in the message.",
                        object.id.c_str());
 
       const Eigen::Affine3d& t = getTransforms().getTransform(object.header.frame_id);
@@ -1819,7 +1810,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
       }
       else
       {
-        ROS_ERROR_NAMED("planning_scene",
+        ROS_ERROR_NAMED(LOGNAME,
                         "Number of supplied poses (%zu) for object '%s' does not match number of shapes (%zu). "
                         "Not moving.",
                         new_poses.size(), object.id.c_str(), obj->shapes_.size());
@@ -1828,10 +1819,10 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
       return true;
     }
     else
-      ROS_ERROR_NAMED("planning_scene", "World object '%s' does not exist. Cannot move.", object.id.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "World object '%s' does not exist. Cannot move.", object.id.c_str());
   }
   else
-    ROS_ERROR_NAMED("planning_scene", "Unknown collision object operation: %d", object.operation);
+    ROS_ERROR_NAMED(LOGNAME, "Unknown collision object operation: %d", object.operation);
   return false;
 }
 
@@ -1860,8 +1851,7 @@ const Eigen::Affine3d& PlanningScene::getFrameTransform(const robot_state::Robot
     collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(id);
     if (obj->shape_poses_.size() > 1)
     {
-      ROS_WARN_NAMED("planning_scene", "More than one shapes in object '%s'. Using first one to decide transform",
-                     id.c_str());
+      ROS_WARN_NAMED(LOGNAME, "More than one shapes in object '%s'. Using first one to decide transform", id.c_str());
       return obj->shape_poses_[0];
     }
     else if (obj->shape_poses_.size() == 1)
@@ -1974,7 +1964,7 @@ void PlanningScene::setObjectColor(const std::string& id, const std_msgs::ColorR
 {
   if (id.empty())
   {
-    ROS_ERROR_NAMED("planning_scene", "Cannot set color of object with empty id.");
+    ROS_ERROR_NAMED(LOGNAME, "Cannot set color of object with empty id.");
     return;
   }
   if (!object_colors_)
@@ -2194,7 +2184,7 @@ bool PlanningScene::isPathValid(const robot_trajectory::RobotTrajectory& traject
       if (!found)
       {
         if (verbose)
-          ROS_INFO_NAMED("planning_scene", "Goal not satisfied");
+          ROS_INFO_NAMED(LOGNAME, "Goal not satisfied");
         if (invalid_index)
           invalid_index->push_back(i);
         result = false;

--- a/moveit_core/robot_state/test/test_transforms.cpp
+++ b/moveit_core/robot_state/test/test_transforms.cpp
@@ -83,12 +83,12 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
   ASSERT_TRUE(urdf_ok_);
   ASSERT_EQ(urdf_model_->getName(), "pr2_test");
 
-  robot_model::RobotModelPtr kmodel(new robot_model::RobotModel(urdf_model_, srdf_model_));
-  robot_state::RobotState ks(kmodel);
+  robot_model::RobotModelPtr robot_model(new robot_model::RobotModel(urdf_model_, srdf_model_));
+  robot_state::RobotState ks(robot_model);
   ks.setToRandomValues();
   ks.setToDefaultValues();
 
-  robot_state::Transforms tf(kmodel->getModelFrame());
+  robot_state::Transforms tf(robot_model->getModelFrame());
 
   Eigen::Affine3d t1;
   t1.setIdentity();
@@ -105,7 +105,7 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
 
   EXPECT_TRUE(tf.isFixedFrame("some_frame_1"));
   EXPECT_FALSE(tf.isFixedFrame("base_footprint"));
-  EXPECT_TRUE(tf.isFixedFrame(kmodel->getModelFrame()));
+  EXPECT_TRUE(tf.isFixedFrame(robot_model->getModelFrame()));
 
   Eigen::Affine3d x;
   x.setIdentity();
@@ -114,7 +114,7 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
   EXPECT_TRUE(t2.translation() == x.translation());
   EXPECT_TRUE(t2.rotation() == x.rotation());
 
-  tf.transformPose(ks, kmodel->getModelFrame(), x, x);
+  tf.transformPose(ks, robot_model->getModelFrame(), x, x);
   EXPECT_TRUE(t2.translation() == x.translation());
   EXPECT_TRUE(t2.rotation() == x.rotation());
 

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_distance_field.h
@@ -63,13 +63,13 @@ class CollisionRobotDistanceField : public CollisionRobot
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& kmodel);
+  CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& robot_model);
 
   CollisionRobotDistanceField(const CollisionRobot& col_robot, const Eigen::Vector3d& size,
                               const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
                               double collision_tolerance, double max_propogation_distance, double padding);
 
-  CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& kmodel,
+  CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& robot_model,
                               const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
                               double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
                               double size_z = DEFAULT_SIZE_Z,

--- a/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_hybrid.h
+++ b/moveit_experimental/collision_distance_field/include/moveit/collision_distance_field/collision_robot_hybrid.h
@@ -51,9 +51,9 @@ class CollisionRobotHybrid : public collision_detection::CollisionRobotFCL
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CollisionRobotHybrid(const robot_model::RobotModelConstPtr& kmodel);
+  CollisionRobotHybrid(const robot_model::RobotModelConstPtr& robot_model);
 
-  CollisionRobotHybrid(const robot_model::RobotModelConstPtr& kmodel,
+  CollisionRobotHybrid(const robot_model::RobotModelConstPtr& robot_model,
                        const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
                        double size_x = 3.0, double size_y = 3.0, double size_z = 4.0,
                        bool use_signed_distance_field = false, double resolution = .02,

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -46,8 +46,8 @@ namespace collision_detection
 {
 const double EPSILON = 0.001f;
 
-CollisionRobotDistanceField::CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& kmodel)
-  : CollisionRobot(kmodel)
+CollisionRobotDistanceField::CollisionRobotDistanceField(const robot_model::RobotModelConstPtr& robot_model)
+  : CollisionRobot(robot_model)
 {
   // planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
 
@@ -59,11 +59,11 @@ CollisionRobotDistanceField::CollisionRobotDistanceField(const robot_model::Robo
 }
 
 CollisionRobotDistanceField::CollisionRobotDistanceField(
-    const robot_model::RobotModelConstPtr& kmodel,
+    const robot_model::RobotModelConstPtr& robot_model,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
     double size_z, bool use_signed_distance_field, double resolution, double collision_tolerance,
     double max_propogation_distance, double padding, double scale)
-  : CollisionRobot(kmodel, padding, scale)
+  : CollisionRobot(robot_model, padding, scale)
 {
   initialize(link_body_decompositions, Eigen::Vector3d(size_x, size_y, size_z), Eigen::Vector3d(0, 0, 0),
              use_signed_distance_field, resolution, collision_tolerance, max_propogation_distance);

--- a/moveit_experimental/collision_distance_field/src/collision_robot_hybrid.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_hybrid.cpp
@@ -38,20 +38,21 @@
 
 namespace collision_detection
 {
-CollisionRobotHybrid::CollisionRobotHybrid(const robot_model::RobotModelConstPtr& kmodel) : CollisionRobotFCL(kmodel)
+CollisionRobotHybrid::CollisionRobotHybrid(const robot_model::RobotModelConstPtr& robot_model)
+  : CollisionRobotFCL(robot_model)
 {
-  crobot_distance_.reset(new collision_detection::CollisionRobotDistanceField(kmodel));
+  crobot_distance_.reset(new collision_detection::CollisionRobotDistanceField(robot_model));
 }
 
 CollisionRobotHybrid::CollisionRobotHybrid(
-    const robot_model::RobotModelConstPtr& kmodel,
+    const robot_model::RobotModelConstPtr& robot_model,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
     double size_z, bool use_signed_distance_field, double resolution, double collision_tolerance,
     double max_propogation_distance, double padding, double scale)
-  : CollisionRobotFCL(kmodel)
+  : CollisionRobotFCL(robot_model)
 {
   crobot_distance_.reset(new collision_detection::CollisionRobotDistanceField(
-      kmodel, link_body_decompositions, size_x, size_y, size_z, use_signed_distance_field, resolution,
+      robot_model, link_body_decompositions, size_x, size_y, size_z, use_signed_distance_field, resolution,
       collision_tolerance, max_propogation_distance, padding, scale));
 }
 

--- a/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/test/test_collision_distance_field.cpp
@@ -112,37 +112,37 @@ protected:
 
 TEST_F(DistanceFieldCollisionDetectionTester, DefaultNotInCollision)
 {
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   ASSERT_TRUE(urdf_ok_ && srdf_ok_);
 
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
   req.group_name = "whole_body";
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_FALSE(res.collision);
 }
 
 TEST_F(DistanceFieldCollisionDetectionTester, ChangeTorsoPosition)
 {
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res1;
   collision_detection::CollisionResult res2;
 
   req.group_name = "right_arm";
-  crobot_->checkSelfCollision(req, res1, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res1, robot_state, *acm_);
   std::map<std::string, double> torso_val;
   torso_val["torso_lift_joint"] = .15;
-  kstate.setVariablePositions(torso_val);
-  kstate.update();
-  crobot_->checkSelfCollision(req, res1, kstate, *acm_);
-  crobot_->checkSelfCollision(req, res1, kstate, *acm_);
+  robot_state.setVariablePositions(torso_val);
+  robot_state.update();
+  crobot_->checkSelfCollision(req, res1, robot_state, *acm_);
+  crobot_->checkSelfCollision(req, res1, robot_state, *acm_);
 }
 
 TEST_F(DistanceFieldCollisionDetectionTester, LinksInCollision)
@@ -155,28 +155,28 @@ TEST_F(DistanceFieldCollisionDetectionTester, LinksInCollision)
   // req.max_contacts = 100;
   req.group_name = "whole_body";
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
 
   Eigen::Affine3d offset = Eigen::Affine3d::Identity();
   offset.translation().x() = .01;
 
-  kstate.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("base_bellow_link", offset);
+  robot_state.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("base_bellow_link", offset);
 
   acm_->setEntry("base_link", "base_bellow_link", false);
-  crobot_->checkSelfCollision(req, res1, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res1, robot_state, *acm_);
   ASSERT_TRUE(res1.collision);
 
   acm_->setEntry("base_link", "base_bellow_link", true);
-  crobot_->checkSelfCollision(req, res2, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res2, robot_state, *acm_);
   ASSERT_FALSE(res2.collision);
 
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", offset);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", offset);
 
   acm_->setEntry("r_gripper_palm_link", "l_gripper_palm_link", false);
-  crobot_->checkSelfCollision(req, res3, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res3, robot_state, *acm_);
   ASSERT_TRUE(res3.collision);
 }
 
@@ -187,23 +187,23 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactReporting)
   req.max_contacts = 1;
   req.group_name = "whole_body";
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
 
   Eigen::Affine3d offset = Eigen::Affine3d::Identity();
   offset.translation().x() = .01;
 
-  kstate.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("base_bellow_link", offset);
+  robot_state.updateStateWithLinkAt("base_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("base_bellow_link", offset);
 
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", offset);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", Eigen::Affine3d::Identity());
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", offset);
 
   acm_->setEntry("base_link", "base_bellow_link", false);
   acm_->setEntry("r_gripper_palm_link", "l_gripper_palm_link", false);
 
   collision_detection::CollisionResult res;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_EQ(res.contacts.size(), 1u);
   EXPECT_EQ(res.contacts.begin()->second.size(), 1u);
@@ -212,7 +212,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactReporting)
   req.max_contacts = 2;
   req.max_contacts_per_pair = 1;
   //  req.verbose = true;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_EQ(res.contact_count, 2u);
   EXPECT_EQ(res.contacts.begin()->second.size(), 1u);
@@ -223,7 +223,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactReporting)
   req.max_contacts = 10;
   req.max_contacts_per_pair = 2;
   acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), false));
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   EXPECT_LE(res.contacts.size(), 10u);
   EXPECT_LE(res.contact_count, 10u);
@@ -236,8 +236,8 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactPositions)
   req.max_contacts = 1;
   req.group_name = "whole_body";
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
 
   Eigen::Affine3d pos1 = Eigen::Affine3d::Identity();
   Eigen::Affine3d pos2 = Eigen::Affine3d::Identity();
@@ -245,13 +245,13 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactPositions)
   pos1.translation().x() = 5.0;
   pos2.translation().x() = 5.01;
 
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", pos2);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", pos2);
 
   acm_->setEntry("r_gripper_palm_link", "l_gripper_palm_link", false);
 
   collision_detection::CollisionResult res;
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
   ASSERT_EQ(res.contacts.size(), 1u);
   ASSERT_EQ(res.contacts.begin()->second.size(), 1u);
@@ -265,11 +265,11 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactPositions)
   pos1 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond::Identity());
   pos2 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond(0.965, 0.0, 0.258, 0.0));
 
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", pos2);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", pos2);
 
   collision_detection::CollisionResult res2;
-  crobot_->checkSelfCollision(req, res2, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res2, robot_state, *acm_);
   ASSERT_TRUE(res2.collision);
   ASSERT_EQ(res2.contacts.size(), 1u);
   ASSERT_EQ(res2.contacts.begin()->second.size(), 1u);
@@ -283,11 +283,11 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactPositions)
   pos1 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond::Identity());
   pos2 = Eigen::Affine3d(Eigen::Translation3d(3.0, 0.0, 0.0) * Eigen::Quaterniond(M_PI / 4.0, 0.0, M_PI / 4.0, 0.0));
 
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  kstate.updateStateWithLinkAt("l_gripper_palm_link", pos2);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  robot_state.updateStateWithLinkAt("l_gripper_palm_link", pos2);
 
   collision_detection::CollisionResult res3;
-  crobot_->checkSelfCollision(req, res2, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res2, robot_state, *acm_);
   ASSERT_FALSE(res3.collision);
 }
 
@@ -300,22 +300,22 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
 
   acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
-  kstate.update();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
   Eigen::Affine3d pos1 = Eigen::Affine3d::Identity();
   pos1.translation().x() = 1.0;
 
-  kstate.updateStateWithLinkAt("r_gripper_palm_link", pos1);
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  robot_state.updateStateWithLinkAt("r_gripper_palm_link", pos1);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_FALSE(res.collision);
 
   shapes::Shape* shape = new shapes::Box(.25, .25, .25);
   cworld_->getWorld()->addToObject("box", shapes::ShapeConstPtr(shape), pos1);
 
   res = collision_detection::CollisionResult();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate, *acm_);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 
   // deletes shape
@@ -328,38 +328,38 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   std::set<std::string> touch_links;
   trajectory_msgs::JointTrajectory empty_state;
   robot_state::AttachedBody* attached_body = new robot_state::AttachedBody(
-      kstate.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
 
-  kstate.attachBody(attached_body);
+  robot_state.attachBody(attached_body);
 
   res = collision_detection::CollisionResult();
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 
   // deletes shape
-  kstate.clearAttachedBody("box");
+  robot_state.clearAttachedBody("box");
 
   touch_links.insert("r_gripper_palm_link");
   shapes[0].reset(new shapes::Box(.1, .1, .1));
 
   robot_state::AttachedBody* attached_body_1 = new robot_state::AttachedBody(
-      kstate.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
-  kstate.attachBody(attached_body_1);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+  robot_state.attachBody(attached_body_1);
 
   res = collision_detection::CollisionResult();
-  crobot_->checkSelfCollision(req, res, kstate, *acm_);
+  crobot_->checkSelfCollision(req, res, robot_state, *acm_);
   // ASSERT_FALSE(res.collision);
 
   pos1.translation().x() = 1.01;
   shapes::Shape* coll = new shapes::Box(.1, .1, .1);
   cworld_->getWorld()->addToObject("coll", shapes::ShapeConstPtr(coll), pos1);
   res = collision_detection::CollisionResult();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate, *acm_);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 
   acm_->setEntry("coll", "r_gripper_palm_link", true);
   res = collision_detection::CollisionResult();
-  cworld_->checkRobotCollision(req, res, *crobot_, kstate, *acm_);
+  cworld_->checkRobotCollision(req, res, *crobot_, robot_state, *acm_);
   ASSERT_TRUE(res.collision);
 }
 

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_distance_field_ros_helpers.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_distance_field_ros_helpers.h
@@ -44,7 +44,7 @@
 namespace collision_detection
 {
 static inline bool loadLinkBodySphereDecompositions(
-    ros::NodeHandle& nh, const planning_models::RobotModelConstPtr& kmodel,
+    ros::NodeHandle& nh, const planning_models::RobotModelConstPtr& robot_model,
     std::map<std::string, std::vector<collision_detection::CollisionSphere> >& link_body_spheres)
 {
   if (!nh.hasParam("link_spheres"))

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_robot_distance_field_ros.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_robot_distance_field_ros.h
@@ -46,14 +46,14 @@ namespace collision_detection
 class CollisionRobotDistanceFieldROS : public CollisionRobotDistanceField
 {
 public:
-  CollisionRobotDistanceFieldROS(const planning_models::RobotModelConstPtr& kmodel, double size_x = DEFAULT_SIZE_X,
+  CollisionRobotDistanceFieldROS(const planning_models::RobotModelConstPtr& robot_model, double size_x = DEFAULT_SIZE_X,
                                  double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
                                  bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                                  double resolution = DEFAULT_RESOLUTION,
                                  double collision_tolerance = DEFAULT_COLLISION_TOLERANCE,
                                  double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE,
                                  double padding = 0.0, double scale = 1.0)
-    : CollisionRobotDistanceField(kmodel)
+    : CollisionRobotDistanceField(robot_model)
   {
     ros::NodeHandle nh;
     std::map<std::string, std::vector<CollisionSphere> > coll_spheres;

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/hybrid_collision_robot_ros.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/hybrid_collision_robot_ros.h
@@ -46,14 +46,14 @@ namespace collision_detection
 class CollisionRobotHybridROS : public CollisionRobotHybrid
 {
 public:
-  CollisionRobotHybridROS(const planning_models::RobotModelConstPtr& kmodel, double size_x = DEFAULT_SIZE_X,
+  CollisionRobotHybridROS(const planning_models::RobotModelConstPtr& robot_model, double size_x = DEFAULT_SIZE_X,
                           double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
                           bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                           double resolution = DEFAULT_RESOLUTION,
                           double collision_tolerance = DEFAULT_COLLISION_TOLERANCE,
                           double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                           double scale = 1.0)
-    : CollisionRobotHybrid(kmodel)
+    : CollisionRobotHybrid(robot_model)
   {
     ros::NodeHandle nh;
     std::map<std::string, std::vector<CollisionSphere> > coll_spheres;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -128,7 +128,7 @@ private:
   unsigned int collision_free_iteration_;
 
   ChompTrajectory* full_trajectory_;
-  const moveit::core::RobotModelConstPtr& kmodel_;
+  const moveit::core::RobotModelConstPtr& robot_model_;
   std::string planning_group_;
   const ChompParameters* parameters_;
   ChompTrajectory group_trajectory_;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
@@ -52,11 +52,11 @@ static const double DIFF_RULES[3][DIFF_RULE_LENGTH] = {
   { 0, 1 / 12.0, -17 / 12.0, 46 / 12.0, -46 / 12.0, 17 / 12.0, -1 / 12.0 }  // jerk
 };
 
-static inline void jointStateToArray(const moveit::core::RobotModelConstPtr& kmodel,
+static inline void jointStateToArray(const moveit::core::RobotModelConstPtr& robot_model,
                                      const sensor_msgs::JointState& joint_state, const std::string& planning_group_name,
                                      Eigen::MatrixXd::RowXpr joint_array)
 {
-  const moveit::core::JointModelGroup* group = kmodel->getJointModelGroup(planning_group_name);
+  const moveit::core::JointModelGroup* group = robot_model->getJointModelGroup(planning_group_name);
   std::vector<const moveit::core::JointModel*> models = group->getActiveJointModels();
 
   for (unsigned int i = 0; i < joint_state.position.size(); i++)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -55,7 +55,7 @@ ChompOptimizer::ChompOptimizer(ChompTrajectory* trajectory, const planning_scene
                                const std::string& planning_group, const ChompParameters* parameters,
                                const moveit::core::RobotState& start_state)
   : full_trajectory_(trajectory)
-  , kmodel_(planning_scene->getRobotModel())
+  , robot_model_(planning_scene->getRobotModel())
   , planning_group_(planning_group)
   , parameters_(parameters)
   , group_trajectory_(*full_trajectory_, planning_group_, DIFF_RULE_LENGTH)
@@ -281,7 +281,7 @@ void ChompOptimizer::registerParents(const moveit::core::JointModel* model)
   const moveit::core::JointModel* parent_model = NULL;
   bool found_root = false;
 
-  if (model == kmodel_->getRootJoint())
+  if (model == robot_model_->getRootJoint())
     return;
 
   while (!found_root)
@@ -302,7 +302,7 @@ void ChompOptimizer::registerParents(const moveit::core::JointModel* model)
     }
     else
     {
-      if (parent_model == kmodel_->getRootJoint())
+      if (parent_model == robot_model_->getRootJoint())
       {
         found_root = true;
       }
@@ -787,9 +787,9 @@ void ChompOptimizer::computeJointProperties(int trajectory_point)
 
     std::string parent_link_name = joint_model->getParentLinkModel()->getName();
     std::string child_link_name = joint_model->getChildLinkModel()->getName();
-    Eigen::Affine3d joint_transform =
-        state_.getGlobalLinkTransform(parent_link_name) *
-        (kmodel_->getLinkModel(child_link_name)->getJointOriginTransform() * (state_.getJointTransform(joint_model)));
+    Eigen::Affine3d joint_transform = state_.getGlobalLinkTransform(parent_link_name) *
+                                      (robot_model_->getLinkModel(child_link_name)->getJointOriginTransform() *
+                                       (state_.getJointTransform(joint_model)));
 
     // joint_transform = inverseWorldTransform * jointTransform;
     Eigen::Vector3d axis;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
@@ -64,7 +64,7 @@ struct ConstraintApproximation
   std::string factory_;
   std::string serialization_;
   moveit_msgs::Constraints constraint_msg_;
-  planning_models::RobotModelConstPtr kmodel_;
+  planning_models::RobotModelConstPtr robot_model_;
   kinematic_constraints::KinematicConstraintSetPtr kconstraints_set_;
   std::vector<int> space_signature_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/threadsafe_state_storage.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/threadsafe_state_storage.h
@@ -46,7 +46,7 @@ namespace ompl_interface
 class TSStateStorage
 {
 public:
-  TSStateStorage(const robot_model::RobotModelPtr& kmodel);
+  TSStateStorage(const robot_model::RobotModelPtr& robot_model);
   TSStateStorage(const robot_state::RobotState& start_state);
   ~TSStateStorage();
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -58,13 +58,13 @@ class OMPLInterface
 public:
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
    * NodeHandle */
-  OMPLInterface(const robot_model::RobotModelConstPtr& kmodel, const ros::NodeHandle& nh = ros::NodeHandle("~"));
+  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model, const ros::NodeHandle& nh = ros::NodeHandle("~"));
 
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
      NodeHandle. However,
       planner configurations are used as specified in \e pconfig instead of reading them from the ROS parameter server
      */
-  OMPLInterface(const robot_model::RobotModelConstPtr& kmodel,
+  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
                 const planning_interface::PlannerConfigurationMap& pconfig,
                 const ros::NodeHandle& nh = ros::NodeHandle("~"));
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -183,7 +183,7 @@ protected:
   ros::NodeHandle nh_;  /// The ROS node handle
 
   /** \brief The kinematic model for which motion plans are computed */
-  robot_model::RobotModelConstPtr kmodel_;
+  robot_model::RobotModelConstPtr robot_model_;
 
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
@@ -68,7 +68,7 @@ public:
       request \e req for group \e group. The group \e group must always be specified and takes precedence over \e
      req.group_name, which may be different */
   virtual int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                                  const robot_model::RobotModelConstPtr& kmodel) const = 0;
+                                  const robot_model::RobotModelConstPtr& robot_model) const = 0;
 
 protected:
   virtual ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const = 0;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -137,7 +137,7 @@ public:
 
   const robot_model::RobotModelConstPtr& getRobotModel() const
   {
-    return kmodel_;
+    return robot_model_;
   }
 
   ModelBasedPlanningContextPtr getLastPlanningContext() const;
@@ -190,7 +190,7 @@ protected:
                                                               const moveit_msgs::MotionPlanRequest& req) const;
 
   /** \brief The kinematic model for which motion plans are computed */
-  robot_model::RobotModelConstPtr kmodel_;
+  robot_model::RobotModelConstPtr robot_model_;
 
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -51,7 +51,8 @@ namespace ompl_interface
 class PlanningContextManager
 {
 public:
-  PlanningContextManager(robot_model::RobotModelConstPtr kmodel, constraint_samplers::ConstraintSamplerManagerPtr csm);
+  PlanningContextManager(robot_model::RobotModelConstPtr robot_model,
+                         constraint_samplers::ConstraintSamplerManagerPtr csm);
   ~PlanningContextManager();
 
   /** @brief Specify configurations for the planners.

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -229,8 +229,8 @@ ompl_interface::ConstraintApproximation::getStateSamplerAllocator(const moveit_m
 void ompl_interface::ConstraintApproximation::visualizeDistribution(const std::string &link_name, unsigned int count,
 visualization_msgs::MarkerArray &arr) const
 {
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToDefaultValues();
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
 
   ompl::RNG rng;
   std_msgs::ColorRGBA color;
@@ -243,9 +243,9 @@ visualization_msgs::MarkerArray &arr) const
 
   for (std::size_t i = 0 ; i < count ; ++i)
   {
-    state_storage_->getStateSpace()->as<ModelBasedStateSpace>()->copyToRobotState(kstate,
+    state_storage_->getStateSpace()->as<ModelBasedStateSpace>()->copyToRobotState(robot_state,
 state_storage_->getState(rng.uniformInt(0, state_storage_->size() - 1)));
-    const Eigen::Vector3d &pos = kstate.getLinkState(link_name)->getGlobalLinkTransform().translation();
+    const Eigen::Vector3d &pos = robot_state.getLinkState(link_name)->getGlobalLinkTransform().translation();
 
     visualization_msgs::Marker mk;
     mk.header.stamp = ros::Time::now();
@@ -460,7 +460,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
   // construct the constrained states
 
-  robot_state::RobotState kstate(default_state);
+  robot_state::RobotState robot_state(default_state);
   const constraint_samplers::ConstraintSamplerManagerPtr& csmng = pcontext->getConstraintSamplerManager();
   ConstrainedSampler* csmp = nullptr;
   if (csmng)
@@ -501,8 +501,8 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     }
 
     ss->sampleUniform(temp.get());
-    pcontext->getOMPLStateSpace()->copyToRobotState(kstate, temp.get());
-    if (kset.decide(kstate).satisfied)
+    pcontext->getOMPLStateSpace()->copyToRobotState(robot_state, temp.get());
+    if (kset.decide(robot_state).satisfied)
     {
       if (sstor->size() < options.samples)
       {
@@ -566,8 +566,8 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
         {
           double this_step = step / (1.0 - (k - 1) * step);
           space->interpolate(int_states[k - 1], sj, this_step, int_states[k]);
-          pcontext->getOMPLStateSpace()->copyToRobotState(kstate, int_states[k]);
-          if (!kset.decide(kstate).satisfied)
+          pcontext->getOMPLStateSpace()->copyToRobotState(robot_state, int_states[k]);
+          if (!kset.decide(robot_state).satisfied)
           {
             ok = false;
             break;

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -229,7 +229,7 @@ ompl_interface::ConstraintApproximation::getStateSamplerAllocator(const moveit_m
 void ompl_interface::ConstraintApproximation::visualizeDistribution(const std::string &link_name, unsigned int count,
 visualization_msgs::MarkerArray &arr) const
 {
-  robot_state::RobotState kstate(kmodel_);
+  robot_state::RobotState kstate(robot_model_);
   kstate.setToDefaultValues();
 
   ompl::RNG rng;
@@ -249,7 +249,7 @@ state_storage_->getState(rng.uniformInt(0, state_storage_->size() - 1)));
 
     visualization_msgs::Marker mk;
     mk.header.stamp = ros::Time::now();
-    mk.header.frame_id = kmodel_->getModelFrame();
+    mk.header.frame_id = robot_model_->getModelFrame();
     mk.ns = "stored_constraint_data";
     mk.id = i;
     mk.type = visualization_msgs::Marker::SPHERE;

--- a/moveit_planners/ompl/ompl_interface/src/detail/threadsafe_state_storage.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/threadsafe_state_storage.cpp
@@ -36,7 +36,8 @@
 
 #include <moveit/ompl_interface/detail/threadsafe_state_storage.h>
 
-ompl_interface::TSStateStorage::TSStateStorage(const robot_model::RobotModelPtr& kmodel) : start_state_(kmodel)
+ompl_interface::TSStateStorage::TSStateStorage(const robot_model::RobotModelPtr& robot_model)
+  : start_state_(robot_model)
 {
   start_state_.setToDefaultValues();
 }

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,11 +42,12 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
-ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& kmodel, const ros::NodeHandle& nh)
+ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
+                                             const ros::NodeHandle& nh)
   : nh_(nh)
-  , robot_model_(kmodel)
+  , robot_model_(robot_model)
   , constraint_sampler_manager_(new constraint_samplers::ConstraintSamplerManager())
-  , context_manager_(kmodel, constraint_sampler_manager_)
+  , context_manager_(robot_model, constraint_sampler_manager_)
   , constraints_library_(new ConstraintsLibrary(context_manager_))
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
@@ -57,13 +58,13 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
   loadConstraintSamplers();
 }
 
-ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& kmodel,
+ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
                                              const planning_interface::PlannerConfigurationMap& pconfig,
                                              const ros::NodeHandle& nh)
   : nh_(nh)
-  , robot_model_(kmodel)
+  , robot_model_(robot_model)
   , constraint_sampler_manager_(new constraint_samplers::ConstraintSamplerManager())
-  , context_manager_(kmodel, constraint_sampler_manager_)
+  , context_manager_(robot_model, constraint_sampler_manager_)
   , constraints_library_(new ConstraintsLibrary(context_manager_))
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -44,7 +44,7 @@
 
 ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& kmodel, const ros::NodeHandle& nh)
   : nh_(nh)
-  , kmodel_(kmodel)
+  , robot_model_(kmodel)
   , constraint_sampler_manager_(new constraint_samplers::ConstraintSamplerManager())
   , context_manager_(kmodel, constraint_sampler_manager_)
   , constraints_library_(new ConstraintsLibrary(context_manager_))
@@ -61,7 +61,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
                                              const planning_interface::PlannerConfigurationMap& pconfig,
                                              const ros::NodeHandle& nh)
   : nh_(nh)
-  , kmodel_(kmodel)
+  , robot_model_(kmodel)
   , constraint_sampler_manager_(new constraint_samplers::ConstraintSamplerManager())
   , context_manager_(kmodel, constraint_sampler_manager_)
   , constraints_library_(new ConstraintsLibrary(context_manager_))
@@ -81,7 +81,7 @@ void ompl_interface::OMPLInterface::setPlannerConfigurations(const planning_inte
   planning_interface::PlannerConfigurationMap pconfig2 = pconfig;
 
   // construct default configurations for planning groups that don't have configs already passed in
-  for (const robot_model::JointModelGroup* group : kmodel_->getJointModelGroups())
+  for (const robot_model::JointModelGroup* group : robot_model_->getJointModelGroups())
   {
     if (pconfig.find(group->getName()) == pconfig.end())
     {
@@ -218,7 +218,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
   planning_interface::PlannerConfigurationMap pconfig;
   pconfig.clear();
 
-  for (const std::string& group_name : kmodel_->getJointModelGroupNames())
+  for (const std::string& group_name : robot_model_->getJointModelGroupNames())
   {
     // the set of planning parameters that can be specific for the group (inherited by configurations of that group)
     static const std::string KNOWN_GROUP_PARAMS[] = { "projection_evaluator", "longest_valid_segment_fraction",

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -177,7 +177,7 @@ private:
     ROS_INFO_STREAM("Displaying states for context " << pc->getName());
     const og::SimpleSetup &ss = pc->getOMPLSimpleSetup();
     ob::ValidStateSamplerPtr vss = ss.getSpaceInformation()->allocValidStateSampler();
-    robot_state::RobotState kstate = pc->getPlanningScene()->getCurrentState();
+    robot_state::RobotState robot_state = pc->getPlanningScene()->getCurrentState();
     ob::ScopedState<> rstate1(ss.getStateSpace());
     ob::ScopedState<> rstate2(ss.getStateSpace());
     ros::WallDuration wait(2);
@@ -188,10 +188,10 @@ private:
       {
         if (!vss->sampleNear(rstate1.get(), rstate2.get(), 10000000))
           continue;
-        pc->getOMPLStateSpace()->copyToRobotState(kstate, rstate1.get());
-        kstate.getJointStateGroup(pc->getJointModelGroupName())->updateLinkTransforms();
+        pc->getOMPLStateSpace()->copyToRobotState(robot_state, rstate1.get());
+        robot_state.getJointStateGroup(pc->getJointModelGroupName())->updateLinkTransforms();
         moveit_msgs::DisplayRobotState state_msg;
-        robot_state::robotStateToRobotStateMsg(kstate, state_msg.state);
+        robot_state::robotStateToRobotStateMsg(robot_state, state_msg.state);
         pub_valid_states_.publish(state_msg);
         n = (n + 1) % 2;
         if (n == 0)
@@ -201,8 +201,8 @@ private:
           ROS_INFO("Generated a motion with %u states", g);
           for (std::size_t i = 0 ; i < g ; ++i)
           {
-            pc->getOMPLStateSpace()->copyToRobotState(kstate, sts[i]);
-            traj.addSuffixWayPoint(kstate, 0.0);
+            pc->getOMPLStateSpace()->copyToRobotState(robot_state, sts[i]);
+            traj.addSuffixWayPoint(robot_state, 0.0);
           }
           moveit_msgs::DisplayTrajectory msg;
           msg.model_id = pc->getRobotModel()->getName();
@@ -224,7 +224,7 @@ private:
     {
       ompl::base::PlannerData pd(pc->getOMPLSimpleSetup()->getSpaceInformation());
       pc->getOMPLSimpleSetup()->getPlannerData(pd);
-      robot_state::RobotState kstate = planning_scene->getCurrentState();
+      robot_state::RobotState robot_state = planning_scene->getCurrentState();
       visualization_msgs::MarkerArray arr;
       std_msgs::ColorRGBA color;
       color.r = 1.0f;
@@ -234,9 +234,9 @@ private:
       unsigned int nv = pd.numVertices();
       for (unsigned int i = 0 ; i < nv ; ++i)
       {
-        pc->getOMPLStateSpace()->copyToRobotState(kstate, pd.getVertex(i).getState());
-        kstate.getJointStateGroup(pc->getJointModelGroupName())->updateLinkTransforms();
-        const Eigen::Vector3d &pos = kstate.getLinkState(link_name)->getGlobalLinkTransform().translation();
+        pc->getOMPLStateSpace()->copyToRobotState(robot_state, pd.getVertex(i).getState());
+        robot_state.getJointStateGroup(pc->getJointModelGroupName())->updateLinkTransforms();
+        const Eigen::Vector3d &pos = robot_state.getLinkState(link_name)->getGlobalLinkTransform().translation();
 
         visualization_msgs::Marker mk;
         mk.header.stamp = ros::Time::now();

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
@@ -44,7 +44,7 @@ ompl_interface::JointModelStateSpaceFactory::JointModelStateSpaceFactory() : Mod
 
 int ompl_interface::JointModelStateSpaceFactory::canRepresentProblem(
     const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-    const robot_model::RobotModelConstPtr& kmodel) const
+    const robot_model::RobotModelConstPtr& robot_model) const
 {
   return 100;
 }

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
@@ -42,11 +42,11 @@ ompl_interface::PoseModelStateSpaceFactory::PoseModelStateSpaceFactory() : Model
   type_ = PoseModelStateSpace::PARAMETERIZATION_TYPE;
 }
 
-int ompl_interface::PoseModelStateSpaceFactory::canRepresentProblem(const std::string& group,
-                                                                    const moveit_msgs::MotionPlanRequest& req,
-                                                                    const robot_model::RobotModelConstPtr& kmodel) const
+int ompl_interface::PoseModelStateSpaceFactory::canRepresentProblem(
+    const std::string& group, const moveit_msgs::MotionPlanRequest& req,
+    const robot_model::RobotModelConstPtr& robot_model) const
 {
-  const robot_model::JointModelGroup* jmg = kmodel->getJointModelGroup(group);
+  const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
     const std::pair<robot_model::JointModelGroup::KinematicsSolver, robot_model::JointModelGroup::KinematicsSolverMap>&

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -113,7 +113,7 @@ struct PlanningContextManager::CachedContexts
 
 ompl_interface::PlanningContextManager::PlanningContextManager(robot_model::RobotModelConstPtr kmodel,
                                                                constraint_samplers::ConstraintSamplerManagerPtr csm)
-  : kmodel_(std::move(kmodel))
+  : robot_model_(std::move(kmodel))
   , constraint_sampler_manager_(std::move(csm))
   , max_goal_samples_(10)
   , max_state_sampling_attempts_(4)
@@ -300,7 +300,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
   // Create a new planning context
   if (!context)
   {
-    ModelBasedStateSpaceSpecification space_spec(kmodel_, config.group);
+    ModelBasedStateSpaceSpecification space_spec(robot_model_, config.group);
     ModelBasedPlanningContextSpecification context_spec;
     context_spec.config_ = config.config;
     context_spec.planner_selector_ = getPlannerSelector();
@@ -323,7 +323,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
         const ompl_interface::ModelBasedStateSpaceFactoryPtr& sub_fact = factory_selector(*beg);
         if (sub_fact)
         {
-          ModelBasedStateSpaceSpecification sub_space_spec(kmodel_, *beg);
+          ModelBasedStateSpaceSpecification sub_space_spec(robot_model_, *beg);
           context_spec.subspaces_.push_back(sub_fact->getNewStateSpace(sub_space_spec));
         }
       }
@@ -374,7 +374,7 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
   int prev_priority = -1;
   for (auto it = state_space_factories_.begin(); it != state_space_factories_.end(); ++it)
   {
-    int priority = it->second->canRepresentProblem(group, req, kmodel_);
+    int priority = it->second->canRepresentProblem(group, req, robot_model_);
     if (priority > 0)
       if (best == state_space_factories_.end() || priority > prev_priority)
       {

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -111,9 +111,9 @@ struct PlanningContextManager::CachedContexts
 
 }  // namespace ompl_interface
 
-ompl_interface::PlanningContextManager::PlanningContextManager(robot_model::RobotModelConstPtr kmodel,
+ompl_interface::PlanningContextManager::PlanningContextManager(robot_model::RobotModelConstPtr robot_model,
                                                                constraint_samplers::ConstraintSamplerManagerPtr csm)
-  : robot_model_(std::move(kmodel))
+  : robot_model_(std::move(robot_model))
   , constraint_sampler_manager_(std::move(csm))
   , max_goal_samples_(10)
   , max_state_sampling_attempts_(4)

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -146,25 +146,25 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   }
   EXPECT_TRUE(passed);
 
-  robot_state::RobotState kstate(robot_model_);
-  kstate.setToRandomPositions();
-  EXPECT_TRUE(kstate.distance(kstate) < 1e-12);
+  robot_state::RobotState robot_state(robot_model_);
+  robot_state.setToRandomPositions();
+  EXPECT_TRUE(robot_state.distance(robot_state) < 1e-12);
   ompl::base::State* state = ss.allocState();
   for (int i = 0; i < 10; ++i)
   {
-    robot_state::RobotState kstate2(kstate);
-    EXPECT_TRUE(kstate.distance(kstate2) < 1e-12);
-    ss.copyToOMPLState(state, kstate);
-    kstate.setToRandomPositions(kstate.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName()));
-    std::cout << (kstate.getGlobalLinkTransform("r_wrist_roll_link").translation() -
-                  kstate2.getGlobalLinkTransform("r_wrist_roll_link").translation())
+    robot_state::RobotState robot_state2(robot_state);
+    EXPECT_TRUE(robot_state.distance(robot_state2) < 1e-12);
+    ss.copyToOMPLState(state, robot_state);
+    robot_state.setToRandomPositions(robot_state.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName()));
+    std::cout << (robot_state.getGlobalLinkTransform("r_wrist_roll_link").translation() -
+                  robot_state2.getGlobalLinkTransform("r_wrist_roll_link").translation())
               << std::endl;
-    EXPECT_TRUE(kstate.distance(kstate2) > 1e-12);
-    ss.copyToRobotState(kstate, state);
-    std::cout << (kstate.getGlobalLinkTransform("r_wrist_roll_link").translation() -
-                  kstate2.getGlobalLinkTransform("r_wrist_roll_link").translation())
+    EXPECT_TRUE(robot_state.distance(robot_state2) > 1e-12);
+    ss.copyToRobotState(robot_state, state);
+    std::cout << (robot_state.getGlobalLinkTransform("r_wrist_roll_link").translation() -
+                  robot_state2.getGlobalLinkTransform("r_wrist_roll_link").translation())
               << std::endl;
-    EXPECT_TRUE(kstate.distance(kstate2) < 1e-12);
+    EXPECT_TRUE(robot_state.distance(robot_state2) < 1e-12);
   }
 
   ss.freeState(state);

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_interface.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_interface.h
@@ -45,7 +45,7 @@ namespace sbpl_interface
 class SBPLInterface
 {
 public:
-  SBPLInterface(const planning_models::RobotModelConstPtr& kmodel)
+  SBPLInterface(const planning_models::RobotModelConstPtr& robot_model)
   {
   }
   virtual ~SBPLInterface()

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_meta_interface.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_meta_interface.h
@@ -46,7 +46,7 @@ namespace sbpl_interface
 class SBPLMetaInterface
 {
 public:
-  SBPLMetaInterface(const planning_models::RobotModelConstPtr& kmodel);
+  SBPLMetaInterface(const planning_models::RobotModelConstPtr& robot_model);
   virtual ~SBPLMetaInterface()
   {
   }

--- a/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_meta_interface.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_meta_interface.cpp
@@ -38,10 +38,10 @@
 
 namespace sbpl_interface
 {
-SBPLMetaInterface::SBPLMetaInterface(const planning_models::RobotModelConstPtr& kmodel)
+SBPLMetaInterface::SBPLMetaInterface(const planning_models::RobotModelConstPtr& robot_model)
 {
-  sbpl_interface_first_.reset(new sbpl_interface::SBPLInterface(kmodel));
-  sbpl_interface_second_.reset(new sbpl_interface::SBPLInterface(kmodel));
+  sbpl_interface_first_.reset(new sbpl_interface::SBPLInterface(robot_model));
+  sbpl_interface_second_.reset(new sbpl_interface::SBPLInterface(robot_model));
 }
 
 bool SBPLMetaInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -163,7 +163,7 @@ public:
   /** \brief Get the robot model that this pipeline is using */
   const robot_model::RobotModelConstPtr& getRobotModel() const
   {
-    return kmodel_;
+    return robot_model_;
   }
 
 private:
@@ -188,7 +188,7 @@ private:
   std::unique_ptr<planning_request_adapter::PlanningRequestAdapterChain> adapter_chain_;
   std::vector<std::string> adapter_plugin_names_;
 
-  robot_model::RobotModelConstPtr kmodel_;
+  robot_model::RobotModelConstPtr robot_model_;
 
   /// Flag indicating whether the reported plans should be checked once again, by the planning pipeline itself
   bool check_solution_paths_;

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -52,7 +52,7 @@ planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotMo
                                                       const ros::NodeHandle& nh,
                                                       const std::string& planner_plugin_param_name,
                                                       const std::string& adapter_plugins_param_name)
-  : nh_(nh), kmodel_(model)
+  : nh_(nh), robot_model_(model)
 {
   std::string planner;
   if (nh_.getParam(planner_plugin_param_name, planner))
@@ -73,7 +73,7 @@ planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotMo
 planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotModelConstPtr& model,
                                                       const ros::NodeHandle& nh, const std::string& planner_plugin_name,
                                                       const std::vector<std::string>& adapter_plugin_names)
-  : nh_(nh), planner_plugin_name_(planner_plugin_name), adapter_plugin_names_(adapter_plugin_names), kmodel_(model)
+  : nh_(nh), planner_plugin_name_(planner_plugin_name), adapter_plugin_names_(adapter_plugin_names), robot_model_(model)
 {
   configure();
 }
@@ -114,7 +114,7 @@ void planning_pipeline::PlanningPipeline::configure()
   try
   {
     planner_instance_.reset(planner_plugin_loader_->createUnmanagedInstance(planner_plugin_name_));
-    if (!planner_instance_->initialize(kmodel_, nh_.getNamespace()))
+    if (!planner_instance_->initialize(robot_model_, nh_.getNamespace()))
       throw std::runtime_error("Unable to initialize planning plugin");
     ROS_INFO_STREAM("Using planning interface '" << planner_instance_->getDescription() << "'");
   }
@@ -332,7 +332,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
   if (display_computed_motion_plans_ && solved)
   {
     moveit_msgs::DisplayTrajectory disp;
-    disp.model_id = kmodel_->getName();
+    disp.model_id = robot_model_->getName();
     disp.trajectory.resize(1);
     res.trajectory_->getRobotTrajectoryMsg(disp.trajectory[0]);
     robot_state::robotStateToRobotStateMsg(res.trajectory_->getFirstWayPoint(), disp.trajectory_start);

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -295,8 +295,8 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
             for (std::size_t i = 0; i < index.size(); ++i)
             {
               // check validity with verbose on
-              const robot_state::RobotState& kstate = res.trajectory_->getWayPoint(index[i]);
-              planning_scene->isStateValid(kstate, req.path_constraints, req.group_name, true);
+              const robot_state::RobotState& robot_state = res.trajectory_->getWayPoint(index[i]);
+              planning_scene->isStateValid(robot_state, req.path_constraints, req.group_name, true);
 
               // compute the contacts if any
               collision_detection::CollisionRequest c_req;
@@ -305,7 +305,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
               c_req.max_contacts = 10;
               c_req.max_contacts_per_pair = 3;
               c_req.verbose = false;
-              planning_scene->checkCollision(c_req, c_res, kstate);
+              planning_scene->checkCollision(c_req, c_res, robot_state);
               if (c_res.contact_count > 0)
               {
                 visualization_msgs::MarkerArray arr_i;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -82,11 +82,11 @@ public:
   };
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& kmodel,
+  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
                              const planning_scene_monitor::CurrentStateMonitorPtr& csm);
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& kmodel,
+  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
                              const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -78,9 +78,9 @@ private:
   dynamic_reconfigure::Server<TrajectoryExecutionDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
 
-TrajectoryExecutionManager::TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& kmodel,
+TrajectoryExecutionManager::TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
                                                        const planning_scene_monitor::CurrentStateMonitorPtr& csm)
-  : robot_model_(kmodel), csm_(csm), node_handle_("~")
+  : robot_model_(robot_model), csm_(csm), node_handle_("~")
 {
   if (!node_handle_.getParam("moveit_manage_controllers", manage_controllers_))
     manage_controllers_ = false;
@@ -88,10 +88,10 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(const robot_model::RobotM
   initialize();
 }
 
-TrajectoryExecutionManager::TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& kmodel,
+TrajectoryExecutionManager::TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
                                                        const planning_scene_monitor::CurrentStateMonitorPtr& csm,
                                                        bool manage_controllers)
-  : robot_model_(kmodel), csm_(csm), node_handle_("~"), manage_controllers_(manage_controllers)
+  : robot_model_(robot_model), csm_(csm), node_handle_("~"), manage_controllers_(manage_controllers)
 {
   initialize();
 }

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -49,25 +49,25 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
 
 /**
   @brief getSharedStateMonitor is a simpler version of getSharedStateMonitor(const robot_model::RobotModelConstPtr
-  &kmodel, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
+  &robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
     ros::NodeHandle nh = ros::NodeHandle() ). It calls this function using the default constructed ros::NodeHandle
 
-  @param kmodel
+  @param robot_model
   @param tf_buffer
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
 /**
   @brief getSharedStateMonitor
 
-  @param kmodel
+  @param robot_model
   @param tf_buffer
   @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                      ros::NodeHandle nh);
 

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -107,25 +107,25 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
   }
 }
 
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
 {
-  return getSharedStateMonitor(kmodel, tf_buffer, ros::NodeHandle());
+  return getSharedStateMonitor(robot_model, tf_buffer, ros::NodeHandle());
 }
 
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& kmodel,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                      ros::NodeHandle nh)
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);
-  if (s.state_monitors_.find(kmodel->getName()) != s.state_monitors_.end())
-    return s.state_monitors_[kmodel->getName()];
+  if (s.state_monitors_.find(robot_model->getName()) != s.state_monitors_.end())
+    return s.state_monitors_[robot_model->getName()];
   else
   {
     planning_scene_monitor::CurrentStateMonitorPtr monitor(
-        new planning_scene_monitor::CurrentStateMonitor(kmodel, tf_buffer, nh));
-    s.state_monitors_[kmodel->getName()] = monitor;
+        new planning_scene_monitor::CurrentStateMonitor(robot_model, tf_buffer, nh));
+    s.state_monitors_[robot_model->getName()] = monitor;
     return monitor;
   }
 }

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -85,7 +85,7 @@ public:
   /// The topic name on which the internal Interactive Marker Server operates
   static const std::string INTERACTIVE_MARKER_TOPIC;
 
-  RobotInteraction(const robot_model::RobotModelConstPtr& kmodel, const std::string& ns = "");
+  RobotInteraction(const robot_model::RobotModelConstPtr& robot_model, const std::string& ns = "");
   virtual ~RobotInteraction();
 
   const std::string& getServerTopic(void) const

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -254,11 +254,11 @@ void MotionPlanningFrame::fillStateSelectionOptions()
   if (!planning_display_->getPlanningSceneMonitor())
     return;
 
-  const robot_model::RobotModelConstPtr& kmodel = planning_display_->getRobotModel();
+  const robot_model::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
   std::string group = planning_display_->getCurrentPlanningGroup();
   if (group.empty())
     return;
-  const robot_model::JointModelGroup* jmg = kmodel->getJointModelGroup(group);
+  const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
     ui_->start_state_selection->addItem(QString("<random valid>"));
@@ -296,19 +296,19 @@ void MotionPlanningFrame::changePlanningGroupHelper()
   planning_display_->addMainLoopJob(
       boost::bind(&MotionPlanningFrame::populateConstraintsList, this, std::vector<std::string>()));
 
-  const robot_model::RobotModelConstPtr& kmodel = planning_display_->getRobotModel();
+  const robot_model::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
   std::string group = planning_display_->getCurrentPlanningGroup();
   planning_display_->addMainLoopJob(
       boost::bind(&MotionPlanningParamWidget::setGroupName, ui_->planner_param_treeview, group));
 
-  if (!group.empty() && kmodel)
+  if (!group.empty() && robot_model)
   {
     if (move_group_ && move_group_->getName() == group)
       return;
     ROS_INFO("Constructing new MoveGroup connection for group '%s' in namespace '%s'", group.c_str(),
              planning_display_->getMoveGroupNS().c_str());
     moveit::planning_interface::MoveGroupInterface::Options opt(group);
-    opt.robot_model_ = kmodel;
+    opt.robot_model_ = robot_model;
     opt.robot_description_.clear();
     opt.node_handle_ = ros::NodeHandle(planning_display_->getMoveGroupNS());
     try

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -376,11 +376,11 @@ void MotionPlanningFrame::configureWorkspace()
     move_group_->setWorkspace(bx.min_position_, by.min_position_, bz.min_position_, bx.max_position_, by.max_position_,
                               bz.max_position_);
   planning_scene_monitor::PlanningSceneMonitorPtr psm = planning_display_->getPlanningSceneMonitor();
-  // get non-const access to the kmodel and update planar & floating joints as indicated by the workspace settings
+  // get non-const access to the robot_model and update planar & floating joints as indicated by the workspace settings
   if (psm && psm->getRobotModelLoader() && psm->getRobotModelLoader()->getModel())
   {
-    const robot_model::RobotModelPtr& kmodel = psm->getRobotModelLoader()->getModel();
-    const std::vector<robot_model::JointModel*>& jm = kmodel->getJointModels();
+    const robot_model::RobotModelPtr& robot_model = psm->getRobotModelLoader()->getModel();
+    const std::vector<robot_model::JointModel*>& jm = robot_model->getJointModels();
     for (std::size_t i = 0; i < jm.size(); ++i)
       if (jm[i]->getType() == robot_model::JointModel::PLANAR)
       {

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -78,7 +78,7 @@ public:
 
   const robot_model::RobotModelConstPtr& getRobotModel() const
   {
-    return kmodel_;
+    return robot_model_;
   }
 
   void setLinkColor(const std::string& link_name, const QColor& color);
@@ -128,8 +128,8 @@ protected:
 
   RobotStateVisualizationPtr robot_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
-  robot_model::RobotModelConstPtr kmodel_;
-  robot_state::RobotStatePtr kstate_;
+  robot_model::RobotModelConstPtr robot_model_;
+  robot_state::RobotStatePtr robot_state_;
   std::map<std::string, std_msgs::ColorRGBA> highlights_;
   bool update_state_;
   bool load_robot_model_;  // for delayed robot initialization

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -613,7 +613,7 @@ void disableNeverInCollisionThread(ThreadComputation tc)
   const unsigned int progress_interval = tc.num_trials_ / 20;  // show progress update every 5%
 
   // Create a new kinematic state for this thread to work on
-  robot_state::RobotState kstate(tc.scene_.getRobotModel());
+  robot_state::RobotState robot_state(tc.scene_.getRobotModel());
 
   // Do a large number of tests
   for (unsigned int i = 0; i < tc.num_trials_; ++i)
@@ -627,8 +627,8 @@ void disableNeverInCollisionThread(ThreadComputation tc)
     }
 
     collision_detection::CollisionResult res;
-    kstate.setToRandomPositions();
-    tc.scene_.checkSelfCollision(tc.req_, res, kstate);
+    robot_state.setToRandomPositions();
+    tc.scene_.checkSelfCollision(tc.req_, res, robot_state);
 
     // Check all contacts
     for (collision_detection::CollisionResult::ContactMap::const_iterator it = res.contacts.begin();


### PR DESCRIPTION
- Cleanup old kinematic_model and kinematic_state names
- Replace kstate and kmodel with longer names
- Add LOGNAME to planning_scene

In the early days of moveit RobotModel was KinematicModel and RobotState was KinematicState

This finishes the cleanup of that transition.

Do not cherry-pick backwards