### PR TITLE
Various Cleanup and Commenting

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -448,10 +448,11 @@ protected:
 
   // GENERIC INFO
 
-  /** \brief The name of the model */
+  /** \brief The name of the robot */
   std::string model_name_;
 
-  /** \brief The reference frame for this model */
+  /** \brief The reference (base) frame for this model. The frame is either extracted from the SRDF as a virtual joint,
+   * or it is assumed to be the name of the root link in the URDF */
   std::string model_frame_;
 
   srdf::ModelConstSharedPtr srdf_;

--- a/moveit_core/transforms/include/moveit/transforms/transforms.h
+++ b/moveit_core/transforms/include/moveit/transforms/transforms.h
@@ -196,7 +196,7 @@ public:
 
 protected:
   std::string target_frame_;
-  FixedTransformsMap transforms_;
+  FixedTransformsMap transforms_map_;
 };
 }
 }

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -211,11 +211,11 @@ int main(int argc, char** argv)
     else
       ROS_INFO("MoveGroup debug mode is OFF");
 
-    printf(MOVEIT_CONSOLE_COLOR_CYAN "Starting context monitors...\n" MOVEIT_CONSOLE_COLOR_RESET);
+    printf(MOVEIT_CONSOLE_COLOR_CYAN "Starting planning scene monitors...\n" MOVEIT_CONSOLE_COLOR_RESET);
     planning_scene_monitor->startSceneMonitor();
     planning_scene_monitor->startWorldGeometryMonitor();
     planning_scene_monitor->startStateMonitor();
-    printf(MOVEIT_CONSOLE_COLOR_CYAN "Context monitors started.\n" MOVEIT_CONSOLE_COLOR_RESET);
+    printf(MOVEIT_CONSOLE_COLOR_CYAN "Planning scene monitors started.\n" MOVEIT_CONSOLE_COLOR_RESET);
 
     move_group::MoveGroupExe mge(planning_scene_monitor, debug);
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -343,8 +343,10 @@ public:
   /** @brief Stop the scene monitor*/
   void stopSceneMonitor();
 
-  /** @brief Start listening for objects in the world, the collision map and attached collision objects. Additionally,
-   * this function starts the OccupancyMapMonitor as well.
+  /** @brief Start the OccupancyMapMonitor and listening for:
+   *     - Requests to add/remove/update collision objects to/from the world
+   *     - The collision map
+   *     - Requests to attached/detach collision objects
    *  @param collision_objects_topic The topic on which to listen for collision objects
    *  @param planning_scene_world_topic The topic to listen to for world scene geometry
    *  @param load_octomap_monitor Flag to disable octomap monitor if desired
@@ -467,6 +469,7 @@ protected:
   ros::NodeHandle root_nh_;
   ros::CallbackQueue queue_;
   std::shared_ptr<ros::AsyncSpinner> spinner_;
+
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 
   std::string robot_description_;

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -85,7 +85,7 @@ ConfigurationFilesWidget::ConfigurationFilesWidget(QWidget* parent,
   stack_path_ = new LoadPathWidget("Configuration Package Save Path",
                                    "Specify the desired directory for the MoveIt! configuration package to be "
                                    "generated. Overwriting an existing configuration package directory is acceptable. "
-                                   "Example: <i>/u/robot/ros/pr2_moveit_config</i>",
+                                   "Example: <i>/u/robot/ros/panda_moveit_config</i>",
                                    this, true);  // is directory
   layout->addWidget(stack_path_);
 


### PR DESCRIPTION
Lots of minor, non-behavior cleanup and commenting as I debugged an issue with the planning scene transforms. Changes are cleanly separated by commits and should be **Rebased and Merged** but not cherry-picked backwards.

- Cleanup PlanningScene
- Cleanup RobotModel
- Cleanup Transforms
- Cleanup various moveit_ros packages