### PR TITLE
Improve clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,10 +26,10 @@ NamespaceIndentation: None
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 60
-PenaltyBreakString: 1
+PenaltyBreakString: 100
 PenaltyBreakFirstLessLess: 1000
 PenaltyExcessCharacter: 1000
-PenaltyReturnTypeOnItsOwnLine: 90
+PenaltyReturnTypeOnItsOwnLine: 70
 SpacesBeforeTrailingComments: 2
 Cpp11BracedListStyle: false
 Standard:        Auto

--- a/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
@@ -39,9 +39,10 @@
 #include <moveit/constraint_samplers/union_constraint_sampler.h>
 #include <sstream>
 
-constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSamplerManager::selectSampler(
-    const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
-    const moveit_msgs::Constraints& constr) const
+constraint_samplers::ConstraintSamplerPtr
+constraint_samplers::ConstraintSamplerManager::selectSampler(const planning_scene::PlanningSceneConstPtr& scene,
+                                                             const std::string& group_name,
+                                                             const moveit_msgs::Constraints& constr) const
 {
   for (std::size_t i = 0; i < sampler_alloc_.size(); ++i)
     if (sampler_alloc_[i]->canService(scene, group_name, constr))
@@ -51,9 +52,10 @@ constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSampler
   return selectDefaultSampler(scene, group_name, constr);
 }
 
-constraint_samplers::ConstraintSamplerPtr constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(
-    const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
-    const moveit_msgs::Constraints& constr)
+constraint_samplers::ConstraintSamplerPtr
+constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(const planning_scene::PlanningSceneConstPtr& scene,
+                                                                    const std::string& group_name,
+                                                                    const moveit_msgs::Constraints& constr)
 {
   const robot_model::JointModelGroup* jmg = scene->getRobotModel()->getJointModelGroup(group_name);
   if (!jmg)

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -512,8 +512,7 @@ TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
   std::vector<kinematic_constraints::JointConstraint> js;
   js.push_back(jc1);
 
-  constraint_samplers::JointConstraintSamplerPtr jcsp(new constraint_samplers::JointConstraintSampler(ps_, "arms_and_"
-                                                                                                           "torso"));
+  constraint_samplers::JointConstraintSamplerPtr jcsp(new constraint_samplers::JointConstraintSampler(ps_, "arms_and_torso"));
   EXPECT_TRUE(jcsp->configure(js));
 
   std::vector<kinematic_constraints::JointConstraint> js2;

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -512,7 +512,8 @@ TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
   std::vector<kinematic_constraints::JointConstraint> js;
   js.push_back(jc1);
 
-  constraint_samplers::JointConstraintSamplerPtr jcsp(new constraint_samplers::JointConstraintSampler(ps_, "arms_and_torso"));
+  constraint_samplers::JointConstraintSamplerPtr jcsp(
+      new constraint_samplers::JointConstraintSampler(ps_, "arms_and_torso"));
   EXPECT_TRUE(jcsp->configure(js));
 
   std::vector<kinematic_constraints::JointConstraint> js2;

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -672,8 +672,7 @@ bool VisibilityConstraint::configure(const moveit_msgs::VisibilityConstraint& vc
   target_radius_ = fabs(vc.target_radius);
 
   if (vc.target_radius <= std::numeric_limits<double>::epsilon())
-    ROS_WARN_NAMED("kinematic_constraints", "The radius of the target disc that must be visible should be strictly "
-                                            "positive");
+    ROS_WARN_NAMED("kinematic_constraints", "The radius of the target disc that must be visible should be strictly positive");
 
   if (vc.cone_sides < 3)
   {

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -672,7 +672,8 @@ bool VisibilityConstraint::configure(const moveit_msgs::VisibilityConstraint& vc
   target_radius_ = fabs(vc.target_radius);
 
   if (vc.target_radius <= std::numeric_limits<double>::epsilon())
-    ROS_WARN_NAMED("kinematic_constraints", "The radius of the target disc that must be visible should be strictly positive");
+    ROS_WARN_NAMED("kinematic_constraints",
+                   "The radius of the target disc that must be visible should be strictly positive");
 
   if (vc.cone_sides < 3)
   {

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -239,10 +239,11 @@ public:
    * redundant the same as in the seed
    * @return True if a valid solution was found, false otherwise
    */
-  virtual bool searchPositionIK(
-      const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-      std::vector<double>& solution, const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
-      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const = 0;
+  virtual bool
+  searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                   std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                   moveit_msgs::MoveItErrorCodes& error_code,
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const = 0;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -1046,8 +1046,8 @@ void CollisionRobotDistanceField::addLinkBodyDecompositions(
   {
     if (link_models[i]->getShapes().empty())
     {
-      ROS_WARN_STREAM("Skipping model generation for link " << link_models[i]->getName() << " since it contains no "
-                                                                                            "geometries");
+      ROS_WARN_STREAM("Skipping model generation for link " << link_models[i]->getName()
+                                                            << " since it contains no geometries");
       continue;
     }
 

--- a/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_experimental/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -175,9 +175,10 @@ void CollisionRobotDistanceField::checkSelfCollisionHelper(const collision_detec
   }
 }
 
-DistanceFieldCacheEntryConstPtr CollisionRobotDistanceField::getDistanceFieldCacheEntry(
-    const std::string& group_name, const moveit::core::RobotState& state,
-    const collision_detection::AllowedCollisionMatrix* acm) const
+DistanceFieldCacheEntryConstPtr
+CollisionRobotDistanceField::getDistanceFieldCacheEntry(const std::string& group_name,
+                                                        const moveit::core::RobotState& state,
+                                                        const collision_detection::AllowedCollisionMatrix* acm) const
 {
   DistanceFieldCacheEntryConstPtr ret;
   if (!distance_field_cache_entry_)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -591,8 +591,8 @@ int IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<doub
       return solutions.GetNumSolutions();
 
     default:
-      ROS_ERROR_NAMED(name_, "Unknown IkParameterizationType! Was the solver generated with an incompatible version "
-                             "of Openrave?");
+      ROS_ERROR_NAMED(name_, "Unknown IkParameterizationType! "
+                             "Was the solver generated with an incompatible version of Openrave?");
       return 0;
   }
 }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -99,8 +99,8 @@ bool ChainIkSolverVel_pinv_mimic::setRedundantJointsMapIndex(
 {
   if (redundant_joints_map_index.size() != chain.getNrOfJoints() - num_mimic_joints - num_redundant_joints)
   {
-    ROS_ERROR("Map index size: %d does not match expected size. No. of joints: %d, num_mimic_joints: %d, "
-              "num_redundant_joints: %d",
+    ROS_ERROR("Map index size: %d does not match expected size. "
+              "No. of joints: %d, num_mimic_joints: %d, num_redundant_joints: %d",
               (int)redundant_joints_map_index.size(), (int)chain.getNrOfJoints(), (int)num_mimic_joints,
               (int)num_redundant_joints);
     return false;

--- a/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/chainiksolver_vel_pinv_mimic.cpp
@@ -110,8 +110,8 @@ bool ChainIkSolverVel_pinv_mimic::setRedundantJointsMapIndex(
 {
   if (redundant_joints_map_index.size() != chain.getNrOfJoints() - num_mimic_joints - num_redundant_joints)
   {
-    ROS_ERROR("Map index size: %d does not match expected size. No. of joints: %d, num_mimic_joints: %d, "
-              "num_redundant_joints: %d",
+    ROS_ERROR("Map index size: %d does not match expected size. "
+              "No. of joints: %d, num_mimic_joints: %d, num_redundant_joints: %d",
               (int)redundant_joints_map_index.size(), (int)chain.getNrOfJoints(), (int)num_mimic_joints,
               (int)num_redundant_joints);
     return false;

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -355,8 +355,8 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   // Convert the robot state message to our robot_state representation
   if (!moveit::core::robotStateMsgToRobotState(ik_srv.response.solution, *robot_state_))
   {
-    ROS_ERROR_STREAM_NAMED("srv", "An error occured converting received robot state message into internal robot "
-                                  "state.");
+    ROS_ERROR_STREAM_NAMED("srv",
+                           "An error occured converting received robot state message into internal robot state.");
     error_code.val = error_code.FAILURE;
     return false;
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -150,8 +150,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   {
     if (!(trajectory.fillInFromTrajectory(res)))
     {
-      ROS_ERROR_STREAM_NAMED("chomp_planner", "Input trajectory has less than 2 points, trajectory must contain "
-                                              "atleast start and goal state");
+      ROS_ERROR_STREAM_NAMED("chomp_planner", "Input trajectory has less than 2 points, "
+                                              "trajectory must contain at least start and goal state");
       return false;
     }
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/constraints_library.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/constraints_library.h
@@ -169,14 +169,16 @@ public:
 
   void saveConstraintApproximations(const std::string& path);
 
-  ConstraintApproximationConstructionResults addConstraintApproximation(
-      const moveit_msgs::Constraints& constr_sampling, const moveit_msgs::Constraints& constr_hard,
-      const std::string& group, const planning_scene::PlanningSceneConstPtr& scene,
-      const ConstraintApproximationConstructionOptions& options);
+  ConstraintApproximationConstructionResults
+  addConstraintApproximation(const moveit_msgs::Constraints& constr_sampling,
+                             const moveit_msgs::Constraints& constr_hard, const std::string& group,
+                             const planning_scene::PlanningSceneConstPtr& scene,
+                             const ConstraintApproximationConstructionOptions& options);
 
-  ConstraintApproximationConstructionResults addConstraintApproximation(
-      const moveit_msgs::Constraints& constr, const std::string& group,
-      const planning_scene::PlanningSceneConstPtr& scene, const ConstraintApproximationConstructionOptions& options);
+  ConstraintApproximationConstructionResults
+  addConstraintApproximation(const moveit_msgs::Constraints& constr, const std::string& group,
+                             const planning_scene::PlanningSceneConstPtr& scene,
+                             const ConstraintApproximationConstructionOptions& options);
 
   void printConstraintApproximations(std::ostream& out = std::cout) const;
   void clearConstraintApproximations();

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -187,9 +187,10 @@ ompl_interface::InterpolationFunction ompl_interface::ConstraintApproximation::g
   return InterpolationFunction();
 }
 
-ompl::base::StateSamplerPtr allocConstraintApproximationStateSampler(
-    const ob::StateSpace* space, const std::vector<int>& expected_signature,
-    const ConstraintApproximationStateStorage* state_storage, std::size_t milestones)
+ompl::base::StateSamplerPtr
+allocConstraintApproximationStateSampler(const ob::StateSpace* space, const std::vector<int>& expected_signature,
+                                         const ConstraintApproximationStateStorage* state_storage,
+                                         std::size_t milestones)
 {
   std::vector<int> sig;
   space->computeSignature(sig);

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -102,9 +102,10 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getP
   return getPlanningContext(planning_scene, req, dummy);
 }
 
-ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getPlanningContext(
-    const planning_scene::PlanningSceneConstPtr& planning_scene, const planning_interface::MotionPlanRequest& req,
-    moveit_msgs::MoveItErrorCodes& error_code) const
+ompl_interface::ModelBasedPlanningContextPtr
+ompl_interface::OMPLInterface::getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                                  const planning_interface::MotionPlanRequest& req,
+                                                  moveit_msgs::MoveItErrorCodes& error_code) const
 {
   ModelBasedPlanningContextPtr ctx = context_manager_.getPlanningContext(planning_scene, req, error_code);
   if (ctx)

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -397,9 +397,10 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
   }
 }
 
-ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextManager::getPlanningContext(
-    const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::MotionPlanRequest& req,
-    moveit_msgs::MoveItErrorCodes& error_code) const
+ompl_interface::ModelBasedPlanningContextPtr
+ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                                           const moveit_msgs::MotionPlanRequest& req,
+                                                           moveit_msgs::MoveItErrorCodes& error_code) const
 {
   if (req.group_name.empty())
   {

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -91,8 +91,8 @@ public:
 
         if (controller_list[i]["joints"].getType() != XmlRpc::XmlRpcValue::TypeArray)
         {
-          ROS_ERROR_STREAM_NAMED("manager", "The list of joints for controller " << name << " is not specified as an "
-                                                                                            "array");
+          ROS_ERROR_STREAM_NAMED("manager", "The list of joints for controller " << name
+                                                                                 << " is not specified as an array");
           continue;
         }
 
@@ -114,8 +114,7 @@ public:
             {
               if (controller_list[i]["joints"].size() != 2)
               {
-                ROS_ERROR_STREAM_NAMED("manager", "Parallel Gripper requires exactly two "
-                                                  "joints");
+                ROS_ERROR_STREAM_NAMED("manager", "Parallel Gripper requires exactly two joints");
                 continue;
               }
               static_cast<GripperControllerHandle*>(new_handle.get())

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -529,8 +529,7 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string& filen
                                           boost::program_options::value<std::string>()->default_value(""),
                                           "Override the planning frame to use")(
         "scene.default_constrained_link", boost::program_options::value<std::string>()->default_value(""),
-        "Specify the default link to consider as constrained when one is not specified in a moveit_msgs::Constraints "
-        "message")("scene.goal_offset_x", boost::program_options::value<std::string>()->default_value("0.0"),
+        "Specify the default link to consider as constrained when one is not specified in a moveit_msgs::Constraints message")("scene.goal_offset_x", boost::program_options::value<std::string>()->default_value("0.0"),
                    "Goal offset in x")(
         "scene.goal_offset_y", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in y")(
         "scene.goal_offset_z", boost::program_options::value<std::string>()->default_value("0.0"),

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -513,37 +513,29 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string& filen
   try
   {
     boost::program_options::options_description desc;
-    desc.add_options()("scene.name", boost::program_options::value<std::string>(), "Scene name")(
-        "scene.runs", boost::program_options::value<std::string>()->default_value("1"), "Number of runs")(
-        "scene.timeout", boost::program_options::value<std::string>()->default_value(""),
-        "Timeout for planning (s)")("scene.start", boost::program_options::value<std::string>()->default_value(""),
-                                    "Regex for the start states to use")(
-        "scene.query", boost::program_options::value<std::string>()->default_value(".*"),
-        "Regex for the queries to execute")("scene.goal",
-                                            boost::program_options::value<std::string>()->default_value(""),
-                                            "Regex for the names of constraints to use as goals")(
-        "scene.trajectory", boost::program_options::value<std::string>()->default_value(""),
-        "Regex for the names of constraints to use as trajectories")(
-        "scene.group", boost::program_options::value<std::string>()->default_value(""),
-        "Override the group to plan for")("scene.planning_frame",
-                                          boost::program_options::value<std::string>()->default_value(""),
-                                          "Override the planning frame to use")(
-        "scene.default_constrained_link", boost::program_options::value<std::string>()->default_value(""),
-        "Specify the default link to consider as constrained when one is not specified in a moveit_msgs::Constraints message")("scene.goal_offset_x", boost::program_options::value<std::string>()->default_value("0.0"),
-                   "Goal offset in x")(
-        "scene.goal_offset_y", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in y")(
-        "scene.goal_offset_z", boost::program_options::value<std::string>()->default_value("0.0"),
-        "Goal offset in z")("scene.goal_offset_roll",
-                            boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in roll")(
-        "scene.goal_offset_pitch", boost::program_options::value<std::string>()->default_value("0.0"),
-        "Goal offset in pitch")("scene.goal_offset_yaw",
-                                boost::program_options::value<std::string>()->default_value("0.0"),
-                                "Goal offset in yaw")("scene.output", boost::program_options::value<std::string>(),
-                                                      "Location of benchmark log file")(
-        "scene.workspace", boost::program_options::value<std::string>(), "Bounding box of workspace to plan in - "
-                                                                         "min_x, min_y, min_z, max_x, max_y, max_z")(
-        "scene.workspace_frame", boost::program_options::value<std::string>(), "Frame id of bounding box of workspace "
-                                                                               "to plan in");
+    // clang-format off
+    desc.add_options()
+      ("scene.name", boost::program_options::value<std::string>(), "Scene name")
+      ("scene.runs", boost::program_options::value<std::string>()->default_value("1"), "Number of runs")
+      ("scene.timeout", boost::program_options::value<std::string>()->default_value(""), "Timeout for planning (s)")
+      ("scene.start", boost::program_options::value<std::string>()->default_value(""), "Regex for the start states to use")
+      ("scene.query", boost::program_options::value<std::string>()->default_value(".*"), "Regex for the queries to execute")
+      ("scene.goal", boost::program_options::value<std::string>()->default_value(""), "Regex for the names of constraints to use as goals")
+      ("scene.trajectory", boost::program_options::value<std::string>()->default_value(""), "Regex for the names of constraints to use as trajectories")
+      ("scene.group", boost::program_options::value<std::string>()->default_value(""), "Override the group to plan for")
+      ("scene.planning_frame", boost::program_options::value<std::string>()->default_value(""), "Override the planning frame to use")
+      ("scene.default_constrained_link", boost::program_options::value<std::string>()->default_value(""),
+       "Specify the default link to consider as constrained when one is not specified in a moveit_msgs::Constraints message")
+      ("scene.goal_offset_x", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in x")
+      ("scene.goal_offset_y", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in y")
+      ("scene.goal_offset_z", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in z")
+      ("scene.goal_offset_roll", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in roll")
+      ("scene.goal_offset_pitch", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in pitch")
+      ("scene.goal_offset_yaw", boost::program_options::value<std::string>()->default_value("0.0"), "Goal offset in yaw")
+      ("scene.output", boost::program_options::value<std::string>(), "Location of benchmark log file")
+      ("scene.workspace", boost::program_options::value<std::string>(), "Bounding box of workspace to plan in - min_x, min_y, min_z, max_x, max_y, max_z")
+      ("scene.workspace_frame", boost::program_options::value<std::string>(), "Frame id of bounding box of workspace to plan in");
+    // clang-format on
 
     boost::program_options::variables_map vm;
     boost::program_options::parsed_options po = boost::program_options::parse_config_file(cfg, desc, true);

--- a/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
+++ b/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
@@ -131,8 +131,7 @@ void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::Poi
       if (!transform_callback_(it->handle, tmp))
       {
         if (!it->body)
-          ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape with handle " << it->handle << " without a "
-                                                                                                           "body");
+          ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape with handle " << it->handle << " without a body");
         else
           ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape " << it->body->getType() << " with handle "
                                                                               << it->handle);

--- a/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
+++ b/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
@@ -131,7 +131,8 @@ void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::Poi
       if (!transform_callback_(it->handle, tmp))
       {
         if (!it->body)
-          ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape with handle " << it->handle << " without a body");
+          ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape with handle " << it->handle
+                                                                                          << " without a body");
         else
           ROS_ERROR_STREAM_NAMED("shape_mask", "Missing transform for shape " << it->body->getType() << " with handle "
                                                                               << it->handle);

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -228,10 +228,11 @@ SemanticWorld::generatePlacePoses(const std::string& table_name, const shapes::S
   return place_poses;
 }
 
-std::vector<geometry_msgs::PoseStamped> SemanticWorld::generatePlacePoses(
-    const object_recognition_msgs::Table& chosen_table, const shapes::ShapeConstPtr& object_shape,
-    const geometry_msgs::Quaternion& object_orientation, double resolution, double delta_height,
-    unsigned int num_heights) const
+std::vector<geometry_msgs::PoseStamped>
+SemanticWorld::generatePlacePoses(const object_recognition_msgs::Table& chosen_table,
+                                  const shapes::ShapeConstPtr& object_shape,
+                                  const geometry_msgs::Quaternion& object_orientation, double resolution,
+                                  double delta_height, unsigned int num_heights) const
 {
   std::vector<geometry_msgs::PoseStamped> place_poses;
   if (object_shape->type != shapes::MESH && object_shape->type != shapes::SPHERE && object_shape->type != shapes::BOX &&

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -110,12 +110,10 @@ const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_ST
 const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC =
     "attached_collision_object";
 const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC = "collision_object";
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC = "planning_scene_"
-                                                                                                     "world";
+const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC = "planning_scene_world";
 const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC = "planning_scene";
 const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE = "get_planning_scene";
-const std::string planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC = "monitored_planning_"
-                                                                                                 "scene";
+const std::string planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC = "monitored_planning_scene";
 
 planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(const std::string& robot_description,
                                                                    const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -104,43 +104,38 @@ private:
   PlanningSceneMonitor* owner_;
   dynamic_reconfigure::Server<PlanningSceneMonitorDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
-}
 
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC = "joint_states";
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC =
-    "attached_collision_object";
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC = "collision_object";
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC = "planning_scene_world";
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC = "planning_scene";
-const std::string planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE = "get_planning_scene";
-const std::string planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC = "monitored_planning_scene";
+const std::string PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC = "joint_states";
+const std::string PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC = "attached_collision_object";
+const std::string PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC = "collision_object";
+const std::string PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC = "planning_scene_world";
+const std::string PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC = "planning_scene";
+const std::string PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE = "get_planning_scene";
+const std::string PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC = "monitored_planning_scene";
 
-planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(const std::string& robot_description,
-                                                                   const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                                                   const std::string& name)
+PlanningSceneMonitor::PlanningSceneMonitor(const std::string& robot_description,
+                                           const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
   : PlanningSceneMonitor(planning_scene::PlanningScenePtr(), robot_description, tf_buffer, name)
 {
 }
 
-planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
-                                                                   const std::string& robot_description,
-                                                                   const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                                                   const std::string& name)
+PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
+                                           const std::string& robot_description,
+                                           const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
   : PlanningSceneMonitor(scene, std::make_shared<robot_model_loader::RobotModelLoader>(robot_description), tf_buffer,
                          name)
 {
 }
 
-planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(
-    const robot_model_loader::RobotModelLoaderPtr& rm_loader, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-    const std::string& name)
+PlanningSceneMonitor::PlanningSceneMonitor(const robot_model_loader::RobotModelLoaderPtr& rm_loader,
+                                           const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
   : PlanningSceneMonitor(planning_scene::PlanningScenePtr(), rm_loader, tf_buffer, name)
 {
 }
 
-planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(
-    const planning_scene::PlanningScenePtr& scene, const robot_model_loader::RobotModelLoaderPtr& rm_loader,
-    const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
+PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
+                                           const robot_model_loader::RobotModelLoaderPtr& rm_loader,
+                                           const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
   : monitor_name_(name), nh_("~"), tf_buffer_(tf_buffer), rm_loader_(rm_loader)
 {
   root_nh_.setCallbackQueue(&queue_);
@@ -150,9 +145,10 @@ planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(
   initialize(scene);
 }
 
-planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(
-    const planning_scene::PlanningScenePtr& scene, const robot_model_loader::RobotModelLoaderPtr& rm_loader,
-    const ros::NodeHandle& nh, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
+PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
+                                           const robot_model_loader::RobotModelLoaderPtr& rm_loader,
+                                           const ros::NodeHandle& nh, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
+                                           const std::string& name)
   : monitor_name_(name), nh_("~"), root_nh_(nh), tf_buffer_(tf_buffer), rm_loader_(rm_loader)
 {
   // use same callback queue as root_nh_
@@ -160,7 +156,7 @@ planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(
   initialize(scene);
 }
 
-planning_scene_monitor::PlanningSceneMonitor::~PlanningSceneMonitor()
+PlanningSceneMonitor::~PlanningSceneMonitor()
 {
   if (scene_)
   {
@@ -182,7 +178,7 @@ planning_scene_monitor::PlanningSceneMonitor::~PlanningSceneMonitor()
   rm_loader_.reset();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& scene)
+void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& scene)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("PlanningSceneMonitor::initialize");
@@ -262,7 +258,7 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
   reconfigure_impl_ = new DynamicReconfigureImpl(this);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::monitorDiffs(bool flag)
+void PlanningSceneMonitor::monitorDiffs(bool flag)
 {
   if (scene_)
   {
@@ -309,7 +305,7 @@ void planning_scene_monitor::PlanningSceneMonitor::monitorDiffs(bool flag)
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::stopPublishingPlanningScene()
+void PlanningSceneMonitor::stopPublishingPlanningScene()
 {
   if (publish_planning_scene_)
   {
@@ -323,8 +319,8 @@ void planning_scene_monitor::PlanningSceneMonitor::stopPublishingPlanningScene()
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::startPublishingPlanningScene(SceneUpdateType update_type,
-                                                                                const std::string& planning_scene_topic)
+void PlanningSceneMonitor::startPublishingPlanningScene(SceneUpdateType update_type,
+                                                        const std::string& planning_scene_topic)
 {
   publish_update_types_ = update_type;
   if (!publish_planning_scene_ && scene_)
@@ -336,7 +332,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startPublishingPlanningScene(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
+void PlanningSceneMonitor::scenePublishingThread()
 {
   ROS_DEBUG_NAMED(LOGNAME, "Started scene publishing thread ...");
 
@@ -419,7 +415,7 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
   } while (publish_planning_scene_);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::getMonitoredTopics(std::vector<std::string>& topics) const
+void PlanningSceneMonitor::getMonitoredTopics(std::vector<std::string>& topics) const
 {
   topics.clear();
   if (current_state_monitor_)
@@ -449,18 +445,17 @@ bool sceneIsParentOf(const planning_scene::PlanningSceneConstPtr& scene,
 }
 }
 
-bool planning_scene_monitor::PlanningSceneMonitor::updatesScene(const planning_scene::PlanningScenePtr& scene) const
+bool PlanningSceneMonitor::updatesScene(const planning_scene::PlanningScenePtr& scene) const
 {
   return sceneIsParentOf(scene_const_, scene.get());
 }
 
-bool planning_scene_monitor::PlanningSceneMonitor::updatesScene(
-    const planning_scene::PlanningSceneConstPtr& scene) const
+bool PlanningSceneMonitor::updatesScene(const planning_scene::PlanningSceneConstPtr& scene) const
 {
   return sceneIsParentOf(scene_const_, scene.get());
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::triggerSceneUpdateEvent(SceneUpdateType update_type)
+void PlanningSceneMonitor::triggerSceneUpdateEvent(SceneUpdateType update_type)
 {
   // do not modify update functions while we are calling them
   boost::recursive_mutex::scoped_lock lock(update_lock_);
@@ -471,7 +466,7 @@ void planning_scene_monitor::PlanningSceneMonitor::triggerSceneUpdateEvent(Scene
   new_scene_update_condition_.notify_all();
 }
 
-bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(const std::string& service_name)
+bool PlanningSceneMonitor::requestPlanningSceneState(const std::string& service_name)
 {
   // use global namespace for service
   ros::ServiceClient client = ros::NodeHandle().serviceClient<moveit_msgs::GetPlanningScene>(service_name);
@@ -503,20 +498,19 @@ bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(con
   return true;
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneCallback(
-    const moveit_msgs::PlanningSceneConstPtr& scene)
+void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr& scene)
 {
   newPlanningSceneMessage(*scene);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::clearOctomap()
+void PlanningSceneMonitor::clearOctomap()
 {
   octomap_monitor_->getOcTreePtr()->lockWrite();
   octomap_monitor_->getOcTreePtr()->clear();
   octomap_monitor_->getOcTreePtr()->unlockWrite();
 }
 
-bool planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
+bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
 {
   if (!scene_)
     return false;
@@ -596,8 +590,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const
   return result;
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneWorldCallback(
-    const moveit_msgs::PlanningSceneWorldConstPtr& world)
+void PlanningSceneMonitor::newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr& world)
 {
   if (scene_)
   {
@@ -621,16 +614,15 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneWorldCallback
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::collisionObjectFailTFCallback(
-    const moveit_msgs::CollisionObjectConstPtr& obj, tf2_ros::filter_failure_reasons::FilterFailureReason reason)
+void PlanningSceneMonitor::collisionObjectFailTFCallback(const moveit_msgs::CollisionObjectConstPtr& obj,
+                                                         tf2_ros::filter_failure_reasons::FilterFailureReason reason)
 {
   // if we just want to remove objects, the frame does not matter
   if (reason == tf2_ros::filter_failure_reasons::EmptyFrameID && obj->operation == moveit_msgs::CollisionObject::REMOVE)
     collisionObjectCallback(obj);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::collisionObjectCallback(
-    const moveit_msgs::CollisionObjectConstPtr& obj)
+void PlanningSceneMonitor::collisionObjectCallback(const moveit_msgs::CollisionObjectConstPtr& obj)
 {
   if (!scene_)
   {
@@ -646,8 +638,7 @@ void planning_scene_monitor::PlanningSceneMonitor::collisionObjectCallback(
   triggerSceneUpdateEvent(UPDATE_GEOMETRY);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::attachObjectCallback(
-    const moveit_msgs::AttachedCollisionObjectConstPtr& obj)
+void PlanningSceneMonitor::attachObjectCallback(const moveit_msgs::AttachedCollisionObjectConstPtr& obj)
 {
   if (scene_)
   {
@@ -661,7 +652,7 @@ void planning_scene_monitor::PlanningSceneMonitor::attachObjectCallback(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::excludeRobotLinksFromOctree()
+void PlanningSceneMonitor::excludeRobotLinksFromOctree()
 {
   if (!octomap_monitor_)
     return;
@@ -697,7 +688,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeRobotLinksFromOctree()
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::includeRobotLinksInOctree()
+void PlanningSceneMonitor::includeRobotLinksInOctree()
 {
   if (!octomap_monitor_)
     return;
@@ -710,7 +701,7 @@ void planning_scene_monitor::PlanningSceneMonitor::includeRobotLinksInOctree()
   link_shape_handles_.clear();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::includeAttachedBodiesInOctree()
+void PlanningSceneMonitor::includeAttachedBodiesInOctree()
 {
   if (!octomap_monitor_)
     return;
@@ -725,7 +716,7 @@ void planning_scene_monitor::PlanningSceneMonitor::includeAttachedBodiesInOctree
   attached_body_shape_handles_.clear();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::excludeAttachedBodiesFromOctree()
+void PlanningSceneMonitor::excludeAttachedBodiesFromOctree()
 {
   boost::recursive_mutex::scoped_lock _(shape_handles_lock_);
 
@@ -737,7 +728,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeAttachedBodiesFromOctr
     excludeAttachedBodyFromOctree(ab[i]);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::includeWorldObjectsInOctree()
+void PlanningSceneMonitor::includeWorldObjectsInOctree()
 {
   if (!octomap_monitor_)
     return;
@@ -752,7 +743,7 @@ void planning_scene_monitor::PlanningSceneMonitor::includeWorldObjectsInOctree()
   collision_body_shape_handles_.clear();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::excludeWorldObjectsFromOctree()
+void PlanningSceneMonitor::excludeWorldObjectsFromOctree()
 {
   boost::recursive_mutex::scoped_lock _(shape_handles_lock_);
 
@@ -762,8 +753,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeWorldObjectsFromOctree
     excludeWorldObjectFromOctree(it->second);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::excludeAttachedBodyFromOctree(
-    const robot_state::AttachedBody* attached_body)
+void PlanningSceneMonitor::excludeAttachedBodyFromOctree(const robot_state::AttachedBody* attached_body)
 {
   if (!octomap_monitor_)
     return;
@@ -785,8 +775,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeAttachedBodyFromOctree
     ROS_DEBUG_NAMED(LOGNAME, "Excluding attached body '%s' from monitored octomap", attached_body->getName().c_str());
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::includeAttachedBodyInOctree(
-    const robot_state::AttachedBody* attached_body)
+void PlanningSceneMonitor::includeAttachedBodyInOctree(const robot_state::AttachedBody* attached_body)
 {
   if (!octomap_monitor_)
     return;
@@ -803,8 +792,7 @@ void planning_scene_monitor::PlanningSceneMonitor::includeAttachedBodyInOctree(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::excludeWorldObjectFromOctree(
-    const collision_detection::World::ObjectConstPtr& obj)
+void PlanningSceneMonitor::excludeWorldObjectFromOctree(const collision_detection::World::ObjectConstPtr& obj)
 {
   if (!octomap_monitor_)
     return;
@@ -827,8 +815,7 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeWorldObjectFromOctree(
     ROS_DEBUG_NAMED(LOGNAME, "Excluding collision object '%s' from monitored octomap", obj->id_.c_str());
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::includeWorldObjectInOctree(
-    const collision_detection::World::ObjectConstPtr& obj)
+void PlanningSceneMonitor::includeWorldObjectInOctree(const collision_detection::World::ObjectConstPtr& obj)
 {
   if (!octomap_monitor_)
     return;
@@ -845,8 +832,8 @@ void planning_scene_monitor::PlanningSceneMonitor::includeWorldObjectInOctree(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback(
-    robot_state::AttachedBody* attached_body, bool just_attached)
+void PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback(robot_state::AttachedBody* attached_body,
+                                                                  bool just_attached)
 {
   if (!octomap_monitor_)
     return;
@@ -857,8 +844,8 @@ void planning_scene_monitor::PlanningSceneMonitor::currentStateAttachedBodyUpdat
     includeAttachedBodyInOctree(attached_body);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::currentWorldObjectUpdateCallback(
-    const collision_detection::World::ObjectConstPtr& obj, collision_detection::World::Action action)
+void PlanningSceneMonitor::currentWorldObjectUpdateCallback(const collision_detection::World::ObjectConstPtr& obj,
+                                                            collision_detection::World::Action action)
 {
   if (!octomap_monitor_)
     return;
@@ -876,7 +863,7 @@ void planning_scene_monitor::PlanningSceneMonitor::currentWorldObjectUpdateCallb
   }
 }
 
-bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(const ros::Time& t, double wait_time)
+bool PlanningSceneMonitor::waitForCurrentRobotState(const ros::Time& t, double wait_time)
 {
   if (t.isZero())
     return false;
@@ -933,35 +920,35 @@ bool planning_scene_monitor::PlanningSceneMonitor::waitForCurrentRobotState(cons
   return success;
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::lockSceneRead()
+void PlanningSceneMonitor::lockSceneRead()
 {
   scene_update_mutex_.lock_shared();
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->lockRead();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::unlockSceneRead()
+void PlanningSceneMonitor::unlockSceneRead()
 {
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->unlockRead();
   scene_update_mutex_.unlock_shared();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::lockSceneWrite()
+void PlanningSceneMonitor::lockSceneWrite()
 {
   scene_update_mutex_.lock();
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->lockWrite();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::unlockSceneWrite()
+void PlanningSceneMonitor::unlockSceneWrite()
 {
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->unlockWrite();
   scene_update_mutex_.unlock();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::startSceneMonitor(const std::string& scene_topic)
+void PlanningSceneMonitor::startSceneMonitor(const std::string& scene_topic)
 {
   stopSceneMonitor();
 
@@ -975,7 +962,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startSceneMonitor(const std::
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::stopSceneMonitor()
+void PlanningSceneMonitor::stopSceneMonitor()
 {
   if (planning_scene_subscriber_)
   {
@@ -984,9 +971,8 @@ void planning_scene_monitor::PlanningSceneMonitor::stopSceneMonitor()
   }
 }
 
-bool planning_scene_monitor::PlanningSceneMonitor::getShapeTransformCache(
-    const std::string& target_frame, const ros::Time& target_time,
-    occupancy_map_monitor::ShapeTransformCache& cache) const
+bool PlanningSceneMonitor::getShapeTransformCache(const std::string& target_frame, const ros::Time& target_time,
+                                                  occupancy_map_monitor::ShapeTransformCache& cache) const
 {
   if (!tf_buffer_)
     return false;
@@ -1032,9 +1018,9 @@ bool planning_scene_monitor::PlanningSceneMonitor::getShapeTransformCache(
   return true;
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::startWorldGeometryMonitor(
-    const std::string& collision_objects_topic, const std::string& planning_scene_world_topic,
-    const bool load_octomap_monitor)
+void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collision_objects_topic,
+                                                     const std::string& planning_scene_world_topic,
+                                                     const bool load_octomap_monitor)
 {
   stopWorldGeometryMonitor();
   ROS_INFO_NAMED(LOGNAME, "Starting world geometry update monitor for collision objects, attached objects, octomap "
@@ -1090,7 +1076,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startWorldGeometryMonitor(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::stopWorldGeometryMonitor()
+void PlanningSceneMonitor::stopWorldGeometryMonitor()
 {
   if (collision_object_subscriber_ || collision_object_filter_)
   {
@@ -1108,8 +1094,8 @@ void planning_scene_monitor::PlanningSceneMonitor::stopWorldGeometryMonitor()
     octomap_monitor_->stopMonitor();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_topic,
-                                                                     const std::string& attached_objects_topic)
+void PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_topic,
+                                             const std::string& attached_objects_topic)
 {
   stopStateMonitor();
   if (scene_)
@@ -1138,7 +1124,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startStateMonitor(const std::
     ROS_ERROR_NAMED(LOGNAME, "Cannot monitor robot state because planning scene is not configured");
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::stopStateMonitor()
+void PlanningSceneMonitor::stopStateMonitor()
 {
   if (current_state_monitor_)
     current_state_monitor_->stopStateMonitor();
@@ -1153,8 +1139,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stopStateMonitor()
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::onStateUpdate(
-    const sensor_msgs::JointStateConstPtr& /* joint_state */)
+void PlanningSceneMonitor::onStateUpdate(const sensor_msgs::JointStateConstPtr& /* joint_state */)
 {
   const ros::WallTime& n = ros::WallTime::now();
   ros::WallDuration dt = n - last_robot_state_update_wall_time_;
@@ -1179,7 +1164,7 @@ void planning_scene_monitor::PlanningSceneMonitor::onStateUpdate(
     updateSceneWithCurrentState();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::stateUpdateTimerCallback(const ros::WallTimerEvent& event)
+void PlanningSceneMonitor::stateUpdateTimerCallback(const ros::WallTimerEvent& event)
 {
   if (state_update_pending_)
   {
@@ -1210,7 +1195,7 @@ void planning_scene_monitor::PlanningSceneMonitor::stateUpdateTimerCallback(cons
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::octomapUpdateCallback()
+void PlanningSceneMonitor::octomapUpdateCallback()
 {
   if (!octomap_monitor_)
     return;
@@ -1234,7 +1219,7 @@ void planning_scene_monitor::PlanningSceneMonitor::octomapUpdateCallback()
   triggerSceneUpdateEvent(UPDATE_GEOMETRY);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::setStateUpdateFrequency(double hz)
+void PlanningSceneMonitor::setStateUpdateFrequency(double hz)
 {
   bool update = false;
   if (hz > std::numeric_limits<double>::epsilon())
@@ -1259,7 +1244,7 @@ void planning_scene_monitor::PlanningSceneMonitor::setStateUpdateFrequency(doubl
     updateSceneWithCurrentState();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::updateSceneWithCurrentState()
+void PlanningSceneMonitor::updateSceneWithCurrentState()
 {
   if (current_state_monitor_)
   {
@@ -1285,28 +1270,27 @@ void planning_scene_monitor::PlanningSceneMonitor::updateSceneWithCurrentState()
     ROS_ERROR_THROTTLE_NAMED(1, LOGNAME, "State monitor is not active. Unable to set the planning scene state");
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::addUpdateCallback(const boost::function<void(SceneUpdateType)>& fn)
+void PlanningSceneMonitor::addUpdateCallback(const boost::function<void(SceneUpdateType)>& fn)
 {
   boost::recursive_mutex::scoped_lock lock(update_lock_);
   if (fn)
     update_callbacks_.push_back(fn);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::clearUpdateCallbacks()
+void PlanningSceneMonitor::clearUpdateCallbacks()
 {
   boost::recursive_mutex::scoped_lock lock(update_lock_);
   update_callbacks_.clear();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::setPlanningScenePublishingFrequency(double hz)
+void PlanningSceneMonitor::setPlanningScenePublishingFrequency(double hz)
 {
   publish_planning_scene_frequency_ = hz;
   ROS_DEBUG_NAMED(LOGNAME, "Maximum frquency for publishing a planning scene is now %lf Hz",
                   publish_planning_scene_frequency_);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::getUpdatedFrameTransforms(
-    std::vector<geometry_msgs::TransformStamped>& transforms)
+void PlanningSceneMonitor::getUpdatedFrameTransforms(std::vector<geometry_msgs::TransformStamped>& transforms)
 {
   const std::string& target = getRobotModel()->getModelFrame();
 
@@ -1335,7 +1319,7 @@ void planning_scene_monitor::PlanningSceneMonitor::getUpdatedFrameTransforms(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::updateFrameTransforms()
+void PlanningSceneMonitor::updateFrameTransforms()
 {
   if (!tf_buffer_)
     return;
@@ -1353,14 +1337,13 @@ void planning_scene_monitor::PlanningSceneMonitor::updateFrameTransforms()
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::publishDebugInformation(bool flag)
+void PlanningSceneMonitor::publishDebugInformation(bool flag)
 {
   if (octomap_monitor_)
     octomap_monitor_->publishDebugInformation(flag);
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::configureCollisionMatrix(
-    const planning_scene::PlanningScenePtr& scene)
+void PlanningSceneMonitor::configureCollisionMatrix(const planning_scene::PlanningScenePtr& scene)
 {
   if (!scene || robot_description_.empty())
     return;
@@ -1403,7 +1386,7 @@ void planning_scene_monitor::PlanningSceneMonitor::configureCollisionMatrix(
   }
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::configureDefaultPadding()
+void PlanningSceneMonitor::configureDefaultPadding()
 {
   if (robot_description_.empty())
   {
@@ -1429,4 +1412,5 @@ void planning_scene_monitor::PlanningSceneMonitor::configureDefaultPadding()
 
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_padd_.size() << " default link paddings");
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_scale_.size() << " default link scales");
+}
 }

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -197,7 +197,8 @@ public:
     request.components.components = request.components.ROBOT_STATE_ATTACHED_OBJECTS;
     if (!planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface", "Could not call planning scene service to get attached object geometries");
+      ROS_WARN_NAMED("planning_scene_interface",
+                     "Could not call planning scene service to get attached object geometries");
       return result;
     }
 

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -197,8 +197,7 @@ public:
     request.components.components = request.components.ROBOT_STATE_ATTACHED_OBJECTS;
     if (!planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface", "Could not call planning scene service to get attached object "
-                                                 "geometries");
+      ROS_WARN_NAMED("planning_scene_interface", "Could not call planning scene service to get attached object geometries");
       return result;
     }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -719,8 +719,7 @@ void MotionPlanningDisplay::changedQueryStartState()
   setStatusTextColor(query_start_color_property_->getColor());
   addStatusText("Changed start state");
   drawQueryStartState();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true), "publishInteractiveMarke"
-                                                                                               "rs");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true), "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::changedQueryGoalState()
@@ -730,8 +729,7 @@ void MotionPlanningDisplay::changedQueryGoalState()
   setStatusTextColor(query_goal_color_property_->getColor());
   addStatusText("Changed goal state");
   drawQueryGoalState();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true), "publishInteractiveMarke"
-                                                                                               "rs");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true), "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::drawQueryGoalState()
@@ -803,8 +801,7 @@ void MotionPlanningDisplay::resetInteractiveMarkers()
 {
   query_start_state_->clearError();
   query_goal_state_->clearError();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMark"
-                                                                                                "ers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::publishInteractiveMarkers(bool pose_update)
@@ -1049,8 +1046,7 @@ void MotionPlanningDisplay::changedPlanningGroup()
 
   if (frame_)
     frame_->changePlanningGroup();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMark"
-                                                                                                "ers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::changedWorkspace()
@@ -1135,8 +1131,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   PlanningSceneDisplay::onRobotModelLoaded();
   trajectory_visual_->onRobotModelLoaded(getRobotModel());
 
-  robot_interaction_.reset(new robot_interaction::RobotInteraction(getRobotModel(), "rviz_moveit_motion_planning_"
-                                                                                    "display"));
+  robot_interaction_.reset(new robot_interaction::RobotInteraction(getRobotModel(), "rviz_moveit_motion_planning_display"));
   int_marker_display_->subProp("Update Topic")
       ->setValue(QString::fromStdString(robot_interaction_->getServerTopic() + "/update"));
   query_robot_start_->load(*getRobotModel()->getURDF());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -719,7 +719,8 @@ void MotionPlanningDisplay::changedQueryStartState()
   setStatusTextColor(query_start_color_property_->getColor());
   addStatusText("Changed start state");
   drawQueryStartState();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true), "publishInteractiveMarkers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true),
+                   "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::changedQueryGoalState()
@@ -729,7 +730,8 @@ void MotionPlanningDisplay::changedQueryGoalState()
   setStatusTextColor(query_goal_color_property_->getColor());
   addStatusText("Changed goal state");
   drawQueryGoalState();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true), "publishInteractiveMarkers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, true),
+                   "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::drawQueryGoalState()
@@ -801,7 +803,8 @@ void MotionPlanningDisplay::resetInteractiveMarkers()
 {
   query_start_state_->clearError();
   query_goal_state_->clearError();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMarkers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false),
+                   "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::publishInteractiveMarkers(bool pose_update)
@@ -1046,7 +1049,8 @@ void MotionPlanningDisplay::changedPlanningGroup()
 
   if (frame_)
     frame_->changePlanningGroup();
-  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMarkers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false),
+                   "publishInteractiveMarkers");
 }
 
 void MotionPlanningDisplay::changedWorkspace()
@@ -1131,7 +1135,8 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   PlanningSceneDisplay::onRobotModelLoaded();
   trajectory_visual_->onRobotModelLoaded(getRobotModel());
 
-  robot_interaction_.reset(new robot_interaction::RobotInteraction(getRobotModel(), "rviz_moveit_motion_planning_display"));
+  robot_interaction_.reset(
+      new robot_interaction::RobotInteraction(getRobotModel(), "rviz_moveit_motion_planning_display"));
   int_marker_display_->subProp("Update Topic")
       ->setValue(QString::fromStdString(robot_interaction_->getServerTopic() + "/update"));
   query_robot_start_->load(*getRobotModel()->getURDF());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -60,8 +60,7 @@ void MotionPlanningFrame::detectObjectsButtonClicked()
       semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
     }
   }
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::triggerObjectDetection, this), "detect "
-                                                                                                       "objects");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::triggerObjectDetection, this), "detect objects");
 }
 
 void MotionPlanningFrame::processDetectedObjects()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -60,7 +60,8 @@ void MotionPlanningFrame::detectObjectsButtonClicked()
       semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
     }
   }
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::triggerObjectDetection, this), "detect objects");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::triggerObjectDetection, this),
+                                      "detect objects");
 }
 
 void MotionPlanningFrame::processDetectedObjects()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -50,7 +50,8 @@ namespace moveit_rviz_plugin
 {
 void MotionPlanningFrame::planButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanButtonClicked, this), "compute plan");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanButtonClicked, this),
+                                      "compute plan");
 }
 
 void MotionPlanningFrame::executeButtonClicked()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -50,8 +50,7 @@ namespace moveit_rviz_plugin
 {
 void MotionPlanningFrame::planButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanButtonClicked, this), "compute "
-                                                                                                         "plan");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanButtonClicked, this), "compute plan");
 }
 
 void MotionPlanningFrame::executeButtonClicked()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -194,14 +194,12 @@ void MotionPlanningFrame::deleteQueryButtonClicked()
 
 void MotionPlanningFrame::loadSceneButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadSceneButtonClicked, this), "load "
-                                                                                                              "scene");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadSceneButtonClicked, this), "load scene");
 }
 
 void MotionPlanningFrame::loadQueryButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadQueryButtonClicked, this), "load "
-                                                                                                              "query");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadQueryButtonClicked, this), "load query");
 }
 
 void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int column)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -194,12 +194,14 @@ void MotionPlanningFrame::deleteQueryButtonClicked()
 
 void MotionPlanningFrame::loadSceneButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadSceneButtonClicked, this), "load scene");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadSceneButtonClicked, this),
+                                      "load scene");
 }
 
 void MotionPlanningFrame::loadQueryButtonClicked()
 {
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadQueryButtonClicked, this), "load query");
+  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadQueryButtonClicked, this),
+                                      "load query");
 }
 
 void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int column)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -161,8 +161,7 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const robot_state::RobotSt
         }
         else
         {
-          QMessageBox::warning(this, "Warning", "Not connected to a database. The state will be created but not "
-                                                "stored");
+          QMessageBox::warning(this, "Warning", "Not connected to a database. The state will be created but not stored");
         }
       }
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -161,7 +161,8 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const robot_state::RobotSt
         }
         else
         {
-          QMessageBox::warning(this, "Warning", "Not connected to a database. The state will be created but not stored");
+          QMessageBox::warning(this, "Warning",
+                               "Not connected to a database. The state will be created but not stored");
         }
       }
     }


### PR DESCRIPTION
This is an attempt to improve the results of clang-format. Particularly:
* increase penalty to break literal strings
* ~~increase penalty to break before first argument in function calls~~
* reduce penalty to put return type on its own line

I think the resulting code is much better readable.