### PR TITLE
select planning group in planning tab and simplify selecting goal and start states

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -159,8 +159,8 @@ private Q_SLOTS:
   void allowLookingToggled(bool checked);
   void allowExternalProgramCommunication(bool enable);
   void pathConstraintsIndexChanged(int index);
-  void useStartStateButtonClicked();
-  void useGoalStateButtonClicked();
+  void startStateTextChanged(const QString& start_state);
+  void goalStateTextChanged(const QString& goal_state);
   void planningGroupTextChanged(const QString& planning_group);
   void onClearOctomapClicked();
 
@@ -230,10 +230,10 @@ private:
   void configureWorkspace();
   void updateQueryStateHelper(robot_state::RobotState& state, const std::string& v);
   void fillStateSelectionOptions();
-  void useStartStateButtonExec();
-  void useGoalStateButtonExec();
   void fillPlanningGroupOptions();
   void setPlanningGroupText();
+  void startStateTextChangedExec(const std::string& start_state);
+  void goalStateTextChangedExec(const std::string& goal_state);
 
   // Scene objects tab
   void addObject(const collision_detection::WorldPtr& world, const std::string& id, const shapes::ShapeConstPtr& shape,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -161,6 +161,7 @@ private Q_SLOTS:
   void pathConstraintsIndexChanged(int index);
   void useStartStateButtonClicked();
   void useGoalStateButtonClicked();
+  void planningGroupTextChanged(const QString& planning_group);
   void onClearOctomapClicked();
 
   // Scene Objects tab
@@ -231,6 +232,8 @@ private:
   void fillStateSelectionOptions();
   void useStartStateButtonExec();
   void useGoalStateButtonExec();
+  void fillPlanningGroupOptions();
+  void setPlanningGroupText();
 
   // Scene objects tab
   void addObject(const collision_detection::WorldPtr& world, const std::string& id, const shapes::ShapeConstPtr& shape,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1007,7 +1007,6 @@ void MotionPlanningDisplay::changePlanningGroup(const std::string& group)
   if (getRobotModel()->hasJointModelGroup(group))
   {
     planning_group_property_->setStdString(group);
-    changedPlanningGroup();
   }
   else
     ROS_ERROR("Group [%s] not found in the robot model.", group.c_str());
@@ -1171,6 +1170,9 @@ void MotionPlanningDisplay::onRobotModelLoaded()
     if (getRobotModel()->getJointModelGroup(groups[i])->isChain())
       dynamics_solver_[groups[i]].reset(
           new dynamics_solver::DynamicsSolver(getRobotModel(), groups[i], gravity_vector));
+
+  if (frame_)
+    frame_->fillPlanningGroupOptions();
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::changedPlanningGroup, this));
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -73,8 +73,8 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->execute_button, SIGNAL(clicked()), this, SLOT(executeButtonClicked()));
   connect(ui_->plan_and_execute_button, SIGNAL(clicked()), this, SLOT(planAndExecuteButtonClicked()));
   connect(ui_->stop_button, SIGNAL(clicked()), this, SLOT(stopButtonClicked()));
-  connect(ui_->use_start_state_button, SIGNAL(clicked()), this, SLOT(useStartStateButtonClicked()));
-  connect(ui_->use_goal_state_button, SIGNAL(clicked()), this, SLOT(useGoalStateButtonClicked()));
+  connect(ui_->start_state_combo_box, SIGNAL(activated(QString)), this, SLOT(startStateTextChanged(QString)));
+  connect(ui_->goal_state_combo_box, SIGNAL(activated(QString)), this, SLOT(goalStateTextChanged(QString)));
   connect(ui_->planning_group_combo_box, SIGNAL(currentIndexChanged(QString)), this,
           SLOT(planningGroupTextChanged(QString)));
   connect(ui_->database_connect_button, SIGNAL(clicked()), this, SLOT(databaseConnectButtonClicked()));
@@ -267,8 +267,10 @@ void MotionPlanningFrame::setPlanningGroupText()
 
 void MotionPlanningFrame::fillStateSelectionOptions()
 {
-  ui_->start_state_selection->clear();
-  ui_->goal_state_selection->clear();
+  const QSignalBlocker start_state_blocker(ui_->start_state_combo_box);
+  const QSignalBlocker goal_state_blocker(ui_->goal_state_combo_box);
+  ui_->start_state_combo_box->clear();
+  ui_->goal_state_combo_box->clear();
 
   if (!planning_display_->getPlanningSceneMonitor())
     return;
@@ -280,29 +282,30 @@ void MotionPlanningFrame::fillStateSelectionOptions()
   const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
-    ui_->start_state_selection->addItem(QString("<random valid>"));
-    ui_->start_state_selection->addItem(QString("<random>"));
-    ui_->start_state_selection->addItem(QString("<current>"));
-    ui_->start_state_selection->addItem(QString("<same as goal>"));
+    ui_->start_state_combo_box->addItem(QString("<random valid>"));
+    ui_->start_state_combo_box->addItem(QString("<random>"));
+    ui_->start_state_combo_box->addItem(QString("<current>"));
+    ui_->start_state_combo_box->addItem(QString("<same as goal>"));
 
-    ui_->goal_state_selection->addItem(QString("<random valid>"));
-    ui_->goal_state_selection->addItem(QString("<random>"));
-    ui_->goal_state_selection->addItem(QString("<current>"));
-    ui_->goal_state_selection->addItem(QString("<same as start>"));
+    ui_->goal_state_combo_box->addItem(QString("<random valid>"));
+    ui_->goal_state_combo_box->addItem(QString("<random>"));
+    ui_->goal_state_combo_box->addItem(QString("<current>"));
+    ui_->goal_state_combo_box->addItem(QString("<same as start>"));
 
     const std::vector<std::string>& known_states = jmg->getDefaultStateNames();
     if (!known_states.empty())
     {
-      ui_->start_state_selection->insertSeparator(ui_->start_state_selection->count());
-      ui_->goal_state_selection->insertSeparator(ui_->goal_state_selection->count());
+      ui_->start_state_combo_box->insertSeparator(ui_->start_state_combo_box->count());
+      ui_->goal_state_combo_box->insertSeparator(ui_->goal_state_combo_box->count());
       for (std::size_t i = 0; i < known_states.size(); ++i)
       {
-        ui_->start_state_selection->addItem(QString::fromStdString(known_states[i]));
-        ui_->goal_state_selection->addItem(QString::fromStdString(known_states[i]));
+        ui_->start_state_combo_box->addItem(QString::fromStdString(known_states[i]));
+        ui_->goal_state_combo_box->addItem(QString::fromStdString(known_states[i]));
       }
     }
-    ui_->start_state_selection->setCurrentIndex(2);  // default to 'current'
-    ui_->goal_state_selection->setCurrentIndex(0);   // default to 'random valid'
+
+    ui_->start_state_combo_box->setCurrentIndex(2);  // default to 'current'
+    ui_->goal_state_combo_box->setCurrentIndex(2);   // default to 'current'
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -210,6 +210,11 @@ void MotionPlanningFrame::useGoalStateButtonExec()
   planning_display_->setQueryGoalState(goal);
 }
 
+void MotionPlanningFrame::planningGroupTextChanged(const QString& planning_group)
+{
+  planning_display_->changePlanningGroup(planning_group.toStdString());
+}
+
 void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState& state, const std::string& v)
 {
   if (v == "<random>")

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -178,35 +178,36 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
   ui_->stop_button->setEnabled(false);
 
   // update query start state to current if neccessary
-  if (ui_->start_state_selection->currentText() == "<current>")
-    useStartStateButtonClicked();
+  if (ui_->start_state_combo_box->currentText() == "<current>")
+    startStateTextChanged(ui_->start_state_combo_box->currentText());
 }
 
-void MotionPlanningFrame::useStartStateButtonClicked()
+void MotionPlanningFrame::startStateTextChanged(const QString& start_state)
 {
   // use background job: fetching the current state might take up to a second
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::useStartStateButtonExec, this),  //
-                                      "update start state");
+  planning_display_->addBackgroundJob(
+      boost::bind(&MotionPlanningFrame::startStateTextChangedExec, this, start_state.toStdString()),
+      "update start state");
 }
 
-void MotionPlanningFrame::useStartStateButtonExec()
+void MotionPlanningFrame::startStateTextChangedExec(const std::string& start_state)
 {
   robot_state::RobotState start = *planning_display_->getQueryStartState();
-  updateQueryStateHelper(start, ui_->start_state_selection->currentText().toStdString());
+  updateQueryStateHelper(start, start_state);
   planning_display_->setQueryStartState(start);
 }
 
-void MotionPlanningFrame::useGoalStateButtonClicked()
+void MotionPlanningFrame::goalStateTextChanged(const QString& goal_state)
 {
   // use background job: fetching the current state might take up to a second
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::useGoalStateButtonExec, this),  //
-                                      "update goal state");
+  planning_display_->addBackgroundJob(
+      boost::bind(&MotionPlanningFrame::goalStateTextChangedExec, this, goal_state.toStdString()), "update goal state");
 }
 
-void MotionPlanningFrame::useGoalStateButtonExec()
+void MotionPlanningFrame::goalStateTextChangedExec(const std::string& goal_state)
 {
   robot_state::RobotState goal = *planning_display_->getQueryGoalState();
-  updateQueryStateHelper(goal, ui_->goal_state_selection->currentText().toStdString());
+  updateQueryStateHelper(goal, goal_state);
   planning_display_->setQueryGoalState(goal);
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -137,10 +137,12 @@ void MotionPlanningFrame::computePlanButtonClicked()
 
 void MotionPlanningFrame::computeExecuteButtonClicked()
 {
-  if (move_group_ && current_plan_)
+  // ensures the MoveGroupInterface is not destroyed while executing
+  moveit::planning_interface::MoveGroupInterfacePtr mgi(move_group_);
+  if (mgi && current_plan_)
   {
     ui_->stop_button->setEnabled(true);  // enable stopping
-    bool success = move_group_->execute(*current_plan_) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
+    bool success = mgi->execute(*current_plan_) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
     onFinishedExecution(success);
   }
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -438,6 +438,20 @@
                <number>4</number>
               </property>
               <item row="1" column="0">
+               <layout class="QVBoxLayout" name="verticalLayout_planning_group">
+                <item>
+                 <widget class="QLabel" name="label_planning_group">
+                  <property name="text">
+                   <string>Planning Group:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="planning_group_combo_box"/>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="0">
                <widget class="QToolBox" name="query_stackedwidget">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -556,14 +570,14 @@
                 </widget>
                </widget>
               </item>
-              <item row="2" column="0">
+              <item row="3" column="0">
                <widget class="QPushButton" name="clear_octomap_button">
                 <property name="text">
                  <string>Clear octomap</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="4" column="0">
                <spacer name="verticalSpacer">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -1690,6 +1704,7 @@
   <tabstop>execute_button</tabstop>
   <tabstop>plan_and_execute_button</tabstop>
   <tabstop>stop_button</tabstop>
+  <tabstop>planning_group_combo_box</tabstop>
   <tabstop>start_state_selection</tabstop>
   <tabstop>use_start_state_button</tabstop>
   <tabstop>goal_state_selection</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -452,132 +452,41 @@
                </layout>
               </item>
               <item row="2" column="0">
-               <widget class="QToolBox" name="query_stackedwidget">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="frameShape">
-                 <enum>QFrame::StyledPanel</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Raised</enum>
-                </property>
-                <property name="currentIndex">
-                 <number>1</number>
-                </property>
-                <widget class="QWidget" name="query_stackedwidgetPage2">
-                 <property name="geometry">
-                  <rect>
-                   <x>0</x>
-                   <y>0</y>
-                   <width>109</width>
-                   <height>82</height>
-                  </rect>
-                 </property>
-                 <attribute name="label">
-                  <string>Select Start State:</string>
-                 </attribute>
-                 <layout class="QGridLayout" name="gridLayout_7">
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QComboBox" name="start_state_selection"/>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QPushButton" name="use_start_state_button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>&amp;Update</string>
-                    </property>
-                    <property name="autoDefault">
-                     <bool>false</bool>
-                    </property>
-                    <property name="default">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <spacer name="horizontalSpacer_3">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="query_stackedwidgetPage1">
-                 <property name="geometry">
-                  <rect>
-                   <x>0</x>
-                   <y>0</y>
-                   <width>225</width>
-                   <height>82</height>
-                  </rect>
-                 </property>
-                 <attribute name="label">
-                  <string>Select Goal State:</string>
-                 </attribute>
-                 <layout class="QGridLayout" name="gridLayout_9">
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QComboBox" name="goal_state_selection"/>
-                  </item>
-                  <item row="1" column="0">
-                   <spacer name="horizontalSpacer_4">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>96</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QPushButton" name="use_goal_state_button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>&amp;Update</string>
-                    </property>
-                    <property name="autoDefault">
-                     <bool>false</bool>
-                    </property>
-                    <property name="default">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </widget>
+               <layout class="QVBoxLayout" name="verticalLayout_start_state">
+                <item>
+                 <widget class="QLabel" name="label_start_state">
+                  <property name="text">
+                   <string>Start State:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="start_state_combo_box"/>
+                </item>
+               </layout>
               </item>
               <item row="3" column="0">
+               <layout class="QVBoxLayout" name="verticalLayout_goal_state">
+                <item>
+                 <widget class="QLabel" name="label_goal_state">
+                  <property name="text">
+                   <string>Goal State:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="goal_state_combo_box"/>
+                </item>
+               </layout>
+              </item>
+              <item row="4" column="0">
                <widget class="QPushButton" name="clear_octomap_button">
                 <property name="text">
                  <string>Clear octomap</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
+              <item row="5" column="0">
                <spacer name="verticalSpacer">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -1705,10 +1614,9 @@
   <tabstop>plan_and_execute_button</tabstop>
   <tabstop>stop_button</tabstop>
   <tabstop>planning_group_combo_box</tabstop>
-  <tabstop>start_state_selection</tabstop>
-  <tabstop>use_start_state_button</tabstop>
-  <tabstop>goal_state_selection</tabstop>
-  <tabstop>use_goal_state_button</tabstop>
+  <tabstop>start_state_combo_box</tabstop>
+  <tabstop>goal_state_combo_box</tabstop>
+  <tabstop>clear_octomap_button</tabstop>
   <tabstop>planning_time</tabstop>
   <tabstop>planning_attempts</tabstop>
   <tabstop>velocity_scaling_factor</tabstop>
@@ -1716,11 +1624,10 @@
   <tabstop>allow_replanning</tabstop>
   <tabstop>allow_looking</tabstop>
   <tabstop>allow_external_program</tabstop>
+  <tabstop>collision_aware_ik</tabstop>
+  <tabstop>approximate_ik</tabstop>
+  <tabstop>path_constraints_combo_box</tabstop>
   <tabstop>goal_tolerance</tabstop>
-  <tabstop>detected_objects_list</tabstop>
-  <tabstop>detect_objects_button</tabstop>
-  <tabstop>support_surfaces_list</tabstop>
-  <tabstop>pick_button</tabstop>
   <tabstop>place_button</tabstop>
   <tabstop>roi_center_x</tabstop>
   <tabstop>roi_center_y</tabstop>
@@ -1759,6 +1666,17 @@
   <tabstop>save_start_state_button</tabstop>
   <tabstop>save_goal_state_button</tabstop>
   <tabstop>status_text</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>wcenter_x</tabstop>
+  <tabstop>wcenter_y</tabstop>
+  <tabstop>wcenter_z</tabstop>
+  <tabstop>wsize_x</tabstop>
+  <tabstop>wsize_y</tabstop>
+  <tabstop>wsize_z</tabstop>
+  <tabstop>pick_button</tabstop>
+  <tabstop>support_surfaces_list</tabstop>
+  <tabstop>detected_objects_list</tabstop>
+  <tabstop>detect_objects_button</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Fixes #1069.

The request consists of multiple commits.

The first one fixes rviz crashing when the planning group is changed while executing a trajectory.
The problem was the destruction of a MoveGroupInterface that also holds the SimpleActionClient used to execute the trajectory. The proposed solution here creates a local shared pointer of the object for execution to ensure that the object is not destroyed asynchronously. 

The other two commits change the gui in the planning tab.
This is the old state of the planning tab: 
![old_gui](https://user-images.githubusercontent.com/4669602/48417591-65bd3280-e753-11e8-907a-bbbbc580307c.png)

The first addition is a dropdown menu for choosing a planning group:
![partial_change](https://user-images.githubusercontent.com/4669602/48417644-8a190f00-e753-11e8-89b2-5e0a54566603.png)
Previously it was only possible to choose the planning group in the MotionPlanning display. The dropdown menu is synchronized with the display property.

The final commit tries to streamline the interface and should improve usability further. It gets rid of the update buttons and makes both dropdown menus for the start and goal state constantly visible:
![full_change](https://user-images.githubusercontent.com/4669602/48418071-ab2e2f80-e754-11e8-908c-a427cd717e6f.png)

The choice is instantly confirmed when it is clicked in the dropdown menu. As a consequence repeatedly updating random states is now a bit more complicated, but still possible by simply clicking on that option repeatedly.

@v4hn 