### PR TITLE
fix several issues in rendering of attached bodies in rviz plugins

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -167,6 +167,7 @@ private Q_SLOTS:
   void changedQueryGoalAlpha();
   void changedQueryCollidingLinkColor();
   void changedQueryJointViolationColor();
+  void changedAttachedBodyColor() override;
   void changedPlanningGroup();
   void changedShowWeightLimit();
   void changedShowManipulabilityIndex();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -195,13 +195,15 @@ void MotionPlanningDisplay::onInitialize()
 
   // Planned Path Display
   trajectory_visual_->onInitialize(planning_scene_node_, context_, update_nh_);
+  QColor qcolor = attached_body_color_property_->getColor();
+  trajectory_visual_->setDefaultAttachedObjectColor(qcolor);
 
   query_robot_start_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Start", NULL));
   query_robot_start_->setCollisionVisible(false);
   query_robot_start_->setVisualVisible(true);
   query_robot_start_->setVisible(query_start_state_property_->getBool());
   std_msgs::ColorRGBA color;
-  QColor qcolor = query_start_color_property_->getColor();
+  qcolor = query_start_color_property_->getColor();
   color.r = qcolor.redF();
   color.g = qcolor.greenF();
   color.b = qcolor.blueF();
@@ -892,6 +894,14 @@ void MotionPlanningDisplay::changedQueryJointViolationColor()
 {
   changedQueryStartState();
   changedQueryGoalState();
+}
+
+void MotionPlanningDisplay::changedAttachedBodyColor()
+{
+  PlanningSceneDisplay::changedAttachedBodyColor();
+  // forward color to TrajectoryVisualization
+  const QColor& color = attached_body_color_property_->getColor();
+  trajectory_visual_->setDefaultAttachedObjectColor(color);
 }
 
 void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::RobotInteraction::InteractionHandler*,

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -136,11 +136,13 @@ private Q_SLOTS:
   void changedRobotSceneAlpha();
   void changedSceneAlpha();
   void changedSceneColor();
-  void changedAttachedBodyColor();
   void changedPlanningSceneTopic();
   void changedSceneDisplayTime();
   void changedOctreeRenderMode();
   void changedOctreeColorMode();
+
+protected Q_SLOTS:
+  virtual void changedAttachedBodyColor();
 
 protected:
   /// This function reloads the robot model and reinitializes the PlanningSceneMonitor

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -326,25 +326,25 @@ void PlanningSceneDisplay::changedSceneName()
 
 void PlanningSceneDisplay::renderPlanningScene()
 {
-    QColor color = scene_color_property_->getColor();
-    rviz::Color env_color(color.redF(), color.greenF(), color.blueF());
-    if (attached_body_color_property_)
-      color = attached_body_color_property_->getColor();
-    rviz::Color attached_color(color.redF(), color.greenF(), color.blueF());
+  QColor color = scene_color_property_->getColor();
+  rviz::Color env_color(color.redF(), color.greenF(), color.blueF());
+  if (attached_body_color_property_)
+    color = attached_body_color_property_->getColor();
+  rviz::Color attached_color(color.redF(), color.greenF(), color.blueF());
 
-    try
-    {
-      const planning_scene_monitor::LockedPlanningSceneRO& ps = getPlanningSceneRO();
-      planning_scene_render_->renderPlanningScene(
-          ps, env_color, attached_color, static_cast<OctreeVoxelRenderMode>(octree_render_property_->getOptionInt()),
-          static_cast<OctreeVoxelColorMode>(octree_coloring_property_->getOptionInt()),
-          scene_alpha_property_->getFloat());
-    }
-    catch (std::exception& ex)
-    {
-      ROS_ERROR("Caught %s while rendering planning scene", ex.what());
-    }
-    planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
+  try
+  {
+    const planning_scene_monitor::LockedPlanningSceneRO& ps = getPlanningSceneRO();
+    planning_scene_render_->renderPlanningScene(
+        ps, env_color, attached_color, static_cast<OctreeVoxelRenderMode>(octree_render_property_->getOptionInt()),
+        static_cast<OctreeVoxelColorMode>(octree_coloring_property_->getOptionInt()),
+        scene_alpha_property_->getFloat());
+  }
+  catch (std::exception& ex)
+  {
+    ROS_ERROR("Caught %s while rendering planning scene", ex.what());
+  }
+  planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
 }
 
 void PlanningSceneDisplay::changedSceneAlpha()
@@ -623,8 +623,8 @@ void PlanningSceneDisplay::update(float wall_dt, float ros_dt)
 void PlanningSceneDisplay::updateInternal(float wall_dt, float ros_dt)
 {
   current_scene_time_ += wall_dt;
-  if (current_scene_time_ > scene_display_time_property_->getFloat() &&
-      planning_scene_render_ && planning_scene_needs_render_)
+  if (current_scene_time_ > scene_display_time_property_->getFloat() && planning_scene_render_ &&
+      planning_scene_needs_render_)
   {
     renderPlanningScene();
     calculateOffsetPosition();

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -590,6 +590,7 @@ void PlanningSceneDisplay::onEnable()
     planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
 
   calculateOffsetPosition();
+  planning_scene_needs_render_ = true;
 }
 
 // ******************************************************************************************

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -395,6 +395,7 @@ void PlanningSceneDisplay::changedSceneRobotVisualEnabled()
   {
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setVisualVisible(scene_robot_visual_enabled_property_->getBool());
+    planning_scene_needs_render_ = true;
   }
 }
 
@@ -404,6 +405,7 @@ void PlanningSceneDisplay::changedSceneRobotCollisionEnabled()
   {
     planning_scene_robot_->setVisible(true);
     planning_scene_robot_->setCollisionVisible(scene_robot_collision_enabled_property_->getBool());
+    planning_scene_needs_render_ = true;
   }
 }
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -326,8 +326,6 @@ void PlanningSceneDisplay::changedSceneName()
 
 void PlanningSceneDisplay::renderPlanningScene()
 {
-  if (planning_scene_render_ && planning_scene_needs_render_)
-  {
     QColor color = scene_color_property_->getColor();
     rviz::Color env_color(color.redF(), color.greenF(), color.blueF());
     if (attached_body_color_property_)
@@ -346,9 +344,7 @@ void PlanningSceneDisplay::renderPlanningScene()
     {
       ROS_ERROR("Caught %s while rendering planning scene", ex.what());
     }
-    planning_scene_needs_render_ = false;
     planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
-  }
 }
 
 void PlanningSceneDisplay::changedSceneAlpha()
@@ -627,11 +623,13 @@ void PlanningSceneDisplay::update(float wall_dt, float ros_dt)
 void PlanningSceneDisplay::updateInternal(float wall_dt, float ros_dt)
 {
   current_scene_time_ += wall_dt;
-  if (current_scene_time_ > scene_display_time_property_->getFloat())
+  if (current_scene_time_ > scene_display_time_property_->getFloat() &&
+      planning_scene_render_ && planning_scene_needs_render_)
   {
     renderPlanningScene();
     calculateOffsetPosition();
     current_scene_time_ = 0.0f;
+    planning_scene_needs_render_ = false;
   }
 }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -99,6 +99,7 @@ public:
 
 public Q_SLOTS:
   void interruptCurrentDisplay();
+  void setDefaultAttachedObjectColor(const QColor& color);
 
 private Q_SLOTS:
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -515,6 +515,19 @@ void TrajectoryVisualization::unsetRobotColor(rviz::Robot* robot)
     link.second->unsetColor();
 }
 
+void TrajectoryVisualization::setDefaultAttachedObjectColor(const QColor& color)
+{
+  if (!display_path_robot_)
+    return;
+
+  std_msgs::ColorRGBA color_msg;
+  color_msg.r = color.redF();
+  color_msg.g = color.greenF();
+  color_msg.b = color.blueF();
+  color_msg.a = color.alphaF();
+  display_path_robot_->setDefaultAttachedObjectColor(color_msg);
+}
+
 void TrajectoryVisualization::setRobotColor(rviz::Robot* robot, const QColor& color)
 {
   for (auto& link : robot->getLinks())


### PR DESCRIPTION
Rebase of #1152. Splitted into the basic fix (this PR) and the additional new feature providing a BoolProperty to switch attached bodies on/off (#1200).
This fixes #512.
Also added bug fixes for several other rendering issues I observed during testing the initial commit.
Look into individual commits for details.