### PR TITLE
Fix build farm error

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -58,9 +58,7 @@ if(CATKIN_ENABLE_TESTING)
   # additional test dependencies
   find_package(moveit_ros_planning_interface REQUIRED)
   find_package(rostest REQUIRED)
-  # add moveit includes *before* the rest for better overlay compliance
-  include_directories(BEFORE ${moveit_ros_planning_interface})
-  include_directories(AFTER ${rostest_INCLUDE_DIRS})
+  include_directories(${moveit_ros_planning_interface_INCLUDE_DIRS})
   add_rostest_gtest(chomp_moveit_test
     test/chomp_moveit.test
     test/chomp_moveit_test.cpp)

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -63,7 +63,7 @@ if(CATKIN_ENABLE_TESTING)
     test/chomp_moveit.test
     test/chomp_moveit_test.cpp)
   target_link_libraries(chomp_moveit_test
-    ${moveit_ros_planning_interface_LIBRARIES}
     ${catkin_LIBRARIES}
+    ${moveit_ros_planning_interface_LIBRARIES}
     ${rostest_LIBRARIES})
 endif()

--- a/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
+++ b/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
@@ -47,7 +47,7 @@ public:
   moveit::planning_interface::MoveGroupInterface::Plan my_plan_;
 
 public:
-  CHOMPMoveitTest() : move_group_(moveit::planning_interface::MoveGroupInterface("arm"))
+  CHOMPMoveitTest() : move_group_("arm")
   {
   }
 };


### PR DESCRIPTION
This PR fixes errors on the ROS build farm due to missing include folders:
http://build.ros.org/job/Kdev__moveit__ubuntu_xenial_amd64/
http://build.ros.org/job/Ldev__moveit__ubuntu_xenial_amd64/