### PR TITLE
Add append function for appending only part of a trajectory

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -186,20 +186,17 @@ public:
   }
 
   /**
-   * \brief Add a trajectory to the end of the current trajectory
-   * \param source - the trajectory to append to the end of current trajectory
-   * \param dt - time step between last traj point in current traj, and first traj point of new traj
-   */
-  void append(const RobotTrajectory& source, double dt);
-
-  /**
-   * \brief Add a specified part of a trajectory to the end of the current trajectory
+   * \brief Add a specified part of a trajectory to the end of the current trajectory. The default (when \p start_index
+   * and \p end_index are omitted) is to add the whole trajectory.
    * \param source - the trajectory containing the part to append to the end of current trajectory
    * \param dt - time step between last traj point in current traj and first traj point of append traj
-   * \param start_index - index of first traj point of the part to append from the source traj
-   * \param end_index - index of last traj point of the part to append from the source traj
+   * \param start_index - index of first traj point of the part to append from the source traj, the default is to add
+   * from the start of the source traj
+   * \param end_index - index of last traj point of the part to append from the source traj, the default is to add until
+   * the end of the source traj
    */
-  void append(const RobotTrajectory& source, double dt, size_t start_index, size_t end_index);
+  void append(const RobotTrajectory& source, double dt, size_t start_index = 0,
+              size_t end_index = std::numeric_limits<std::size_t>::max());
 
   void swap(robot_trajectory::RobotTrajectory& other);
 

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -192,6 +192,15 @@ public:
    */
   void append(const RobotTrajectory& source, double dt);
 
+  /**
+   * \brief Add a specified part of a trajectory to the end of the current trajectory
+   * \param source - the trajectory containing the part to append to the end of current trajectory
+   * \param dt - time step between last traj point in current traj and first traj point of append traj
+   * \param start_index - index of first traj point of the part to append from the source traj
+   * \param end_index - index of last traj point of the part to append from the source traj
+   */
+  void append(const RobotTrajectory& source, double dt, size_t start_index, size_t end_index);
+
   void swap(robot_trajectory::RobotTrajectory& other);
 
   void clear();

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -85,12 +85,7 @@ void RobotTrajectory::swap(RobotTrajectory& other)
 
 void RobotTrajectory::append(const RobotTrajectory& source, double dt)
 {
-  waypoints_.insert(waypoints_.end(), source.waypoints_.begin(), source.waypoints_.end());
-  std::size_t index = duration_from_previous_.size();
-  duration_from_previous_.insert(duration_from_previous_.end(), source.duration_from_previous_.begin(),
-                                 source.duration_from_previous_.end());
-  if (duration_from_previous_.size() > index)
-    duration_from_previous_[index] += dt;
+  append(source, dt, 0, source.waypoints_.size());
 }
 
 void RobotTrajectory::append(const RobotTrajectory& source, double dt, size_t start_index, size_t end_index)

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -83,11 +83,6 @@ void RobotTrajectory::swap(RobotTrajectory& other)
   duration_from_previous_.swap(other.duration_from_previous_);
 }
 
-void RobotTrajectory::append(const RobotTrajectory& source, double dt)
-{
-  append(source, dt, 0, source.waypoints_.size());
-}
-
 void RobotTrajectory::append(const RobotTrajectory& source, double dt, size_t start_index, size_t end_index)
 {
   end_index = std::min(end_index, source.waypoints_.size());

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -93,6 +93,21 @@ void RobotTrajectory::append(const RobotTrajectory& source, double dt)
     duration_from_previous_[index] += dt;
 }
 
+void RobotTrajectory::append(const RobotTrajectory& source, double dt, size_t start_index, size_t end_index)
+{
+  end_index = std::min(end_index, source.waypoints_.size());
+  if (start_index >= end_index)
+    return;
+  waypoints_.insert(waypoints_.end(), std::next(source.waypoints_.begin(), start_index),
+                    std::next(source.waypoints_.begin(), end_index));
+  std::size_t index = duration_from_previous_.size();
+  duration_from_previous_.insert(duration_from_previous_.end(),
+                                 std::next(source.duration_from_previous_.begin(), start_index),
+                                 std::next(source.duration_from_previous_.begin(), end_index));
+  if (duration_from_previous_.size() > index)
+    duration_from_previous_[index] += dt;
+}
+
 void RobotTrajectory::reverse()
 {
   std::reverse(waypoints_.begin(), waypoints_.end());


### PR DESCRIPTION
### Description

As a solution to #1212, we propose adding an append function to robot_trajectory::RobotTrajectory, which takes a start- and end-index for appending only a part of the trajectory. By this, we avoid re-assembling or removing points from an existing trajectory.

A cherry-pick to kinetic would be desirable.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Document API changes relevant to the user in the moveit/MIGRATION.md notes(http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
