### PR TITLE
Add getMoveGroupClient() to move_group_interface

### DIFF
--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -64,6 +64,7 @@ catkin_package(
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS
+    actionlib
     moveit_ros_planning
     moveit_ros_warehouse
     moveit_ros_manipulation

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -688,7 +688,7 @@ public:
   /** \brief Get the move_group action client used by the \e MoveGroupInterface.
       The client can be used for querying the execution state of the trajectory and abort trajectory execution
       during asynchronous execution. */
-  actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient();
+  actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient() const;
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified
      target.

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -48,7 +48,9 @@
 #include <moveit_msgs/Grasp.h>
 #include <moveit_msgs/PlaceLocation.h>
 #include <moveit_msgs/MotionPlanRequest.h>
+#include <moveit_msgs/MoveGroupAction.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <actionlib/client/simple_action_client.h>
 #include <boost/shared_ptr.hpp>
 #include <tf/tf.h>
 
@@ -682,6 +684,11 @@ public:
      target.
       This call is not blocking (does not wait for the execution of the trajectory to complete). */
   MoveItErrorCode asyncMove();
+
+  /** \brief Get the move action client used by \e move_group.
+      The client can be used for querying the execution state of the trajectory and abort trajectory execution
+      during asynchronous execution. */
+  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveActionClient();
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified
      target.

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -688,7 +688,7 @@ public:
   /** \brief Get the move_group action client used by the \e MoveGroupInterface.
       The client can be used for querying the execution state of the trajectory and abort trajectory execution
       during asynchronous execution. */
-  const actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient();
+  actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient();
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified
      target.

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -685,10 +685,10 @@ public:
       This call is not blocking (does not wait for the execution of the trajectory to complete). */
   MoveItErrorCode asyncMove();
 
-  /** \brief Get the move action client used by \e move_group.
+  /** \brief Get the move_group action client used by the \e MoveGroupInterface.
       The client can be used for querying the execution state of the trajectory and abort trajectory execution
       during asynchronous execution. */
-  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveGroupClient();
+  const actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient();
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified
      target.

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -688,7 +688,7 @@ public:
   /** \brief Get the move action client used by \e move_group.
       The client can be used for querying the execution state of the trajectory and abort trajectory execution
       during asynchronous execution. */
-  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveActionClient();
+  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveGroupClient();
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified
      target.

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -329,9 +329,9 @@ public:
     return joint_model_group_;
   }
 
-  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveGroupClient() const
+  const actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient() const
   {
-    return move_action_client_;
+    return *move_action_client_;
   }
 
   bool getInterfaceDescription(moveit_msgs::PlannerInterfaceDescription& desc)
@@ -1312,7 +1312,7 @@ private:
   boost::shared_ptr<tf::Transformer> tf_;
   robot_model::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
-  std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
+  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::ExecuteTrajectoryAction> > execute_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PickupAction> > pick_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction> > place_action_client_;
@@ -1505,7 +1505,7 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
   return impl_->move(false);
 }
 
-const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> >
+const actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>&
 moveit::planning_interface::MoveGroupInterface::getMoveGroupClient()
 {
   return impl_->getMoveGroupClient();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -50,7 +50,6 @@
 #include <moveit/trajectory_execution_manager/trajectory_execution_manager.h>
 #include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/robot_state/conversions.h>
-#include <moveit_msgs/MoveGroupAction.h>
 #include <moveit_msgs/PickupAction.h>
 #include <moveit_msgs/ExecuteTrajectoryAction.h>
 #include <moveit_msgs/PlaceAction.h>
@@ -61,7 +60,6 @@
 #include <moveit_msgs/GetPlannerParams.h>
 #include <moveit_msgs/SetPlannerParams.h>
 
-#include <actionlib/client/simple_action_client.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <std_msgs/String.h>
 #include <tf/transform_listener.h>
@@ -329,6 +327,11 @@ public:
   const robot_model::JointModelGroup* getJointModelGroup() const
   {
     return joint_model_group_;
+  }
+
+  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveActionClient() const
+  {
+    return move_action_client_;
   }
 
   bool getInterfaceDescription(moveit_msgs::PlannerInterfaceDescription& desc)
@@ -1309,7 +1312,7 @@ private:
   boost::shared_ptr<tf::Transformer> tf_;
   robot_model::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
-  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
+  std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::ExecuteTrajectoryAction> > execute_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PickupAction> > pick_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction> > place_action_client_;
@@ -1500,6 +1503,12 @@ void moveit::planning_interface::MoveGroupInterface::setMaxAccelerationScalingFa
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::asyncMove()
 {
   return impl_->move(false);
+}
+
+const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> >
+moveit::planning_interface::MoveGroupInterface::getMoveActionClient()
+{
+  return impl_->getMoveActionClient();
 }
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::move()

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -329,7 +329,7 @@ public:
     return joint_model_group_;
   }
 
-  const actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient() const
+  actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>& getMoveGroupClient() const
   {
     return *move_action_client_;
   }
@@ -1505,7 +1505,7 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
   return impl_->move(false);
 }
 
-const actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>&
+actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>&
 moveit::planning_interface::MoveGroupInterface::getMoveGroupClient()
 {
   return impl_->getMoveGroupClient();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1506,7 +1506,7 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 }
 
 actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>&
-moveit::planning_interface::MoveGroupInterface::getMoveGroupClient()
+moveit::planning_interface::MoveGroupInterface::getMoveGroupClient() const
 {
   return impl_->getMoveGroupClient();
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -329,7 +329,7 @@ public:
     return joint_model_group_;
   }
 
-  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveActionClient() const
+  const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > getMoveGroupClient() const
   {
     return move_action_client_;
   }
@@ -1506,9 +1506,9 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 }
 
 const std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> >
-moveit::planning_interface::MoveGroupInterface::getMoveActionClient()
+moveit::planning_interface::MoveGroupInterface::getMoveGroupClient()
 {
-  return impl_->getMoveActionClient();
+  return impl_->getMoveGroupClient();
 }
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroupInterface::move()


### PR DESCRIPTION
Use case: I want to execute a trajectory asynchronously while also being able to monitor its execution and perhaps abort it.

* `MoveGroupInterface::asyncMove()` lets me start asynchronous execution
* `MoveGroupInterface::stop()` lets me abort it
* but there is no way to monitor the execution or get the result

This PR simply adds a getter for the internal `move_action_client`. This enables code like shown in the usage example below. I'm not sure that exposing the internal `move_action_client` is the nicest API (comments welcome), but at least it seems more elegant than replicating all of the client's API one-by-one. In the example below, I've only used `getState()`, `getResult()` and `cancelGoal()`; but the other methods are useful as well (for example `waitForResult()`).

### usage example

```cpp
moveit::planning_interface::MoveGroupInterface group;
// [...]
group.setNamedTarget("home");
group.plan(plan);
group.asyncMove();
std::shared_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> >
    move_action_client = group.getMoveActionClient();

ros::Rate rate(10);
while (!move_action_client->getState().isDone() && ros::ok()) {
  ROS_DEBUG("move_action_client: %s", move_action_client->getState().toString().c_str());
  rate.sleep();
  // to abort execution of the trajectory: `move_action_client->cancelGoal();` or `group.stop();`
}

ROS_DEBUG("move_action_client: %s %s",
          move_action_client->getState().toString().c_str(),
          move_action_client->getState().getText().c_str());

auto error_code = move_action_client->getResult()->error_code.val;

if (error_code == moveit::planning_interface::MoveItErrorCode::SUCCESS) {
  ROS_INFO("Moving to home pose SUCCESSFUL");
  return 0;
} else {
  ROS_ERROR("Moving to home pose FAILED");
  return 1;
}
```

### TODOs

- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers. You can refer to our [ROS code review guide](https://github.com/rosin-project/ros_code_review_guide/blob/master/README.md) for direction
