### PR TITLE
RobotModelLoader: use namespace robot_model_loader

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -39,20 +39,21 @@
 #include <ros/ros.h>
 #include <typeinfo>
 
-robot_model_loader::RobotModelLoader::RobotModelLoader(const std::string& robot_description,
-                                                       bool load_kinematics_solvers)
+namespace robot_model_loader
+{
+RobotModelLoader::RobotModelLoader(const std::string& robot_description, bool load_kinematics_solvers)
 {
   Options opt(robot_description);
   opt.load_kinematics_solvers_ = load_kinematics_solvers;
   configure(opt);
 }
 
-robot_model_loader::RobotModelLoader::RobotModelLoader(const Options& opt)
+RobotModelLoader::RobotModelLoader(const Options& opt)
 {
   configure(opt);
 }
 
-robot_model_loader::RobotModelLoader::~RobotModelLoader()
+RobotModelLoader::~RobotModelLoader()
 {
   // Make sure we destroy the robot model first. It contains the loaded
   // kinematics plugins, and those must be destroyed before the pluginlib class
@@ -82,7 +83,7 @@ bool canSpecifyPosition(const robot_model::JointModel* jmodel, const unsigned in
 }
 }
 
-void robot_model_loader::RobotModelLoader::configure(const Options& opt)
+void RobotModelLoader::configure(const Options& opt)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("RobotModelLoader::configure");
@@ -165,8 +166,7 @@ void robot_model_loader::RobotModelLoader::configure(const Options& opt)
                                                                             << " seconds");
 }
 
-void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(
-    const kinematics_plugin_loader::KinematicsPluginLoaderPtr& kloader)
+void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr& kloader)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("RobotModelLoader::loadKinematicsSolvers");
@@ -237,4 +237,5 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(
       jmg->setDefaultIKAttempts(it->second);
     }
   }
+}
 }


### PR DESCRIPTION
Use namespace to shorten source lines.