### PR TITLE
add more ROS_ERROR_STREAM_NAMED in chomp_planner.cpp

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -293,7 +293,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     constraints_are_ok = constraints_are_ok and jc.decide(last_state).satisfied;
     if (not constraints_are_ok)
     {
-      ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal constraints are violated.");
+      ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal constraints are violated: " << constraint.joint_name);
       res.error_code.val = moveit_msgs::MoveItErrorCodes::GOAL_CONSTRAINTS_VIOLATED;
       return false;
     }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -276,6 +276,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   // report planning failure if path has collisions
   if (not optimizer->isCollisionFree())
   {
+    ROS_ERROR_STREAM_NAMED("chomp_planner", "Motion plan is invalid.");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
@@ -292,6 +293,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     constraints_are_ok = constraints_are_ok and jc.decide(last_state).satisfied;
     if (not constraints_are_ok)
     {
+      ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal constraints are violated.");
       res.error_code.val = moveit_msgs::MoveItErrorCodes::GOAL_CONSTRAINTS_VIOLATED;
       return false;
     }


### PR DESCRIPTION
### Description
add `ROS_ERROR_STREAM_NAME` for `INVALID_MOTION_PLAN` and `GOAL_CONSTRAINTS_VIOLATED` in `chomp_planner`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
