### PR TITLE
set last_state only for active joints in chomp_planner

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -284,7 +284,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   kinematic_constraints::JointConstraint jc(planning_scene->getRobotModel());
   robot_state::RobotState last_state(planning_scene->getRobotModel());
   last_state.setVariablePositions(req.start_state.joint_state.position.data());
-  last_state.setVariablePositions(res.trajectory[0].joint_trajectory.joint_names, res.trajectory[0].joint_trajectory.points.back().positions);
+  last_state.setVariablePositions(res.trajectory[0].joint_trajectory.joint_names,
+                                  res.trajectory[0].joint_trajectory.points.back().positions);
 
   bool constraints_are_ok = true;
   for (const moveit_msgs::JointConstraint& constraint : req.goal_constraints[0].joint_constraints)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -283,7 +283,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   // check that final state is within goal tolerances
   kinematic_constraints::JointConstraint jc(planning_scene->getRobotModel());
   robot_state::RobotState last_state(planning_scene->getRobotModel());
-  last_state.setVariablePositions(res.trajectory[0].joint_trajectory.points.back().positions.data());
+  last_state.setVariablePositions(req.start_state.joint_state.position.data());
+  last_state.setVariablePositions(res.trajectory[0].joint_trajectory.joint_names, res.trajectory[0].joint_trajectory.points.back().positions);
 
   bool constraints_are_ok = true;
   for (const moveit_msgs::JointConstraint& constraint : req.goal_constraints[0].joint_constraints)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -282,8 +282,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   // check that final state is within goal tolerances
   kinematic_constraints::JointConstraint jc(planning_scene->getRobotModel());
-  robot_state::RobotState last_state(planning_scene->getRobotModel());
-  last_state.setVariablePositions(req.start_state.joint_state.position.data());
+  robot_state::RobotState last_state(start_state);
   last_state.setVariablePositions(res.trajectory[0].joint_trajectory.joint_names,
                                   res.trajectory[0].joint_trajectory.points.back().positions);
 


### PR DESCRIPTION
### Description

Current `last_state` implementation in `chomp_planner` regards `active joints == all joints`, which does not happen for dual arm robot such as `baxter`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
