### PR TITLE
fix compatibility with KDL 1.3

### DIFF
--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -29,12 +29,6 @@ if(CATKIN_ENABLE_TESTING)
   find_package(tf2_kdl REQUIRED)
   find_package(moveit_resources REQUIRED)
 
-# Does kdl provide updateInternalDataStructures()?
-# TODO: remove when Kinetic support is dropped
-if(orocos_kdl_VERSION VERSION_LESS 1.4.0)
-  add_definitions(-DKDL_MISSES_UPDATE_INTERNAL)
-endif()
-
 include_directories(${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS} ${moveit_resources_INCLUDE_DIRS})
 
   catkin_add_gtest(test_constraint_samplers

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -37,6 +37,7 @@
 #ifndef PR2_ARM_IK_NODE_H
 #define PR2_ARM_IK_NODE_H
 
+#include <kdl/config.h>
 #include <kdl/frames.hpp>
 #include <kdl/jntarray.hpp>
 #include <kdl/tree.hpp>
@@ -86,11 +87,14 @@ public:
 
   ~PR2ArmIKSolver() override{};
 
-#ifdef KDL_MISSES_UPDATE_INTERNAL
+// TODO: simplify after kinetic support is dropped
+#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION > ((a << 16) | (b << 8) | c))
+#if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else
   void updateInternalDataStructures() override;
 #endif
+#undef KDL_VERSION_LESS
 
   /**
    * @brief The PR2 inverse kinematics solver

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -22,12 +22,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_kdl
 )
 
-# Does kdl provide updateInternalDataStructures()?
-# TODO: remove when Kinetic support is dropped
-if(orocos_kdl_VERSION VERSION_LESS 1.4.0)
-  add_definitions(-DKDL_MISSES_UPDATE_INTERNAL)
-endif()
-
 find_package(PkgConfig REQUIRED)
 pkg_search_module(EIGEN3 REQUIRED eigen3)
 

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_pos_nr_jl_mimic.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_pos_nr_jl_mimic.hpp
@@ -28,6 +28,7 @@
 #ifndef KDLCHAINIKSOLVERPOS_NR_JL_Mimic_HPP
 #define KDLCHAINIKSOLVERPOS_NR_JL_Mimic_HPP
 
+#include "kdl/config.h"
 #include "kdl/chainiksolver.hpp"
 #include "kdl/chainfksolver.hpp"
 
@@ -67,11 +68,14 @@ public:
                                ChainFkSolverPos& fksolver, ChainIkSolverVel& iksolver, unsigned int maxiter = 100,
                                double eps = 1e-6, bool position_ik = false);
 
-#ifdef KDL_MISSES_UPDATE_INTERNAL
+// TODO: simplify after kinetic support is dropped
+#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else
   void updateInternalDataStructures() override;
 #endif
+#undef KDL_VERSION_LESS
 
   ~ChainIkSolverPos_NR_JL_Mimic() override;
 

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_pinv_mimic.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_pinv_mimic.hpp
@@ -26,6 +26,7 @@
 #ifndef KDL_CHAIN_IKSOLVERVEL_PINV_Mimic_HPP
 #define KDL_CHAIN_IKSOLVERVEL_PINV_Mimic_HPP
 
+#include "kdl/config.h"
 #include "kdl/chainiksolver.hpp"
 #include "kdl/chainjnttojacsolver.hpp"
 #include "kdl/utilities/svd_HH.hpp"
@@ -66,11 +67,14 @@ public:
   explicit ChainIkSolverVel_pinv_mimic(const Chain& chain, int num_mimic_joints = 0, int num_redundant_joints = 0,
                                        bool position_ik = false, double eps = 0.00001, int maxiter = 150);
 
-#ifdef KDL_MISSES_UPDATE_INTERNAL
+// TODO: simplify after kinetic support is dropped
+#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else
   void updateInternalDataStructures() override;
 #endif
+#undef KDL_VERSION_LESS
 
   ~ChainIkSolverVel_pinv_mimic() override;
 

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_pos_lma_jl_mimic.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_pos_lma_jl_mimic.h
@@ -37,6 +37,7 @@
 #ifndef KDLCHAINIKSOLVERPOS_LMA_JL_MIMIC_H
 #define KDLCHAINIKSOLVERPOS_LMA_JL_MIMIC_H
 
+#include "kdl/config.h"
 #include "kdl/chainiksolverpos_lma.hpp"  // Solver for the inverse position kinematics that uses Levenberg-Marquardt.
 #include "kdl/chainfksolver.hpp"
 
@@ -76,11 +77,14 @@ public:
                                 ChainFkSolverPos& fksolver, ChainIkSolverPos_LMA& iksolver, unsigned int maxiter = 100,
                                 double eps = 1e-6, bool position_ik = false);
 
-#ifdef KDL_MISSES_UPDATE_INTERNAL
+// TODO: simplify after kinetic support is dropped
+#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else
   void updateInternalDataStructures() override;
 #endif
+#undef KDL_VERSION_LESS
 
   ~ChainIkSolverPos_LMA_JL_Mimic() override;
 

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_vel_pinv_mimic.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_vel_pinv_mimic.h
@@ -37,6 +37,7 @@
 #ifndef KDL_CHAIN_IKSOLVERVEL_PINV_MIMIC_H
 #define KDL_CHAIN_IKSOLVERVEL_PINV_MIMIC_H
 
+#include "kdl/config.h"
 #include "kdl/chainiksolver.hpp"
 #include "kdl/chainjnttojacsolver.hpp"
 #include "kdl/utilities/svd_HH.hpp"
@@ -77,11 +78,14 @@ public:
   explicit ChainIkSolverVel_pinv_mimic(const Chain& chain, int num_mimic_joints = 0, int num_redundant_joints = 0,
                                        bool position_ik = false, double eps = 0.00001, int maxiter = 150);
 
-#ifdef KDL_MISSES_UPDATE_INTERNAL
+// TODO: simplify after kinetic support is dropped
+#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else
   void updateInternalDataStructures() override;
 #endif
+#undef KDL_VERSION_LESS
 
   ~ChainIkSolverVel_pinv_mimic() override;
 


### PR DESCRIPTION
- The previous VERSION_LESS check is broken,
the orocos_kdl_VERSION is not evaluated in this context

- The definition is not exported to third-party projects
that might include the header. After all these headers are public API.

Verified to compile with ROS kinetic + external kinematics plugin that include the headers (ur_kinematics).