### PR TITLE
Selective backport of #1196 (clang fixes)

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -49,6 +49,10 @@ MOVEIT_CLASS_FORWARD(CollisionDetectorAllocator);
 class CollisionDetectorAllocator
 {
 public:
+  virtual ~CollisionDetectorAllocator()
+  {
+  }
+
   /** A unique name identifying the CollisionWorld/CollisionRobot pairing. */
   virtual const std::string& getName() const = 0;
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -68,13 +68,13 @@ public:
    * This does copy on write and should be quick. */
   World(const World& other);
 
-  ~World();
+  virtual ~World();
 
   /**********************************************************************/
   /* Collision Bodies                                                   */
   /**********************************************************************/
 
-  MOVEIT_CLASS_FORWARD(Object);
+  MOVEIT_STRUCT_FORWARD(Object);
 
   /** \brief A representation of an object */
   struct Object

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -48,7 +48,7 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(CollisionGeometryData);
+MOVEIT_STRUCT_FORWARD(CollisionGeometryData);
 
 struct CollisionGeometryData
 {
@@ -168,7 +168,7 @@ struct DistanceData
   bool done;
 };
 
-MOVEIT_CLASS_FORWARD(FCLGeometry);
+MOVEIT_STRUCT_FORWARD(FCLGeometry);
 
 struct FCLGeometry
 {

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -57,9 +57,6 @@ static const double origin_y = 0.0;
 static const double origin_z = 0.0;
 static const double max_dist = 0.3;
 
-static const int max_dist_in_voxels = max_dist / resolution + 0.5;
-static const int max_dist_sq_in_voxels = max_dist_in_voxels * max_dist_in_voxels;
-
 static const Eigen::Vector3d point1(0.1, 0.0, 0.0);
 static const Eigen::Vector3d point2(0.0, 0.1, 0.2);
 static const Eigen::Vector3d point3(0.4, 0.0, 0.0);

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -961,7 +961,7 @@ private:
   static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
                                                      const srdf::ModelConstSharedPtr& srdf_model);
 
-  MOVEIT_CLASS_FORWARD(CollisionDetector);
+  MOVEIT_STRUCT_FORWARD(CollisionDetector);
 
   /* \brief A set of compatible collision detectors */
   struct CollisionDetector

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -295,7 +295,7 @@ void RobotModel::buildJointInfo()
     }
   }
 
-  bool link_considered[link_model_vector_.size()] = { false };
+  std::vector<bool> link_considered(link_model_vector_.size(), false);
   for (const LinkModel* link : link_model_vector_)
   {
     if (link_considered[link->getLinkIndex()])

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -124,7 +124,7 @@ void IKCache::initializeCache(const std::string& robot_description, const std::s
       ik_cache_.push_back(entry);
     }
     ROS_INFO_NAMED("cached_ik", "freeing buffer");
-    delete buffer;
+    delete[] buffer;
     ROS_INFO_NAMED("cached_ik", "freed buffer");
     std::vector<IKEntry*> ik_entry_ptrs(last_saved_cache_size_);
     for (unsigned int i = 0; i < last_saved_cache_size_; ++i)
@@ -246,7 +246,7 @@ void IKCache::saveCache() const
     memcpy(buffer + offset_conf, &entry.second[0], config_size);
     cache_file.write(buffer, bufsize);
   }
-  delete buffer;
+  delete[] buffer;
 }
 
 void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
@@ -78,6 +78,7 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
   , covariance_(covariance)
   , covariance_cholesky_(covariance_.llt().matrixL())
   , normal_dist_(0.0, 1.0)
+  , rng_()
   , gaussian_(rng_, normal_dist_)
 {
   rng_.seed(rand());

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1117,7 +1117,7 @@ public:
     : dc_(dc), key_(dc.link1_ < dc.link2_ ? (dc.link1_ + "|" + dc.link2_) : (dc.link2_ + "|" + dc.link1_))
   {
   }
-  operator const srdf::Model::DisabledCollision() const
+  operator const srdf::Model::DisabledCollision&() const
   {
     return dc_;
   }


### PR DESCRIPTION
fix clang issues

- use MOVEIT_STRUCT_FORWARD for structs
- fix initialization of dynamic-size array
- fix implicit conversion for SortableDisabledCollision -> srdf::Model::DisabledCollision
- virtual destructors for classes with virtual methods
- use delete[] for memory allocated with new[]