### PR TITLE
enforce OpenMP support for perception

### DIFF
--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(OpenMP)
+find_package(OpenMP REQUIRED)
 find_package(octomap REQUIRED)
 find_package(OpenCV)
 


### PR DESCRIPTION
The build is broken without it for a long time already
and it is not reasonable to compile the octomap updater
plugins without OpenMP speedup.