### PR TITLE
Use correct trajectory_initialization_method param

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/chomp_optimizer_adapter.cpp
@@ -151,7 +151,7 @@ public:
       ROS_INFO_STREAM(
           "Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_);
     }
-    if (!nh_.getParam("trajectory_initialization_method", params_.use_stochastic_descent_))
+    if (!nh_.getParam("trajectory_initialization_method", params_.trajectory_initialization_method_))
     {
       params_.trajectory_initialization_method_ = std::string("fillTrajectory");
       ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using New value as: "


### PR DESCRIPTION
### Description
The parameter updated for `"trajectory_initialization_method"` was `use_stochastic_descent_` instead, possibly due to a copy-paste leftover.
This caused a segfault when trying to load this plugin with this parameter set, as the value of `params_.trajectory_initialization_method_` was never actually read.

This should also be forward-ported to `melodic`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
