### PR TITLE
motion_planning_rviz_plugin : add CartesianPath planning check box

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -151,8 +151,8 @@ private Q_SLOTS:
   void approximateIKChanged(int state);
 
   // Planning tab
-  void computeCartesianPlan();
-  void computeJointSpacePlan();
+  bool computeCartesianPlan();
+  bool computeJointSpacePlan();
   void planButtonClicked();
   void executeButtonClicked();
   void planAndExecuteButtonClicked();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -151,12 +151,15 @@ private Q_SLOTS:
   void approximateIKChanged(int state);
 
   // Planning tab
+  void computeCartesianPlan();
+  void computeJointSpacePlan();
   void planButtonClicked();
   void executeButtonClicked();
   void planAndExecuteButtonClicked();
   void stopButtonClicked();
   void allowReplanningToggled(bool checked);
   void allowLookingToggled(bool checked);
+  void cartesianPathToggled(bool checked);
   void allowExternalProgramCommunication(bool enable);
   void pathConstraintsIndexChanged(int index);
   void startStateTextChanged(const QString& start_state);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -159,7 +159,6 @@ private Q_SLOTS:
   void stopButtonClicked();
   void allowReplanningToggled(bool checked);
   void allowLookingToggled(bool checked);
-  void cartesianPathToggled(bool checked);
   void allowExternalProgramCommunication(bool enable);
   void pathConstraintsIndexChanged(int index);
   void startStateTextChanged(const QString& start_state);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1313,6 +1313,8 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     if (config.mapGetFloat("MoveIt_Goal_Tolerance", &d))
       frame_->ui_->goal_tolerance->setValue(d);
     bool b;
+    if (config.mapGetBool("MoveIt_Use_Cartesian_Path", &b))
+      frame_->ui_->use_cartesian_path->setChecked(b);
     if (config.mapGetBool("MoveIt_Use_Constraint_Aware_IK", &b))
       frame_->ui_->collision_aware_ik->setChecked(b);
     if (config.mapGetBool("MoveIt_Allow_Approximate_IK", &b))
@@ -1384,6 +1386,7 @@ void MotionPlanningDisplay::save(rviz::Config config) const
     config.mapSetValue("MoveIt_Allow_Replanning", frame_->ui_->allow_replanning->isChecked());
     config.mapSetValue("MoveIt_Allow_Sensor_Positioning", frame_->ui_->allow_looking->isChecked());
     config.mapSetValue("MoveIt_Allow_External_Program", frame_->ui_->allow_external_program->isChecked());
+    config.mapSetValue("MoveIt_Use_Cartesian_Path", frame_->ui_->use_cartesian_path->isChecked());
     config.mapSetValue("MoveIt_Use_Constraint_Aware_IK", frame_->ui_->collision_aware_ik->isChecked());
     config.mapSetValue("MoveIt_Allow_Approximate_IK", frame_->ui_->approximate_ik->isChecked());
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -351,6 +351,8 @@ void MotionPlanningFrame::changePlanningGroupHelper()
     {
       move_group_->allowLooking(ui_->allow_looking->isChecked());
       move_group_->allowReplanning(ui_->allow_replanning->isChecked());
+      bool hasUniqueEndeffector = !move_group_->getEndEffectorLink().empty();
+      planning_display_->addMainLoopJob([=](){ui_->use_cartesian_path->setEnabled(hasUniqueEndeffector);});
       moveit_msgs::PlannerInterfaceDescription desc;
       if (move_group_->getInterfaceDescription(desc))
         planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlannersList, this, desc));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -88,6 +88,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->allow_looking, SIGNAL(toggled(bool)), this, SLOT(allowLookingToggled(bool)));
   connect(ui_->allow_replanning, SIGNAL(toggled(bool)), this, SLOT(allowReplanningToggled(bool)));
   connect(ui_->allow_external_program, SIGNAL(toggled(bool)), this, SLOT(allowExternalProgramCommunication(bool)));
+  connect(ui_->use_cartesian_path, SIGNAL(toggled(bool)), this, SLOT(cartesianPathToggled(bool)));
   connect(ui_->planning_algorithm_combo_box, SIGNAL(currentIndexChanged(int)), this,
           SLOT(planningAlgorithmIndexChanged(int)));
   connect(ui_->planning_algorithm_combo_box, SIGNAL(currentIndexChanged(int)), this,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -317,7 +317,8 @@ void MotionPlanningFrame::changePlanningGroupHelper()
   std::string group = planning_display_->getCurrentPlanningGroup();
   planning_display_->addMainLoopJob(
       boost::bind(&MotionPlanningParamWidget::setGroupName, ui_->planner_param_treeview, group));
-  planning_display_->addMainLoopJob([=](){ui_->planning_group_combo_box->setCurrentText(QString::fromStdString(group));});
+  planning_display_->addMainLoopJob(
+      [=]() { ui_->planning_group_combo_box->setCurrentText(QString::fromStdString(group)); });
 
   if (!group.empty() && robot_model)
   {
@@ -352,7 +353,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
       move_group_->allowLooking(ui_->allow_looking->isChecked());
       move_group_->allowReplanning(ui_->allow_replanning->isChecked());
       bool hasUniqueEndeffector = !move_group_->getEndEffectorLink().empty();
-      planning_display_->addMainLoopJob([=](){ui_->use_cartesian_path->setEnabled(hasUniqueEndeffector);});
+      planning_display_->addMainLoopJob([=]() { ui_->use_cartesian_path->setEnabled(hasUniqueEndeffector); });
       moveit_msgs::PlannerInterfaceDescription desc;
       if (move_group_->getInterfaceDescription(desc))
         planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlannersList, this, desc));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -88,7 +88,6 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->allow_looking, SIGNAL(toggled(bool)), this, SLOT(allowLookingToggled(bool)));
   connect(ui_->allow_replanning, SIGNAL(toggled(bool)), this, SLOT(allowReplanningToggled(bool)));
   connect(ui_->allow_external_program, SIGNAL(toggled(bool)), this, SLOT(allowExternalProgramCommunication(bool)));
-  connect(ui_->use_cartesian_path, SIGNAL(toggled(bool)), this, SLOT(cartesianPathToggled(bool)));
   connect(ui_->planning_algorithm_combo_box, SIGNAL(currentIndexChanged(int)), this,
           SLOT(planningAlgorithmIndexChanged(int)));
   connect(ui_->planning_algorithm_combo_box, SIGNAL(currentIndexChanged(int)), this,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -112,6 +112,7 @@ void MotionPlanningFrame::onClearOctomapClicked()
 
 bool MotionPlanningFrame::computeCartesianPlan()
 {
+  ros::WallTime start = ros::WallTime::now();
   // get goal pose
   robot_state::RobotState goal = *planning_display_->getQueryGoalState();
   std::vector<geometry_msgs::Pose> waypoints;
@@ -150,6 +151,7 @@ bool MotionPlanningFrame::computeCartesianPlan()
     // Store trajectory in current_plan_
     current_plan_.reset(new moveit::planning_interface::MoveGroupInterface::Plan());
     rt.getRobotTrajectoryMsg(current_plan_->trajectory_);
+    current_plan_->planning_time_ = (ros::WallTime::now() - start).toSec();
     return success;
   }
   return false;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -43,6 +43,8 @@
 
 #include <std_srvs/Empty.h>
 #include <moveit_msgs/RobotState.h>
+#include <eigen_conversions/eigen_msg.h>
+#include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
@@ -87,6 +89,10 @@ void MotionPlanningFrame::allowLookingToggled(bool checked)
     move_group_->allowLooking(checked);
 }
 
+void MotionPlanningFrame::cartesianPathToggled(bool checked)
+{
+}
+
 void MotionPlanningFrame::pathConstraintsIndexChanged(int index)
 {
   if (move_group_)
@@ -108,7 +114,77 @@ void MotionPlanningFrame::onClearOctomapClicked()
   clear_octomap_service_client_.call(srv);
 }
 
-void MotionPlanningFrame::computePlanButtonClicked()
+void MotionPlanningFrame::computeCartesianPlan()
+{
+  if (!move_group_)
+    return;
+
+  // Clear status
+  ui_->result_label->setText("Planning...");
+
+  // get start and goal points
+  std::vector<geometry_msgs::Pose> waypoints;
+  robot_state::RobotState start = *planning_display_->getQueryStartState();
+  robot_state::RobotState goal = *planning_display_->getQueryGoalState();
+  geometry_msgs::Pose start_msg;
+  geometry_msgs::Pose goal_msg;
+  tf::poseEigenToMsg(start.getGlobalLinkTransform(move_group_->getEndEffectorLink()), start_msg);
+  tf::poseEigenToMsg(goal.getGlobalLinkTransform(move_group_->getEndEffectorLink()), goal_msg);
+  waypoints.push_back(start_msg);
+  waypoints.push_back(goal_msg);
+
+  // setup default params
+  double cart_step_size = 0.01;
+  double cart_jump_thresh = 0.0;
+  bool avoid_collisions = false;
+
+  // compute trajectory
+  current_plan_.reset();
+  moveit_msgs::RobotTrajectory trajectory;
+  double fraction =
+      move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, trajectory, avoid_collisions);
+  Q_EMIT planningFinished();
+
+  if (fraction > 0)
+  {
+    // Success
+    ui_->result_label->setText(QString::number(fraction * 100, 'f', 0).append(" % achieved"));
+
+    moveit_msgs::RobotTrajectory scaled_trajectory = moveit_msgs::RobotTrajectory(trajectory);
+
+    // Scaling (https://groups.google.com/forum/#!topic/moveit-users/MOoFxy2exT4)
+
+    // The trajectory needs to be modified so it will include velocities as well.
+    // First to create a RobotTrajectory object
+    robot_trajectory::RobotTrajectory rt(move_group_->getRobotModel(), move_group_->getName());
+
+    // Second get a RobotTrajectory from trajectory
+    rt.setRobotTrajectoryMsg(*move_group_->getCurrentState(), scaled_trajectory);
+
+    // Thrid create a IterativeParabolicTimeParameterization object
+    trajectory_processing::IterativeParabolicTimeParameterization iptp;
+
+    // Fourth compute computeTimeStamps
+    bool success =
+        iptp.computeTimeStamps(rt, ui_->velocity_scaling_factor->value(), ui_->acceleration_scaling_factor->value());
+    ROS_INFO("Computed time stamp %s", success ? "SUCCEDED" : "FAILED");
+
+    // Get RobotTrajectory_msg from RobotTrajectory
+    rt.getRobotTrajectoryMsg(scaled_trajectory);
+
+    // Fill in move_group_
+    current_plan_.reset(new moveit::planning_interface::MoveGroupInterface::Plan());
+    current_plan_->trajectory_ = scaled_trajectory;
+  }
+  else
+  {
+    // Failure
+    ui_->result_label->setText("Failed");
+    ROS_WARN("Failed to compute CartesianPath");
+  }
+}
+
+void MotionPlanningFrame::computeJointSpacePlan()
 {
   if (!move_group_)
     return;
@@ -135,6 +211,14 @@ void MotionPlanningFrame::computePlanButtonClicked()
   Q_EMIT planningFinished();
 }
 
+void MotionPlanningFrame::computePlanButtonClicked()
+{
+  if (ui_->use_cartesian_path->checkState())
+    return computeCartesianPlan();
+  else
+    return computeJointSpacePlan();
+}
+
 void MotionPlanningFrame::computeExecuteButtonClicked()
 {
   // ensures the MoveGroupInterface is not destroyed while executing
@@ -156,7 +240,16 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   // to suppress a warning, we pass an empty state (which encodes "start from current state")
   move_group_->setStartStateToCurrentState();
   ui_->stop_button->setEnabled(true);
-  bool success = move_group_->move() == moveit::planning_interface::MoveItErrorCode::SUCCESS;
+  bool success;
+  if (ui_->use_cartesian_path->checkState())
+  {
+    computeCartesianPlan();
+    computeExecuteButtonClicked();
+  }
+  else
+  {
+    success = move_group_->move() == moveit::planning_interface::MoveItErrorCode::SUCCESS;
+  }
   onFinishedExecution(success);
   ui_->plan_and_execute_button->setEnabled(true);
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -89,10 +89,6 @@ void MotionPlanningFrame::allowLookingToggled(bool checked)
     move_group_->allowLooking(checked);
 }
 
-void MotionPlanningFrame::cartesianPathToggled(bool checked)
-{
-}
-
 void MotionPlanningFrame::pathConstraintsIndexChanged(int index)
 {
   if (move_group_)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -172,7 +172,8 @@ void MotionPlanningFrame::computePlanButtonClicked()
   ui_->result_label->setText("Planning...");
 
   configureForPlanning();
-  bool success = ui_->use_cartesian_path->checkState() ? computeCartesianPlan() : computeJointSpacePlan();
+  bool success = (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState())
+      ? computeCartesianPlan() : computeJointSpacePlan();
 
   if (success)
   {
@@ -208,7 +209,7 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   // to suppress a warning, we pass an empty state (which encodes "start from current state")
   move_group_->setStartStateToCurrentState();
   ui_->stop_button->setEnabled(true);
-  if (ui_->use_cartesian_path->checkState())
+  if (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState())
   {
     if (computeCartesianPlan())
       computeExecuteButtonClicked();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -172,8 +172,9 @@ void MotionPlanningFrame::computePlanButtonClicked()
   ui_->result_label->setText("Planning...");
 
   configureForPlanning();
-  bool success = (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState())
-      ? computeCartesianPlan() : computeJointSpacePlan();
+  bool success = (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState()) ?
+                     computeCartesianPlan() :
+                     computeJointSpacePlan();
 
   if (success)
   {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -112,10 +112,17 @@ void MotionPlanningFrame::onClearOctomapClicked()
 
 bool MotionPlanningFrame::computeCartesianPlan()
 {
-  // get start and goal points
+  // get goal pose
   robot_state::RobotState goal = *planning_display_->getQueryGoalState();
   std::vector<geometry_msgs::Pose> waypoints;
-  waypoints.push_back(tf2::toMsg(goal.getGlobalLinkTransform(move_group_->getEndEffectorLink())));
+  const std::string& link_name = move_group_->getEndEffectorLink();
+  const robot_model::LinkModel* link = move_group_->getRobotModel()->getLinkModel(link_name);
+  if (!link)
+  {
+    ROS_ERROR_STREAM("Failed to determine unique end-effector link: " << link_name);
+    return false;
+  }
+  waypoints.push_back(tf2::toMsg(goal.getGlobalLinkTransform(link)));
 
   // setup default params
   double cart_step_size = 0.01;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -705,6 +705,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="use_cartesian_path">
+            <property name="text">
+             <string>Use Cartesian Path</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="collision_aware_ik">
             <property name="text">
              <string>Use Collision-Aware IK</string>


### PR DESCRIPTION
Rebase of #931 for Melodic, with additional cleanup and fixes:
- remove `cartesianPathToggled()`
- reduce code duplication in `computeCartesianPlan()` and `computeJointSpacePlan()`
- fix seg-fault occuring when there is no unique end-effector link
- save/load status of new checkbox
- report planning time as requested by @felixvd

@k-okada, please review.