### PR TITLE
New command line utility tool to print planning scene info

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -948,7 +948,7 @@ public:
                       std::set<collision_detection::CostSource>& costs) const;
 
   /** \brief Outputs debug information about the planning scene contents */
-  void printKnownObjects(std::ostream& out) const;
+  void printKnownObjects(std::ostream& out = std::cout) const;
 
   /** \brief Check if a message includes any information about a planning scene, or it is just a default, empty message.
    */

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -2303,18 +2303,24 @@ void PlanningScene::getCostSources(const robot_state::RobotState& state, std::si
 void PlanningScene::printKnownObjects(std::ostream& out) const
 {
   const std::vector<std::string>& objects = getWorld()->getObjectIds();
-
-  out << "Collision World Objects:\n\t ";
-  std::copy(objects.begin(), objects.end(), std::ostream_iterator<std::string>(out, "\n\t "));
-
   std::vector<const robot_state::AttachedBody*> attached_bodies;
   getCurrentState().getAttachedBodies(attached_bodies);
 
-  out << "\nAttached Bodies:\n";
+  // Output
+  out << "-----------------------------------------\n";
+  out << "PlanningScene Known Objects:\n";
+  out << "  - Collision World Objects:\n ";
+  for (std::size_t i = 0; i < objects.size(); ++i)
+  {
+    out << "\t- " << objects[i] << "\n";
+  }
+
+  out << "  - Attached Bodies:\n";
   for (std::size_t i = 0; i < attached_bodies.size(); ++i)
   {
-    out << "\t " << attached_bodies[i]->getName() << "\n";
+    out << "\t- " << attached_bodies[i]->getName() << "\n";
   }
+  out << "-----------------------------------------\n";
 }
 
 }  // end of namespace planning_scene

--- a/moveit_ros/planning/planning_components_tools/CMakeLists.txt
+++ b/moveit_ros/planning/planning_components_tools/CMakeLists.txt
@@ -2,6 +2,9 @@
 add_executable(moveit_print_planning_model_info src/print_planning_model_info.cpp)
 target_link_libraries(moveit_print_planning_model_info moveit_robot_model_loader ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_executable(moveit_print_planning_scene_info src/print_planning_scene_info.cpp)
+target_link_libraries(moveit_print_planning_scene_info moveit_planning_scene_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 add_executable(moveit_display_random_state src/display_random_state.cpp)
 target_link_libraries(moveit_display_random_state moveit_planning_scene_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -22,6 +25,7 @@ target_link_libraries(moveit_publish_scene_from_text moveit_planning_scene_monit
 
 install(TARGETS
   moveit_print_planning_model_info
+  moveit_print_planning_scene_info
   moveit_display_random_state
   moveit_visualize_robot_collision_volume
   moveit_evaluate_collision_checking_speed
@@ -29,4 +33,3 @@ install(TARGETS
   moveit_kinematics_speed_and_validity_evaluator
   moveit_publish_scene_from_text
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-

--- a/moveit_ros/planning/planning_components_tools/src/print_planning_scene_info.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/print_planning_scene_info.cpp
@@ -1,0 +1,70 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman
+   Desc:   Simple utility to see all the collision objects in a planning scene, including attached
+*/
+
+#include <ros/ros.h>
+
+// MoveIt!
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+
+static const std::string ROBOT_DESCRIPTION = "robot_description";
+static const std::string LOGNAME = "print_planning_scene_info";
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "print_model_info_to_console");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  ros::NodeHandle nh;
+  ROS_INFO_STREAM_NAMED(LOGNAME, "Getting planning scene info to print");
+
+  // Create planning scene monitor
+  planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION);
+  if (!psm.getPlanningScene())
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Planning scene not configured");
+    return 1;
+  }
+
+  psm.requestPlanningSceneState(planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE);
+
+  psm.getPlanningScene()->printKnownObjects();
+
+  return 0;
+}

--- a/moveit_ros/planning_interface/test/python_move_group.test
+++ b/moveit_ros/planning_interface/test/python_move_group.test
@@ -1,5 +1,9 @@
+<!-- -*- mode: XML -*- -->
 <launch>
+  <!-- Start joint_state_publisher, robot_state_publisher, and MoveGroup -->
   <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+
+  <!-- Test MoveGroupInterface for Python -->
   <test pkg="moveit_ros_planning_interface" type="python_move_group.py" test-name="python_move_group"
         time-limit="300" args=""/>
 </launch>


### PR DESCRIPTION
There was already a ``moveit_print_planning_model_info`` utility so I copied that and adapted it as a debugging tool for the planning_scene attached objects