### PR TITLE
OMPL Interface: remove last_planning_context_

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -90,11 +90,6 @@ public:
   ModelBasedPlanningContextPtr getPlanningContext(const std::string& config,
                                                   const std::string& factory_type = "") const;
 
-  ModelBasedPlanningContextPtr getLastPlanningContext() const
-  {
-    return context_manager_.getLastPlanningContext();
-  }
-
   const PlanningContextManager& getPlanningContextManager() const
   {
     return context_manager_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -141,8 +141,6 @@ public:
     return robot_model_;
   }
 
-  ModelBasedPlanningContextPtr getLastPlanningContext() const;
-
   ModelBasedPlanningContextPtr getPlanningContext(const std::string& config,
                                                   const std::string& factory_type = "") const;
 
@@ -227,9 +225,6 @@ protected:
   unsigned int minimum_waypoint_count_;
 
 private:
-  MOVEIT_CLASS_FORWARD(LastPlanningContext);
-  LastPlanningContextPtr last_planning_context_;
-
   MOVEIT_CLASS_FORWARD(CachedContexts);
   CachedContextsPtr cached_contexts_;
 };

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -76,33 +76,6 @@ using namespace std::placeholders;
 
 namespace ompl_interface
 {
-class PlanningContextManager::LastPlanningContext
-{
-public:
-  ModelBasedPlanningContextPtr getContext()
-  {
-    std::unique_lock<std::mutex> slock(lock_);
-    return last_planning_context_solve_;
-  }
-
-  void setContext(const ModelBasedPlanningContextPtr& context)
-  {
-    std::unique_lock<std::mutex> slock(lock_);
-    last_planning_context_solve_ = context;
-  }
-
-  void clear()
-  {
-    std::unique_lock<std::mutex> slock(lock_);
-    last_planning_context_solve_.reset();
-  }
-
-private:
-  /* The planning group for which solve() was called last */
-  ModelBasedPlanningContextPtr last_planning_context_solve_;
-  std::mutex lock_;
-};
-
 struct PlanningContextManager::CachedContexts
 {
   std::map<std::pair<std::string, std::string>, std::vector<ModelBasedPlanningContextPtr> > contexts_;
@@ -122,7 +95,6 @@ ompl_interface::PlanningContextManager::PlanningContextManager(robot_model::Robo
   , max_solution_segment_length_(0.0)
   , minimum_waypoint_count_(2)
 {
-  last_planning_context_.reset(new LastPlanningContext());
   cached_contexts_.reset(new CachedContexts());
   registerDefaultPlanners();
   registerDefaultStateSpaces();
@@ -348,7 +320,6 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 
   context->setSpecificationConfig(config.config);
 
-  last_planning_context_->setContext(context);
   return context;
 }
 
@@ -491,9 +462,4 @@ ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene:
   }
 
   return context;
-}
-
-ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextManager::getLastPlanningContext() const
-{
-  return last_planning_context_->getContext();
 }


### PR DESCRIPTION
The `last_planning_context_` is not used inside the MoveIt codebase (anymore).
