### PR TITLE
cleanup .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,16 +1,18 @@
 ---
-Checks:          '-clang-analyzer-*,
+Checks:          '-*,
+                  clang-analyzer-*,
+                  performance-*,
+                  modernize-redundant-void-arg,
+                  modernize-use-nullptr,
+                  modernize-use-default,
+                  modernize-use-override,
                   readability-identifier-naming,
                   readability-named-parameter,
                   readability-redundant-smartptr-get,
                   readability-redundant-string-cstr,
                   readability-simplify-boolean-expr,
                   readability-container-size-empty,
-                  performance-*,
-                  modernize-redundant-void-arg,
-                  modernize-use-nullptr,
-                  modernize-use-default,
-                  modernize-use-override,'
+                  '
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 CheckOptions:


### PR DESCRIPTION
- disable all checks
- to allow selective enabling afterwards (otherwise many undesired checks are enabled too)
- order checks