### PR TITLE
move_group: remove redundant list of capabilities

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -38,7 +38,6 @@
 #include <tf2_ros/transform_listener.h>
 #include <moveit/move_group/capability_names.h>
 #include <moveit/move_group/move_group_capability.h>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/tokenizer.hpp>
 #include <moveit/macros/console_colors.h>
 #include <moveit/move_group/node_name.h>
@@ -158,10 +157,7 @@ private:
       }
       catch (pluginlib::PluginlibException& ex)
       {
-        ROS_ERROR_STREAM("Exception while loading move_group capability '"
-                         << *plugin << "': " << ex.what() << std::endl
-                         << "Available capabilities: "
-                         << boost::algorithm::join(capability_plugin_loader_->getDeclaredClasses(), ", "));
+        ROS_ERROR_STREAM("Exception while loading move_group capability '" << *plugin << "': " << ex.what());
       }
     }
 


### PR DESCRIPTION
When a move_group capability is not found, both pluginlib and move_group prints the list of available types. This PR removes this redundancy:

```
[ERROR] ros.moveit_ros_move_group: Exception while loading move_group capability 'dummy/unknown': According to the loaded plugin descriptions the class dummy/unknown with base class type move_group::MoveGroupCapability does not exist. Declared types are  move_group/ApplyPlanningSceneService move_group/ClearOctomapService move_group/ExecuteTaskSolutionCapability move_group/MoveGroupCartesianPathService move_group/MoveGroupExecuteService move_group/MoveGroupExecuteTrajectoryAction move_group/MoveGroupGetPlanningSceneService move_group/MoveGroupKinematicsService move_group/MoveGroupMoveAction move_group/MoveGroupPickPlaceAction move_group/MoveGroupPlanService move_group/MoveGroupQueryPlannersService move_group/MoveGroupStateValidationService move_group/OnlineCollisionPredictor
Available capabilities: move_group/ApplyPlanningSceneService, move_group/ClearOctomapService, move_group/ExecuteTaskSolutionCapability, move_group/MoveGroupCartesianPathService, move_group/MoveGroupExecuteService, move_group/MoveGroupExecuteTrajectoryAction, move_group/MoveGroupGetPlanningSceneService, move_group/MoveGroupKinematicsService, move_group/MoveGroupMoveAction, move_group/MoveGroupPickPlaceAction, move_group/MoveGroupPlanService, move_group/MoveGroupQueryPlannersService, move_group/MoveGroupStateValidationService, move_group/OnlineCollisionPredictor
```
