### PR TITLE
chomp: explicitly set variable as empty when unused

### DIFF
--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -7,6 +7,8 @@ add_definitions(-std=c++14)
 find_package(catkin REQUIRED)
 if (CATKIN_ENABLE_TESTING)
   set(CHOMP_TEST_DEPS moveit_ros_planning_interface)
+else()
+  set(CHOMP_TEST_DEPS)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
Followup to https://github.com/ros-planning/moveit/pull/1251#discussion_r240041450

@rhaschke