### PR TITLE
[proposal] RDFLoader / RobotModelLoader: remove parsing of TinyXML documents

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,7 +16,7 @@ API changes in MoveIt! releases
   Use `tip_frames_` and `redundant_joint_discretization_` instead.
 - KinematicsBase: Deprecated `initialize(robot_description, ...)` in favour of `initialize(robot_model, ...)`.
   Adapt your kinematics plugin to directly receive a `RobotModel`. See the [KDL plugin](https://github.com/ros-planning/moveit/tree/melodic-devel/moveit_kinematics/kdl_kinematics_plugin) for an example.
-- ``RDFLoader`` / ``RobotModelLoader``: removed TinyXML-based API
+- ``RDFLoader`` / ``RobotModelLoader``: removed TinyXML-based API (https://github.com/ros-planning/moveit/pull/1254)
 
 ## ROS Kinetic
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,6 +16,7 @@ API changes in MoveIt! releases
   Use `tip_frames_` and `redundant_joint_discretization_` instead.
 - KinematicsBase: Deprecated `initialize(robot_description, ...)` in favour of `initialize(robot_model, ...)`.
   Adapt your kinematics plugin to directly receive a `RobotModel`. See the [KDL plugin](https://github.com/ros-planning/moveit/tree/melodic-devel/moveit_kinematics/kdl_kinematics_plugin) for an example.
+- ``RDFLoader`` / ``RobotModelLoader``: removed TinyXML-based API
 
 ## ROS Kinetic
 

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -41,8 +41,6 @@
 #include <urdf/model.h>
 #include <srdfdom/model.h>
 
-class TiXmlDocument;
-
 namespace rdf_loader
 {
 MOVEIT_CLASS_FORWARD(RDFLoader);
@@ -60,9 +58,6 @@ public:
 
   /** \brief Initialize the robot model from a string representation of the URDF and SRDF documents */
   RDFLoader(const std::string& urdf_string, const std::string& srdf_string);
-
-  /** \brief Initialize the robot model from a parsed XML representation of the URDF and SRDF */
-  RDFLoader(TiXmlDocument* urdf_doc, TiXmlDocument* srdf_doc);
 
   /** @brief Get the resolved parameter name for the robot description */
   const std::string& getRobotDescription() const

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -116,29 +116,6 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& urdf_string, const std::stri
   }
 }
 
-rdf_loader::RDFLoader::RDFLoader(TiXmlDocument* urdf_doc, TiXmlDocument* srdf_doc)
-{
-  moveit::tools::Profiler::ScopedStart prof_start;
-  moveit::tools::Profiler::ScopedBlock prof_block("RDFLoader(XML)");
-
-  urdf::Model* umodel = new urdf::Model();
-  urdf_.reset(umodel);
-  if (umodel->initXml(urdf_doc))
-  {
-    srdf_.reset(new srdf::Model());
-    if (!srdf_->initXml(*urdf_, srdf_doc))
-    {
-      ROS_ERROR_NAMED("rdf_loader", "Unable to parse SRDF");
-      srdf_.reset();
-    }
-  }
-  else
-  {
-    ROS_ERROR_NAMED("rdf_loader", "Unable to parse URDF");
-    urdf_.reset();
-  }
-}
-
 bool rdf_loader::RDFLoader::isXacroFile(const std::string& path)
 {
   std::string lower_path = path;

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -54,21 +54,12 @@ public:
   struct Options
   {
     Options(const std::string& robot_description = "robot_description")
-      : robot_description_(robot_description), urdf_doc_(NULL), srdf_doc_(NULL), load_kinematics_solvers_(true)
+      : robot_description_(robot_description), load_kinematics_solvers_(true)
     {
     }
 
     Options(const std::string& urdf_string, const std::string& srdf_string)
-      : urdf_string_(urdf_string)
-      , srdf_string_(srdf_string)
-      , urdf_doc_(NULL)
-      , srdf_doc_(NULL)
-      , load_kinematics_solvers_(true)
-    {
-    }
-
-    Options(TiXmlDocument* urdf_doc, TiXmlDocument* srdf_doc)
-      : urdf_doc_(urdf_doc), srdf_doc_(srdf_doc), load_kinematics_solvers_(true)
+      : urdf_string_(urdf_string), srdf_string_(srdf_string), load_kinematics_solvers_(true)
     {
     }
 
@@ -80,9 +71,6 @@ public:
     /** @brief The string content of the URDF and SRDF documents. Loading from string is attempted only if loading from
      * XML fails */
     std::string urdf_string_, srdf_string_;
-
-    /** @brief The parsed XML content of the URDF and SRDF documents. */
-    TiXmlDocument *urdf_doc_, *srdf_doc_;
 
     /** @brief Flag indicating whether the kinematics solvers should be loaded as well, using specified ROS parameters
      */

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -89,9 +89,7 @@ void RobotModelLoader::configure(const Options& opt)
   moveit::tools::Profiler::ScopedBlock prof_block("RobotModelLoader::configure");
 
   ros::WallTime start = ros::WallTime::now();
-  if (opt.urdf_doc_ && opt.srdf_doc_)
-    rdf_loader_.reset(new rdf_loader::RDFLoader(opt.urdf_doc_, opt.srdf_doc_));
-  else if (!opt.urdf_string_.empty() && !opt.srdf_string_.empty())
+  if (!opt.urdf_string_.empty() && !opt.srdf_string_.empty())
     rdf_loader_.reset(new rdf_loader::RDFLoader(opt.urdf_string_, opt.srdf_string_));
   else
     rdf_loader_.reset(new rdf_loader::RDFLoader(opt.robot_description_));


### PR DESCRIPTION
`urdf::Model::initXml()` is highly inefficient, as it first serializes the string and eventually
parses it again (see https://github.com/ros/urdf/issues/24#issue-389498748). We should discourage and eventually remove the TinyXML API and solely rely on parsing from string.

For now, this is just a proof-of-concept that the MoveIt source repo doesn't need the TinyXML support.
A user-friendly approach would deprecate the TinyXML API first, but, maybe, that's not really necessary?

Opinions?