### PR TITLE
moveit_experimental: commenting out dependencies

### DIFF
--- a/moveit_experimental/CMakeLists.txt
+++ b/moveit_experimental/CMakeLists.txt
@@ -7,27 +7,28 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time thread iostreams)
-find_package(catkin REQUIRED
-COMPONENTS
-  moveit_core
-  moveit_msgs
-  resource_retriever
-  kdl_parser
-  geometric_shapes
-  eigen_stl_containers
-  tf2_eigen
-  random_numbers
-  visualization_msgs
-  roslib
-  rostime
-  rosconsole
-  pluginlib
-)
-find_package(Eigen3 REQUIRED)
-find_package(octomap REQUIRED)
-find_package(urdfdom REQUIRED)
-find_package(urdfdom_headers REQUIRED)
+# find_package(Boost REQUIRED system filesystem date_time thread iostreams)
+find_package(catkin REQUIRED)
+# find_package(catkin REQUIRED
+# COMPONENTS
+#   moveit_core
+#   moveit_msgs
+#   resource_retriever
+#   kdl_parser
+#   geometric_shapes
+#   eigen_stl_containers
+#   tf2_eigen
+#   random_numbers
+#   visualization_msgs
+#   roslib
+#   rostime
+#   rosconsole
+#   pluginlib
+# )
+# find_package(Eigen3 REQUIRED)
+# find_package(octomap REQUIRED)
+# find_package(urdfdom REQUIRED)
+# find_package(urdfdom_headers REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DIRS)
 
@@ -36,18 +37,18 @@ catkin_package(
     ${THIS_PACKAGE_INCLUDE_DIRS}
   LIBRARIES
   CATKIN_DEPENDS
-    moveit_core
-    geometric_shapes
-    eigen_stl_containers
-    moveit_msgs
-    kdl_parser
-    pluginlib
+  #   moveit_core
+  #   geometric_shapes
+  #   eigen_stl_containers
+  #   moveit_msgs
+  #   kdl_parser
+  #   pluginlib
   DEPENDS
-    EIGEN3
-    Boost
-    OCTOMAP
-    urdfdom
-    urdfdom_headers
+  #   EIGEN3
+  #   Boost
+  #   OCTOMAP
+  #   urdfdom
+  #   urdfdom_headers
 )
 
 include_directories(

--- a/moveit_experimental/package.xml
+++ b/moveit_experimental/package.xml
@@ -1,14 +1,7 @@
 <package>
   <name>moveit_experimental</name>
   <version>0.10.6</version>
-  <description>Experimental packages for moveit.</description>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-  <author email="acorn.pooley@sri.com">Acorn Pooley</author>
-  <author email="jnicho@swri.org">Jorge Nicho</author>
-
-  <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
-  <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>
+  <description>Experimental packages for MoveIt!</description>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt! Release Team</maintainer>
 
   <license>BSD</license>
@@ -16,6 +9,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!--
   <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
@@ -71,6 +65,7 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>orocos_kdl</test_depend>
   <test_depend>angles</test_depend>
+  -->
 
   <export>
   </export>


### PR DESCRIPTION
As suggested in https://github.com/ros-planning/moveit/pull/1251#discussion_r240238940, comment-out all stuff in moveit_experimental, as there is nothing built.
