### PR TITLE
fix Travis Indigo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ notifications:
     recipients:
       - 130s@2000.jukuin.keio.ac.jp
 env:
-  global:
-    - TEST_BLACKLIST=moveit,moveit_ros,moveit_runtime,moveit_ros_perception  # mesh_filter_test fails due to broken Mesa OpenGL
   matrix:
     - ROS_DISTRO=indigo ROS_REPO=ros              UPSTREAM_WORKSPACE=moveit.rosinstall
     - ROS_DISTRO=indigo ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=moveit.rosinstall

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -13,7 +13,8 @@ target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} glut GLE
 
 if (CATKIN_ENABLE_TESTING)
   # Can only run this test if we have a display
-  if (DEFINED ENV{DISPLAY} AND NOT $ENV{DISPLAY} STREQUAL "")
+  # mesh tests are failing when running with Mesa OpenGL (on Travis)
+  if (DEFINED ENV{DISPLAY} AND NOT $ENV{DISPLAY} STREQUAL "" AND NOT DEFINED ENV{TRAVIS})
     catkin_add_gtest(mesh_filter_test test/mesh_filter_test.cpp)
     target_link_libraries(mesh_filter_test ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_mesh_filter)
   else()


### PR DESCRIPTION
Apparently [`TEST_BLACKLIST` doesn't work on Indigo to disable tests](https://travis-ci.org/ros-planning/moveit/jobs/459651275#L1452).
Using environment variable `TRAVIS` to disable mesh-filter tests (similarly as in Kinetic / Melodic, #982).