### PR TITLE
Handle exception in RobotStateDisplay and print warning to not crash RViz

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -304,7 +304,14 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   if (!robot_state_)
     robot_state_.reset(new robot_state::RobotState(robot_model_));
   // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
-  robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
+  try
+  {
+    robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
+  }
+  catch (const moveit::Exception& e)
+  {
+    ROS_WARN_ONCE("moveit::Exception %s", e.what());
+  }
   setRobotHighlights(state_msg->highlight_links);
   update_state_ = true;
 }

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -307,16 +307,17 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   try
   {
     robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
-    setStatus(rviz::StatusProperty::Ok, "RobotState", "");
     setRobotHighlights(state_msg->highlight_links);
-    update_state_ = true;
+    setStatus(rviz::StatusProperty::Ok, "RobotState", "");
   }
   catch (const moveit::Exception& e)
   {
     robot_state_->setToDefaultValues();
+    setRobotHighlights(moveit_msgs::DisplayRobotState::_highlight_links_type());
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
     return;
   }
+  update_state_ = true;
 }
 
 void RobotStateDisplay::setLinkColor(const std::string& link_name, const QColor& color)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -310,7 +310,10 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   }
   catch (const moveit::Exception& e)
   {
+    setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
     ROS_WARN_ONCE("moveit::Exception %s", e.what());
+    update_state_ = false;
+    return;
   }
   setRobotHighlights(state_msg->highlight_links);
   update_state_ = true;

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -313,7 +313,6 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   catch (const moveit::Exception& e)
   {
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
-    ROS_WARN_STREAM_THROTTLE_NAMED(1, "RobotStateDisplay", e.what());
     return;
   }
   setRobotHighlights(state_msg->highlight_links);

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -301,22 +301,22 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
 {
   if (!robot_model_)
     return;
-
+  if (!robot_state_)
+    robot_state_.reset(new robot_state::RobotState(robot_model_));
   // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
   try
   {
-    auto robot_state = std::make_shared<robot_state::RobotState>(robot_model_);
-    robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state);
-    robot_state_.swap(robot_state);
+    robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
     setStatus(rviz::StatusProperty::Ok, "RobotState", "");
+    setRobotHighlights(state_msg->highlight_links);
+    update_state_ = true;
   }
   catch (const moveit::Exception& e)
   {
+    robot_state_->setToDefaultValues();
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
     return;
   }
-  setRobotHighlights(state_msg->highlight_links);
-  update_state_ = true;
 }
 
 void RobotStateDisplay::setLinkColor(const std::string& link_name, const QColor& color)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -301,18 +301,18 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
 {
   if (!robot_model_)
     return;
-  if (!robot_state_)
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
+
   // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
   try
   {
-    robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
+    auto robot_state = std::make_shared<robot_state::RobotState>(robot_model_);
+    robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state);
+    robot_state_.swap(robot_state);
   }
   catch (const moveit::Exception& e)
   {
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
-    ROS_WARN_ONCE("moveit::Exception %s", e.what());
-    update_state_ = false;
+    ROS_WARN_STREAM_THROTTLE_NAMED(1, "RobotStateDisplay", e.what());
     return;
   }
   setRobotHighlights(state_msg->highlight_links);

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -308,6 +308,7 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
     auto robot_state = std::make_shared<robot_state::RobotState>(robot_model_);
     robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state);
     robot_state_.swap(robot_state);
+    setStatus(rviz::StatusProperty::Ok, "RobotState", "");
   }
   catch (const moveit::Exception& e)
   {

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -303,7 +303,7 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
     return;
   if (!robot_state_)
     robot_state_.reset(new robot_state::RobotState(robot_model_));
-  // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion functio?
+  // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
   robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
   setRobotHighlights(state_msg->highlight_links);
   update_state_ = true;

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -66,8 +66,8 @@ RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false), load_r
 
   robot_state_topic_property_ = new rviz::RosTopicProperty(
       "Robot State Topic", "display_robot_state", ros::message_traits::datatype<moveit_msgs::DisplayRobotState>(),
-      "The topic on which the moveit_msgs::RobotState messages are received", this, SLOT(changedRobotStateTopic()),
-      this);
+      "The topic on which the moveit_msgs::DisplayRobotState messages are received", this,
+      SLOT(changedRobotStateTopic()), this);
 
   // Planning scene category -------------------------------------------------------------------------------------------
   root_link_name_property_ =


### PR DESCRIPTION
### Description
The RobotStateDisplay plugin crashes RVIz if a robot state with a non-existing joint is provided. See: https://github.com/ros-planning/moveit/issues/1266

This PR simply catches the exception and shows a warning instead of forwarding the exception an have RViz crash.
