### PR TITLE
fix uninitialized RobotState transforms

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1739,7 +1739,7 @@ as the new values that correspond to the group */
 
 private:
   void allocMemory();
-
+  void initTransforms();
   void copyFrom(const RobotState& other);
 
   void markDirtyJointTransforms(const JointModel* joint)


### PR DESCRIPTION
With #1096, 6cc3d62c7ae713413d8df7d4cf9ff09c43b5b486, I slightly improved FK in RobotState, exploiting the fact that the last row of the transform matrix is always `[0 0 0 1]`, performing a `3x4` * `4x4` matrix multiplication. However, this improvement also requires an initialization of this row, once.
This PR fixes this and also improves the corresponding timing tests.