### PR TITLE
Remove (redundant) random seeding and #attempts from RobotState::setFromIK

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,6 +16,8 @@ API changes in MoveIt! releases
   Use `tip_frames_` and `redundant_joint_discretization_` instead.
 - KinematicsBase: Deprecated `initialize(robot_description, ...)` in favour of `initialize(robot_model, ...)`.
   Adapt your kinematics plugin to directly receive a `RobotModel`. See the [KDL plugin](https://github.com/ros-planning/moveit/tree/melodic-devel/moveit_kinematics/kdl_kinematics_plugin) for an example.
+- IK: Removed notion of IK attempts and redundant random seeding in RobotState::setFromIK(). Number of attempts is limited by timeout only. ([#1288](https://github.com/ros-planning/moveit/pull/1288))
+  Remove parameters `kinematics_solver_attempts` from your `kinematics.yaml` config files.
 - ``RDFLoader`` / ``RobotModelLoader``: removed TinyXML-based API (https://github.com/ros-planning/moveit/pull/1254)
 - Deprecated `EndEffectorInteractionStyle` got removed from `RobotInteraction` (https://github.com/ros-planning/moveit/pull/1287)
   Use [the corresponding `InteractionStyle` definitions](https://github.com/ros-planning/moveit/pull/1287/files#diff-24e57a8ea7f2f2d8a63cfc31580d09ddL240) instead

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -71,7 +71,7 @@ class JointModelGroup
 public:
   struct KinematicsSolver
   {
-    KinematicsSolver() : default_ik_timeout_(0.5), default_ik_attempts_(2)
+    KinematicsSolver() : default_ik_timeout_(0.5)
     {
     }
 
@@ -100,8 +100,6 @@ public:
     kinematics::KinematicsBasePtr solver_instance_;
 
     double default_ik_timeout_;
-
-    unsigned int default_ik_attempts_;
   };
 
   /// Map from group instances to allocator functions & bijections
@@ -556,15 +554,6 @@ public:
 
   /** \brief Set the default IK timeout */
   void setDefaultIKTimeout(double ik_timeout);
-
-  /** \brief Get the default IK attempts */
-  unsigned int getDefaultIKAttempts() const
-  {
-    return group_kinematics_.first.default_ik_attempts_;
-  }
-
-  /** \brief Set the default IK attempts */
-  void setDefaultIKAttempts(unsigned int ik_attempts);
 
   /** \brief Return the mapping between the order of the joints in this group and the order of the joints in the
      kinematics solver.

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -554,13 +554,6 @@ void JointModelGroup::setDefaultIKTimeout(double ik_timeout)
     it->second.default_ik_timeout_ = ik_timeout;
 }
 
-void JointModelGroup::setDefaultIKAttempts(unsigned int ik_attempts)
-{
-  group_kinematics_.first.default_ik_attempts_ = ik_attempts;
-  for (KinematicsSolverMap::iterator it = group_kinematics_.second.begin(); it != group_kinematics_.second.end(); ++it)
-    it->second.default_ik_attempts_ = ik_attempts;
-}
-
 bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik_jnames,
                                               std::vector<unsigned int>& joint_bijection) const
 {
@@ -608,7 +601,6 @@ void JointModelGroup::setSolverAllocators(const std::pair<SolverAllocatorFn, Sol
         ks.allocator_ = it->second;
         ks.solver_instance_ = const_cast<JointModelGroup*>(it->first)->getSolverInstance();
         ks.default_ik_timeout_ = group_kinematics_.first.default_ik_timeout_;
-        ks.default_ik_attempts_ = group_kinematics_.first.default_ik_attempts_;
         if (!computeIKIndexBijection(ks.solver_instance_->getJointNames(), ks.bijection_))
         {
           group_kinematics_.second.clear();

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -952,6 +952,13 @@ as the new values that correspond to the group */
   bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, unsigned int attempts, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, pose, timeout, constraint, options);
+  }
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -963,6 +970,14 @@ as the new values that correspond to the group */
   bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip,
+            unsigned int attempts, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, pose, tip, timeout, constraint, options);
+  }
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -973,6 +988,13 @@ as the new values that correspond to the group */
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, unsigned int attempts, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, pose, timeout, constraint, options);
+  }
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -983,6 +1005,13 @@ as the new values that correspond to the group */
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip, unsigned int attempts,
+            double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, pose, tip, timeout, constraint, options);
+  }
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -996,6 +1025,14 @@ as the new values that correspond to the group */
                  const std::vector<double>& consistency_limits, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
+            const std::vector<double>& consistency_limits, unsigned int attempts, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, pose, tip, consistency_limits, timeout, constraint, options);
+  }
 
   /** \brief  Warning: This function inefficiently copies all transforms around.
       If the group consists of a set of sub-groups that are each a chain and a solver
@@ -1010,6 +1047,14 @@ as the new values that correspond to the group */
                  const std::vector<std::string>& tips, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
+            const std::vector<std::string>& tips, unsigned int attempts, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, poses, tips, timeout, constraint, options);
+  }
 
   /** \brief Warning: This function inefficiently copies all transforms around.
       If the group consists of a set of sub-groups that are each a chain and a solver
@@ -1025,6 +1070,15 @@ as the new values that correspond to the group */
                  const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
+            const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
+            unsigned int attempts, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIK(group, poses, tips, consistency_limits, timeout, constraint, options);
+  }
 
   /**
       \brief setFromIK for multiple poses and tips (end effectors) when no solver exists for the jmg that can solver for
@@ -1039,6 +1093,15 @@ as the new values that correspond to the group */
                           const std::vector<std::vector<double> >& consistency_limits, double timeout = 0.0,
                           const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+  [[deprecated("The attempts argument is not supported anymore.")]] bool
+  setFromIKSubgroups(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
+                     const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
+                     unsigned int attempts, double timeout = 0.0,
+                     const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+                     const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return setFromIKSubgroups(group, poses, tips, consistency_limits, timeout, constraint, options);
+  }
 
   /** \brief Set the joint values from a Cartesian velocity applied during a time dt
    * @param group the group of joints this function operates on

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -947,10 +947,9 @@ as the new values that correspond to the group */
      set by computing inverse kinematics.
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
       @param pose The pose the last link in the chain needs to achieve
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
-  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, unsigned int attempts = 0,
+  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -959,11 +958,9 @@ as the new values that correspond to the group */
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
       @param pose The pose the \e tip  link in the chain needs to achieve
       @param tip The name of the link the pose is specified for
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
-  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip,
-                 unsigned int attempts = 0, double timeout = 0.0,
+  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -972,9 +969,8 @@ as the new values that correspond to the group */
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
       @param pose The pose the last link in the chain needs to achieve
       @param tip The name of the link the pose is specified for
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt */
-  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, unsigned int attempts = 0,
+  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -982,11 +978,9 @@ as the new values that correspond to the group */
      set by computing inverse kinematics.
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
       @param pose The pose the last link in the chain needs to achieve
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
-  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
-                 unsigned int attempts = 0, double timeout = 0.0,
+  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -996,11 +990,10 @@ as the new values that correspond to the group */
       @param pose The pose the last link in the chain needs to achieve
       @param tip The name of the frame for which IK is attempted.
       @param consistency_limits This specifies the desired distance between the solution and the seed state
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
-                 const std::vector<double>& consistency_limits, unsigned int attempts = 0, double timeout = 0.0,
+                 const std::vector<double>& consistency_limits, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -1011,11 +1004,10 @@ as the new values that correspond to the group */
       to be in the same order as the order of the sub-groups in this group. Returns true on success.
       @param poses The poses the last link in each chain needs to achieve
       @param tips The names of the frames for which IK is attempted.
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-                 const std::vector<std::string>& tips, unsigned int attempts = 0, double timeout = 0.0,
+                 const std::vector<std::string>& tips, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -1027,12 +1019,10 @@ as the new values that correspond to the group */
       @param poses The poses the last link in each chain needs to achieve
       @param tips The names of the frames for which IK is attempted.
       @param consistency_limits This specifies the desired distance between the solution and the seed state
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-                 const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
-                 unsigned int attempts = 0, double timeout = 0.0,
+                 const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
@@ -1042,12 +1032,11 @@ as the new values that correspond to the group */
       @param poses The poses the last link in each chain needs to achieve
       @param tips The names of the frames for which IK is attempted.
       @param consistency_limits This specifies the desired distance between the solution and the seed state
-      @param attempts The number of times IK is attempted
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIKSubgroups(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
                           const std::vector<std::string>& tips,
-                          const std::vector<std::vector<double> >& consistency_limits, unsigned int attempts = 0,
+                          const std::vector<std::vector<double> >& consistency_limits,
                           double timeout = 0.0,
                           const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -949,8 +949,8 @@ as the new values that correspond to the group */
       @param pose The pose the last link in the chain needs to achieve
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
-  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose,
-                 double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, double timeout = 0.0,
+                 const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
@@ -960,8 +960,8 @@ as the new values that correspond to the group */
       @param tip The name of the link the pose is specified for
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
-  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip, double timeout = 0.0,
-                 const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  bool setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip,
+                 double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
@@ -970,8 +970,8 @@ as the new values that correspond to the group */
       @param pose The pose the last link in the chain needs to achieve
       @param tip The name of the link the pose is specified for
       @param timeout The timeout passed to the kinematics solver on each attempt */
-  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose,
-                 double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, double timeout = 0.0,
+                 const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
@@ -980,8 +980,8 @@ as the new values that correspond to the group */
       @param pose The pose the last link in the chain needs to achieve
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
-  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip, double timeout = 0.0,
-                 const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
+                 double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
@@ -1022,8 +1022,8 @@ as the new values that correspond to the group */
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-                 const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits, double timeout = 0.0,
-                 const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+                 const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
+                 double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 
   /**
@@ -1036,8 +1036,7 @@ as the new values that correspond to the group */
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIKSubgroups(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
                           const std::vector<std::string>& tips,
-                          const std::vector<std::vector<double> >& consistency_limits,
-                          double timeout = 0.0,
+                          const std::vector<std::vector<double> >& consistency_limits, double timeout = 0.0,
                           const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1449,7 +1449,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
     if (poses_in.size() > 1)
     {
       // Forward to setFromIKSubgroups() to allow different subgroup IK solvers to work together
-      return setFromIKSubgroups(jmg, poses_in, tips_in, consistency_limit_sets, attempts, timeout, constraint, options);
+      return setFromIKSubgroups(jmg, poses_in, tips_in, consistency_limit_sets, timeout, constraint, options);
     }
     else
     {
@@ -1947,7 +1947,7 @@ double RobotState::computeCartesianPath(const JointModelGroup* group, std::vecto
 
     // Explicitly use a single IK attempt only: We want a smooth trajectory.
     // Random seeding (of additional attempts) would probably create IK jumps.
-    if (setFromIK(group, pose, link->getName(), consistency_limits, 1, 0.0, validCallback, options))
+    if (setFromIK(group, pose, link->getName(), consistency_limits, 0.0, validCallback, options))
       traj.push_back(RobotStatePtr(new RobotState(*this)));
     else
       break;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1298,8 +1298,8 @@ bool RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eig
     return true;
 }
 
-bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose,
-                           double timeout, const GroupStateValidityCallbackFn& constraint,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose& pose, double timeout,
+                           const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options)
 {
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
@@ -1321,8 +1321,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::Pose
   return setFromIK(jmg, mat, tip, consistency_limits, timeout, constraint, options);
 }
 
-bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose,
-                           double timeout, const GroupStateValidityCallbackFn& constraint,
+bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose, double timeout,
+                           const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options)
 {
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
@@ -1411,8 +1411,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Isometry3d& poses_in,
                            const std::vector<std::string>& tips_in,
-                           const std::vector<std::vector<double> >& consistency_limit_sets,
-                           double timeout, const GroupStateValidityCallbackFn& constraint,
+                           const std::vector<std::vector<double> >& consistency_limit_sets, double timeout,
+                           const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options)
 {
   // Error check
@@ -1624,30 +1624,31 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   const std::vector<unsigned int>& bij = jmg->getKinematicsSolverJointBijection();
 
   std::vector<double> initial_values;
-      copyJointGroupPositions(jmg, initial_values);
-      std::vector<double> seed(bij.size());
-      for (std::size_t i = 0; i < bij.size(); ++i)
-        seed[i] = initial_values[bij[i]];
+  copyJointGroupPositions(jmg, initial_values);
+  std::vector<double> seed(bij.size());
+  for (std::size_t i = 0; i < bij.size(); ++i)
+    seed[i] = initial_values[bij[i]];
 
-    // compute the IK solution
-    std::vector<double> ik_sol;
-    moveit_msgs::MoveItErrorCodes error;
+  // compute the IK solution
+  std::vector<double> ik_sol;
+  moveit_msgs::MoveItErrorCodes error;
 
-    if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn, error, options, this))
-    {
-      std::vector<double> solution(bij.size());
-      for (std::size_t i = 0; i < bij.size(); ++i)
-        solution[bij[i]] = ik_sol[i];
-      setJointGroupPositions(jmg, solution);
-      return true;
-    }
+  if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn, error, options,
+                               this))
+  {
+    std::vector<double> solution(bij.size());
+    for (std::size_t i = 0; i < bij.size(); ++i)
+      solution[bij[i]] = ik_sol[i];
+    setJointGroupPositions(jmg, solution);
+    return true;
+  }
   return false;
 }
 
 bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::vector_Isometry3d& poses_in,
                                     const std::vector<std::string>& tips_in,
-                                    const std::vector<std::vector<double> >& consistency_limits,
-                                    double timeout, const GroupStateValidityCallbackFn& constraint,
+                                    const std::vector<std::vector<double> >& consistency_limits, double timeout,
+                                    const GroupStateValidityCallbackFn& constraint,
                                     const kinematics::KinematicsQueryOptions& options)
 {
   // Assume we have already ran setFromIK() and those checks
@@ -1786,7 +1787,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 
   bool first_seed = true;
   unsigned int attempts = 0;
-  do {
+  do
+  {
     ++attempts;
     ROS_DEBUG_NAMED(LOGNAME, "IK attempt: %d", attempts);
     bool found_solution = true;

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -107,9 +107,9 @@ int main(int argc, char* argv[])
     for (const auto& end_effector : end_effectors)
       default_eef_states.push_back(kinematic_state.getGlobalLinkTransform(end_effector));
     if (end_effectors.size() == 1)
-      kinematic_state.setFromIK(group, default_eef_states[0], end_effectors[0], 1, 0.1);
+      kinematic_state.setFromIK(group, default_eef_states[0], end_effectors[0], 0.1);
     else
-      kinematic_state.setFromIK(group, default_eef_states, end_effectors, 1, 0.1);
+      kinematic_state.setFromIK(group, default_eef_states, end_effectors, 0.1);
 
     bool found_ik;
     unsigned int num_failed_calls = 0, num_self_collisions = 0;
@@ -131,9 +131,9 @@ int main(int argc, char* argv[])
         kinematic_state.setToDefaultValues();
       start = std::chrono::system_clock::now();
       if (end_effectors.size() == 1)
-        found_ik = kinematic_state.setFromIK(group, end_effector_states[0], end_effectors[0], 10, 0.1);
+        found_ik = kinematic_state.setFromIK(group, end_effector_states[0], end_effectors[0], 0.1);
       else
-        found_ik = kinematic_state.setFromIK(group, end_effector_states, end_effectors, 10, 0.1);
+        found_ik = kinematic_state.setFromIK(group, end_effector_states, end_effectors, 0.1);
       ik_time += std::chrono::system_clock::now() - start;
       if (!found_ik)
         num_failed_calls++;

--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -130,7 +130,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
   plan_data->path_constraints_ = goal.path_constraints;
   plan_data->planner_id_ = goal.planner_id;
   plan_data->minimize_object_distance_ = goal.minimize_object_distance;
-  plan_data->max_goal_sampling_attempts_ = std::max(2u, plan_data->planning_group_->getDefaultIKAttempts());
+  plan_data->max_goal_sampling_attempts_ = 2;
   moveit_msgs::AttachedCollisionObject& attach_object_msg = plan_data->diff_attached_object_;
 
   // construct the attached object message that will change the world to what it would become after a pick

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -261,7 +261,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   plan_data->path_constraints_ = goal.path_constraints;
   plan_data->planner_id_ = goal.planner_id;
   plan_data->minimize_object_distance_ = false;
-  plan_data->max_goal_sampling_attempts_ = std::max(2u, jmg->getDefaultIKAttempts());
+  plan_data->max_goal_sampling_attempts_ = 2;
   moveit_msgs::AttachedCollisionObject& detach_object_msg = plan_data->diff_attached_object_;
 
   // construct the attached object message that will change the world to what it would become after a placement

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -88,9 +88,9 @@ void move_group::MoveGroupKinematicsService::computeIK(
       {
         bool result_ik = false;
         if (ik_link.empty())
-          result_ik = rs.setFromIK(jmg, req_pose.pose, req.attempts, req.timeout.toSec(), constraint);
+          result_ik = rs.setFromIK(jmg, req_pose.pose, req.timeout.toSec(), constraint);
         else
-          result_ik = rs.setFromIK(jmg, req_pose.pose, ik_link, req.attempts, req.timeout.toSec(), constraint);
+          result_ik = rs.setFromIK(jmg, req_pose.pose, ik_link, req.timeout.toSec(), constraint);
 
         if (result_ik)
         {
@@ -125,7 +125,7 @@ void move_group::MoveGroupKinematicsService::computeIK(
         }
         if (ok)
         {
-          if (rs.setFromIK(jmg, req_poses, req.ik_link_names, req.attempts, req.timeout.toSec(), constraint))
+          if (rs.setFromIK(jmg, req_poses, req.ik_link_names, req.timeout.toSec(), constraint))
           {
             robot_state::robotStateToRobotStateMsg(rs, solution, false);
             error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -75,7 +75,6 @@ public:
     , default_search_resolution_(default_search_resolution)
     , default_solver_plugin_(solver_plugin)
     , default_solver_timeout_(solve_timeout)
-    , default_ik_attempts_(ik_attempts)
   {
   }
 
@@ -99,12 +98,6 @@ public:
     return ik_timeout_;
   }
 
-  /** \brief Get a map from group name to default IK attempts */
-  const std::map<std::string, unsigned int>& getIKAttempts() const
-  {
-    return ik_attempts_;
-  }
-
   void status() const;
 
 private:
@@ -116,12 +109,10 @@ private:
 
   std::vector<std::string> groups_;
   std::map<std::string, double> ik_timeout_;
-  std::map<std::string, unsigned int> ik_attempts_;
 
   // default configuration
   std::string default_solver_plugin_;
   double default_solver_timeout_;
-  unsigned int default_ik_attempts_;
 };
 }
 

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -344,12 +344,13 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const s
             }
           }
 
+          // TODO: Remove in future release (deprecated in PR #1288, Jan-2019, Melodic)
           std::string ksolver_attempts_param_name;
           if (nh.searchParam(base_param_name + "/kinematics_solver_attempts", ksolver_attempts_param_name))
           {
-            int ksolver_attempts;
-            if (nh.getParam(ksolver_attempts_param_name, ksolver_attempts))
-              ik_attempts_[known_groups[i].name_] = ksolver_attempts;
+            ROS_WARN_ONCE_NAMED(LOGNAME, "Kinematics solver doesn't support #attempts anymore, but only a timeout.\n"
+                                         "Please remove the parameter '%s' from your configuration.",
+                                ksolver_attempts_param_name.c_str());
           }
 
           std::string ksolver_res_param_name;
@@ -434,7 +435,6 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const s
           possible_kinematics_solvers[known_groups[i].name_].resize(1, default_solver_plugin_);
           search_res[known_groups[i].name_].resize(1, default_search_resolution_);
           ik_timeout_[known_groups[i].name_] = default_solver_timeout_;
-          ik_attempts_[known_groups[i].name_] = default_ik_attempts_;
           groups_.push_back(known_groups[i].name_);
         }
       }

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -224,16 +224,6 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
       robot_model::JointModelGroup* jmg = model_->getJointModelGroup(it->first);
       jmg->setDefaultIKTimeout(it->second);
     }
-
-    // set the default IK attempts
-    const std::map<std::string, unsigned int>& attempts = kinematics_loader_->getIKAttempts();
-    for (std::map<std::string, unsigned int>::const_iterator it = attempts.begin(); it != attempts.end(); ++it)
-    {
-      if (!model_->hasJointModelGroup(it->first))
-        continue;
-      robot_model::JointModelGroup* jmg = model_->getJointModelGroup(it->first);
-      jmg->setDefaultIKAttempts(it->second);
-    }
   }
 }
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -398,7 +398,7 @@ public:
 
       // if no frame transforms are needed, call IK directly
       if (frame.empty() || moveit::core::Transforms::sameFrame(frame, getRobotModel()->getModelFrame()))
-        return getJointStateTarget().setFromIK(getJointModelGroup(), eef_pose, eef, 0, 0.0,
+        return getJointStateTarget().setFromIK(getJointModelGroup(), eef_pose, eef, 0.0,
                                                moveit::core::GroupStateValidityCallbackFn(), o);
       else
       {
@@ -408,7 +408,7 @@ public:
           const Eigen::Isometry3d& t = getJointStateTarget().getFrameTransform(frame);
           Eigen::Isometry3d p;
           tf2::fromMsg(eef_pose, p);
-          return getJointStateTarget().setFromIK(getJointModelGroup(), t * p, eef, 0, 0.0,
+          return getJointStateTarget().setFromIK(getJointModelGroup(), t * p, eef, 0.0,
                                                  moveit::core::GroupStateValidityCallbackFn(), o);
         }
         else

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -57,11 +57,10 @@ struct KinematicOptions
   enum OptionBitmask
   {
     TIMEOUT = 0x00000001,                      // timeout_seconds_
-    MAX_ATTEMPTS = 0x00000002,                 // max_attempts_
-    STATE_VALIDITY_CALLBACK = 0x00000004,      // state_validity_callback_
-    LOCK_REDUNDANT_JOINTS = 0x00000008,        // options_.lock_redundant_joints
-    RETURN_APPROXIMATE_SOLUTION = 0x00000010,  // options_.return_approximate_solution
-    DISCRETIZATION_METHOD = 0x00000020,
+    STATE_VALIDITY_CALLBACK = 0x00000002,      // state_validity_callback_
+    LOCK_REDUNDANT_JOINTS = 0x00000004,        // options_.lock_redundant_joints
+    RETURN_APPROXIMATE_SOLUTION = 0x00000008,  // options_.return_approximate_solution
+    DISCRETIZATION_METHOD = 0x00000010,
     ALL_QUERY_OPTIONS = LOCK_REDUNDANT_JOINTS | RETURN_APPROXIMATE_SOLUTION | DISCRETIZATION_METHOD,
     ALL = 0x7fffffff
   };
@@ -82,9 +81,6 @@ struct KinematicOptions
 
   /// max time an IK attempt can take before we give up.
   double timeout_seconds_;
-
-  /// how many attempts before we give up.
-  unsigned int max_attempts_;
 
   /// This is called to determine if the state is valid
   robot_state::GroupStateValidityCallbackFn state_validity_callback_;

--- a/moveit_ros/robot_interaction/src/kinematic_options.cpp
+++ b/moveit_ros/robot_interaction/src/kinematic_options.cpp
@@ -40,7 +40,6 @@
 
 robot_interaction::KinematicOptions::KinematicOptions()
   : timeout_seconds_(0.0)  // 0.0 = use default timeout
-  , max_attempts_(0)       // 0 = use default max attempts
 {
 }
 
@@ -55,7 +54,7 @@ bool robot_interaction::KinematicOptions::setStateFromIK(robot_state::RobotState
     ROS_ERROR("No getJointModelGroup('%s') found", group.c_str());
     return false;
   }
-  bool result = state.setFromIK(jmg, pose, tip, max_attempts_,
+  bool result = state.setFromIK(jmg, pose, tip,
                                 // limit timeout to 0.1s if set from JMG's default, i.e. when timeout_seconds_ == 0
                                 timeout_seconds_ > 0.0 ? timeout_seconds_ : std::min(0.1, jmg->getDefaultIKTimeout()),
                                 state_validity_callback_, options_);
@@ -74,7 +73,6 @@ void robot_interaction::KinematicOptions::setOptions(const KinematicOptions& sou
 // robot_interaction::KinematicOptions except options_
 #define O_FIELDS(F)                                                                                                    \
   F(double, timeout_seconds_, TIMEOUT)                                                                                 \
-  F(unsigned int, max_attempts_, MAX_ATTEMPTS)                                                                         \
   F(robot_state::GroupStateValidityCallbackFn, state_validity_callback_, STATE_VALIDITY_CALLBACK)
 
 // This needs to represent all the fields in

--- a/moveit_ros/robot_interaction/src/kinematic_options.cpp
+++ b/moveit_ros/robot_interaction/src/kinematic_options.cpp
@@ -38,8 +38,7 @@
 #include <boost/static_assert.hpp>
 #include <ros/console.h>
 
-robot_interaction::KinematicOptions::KinematicOptions()
-  : timeout_seconds_(0.0)  // 0.0 = use default timeout
+robot_interaction::KinematicOptions::KinematicOptions() : timeout_seconds_(0.0)  // 0.0 = use default timeout
 {
 }
 

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -57,7 +57,6 @@ static const std::string MOVEIT_ROBOT_STATE = "moveit_robot_state";
 // Default kin solver values
 static const double DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION_ = 0.005;
 static const double DEFAULT_KIN_SOLVER_TIMEOUT_ = 0.005;
-static const int DEFAULT_KIN_SOLVER_ATTEMPTS_ = 3;
 
 // ******************************************************************************************
 // Structs
@@ -71,7 +70,6 @@ struct GroupMetaData
   std::string kinematics_solver_;               // Name of kinematics plugin to use
   double kinematics_solver_search_resolution_;  // resolution to use with solver
   double kinematics_solver_timeout_;            // solver timeout
-  int kinematics_solver_attempts_;              // solver attempts
   std::string default_planner_;                 // Name of the default planner to use
 };
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -353,10 +353,6 @@ bool MoveItConfigData::outputKinematicsYAML(const std::string& file_path)
     emitter << YAML::Key << "kinematics_solver_timeout";
     emitter << YAML::Value << group_meta_data_[group_it->name_].kinematics_solver_timeout_;
 
-    // Solver Attempts
-    emitter << YAML::Key << "kinematics_solver_attempts";
-    emitter << YAML::Value << group_meta_data_[group_it->name_].kinematics_solver_attempts_;
-
     emitter << YAML::EndMap;
   }
 
@@ -1280,7 +1276,6 @@ bool MoveItConfigData::inputKinematicsYAML(const std::string& file_path)
       parse(group, "kinematics_solver_search_resolution", meta_data.kinematics_solver_search_resolution_,
             DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION_);
       parse(group, "kinematics_solver_timeout", meta_data.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT_);
-      parse(group, "kinematics_solver_attempts", meta_data.kinematics_solver_attempts_, DEFAULT_KIN_SOLVER_ATTEMPTS_);
 
       // Assign meta data to vector
       group_meta_data_[group_name] = meta_data;

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -88,11 +88,6 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, moveit_setup_assistant::MoveIt
   kinematics_timeout_field_->setMaximumWidth(400);
   form_layout->addRow("Kin. Search Timeout (sec):", kinematics_timeout_field_);
 
-  // number of IK attempts
-  kinematics_attempts_field_ = new QLineEdit(this);
-  kinematics_attempts_field_->setMaximumWidth(400);
-  form_layout->addRow("Kin. Solver Attempts:", kinematics_attempts_field_);
-
   group1->setLayout(form_layout);
 
   // OMPL Planner form --------------------------------------------
@@ -237,15 +232,6 @@ void GroupEditWidget::setSelected(const std::string& group_name)
     *timeout = DEFAULT_KIN_SOLVER_TIMEOUT_;
   }
   kinematics_timeout_field_->setText(QString::number(*timeout));
-
-  // Load attempts
-  int* attempts = &config_data_->group_meta_data_[group_name].kinematics_solver_attempts_;
-  if (*attempts == 0)
-  {
-    // Set default value
-    *attempts = DEFAULT_KIN_SOLVER_ATTEMPTS_;
-  }
-  kinematics_attempts_field_->setText(QString::number(*attempts));
 
   // Set kin solver
   std::string kin_solver = config_data_->group_meta_data_[group_name].kinematics_solver_;

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.h
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.h
@@ -76,7 +76,6 @@ public:
   QComboBox* kinematics_solver_field_;
   QLineEdit* kinematics_resolution_field_;
   QLineEdit* kinematics_timeout_field_;
-  QLineEdit* kinematics_attempts_field_;
   QComboBox* default_planner_field_;
   QPushButton* btn_delete_;      // this button is hidden for new groups
   QPushButton* btn_save_;        // this button is hidden for new groups

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1092,7 +1092,6 @@ bool PlanningGroupsWidget::saveGroupScreen()
   const std::string& default_planner = group_edit_widget_->default_planner_field_->currentText().toStdString();
   const std::string& kinematics_resolution = group_edit_widget_->kinematics_resolution_field_->text().toStdString();
   const std::string& kinematics_timeout = group_edit_widget_->kinematics_timeout_field_->text().toStdString();
-  const std::string& kinematics_attempts = group_edit_widget_->kinematics_attempts_field_->text().toStdString();
 
   // Used for editing existing groups
   srdf::Model::Group* searched_group = NULL;
@@ -1150,18 +1149,6 @@ bool PlanningGroupsWidget::saveGroupScreen()
     return false;
   }
 
-  // Check that the attempts is an int number
-  int kinematics_attempts_int;
-  try
-  {
-    kinematics_attempts_int = boost::lexical_cast<int>(kinematics_attempts);
-  }
-  catch (boost::bad_lexical_cast&)
-  {
-    QMessageBox::warning(this, "Error Saving", "Unable to convert kinematics solver attempts to an int number.");
-    return false;
-  }
-
   // Check that all numbers are >0
   if (kinematics_resolution_double <= 0)
   {
@@ -1171,11 +1158,6 @@ bool PlanningGroupsWidget::saveGroupScreen()
   if (kinematics_timeout_double <= 0)
   {
     QMessageBox::warning(this, "Error Saving", "Kinematics solver search timeout must be greater than 0.");
-    return false;
-  }
-  if (kinematics_attempts_int <= 0)
-  {
-    QMessageBox::warning(this, "Error Saving", "Kinematics solver attempts must be greater than 0.");
     return false;
   }
 
@@ -1262,7 +1244,6 @@ bool PlanningGroupsWidget::saveGroupScreen()
   config_data_->group_meta_data_[group_name].kinematics_solver_ = kinematics_solver;
   config_data_->group_meta_data_[group_name].kinematics_solver_search_resolution_ = kinematics_resolution_double;
   config_data_->group_meta_data_[group_name].kinematics_solver_timeout_ = kinematics_timeout_double;
-  config_data_->group_meta_data_[group_name].kinematics_solver_attempts_ = kinematics_attempts_int;
   config_data_->group_meta_data_[group_name].default_planner_ = default_planner;
   config_data_->changes |= MoveItConfigData::GROUP_KINEMATICS;
 


### PR DESCRIPTION
As originally pointed out in https://github.com/ros-planning/moveit/pull/725, both `RobotState::setFromIK()` and (all?) actual kinematics solvers in `searchPositionIK()` perform _random seeding_ if IK attempts fail, until the given timeout is reached. In `setFromIK()` the number of attempts was - additionally to the timeout - limited by a max number of attempts.

@v4hn suggested to remove the random sampling from `RobotState` as all important IK solvers (KDL, IKFast, TracIK) perform this random seeding internally anyway, and sometimes (IKFast) they rely on it.

This PR removes the random sampling from `RobotState::setFromIK()` and, simultaneously, removes the notion of max IK attempts from MoveIt. Thus, the number of attempts can only be limited by a timeout or appropriate measures in IK solvers (but there is no general support by `KinematicsBase` for this).

In my point of view, the only relevant use for a max number of attempts is to request a single attempt only (finding the one and only solution closest to the initial seed). In all other cases, when we just want to find any solution, there is no need to limit the attempts other than by a timeout.

If this PR is accepted, we should also remove `attempts` from [PositionIKRequest](http://docs.ros.org/melodic/api/moveit_msgs/html/msg/PositionIKRequest.html).
**Please merge in conjuction with #1272 and #1294.**