### PR TITLE
kinematics: cleanup cmake

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -7,8 +7,9 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost)
-find_package(orocos_kdl)
+find_package(Boost REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_planning
@@ -21,9 +22,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_kdl
 )
-
-find_package(PkgConfig REQUIRED)
-pkg_search_module(EIGEN3 REQUIRED eigen3)
 
 set(THIS_PACKAGE_INCLUDE_DIRS
     kdl_kinematics_plugin/include
@@ -46,10 +44,8 @@ catkin_package(
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS}
-)
-include_directories(SYSTEM
                     ${EIGEN3_INCLUDE_DIRS}
+                    ${catkin_INCLUDE_DIRS}
 )
 
 link_directories(${Boost_LIBRARY_DIRS})

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -48,9 +48,6 @@ include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
 )
 
-link_directories(${Boost_LIBRARY_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
-
 add_subdirectory(kdl_kinematics_plugin)
 add_subdirectory(lma_kinematics_plugin)
 add_subdirectory(srv_kinematics_plugin)

--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(${MOVEIT_LIB_NAME} src/kdl_kinematics_plugin.cpp
   src/chainiksolver_vel_pinv_mimic.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(${MOVEIT_LIB_NAME} src/lma_kinematics_plugin.cpp
   src/chainiksolver_vel_pinv_mimic.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME moveit_srv_kinematics_plugin)
 add_library(${MOVEIT_LIB_NAME} src/srv_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader ${catkin_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)


### PR DESCRIPTION
Simple fixes to cmake:
* package dependencies are required
* remove `link_directories`
* remove unnecessary, hard-coded linking of `libmoveit_rdf_loader`