### PR TITLE
Added missing robot state update to iterative spline parameterization

### DIFF
--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -340,11 +340,19 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   {
     for (unsigned int j = 0; j < num_joints; j++)
     {
-      trajectory.getWayPointPtr(i)->setVariablePosition(idx[j], t2[j].positions[i]);
       trajectory.getWayPointPtr(i)->setVariableVelocity(idx[j], t2[j].velocities[i]);
       trajectory.getWayPointPtr(i)->setVariableAcceleration(idx[j], t2[j].accelerations[i]);
     }
-    trajectory.getWayPointPtr(i)->update();
+
+    // Only update position of additional points
+    if (add_points_ && (i == 1 || i == num_points-2))
+    {
+      for (unsigned int j = 0; j < num_joints; j++)
+      {
+        trajectory.getWayPointPtr(i)->setVariablePosition(idx[j], t2[j].positions[i]);
+      }
+      trajectory.getWayPointPtr(i)->update();
+    }
   }
 
   return true;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -345,7 +345,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     }
 
     // Only update position of additionally inserted points (at second and next-to-last position)
-    if (add_points_ && (i == 1 || i == num_points-2))
+    if (add_points_ && (i == 1 || i == num_points - 2))
     {
       for (unsigned int j = 0; j < num_joints; j++)
       {

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -344,6 +344,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
       trajectory.getWayPointPtr(i)->setVariableVelocity(idx[j], t2[j].velocities[i]);
       trajectory.getWayPointPtr(i)->setVariableAcceleration(idx[j], t2[j].accelerations[i]);
     }
+    trajectory.getWayPointPtr(i)->update();
   }
 
   return true;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -344,7 +344,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
       trajectory.getWayPointPtr(i)->setVariableAcceleration(idx[j], t2[j].accelerations[i]);
     }
 
-    // Only update position of additional points
+    // Only update position of additionally inserted points (at second and next-to-last position)
     if (add_points_ && (i == 1 || i == num_points-2))
     {
       for (unsigned int j = 0; j < num_joints; j++)


### PR DESCRIPTION
### Description
The iterative spline parameterization is missing an update to the robot states of the trajectory after iterating over each point. These leads to lots of warnings of the following kind:
```
[ WARN] [1547043223.679662634, 8.816000000] [/move_group]: Returning dirty collision body transforms
```
This PR adds the missing `update()` call (just one line).

I did not auto-format with clang as this changed lines unrelated to my PR. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
