### PR TITLE
Expose get_named_targets and get_named_target_values functions

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -316,10 +316,18 @@ class MoveGroupCommander(object):
         """ Set a random joint configuration target """
         self._g.set_random_target()
 
+    def get_named_targets(self):
+        """ Get a list of all the names of joint configurations."""
+        return self._g.get_named_targets()
+
     def set_named_target(self, name):
         """ Set a joint configuration by name. The name can be a name previlusy remembered with remember_joint_values() or a configuration specified in the SRDF. """
         if not self._g.set_named_target(name):
             raise MoveItCommanderException("Unable to set target %s. Is the target within bounds?" % name)
+
+    def get_named_target_values(self, target):
+        """Get a dictionary of joint values of a named target"""
+        return self._g.get_named_target_values(target)
 
     def remember_joint_values(self, name, values = None):
         """ Record the specified joint configuration of the group under the specified name. If no values are specified, the current state of the group is recorded. """


### PR DESCRIPTION
### Description

I needed to access the get_named_target_values function, so I just exposed it. Related issue: #1063 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
