### PR TITLE
addressing race condition where the object is being removed

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1846,9 +1846,10 @@ bool PlanningScene::knowsFrameTransform(const robot_state::RobotState& state, co
     return knowsFrameTransform(id.substr(1));
   if (state.knowsFrameTransform(id))
     return true;
-  if (getWorld()->hasObject(id))
+
+  collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(id);
+  if (obj)
   {
-    collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(id);
     return obj->shape_poses_.size() == 1;
   }
   return getTransforms().Transforms::canTransform(id);


### PR DESCRIPTION
### Description

There was a bug here where the object gets removed in between `getWorld()->hasObject(id)` and `getWorld()->getObject(id)` which resulted in segfaults. 

This PR fixes the issue by calling `getObject` and then checking if the pointer is empty. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
