### PR TITLE
KDL IK solver improvements

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
@@ -57,11 +57,11 @@ public:
    * @param num_mimic_joints The number of joints that are setup to follow other joints
    * @param position_ik false if you want to solve for the full 6 dof end-effector pose,
    *        true if you want to solve only for the 3 dof end-effector position.
-   * @param threshold if a singular value is below this value, its inverse is set to zero, default: 0.00001
+   * @param threshold if a singular value is below this value, its inverse is set to zero, default: 0.001
    */
   explicit ChainIkSolverVelMimicSVD(const Chain& chain_,
                                     const std::vector<kdl_kinematics_plugin::JointMimic>& mimic_joints,
-                                    bool position_ik = false, double threshold = 0.00001);
+                                    bool position_ik = false, double threshold = 0.001);
 
 // TODO: simplify after kinetic support is dropped
 #define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/joint_mimic.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/joint_mimic.hpp
@@ -49,7 +49,7 @@ public:
   JointMimic()
   {
     this->reset(0);
-  };
+  }
 
   /** \brief Offset for this joint value from the joint that it mimics */
   double offset;
@@ -68,7 +68,7 @@ public:
     multiplier = 1.0;
     map_index = index;
     active = false;
-  };
+  }
 };
 }
 

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -170,6 +170,9 @@ private:
   void getRandomConfiguration(const Eigen::VectorXd& seed_state, const std::vector<double>& consistency_limits,
                               Eigen::VectorXd& jnt_array) const;
 
+  /// clip q_delta such that joint limits will not be violated
+  void clipToJointLimits(const KDL::JntArray& q, KDL::JntArray& q_delta, Eigen::ArrayXd& weighting) const;
+
   bool initialized_;  ///< Internal variable that indicates whether solver is configured and ready
 
   unsigned int dimension_;                        ///< Dimension of the group

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -420,7 +420,14 @@ int KDLKinematicsPlugin::CartToJnt(KDL::ChainIkSolverVel& ik_solver, const KDL::
                    delta_q_norm);
 
     if (delta_q_norm < epsilon_)  // stuck in singularity
-      break;
+    {
+      if (step_size < 0.005)  // cannot reach target
+        break;
+      // wiggle joints
+      last_delta_twist_norm = DBL_MAX;
+      delta_q.data.setRandom();
+      delta_q.data *= std::min(0.1, delta_twist_norm);
+    }
 
     KDL::Add(q_out, delta_q, q_out);
 

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -370,32 +370,58 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
 int KDLKinematicsPlugin::CartToJnt(KDL::ChainIkSolverVel& ik_solver, const KDL::JntArray& q_init,
                                    const KDL::Frame& p_in, KDL::JntArray& q_out, const unsigned int max_iter) const
 {
+  double last_delta_twist_norm = DBL_MAX;
+  double step_size = 1.0;
   KDL::Frame f;
   KDL::Twist delta_twist;
-  KDL::JntArray delta_q(q_out.rows());
+  KDL::JntArray delta_q(q_out.rows()), q_backup(q_out.rows());
 
   q_out = q_init;
   ROS_DEBUG_STREAM_NAMED("kdl", "Input: " << q_init);
 
   unsigned int i;
+  bool success = false;
   for (i = 0; i < max_iter; ++i)
   {
     fk_solver_->JntToCart(q_out, f);
     delta_twist = diff(f, p_in);
     ROS_DEBUG_STREAM_NAMED("kdl", "[" << std::setw(3) << i << "] delta_twist: " << delta_twist);
 
-    if (position_ik_)
+    // check norms of position and orientation errors
+    const double position_error = delta_twist.vel.Norm();
+    const double orientation_error = position_ik_ ? 0 : delta_twist.rot.Norm();
+    const double delta_twist_norm = std::max(position_error, orientation_error);
+    if (delta_twist_norm <= epsilon_)
     {
-      if (fabs(delta_twist(0)) < epsilon_ && fabs(delta_twist(1)) < epsilon_ && fabs(delta_twist(2)) < epsilon_)
-        break;
+      success = true;
+      break;
+    }
+
+    if (delta_twist_norm >= last_delta_twist_norm)
+    {
+      // if the error increased, we are close to a singularity -> reduce step size
+      double old_step_size = step_size;
+      step_size *= std::min(0.5, last_delta_twist_norm / delta_twist_norm);  // reduce scale;
+      KDL::Multiply(delta_q, step_size / old_step_size, delta_q);
+      ROS_WARN_NAMED("kdl", "      error increased: %f -> %f, scale: %f", last_delta_twist_norm, delta_twist_norm,
+                     step_size);
+      q_out = q_backup;  // restore previous unclipped joint values
     }
     else
     {
-      if (KDL::Equal(delta_twist, KDL::Twist::Zero(), epsilon_))
-        break;
-    }
+      q_backup = q_out;  // remember joint values of last successful step
+      step_size = 1.0;   // reset step size
+      last_delta_twist_norm = delta_twist_norm;
 
-    ik_solver.CartToJnt(q_out, delta_twist, delta_q);
+      ik_solver.CartToJnt(q_out, delta_twist, delta_q);
+    }
+    const double delta_q_norm = delta_q.data.lpNorm<1>();
+    ROS_INFO_NAMED("kdl", "[%3d] pos err: %f  rot err: %f  delta_q: %f", i, position_error, orientation_error,
+                   delta_q_norm);
+
+    if (delta_q_norm < epsilon_)  // stuck in singularity
+      break;
+
     KDL::Add(q_out, delta_q, q_out);
 
     ROS_DEBUG_STREAM_NAMED("kdl", "      delta_q: " << delta_q);
@@ -413,12 +439,10 @@ int KDLKinematicsPlugin::CartToJnt(KDL::ChainIkSolverVel& ik_solver, const KDL::
     }
   }
 
-  ROS_DEBUG_STREAM_NAMED("kdl", "[" << std::setw(3) << i << "] Solution : " << q_out);
+  int result = (i == max_iter) ? -3 : (success ? 0 : -2);
+  ROS_INFO_STREAM_NAMED("kdl", "Result " << result << " after " << i << " iterations: " << q_out);
 
-  if (i != max_iter)
-    return 0;
-  else
-    return -3;
+  return result;
 }
 
 bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_names,


### PR DESCRIPTION
This PR addresses #1255, a regression of KDL-IK performance in Melodic. I didn't find any particular reason for the regression, but I noticed the following general issues:
* The IK solver was often stuck when running into joint limits (wasting most cycles trying to move outside the limits and being reset inside again).
* Singularities were not handled gracefully.

These issues are addressed as follows:
* Decrease step size when error-to-target has increased since last iteration (which is usually also an indicator for a singularity).
* When getting stuck passing a singularity, try to (locally!) wiggle all joints or bail out if target cannot be reached, thus not wasting more cycles to reach an unreachable goal.
* When joint values are clipped back to allowed range, reduce their motion contribution for the next cycle by using a weighted Jacobian. This allows the solver to find an alternative solution in the redundant space (if there is one). If there is no progress due to joint clipping, bail out.
* The outer loop, might reach the goal from another randomly chosen seed.

The solver is now able to pass a singularity without re-seeding (and thus having large joint-space jumps):
![singular](https://user-images.githubusercontent.com/5376030/51635252-a658d980-1f56-11e9-9414-27c70a07d032.gif)
