### PR TITLE
Dockerfile: install clang tools

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -31,7 +31,7 @@ RUN \
         sudo \
         # Preferred build tools
         python-catkin-tools \
-        clang \
+        clang clang-format-3.9 clang-tidy clang-tools \
         ccache && \
     #
     # Download all dependencies of MoveIt!


### PR DESCRIPTION
This will speed up the CI build, which doesn't need to install the clang tools anymore.