### PR TITLE
Cleanup dependencies

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Eigen3 REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
+  moveit_ros_planning
   pluginlib
   roscpp
   rosconsole
@@ -35,6 +36,7 @@ catkin_package(
   CATKIN_DEPENDS
     pluginlib
     moveit_core
+    moveit_ros_planning
   DEPENDS
     EIGEN3
 )

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -12,9 +12,7 @@ find_package(Eigen3 REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
-  moveit_ros_planning
   pluginlib
-  actionlib
   roscpp
   rosconsole
   srdfdom
@@ -37,7 +35,6 @@ catkin_package(
   CATKIN_DEPENDS
     pluginlib
     moveit_core
-    moveit_ros_planning
   DEPENDS
     EIGEN3
 )

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -50,8 +50,7 @@ endif()
 add_executable(measure_ik_call_cost src/measure_ik_call_cost.cpp)
 target_link_libraries(measure_ik_call_cost
     ${catkin_LIBRARIES}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${MOVEIT_ROBOT_MODEL_LOADER_LIBRARY})
+    ${Boost_PROGRAM_OPTIONS_LIBRARY})
 install(TARGETS measure_ik_call_cost DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -45,10 +45,6 @@
 #include <kdl/frames_io.hpp>
 #include <kdl/kinfam_io.hpp>
 
-// URDF, SRDF
-#include <urdf_model/model.h>
-#include <srdfdom/model.h>
-
 // register KDLKinematics as a KinematicsBase implementation
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(kdl_kinematics_plugin::KDLKinematicsPlugin, kinematics::KinematicsBase)

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -40,10 +40,6 @@
 #include <tf2_kdl/tf2_kdl.h>
 #include <kdl_parser/kdl_parser.hpp>
 
-// URDF, SRDF
-#include <urdf_model/model.h>
-#include <srdfdom/model.h>
-
 // register KDLKinematics as a KinematicsBase implementation
 CLASS_LOADER_REGISTER_CLASS(lma_kinematics_plugin::LMAKinematicsPlugin, kinematics::KinematicsBase)
 

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -23,19 +23,16 @@
 
   <build_depend>moveit_core</build_depend>
   <build_depend version_gte="1.11.2">pluginlib</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>moveit_ros_planning</build_depend>
   <build_depend>tf2_kdl</build_depend>
   <build_depend>orocos_kdl</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend version_gte="1.11.2">pluginlib</run_depend>
-  <run_depend>actionlib</run_depend>
-  <run_depend>moveit_ros_planning</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_kdl</run_depend>
   <run_depend>orocos_kdl</run_depend>
+  <run_depend>python-lxml</run_depend>
 
   <test_depend>xmlrpcpp</test_depend>
 

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -24,6 +24,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>moveit_ros_planning</build_depend>
   <build_depend>tf2_kdl</build_depend>
   <build_depend>orocos_kdl</build_depend>
 
@@ -33,6 +34,7 @@
   <run_depend>tf2_kdl</run_depend>
   <run_depend>orocos_kdl</run_depend>
   <run_depend>python-lxml</run_depend>
+  <run_depend>moveit_ros_planning</run_depend>
 
   <test_depend>xmlrpcpp</test_depend>
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -36,11 +36,6 @@
 
 #include <moveit/srv_kinematics_plugin/srv_kinematics_plugin.h>
 #include <class_loader/class_loader.hpp>
-
-// URDF, SRDF
-#include <urdf_model/model.h>
-#include <srdfdom/model.h>
-
 #include <moveit/robot_state/conversions.h>
 
 // Eigen


### PR DESCRIPTION
Remove obsolete dependencies in moveit_kinematics and add python-lxml as suggested in https://github.com/ros-planning/moveit/pull/1320#discussion_r250704050. This is a squash-commit candidate ;-)