### PR TITLE
Travis: enable warnings and catkin_lint checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
 sudo: required
-dist: trusty
+dist: xenial  # distro used by Travis, moveit_ci uses the docker image's distro
 services:
   - docker
 language: cpp
@@ -13,12 +13,15 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   global:
+    - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
     - ROS_DISTRO=melodic
     - ROS_REPO=ros
     - UPSTREAM_WORKSPACE=moveit.rosinstall
     - TEST_BLACKLIST=moveit_ros_perception  # mesh_filter_test fails due to broken Mesa OpenGL
+    - WARNINGS_OK=false
   matrix:
     - TEST=clang-format
+    - TEST=catkin_lint
     - ROS_DISTRO=melodic
     - ROS_DISTRO=kinetic
 
@@ -28,6 +31,9 @@ matrix: # Add a separate config to the matrix, using clang as compiler
     - compiler: clang
       env: ROS_REPO=ros-shadow-fixed
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+
+  allow_failures:
+    - env: TEST=catkin_lint  # need to fix catkin_lint errors
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(MOVEIT_LIB_NAME moveit_collision_distance_field)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # clang is picky about new virtual functions hiding existing ones
+  add_compile_options(-Wno-overloaded-virtual)
+endif()
+
 add_library(${MOVEIT_LIB_NAME}
   src/collision_distance_field_types.cpp
   src/collision_common_distance_field.cpp

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -45,8 +45,8 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(GroupStateRepresentation);
-MOVEIT_CLASS_FORWARD(DistanceFieldCacheEntry);
+MOVEIT_STRUCT_FORWARD(GroupStateRepresentation)
+MOVEIT_STRUCT_FORWARD(DistanceFieldCacheEntry)
 
 /** collision volume representation for a particular pose and link group
  *

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_world_distance_field.h
@@ -51,7 +51,7 @@ class CollisionWorldDistanceField : public CollisionWorld
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  MOVEIT_CLASS_FORWARD(DistanceFieldCacheEntry)
+  MOVEIT_STRUCT_FORWARD(DistanceFieldCacheEntry)
   struct DistanceFieldCacheEntry
   {
     std::map<std::string, std::vector<PosedBodyPointDecompositionPtr>> posed_body_point_decompositions_;

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -41,7 +41,6 @@
 #include <ros/console.h>
 #include <memory>
 
-const static double RESOLUTION_SCALE = 1.0;
 const static double EPSILON = 0.0001;
 
 std::vector<collision_detection::CollisionSphere>

--- a/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -212,7 +212,7 @@ void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::
                                                      const moveit::core::RobotState& state) const
 {
   GroupStateRepresentationPtr gsr;
-  checkSelfCollisionHelper(req, res, state, NULL, gsr);
+  checkSelfCollisionHelper(req, res, state, nullptr, gsr);
 }
 
 void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::CollisionRequest& req,
@@ -220,7 +220,7 @@ void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::
                                                      const moveit::core::RobotState& state,
                                                      GroupStateRepresentationPtr& gsr) const
 {
-  checkSelfCollisionHelper(req, res, state, NULL, gsr);
+  checkSelfCollisionHelper(req, res, state, nullptr, gsr);
 }
 
 void CollisionRobotDistanceField::checkSelfCollision(const collision_detection::CollisionRequest& req,
@@ -703,7 +703,7 @@ DistanceFieldCacheEntryPtr CollisionRobotDistanceField::generateDistanceFieldCac
 {
   DistanceFieldCacheEntryPtr dfce(new DistanceFieldCacheEntry());
 
-  if (robot_model_->getJointModelGroup(group_name) == NULL)
+  if (robot_model_->getJointModelGroup(group_name) == nullptr)
   {
     ROS_WARN("No group %s", group_name.c_str());
     return dfce;

--- a/moveit_core/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_world_distance_field.cpp
@@ -121,7 +121,7 @@ void CollisionWorldDistanceField::checkCollision(const CollisionRequest& req, Co
     const CollisionRobotDistanceField& cdr = dynamic_cast<const CollisionRobotDistanceField&>(robot);
     if (!gsr)
     {
-      cdr.generateCollisionCheckingStructures(req.group_name, state, NULL, gsr, true);
+      cdr.generateCollisionCheckingStructures(req.group_name, state, nullptr, gsr, true);
     }
     else
     {
@@ -208,7 +208,7 @@ void CollisionWorldDistanceField::checkRobotCollision(const CollisionRequest& re
     DistanceFieldCacheEntryConstPtr dfce;
     if (!gsr)
     {
-      cdr.generateCollisionCheckingStructures(req.group_name, state, NULL, gsr, false);
+      cdr.generateCollisionCheckingStructures(req.group_name, state, nullptr, gsr, false);
     }
     else
     {

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -88,7 +88,7 @@ public:
   ~PR2ArmIKSolver() override{};
 
 // TODO: simplify after kinetic support is dropped
-#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION > ((a << 16) | (b << 8) | c))
+#define KDL_VERSION_LESS(a, b, c) ((KDL_VERSION) < ((a << 16) | (b << 8) | c))
 #if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(MOVEIT_LIB_NAME moveit_robot_state)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # clang is picky about typeid(*solver)
+  add_compile_options(-Wno-potentially-evaluated-expression)
+endif()
+
 add_library(${MOVEIT_LIB_NAME}
   src/attached_body.cpp
   src/conversions.cpp

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
@@ -64,7 +64,7 @@ public:
                                     bool position_ik = false, double threshold = 0.00001);
 
 // TODO: simplify after kinetic support is dropped
-#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#define KDL_VERSION_LESS(a, b, c) ((KDL_VERSION) < ((a << 16) | (b << 8) | c))
 #if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_pos_lma_jl_mimic.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_pos_lma_jl_mimic.h
@@ -78,7 +78,7 @@ public:
                                 double eps = 1e-6, bool position_ik = false);
 
 // TODO: simplify after kinetic support is dropped
-#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#define KDL_VERSION_LESS(a, b, c) ((KDL_VERSION) < ((a << 16) | (b << 8) | c))
 #if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_vel_pinv_mimic.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/chainiksolver_vel_pinv_mimic.h
@@ -79,7 +79,7 @@ public:
                                        bool position_ik = false, double eps = 0.00001, int maxiter = 150);
 
 // TODO: simplify after kinetic support is dropped
-#define KDL_VERSION_LESS(a, b, c) (KDL_VERSION < ((a << 16) | (b << 8) | c))
+#define KDL_VERSION_LESS(a, b, c) ((KDL_VERSION) < ((a << 16) | (b << 8) | c))
 #if KDL_VERSION_LESS(1, 4, 0)
   void updateInternalDataStructures();
 #else

--- a/moveit_ros/planning/robot_model_loader/CMakeLists.txt
+++ b/moveit_ros/planning/robot_model_loader/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(MOVEIT_LIB_NAME moveit_robot_model_loader)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_compile_options(-Wno-potentially-evaluated-expression)
+endif()
+
 add_library(${MOVEIT_LIB_NAME} src/robot_model_loader.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_rdf_loader moveit_kinematics_plugin_loader ${catkin_LIBRARIES})

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.12)
 project(moveit_setup_assistant)
 
 add_compile_options(-std=c++14)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # suppress warning in Ogre
+  add_compile_options(-Wno-deprecated-register)
+endif()
 
 # definition needed for boost/math/constants/constants.hpp included by Ogre to compile
 add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)


### PR DESCRIPTION
This PR enables more checkers in Travis using the new features of https://github.com/ros-planning/moveit_ci/pull/45.

- increase Travis timeout (90min - 5min margin)
- update Travis distro to Xenial as suggested by Travis folks
- add catkin_lint (currently failing)
- enable warnings checker (failing on clang)

Fixes for clang warnings will immediately follow.