### PR TITLE
Travis: enable clang-tidy-fix

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,5 @@
 ---
 Checks:          '-*,
-                  clang-analyzer-*,
                   performance-*,
                   modernize-redundant-void-arg,
                   modernize-use-nullptr,
@@ -22,30 +21,28 @@ CheckOptions:
     value:           '2'
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '2'
+  # type names
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
-  - key:             readability-identifier-naming.EnumConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.MethodCase
-    value:           camelBack
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
+  # method names
+  - key:             readability-identifier-naming.MethodCase
+    value:           camelBack
+  # variable names
   - key:             readability-identifier-naming.VariableCase
     value:           lower_case
-  - key:             readability-identifier-naming.ConstantCase
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           '_'
+  # const static or global variables are UPPER_CASE
+  - key:             readability-identifier-naming.EnumConstantCase
     value:           UPPER_CASE
-  - key:             readability-identifier-naming.ConstantParameterCase
-    value:           lower_case
-  - key:             readability-identifier-naming.LocalConstantCase
-    value:           lower_case
   - key:             readability-identifier-naming.StaticConstantCase
     value:           UPPER_CASE
-  - key:             readability-identifier-naming.MemberCase
-    value:           lower_case
-  - key:             readability-identifier-naming.ConstantMemberCase
+  - key:             readability-identifier-naming.ClassConstantCase
     value:           UPPER_CASE
-  - key:             readability-identifier-naming.MemberSuffix
-    value:           '_'
+  - key:             readability-identifier-naming.GlobalVariableCase
+    value:           UPPER_CASE
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - WARNINGS_OK=false
   matrix:
     - TEST="clang-format catkin_lint"
+    - TEST=clang-tidy-fix
     - ROS_DISTRO=melodic
     - ROS_DISTRO=kinetic
 
@@ -30,6 +31,10 @@ matrix: # Add a separate config to the matrix, using clang as compiler
     - compiler: clang
       env: ROS_REPO=ros-shadow-fixed
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+
+  fast_finish: true  # finish, even if allow-failure-tests still running
+  allow_failures:
+    - env: TEST=clang-tidy-fix  # need to fix clang-tidy issues
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci


### PR DESCRIPTION
In https://github.com/ros-planning/moveit/pull/1185 @BryceStevenWilley  introduced some naming conventions, I don't agree with, namely enforcing UPPER_CASE for all constant variables. I think we agreed, that UPPER_CASE is reserved for macros, maybe static const variables as well. However, const members should be lower_case as other variables as well.

This PR also removes the very time-consuming code analysis checks (clang-analyzer-*). They are nice to have locally, but they don't provided automatic fixes and thus are not useful on Travis.

Some remarks on the next steps can be found in https://github.com/ros-planning/moveit/issues/28#issuecomment-451624912.