### PR TITLE
remove catkin_lint suppressions

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(moveit_core)
 
-#suppress spurious errors: https://github.com/fkie/catkin_lint/issues/62
-#catkin_lint: ignore duplicate_find  (find_package(moveit_resources))
-
 add_compile_options(-std=c++14)
 
 # Warnings
@@ -25,12 +22,12 @@ endif()
 
 find_package(Boost REQUIRED system filesystem date_time thread iostreams)
 find_package(Eigen3 REQUIRED)
-find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(LIBFCL REQUIRED fcl)
-# replace LIBFCL_LIBRARIES with full path to the library
-find_library(LIBFCL_LIBRARIES_FULL ${LIBFCL_LIBRARIES} ${LIBFCL_LIBRARY_DIRS})
-set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBFCL_PC REQUIRED fcl)
+# find *absolute* paths to LIBFCL_INCLUDE_DIRS and LIBFCL_LIBRARIES
+find_path(LIBFCL_INCLUDE_DIRS fcl/config.h HINTS ${LIBFCL_PC_INCLUDE_DIR} ${LIBFCL_PC_INCLUDE_DIRS})
+find_library(LIBFCL_LIBRARIES fcl HINTS ${LIBFCL_PC_LIBRARY_DIRS})
 
 find_package(octomap REQUIRED)
 find_package(urdfdom REQUIRED)
@@ -95,8 +92,6 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     utils/include
 )
 
-#suppress spurious error: https://github.com/fkie/catkin_lint/issues/62
-#catkin_lint: ignore_once exported_pkg_config  (LIBFCL)
 catkin_package(
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
@@ -162,8 +157,7 @@ include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
                            ${LIBFCL_INCLUDE_DIRS}
                            )
 
-#suppress spurious error: https://github.com/fkie/catkin_lint/issues/62
-#catkin_lint: ignore_once external_directory missing_directory  (${VERSION_FILE_PATH})
+#catkin_lint: ignore_once external_directory  (${VERSION_FILE_PATH})
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${VERSION_FILE_PATH}
                     ${Boost_INCLUDE_DIRS}

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -1,7 +1,6 @@
 find_package(trac_ik_kinematics_plugin QUIET)
 find_package(ur_kinematics QUIET)
 
-#catkin_lint: ignore_once duplicate_find
 find_package(Boost COMPONENTS filesystem program_options REQUIRED)
 
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_base)

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -11,7 +11,6 @@ else()
   set(CHOMP_TEST_DEPS)
 endif()
 
-#catkin_lint: ignore_once duplicate_find  (find_package(catkin))
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   moveit_core

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -34,7 +34,6 @@ elseif()
   set(BOOST_PYTHON_COMPONENT python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
 endif()
 
-#catkin_lint: ignore_once duplicate_find
 find_package(Boost REQUIRED COMPONENTS
   date_time
   filesystem

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -5,7 +5,6 @@ set(HEADERS
 )
 qt_wrap_ui(UIC_FILES src/ui/motion_planning_rviz_plugin_frame.ui)
 
-#catkin_lint: ignore_once missing_directory
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Plugin Source

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -10,7 +10,6 @@ set(HEADERS
   include/moveit/rviz_plugin_render_tools/trajectory_panel.h
 )
 
-#catkin_lint: ignore_once missing_directory
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(${MOVEIT_LIB_NAME}

--- a/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -5,7 +5,6 @@ set(HEADERS
   include/moveit/trajectory_rviz_plugin/trajectory_display.h
 )
 
-#catkin_lint: ignore_once missing_directory
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Trajectory Display


### PR DESCRIPTION
https://github.com/fkie/catkin_lint/issues/62 has been resolved and catkin_lint 1.5.6 has been released.
Thus, we can remove some catkin_lint suppressions again.
- [ ] We need to wait until this new release will become available in the standard ROS repositories (https://github.com/ros/rosdistro/issues/20283)