### PR TITLE
allow multiple eefs per planning group

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -484,8 +484,8 @@ public:
   }
 
   /**
-   * \brief Get a vector of end effector tips included in a particular joint model group as defined by the SRDF end
-   * effector semantic
+   * \brief Get the unique set of end effector tips included in a particular joint model group
+   * as defined by the SRDF end effector elements
    *        e.g. for a humanoid robot this would return 4 tips for the hands and feet
    * \param tips - the output vector of link models of the tips
    * \return true on success
@@ -493,8 +493,8 @@ public:
   bool getEndEffectorTips(std::vector<const LinkModel*>& tips) const;
 
   /**
-   * \brief Get a vector of end effector tips included in a particular joint model group as defined by the SRDF end
-   * effector semantic
+   * \brief Get the unique set of end effector tips included in a particular joint model group
+   * as defined by the SRDF end effector elements
    *        e.g. for a humanoid robot this would return 4 tips for the hands and feet
    * \param tips - the output vector of link names of the tips
    * \return true on success

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -489,18 +489,17 @@ bool JointModelGroup::getEndEffectorTips(std::vector<std::string>& tips) const
 
   // Convert to string names
   tips.clear();
-  for (std::size_t i = 0; i < tip_links.size(); ++i)
-  {
-    tips.push_back(tip_links[i]->getName());
-  }
+  for (const LinkModel* link_model : tip_links)
+    tips.push_back(link_model->getName());
   return true;
 }
 
 bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) const
 {
-  for (std::size_t i = 0; i < getAttachedEndEffectorNames().size(); ++i)
+  tips.clear();
+  for (const std::string& name : getAttachedEndEffectorNames())
   {
-    const JointModelGroup* eef = parent_model_->getEndEffector(getAttachedEndEffectorNames()[i]);
+    const JointModelGroup* eef = parent_model_->getEndEffector(name);
     if (!eef)
     {
       ROS_ERROR_NAMED("robot_model.jmg", "Unable to find joint model group for eef");
@@ -514,8 +513,10 @@ bool JointModelGroup::getEndEffectorTips(std::vector<const LinkModel*>& tips) co
       ROS_ERROR_NAMED("robot_model.jmg", "Unable to find end effector link for eef");
       return false;
     }
-
-    tips.push_back(eef_link);
+    // insert eef_link into tips, maintaining a *sorted* vector, thus enabling use of std::lower_bound
+    const auto insert_it = std::lower_bound(tips.cbegin(), tips.cend(), eef_link);
+    if (insert_it == tips.end() || eef_link != *insert_it)  // only insert if not a duplicate
+      tips.insert(insert_it, eef_link);
   }
   return true;
 }

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -637,7 +637,6 @@ void RobotModel::buildGroupsInfoEndEffectors(const srdf::Model& srdf_model)
           ROS_WARN_NAMED(LOGNAME, "Could not identify parent group for end-effector '%s'", eefs[k].name_.c_str());
           it->second->setEndEffectorParent("", eefs[k].parent_link_);
         }
-        break;
       }
   }
   std::sort(end_effectors_.begin(), end_effectors_.end(), OrderGroupsByName());


### PR DESCRIPTION
Due to an early escape from the loop (after the first found eef for a group), MoveIt!
wasn't aware of other eef names (with possibly a different `parent_link`) associated to a group.
