### PR TITLE
remove deprecated (and unused) boost::signals

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time program_options signals thread)
+find_package(Boost REQUIRED system filesystem date_time program_options thread)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_planning

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED thread signals)
+find_package(Boost REQUIRED thread)
 
 if(WITH_OPENGL)
   find_package(OpenGL REQUIRED)

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time program_options signals thread chrono)
+find_package(Boost REQUIRED system filesystem date_time program_options thread chrono)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_msgs

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -53,9 +53,7 @@ typedef boost::function<void(const sensor_msgs::JointStateConstPtr& joint_state)
     @brief Monitors the joint_states topic and tf to maintain the current state of the robot. */
 class CurrentStateMonitor
 {
-  /* tf changed their interface between indigo and kinetic
-     from boost::signals::connection to boost::signals2::connection */
-  typedef decltype(tf2_ros::Buffer()._addTransformsChangedListener(boost::function<void(void)>())) TFConnection;
+  typedef boost::signals2::connection TFConnection;
 
 public:
   /**


### PR DESCRIPTION
Addresses #1350. boost::signals(1) was used by `tf` < 1.11.3, which is more than 5 years old now.
Also, we migrated to `tf2` already...