### PR TITLE
Graphically print current robot joint states with joint limits

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1792,6 +1792,10 @@ as the new values that correspond to the group */
 
   void printStatePositions(std::ostream& out = std::cout) const;
 
+  /** \brief Output to console the current state of the robot's joint limits */
+  void printStatePositionsWithJointLimits(const moveit::core::JointModelGroup* jmg,
+                                          std::ostream& out = std::cout) const;
+
   void printStateInfo(std::ostream& out = std::cout) const;
 
   void printTransforms(std::ostream& out = std::cout) const;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -41,6 +41,7 @@
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/backtrace/backtrace.h>
 #include <moveit/profiler/profiler.h>
+#include <moveit/macros/console_colors.h>
 #include <boost/bind.hpp>
 #include <moveit/robot_model/aabb.h>
 
@@ -2172,6 +2173,58 @@ void RobotState::printStatePositions(std::ostream& out) const
   const std::vector<std::string>& nm = robot_model_->getVariableNames();
   for (std::size_t i = 0; i < nm.size(); ++i)
     out << nm[i] << "=" << position_[i] << std::endl;
+}
+
+void RobotState::printStatePositionsWithJointLimits(const moveit::core::JointModelGroup* jmg, std::ostream& out) const
+{
+  // TODO(davetcoleman): support joints with multiple variables / multiple DOFs such as floating joints
+  // TODO(davetcoleman): support unbounded joints
+
+  const std::vector<const moveit::core::JointModel*>& joints = jmg->getActiveJointModels();
+
+  // Loop through joints
+  for (std::size_t i = 0; i < joints.size(); ++i)
+  {
+    // Ignore joints with more than one variable
+    if (joints[i]->getVariableCount() > 1)
+      continue;
+
+    double current_value = getVariablePosition(joints[i]->getName());
+
+    // check if joint is beyond limits
+    bool out_of_bounds = !satisfiesBounds(joints[i]);
+
+    const moveit::core::VariableBounds& bound = joints[i]->getVariableBounds()[0];
+
+    if (out_of_bounds)
+      out << MOVEIT_CONSOLE_COLOR_RED;
+
+    out << "   " << std::fixed << std::setprecision(5) << bound.min_position_ << "\t";
+    double delta = bound.max_position_ - bound.min_position_;
+    double step = delta / 20.0;
+
+    bool marker_shown = false;
+    for (double value = bound.min_position_; value < bound.max_position_; value += step)
+    {
+      // show marker of current value
+      if (!marker_shown && current_value < value)
+      {
+        out << "|";
+        marker_shown = true;
+      }
+      else
+        out << "-";
+    }
+    if (!marker_shown)
+      out << "|";
+
+    // show max position
+    out << " \t" << std::fixed << std::setprecision(5) << bound.max_position_ << "  \t" << joints[i]->getName()
+        << " current: " << std::fixed << std::setprecision(5) << current_value << std::endl;
+
+    if (out_of_bounds)
+      out << MOVEIT_CONSOLE_COLOR_RESET;
+  }
 }
 
 void RobotState::printDirtyInfo(std::ostream& out) const

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -579,6 +579,7 @@ std::size_t generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState
 TEST_F(OneRobot, testGenerateTrajectory)
 {
   const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("base_from_base_to_e");
+  ASSERT_TRUE(joint_model_group);
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
 
   // The full trajectory should be of length 7
@@ -594,6 +595,7 @@ TEST_F(OneRobot, testGenerateTrajectory)
 TEST_F(OneRobot, testAbsoluteJointSpaceJump)
 {
   const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("base_from_base_to_e");
+  ASSERT_TRUE(joint_model_group);
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
 
   // A revolute joint jumps 1.01 at the 5th waypoint and a prismatic joint jumps 1.01 at the 6th waypoint
@@ -641,6 +643,7 @@ TEST_F(OneRobot, testAbsoluteJointSpaceJump)
 TEST_F(OneRobot, testRelativeJointSpaceJump)
 {
   const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("base_from_base_to_e");
+  ASSERT_TRUE(joint_model_group);
   std::vector<std::shared_ptr<robot_state::RobotState>> traj;
 
   // The first large jump of 1.01 occurs at the 5th waypoint so the test should trim the trajectory to length 4
@@ -669,6 +672,34 @@ TEST_F(OneRobot, testRelativeJointSpaceJump)
   fraction = robot_state::RobotState::testJointSpaceJump(joint_model_group, traj, robot_state::JumpThreshold(2.98));
   EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
   EXPECT_NEAR(1.0, fraction, 0.01);
+}
+
+TEST_F(OneRobot, testPrintCurrentPositionWithJointLimits)
+{
+  moveit::core::RobotState state(robot_model_);
+  const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("base_from_base_to_e");
+  ASSERT_TRUE(joint_model_group);
+
+  state.setToDefaultValues();
+
+  std::cout << "\nVisual inspection should show NO joints out of bounds:" << std::endl;
+  state.printStatePositionsWithJointLimits(joint_model_group);
+
+  std::cout << "\nVisual inspection should show ONE joint out of bounds:" << std::endl;
+  std::vector<double> single_joint(1);
+  single_joint[0] = -1.0;
+  state.setJointPositions("joint_c", single_joint);
+  state.printStatePositionsWithJointLimits(joint_model_group);
+
+  std::cout << "\nVisual inspection should show TWO joint out of bounds:" << std::endl;
+  single_joint[0] = 1.0;
+  state.setJointPositions("joint_f", single_joint);
+  state.printStatePositionsWithJointLimits(joint_model_group);
+
+  std::cout << "\nVisual inspection should show ONE joint out of bounds:" << std::endl;
+  single_joint[0] = 0.19;
+  state.setJointPositions("joint_f", single_joint);
+  state.printStatePositionsWithJointLimits(joint_model_group);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
A trivial feature I made a long time ago, with unit tests

![image](https://user-images.githubusercontent.com/561060/53130833-805c3000-3528-11e9-8eae-10c3a5c2d11f.png)
