### PR TITLE
Apply clang tidy fix to entire code base (Part 1)

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -901,7 +901,7 @@ void cleanCollisionGeometryCache()
     cache2.bumpUseCount(true);
   }
 }
-}
+}  // namespace collision_detection
 
 void collision_detection::CollisionData::enableGroup(const robot_model::RobotModelConstPtr& robot_model)
 {

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -221,4 +221,4 @@ void getBodySphereVisualizationMarkers(GroupStateRepresentationConstPtr& gsr, st
     }
   }
 }
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -39,6 +39,7 @@
 #include <boost/thread/mutex.hpp>
 #include <tf2_eigen/tf2_eigen.h>
 #include <memory>
+#include <utility>
 
 namespace collision_detection
 {
@@ -150,7 +151,7 @@ void getBodySphereVisualizationMarkers(GroupStateRepresentationConstPtr& gsr, st
 
   // creating sphere marker
   visualization_msgs::Marker sphere_marker;
-  sphere_marker.header.frame_id = reference_frame;
+  sphere_marker.header.frame_id = std::move(reference_frame);
   sphere_marker.header.stamp = ros::Time(0);
   sphere_marker.ns = robot_ns;
   sphere_marker.id = 0;

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -402,11 +402,7 @@ bool collision_detection::doBoundingSpheresIntersect(const PosedBodySphereDecomp
   double p2_radius = p2->getBoundingSphereRadius();
 
   double dist = (p1_sphere_center - p2_sphere_center).squaredNorm();
-  if (dist < (p1_radius + p2_radius))
-  {
-    return true;
-  }
-  return false;
+  return dist < (p1_radius + p2_radius);
 }
 
 void collision_detection::getCollisionSphereMarkers(

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -249,7 +249,7 @@ bool collision_detection::getCollisionSphereCollision(const distance_field::Dist
     }
   }
 
-  return colls.size() > 0;
+  return !colls.empty();
 }
 
 ///

--- a/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -874,7 +874,7 @@ DistanceFieldCacheEntryPtr CollisionRobotDistanceField::generateDistanceFieldCac
     }
   }
 
-  const std::vector<std::string> state_variable_names = state.getVariableNames();
+  const std::vector<std::string>& state_variable_names = state.getVariableNames();
   for (std::vector<std::string>::const_iterator name_iter = state_variable_names.begin();
        name_iter != state_variable_names.end(); name_iter++)
   {

--- a/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -757,7 +757,7 @@ DistanceFieldCacheEntryPtr CollisionRobotDistanceField::generateDistanceFieldCac
       continue;
     }
 
-    if (link_state->getShapes().size() > 0)
+    if (!link_state->getShapes().empty())
     {
       dfce->link_has_geometry_.push_back(true);
       dfce->link_body_indices_.push_back(link_body_decomposition_index_map_.find(link_name)->second);

--- a/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_robot_distance_field.cpp
@@ -1372,4 +1372,4 @@ bool CollisionRobotDistanceField::compareCacheEntryToAllowedCollisionMatrix(
 //     if(dfce->acm.find
 //   }
 // }
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/src/collision_robot_hybrid.cpp
+++ b/moveit_core/collision_distance_field/src/collision_robot_hybrid.cpp
@@ -93,4 +93,4 @@ void CollisionRobotHybrid::checkSelfCollisionDistanceField(const collision_detec
 {
   crobot_distance_->checkSelfCollision(req, res, state, acm, gsr);
 }
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/src/collision_world_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_world_distance_field.cpp
@@ -562,7 +562,7 @@ CollisionWorldDistanceField::DistanceFieldCacheEntryPtr CollisionWorldDistanceFi
   dfce->distance_field_->addPointsToField(add_points);
   return dfce;
 }
-}
+}  // namespace collision_detection
 
 #include <moveit/collision_distance_field/collision_detector_allocator_distance_field.h>
 const std::string collision_detection::CollisionDetectorAllocatorDistanceField::NAME_("DISTANCE_FIELD");

--- a/moveit_core/collision_distance_field/src/collision_world_hybrid.cpp
+++ b/moveit_core/collision_distance_field/src/collision_world_hybrid.cpp
@@ -151,7 +151,7 @@ void CollisionWorldHybrid::getAllCollisions(const CollisionRequest& req, Collisi
 {
   cworld_distance_->getAllCollisions(req, res, robot, state, acm, gsr);
 }
-}
+}  // namespace collision_detection
 
 #include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
 const std::string collision_detection::CollisionDetectorAllocatorHybrid::NAME_("HYBRID");

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -73,7 +73,7 @@ protected:
       }
       xml_file.close();
       urdf_model_ = urdf::parseURDF(xml_string);
-      urdf_ok_ = urdf_model_ ? true : false;
+      urdf_ok_ = static_cast<bool>(urdf_model_);
     }
     else
       urdf_ok_ = false;

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -520,7 +520,7 @@ void samplingIkCallbackFnAdapter(robot_state::RobotState* state, const robot_mod
   else
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
 }
-}
+}  // namespace
 
 bool IKConstraintSampler::sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
                                  unsigned int max_attempts)

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -428,4 +428,4 @@ const std::vector<std::string>& PR2ArmKinematicsPlugin::getLinkNames() const
   return fk_solver_info_.link_names;
 }
 
-}  // namespace
+}  // namespace pr2_arm_kinematics

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -770,4 +770,4 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
   addNewObstacleVoxels(obs_points);
   return true;
 }
-}
+}  // namespace distance_field

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -62,7 +62,7 @@ inline geometry_msgs::Vector3 transformVector(const Eigen::Isometry3d& transform
 
   return result;
 }
-}
+}  // namespace
 
 DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
                                const geometry_msgs::Vector3& gravity_vector)

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -527,4 +527,4 @@ bool constructConstraints(XmlRpc::XmlRpcValue& params, moveit_msgs::Constraints&
   constraints.name = static_cast<std::string>(params["name"]);
   return collectConstraints(params["constraints"], constraints);
 }
-}
+}  // namespace kinematic_constraints

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -186,8 +186,7 @@ KinematicsBase::KinematicsBase()
   supported_methods_.push_back(DiscretizationMethods::NO_DISCRETIZATION);
 }
 
-KinematicsBase::~KinematicsBase()
-= default;
+KinematicsBase::~KinematicsBase() = default;
 
 bool KinematicsBase::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                    const std::vector<double>& ik_seed_state,

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -44,7 +44,7 @@ namespace kinematics
 const double KinematicsBase::DEFAULT_SEARCH_DISCRETIZATION = 0.1;
 const double KinematicsBase::DEFAULT_TIMEOUT = 1.0;
 
-static void noDeleter(const moveit::core::RobotModel*)
+static void noDeleter(const moveit::core::RobotModel* /*unused*/)
 {
 }
 

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -187,8 +187,7 @@ KinematicsBase::KinematicsBase()
 }
 
 KinematicsBase::~KinematicsBase()
-{
-}
+= default;
 
 bool KinematicsBase::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                    const std::vector<double>& ik_seed_state,

--- a/moveit_core/planning_interface/src/planning_interface.cpp
+++ b/moveit_core/planning_interface/src/planning_interface.cpp
@@ -54,7 +54,7 @@ static ActiveContexts& getActiveContexts()
   static ActiveContexts ac;
   return ac;
 }
-}
+}  // namespace
 
 PlanningContext::PlanningContext(const std::string& name, const std::string& group) : name_(name), group_(group)
 {

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -55,7 +55,7 @@ bool callPlannerInterfaceSolve(const planning_interface::PlannerManager* planner
   else
     return false;
 }
-}
+}  // namespace
 
 bool PlanningRequestAdapter::adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
                                           const planning_scene::PlanningSceneConstPtr& planning_scene,
@@ -115,7 +115,7 @@ bool callAdapter2(const PlanningRequestAdapter* adapter, const PlanningRequestAd
     return planner(planning_scene, req, res);
   }
 }
-}
+}  // namespace
 
 bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
                                                const planning_scene::PlanningSceneConstPtr& planning_scene,

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -812,7 +812,7 @@ private:
   moveit_msgs::CollisionObject* obj_;
   const geometry_msgs::Pose* pose_;
 };
-}
+}  // namespace
 
 bool PlanningScene::getCollisionObjectMsg(moveit_msgs::CollisionObject& collision_obj, const std::string& ns) const
 {

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1603,7 +1603,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         poses.insert(poses.end(), ab->getFixedTransforms().begin(), ab->getFixedTransforms().end());
         trajectory_msgs::JointTrajectory detach_posture =
             object.detach_posture.joint_names.empty() ? ab->getDetachPosture() : object.detach_posture;
-        std::set<std::string> ab_touch_links = ab->getTouchLinks();
+        const std::set<std::string>& ab_touch_links = ab->getTouchLinks();
         robot_state_->clearAttachedBody(object.object.id);
         if (object.touch_links.empty())
           robot_state_->attachBody(object.object.id, shapes, poses, ab_touch_links, object.link_name, detach_posture);

--- a/moveit_core/profiler/src/profiler.cpp
+++ b/moveit_core/profiler/src/profiler.cpp
@@ -208,7 +208,7 @@ struct SortDoubleByValue
     return a.value_ > b.value_;
   }
 };
-}
+}  // namespace
 /// @endcond
 
 void Profiler::printThreadInfo(std::ostream& out, const PerThread& data)

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -216,7 +216,7 @@ inline void printBoundHelper(std::ostream& out, double v)
   else
     out << v;
 }
-}
+}  // namespace
 
 std::ostream& operator<<(std::ostream& out, const VariableBounds& b)
 {

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -94,7 +94,7 @@ bool jointPrecedes(const JointModel* a, const JointModel* b)
 
   return false;
 }
-}
+}  // namespace
 
 JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Model::Group& config,
                                  const std::vector<const JointModel*>& unsorted_group_joints,

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -191,7 +191,7 @@ void computeCommonRootsHelper(const JointModel* joint, std::vector<int>& common_
     computeCommonRootsHelper(ch[i], common_roots, size);
   }
 }
-}
+}  // namespace
 
 void RobotModel::computeCommonRoots()
 {
@@ -840,7 +840,7 @@ static inline VariableBounds jointBoundsFromURDF(const urdf::Joint* urdf_joint)
   }
   return b;
 }
-}
+}  // namespace
 
 JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const urdf::Link* child_link,
                                             const srdf::Model& srdf_model)

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -357,7 +357,7 @@ static bool _robotStateMsgToRobotStateHelper(const Transforms* tf, const moveit_
 
   return valid;
 }
-}
+}  // namespace
 
 // ********************************************
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1380,7 +1380,7 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return true;
 }
-}
+}  // namespace
 
 bool RobotState::setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver)
 {
@@ -2290,7 +2290,7 @@ void getPoseString(std::ostream& ss, const Eigen::Isometry3d& pose, const std::s
     ss << std::endl;
   }
 }
-}
+}  // namespace
 
 void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm, const std::string& pfx0,
                                          bool last) const

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -62,13 +62,13 @@ class TestAABB : public testing::Test
 protected:
   void SetUp() override{};
 
-  robot_state::RobotState loadModel(const std::string robot_name)
+  robot_state::RobotState loadModel(const std::string& robot_name)
   {
     robot_model::RobotModelPtr model = moveit::core::loadTestingRobotModel(robot_name);
     return loadModel(model);
   }
 
-  robot_state::RobotState loadModel(robot_model::RobotModelPtr model)
+  robot_state::RobotState loadModel(const robot_model::RobotModelPtr& model)
   {
     robot_state::RobotState robot_state = robot_state::RobotState(model);
     robot_state.setToDefaultValues();

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -602,4 +602,4 @@ void globalAdjustment(std::vector<SingleJointTrajectory>& t2, int num_joints, co
     fit_cubic_spline(num_points, &time_diff[0], &t2[j].positions_[0], &t2[j].velocities_[0], &t2[j].accelerations_[0]);
   }
 }
-}
+}  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -95,7 +95,7 @@ void printStats(const trajectory_msgs::JointTrajectory& trajectory, const std::v
   for (std::size_t i = 0; i < trajectory.points.size(); ++i)
     printPoint(trajectory.points[i], i);
 }
-}
+}  // namespace
 
 // Applies velocity
 void IterativeParabolicTimeParameterization::applyVelocityConstraints(robot_trajectory::RobotTrajectory& rob_trajectory,
@@ -294,7 +294,7 @@ void updateTrajectory(robot_trajectory::RobotTrajectory& rob_trajectory, const s
     }
   }
 }
-}
+}  // namespace
 
 // Applies Acceleration constraints
 void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
@@ -484,4 +484,4 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
   updateTrajectory(trajectory, time_diff);
   return true;
 }
-}
+}  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/trajectory_tools.cpp
+++ b/moveit_core/trajectory_processing/src/trajectory_tools.cpp
@@ -47,4 +47,4 @@ std::size_t trajectoryWaypointCount(const moveit_msgs::RobotTrajectory& trajecto
 {
   return std::max(trajectory.joint_trajectory.points.size(), trajectory.multi_dof_joint_trajectory.points.size());
 }
-}
+}  // namespace trajectory_processing

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -179,10 +179,10 @@ public:
 
 private:
   /** \brief Adds different collision geometries to a link. */
-  void addLinkCollision(const std::string& link_name, urdf::CollisionSharedPtr coll, geometry_msgs::Pose origin);
+  void addLinkCollision(const std::string& link_name, const urdf::CollisionSharedPtr& coll, geometry_msgs::Pose origin);
 
   /** \brief Adds different visual geometries to a link. */
-  void addLinkVisual(const std::string& link_name, urdf::VisualSharedPtr vis, geometry_msgs::Pose origin);
+  void addLinkVisual(const std::string& link_name, const urdf::VisualSharedPtr& vis, geometry_msgs::Pose origin);
 
   /// The URDF model, holds all of the URDF components of the robot added so far.
   urdf::ModelInterfaceSharedPtr urdf_model_;

--- a/moveit_core/utils/src/lexical_casts.cpp
+++ b/moveit_core/utils/src/lexical_casts.cpp
@@ -87,5 +87,5 @@ float toFloat(const std::string& s)
 {
   return toRealImpl<float>(s);
 }
-}
-}
+}  // namespace core
+}  // namespace moveit

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -237,7 +237,7 @@ void RobotModelBuilder::addCollisionMesh(const std::string& link_name, const std
   addLinkCollision(link_name, coll, origin);
 }
 
-void RobotModelBuilder::addLinkCollision(const std::string& link_name, urdf::CollisionSharedPtr collision,
+void RobotModelBuilder::addLinkCollision(const std::string& link_name, const urdf::CollisionSharedPtr& collision,
                                          geometry_msgs::Pose origin)
 {
   if (not urdf_model_->getLink(link_name))
@@ -255,7 +255,7 @@ void RobotModelBuilder::addLinkCollision(const std::string& link_name, urdf::Col
   link->collision_array.push_back(collision);
 }
 
-void RobotModelBuilder::addLinkVisual(const std::string& link_name, urdf::VisualSharedPtr vis,
+void RobotModelBuilder::addLinkVisual(const std::string& link_name, const urdf::VisualSharedPtr& vis,
                                       geometry_msgs::Pose origin)
 {
   if (not urdf_model_->getLink(link_name))

--- a/moveit_core/utils/src/xmlrpc_casts.cpp
+++ b/moveit_core/utils/src/xmlrpc_casts.cpp
@@ -87,5 +87,5 @@ bool isStruct(XmlRpc::XmlRpcValue& v, const std::vector<std::string>& keys, cons
 
   return missing.empty();
 }
-}
-}
+}  // namespace core
+}  // namespace moveit

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -335,4 +335,4 @@ std::string IKCacheMap::getKey(const std::vector<std::string>& fixed, const std:
   std::accumulate(active.begin(), active.end(), key);
   return key;
 }
-}
+}  // namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -251,7 +251,7 @@ void IKCache::saveCache() const
 
 void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const
 {
-  std::vector<std::string> tip_names(fk.getTipFrames());
+  const std::vector<std::string>& tip_names(fk.getTipFrames());
   std::vector<geometry_msgs::Pose> poses(tip_names.size());
   double error, max_error = 0.;
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
   spinner.start();
 
   robot_model_loader::RobotModelLoader robot_model_loader;
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  const robot_model::RobotModelPtr& kinematic_model = robot_model_loader.getModel();
   planning_scene::PlanningScene planning_scene(kinematic_model);
   robot_state::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
   collision_detection::CollisionRequest collision_request;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -70,8 +70,7 @@ void ChainIkSolverVelMimicSVD::updateInternalDataStructures()
   // to react to changes in chain
 }
 
-ChainIkSolverVelMimicSVD::~ChainIkSolverVelMimicSVD()
-= default;
+ChainIkSolverVelMimicSVD::~ChainIkSolverVelMimicSVD() = default;
 
 bool ChainIkSolverVelMimicSVD::jacToJacReduced(const Jacobian& jac, Jacobian& jac_reduced)
 {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -40,7 +40,7 @@ unsigned int countMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimi
   }
   return num_mimic;
 }
-}
+}  // namespace
 
 namespace KDL
 {
@@ -129,4 +129,4 @@ int ChainIkSolverVelMimicSVD::CartToJnt(const JntArray& q_in, const Twist& v_in,
 
   return 0;
 }
-}
+}  // namespace KDL

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -71,8 +71,7 @@ void ChainIkSolverVelMimicSVD::updateInternalDataStructures()
 }
 
 ChainIkSolverVelMimicSVD::~ChainIkSolverVelMimicSVD()
-{
-}
+= default;
 
 bool ChainIkSolverVelMimicSVD::jacToJacReduced(const Jacobian& jac, Jacobian& jac_reduced)
 {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -573,4 +573,4 @@ const std::vector<std::string>& KDLKinematicsPlugin::getLinkNames() const
   return solver_info_.link_names;
 }
 
-}  // namespace
+}  // namespace kdl_kinematics_plugin

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -360,4 +360,4 @@ const std::vector<std::string>& LMAKinematicsPlugin::getLinkNames() const
   return getTipFrames();
 }
 
-}  // namespace
+}  // namespace lma_kinematics_plugin

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -411,4 +411,4 @@ const std::vector<std::string>& SrvKinematicsPlugin::getVariableNames() const
   return joint_model_group_->getVariableNames();
 }
 
-}  // namespace
+}  // namespace srv_kinematics_plugin

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -171,7 +171,7 @@ bool SrvKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, cons
                                         std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
                                         const kinematics::KinematicsQueryOptions& options) const
 {
-  const IKCallbackFn solution_callback = 0;
+  const IKCallbackFn solution_callback = 0;  // NOLINT(modernize-use-nullptr)
   std::vector<double> consistency_limits;
 
   return searchPositionIK(ik_pose, ik_seed_state, default_timeout_, solution, solution_callback, error_code,
@@ -183,7 +183,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
                                            moveit_msgs::MoveItErrorCodes& error_code,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
-  const IKCallbackFn solution_callback = 0;
+  const IKCallbackFn solution_callback = 0;  // NOLINT(modernize-use-nullptr)
   std::vector<double> consistency_limits;
 
   return searchPositionIK(ik_pose, ik_seed_state, timeout, solution, solution_callback, error_code, consistency_limits,
@@ -195,7 +195,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose, c
                                            std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
-  const IKCallbackFn solution_callback = 0;
+  const IKCallbackFn solution_callback = 0;  // NOLINT(modernize-use-nullptr)
   return searchPositionIK(ik_pose, ik_seed_state, timeout, solution, solution_callback, error_code, consistency_limits,
                           options);
 }

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -68,10 +68,7 @@ inline bool getParam(const std::string& param, T& val)
 
   // then in local namespace
   ros::NodeHandle nh;
-  if (nh.getParam(param, val))
-    return true;
-
-  return false;
+  return nh.getParam(param, val);
 }
 
 // As loading of parameters is quite slow, we share them across all tests

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -74,4 +74,4 @@ void CHOMPInterface::loadParams()
   nh_.param("enable_failure_recovery", params_.enable_failure_recovery_, false);
   nh_.param("max_recovery_attempts", params_.max_recovery_attempts_, 5);
 }
-}
+}  // namespace chomp_interface

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -18,8 +18,7 @@ CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::s
   chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface());
 }
 
-CHOMPPlanningContext::~CHOMPPlanningContext()
-= default;
+CHOMPPlanningContext::~CHOMPPlanningContext() = default;
 
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -19,8 +19,7 @@ CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::s
 }
 
 CHOMPPlanningContext::~CHOMPPlanningContext()
-{
-}
+= default;
 
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -114,6 +114,6 @@ protected:
   std::map<std::string, CHOMPPlanningContextPtr> planning_contexts_;
 };
 
-}  // ompl_interface_ros
+}  // namespace chomp_interface
 
 PLUGINLIB_EXPORT_CLASS(chomp_interface::CHOMPPlannerManager, planning_interface::PlannerManager);

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -101,6 +101,5 @@ void ChompCost::scale(double scale)
   quad_cost_full_ *= scale;
 }
 
-ChompCost::~ChompCost()
-= default;
+ChompCost::~ChompCost() = default;
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -103,4 +103,4 @@ void ChompCost::scale(double scale)
 
 ChompCost::~ChompCost()
 = default;
-}
+}  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -102,6 +102,5 @@ void ChompCost::scale(double scale)
 }
 
 ChompCost::~ChompCost()
-{
-}
+= default;
 }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -217,12 +217,12 @@ void ChompOptimizer::initialize()
             joint_model_group_->getUpdatedLinkModels()[i]->getParentJointModel()->getName()) ==
         fixed_link_resolution_map.end())
     {
-      const moveit::core::JointModel* parent_model = NULL;
+      const moveit::core::JointModel* parent_model = nullptr;
       bool found_root = false;
 
       while (!found_root)
       {
-        if (parent_model == NULL)
+        if (parent_model == nullptr)
         {
           parent_model = joint_model_group_->getUpdatedLinkModels()[i]->getParentJointModel();
         }
@@ -276,7 +276,7 @@ ChompOptimizer::~ChompOptimizer()
 
 void ChompOptimizer::registerParents(const moveit::core::JointModel* model)
 {
-  const moveit::core::JointModel* parent_model = NULL;
+  const moveit::core::JointModel* parent_model = nullptr;
   bool found_root = false;
 
   if (model == robot_model_->getRootJoint())
@@ -284,14 +284,14 @@ void ChompOptimizer::registerParents(const moveit::core::JointModel* model)
 
   while (!found_root)
   {
-    if (parent_model == NULL)
+    if (parent_model == nullptr)
     {
-      if (model->getParentLinkModel() == NULL)
+      if (model->getParentLinkModel() == nullptr)
       {
         ROS_ERROR_STREAM("Model " << model->getName() << " not root but has NULL link model parent");
         return;
       }
-      else if (model->getParentLinkModel()->getParentJointModel() == NULL)
+      else if (model->getParentLinkModel()->getParentJointModel() == nullptr)
       {
         ROS_ERROR_STREAM("Model " << model->getName() << " not root but has NULL joint model parent");
         return;
@@ -792,11 +792,11 @@ void ChompOptimizer::computeJointProperties(int trajectory_point)
     // joint_transform = inverseWorldTransform * jointTransform;
     Eigen::Vector3d axis;
 
-    if (revolute_joint != NULL)
+    if (revolute_joint != nullptr)
     {
       axis = revolute_joint->getAxis();
     }
-    else if (prismatic_joint != NULL)
+    else if (prismatic_joint != nullptr)
     {
       axis = prismatic_joint->getAxis();
     }
@@ -946,7 +946,7 @@ void ChompOptimizer::performForwardKinematics()
     setRobotStateFromPoint(group_trajectory_, i);
     ros::WallTime grad = ros::WallTime::now();
 
-    hy_world_->getCollisionGradients(req, res, *hy_robot_->getCollisionRobotDistanceField().get(), state_, NULL, gsr_);
+    hy_world_->getCollisionGradients(req, res, *hy_robot_->getCollisionRobotDistanceField().get(), state_, nullptr, gsr_);
     total_dur += (ros::WallTime::now() - grad);
     computeJointProperties(i);
     state_is_in_collision_[i] = false;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -128,7 +128,7 @@ void ChompOptimizer::initialize()
   {
     const moveit::core::JointModel* model = joint_models[i];
     double joint_cost = 1.0;
-    std::string joint_name = model->getName();
+    const std::string& joint_name = model->getName();
     // nh.param("joint_costs/" + joint_name, joint_cost, 1.0);
     std::vector<double> derivative_costs(3);
     derivative_costs[0] = joint_cost * parameters_->smoothness_cost_velocity_;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -946,7 +946,8 @@ void ChompOptimizer::performForwardKinematics()
     setRobotStateFromPoint(group_trajectory_, i);
     ros::WallTime grad = ros::WallTime::now();
 
-    hy_world_->getCollisionGradients(req, res, *hy_robot_->getCollisionRobotDistanceField().get(), state_, nullptr, gsr_);
+    hy_world_->getCollisionGradients(req, res, *hy_robot_->getCollisionRobotDistanceField().get(), state_, nullptr,
+                                     gsr_);
     total_dur += (ros::WallTime::now() - grad);
     computeJointProperties(i);
     state_is_in_collision_[i] = false;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -71,8 +71,7 @@ ChompParameters::ChompParameters()
 }
 
 ChompParameters::~ChompParameters()
-{
-}
+= default;
 
 void ChompParameters::setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit,
                                         int max_iterations)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -70,8 +70,7 @@ ChompParameters::ChompParameters()
   max_recovery_attempts_ = 5;
 }
 
-ChompParameters::~ChompParameters()
-= default;
+ChompParameters::~ChompParameters() = default;
 
 void ChompParameters::setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit,
                                         int max_iterations)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -44,8 +44,7 @@
 namespace chomp
 {
 ChompPlanner::ChompPlanner()
-{
-}
+= default;
 
 bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
                          const moveit_msgs::MotionPlanRequest& req, const chomp::ChompParameters& params,

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -43,8 +43,7 @@
 
 namespace chomp
 {
-ChompPlanner::ChompPlanner()
-= default;
+ChompPlanner::ChompPlanner() = default;
 
 bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
                          const moveit_msgs::MotionPlanRequest& req, const chomp::ChompParameters& params,

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -114,7 +114,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     const moveit::core::RevoluteJointModel* revolute_joint =
         dynamic_cast<const moveit::core::RevoluteJointModel*>(model);
 
-    if (revolute_joint != NULL)
+    if (revolute_joint != nullptr)
     {
       if (revolute_joint->isContinuous())
       {

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -299,4 +299,4 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   return true;
 }
-}
+}  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -139,8 +139,7 @@ ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_m
   overwriteTrajectory(traj);
 }
 
-ChompTrajectory::~ChompTrajectory()
-= default;
+ChompTrajectory::~ChompTrajectory() = default;
 
 void ChompTrajectory::overwriteTrajectory(const trajectory_msgs::JointTrajectory& traj)
 {

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -140,8 +140,7 @@ ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_m
 }
 
 ChompTrajectory::~ChompTrajectory()
-{
-}
+= default;
 
 void ChompTrajectory::overwriteTrajectory(const trajectory_msgs::JointTrajectory& traj)
 {

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -223,6 +223,6 @@ private:
   ros::NodeHandle nh_;
   chomp::ChompParameters params_;
 };
-}
+}  // namespace chomp
 
 CLASS_LOADER_REGISTER_CLASS(chomp::OptimizerAdapter, planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -461,7 +461,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
   // construct the constrained states
 
-  robot_state::RobotState robot_state(default_state);
+  robot_state::RobotState robot_state(default_state);  // NOLINT(performance-unnecessary-copy-initialization)
   const constraint_samplers::ConstraintSamplerManagerPtr& csmng = pcontext->getConstraintSamplerManager();
   ConstrainedSampler* csmp = nullptr;
   if (csmng)

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -214,7 +214,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(
       verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *robot_state);
-  if (!res.collision)
+  if (!res.collision)  // NOLINT(readability-simplify-boolean-expr)
   {
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markValid();
     return true;

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -214,16 +214,15 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(
       verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *robot_state);
-  if (!res.collision)  // NOLINT(readability-simplify-boolean-expr)
+  if (!res.collision)
   {
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markValid();
-    return true;
   }
   else
   {
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
-    return false;
   }
+  return !res.collision;
 }
 
 bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State* state, double& dist,

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -406,7 +406,7 @@ void ompl_interface::ModelBasedPlanningContext::convertPath(const ompl::geometri
 bool ompl_interface::ModelBasedPlanningContext::getSolutionPath(robot_trajectory::RobotTrajectory& traj) const
 {
   traj.clear();
-  if (!ompl_simple_setup_->haveSolutionPath())
+  if (!ompl_simple_setup_->haveSolutionPath())  // NOLINT(readability-simplify-boolean-expr)
     return false;
   convertPath(ompl_simple_setup_->getSolutionPath(), traj);
   return true;

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -288,7 +288,8 @@ bool ompl_interface::PoseModelStateSpace::computeStateK(ompl::base::State* state
     return computeStateFK(state);
   if (!state->as<StateType>()->jointsComputed() && state->as<StateType>()->poseComputed())
     return computeStateIK(state);
-  if (state->as<StateType>()->jointsComputed() && state->as<StateType>()->poseComputed())  // NOLINT(readability-simplify-boolean-expr)
+  if (state->as<StateType>()->jointsComputed() &&
+      state->as<StateType>()->poseComputed())  // NOLINT(readability-simplify-boolean-expr)
     return true;
   state->as<StateType>()->markInvalid();
   return false;

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -288,7 +288,7 @@ bool ompl_interface::PoseModelStateSpace::computeStateK(ompl::base::State* state
     return computeStateFK(state);
   if (!state->as<StateType>()->jointsComputed() && state->as<StateType>()->poseComputed())
     return computeStateIK(state);
-  if (state->as<StateType>()->jointsComputed() && state->as<StateType>()->poseComputed())
+  if (state->as<StateType>()->jointsComputed() && state->as<StateType>()->poseComputed())  // NOLINT(readability-simplify-boolean-expr)
     return true;
   state->as<StateType>()->markInvalid();
   return false;

--- a/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
+++ b/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
@@ -81,8 +81,7 @@ public:
   }
 
   ~MoveItControllerManagerExample() override
-  {
-  }
+  = default;
 
   moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
   {

--- a/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
+++ b/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
@@ -61,7 +61,7 @@ public:
     return true;
   }
 
-  bool waitForExecution(const ros::Duration&) override
+  bool waitForExecution(const ros::Duration& /*timeout*/) override
   {
     // wait for the current execution to finish
     return true;

--- a/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
+++ b/moveit_plugins/moveit_controller_manager_example/src/moveit_controller_manager_example.cpp
@@ -80,8 +80,7 @@ public:
   {
   }
 
-  ~MoveItControllerManagerExample() override
-  = default;
+  ~MoveItControllerManagerExample() override = default;
 
   moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
   {

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -197,8 +197,7 @@ public:
   }
 
   ~MoveItFakeControllerManager() override
-  {
-  }
+  = default;
 
   /*
    * Get a controller, by controller name (which was specified in the controllers.yaml

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -134,7 +134,7 @@ public:
     }
 
     robot_model_loader::RobotModelLoader robot_model_loader(ROBOT_DESCRIPTION);
-    robot_model::RobotModelPtr robot_model = robot_model_loader.getModel();
+    const robot_model::RobotModelPtr& robot_model = robot_model_loader.getModel();
     typedef std::map<std::string, double> JointPoseMap;
     JointPoseMap joints;
 

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -196,8 +196,7 @@ public:
     return js;
   }
 
-  ~MoveItFakeControllerManager() override
-  = default;
+  ~MoveItFakeControllerManager() override = default;
 
   /*
    * Get a controller, by controller name (which was specified in the controllers.yaml

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -216,7 +216,7 @@ void interpolate(sensor_msgs::JointState& js, const trajectory_msgs::JointTrajec
     js.position[i] = prev.positions[i] + alpha * (next.positions[i] - prev.positions[i]);
   }
 }
-}
+}  // namespace
 
 void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
 {

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -97,7 +97,7 @@ bool LastPointController::cancelExecution()
   return true;
 }
 
-bool LastPointController::waitForExecution(const ros::Duration&)
+bool LastPointController::waitForExecution(const ros::Duration& /*timeout*/)
 {
   ros::Duration(0.5).sleep();  // give some time to receive the published JointState
   return true;
@@ -137,7 +137,7 @@ bool ThreadedController::cancelExecution()
   return true;
 }
 
-bool ThreadedController::waitForExecution(const ros::Duration&)
+bool ThreadedController::waitForExecution(const ros::Duration& /*timeout*/)
 {
   thread_.join();
   status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -71,8 +71,7 @@ LastPointController::LastPointController(const std::string& name, const std::vec
 }
 
 LastPointController::~LastPointController()
-{
-}
+= default;
 
 bool LastPointController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
@@ -157,8 +156,7 @@ ViaPointController::ViaPointController(const std::string& name, const std::vecto
 }
 
 ViaPointController::~ViaPointController()
-{
-}
+= default;
 
 void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
@@ -200,8 +198,7 @@ InterpolatingController::InterpolatingController(const std::string& name, const 
 }
 
 InterpolatingController::~InterpolatingController()
-{
-}
+= default;
 
 namespace
 {

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -70,8 +70,7 @@ LastPointController::LastPointController(const std::string& name, const std::vec
 {
 }
 
-LastPointController::~LastPointController()
-= default;
+LastPointController::~LastPointController() = default;
 
 bool LastPointController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
@@ -155,8 +154,7 @@ ViaPointController::ViaPointController(const std::string& name, const std::vecto
 {
 }
 
-ViaPointController::~ViaPointController()
-= default;
+ViaPointController::~ViaPointController() = default;
 
 void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
@@ -197,8 +195,7 @@ InterpolatingController::InterpolatingController(const std::string& name, const 
     rate_ = ros::WallRate(r);
 }
 
-InterpolatingController::~InterpolatingController()
-= default;
+InterpolatingController::~InterpolatingController() = default;
 
 namespace
 {

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -136,7 +136,7 @@ const char* errorCodeToMessage(int error_code)
       return "unknown error";
   }
 }
-}
+}  // namespace
 
 void FollowJointTrajectoryControllerHandle::configure(XmlRpc::XmlRpcValue& config, const std::string& config_name,
                                                       std::vector<control_msgs::JointTolerance>& tolerances)

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -158,8 +158,7 @@ public:
     }
   }
 
-  ~MoveItSimpleControllerManager() override
-  = default;
+  ~MoveItSimpleControllerManager() override = default;
 
   /*
    * Get a controller, by controller name (which was specified in the controllers.yaml

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -159,8 +159,7 @@ public:
   }
 
   ~MoveItSimpleControllerManager() override
-  {
-  }
+  = default;
 
   /*
    * Get a controller, by controller name (which was specified in the controllers.yaml

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -102,12 +102,12 @@ public:
   // given set of classes
   void initialize(const std::vector<std::string>& plugin_classes);
 
-  void addPreRunEvent(PreRunEventFunction func);
-  void addPostRunEvent(PostRunEventFunction func);
-  void addPlannerStartEvent(PlannerStartEventFunction func);
-  void addPlannerCompletionEvent(PlannerCompletionEventFunction func);
-  void addQueryStartEvent(QueryStartEventFunction func);
-  void addQueryCompletionEvent(QueryCompletionEventFunction func);
+  void addPreRunEvent(const PreRunEventFunction& func);
+  void addPostRunEvent(const PostRunEventFunction& func);
+  void addPlannerStartEvent(const PlannerStartEventFunction& func);
+  void addPlannerCompletionEvent(const PlannerCompletionEventFunction& func);
+  void addQueryStartEvent(const QueryStartEventFunction& func);
+  void addQueryCompletionEvent(const QueryCompletionEventFunction& func);
 
   virtual void clear();
 
@@ -146,7 +146,7 @@ protected:
 
   virtual void writeOutput(const BenchmarkRequest& brequest, const std::string& start_time, double benchmark_duration);
 
-  void shiftConstraintsByOffset(moveit_msgs::Constraints& constraints, const std::vector<double> offset);
+  void shiftConstraintsByOffset(moveit_msgs::Constraints& constraints, const std::vector<double>& offset);
 
   /// Check that the desired planner plugins and algorithms exist for the given group
   bool plannerConfigurationsExist(const std::map<std::string, std::vector<std::string>>& planners,

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -179,32 +179,32 @@ void BenchmarkExecutor::clear()
   query_end_fns_.clear();
 }
 
-void BenchmarkExecutor::addPreRunEvent(PreRunEventFunction func)
+void BenchmarkExecutor::addPreRunEvent(const PreRunEventFunction& func)
 {
   pre_event_fns_.push_back(func);
 }
 
-void BenchmarkExecutor::addPostRunEvent(PostRunEventFunction func)
+void BenchmarkExecutor::addPostRunEvent(const PostRunEventFunction& func)
 {
   post_event_fns_.push_back(func);
 }
 
-void BenchmarkExecutor::addPlannerStartEvent(PlannerStartEventFunction func)
+void BenchmarkExecutor::addPlannerStartEvent(const PlannerStartEventFunction& func)
 {
   planner_start_fns_.push_back(func);
 }
 
-void BenchmarkExecutor::addPlannerCompletionEvent(PlannerCompletionEventFunction func)
+void BenchmarkExecutor::addPlannerCompletionEvent(const PlannerCompletionEventFunction& func)
 {
   planner_completion_fns_.push_back(func);
 }
 
-void BenchmarkExecutor::addQueryStartEvent(QueryStartEventFunction func)
+void BenchmarkExecutor::addQueryStartEvent(const QueryStartEventFunction& func)
 {
   query_start_fns_.push_back(func);
 }
 
-void BenchmarkExecutor::addQueryCompletionEvent(QueryCompletionEventFunction func)
+void BenchmarkExecutor::addQueryCompletionEvent(const QueryCompletionEventFunction& func)
 {
   query_end_fns_.push_back(func);
 }
@@ -436,7 +436,7 @@ bool BenchmarkExecutor::initializeBenchmarks(const BenchmarkOptions& opts, movei
 }
 
 void BenchmarkExecutor::shiftConstraintsByOffset(moveit_msgs::Constraints& constraints,
-                                                 const std::vector<double> offset)
+                                                 const std::vector<double>& offset)
 {
   Eigen::Isometry3d offset_tf(Eigen::AngleAxis<double>(offset[3], Eigen::Vector3d::UnitX()) *
                               Eigen::AngleAxis<double>(offset[4], Eigen::Vector3d::UnitY()) *

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -211,7 +211,7 @@ void BenchmarkExecutor::addQueryCompletionEvent(const QueryCompletionEventFuncti
 
 bool BenchmarkExecutor::runBenchmarks(const BenchmarkOptions& opts)
 {
-  if (planner_interfaces_.size() == 0)
+  if (planner_interfaces_.empty())
   {
     ROS_ERROR("No planning interfaces configured.  Did you call BenchmarkExecutor::initialize?");
     return false;
@@ -368,8 +368,8 @@ bool BenchmarkExecutor::initializeBenchmarks(const BenchmarkOptions& opts, movei
     if (brequest.request.goal_constraints.size() == 1 &&
         brequest.request.goal_constraints[0].position_constraints.size() == 1 &&
         brequest.request.goal_constraints[0].orientation_constraints.size() == 1 &&
-        brequest.request.goal_constraints[0].visibility_constraints.size() == 0 &&
-        brequest.request.goal_constraints[0].joint_constraints.size() == 0)
+        brequest.request.goal_constraints[0].visibility_constraints.empty() &&
+        brequest.request.goal_constraints[0].joint_constraints.empty())
       shiftConstraintsByOffset(brequest.request.goal_constraints[0], goal_offset);
 
     std::vector<BenchmarkRequest> request_combos;
@@ -421,8 +421,8 @@ bool BenchmarkExecutor::initializeBenchmarks(const BenchmarkOptions& opts, movei
     if (brequest.request.trajectory_constraints.constraints.size() == 1 &&
         brequest.request.trajectory_constraints.constraints[0].position_constraints.size() == 1 &&
         brequest.request.trajectory_constraints.constraints[0].orientation_constraints.size() == 1 &&
-        brequest.request.trajectory_constraints.constraints[0].visibility_constraints.size() == 0 &&
-        brequest.request.trajectory_constraints.constraints[0].joint_constraints.size() == 0)
+        brequest.request.trajectory_constraints.constraints[0].visibility_constraints.empty() &&
+        brequest.request.trajectory_constraints.constraints[0].joint_constraints.empty())
       shiftConstraintsByOffset(brequest.request.trajectory_constraints.constraints[0], goal_offset);
 
     std::vector<BenchmarkRequest> request_combos;
@@ -645,7 +645,7 @@ bool BenchmarkExecutor::loadQueries(const std::string& regex, const std::string&
 
 bool BenchmarkExecutor::loadStates(const std::string& regex, std::vector<StartState>& start_states)
 {
-  if (regex.size())
+  if (!regex.empty())
   {
     boost::regex start_regex(regex);
     std::vector<std::string> state_names;
@@ -683,7 +683,7 @@ bool BenchmarkExecutor::loadStates(const std::string& regex, std::vector<StartSt
 
 bool BenchmarkExecutor::loadPathConstraints(const std::string& regex, std::vector<PathConstraints>& constraints)
 {
-  if (regex.size())
+  if (!regex.empty())
   {
     std::vector<std::string> cnames;
     cs_->getKnownConstraints(regex, cnames);
@@ -719,7 +719,7 @@ bool BenchmarkExecutor::loadPathConstraints(const std::string& regex, std::vecto
 bool BenchmarkExecutor::loadTrajectoryConstraints(const std::string& regex,
                                                   std::vector<TrajectoryConstraints>& constraints)
 {
-  if (regex.size())
+  if (!regex.empty())
   {
     std::vector<std::string> cnames;
     tcs_->getKnownTrajectoryConstraints(regex, cnames);
@@ -920,7 +920,7 @@ void BenchmarkExecutor::writeOutput(const BenchmarkRequest& brequest, const std:
     hostname = "UNKNOWN";
 
   std::string filename = options_.getOutputDirectory();
-  if (filename.size() && filename[filename.size() - 1] != '/')
+  if (!filename.empty() && filename[filename.size() - 1] != '/')
     filename.append("/");
 
   // Ensure directories exist

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -64,11 +64,11 @@ static std::string getHostname()
 
 BenchmarkExecutor::BenchmarkExecutor(const std::string& robot_description_param)
 {
-  pss_ = NULL;
-  psws_ = NULL;
-  rs_ = NULL;
-  cs_ = NULL;
-  tcs_ = NULL;
+  pss_ = nullptr;
+  psws_ = nullptr;
+  rs_ = nullptr;
+  cs_ = nullptr;
+  tcs_ = nullptr;
   psm_ = new planning_scene_monitor::PlanningSceneMonitor(robot_description_param);
   planning_scene_ = psm_->getPlanningScene();
 
@@ -147,27 +147,27 @@ void BenchmarkExecutor::clear()
   if (pss_)
   {
     delete pss_;
-    pss_ = NULL;
+    pss_ = nullptr;
   }
   if (psws_)
   {
     delete psws_;
-    psws_ = NULL;
+    psws_ = nullptr;
   }
   if (rs_)
   {
     delete rs_;
-    rs_ = NULL;
+    rs_ = nullptr;
   }
   if (cs_)
   {
     delete cs_;
-    cs_ = NULL;
+    cs_ = nullptr;
   }
   if (tcs_)
   {
     delete tcs_;
-    tcs_ = NULL;
+    tcs_ = nullptr;
   }
 
   benchmark_data_.clear();

--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -48,8 +48,7 @@ BenchmarkOptions::BenchmarkOptions(const std::string& ros_namespace)
 }
 
 BenchmarkOptions::~BenchmarkOptions()
-{
-}
+= default;
 
 void BenchmarkOptions::setNamespace(const std::string& ros_namespace)
 {

--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -47,8 +47,7 @@ BenchmarkOptions::BenchmarkOptions(const std::string& ros_namespace)
   readBenchmarkOptions(ros_namespace);
 }
 
-BenchmarkOptions::~BenchmarkOptions()
-= default;
+BenchmarkOptions::~BenchmarkOptions() = default;
 
 void BenchmarkOptions::setNamespace(const std::string& ros_namespace)
 {

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -190,7 +190,7 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
   }
 }
 
-}  // annonymous namespace
+}  // namespace
 
 bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 {
@@ -357,4 +357,4 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 
   return false;
 }
-}
+}  // namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -66,7 +66,7 @@ bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
   req.verbose = verbose;
   req.group_name = group->getName();
 
-  if (grasp_posture->joint_names.size() > 0)
+  if (!grasp_posture->joint_names.empty())
   {
     // apply the grasp posture for the end effector (we always apply it here since it could be the case the sampler
     // changes this posture)
@@ -164,7 +164,7 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
     ee_closed_traj->setRobotTrajectoryMsg(*ee_closed_state, plan->retreat_posture_);
     // If user has defined a time for it's gripper movement time, don't add the
     // DEFAULT_GRASP_POSTURE_COMPLETION_DURATION
-    if (plan->retreat_posture_.points.size() > 0 &&
+    if (!plan->retreat_posture_.points.empty() &&
         plan->retreat_posture_.points.back().time_from_start > ros::Duration(0.0))
     {
       ee_closed_traj->addPrefixWayPoint(ee_closed_state, 0.0);

--- a/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -42,7 +42,7 @@ namespace pick_place
 ManipulationPipeline::ManipulationPipeline(const std::string& name, unsigned int nthreads)
   : name_(name), nthreads_(nthreads), verbose_(false), stop_processing_(true)
 {
-  processing_threads_.resize(nthreads, NULL);
+  processing_threads_.resize(nthreads, nullptr);
 }
 
 ManipulationPipeline::~ManipulationPipeline()
@@ -133,7 +133,7 @@ void ManipulationPipeline::stop()
     {
       processing_threads_[i]->join();
       delete processing_threads_[i];
-      processing_threads_[i] = NULL;
+      processing_threads_[i] = nullptr;
     }
 }
 

--- a/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -173,7 +173,7 @@ void ManipulationPipeline::processingThread(unsigned int index)
         {
           bool res = stages_[i]->evaluate(g);
           g->processing_stage_ = i + 1;
-          if (res == false)
+          if (!res)
           {
             boost::mutex::scoped_lock slock(result_lock_);
             failed_.push_back(g);

--- a/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/moveit_ros/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -227,4 +227,4 @@ void ManipulationPipeline::reprocessLastFailure()
                                             << name_ << "'. Queue is now of size " << queue_.size());
   queue_access_cond_.notify_all();
 }
-}
+}  // namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -109,7 +109,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                                                              << planning_group << "'");
   }
   const robot_model::JointModelGroup* eef =
-      end_effector.empty() ? NULL : planning_scene->getRobotModel()->getEndEffector(end_effector);
+      end_effector.empty() ? nullptr : planning_scene->getRobotModel()->getEndEffector(end_effector);
   if (!eef)
   {
     ROS_ERROR_NAMED("manipulation", "No end-effector specified for pick action");

--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -61,7 +61,7 @@ struct OrderGraspQuality
 
   const std::vector<moveit_msgs::Grasp>& grasps_;
 };
-}
+}  // namespace
 
 bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::PickupGoal& goal)
 {
@@ -252,4 +252,4 @@ PickPlanPtr PickPlace::planPick(const planning_scene::PlanningSceneConstPtr& pla
 
   return p;
 }
-}
+}  // namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -206,7 +206,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
     else
     {
       error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
-      if (goal.possible_grasps.size() > 0)
+      if (!goal.possible_grasps.empty())
       {
         ROS_WARN_NAMED("manipulation", "All supplied grasps failed. Retrying last grasp in verbose mode.");
         // everything failed. we now start the pipeline again in verbose mode for one grasp

--- a/moveit_ros/manipulation/pick_place/src/pick_place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place.cpp
@@ -173,7 +173,7 @@ std::vector<std_msgs::ColorRGBA> setupDefaultGraspColors()
   result[5].a = 0.75f;
   return result;
 }
-}
+}  // namespace
 
 void PickPlace::visualizeGrasps(const std::vector<ManipulationPlanPtr>& plans) const
 {
@@ -200,4 +200,4 @@ void PickPlace::visualizeGrasps(const std::vector<ManipulationPlanPtr>& plans) c
 
   grasps_publisher_.publish(ma);
 }
-}
+}  // namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/pick_place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place.cpp
@@ -57,8 +57,7 @@ PickPlacePlanBase::PickPlacePlanBase(const PickPlaceConstPtr& pick_place, const 
 }
 
 PickPlacePlanBase::~PickPlacePlanBase()
-{
-}
+= default;
 
 void PickPlacePlanBase::foundSolution()
 {

--- a/moveit_ros/manipulation/pick_place/src/pick_place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place.cpp
@@ -56,8 +56,7 @@ PickPlacePlanBase::PickPlacePlanBase(const PickPlaceConstPtr& pick_place, const 
   pipeline_.setEmptyQueueCallback(boost::bind(&PickPlacePlanBase::emptyQueue, this));
 }
 
-PickPlacePlanBase::~PickPlacePlanBase()
-= default;
+PickPlacePlanBase::~PickPlacePlanBase() = default;
 
 void PickPlacePlanBase::foundSolution()
 {

--- a/moveit_ros/manipulation/pick_place/src/pick_place_params.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place_params.cpp
@@ -71,8 +71,8 @@ private:
 
   dynamic_reconfigure::Server<PickPlaceDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
-}
-}
+}  // namespace
+}  // namespace pick_place
 
 pick_place::PickPlaceParams::PickPlaceParams() : max_goal_count_(5), max_fail_(3), max_step_(0.02), jump_factor_(2.0)
 {

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -64,7 +64,7 @@ bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
   place_pose.pose = tf2::toMsg(end_effector_transform);
   return true;
 }
-}
+}  // namespace
 
 bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::PlaceGoal& goal)
 {
@@ -391,4 +391,4 @@ PlacePlanPtr PickPlace::planPlace(const planning_scene::PlanningSceneConstPtr& p
 
   return p;
 }
-}
+}  // namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -71,8 +71,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   double timeout = goal.allowed_planning_time;
   ros::WallTime endtime = ros::WallTime::now() + ros::WallDuration(timeout);
   std::string attached_object_name = goal.attached_object_name;
-  const robot_model::JointModelGroup* jmg = NULL;
-  const robot_model::JointModelGroup* eef = NULL;
+  const robot_model::JointModelGroup* jmg = nullptr;
+  const robot_model::JointModelGroup* eef = nullptr;
 
   // if the group specified is actually an end-effector, we use it as such
   if (planning_scene->getRobotModel()->hasEndEffector(goal.group_name))
@@ -96,7 +96,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   else
   {
     // if a group name was specified, try to use it
-    jmg = goal.group_name.empty() ? NULL : planning_scene->getRobotModel()->getJointModelGroup(goal.group_name);
+    jmg = goal.group_name.empty() ? nullptr : planning_scene->getRobotModel()->getJointModelGroup(goal.group_name);
     if (jmg)
     {
       // we also try to find the corresponding eef

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -346,7 +346,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
     else
     {
       error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
-      if (goal.place_locations.size() > 0)
+      if (!goal.place_locations.empty())
       {
         ROS_WARN_NAMED("manipulation", "All supplied place locations failed. Retrying last location in verbose mode.");
         // everything failed. we now start the pipeline again in verbose mode for one grasp

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -120,4 +120,4 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
 
   return false;
 }
-}
+}  // namespace pick_place

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -85,7 +85,7 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
         // Apply the open gripper state to the waypoint
         // If user has defined a time for it's gripper movement time, don't add the
         // DEFAULT_GRASP_POSTURE_COMPLETION_DURATION
-        if (plan->approach_posture_.points.size() > 0 &&
+        if (!plan->approach_posture_.points.empty() &&
             plan->approach_posture_.points.back().time_from_start > ros::Duration(0.0))
         {
           pre_approach_traj->addPrefixWayPoint(pre_approach_state, 0.0);

--- a/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
+++ b/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
@@ -101,7 +101,7 @@ bool pick_place::ReachableAndValidPoseFilter::isEndEffectorFree(const Manipulati
   collision_detection::CollisionResult res;
   req.group_name = plan->shared_data_->end_effector_group_->getName();
   planning_scene_->checkCollision(req, res, token_state, *collision_matrix_);
-  return res.collision == false;
+  return !res.collision;
 }
 
 bool pick_place::ReachableAndValidPoseFilter::evaluate(const ManipulationPlanPtr& plan) const

--- a/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
+++ b/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
@@ -87,7 +87,7 @@ bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
     }
   return planning_scene->isStateFeasible(*state);
 }
-}
+}  // namespace
 
 bool pick_place::ReachableAndValidPoseFilter::isEndEffectorFree(const ManipulationPlanPtr& plan,
                                                                 robot_state::RobotState& token_state) const

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -122,7 +122,7 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
       }
       else
       {
-        if (waypoints.size() > 0)
+        if (!waypoints.empty())
         {
           robot_state::GroupStateValidityCallbackFn constraint_fn;
           std::unique_ptr<planning_scene_monitor::LockedPlanningSceneRO> ls;

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -134,8 +134,8 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
             kset->add(req.path_constraints, (*ls)->getTransforms());
             constraint_fn = boost::bind(
                 &isStateValid,
-                req.avoid_collisions ? static_cast<const planning_scene::PlanningSceneConstPtr&>(*ls).get() : NULL,
-                kset->empty() ? NULL : kset.get(), _1, _2, _3);
+                req.avoid_collisions ? static_cast<const planning_scene::PlanningSceneConstPtr&>(*ls).get() : nullptr,
+                kset->empty() ? nullptr : kset.get(), _1, _2, _3);
           }
           bool global_frame = !robot_state::Transforms::sameFrame(link_name, req.header.frame_id);
           ROS_INFO("Attempting to follow %u waypoints for link '%s' using a step of %lf m and jump threshold %lf (in "

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -68,7 +68,7 @@ bool isStateValid(const planning_scene::PlanningScene* planning_scene,
   return (!planning_scene || !planning_scene->isStateColliding(*state, group->getName())) &&
          (!constraint_set || constraint_set->decide(*state).satisfied);
 }
-}
+}  // namespace
 
 bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath::Request& req,
                                                                moveit_msgs::GetCartesianPath::Response& res)

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -155,8 +155,8 @@ bool move_group::MoveGroupKinematicsService::computeIKService(moveit_msgs::GetPo
     computeIK(req.ik_request, res.solution, res.error_code, rs,
               boost::bind(&isIKSolutionValid, req.ik_request.avoid_collisions ?
                                                   static_cast<const planning_scene::PlanningSceneConstPtr&>(ls).get() :
-                                                  NULL,
-                          kset.empty() ? NULL : &kset, _1, _2, _3));
+                                                  nullptr,
+                          kset.empty() ? nullptr : &kset, _1, _2, _3));
   }
   else
   {

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -64,7 +64,7 @@ bool isIKSolutionValid(const planning_scene::PlanningScene* planning_scene,
   return (!planning_scene || !planning_scene->isStateColliding(*state, jmg->getName())) &&
          (!constraint_set || constraint_set->decide(*state).satisfied);
 }
-}
+}  // namespace
 
 void move_group::MoveGroupKinematicsService::computeIK(
     moveit_msgs::PositionIKRequest& req, moveit_msgs::RobotState& solution, moveit_msgs::MoveItErrorCodes& error_code,

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -53,7 +53,7 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
 {
   ROS_INFO("Received new planning service request...");
   // before we start planning, ensure that we have the latest robot state received...
-  if (req.motion_plan_request.start_state.is_diff == true)
+  if (static_cast<bool>(req.motion_plan_request.start_state.is_diff))
     context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -177,7 +177,7 @@ private:
   std::shared_ptr<pluginlib::ClassLoader<MoveGroupCapability> > capability_plugin_loader_;
   std::vector<MoveGroupCapabilityPtr> capabilities_;
 };
-}
+}  // namespace move_group
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -83,7 +83,7 @@ void move_group::MoveGroupCapability::convertToMsg(const std::vector<plan_execut
 {
   if (trajectory.size() > 1)
     ROS_ERROR_STREAM("Internal logic error: trajectory component ignored. !!! THIS IS A SERIOUS ERROR !!!");
-  if (trajectory.size() > 0)
+  if (!trajectory.empty())
     convertToMsg(trajectory[0].trajectory_, first_state_msg, trajectory_msg);
 }
 

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -204,7 +204,7 @@ bool host_is_big_endian()
   } bint = { 0x01020304 };
   return bint.c[0] == 1;
 }
-}
+}  // namespace
 
 static const bool HOST_IS_BIG_ENDIAN = host_is_big_endian();
 
@@ -549,4 +549,4 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
 
   ROS_DEBUG("Processed depth image in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
 }
-}
+}  // namespace occupancy_map_monitor

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -195,7 +195,7 @@ bool DepthImageOctomapUpdater::getShapeTransform(mesh_filter::MeshHandle h, Eige
 
 namespace
 {
-bool host_is_big_endian(void)
+bool host_is_big_endian()
 {
   union
   {

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -264,4 +264,4 @@ void LazyFreeSpaceUpdater::lazyUpdateThread()
     }
   }
 }
-}
+}  // namespace occupancy_map_monitor

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -45,8 +45,8 @@ LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned i
   , max_batch_size_(max_batch_size)
   , max_sensor_delta_(1e-3)
   ,  // 1mm
-  process_occupied_cells_set_(NULL)
-  , process_model_cells_set_(NULL)
+  process_occupied_cells_set_(nullptr)
+  , process_model_cells_set_(nullptr)
   , update_thread_(boost::bind(&LazyFreeSpaceUpdater::lazyUpdateThread, this))
   , process_thread_(boost::bind(&LazyFreeSpaceUpdater::processThread, this))
 {
@@ -195,16 +195,16 @@ void LazyFreeSpaceUpdater::processThread()
     ROS_DEBUG("Marked free cells in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
 
     delete process_occupied_cells_set_;
-    process_occupied_cells_set_ = NULL;
+    process_occupied_cells_set_ = nullptr;
     delete process_model_cells_set_;
-    process_model_cells_set_ = NULL;
+    process_model_cells_set_ = nullptr;
   }
 }
 
 void LazyFreeSpaceUpdater::lazyUpdateThread()
 {
-  OcTreeKeyCountMap* occupied_cells_set = NULL;
-  octomap::KeySet* model_cells_set = NULL;
+  OcTreeKeyCountMap* occupied_cells_set = nullptr;
+  octomap::KeySet* model_cells_set = nullptr;
   octomap::point3d sensor_origin;
   unsigned int batch_size = 0;
 
@@ -259,7 +259,7 @@ void LazyFreeSpaceUpdater::lazyUpdateThread()
     {
       ROS_DEBUG("Pushing %u sets of occupied/model cells to free cells update thread", batch_size);
       pushBatchToProcess(occupied_cells_set, model_cells_set, sensor_origin);
-      occupied_cells_set = NULL;
+      occupied_cells_set = nullptr;
       batch_size = 0;
     }
   }

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -130,7 +130,7 @@ void mesh_filter::GLRenderer::initFrameBuffers()
 {
   glGenTextures(1, &rgb_id_);
   glBindTexture(GL_TEXTURE_2D, rgb_id_);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width_, height_, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width_, height_, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -139,7 +139,7 @@ void mesh_filter::GLRenderer::initFrameBuffers()
 
   glGenTextures(1, &depth_id_);
   glBindTexture(GL_TEXTURE_2D, depth_id_);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width_, height_, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width_, height_, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -262,7 +262,7 @@ GLuint mesh_filter::GLRenderer::createShader(GLuint shaderType, const string& Sh
 
   // Compile Shader
   char const* SourcePointer = ShaderCode.c_str();
-  glShaderSource(ShaderID, 1, &SourcePointer, NULL);
+  glShaderSource(ShaderID, 1, &SourcePointer, nullptr);
   glCompileShader(ShaderID);
 
   // Check Shader
@@ -275,7 +275,7 @@ GLuint mesh_filter::GLRenderer::createShader(GLuint shaderType, const string& Sh
     if (InfoLogLength > 0)
     {
       vector<char> ShaderErrorMessage(InfoLogLength + 1);
-      glGetShaderInfoLog(ShaderID, InfoLogLength, NULL, &ShaderErrorMessage[0]);
+      glGetShaderInfoLog(ShaderID, InfoLogLength, nullptr, &ShaderErrorMessage[0]);
       stringstream errorStream;
       errorStream << "Could not compile shader: " << (const char*)&ShaderErrorMessage[0];
 
@@ -340,7 +340,7 @@ GLuint mesh_filter::GLRenderer::loadShaders(const string& vertex_source, const s
   if (InfoLogLength > 0)
   {
     vector<char> ProgramErrorMessage(InfoLogLength + 1);
-    glGetProgramInfoLog(ProgramID, InfoLogLength, NULL, &ProgramErrorMessage[0]);
+    glGetProgramInfoLog(ProgramID, InfoLogLength, nullptr, &ProgramErrorMessage[0]);
     std::size_t l = strnlen(&ProgramErrorMessage[0], ProgramErrorMessage.size());
     if (l > 0)
       ROS_ERROR("%s\n", &ProgramErrorMessage[0]);

--- a/moveit_ros/perception/mesh_filter/src/sensor_model.cpp
+++ b/moveit_ros/perception/mesh_filter/src/sensor_model.cpp
@@ -39,8 +39,7 @@
 #include <stdexcept>
 
 mesh_filter::SensorModel::~SensorModel()
-{
-}
+= default;
 
 mesh_filter::SensorModel::Parameters::Parameters(unsigned width, unsigned height, float near_clipping_plane_distance,
                                                  float far_clipping_plane_distance)
@@ -52,8 +51,7 @@ mesh_filter::SensorModel::Parameters::Parameters(unsigned width, unsigned height
 }
 
 mesh_filter::SensorModel::Parameters::~Parameters()
-{
-}
+= default;
 
 void mesh_filter::SensorModel::Parameters::setImageSize(unsigned width, unsigned height)
 {

--- a/moveit_ros/perception/mesh_filter/src/sensor_model.cpp
+++ b/moveit_ros/perception/mesh_filter/src/sensor_model.cpp
@@ -101,7 +101,7 @@ inline bool isAligned16(const void* pointer)
 {
   return (((uintptr_t)pointer & 15) == 0);
 }
-}
+}  // namespace
 
 void mesh_filter::SensorModel::Parameters::transformModelDepthToMetricDepth(float* depth) const
 {

--- a/moveit_ros/perception/mesh_filter/src/sensor_model.cpp
+++ b/moveit_ros/perception/mesh_filter/src/sensor_model.cpp
@@ -38,8 +38,7 @@
 #include <stdint.h>
 #include <stdexcept>
 
-mesh_filter::SensorModel::~SensorModel()
-= default;
+mesh_filter::SensorModel::~SensorModel() = default;
 
 mesh_filter::SensorModel::Parameters::Parameters(unsigned width, unsigned height, float near_clipping_plane_distance,
                                                  float far_clipping_plane_distance)
@@ -50,8 +49,7 @@ mesh_filter::SensorModel::Parameters::Parameters(unsigned width, unsigned height
 {
 }
 
-mesh_filter::SensorModel::Parameters::~Parameters()
-= default;
+mesh_filter::SensorModel::Parameters::~Parameters() = default;
 
 void mesh_filter::SensorModel::Parameters::setImageSize(unsigned width, unsigned height)
 {

--- a/moveit_ros/perception/mesh_filter/src/stereo_camera_model.cpp
+++ b/moveit_ros/perception/mesh_filter/src/stereo_camera_model.cpp
@@ -55,8 +55,7 @@ mesh_filter::StereoCameraModel::Parameters::Parameters(unsigned width, unsigned 
 }
 
 mesh_filter::StereoCameraModel::Parameters::~Parameters()
-{
-}
+= default;
 
 mesh_filter::SensorModel::Parameters* mesh_filter::StereoCameraModel::Parameters::clone() const
 {

--- a/moveit_ros/perception/mesh_filter/src/stereo_camera_model.cpp
+++ b/moveit_ros/perception/mesh_filter/src/stereo_camera_model.cpp
@@ -54,8 +54,7 @@ mesh_filter::StereoCameraModel::Parameters::Parameters(unsigned width, unsigned 
 {
 }
 
-mesh_filter::StereoCameraModel::Parameters::~Parameters()
-= default;
+mesh_filter::StereoCameraModel::Parameters::~Parameters() = default;
 
 mesh_filter::SensorModel::Parameters* mesh_filter::StereoCameraModel::Parameters::clone() const
 {

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -352,4 +352,4 @@ OccupancyMapMonitor::~OccupancyMapMonitor()
 {
   stopMonitor();
 }
-}
+}  // namespace occupancy_map_monitor

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -80,4 +80,4 @@ bool OccupancyMapUpdater::updateTransformCache(const std::string& target_frame, 
     return false;
   }
 }
-}
+}  // namespace occupancy_map_monitor

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -43,8 +43,7 @@ OccupancyMapUpdater::OccupancyMapUpdater(const std::string& type) : type_(type)
 {
 }
 
-OccupancyMapUpdater::~OccupancyMapUpdater()
-= default;
+OccupancyMapUpdater::~OccupancyMapUpdater() = default;
 
 void OccupancyMapUpdater::setMonitor(OccupancyMapMonitor* monitor)
 {

--- a/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -44,8 +44,7 @@ OccupancyMapUpdater::OccupancyMapUpdater(const std::string& type) : type_(type)
 }
 
 OccupancyMapUpdater::~OccupancyMapUpdater()
-{
-}
+= default;
 
 void OccupancyMapUpdater::setMonitor(OccupancyMapMonitor* monitor)
 {

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -360,4 +360,4 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
     filtered_cloud_publisher_.publish(*filtered_cloud);
   }
 }
-}
+}  // namespace occupancy_map_monitor

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -155,7 +155,7 @@ void PointCloudOctomapUpdater::forgetShape(ShapeHandle handle)
 bool PointCloudOctomapUpdater::getShapeTransform(ShapeHandle h, Eigen::Isometry3d& transform) const
 {
   ShapeTransformCache::const_iterator it = transform_cache_.find(h);
-  if (it == transform_cache_.end())
+  if (it == transform_cache_.end())  // NOLINT(readability-simplify-boolean-expr)
   {
     return false;
   }

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -155,12 +155,11 @@ void PointCloudOctomapUpdater::forgetShape(ShapeHandle handle)
 bool PointCloudOctomapUpdater::getShapeTransform(ShapeHandle h, Eigen::Isometry3d& transform) const
 {
   ShapeTransformCache::const_iterator it = transform_cache_.find(h);
-  if (it == transform_cache_.end())  // NOLINT(readability-simplify-boolean-expr)
+  if (it != transform_cache_.end())
   {
-    return false;
+    transform = it->second;
   }
-  transform = it->second;
-  return true;
+  return it != transform_cache_.end();
 }
 
 void PointCloudOctomapUpdater::updateMask(const sensor_msgs::PointCloud2& cloud, const Eigen::Vector3d& sensor_origin,

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -55,8 +55,8 @@ PointCloudOctomapUpdater::PointCloudOctomapUpdater()
   , max_range_(std::numeric_limits<double>::infinity())
   , point_subsample_(1)
   , max_update_rate_(0)
-  , point_cloud_subscriber_(NULL)
-  , point_cloud_filter_(NULL)
+  , point_cloud_subscriber_(nullptr)
+  , point_cloud_filter_(nullptr)
 {
 }
 
@@ -132,8 +132,8 @@ void PointCloudOctomapUpdater::stopHelper()
 void PointCloudOctomapUpdater::stop()
 {
   stopHelper();
-  point_cloud_filter_ = NULL;
-  point_cloud_subscriber_ = NULL;
+  point_cloud_filter_ = nullptr;
+  point_cloud_subscriber_ = nullptr;
 }
 
 ShapeHandle PointCloudOctomapUpdater::excludeShape(const shapes::ShapeConstPtr& shape)

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -506,7 +506,7 @@ void SemanticWorld::transformTableArray(object_recognition_msgs::TableArray& tab
 shapes::Mesh* SemanticWorld::orientPlanarPolygon(const shapes::Mesh& polygon) const
 {
   if (polygon.vertex_count < 3 || polygon.triangle_count < 1)
-    return 0;
+    return nullptr;
   // first get the normal of the first triangle of the input polygon
   Eigen::Vector3d vec1, vec2, vec3, normal;
 
@@ -560,7 +560,7 @@ shapes::Mesh* SemanticWorld::orientPlanarPolygon(const shapes::Mesh& polygon) co
 shapes::Mesh* SemanticWorld::createSolidMeshFromPlanarPolygon(const shapes::Mesh& polygon, double thickness) const
 {
   if (polygon.vertex_count < 3 || polygon.triangle_count < 1 || thickness <= 0)
-    return 0;
+    return nullptr;
   // first get the normal of the first triangle of the input polygon
   Eigen::Vector3d vec1, vec2, vec3, normal;
 

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -446,10 +446,7 @@ bool SemanticWorld::isInsideTableContour(const geometry_msgs::Pose& pose, const 
   double result = cv::pointPolygonTest(contours[0], point2f, true);
   ROS_DEBUG("table distance: %f", result);
 
-  if ((int)result >= (int)(min_distance_from_edge * scale_factor))
-    return true;
-
-  return false;
+  return (int)result >= (int)(min_distance_from_edge * scale_factor);
 }
 
 std::string SemanticWorld::findObjectTable(const geometry_msgs::Pose& pose, double min_distance_from_edge,

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -626,5 +626,5 @@ shapes::Mesh* SemanticWorld::createSolidMeshFromPlanarPolygon(const shapes::Mesh
 
   return solid;
 }
-}
-}
+}  // namespace semantic_world
+}  // namespace moveit

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -98,8 +98,7 @@ CollisionPluginLoader::CollisionPluginLoader()
 }
 
 CollisionPluginLoader::~CollisionPluginLoader()
-{
-}
+= default;
 
 bool CollisionPluginLoader::activate(const std::string& name, const planning_scene::PlanningScenePtr& scene,
                                      bool exclusive)

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -97,8 +97,7 @@ CollisionPluginLoader::CollisionPluginLoader()
   loader_.reset(new CollisionPluginLoaderImpl());
 }
 
-CollisionPluginLoader::~CollisionPluginLoader()
-= default;
+CollisionPluginLoader::~CollisionPluginLoader() = default;
 
 bool CollisionPluginLoader::activate(const std::string& name, const planning_scene::PlanningScenePtr& scene,
                                      bool exclusive)

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -93,4 +93,4 @@ ConstraintSamplerManagerLoader::ConstraintSamplerManagerLoader(
   , impl_(new Helper(constraint_sampler_manager_))
 {
 }
-}
+}  // namespace constraint_sampler_manager_loader

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -446,4 +446,4 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const s
 
   return boost::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(), _1);
 }
-}
+}  // namespace kinematics_plugin_loader

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -67,7 +67,7 @@ private:
   PlanExecution* owner_;
   dynamic_reconfigure::Server<PlanExecutionDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
-}
+}  // namespace plan_execution
 
 plan_execution::PlanExecution::PlanExecution(
     const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -484,7 +484,7 @@ void plan_execution::PlanExecution::doneWithTrajectoryExecution(
 void plan_execution::PlanExecution::successfulTrajectorySegmentExecution(const ExecutableMotionPlan* plan,
                                                                          std::size_t index)
 {
-  if (plan->plan_components_.size() == 0)
+  if (plan->plan_components_.empty())
   {
     ROS_WARN_NAMED("plan_execution", "Length of provided motion plan is zero.");
     return;

--- a/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
@@ -68,7 +68,7 @@ private:
   PlanWithSensing* owner_;
   dynamic_reconfigure::Server<SenseForPlanDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
-}
+}  // namespace plan_execution
 
 plan_execution::PlanWithSensing::PlanWithSensing(
     const trajectory_execution_manager::TrajectoryExecutionManagerPtr& trajectory_execution)

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
       moveit::tools::Profiler::End("FK Random");
     }
 
-    std::vector<robot_state::RobotState*> copies(N, (robot_state::RobotState*)NULL);
+    std::vector<robot_state::RobotState*> copies(N, (robot_state::RobotState*)nullptr);
     printf("Evaluating Copy State ...\n");
     for (int i = 0; i < N; ++i)
     {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -73,7 +73,7 @@ public:
 private:
   trajectory_processing::IterativeSplineParameterization time_param_;
 };
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddIterativeSplineParameterization,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -72,7 +72,7 @@ public:
 private:
   trajectory_processing::IterativeParabolicTimeParameterization time_param_;
 };
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::AddTimeParameterization,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -54,6 +54,6 @@ public:
     return planner(planning_scene, req, res);
   }
 };
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::Empty, planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -209,7 +209,7 @@ private:
 
 const std::string FixStartStateBounds::BOUNDS_PARAM_NAME = "start_state_max_bounds_error";
 const std::string FixStartStateBounds::DT_PARAM_NAME = "start_state_max_dt";
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::FixStartStateBounds,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -191,7 +191,7 @@ private:
 const std::string FixStartStateCollision::DT_PARAM_NAME = "start_state_max_dt";
 const std::string FixStartStateCollision::JIGGLE_PARAM_NAME = "jiggle_fraction";
 const std::string FixStartStateCollision::ATTEMPTS_PARAM_NAME = "max_sampling_attempts";
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::FixStartStateCollision,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -128,7 +128,7 @@ public:
     }
   }
 };
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::FixStartStatePathConstraints,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -89,7 +89,7 @@ private:
 };
 
 const std::string FixWorkspaceBounds::WBOUNDS_PARAM_NAME = "default_workspace_bounds";
-}
+}  // namespace default_planner_request_adapters
 
 CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::FixWorkspaceBounds,
                             planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -143,7 +143,7 @@ void planning_scene_monitor::CurrentStateMonitor::startStateMonitor(const std::s
       ROS_ERROR("The joint states topic cannot be an empty string");
     else
       joint_state_subscriber_ = nh_.subscribe(joint_states_topic, 25, &CurrentStateMonitor::jointStateCallback, this);
-    if (tf_buffer_ && robot_model_->getMultiDOFJointModels().size() > 0)
+    if (tf_buffer_ && !robot_model_->getMultiDOFJointModels().empty())
     {
       tf_connection_.reset(new TFConnection(
           tf_buffer_->_addTransformsChangedListener(boost::bind(&CurrentStateMonitor::tfCallback, this))));

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -581,7 +581,7 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningSc
       if (!planning_scene::PlanningScene::isEmpty(scene.robot_state))
       {
         upd = (SceneUpdateType)((int)upd | (int)UPDATE_STATE);
-        if (!scene.robot_state.attached_collision_objects.empty() || scene.robot_state.is_diff == false)
+        if (!scene.robot_state.attached_collision_objects.empty() || !static_cast<bool>(scene.robot_state.is_diff))
           upd = (SceneUpdateType)((int)upd | (int)UPDATE_GEOMETRY);
       }
     }

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -443,7 +443,7 @@ bool sceneIsParentOf(const planning_scene::PlanningSceneConstPtr& scene,
     return sceneIsParentOf(scene->getParent(), possible_parent);
   return false;
 }
-}
+}  // namespace
 
 bool PlanningSceneMonitor::updatesScene(const planning_scene::PlanningScenePtr& scene) const
 {
@@ -1413,4 +1413,4 @@ void PlanningSceneMonitor::configureDefaultPadding()
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_padd_.size() << " default link paddings");
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_scale_.size() << " default link scales");
 }
-}
+}  // namespace planning_scene_monitor

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -185,7 +185,7 @@ bool rdf_loader::RDFLoader::loadXacroFileToString(std::string& buffer, const std
   char pipe_buffer[128];
   while (!feof(pipe))
   {
-    if (fgets(pipe_buffer, 128, pipe) != NULL)
+    if (fgets(pipe_buffer, 128, pipe) != nullptr)
       buffer += pipe_buffer;
   }
   pclose(pipe);

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -81,7 +81,7 @@ bool canSpecifyPosition(const robot_model::JointModel* jmodel, const unsigned in
     ok = true;
   return ok;
 }
-}
+}  // namespace
 
 void RobotModelLoader::configure(const Options& opt)
 {
@@ -226,4 +226,4 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
     }
   }
 }
-}
+}  // namespace robot_model_loader

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -666,7 +666,7 @@ struct OrderPotentialControllerCombination
   std::vector<std::size_t> nrjoints;
   std::vector<std::size_t> nractive;
 };
-}
+}  // namespace
 
 bool TrajectoryExecutionManager::findControllers(const std::set<std::string>& actuated_joints,
                                                  std::size_t controller_count,
@@ -1764,4 +1764,4 @@ void TrajectoryExecutionManager::loadControllerParams()
     }
   }
 }
-}
+}  // namespace trajectory_execution_manager

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1200,7 +1200,7 @@ void TrajectoryExecutionManager::execute(const ExecutionCompleteCallback& callba
   stopExecution(false);
 
   // check whether first trajectory starts at current robot state
-  if (trajectories_.size() && !validate(*trajectories_.front()))
+  if (!trajectories_.empty() && !validate(*trajectories_.front()))
   {
     last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
     if (auto_clear)

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -105,7 +105,7 @@ TrajectoryExecutionManager::~TrajectoryExecutionManager()
 
 void TrajectoryExecutionManager::initialize()
 {
-  reconfigure_impl_ = NULL;
+  reconfigure_impl_ = nullptr;
   verbose_ = false;
   execution_complete_ = true;
   stop_continuous_execution_ = false;
@@ -402,7 +402,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
 
     while (!continuous_execution_queue_.empty())
     {
-      TrajectoryExecutionContext* context = NULL;
+      TrajectoryExecutionContext* context = nullptr;
       {
         boost::mutex::scoped_lock slock(continuous_execution_mutex_);
         if (continuous_execution_queue_.empty())
@@ -811,7 +811,7 @@ bool TrajectoryExecutionManager::distributeTrajectory(const moveit_msgs::RobotTr
     const robot_model::JointModel* jm = robot_model_->getJointModel(trajectory.joint_trajectory.joint_names[i]);
     if (jm)
     {
-      if (jm->isPassive() || jm->getMimic() != NULL || jm->getType() == robot_model::JointModel::FIXED)
+      if (jm->isPassive() || jm->getMimic() != nullptr || jm->getType() == robot_model::JointModel::FIXED)
         continue;
       actuated_joints_single.insert(jm->getName());
     }
@@ -1627,7 +1627,7 @@ bool TrajectoryExecutionManager::ensureActiveControllersForJoints(const std::vec
     const robot_model::JointModel* jm = robot_model_->getJointModel(joints[i]);
     if (jm)
     {
-      if (jm->isPassive() || jm->getMimic() != NULL || jm->getType() == robot_model::JointModel::FIXED)
+      if (jm->isPassive() || jm->getMimic() != nullptr || jm->getType() == robot_model::JointModel::FIXED)
         continue;
       jset.insert(joints[i]);
     }

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -69,7 +69,7 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot
  */
 planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                                                     ros::NodeHandle nh);
+                                                                     const ros::NodeHandle& nh);
 
 }  // namespace planning interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -139,7 +139,7 @@ CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstP
 }
 
 CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
-                                             const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, ros::NodeHandle nh)
+                                             const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::NodeHandle& nh)
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -139,7 +139,8 @@ CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstP
 }
 
 CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
-                                             const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::NodeHandle& nh)
+                                             const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
+                                             const ros::NodeHandle& nh)
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -91,7 +91,7 @@ struct CoupledDeleter
     delete p;
   }
 };
-}
+}  // namespace
 
 namespace moveit
 {

--- a/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
@@ -101,7 +101,7 @@ void demoPlace(moveit::planning_interface::MoveGroupInterface& group)
   group.place("bubu", loc);
 }
 
-void attachObject(void)
+void attachObject()
 {
 }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -693,7 +693,7 @@ public:
 
     std::map<std::string, moveit_msgs::CollisionObject> objects = psi.getObjects(std::vector<std::string>(1, object));
 
-    if (objects.size() < 1)
+    if (objects.empty())
     {
       ROS_ERROR_STREAM_NAMED("move_group_interface", "Asked for grasps for the object '"
                                                          << object << "', but the object could not be found");

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1272,8 +1272,8 @@ private:
   std::unique_ptr<boost::thread> constraints_init_thread_;
   bool initializing_constraints_;
 };
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit
 
 moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(const std::string& group_name,
                                                                    const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
@@ -1830,7 +1830,7 @@ inline void transformPose(const tf2_ros::Buffer& tf_buffer, const std::string& d
     target.header.stamp = ros::Time(0);
   }
 }
-}
+}  // namespace
 
 bool moveit::planning_interface::MoveGroupInterface::setPositionTarget(double x, double y, double z,
                                                                        const std::string& end_effector_link)

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -654,8 +654,8 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("get_named_target_values", &MoveGroupInterfaceWrapper::getNamedTargetValuesPython);
   MoveGroupInterfaceClass.def("get_current_state_bounded", &MoveGroupInterfaceWrapper::getCurrentStateBoundedPython);
 }
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit
 
 BOOST_PYTHON_MODULE(_moveit_move_group_interface)
 {

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -390,5 +390,5 @@ void PlanningSceneInterface::removeCollisionObjects(const std::vector<std::strin
 {
   impl_->removeCollisionObjects(object_ids);
 }
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -71,7 +71,7 @@ public:
     return py_bindings_tools::listFromString(getKnownObjectNamesInROI(minx, miny, minz, maxx, maxy, maxz, with_type));
   }
 
-  bp::dict getObjectPosesPython(bp::list object_ids)
+  bp::dict getObjectPosesPython(const bp::list& object_ids)
   {
     std::map<std::string, geometry_msgs::Pose> ops = getObjectPoses(py_bindings_tools::stringFromList(object_ids));
     std::map<std::string, std::string> ser_ops;
@@ -81,7 +81,7 @@ public:
     return py_bindings_tools::dictFromType(ser_ops);
   }
 
-  bp::dict getObjectsPython(bp::list object_ids)
+  bp::dict getObjectsPython(const bp::list& object_ids)
   {
     std::map<std::string, moveit_msgs::CollisionObject> objs =
         getObjects(py_bindings_tools::stringFromList(object_ids));

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -125,8 +125,8 @@ static void wrap_planning_scene_interface()
   PlanningSceneClass.def("get_attached_objects", &PlanningSceneInterfaceWrapper::getAttachedObjectsPython);
   PlanningSceneClass.def("apply_planning_scene", &PlanningSceneInterfaceWrapper::applyPlanningScenePython);
 }
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit
 
 BOOST_PYTHON_MODULE(_moveit_planning_scene_interface)
 {

--- a/moveit_ros/planning_interface/py_bindings_tools/src/roscpp_initializer.cpp
+++ b/moveit_ros/planning_interface/py_bindings_tools/src/roscpp_initializer.cpp
@@ -83,7 +83,7 @@ struct InitProxy
       ros::shutdown();
   }
 };
-}
+}  // namespace
 
 static void roscpp_init_or_stop(bool init)
 {

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -367,7 +367,7 @@ private:
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
   ros::NodeHandle nh_;
 };
-}
+}  // namespace moveit
 
 static void wrap_robot_interface()
 {

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -233,7 +233,7 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  bp::tuple getEndEffectorParentGroup(std::string group)
+  bp::tuple getEndEffectorParentGroup(const std::string& group)
   {
     // name of the group that is parent to this end-effector group;
     // Second: the link this in the parent group that this group attaches to
@@ -303,7 +303,7 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersPythonList(bp::list links)
+  std::string getRobotMarkersPythonList(const bp::list& links)
   {
     if (!ensureCurrentState())
       return "";
@@ -314,7 +314,7 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersGroup(std::string group)
+  std::string getRobotMarkersGroup(const std::string& group)
   {
     if (!ensureCurrentState())
       return "";
@@ -329,7 +329,7 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersGroupPythonDict(std::string group, bp::dict& values)
+  std::string getRobotMarkersGroupPythonDict(const std::string& group, bp::dict& values)
   {
     const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (!jmg)

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -173,9 +173,9 @@ private:
   // called by decideActiveComponents(); add markers for planar and floating joints
   void decideActiveJoints(const std::string& group);
 
-  void moveInteractiveMarker(const std::string name, const geometry_msgs::PoseStampedConstPtr& msg);
+  void moveInteractiveMarker(const std::string& name, const geometry_msgs::PoseStampedConstPtr& msg);
   // register the name of the topic and marker name to move interactive marker from other ROS nodes
-  void registerMoveInteractiveMarkerTopic(const std::string marker_name, const std::string& name);
+  void registerMoveInteractiveMarkerTopic(const std::string& marker_name, const std::string& name);
   // return the diameter of the sphere that certainly can enclose the AABB of the link
   double computeLinkMarkerSize(const std::string& link);
   // return the diameter of the sphere that certainly can enclose the AABB of the links in this group

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -434,4 +434,4 @@ bool InteractionHandler::getControlsVisible() const
   boost::mutex::scoped_lock lock(state_lock_);
   return display_controls_;
 }
-}
+}  // namespace robot_interaction

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -335,7 +335,7 @@ bool InteractionHandler::inError(const JointInteraction& vj) const
   return false;
 }
 
-void InteractionHandler::clearError(void)
+void InteractionHandler::clearError()
 {
   boost::mutex::scoped_lock lock(state_lock_);
   error_state_.clear();

--- a/moveit_ros/robot_interaction/src/interactive_marker_helpers.cpp
+++ b/moveit_ros/robot_interaction/src/interactive_marker_helpers.cpp
@@ -276,4 +276,4 @@ visualization_msgs::InteractiveMarker make6DOFMarker(const std::string& name, co
   add6DOFControl(int_marker, orientation_fixed);
   return int_marker;
 }
-}
+}  // namespace robot_interaction

--- a/moveit_ros/robot_interaction/src/locked_robot_state.cpp
+++ b/moveit_ros/robot_interaction/src/locked_robot_state.cpp
@@ -52,8 +52,7 @@ robot_interaction::LockedRobotState::LockedRobotState(const robot_model::RobotMo
 }
 
 robot_interaction::LockedRobotState::~LockedRobotState()
-{
-}
+= default;
 
 robot_state::RobotStateConstPtr robot_interaction::LockedRobotState::getState() const
 {

--- a/moveit_ros/robot_interaction/src/locked_robot_state.cpp
+++ b/moveit_ros/robot_interaction/src/locked_robot_state.cpp
@@ -51,8 +51,7 @@ robot_interaction::LockedRobotState::LockedRobotState(const robot_model::RobotMo
   state_->update();
 }
 
-robot_interaction::LockedRobotState::~LockedRobotState()
-= default;
+robot_interaction::LockedRobotState::~LockedRobotState() = default;
 
 robot_state::RobotStateConstPtr robot_interaction::LockedRobotState::getState() const
 {

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -568,7 +568,7 @@ void RobotInteraction::toggleMoveInteractiveMarkerTopic(bool enable)
   if (enable)
   {
     boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
-    if (int_marker_move_subscribers_.size() == 0)
+    if (int_marker_move_subscribers_.empty())
     {
       ros::NodeHandle nh;
       for (size_t i = 0; i < int_marker_move_topics_.size(); i++)

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -709,7 +709,7 @@ void RobotInteraction::processInteractiveMarkerFeedback(
     return;
   }
 
-  std::size_t u = feedback->marker_name.find_first_of("_");
+  std::size_t u = feedback->marker_name.find_first_of('_');
   if (u == std::string::npos || u < 4)
   {
     ROS_ERROR("Invalid marker name: '%s'", feedback->marker_name.c_str());
@@ -744,7 +744,7 @@ void RobotInteraction::processingThread()
                   feedback->marker_name.c_str());
         continue;
       }
-      std::size_t u = feedback->marker_name.find_first_of("_");
+      std::size_t u = feedback->marker_name.find_first_of('_');
       if (u == std::string::npos || u < 4)
       {
         ROS_ERROR("Invalid marker name: '%s' (should never have ended up in the feedback_map!)",

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -553,7 +553,7 @@ void RobotInteraction::addInteractiveMarkers(const InteractionHandlerPtr& handle
   }
 }
 
-void RobotInteraction::registerMoveInteractiveMarkerTopic(const std::string marker_name, const std::string& name)
+void RobotInteraction::registerMoveInteractiveMarkerTopic(const std::string& marker_name, const std::string& name)
 {
   ros::NodeHandle nh;
   std::stringstream ss;
@@ -678,7 +678,7 @@ bool RobotInteraction::showingMarkers(const InteractionHandlerPtr& handler)
   return true;
 }
 
-void RobotInteraction::moveInteractiveMarker(const std::string name, const geometry_msgs::PoseStampedConstPtr& msg)
+void RobotInteraction::moveInteractiveMarker(const std::string& name, const geometry_msgs::PoseStampedConstPtr& msg)
 {
   std::map<std::string, std::size_t>::const_iterator it = shown_markers_.find(name);
   if (it != shown_markers_.end())

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -134,7 +134,7 @@ double RobotInteraction::computeLinkMarkerSize(const std::string& link)
     if (lm->getParentJointModel()->getType() == robot_model::JointModel::FIXED)
       lm = lm->getParentLinkModel();
     else
-      lm = 0;
+      lm = nullptr;
   }
   if (!lm)
     return DEFAULT_SCALE;  // no link with non-zero shape extends found

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -820,4 +820,4 @@ void RobotInteraction::processingThread()
     }
   }
 }
-}
+}  // namespace robot_interaction

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -523,7 +523,7 @@ static void runThreads(int ncheck, int nset, int nmod)
   }
 
   ASSERT_EQ(p, num);
-  counters[p] = NULL;
+  counters[p] = nullptr;
 
   // this thread waits for all the other threads to make progress, then stops
   // everything.

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -199,7 +199,8 @@ void MotionPlanningDisplay::onInitialize()
   QColor qcolor = attached_body_color_property_->getColor();
   trajectory_visual_->setDefaultAttachedObjectColor(qcolor);
 
-  query_robot_start_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Start", nullptr));
+  query_robot_start_.reset(
+      new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Start", nullptr));
   query_robot_start_->setCollisionVisible(false);
   query_robot_start_->setVisualVisible(true);
   query_robot_start_->setVisible(query_start_state_property_->getBool());
@@ -211,7 +212,8 @@ void MotionPlanningDisplay::onInitialize()
   color.a = 1.0f;
   query_robot_start_->setDefaultAttachedObjectColor(color);
 
-  query_robot_goal_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Goal", nullptr));
+  query_robot_goal_.reset(
+      new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Goal", nullptr));
   query_robot_goal_->setCollisionVisible(false);
   query_robot_goal_->setVisualVisible(true);
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
@@ -311,7 +313,8 @@ void MotionPlanningDisplay::setName(const QString& name)
   trajectory_visual_->setName(name);
 }
 
-void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent /*unused*/, const std::string& /*unused*/)
+void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent /*unused*/,
+                                                const std::string& /*unused*/)
 {
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::updateBackgroundJobProgressBar, this));
 }
@@ -907,7 +910,8 @@ void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::Inter
   context_->queueRender();
 }
 
-void MotionPlanningDisplay::scheduleDrawQueryGoalState(robot_interaction::InteractionHandler* /*unused*/, bool error_state_changed)
+void MotionPlanningDisplay::scheduleDrawQueryGoalState(robot_interaction::InteractionHandler* /*unused*/,
+                                                       bool error_state_changed)
 {
   if (!planning_scene_monitor_)
     return;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -79,13 +79,13 @@ namespace moveit_rviz_plugin
 // ******************************************************************************************
 MotionPlanningDisplay::MotionPlanningDisplay()
   : PlanningSceneDisplay()
-  , text_to_display_(NULL)
+  , text_to_display_(nullptr)
   , private_handle_("~")
-  , frame_(NULL)
-  , frame_dock_(NULL)
+  , frame_(nullptr)
+  , frame_dock_(nullptr)
   , menu_handler_start_(new interactive_markers::MenuHandler)
   , menu_handler_goal_(new interactive_markers::MenuHandler)
-  , int_marker_display_(NULL)
+  , int_marker_display_(nullptr)
 {
   // Category Groups
   plan_category_ = new rviz::Property("Planning Request", QVariant(), "", this);
@@ -199,7 +199,7 @@ void MotionPlanningDisplay::onInitialize()
   QColor qcolor = attached_body_color_property_->getColor();
   trajectory_visual_->setDefaultAttachedObjectColor(qcolor);
 
-  query_robot_start_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Start", NULL));
+  query_robot_start_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Start", nullptr));
   query_robot_start_->setCollisionVisible(false);
   query_robot_start_->setVisualVisible(true);
   query_robot_start_->setVisible(query_start_state_property_->getBool());
@@ -211,7 +211,7 @@ void MotionPlanningDisplay::onInitialize()
   color.a = 1.0f;
   query_robot_start_->setDefaultAttachedObjectColor(color);
 
-  query_robot_goal_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Goal", NULL));
+  query_robot_goal_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Goal", nullptr));
   query_robot_goal_->setCollisionVisible(false);
   query_robot_goal_->setVisualVisible(true);
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
@@ -222,7 +222,7 @@ void MotionPlanningDisplay::onInitialize()
   query_robot_goal_->setDefaultAttachedObjectColor(color);
 
   rviz::WindowManagerInterface* window_context = context_->getWindowManager();
-  frame_ = new MotionPlanningFrame(this, context_, window_context ? window_context->getParentWindow() : NULL);
+  frame_ = new MotionPlanningFrame(this, context_, window_context ? window_context->getParentWindow() : nullptr);
   resetStatusTextColor();
   addStatusText("Initialized.");
 
@@ -583,7 +583,7 @@ void MotionPlanningDisplay::displayMetrics(bool start)
       }
     }
 
-    const robot_state::LinkModel* lm = NULL;
+    const robot_state::LinkModel* lm = nullptr;
     const robot_model::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(eef[i].parent_group);
     if (jmg)
       if (!jmg->getLinkModelNames().empty())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -311,7 +311,7 @@ void MotionPlanningDisplay::setName(const QString& name)
   trajectory_visual_->setName(name);
 }
 
-void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent, const std::string&)
+void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent /*unused*/, const std::string& /*unused*/)
 {
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::updateBackgroundJobProgressBar, this));
 }
@@ -895,7 +895,7 @@ void MotionPlanningDisplay::changedAttachedBodyColor()
   trajectory_visual_->setDefaultAttachedObjectColor(color);
 }
 
-void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::InteractionHandler*,
+void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::InteractionHandler* /*unused*/,
                                                         bool error_state_changed)
 {
   if (!planning_scene_monitor_)
@@ -907,7 +907,7 @@ void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::Inter
   context_->queueRender();
 }
 
-void MotionPlanningDisplay::scheduleDrawQueryGoalState(robot_interaction::InteractionHandler*, bool error_state_changed)
+void MotionPlanningDisplay::scheduleDrawQueryGoalState(robot_interaction::InteractionHandler* /*unused*/, bool error_state_changed)
 {
   if (!planning_scene_monitor_)
     return;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -525,4 +525,4 @@ void MotionPlanningFrame::updateExternalCommunication()
   }
 }
 
-}  // namespace
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -256,7 +256,7 @@ void MotionPlanningFrame::fillPlanningGroupOptions()
   ui_->planning_group_combo_box->clear();
 
   const robot_model::RobotModelConstPtr& kmodel = planning_display_->getRobotModel();
-  for (const std::string group_name : kmodel->getJointModelGroupNames())
+  for (const std::string& group_name : kmodel->getJointModelGroupNames())
     ui_->planning_group_combo_box->addItem(QString::fromStdString(group_name));
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -215,4 +215,4 @@ void MotionPlanningFrame::computeResetDbButtonClicked(const std::string& db)
   else if (db == "Planning Scenes")
     planning_scene_storage_->reset();
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -354,4 +354,4 @@ void MotionPlanningFrame::placeObject()
   move_group_->place(place_object_name_, place_poses_);
   return;
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -647,7 +647,7 @@ void MotionPlanningFrame::computeLoadQueryButtonClicked()
 
           robot_state::RobotStatePtr goal_state(new robot_state::RobotState(*planning_display_->getQueryGoalState()));
           for (std::size_t i = 0; i < mp->goal_constraints.size(); ++i)
-            if (mp->goal_constraints[i].joint_constraints.size() > 0)
+            if (!mp->goal_constraints[i].joint_constraints.empty())
             {
               std::map<std::string, double> vals;
               for (std::size_t j = 0; j < mp->goal_constraints[i].joint_constraints.size(); ++j)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -955,4 +955,4 @@ void MotionPlanningFrame::importFromTextButtonClicked()
     planning_display_->addBackgroundJob(
         boost::bind(&MotionPlanningFrame::computeImportFromText, this, path.toStdString()), "import from text");
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -557,4 +557,4 @@ void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs:
     }
   }
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -298,4 +298,4 @@ void MotionPlanningFrame::populatePlanningSceneTreeView()
   ui_->planning_scene_tree->setUpdatesEnabled(true);
   checkPlanningSceneTreeEnabledButtons();
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -46,7 +46,7 @@
 
 namespace moveit_rviz_plugin
 {
-void MotionPlanningFrame::populateRobotStatesList(void)
+void MotionPlanningFrame::populateRobotStatesList()
 {
   ui_->list_states->clear();
   for (RobotStateMap::iterator it = robot_states_.begin(); it != robot_states_.end(); ++it)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -249,4 +249,4 @@ void MotionPlanningFrame::clearStatesButtonClicked()
   populateRobotStatesList();
 }
 
-}  // namespace
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
@@ -46,7 +46,7 @@ namespace moveit_rviz_plugin
 {
 MotionPlanningParamWidget::MotionPlanningParamWidget(QWidget* parent) : rviz::PropertyTreeWidget(parent)
 {
-  property_tree_model_ = NULL;
+  property_tree_model_ = nullptr;
 }
 
 MotionPlanningParamWidget::~MotionPlanningParamWidget()
@@ -65,10 +65,10 @@ void MotionPlanningParamWidget::setMoveGroup(const mpi::MoveGroupInterfacePtr& m
 void MotionPlanningParamWidget::setGroupName(const std::string& group_name)
 {
   group_name_ = group_name;
-  this->setModel(NULL);
+  this->setModel(nullptr);
   if (property_tree_model_)
     delete property_tree_model_;
-  property_tree_model_ = NULL;
+  property_tree_model_ = nullptr;
 }
 
 bool try_lexical_convert(const QString& value, long& lvalue)
@@ -88,7 +88,7 @@ bool try_lexical_convert(const QString& value, double& dvalue)
 rviz::Property* MotionPlanningParamWidget::createPropertyTree()
 {
   if (planner_id_.empty())
-    return NULL;
+    return nullptr;
   const std::map<std::string, std::string>& params = move_group_->getPlannerParams(planner_id_, group_name_);
 
   rviz::Property* root = new rviz::Property(QString::fromStdString(planner_id_ + " parameters"));
@@ -131,7 +131,7 @@ void MotionPlanningParamWidget::setPlannerId(const std::string& planner_id)
 
   rviz::PropertyTreeModel* old_model = property_tree_model_;
   rviz::Property* root = createPropertyTree();
-  property_tree_model_ = root ? new rviz::PropertyTreeModel(root) : NULL;
+  property_tree_model_ = root ? new rviz::PropertyTreeModel(root) : nullptr;
   this->setModel(property_tree_model_);
   if (old_model)
     delete old_model;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
@@ -136,4 +136,4 @@ void MotionPlanningParamWidget::setPlannerId(const std::string& planner_id)
   if (old_model)
     delete old_model;
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -80,7 +80,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
                                    "The topic on which the moveit_msgs::PlanningScene messages are received", this,
                                    SLOT(changedPlanningSceneTopic()), this);
   else
-    planning_scene_topic_property_ = NULL;
+    planning_scene_topic_property_ = nullptr;
 
   // Planning scene category -------------------------------------------------------------------------------------------
   scene_category_ = new rviz::Property("Scene Geometry", QVariant(), "", this);
@@ -145,11 +145,11 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   }
   else
   {
-    robot_category_ = NULL;
-    scene_robot_visual_enabled_property_ = NULL;
-    scene_robot_collision_enabled_property_ = NULL;
-    robot_alpha_property_ = NULL;
-    attached_body_color_property_ = NULL;
+    robot_category_ = nullptr;
+    scene_robot_visual_enabled_property_ = nullptr;
+    scene_robot_collision_enabled_property_ = nullptr;
+    robot_alpha_property_ = nullptr;
+    attached_body_color_property_ = nullptr;
   }
 }
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -101,8 +101,7 @@ RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false), load_r
 // ******************************************************************************************
 // Deconstructor
 // ******************************************************************************************
-RobotStateDisplay::~RobotStateDisplay()
-= default;
+RobotStateDisplay::~RobotStateDisplay() = default;
 
 void RobotStateDisplay::onInitialize()
 {

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -102,8 +102,7 @@ RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false), load_r
 // Deconstructor
 // ******************************************************************************************
 RobotStateDisplay::~RobotStateDisplay()
-{
-}
+= default;
 
 void RobotStateDisplay::onInitialize()
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -89,7 +89,7 @@ public:
   virtual void update(float wall_dt, float ros_dt);
   virtual void reset();
 
-  void onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context, ros::NodeHandle update_nh);
+  void onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context, const ros::NodeHandle& update_nh);
   void onRobotModelLoaded(robot_model::RobotModelConstPtr robot_model);
   void onEnable();
   void onDisable();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -250,4 +250,4 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
     pointBuf_[i].clear();
   }
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -52,7 +52,7 @@ typedef std::vector<VPoint> VVPoint;
 OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
                            OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
                            std::size_t max_octree_depth, Ogre::SceneManager* scene_manager,
-                           Ogre::SceneNode* parent_node = NULL)
+                           Ogre::SceneNode* parent_node = nullptr)
   : octree_(octree), colorFactor_(0.8)
 {
   if (!parent_node)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -106,4 +106,4 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
                                   octree_voxel_rendering, octree_color_mode, color, alpha);
   }
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -186,4 +186,4 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
     scene_shapes_.emplace_back(ogre_shape);
   }
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -75,7 +75,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
                                OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
                                const rviz::Color& color, float alpha)
 {
-  rviz::Shape* ogre_shape = NULL;
+  rviz::Shape* ogre_shape = nullptr;
   Eigen::Vector3d translation = p.translation();
   Ogre::Vector3 position(translation.x(), translation.y(), translation.z());
   Eigen::Quaterniond q(p.rotation());

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -82,13 +82,13 @@ void RobotStateVisualization::setDefaultAttachedObjectColor(const std_msgs::Colo
 
 void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state)
 {
-  updateHelper(kinematic_state, default_attached_object_color_, NULL);
+  updateHelper(kinematic_state, default_attached_object_color_, nullptr);
 }
 
 void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state,
                                      const std_msgs::ColorRGBA& default_attached_object_color)
 {
-  updateHelper(kinematic_state, default_attached_object_color, NULL);
+  updateHelper(kinematic_state, default_attached_object_color, nullptr);
 }
 
 void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state,

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -160,4 +160,4 @@ void RobotStateVisualization::setAlpha(float alpha)
 {
   robot_.setAlpha(alpha);
 }
-}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -43,8 +43,7 @@ TrajectoryPanel::TrajectoryPanel(QWidget* parent) : Panel(parent)
 {
 }
 
-TrajectoryPanel::~TrajectoryPanel()
-= default;
+TrajectoryPanel::~TrajectoryPanel() = default;
 
 void TrajectoryPanel::onInitialize()
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -44,8 +44,7 @@ TrajectoryPanel::TrajectoryPanel(QWidget* parent) : Panel(parent)
 }
 
 TrajectoryPanel::~TrajectoryPanel()
-{
-}
+= default;
 
 void TrajectoryPanel::onInitialize()
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -36,6 +36,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <utility>
 
 #include <moveit/rviz_plugin_render_tools/trajectory_visualization.h>
 
@@ -132,7 +133,7 @@ TrajectoryVisualization::~TrajectoryVisualization()
 }
 
 void TrajectoryVisualization::onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context,
-                                           ros::NodeHandle update_nh)
+                                           const ros::NodeHandle& update_nh)
 {
   // Save pointers for later use
   scene_node_ = scene_node;
@@ -166,7 +167,7 @@ void TrajectoryVisualization::setName(const QString& name)
 
 void TrajectoryVisualization::onRobotModelLoaded(robot_model::RobotModelConstPtr robot_model)
 {
-  robot_model_ = robot_model;
+  robot_model_ = std::move(robot_model);
 
   // Error check
   if (!robot_model_)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -65,8 +65,8 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   , current_state_(-1)
   , display_(display)
   , widget_(widget)
-  , trajectory_slider_panel_(NULL)
-  , trajectory_slider_dock_panel_(NULL)
+  , trajectory_slider_panel_(nullptr)
+  , trajectory_slider_dock_panel_(nullptr)
 {
   trajectory_topic_property_ =
       new rviz::RosTopicProperty("Trajectory Topic", "/move_group/display_planned_path",
@@ -232,7 +232,7 @@ void TrajectoryVisualization::changedShowTrail()
   for (std::size_t i = 0; i < trajectory_trail_.size(); i++)
   {
     int waypoint_i = std::min(i * stepsize, t->getWayPointCount() - 1);  // limit to last trajectory point
-    rviz::Robot* r = new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), NULL);
+    rviz::Robot* r = new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), nullptr);
     r->load(*robot_model_->getURDF());
     r->setVisualVisible(display_path_visual_enabled_property_->getBool());
     r->setCollisionVisible(display_path_collision_enabled_property_->getBool());

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -232,7 +232,8 @@ void TrajectoryVisualization::changedShowTrail()
   for (std::size_t i = 0; i < trajectory_trail_.size(); i++)
   {
     int waypoint_i = std::min(i * stepsize, t->getWayPointCount() - 1);  // limit to last trajectory point
-    rviz::Robot* r = new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), nullptr);
+    rviz::Robot* r =
+        new rviz::Robot(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), nullptr);
     r->load(*robot_model_->getURDF());
     r->setVisualVisible(display_path_visual_enabled_property_->getBool());
     r->setCollisionVisible(display_path_collision_enabled_property_->getBool());

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -52,8 +52,7 @@ TrajectoryDisplay::TrajectoryDisplay() : Display(), load_robot_model_(false)
   trajectory_visual_.reset(new TrajectoryVisualization(this, this));
 }
 
-TrajectoryDisplay::~TrajectoryDisplay()
-= default;
+TrajectoryDisplay::~TrajectoryDisplay() = default;
 
 void TrajectoryDisplay::onInitialize()
 {

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -53,8 +53,7 @@ TrajectoryDisplay::TrajectoryDisplay() : Display(), load_robot_model_(false)
 }
 
 TrajectoryDisplay::~TrajectoryDisplay()
-{
-}
+= default;
 
 void TrajectoryDisplay::onInitialize()
 {

--- a/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
       {
         std::ofstream qfout((scene_names[i] + ".queries").c_str());
         qfout << scene_names[i] << std::endl;
-        if (robotStateNames.size())
+        if (!robotStateNames.empty())
         {
           qfout << "start" << std::endl;
           qfout << robotStateNames.size() << std::endl;
@@ -158,7 +158,7 @@ int main(int argc, char** argv)
           }
         }
 
-        if (constraintNames.size())
+        if (!constraintNames.empty())
         {
           qfout << "goal" << std::endl;
           qfout << constraintNames.size() << std::endl;

--- a/moveit_ros/warehouse/warehouse/src/trajectory_constraints_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/trajectory_constraints_storage.cpp
@@ -52,13 +52,13 @@ moveit_warehouse::TrajectoryConstraintsStorage::TrajectoryConstraintsStorage(
   createCollections();
 }
 
-void moveit_warehouse::TrajectoryConstraintsStorage::createCollections(void)
+void moveit_warehouse::TrajectoryConstraintsStorage::createCollections()
 {
   constraints_collection_ =
       conn_->openCollectionPtr<moveit_msgs::TrajectoryConstraints>(DATABASE_NAME, "trajectory_constraints");
 }
 
-void moveit_warehouse::TrajectoryConstraintsStorage::reset(void)
+void moveit_warehouse::TrajectoryConstraintsStorage::reset()
 {
   constraints_collection_.reset();
   conn_->dropDatabase(DATABASE_NAME);

--- a/moveit_ros/warehouse/warehouse/src/warehouse_connector.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_connector.cpp
@@ -99,4 +99,4 @@ bool WarehouseConnector::connectToDatabase(const std::string& dirname)
   }
   return true;
 }
-}
+}  // namespace moveit_warehouse

--- a/moveit_ros/warehouse/warehouse/src/warehouse_connector.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_connector.cpp
@@ -81,7 +81,7 @@ bool WarehouseConnector::connectToDatabase(const std::string& dirname)
       argv[2] = new char[1024];
       snprintf(argv[2], 1023, "%s", dirname.c_str());
 
-      argv[3] = NULL;
+      argv[3] = nullptr;
 
       int code = execv(dbexec_.c_str(), argv);
       delete[] argv[0];

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -347,7 +347,7 @@ public:
    * \param planning_group name of group to use
    * \return string - value to insert into yaml file
    */
-  std::string decideProjectionJoints(std::string planning_group);
+  std::string decideProjectionJoints(const std::string& planning_group);
 
   /**
    * Input ompl_planning.yaml file for editing its values

--- a/moveit_setup_assistant/src/setup_assistant_main.cpp
+++ b/moveit_setup_assistant/src/setup_assistant_main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
   setlocale(LC_NUMERIC, "C");
 
   // Load Qt Widget
-  moveit_setup_assistant::SetupAssistantWidget saw(NULL, vm);
+  moveit_setup_assistant::SetupAssistantWidget saw(nullptr, vm);
   saw.setMinimumWidth(980);
   saw.setMinimumHeight(550);
   //  saw.setWindowState( Qt::WindowMaximized );

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
@@ -166,7 +166,7 @@ void CollisionMatrixModel::setEnabled(const QItemSelection& selection, bool valu
   // perform changes without signalling
   QItemSelection changes;
   blockSignals(true);
-  for (const auto range : selection)
+  for (const auto& range : selection)
   {
     setEnabled(range.indexes(), value);
 
@@ -179,7 +179,7 @@ void CollisionMatrixModel::setEnabled(const QItemSelection& selection, bool valu
   blockSignals(false);
 
   // emit changes
-  for (const auto range : changes)
+  for (const auto& range : changes)
     Q_EMIT dataChanged(range.topLeft(), range.bottomRight());
 }
 

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
@@ -202,7 +202,7 @@ void CollisionMatrixModel::setFilterRegExp(const QString& filter)
   endResetModel();
 }
 
-QVariant CollisionMatrixModel::headerData(int section, Qt::Orientation, int role) const
+QVariant CollisionMatrixModel::headerData(int section, Qt::Orientation /*orientation*/, int role) const
 {
   if (role == Qt::DisplayRole)
     return q_names[visual_to_index[section]];

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
@@ -212,7 +212,7 @@ QVariant CollisionMatrixModel::headerData(int section, Qt::Orientation, int role
 Qt::ItemFlags CollisionMatrixModel::flags(const QModelIndex& index) const
 {
   if (!index.isValid())
-    return 0;
+    return Qt::NoItemFlags;
 
   Qt::ItemFlags f = QAbstractTableModel::flags(index);
   if (index.row() != index.column())

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
@@ -146,11 +146,11 @@ bool CollisionMatrixModel::setData(const QModelIndex& index, const QVariant& val
     item->second.disable_check = new_value;
 
     // Handle USER Reasons: 1) pair is disabled by user
-    if (item->second.disable_check == true && item->second.reason == moveit_setup_assistant::NOT_DISABLED)
+    if (item->second.disable_check && item->second.reason == moveit_setup_assistant::NOT_DISABLED)
       item->second.reason = moveit_setup_assistant::USER;
 
     // Handle USER Reasons: 2) pair was disabled by user and now is enabled (not checked)
-    else if (item->second.disable_check == false && item->second.reason == moveit_setup_assistant::USER)
+    else if (!item->second.disable_check && item->second.reason == moveit_setup_assistant::USER)
       item->second.reason = moveit_setup_assistant::NOT_DISABLED;
 
     QModelIndex mirror = this->index(index.column(), index.row());

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -675,4 +675,4 @@ DisabledReason disabledReasonFromString(const std::string& reason)
   return r;
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -303,7 +303,7 @@ bool setLinkPair(const std::string& linkA, const std::string& linkB, const Disab
   LinkPairData* link_pair_ptr = &link_pairs[link_pair];
 
   // Check if link pair was already disabled. It also creates the entry if none existed
-  if (link_pairs[link_pair].disable_check == false)  // it was not previously disabled
+  if (!link_pairs[link_pair].disable_check)  // it was not previously disabled
   {
     isUnique = true;
     link_pair_ptr->reason = reason;  // only change the reason if the pair was previously enabled

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -75,8 +75,7 @@ MoveItConfigData::MoveItConfigData() : config_pkg_generated_timestamp_(0)
 // ******************************************************************************************
 // Destructor
 // ******************************************************************************************
-MoveItConfigData::~MoveItConfigData()
-= default;
+MoveItConfigData::~MoveItConfigData() = default;
 
 // ******************************************************************************************
 // Load a robot model
@@ -414,7 +413,8 @@ std::string MoveItConfigData::getGazeboCompatibleURDF()
       if (static_cast<std::string>(doc_element->Value()).find("link") != std::string::npos)
       {
         // Before adding inertial elements, make sure there is none and the link has collision element
-        if (doc_element->FirstChildElement("inertial") == nullptr && doc_element->FirstChildElement("collision") != nullptr)
+        if (doc_element->FirstChildElement("inertial") == nullptr &&
+            doc_element->FirstChildElement("collision") != nullptr)
         {
           new_urdf_needed = true;
           TiXmlElement inertia_link("inertial");

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -226,7 +226,7 @@ bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)
     {
       emitter << YAML::Key << planner_des[i].parameter_list_[j].name;
       emitter << YAML::Value << planner_des[i].parameter_list_[j].value;
-      emitter << YAML::Comment(planner_des[i].parameter_list_[j].comment.c_str());
+      emitter << YAML::Comment(planner_des[i].parameter_list_[j].comment);
     }
     emitter << YAML::EndMap;
 
@@ -1707,7 +1707,7 @@ std::string MoveItConfigData::appendPaths(const std::string& path1, const std::s
 {
   fs::path result = path1;
   result /= path2;
-  return result.make_preferred().native().c_str();
+  return result.make_preferred().native();
 }
 
 srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1830,4 +1830,4 @@ void MoveItConfigData::clearSensorPluginConfig()
   }
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -182,7 +182,7 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
   emitter << YAML::Value << YAML::BeginMap;
   emitter << YAML::Key << "author_name" << YAML::Value << author_name_;
   emitter << YAML::Key << "author_email" << YAML::Value << author_email_;
-  emitter << YAML::Key << "generated_timestamp" << YAML::Value << std::time(NULL);  // TODO: is this cross-platform?
+  emitter << YAML::Key << "generated_timestamp" << YAML::Value << std::time(nullptr);  // TODO: is this cross-platform?
   emitter << YAML::EndMap;
 
   emitter << YAML::EndMap;
@@ -406,16 +406,16 @@ std::string MoveItConfigData::getGazeboCompatibleURDF()
 
   // Used to convert XmlDocument to std string
   TiXmlPrinter printer;
-  urdf_document.Parse((const char*)urdf_string_.c_str(), 0, TIXML_ENCODING_UTF8);
+  urdf_document.Parse((const char*)urdf_string_.c_str(), nullptr, TIXML_ENCODING_UTF8);
   try
   {
-    for (TiXmlElement* doc_element = urdf_document.RootElement()->FirstChildElement(); doc_element != NULL;
+    for (TiXmlElement* doc_element = urdf_document.RootElement()->FirstChildElement(); doc_element != nullptr;
          doc_element = doc_element->NextSiblingElement())
     {
       if (static_cast<std::string>(doc_element->Value()).find("link") != std::string::npos)
       {
         // Before adding inertial elements, make sure there is none and the link has collision element
-        if (doc_element->FirstChildElement("inertial") == NULL && doc_element->FirstChildElement("collision") != NULL)
+        if (doc_element->FirstChildElement("inertial") == nullptr && doc_element->FirstChildElement("collision") != nullptr)
         {
           new_urdf_needed = true;
           TiXmlElement inertia_link("inertial");
@@ -525,7 +525,7 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     // Iterate through the joints
     for (const robot_model::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != NULL || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
         continue;
       emitter << joint->getName();
     }
@@ -817,7 +817,7 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
     // Iterate through the joints and push into group_joints vector.
     for (const robot_model::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != NULL || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
         continue;
       else
         group_joints.push_back(joint->getName());
@@ -869,7 +869,7 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
           for (std::vector<const robot_model::JointModel*>::const_iterator joint_it = joint_models.begin();
                joint_it < joint_models.end(); ++joint_it)
           {
-            if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != NULL ||
+            if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != nullptr ||
                 (*joint_it)->getType() == robot_model::JointModel::FIXED)
               continue;
             else
@@ -1439,7 +1439,7 @@ bool MoveItConfigData::addDefaultControllers()
     // Iterate through the joints
     for (const robot_model::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != NULL || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
         continue;
       group_controller.joints_.push_back(joint->getName());
     }
@@ -1714,7 +1714,7 @@ std::string MoveItConfigData::appendPaths(const std::string& path1, const std::s
 srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)
 {
   // Find the group we are editing based on the goup name string
-  srdf::Model::Group* searched_group = NULL;  // used for holding our search results
+  srdf::Model::Group* searched_group = nullptr;  // used for holding our search results
 
   for (std::vector<srdf::Model::Group>::iterator group_it = srdf_->groups_.begin(); group_it != srdf_->groups_.end();
        ++group_it)
@@ -1727,7 +1727,7 @@ srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)
   }
 
   // Check if subgroup was found
-  if (searched_group == NULL)  // not found
+  if (searched_group == nullptr)  // not found
     ROS_FATAL_STREAM("An internal error has occured while searching for groups. Group '" << name << "' was not found "
                                                                                                     "in the SRDF.");
 
@@ -1740,7 +1740,7 @@ srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)
 ROSControlConfig* MoveItConfigData::findROSControllerByName(const std::string& controller_name)
 {
   // Find the ROSController we are editing based on the ROSController name string
-  ROSControlConfig* searched_ros_controller = NULL;  // used for holding our search results
+  ROSControlConfig* searched_ros_controller = nullptr;  // used for holding our search results
 
   for (std::vector<ROSControlConfig>::iterator controller_it = ros_controllers_config_.begin();
        controller_it != ros_controllers_config_.end(); ++controller_it)
@@ -1779,7 +1779,7 @@ bool MoveItConfigData::deleteROSController(const std::string& controller_name)
 bool MoveItConfigData::addROSController(const ROSControlConfig& new_controller)
 {
   // Used for holding our search results
-  ROSControlConfig* searched_ros_controller = NULL;
+  ROSControlConfig* searched_ros_controller = nullptr;
 
   // Find if there is an existing controller with the same name
   searched_ros_controller = findROSControllerByName(new_controller.name_);

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1175,7 +1175,7 @@ std::string MoveItConfigData::decideProjectionJoints(std::string planning_group)
   const robot_model::JointModelGroup* group = model->getJointModelGroup(planning_group);
 
   // get vector of joint names
-  const std::vector<std::string> joints = group->getJointModelNames();
+  const std::vector<std::string>& joints = group->getJointModelNames();
 
   if (joints.size() >= 2)
   {

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1424,7 +1424,7 @@ bool MoveItConfigData::inputROSControllersYAML(const std::string& file_path)
 // ******************************************************************************************
 bool MoveItConfigData::addDefaultControllers()
 {
-  if (srdf_->srdf_model_->getGroups().size() == 0)
+  if (srdf_->srdf_model_->getGroups().empty())
     return false;
   // Loop through groups
   for (std::vector<srdf::Model::Group>::const_iterator group_it = srdf_->srdf_model_->getGroups().begin();

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -76,8 +76,7 @@ MoveItConfigData::MoveItConfigData() : config_pkg_generated_timestamp_(0)
 // Destructor
 // ******************************************************************************************
 MoveItConfigData::~MoveItConfigData()
-{
-}
+= default;
 
 // ******************************************************************************************
 // Load a robot model

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -41,6 +41,7 @@
 #include <boost/filesystem/path.hpp>        // for creating folders/files
 #include <boost/filesystem/operations.hpp>  // is_regular_file, is_directory, etc.
 #include <boost/algorithm/string/trim.hpp>
+#include <utility>
 
 // ROS
 #include <ros/console.h>
@@ -83,7 +84,7 @@ MoveItConfigData::~MoveItConfigData()
 // ******************************************************************************************
 void MoveItConfigData::setRobotModel(robot_model::RobotModelPtr robot_model)
 {
-  robot_model_ = robot_model;
+  robot_model_ = std::move(robot_model);
 }
 
 // ******************************************************************************************
@@ -1160,7 +1161,7 @@ void MoveItConfigData::setCollisionLinkPairs(const moveit_setup_assistant::LinkP
 // ******************************************************************************************
 // Decide the best two joints to be used for the projection evaluator
 // ******************************************************************************************
-std::string MoveItConfigData::decideProjectionJoints(std::string planning_group)
+std::string MoveItConfigData::decideProjectionJoints(const std::string& planning_group)
 {
   std::string joint_pair = "";
 

--- a/moveit_setup_assistant/src/tools/rotated_header_view.cpp
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.cpp
@@ -126,4 +126,4 @@ int RotatedHeaderView::sectionSizeHint(int logicalIndex) const
   int hint = size.height();
   return qMax(minimumSectionSize(), hint);
 }
-}
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/author_information_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.cpp
@@ -108,4 +108,4 @@ void AuthorInformationWidget::edited_email()
   config_data_->changes |= MoveItConfigData::AUTHOR_INFO;
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -570,25 +570,25 @@ bool ConfigurationFilesWidget::checkDependencies()
   bool requiredActions = false;
 
   // Check that at least 1 planning group exists
-  if (!config_data_->srdf_->groups_.size())
+  if (config_data_->srdf_->groups_.empty())
   {
     dependencies << "No robot model planning groups have been created";
   }
 
   // Check that at least 1 link pair is disabled from collision checking
-  if (!config_data_->srdf_->disabled_collisions_.size())
+  if (config_data_->srdf_->disabled_collisions_.empty())
   {
     dependencies << "No self-collisions have been disabled";
   }
 
   // Check that there is at least 1 end effector added
-  if (!config_data_->srdf_->end_effectors_.size())
+  if (config_data_->srdf_->end_effectors_.empty())
   {
     dependencies << "No end effectors have been added";
   }
 
   // Check that there is at least 1 virtual joint added
-  if (!config_data_->srdf_->virtual_joints_.size())
+  if (config_data_->srdf_->virtual_joints_.empty())
   {
     dependencies << "No virtual joints have been added";
   }
@@ -1028,13 +1028,13 @@ bool ConfigurationFilesWidget::noGroupsEmpty()
        group_it != config_data_->srdf_->groups_.end(); ++group_it)
   {
     // Whenever 1 of the 4 component types are found, stop checking this group
-    if (group_it->joints_.size())
+    if (!group_it->joints_.empty())
       continue;
-    if (group_it->links_.size())
+    if (!group_it->links_.empty())
       continue;
-    if (group_it->chains_.size())
+    if (!group_it->chains_.empty())
       continue;
-    if (group_it->subgroups_.size())
+    if (!group_it->subgroups_.empty())
       continue;
 
     // This group has no contents, bad

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -184,7 +184,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   fs::path template_package_path = config_data_->setup_assistant_path_;
   template_package_path /= "templates";
   template_package_path /= "moveit_config_pkg_template";
-  config_data_->template_package_path_ = template_package_path.make_preferred().native().c_str();
+  config_data_->template_package_path_ = template_package_path.make_preferred().native();
 
   if (!fs::is_directory(config_data_->template_package_path_))
   {

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1207,4 +1207,4 @@ bool ConfigurationFilesWidget::createFolder(const std::string& output_path)
   return true;
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
@@ -259,4 +259,4 @@ std::string ControllerEditWidget::getControllerType()
   return controller_type_field_->currentText().toStdString();
 }
 
-}  // namespace
+}  // namespace moveit_ros_control

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
@@ -163,7 +163,7 @@ void ControllerEditWidget::setSelected(const std::string& controller_name)
   controller_name_field_->setText(QString(controller_name.c_str()));
   moveit_setup_assistant::ROSControlConfig* searched_controller =
       config_data_->findROSControllerByName(controller_name);
-  if (searched_controller != NULL)
+  if (searched_controller != nullptr)
   {
     const std::string controller_type = searched_controller->type_;
     int type_index = controller_type_field_->findText(controller_type.c_str());

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -838,4 +838,4 @@ void moveit_setup_assistant::MonitorThread::run()
   Q_EMIT progress(progress_);
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -420,8 +420,8 @@ void DefaultCollisionsWidget::showHeaderContextMenu(const QPoint& p)
     menu.addActions(header_actions_);
   menu.exec(global);
 
-  // clicked_headers_ = nullptr;
-  // clicked_section_ = -1;
+  clicked_headers_ = {};
+  clicked_section_ = -1;
 }
 
 void DefaultCollisionsWidget::hideSections()

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -58,7 +58,7 @@ namespace moveit_setup_assistant
 // User interface for editing the default collision matrix list in an SRDF
 // ******************************************************************************************
 DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, MoveItConfigDataPtr config_data)
-  : SetupScreenWidget(parent), model_(NULL), selection_model_(NULL), worker_(NULL), config_data_(config_data)
+  : SetupScreenWidget(parent), model_(nullptr), selection_model_(nullptr), worker_(nullptr), config_data_(config_data)
 {
   // Basic widget container
   layout_ = new QVBoxLayout(this);
@@ -246,7 +246,7 @@ void DefaultCollisionsWidget::finishGeneratingCollisionTable()
 
   config_data_->changes |= MoveItConfigData::COLLISIONS;
   worker_->deleteLater();
-  worker_ = NULL;
+  worker_ = nullptr;
 }
 
 // ******************************************************************************************
@@ -420,14 +420,14 @@ void DefaultCollisionsWidget::showHeaderContextMenu(const QPoint& p)
     menu.addActions(header_actions_);
   menu.exec(global);
 
-  clicked_headers_ = 0;
-  clicked_section_ = -1;
+  // clicked_headers_ = nullptr;
+  // clicked_section_ = -1;
 }
 
 void DefaultCollisionsWidget::hideSections()
 {
   QList<int> list;
-  QHeaderView* header = 0;
+  QHeaderView* header = nullptr;
   if (clicked_headers_ == Qt::Horizontal)
   {
     for (const QModelIndex& index : selection_model_->selectedColumns())
@@ -455,7 +455,7 @@ void DefaultCollisionsWidget::hideSections()
 void DefaultCollisionsWidget::hideOtherSections()
 {
   QList<int> list;
-  QHeaderView* header = 0;
+  QHeaderView* header = nullptr;
   if (clicked_headers_ == Qt::Horizontal)
   {
     header = collision_table_->horizontalHeader();
@@ -509,7 +509,7 @@ void DefaultCollisionsWidget::showSections()
     return;
   }
 
-  QHeaderView* header = 0;
+  QHeaderView* header = nullptr;
   if (clicked_headers_ == Qt::Horizontal)
   {
     for (const QModelIndex& index : selection_model_->selectedColumns())

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -398,7 +398,7 @@ void EndEffectorsWidget::loadParentComboBox()
 srdf::Model::EndEffector* EndEffectorsWidget::findEffectorByName(const std::string& name)
 {
   // Find the group state we are editing based on the effector name
-  srdf::Model::EndEffector* searched_group = NULL;  // used for holding our search results
+  srdf::Model::EndEffector* searched_group = nullptr;  // used for holding our search results
 
   for (std::vector<srdf::Model::EndEffector>::iterator effector_it = config_data_->srdf_->end_effectors_.begin();
        effector_it != config_data_->srdf_->end_effectors_.end(); ++effector_it)
@@ -411,7 +411,7 @@ srdf::Model::EndEffector* EndEffectorsWidget::findEffectorByName(const std::stri
   }
 
   // Check if effector was found
-  if (searched_group == NULL)  // not found
+  if (searched_group == nullptr)  // not found
   {
     QMessageBox::critical(this, "Error Saving", "An internal error has occured while saving. Quitting.");
     QApplication::quit();
@@ -471,7 +471,7 @@ void EndEffectorsWidget::doneEditing()
   const std::string effector_name = effector_name_field_->text().toStdString();
 
   // Used for editing existing groups
-  srdf::Model::EndEffector* searched_data = NULL;
+  srdf::Model::EndEffector* searched_data = nullptr;
 
   // Check that name field is not empty
   if (effector_name.empty())
@@ -549,7 +549,7 @@ void EndEffectorsWidget::doneEditing()
   // Save the new effector name or create the new effector ----------------------------
   bool isNew = false;
 
-  if (searched_data == NULL)  // create new
+  if (searched_data == nullptr)  // create new
   {
     isNew = true;
 

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -644,7 +644,7 @@ void EndEffectorsWidget::loadDataTable()
   data_table_->resizeColumnToContents(3);
 
   // Show edit button if applicable
-  if (config_data_->srdf_->end_effectors_.size() > 0)
+  if (!config_data_->srdf_->end_effectors_.empty())
     btn_edit_->show();
 }
 

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -664,4 +664,4 @@ void EndEffectorsWidget::focusGiven()
   loadParentComboBox();
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -338,4 +338,4 @@ void GroupEditWidget::loadKinematicPlannersComboBox()
   }
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/header_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/header_widget.cpp
@@ -229,4 +229,4 @@ void LoadPathArgsWidget::setArgsEnabled(bool enabled)
 {
   args_->setEnabled(enabled);
 }
-}
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/header_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/header_widget.cpp
@@ -166,7 +166,7 @@ void LoadPathWidget::btn_file_dialog()
   }
 
   // check they did not press cancel
-  if (path != NULL)
+  if (!path.isNull())
     path_box_->setText(path);
 }
 

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -151,7 +151,7 @@ void KinematicChainWidget::setAvailable()
   // Get the root joint
   const robot_model::JointModel* root_joint = model->getRootJoint();
 
-  addLinktoTreeRecursive(root_joint->getChildLinkModel(), NULL);
+  addLinktoTreeRecursive(root_joint->getChildLinkModel(), nullptr);
 
   // Remember that we have loaded the chain
   kinematic_chain_loaded_ = true;
@@ -167,7 +167,7 @@ void KinematicChainWidget::addLinktoTreeRecursive(const robot_model::LinkModel* 
   QTreeWidgetItem* new_item = new QTreeWidgetItem(link_tree_);
 
   // Add item to tree
-  if (parent == NULL)
+  if (parent == nullptr)
   {
     new_item->setText(0, link->getName().c_str());
     link_tree_->addTopLevelItem(new_item);
@@ -231,7 +231,7 @@ void KinematicChainWidget::setSelected(const std::string& base_link, const std::
 void KinematicChainWidget::baseLinkTreeClick()
 {
   QTreeWidgetItem* item = link_tree_->currentItem();
-  if (item != NULL)
+  if (item != nullptr)
   {
     base_link_field_->setText(item->text(0));
   }
@@ -243,7 +243,7 @@ void KinematicChainWidget::baseLinkTreeClick()
 void KinematicChainWidget::tipLinkTreeClick()
 {
   QTreeWidgetItem* item = link_tree_->currentItem();
-  if (item != NULL)
+  if (item != nullptr)
   {
     tip_link_field_->setText(item->text(0));
   }
@@ -266,7 +266,7 @@ void KinematicChainWidget::alterTree(const QString& link)
 void KinematicChainWidget::itemSelected()
 {
   QTreeWidgetItem* item = link_tree_->currentItem();
-  if (item != NULL)
+  if (item != nullptr)
   {
     Q_EMIT unhighlightAll();
 

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -280,4 +280,4 @@ void KinematicChainWidget::itemSelected()
     Q_EMIT highlightLink(item->text(0).toStdString(), QColor(255, 0, 0));
   }
 }
-}
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -171,4 +171,4 @@ void NavDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
 
   painter->restore();
 }
-}
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -71,7 +71,7 @@ NavigationWidget::NavigationWidget(QWidget* parent) : QListView(parent)
 
 void NavigationWidget::setNavs(const QList<QString>& navs)
 {
-  setModel(NULL);
+  setModel(nullptr);
   model_->clear();
 
   for (int i = 0; i < navs.size(); i++)

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
@@ -89,7 +89,7 @@ void PassiveJointsWidget::focusGiven()
   // Get the names of the all joints
   const std::vector<std::string>& joints = model->getJointModelNames();
 
-  if (joints.size() == 0)
+  if (joints.empty())
   {
     QMessageBox::critical(this, "Error Loading", "No joints found for robot model");
     return;

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
@@ -154,4 +154,4 @@ void PassiveJointsWidget::previewSelectedJoints(std::vector<std::string> joints)
   }
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -337,4 +337,4 @@ void PerceptionWidget::loadSensorPluginsComboBox()
   }
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1473,7 +1473,7 @@ void PlanningGroupsWidget::previewSelectedSubgroup(std::vector<std::string> grou
   }
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant
 
 // ******************************************************************************************
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -260,7 +260,7 @@ void PlanningGroupsWidget::loadGroupsTree()
   for (std::vector<srdf::Model::Group>::iterator group_it = config_data_->srdf_->groups_.begin();
        group_it != config_data_->srdf_->groups_.end(); ++group_it)
   {
-    loadGroupsTreeRecursive(*group_it, NULL);
+    loadGroupsTreeRecursive(*group_it, nullptr);
   }
 
   // Reenable Tree
@@ -294,7 +294,7 @@ void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it,
   QTreeWidgetItem* group;
 
   // Allow a subgroup to open into a whole new group
-  if (parent == NULL)
+  if (parent == nullptr)
   {
     group = new QTreeWidgetItem(groups_tree_);
     group->setText(0, group_it.name_.c_str());
@@ -403,7 +403,7 @@ void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it,
   {
     // Find group with this subgroups' name
 
-    srdf::Model::Group* searched_group = NULL;  // used for holding our search results
+    srdf::Model::Group* searched_group = nullptr;  // used for holding our search results
 
     for (std::vector<srdf::Model::Group>::iterator group2_it = config_data_->srdf_->groups_.begin();
          group2_it != config_data_->srdf_->groups_.end(); ++group2_it)
@@ -416,7 +416,7 @@ void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it,
     }
 
     // Check if subgroup was found
-    if (searched_group == NULL)  // not found
+    if (searched_group == nullptr)  // not found
     {
       QMessageBox::critical(this, "Error Loading SRDF", QString("Subgroup '")
                                                             .append(subgroup_it->c_str())
@@ -441,7 +441,7 @@ void PlanningGroupsWidget::previewSelected()
   QTreeWidgetItem* item = groups_tree_->currentItem();
 
   // Check that something was actually selected
-  if (item == NULL)
+  if (item == nullptr)
     return;
 
   // Get the user custom properties of the currently selected row
@@ -462,7 +462,7 @@ void PlanningGroupsWidget::editSelected()
   QTreeWidgetItem* item = groups_tree_->currentItem();
 
   // Check that something was actually selected
-  if (item == NULL)
+  if (item == nullptr)
     return;
 
   adding_new_group_ = false;
@@ -654,7 +654,7 @@ void PlanningGroupsWidget::loadGroupScreen(srdf::Model::Group* this_group)
   // Load the avail kin solvers. This function only runs once
   group_edit_widget_->loadKinematicPlannersComboBox();
 
-  if (this_group == NULL)  // this is a new screen
+  if (this_group == nullptr)  // this is a new screen
   {
     current_edit_group_.clear();  // provide a blank group name
     group_edit_widget_->title_->setText("Create New Planning Group");
@@ -689,7 +689,7 @@ void PlanningGroupsWidget::deleteGroup()
   {
     QTreeWidgetItem* item = groups_tree_->currentItem();
     // Check that something was actually selected
-    if (item == NULL)
+    if (item == nullptr)
       return;
     // Get the user custom properties of the currently selected row
     PlanGroupType plan_group = item->data(0, Qt::UserRole).value<PlanGroupType>();
@@ -844,7 +844,7 @@ void PlanningGroupsWidget::addGroup()
   adding_new_group_ = true;
 
   // Load the data
-  loadGroupScreen(NULL);  // NULL indicates this is a new group, not an existing one
+  loadGroupScreen(nullptr);  // NULL indicates this is a new group, not an existing one
 
   // Switch to screen
   changeScreen(5);
@@ -1094,7 +1094,7 @@ bool PlanningGroupsWidget::saveGroupScreen()
   const std::string& kinematics_timeout = group_edit_widget_->kinematics_timeout_field_->text().toStdString();
 
   // Used for editing existing groups
-  srdf::Model::Group* searched_group = NULL;
+  srdf::Model::Group* searched_group = nullptr;
 
   // Check that a valid group name has been given
   if (group_name.empty())
@@ -1164,7 +1164,7 @@ bool PlanningGroupsWidget::saveGroupScreen()
   adding_new_group_ = false;
 
   // Save the new group name or create the new group
-  if (searched_group == NULL)  // create new
+  if (searched_group == nullptr)  // create new
   {
     srdf::Model::Group new_group;
     new_group.name_ = group_name;

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -527,7 +527,7 @@ void PlanningGroupsWidget::loadJointsScreen(srdf::Model::Group* this_group)
   // Get the names of the all joints
   const std::vector<std::string>& joints = model->getJointModelNames();
 
-  if (joints.size() == 0)
+  if (joints.empty())
   {
     QMessageBox::critical(this, "Error Loading", "No joints found for robot model");
     return;
@@ -559,7 +559,7 @@ void PlanningGroupsWidget::loadLinksScreen(srdf::Model::Group* this_group)
   // Get the names of the all links
   const std::vector<std::string>& links = model->getLinkModelNames();
 
-  if (links.size() == 0)
+  if (links.empty())
   {
     QMessageBox::critical(this, "Error Loading", "No links found for robot model");
     return;
@@ -598,7 +598,7 @@ void PlanningGroupsWidget::loadChainScreen(srdf::Model::Group* this_group)
   }
 
   // Set the selected tip and base of chain if one exists
-  if (this_group->chains_.size() > 0)
+  if (!this_group->chains_.empty())
   {
     chain_widget_->setSelected(this_group->chains_[0].first, this_group->chains_[0].second);
   }

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -80,7 +80,7 @@ struct cycle_detector : public boost::dfs_visitor<>
   }
 
   template <class Edge, class Graph>
-  void back_edge(Edge, Graph&)
+  void back_edge(Edge /*unused*/, Graph& /*unused*/)
   {
     m_has_cycle = true;
   }

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -764,7 +764,7 @@ void RobotPosesWidget::loadDataTable()
   data_table_->resizeColumnToContents(1);
 
   // Show edit button if applicable
-  if (config_data_->srdf_->group_states_.size())
+  if (!config_data_->srdf_->group_states_.empty())
     btn_edit_->show();
 }
 
@@ -822,7 +822,7 @@ void RobotPosesWidget::publishJoints()
   config_data_->getPlanningScene()->checkSelfCollision(
       request, result, config_data_->getPlanningScene()->getCurrentState(), config_data_->allowed_collision_matrix_);
   // Show result notification
-  if (result.contacts.size())
+  if (!result.contacts.empty())
   {
     collision_warning_->show();
   }

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -909,8 +909,7 @@ SliderWidget::SliderWidget(QWidget* parent, const robot_model::JointModel* joint
 // ******************************************************************************************
 // Deconstructor
 // ******************************************************************************************
-SliderWidget::~SliderWidget()
-= default;
+SliderWidget::~SliderWidget() = default;
 
 // ******************************************************************************************
 // Called when the joint value slider is changed

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -948,4 +948,4 @@ void SliderWidget::changeJointSlider()
   Q_EMIT jointValueChanged(joint_model_->getName(), value);
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -55,7 +55,7 @@ RobotPosesWidget::RobotPosesWidget(QWidget* parent, moveit_setup_assistant::Move
   : SetupScreenWidget(parent), config_data_(config_data)
 {
   // Set pointer to null so later we can tell if we need to delete it
-  joint_list_layout_ = NULL;
+  joint_list_layout_ = nullptr;
 
   // Basic widget container
   QVBoxLayout* layout = new QVBoxLayout();
@@ -563,7 +563,7 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
 srdf::Model::GroupState* RobotPosesWidget::findPoseByName(const std::string& name, const std::string& group)
 {
   // Find the group state we are editing based on the pose name
-  srdf::Model::GroupState* searched_state = NULL;  // used for holding our search results
+  srdf::Model::GroupState* searched_state = nullptr;  // used for holding our search results
 
   for (srdf::Model::GroupState& state : config_data_->srdf_->group_states_)
   {
@@ -625,7 +625,7 @@ void RobotPosesWidget::doneEditing()
   const std::string& group = group_name_field_->currentText().toStdString();
 
   // Used for editing existing groups
-  srdf::Model::GroupState* searched_data = NULL;
+  srdf::Model::GroupState* searched_data = nullptr;
 
   // Check that name field is not empty
   if (name.empty())
@@ -661,7 +661,7 @@ void RobotPosesWidget::doneEditing()
   // Save the new pose name or create the new pose ----------------------------
   bool isNew = false;
 
-  if (searched_data == NULL)  // create new
+  if (searched_data == nullptr)  // create new
   {
     isNew = true;
     searched_data = new srdf::Model::GroupState();

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -910,8 +910,7 @@ SliderWidget::SliderWidget(QWidget* parent, const robot_model::JointModel* joint
 // Deconstructor
 // ******************************************************************************************
 SliderWidget::~SliderWidget()
-{
-}
+= default;
 
 // ******************************************************************************************
 // Called when the joint value slider is changed

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -291,7 +291,7 @@ void ROSControllersWidget::loadJointsScreen(moveit_setup_assistant::ROSControlCo
   // Get the names of the all joints
   const std::vector<std::string>& joints = model->getJointModelNames();
 
-  if (joints.size() == 0)
+  if (joints.empty())
   {
     QMessageBox::critical(this, "Error Loading", "No joints found for robot model");
     return;

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -398,7 +398,7 @@ void ROSControllersWidget::addController()
 
   // Load the data
   loadControllerScreen(nullptr);  // NULL indicates this is a new controller, not an existing one
-  changeScreen(2);             // 1 is index of controller edit
+  changeScreen(2);                // 1 is index of controller edit
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -352,7 +352,7 @@ void ROSControllersWidget::deleteController()
   {
     QTreeWidgetItem* item = controllers_tree_->currentItem();
     // Check that something was actually selected
-    if (item == NULL)
+    if (item == nullptr)
       return;
 
     // Get the user custom properties of the currently selected row
@@ -397,7 +397,7 @@ void ROSControllersWidget::addController()
   adding_new_controller_ = true;
 
   // Load the data
-  loadControllerScreen(NULL);  // NULL indicates this is a new controller, not an existing one
+  loadControllerScreen(nullptr);  // NULL indicates this is a new controller, not an existing one
   changeScreen(2);             // 1 is index of controller edit
 }
 
@@ -419,7 +419,7 @@ void ROSControllersWidget::loadControllerScreen(moveit_setup_assistant::ROSContr
   // Load the avail controllers. This function only runs once
   controller_edit_widget_->loadControllersTypesComboBox();
 
-  if (this_controller == NULL)  // this is a new screen
+  if (this_controller == nullptr)  // this is a new screen
   {
     current_edit_controller_.clear();  // provide a blank controller name
     controller_edit_widget_->setTitle("Create New Controller");
@@ -619,7 +619,7 @@ void ROSControllersWidget::saveJointsGroupsScreen()
     // Iterate through the joints
     for (const robot_model::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != NULL || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
         continue;
       searched_controller->joints_.push_back(joint->getName());
     }
@@ -655,7 +655,7 @@ bool ROSControllersWidget::saveControllerScreen()
   const std::string& controller_type = controller_edit_widget_->getControllerType();
 
   // Used for editing existing controllers
-  moveit_setup_assistant::ROSControlConfig* searched_controller = NULL;
+  moveit_setup_assistant::ROSControlConfig* searched_controller = nullptr;
 
   std::smatch invalid_name_match;
   std::regex invalid_reg_ex("[^a-z|^1-9|^_]");
@@ -693,7 +693,7 @@ bool ROSControllersWidget::saveControllerScreen()
   adding_new_controller_ = false;
 
   // Save the new controller name or create the new controller
-  if (searched_controller == NULL)  // create new
+  if (searched_controller == nullptr)  // create new
   {
     moveit_setup_assistant::ROSControlConfig new_controller;
     new_controller.name_ = controller_name;
@@ -730,7 +730,7 @@ void ROSControllersWidget::editSelected()
   QTreeWidgetItem* controller_item;
 
   // Check that something was actually selected
-  if (item == NULL)
+  if (item == nullptr)
     return;
 
   adding_new_controller_ = false;
@@ -790,7 +790,7 @@ void ROSControllersWidget::editController()
   QTreeWidgetItem* item = controllers_tree_->currentItem();
 
   // Check that something was actually selected
-  if (item == NULL)
+  if (item == nullptr)
     return;
 
   adding_new_controller_ = false;

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -844,4 +844,4 @@ void ROSControllersWidget::itemSelectionChanged()
   }
 }
 
-}  // namespace
+}  // namespace moveit_ros_control

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -63,8 +63,8 @@ namespace moveit_setup_assistant
 SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_options::variables_map args)
   : QWidget(parent)
 {
-  rviz_manager_ = NULL;
-  rviz_render_panel_ = NULL;
+  rviz_manager_ = nullptr;
+  rviz_render_panel_ = nullptr;
 
   // Create object to hold all MoveIt! configuration data
   config_data_.reset(new MoveItConfigData());
@@ -175,11 +175,11 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, boost::program_optio
 // ******************************************************************************************
 SetupAssistantWidget::~SetupAssistantWidget()
 {
-  if (rviz_manager_ != NULL)
+  if (rviz_manager_ != nullptr)
     rviz_manager_->removeAllDisplays();
-  if (rviz_render_panel_ != NULL)
+  if (rviz_render_panel_ != nullptr)
     delete rviz_render_panel_;
-  if (rviz_manager_ != NULL)
+  if (rviz_manager_ != nullptr)
     delete rviz_manager_;
 }
 

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -519,4 +519,4 @@ void SetupAssistantWidget::setModalMode(bool isModal)
   }
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -224,4 +224,4 @@ void SimulationWidget::copyURDF(const QString& link)
   simulation_text_->copy();
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -400,7 +400,7 @@ bool StartScreenWidget::loadExistingFiles()
   fs::path kinematics_yaml_path = config_data_->config_pkg_path_;
   kinematics_yaml_path /= "config/kinematics.yaml";
 
-  if (!config_data_->inputKinematicsYAML(kinematics_yaml_path.make_preferred().native().c_str()))
+  if (!config_data_->inputKinematicsYAML(kinematics_yaml_path.make_preferred().native()))
   {
     QMessageBox::warning(this, "No Kinematic YAML File",
                          QString("Failed to parse kinematics yaml file. This file is not critical but any previous "
@@ -416,11 +416,11 @@ bool StartScreenWidget::loadExistingFiles()
   // Load ros controllers yaml file if available-----------------------------------------------
   fs::path ros_controllers_yaml_path = config_data_->config_pkg_path_;
   ros_controllers_yaml_path /= "config/ros_controllers.yaml";
-  config_data_->inputROSControllersYAML(ros_controllers_yaml_path.make_preferred().native().c_str());
+  config_data_->inputROSControllersYAML(ros_controllers_yaml_path.make_preferred().native());
 
   fs::path ompl_yaml_path = config_data_->config_pkg_path_;
   ompl_yaml_path /= "config/ompl_planning.yaml";
-  config_data_->inputOMPLYAML(ompl_yaml_path.make_preferred().native().c_str());
+  config_data_->inputOMPLYAML(ompl_yaml_path.make_preferred().native());
 
   // DONE LOADING --------------------------------------------------------------------------
 
@@ -781,12 +781,12 @@ bool StartScreenWidget::load3DSensorsFile()
 
   if (!fs::is_regular_file(sensors_3d_yaml_path))
   {
-    return config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().native().c_str());
+    return config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().native());
   }
   else
   {
-    return config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().native().c_str(),
-                                            sensors_3d_yaml_path.make_preferred().native().c_str());
+    return config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().native(),
+                                            sensors_3d_yaml_path.make_preferred().native());
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -852,4 +852,4 @@ SelectModeWidget::SelectModeWidget(QWidget* parent) : QFrame(parent)
   btn_new_->setCheckable(true);
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -628,4 +628,4 @@ void VirtualJointsWidget::focusGiven()
   loadChildLinksComboBox();
 }
 
-}  // namespace
+}  // namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -375,7 +375,7 @@ void VirtualJointsWidget::loadChildLinksComboBox()
 srdf::Model::VirtualJoint* VirtualJointsWidget::findVJointByName(const std::string& name)
 {
   // Find the group state we are editing based on the vjoint name
-  srdf::Model::VirtualJoint* searched_group = NULL;  // used for holding our search results
+  srdf::Model::VirtualJoint* searched_group = nullptr;  // used for holding our search results
 
   for (std::vector<srdf::Model::VirtualJoint>::iterator vjoint_it = config_data_->srdf_->virtual_joints_.begin();
        vjoint_it != config_data_->srdf_->virtual_joints_.end(); ++vjoint_it)
@@ -388,7 +388,7 @@ srdf::Model::VirtualJoint* VirtualJointsWidget::findVJointByName(const std::stri
   }
 
   // Check if vjoint was found
-  if (searched_group == NULL)  // not found
+  if (searched_group == nullptr)  // not found
   {
     QMessageBox::critical(this, "Error Saving", "An internal error has occured while saving. Quitting.");
     QApplication::quit();
@@ -449,7 +449,7 @@ void VirtualJointsWidget::doneEditing()
   const std::string parent_name = parent_name_field_->text().trimmed().toStdString();
 
   // Used for editing existing groups
-  srdf::Model::VirtualJoint* searched_data = NULL;
+  srdf::Model::VirtualJoint* searched_data = nullptr;
 
   // Check that name field is not empty
   if (vjoint_name.empty())
@@ -506,7 +506,7 @@ void VirtualJointsWidget::doneEditing()
   // Save the new vjoint name or create the new vjoint ----------------------------
   bool isNew = false;
 
-  if (searched_data == NULL)  // create new
+  if (searched_data == nullptr)  // create new
   {
     isNew = true;
     searched_data = new srdf::Model::VirtualJoint();

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -609,7 +609,7 @@ void VirtualJointsWidget::loadDataTable()
   data_table_->resizeColumnToContents(3);
 
   // Show edit button if applicable
-  if (config_data_->srdf_->virtual_joints_.size())
+  if (!config_data_->srdf_->virtual_joints_.empty())
     btn_edit_->show();
 }
 


### PR DESCRIPTION
### Description

Redo [moveit#1354](https://github.com/ros-planning/moveit/pull/1354) for Melodic.

Since the clang-tidy fixes can involve many file changes, which makes it difficult for reviewing. The previous PR will be split into several PRs. This is the first one which contains some low risk fixes. Please note `clang-tidy-3.9` is used, and there are some manual fixes to the auto clang-tidy fix, they are related to:

- `performance-unnecessary-copy-initialization` may falsely convert `non-const` variable to `const` variable
- `modernize-use-nullptr` may convert some unnecessary `NULL` and `0` to `nullptr`. 
  * Boost function pointer initialization by `nullptr` seems not allowed.
  * Some `NULL` and `0` refer to `int` or `enum` or null `Qstring`, it may not be safe to replace them by `nullptr`.
- `readability-simplify-boolean-expr` may convert `if(...){...}...return...` clause by `return...` clause. But some code cannot be ignored.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format]