### PR TITLE
Add CODEOWNERS file for automatic reviewer assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 # The users below will be the default owners for everything in the repository.
 # Unless a line further in this file matches, all of the users here will be
 # requested for review when someone opens a pull request.
-*	@davetcoleman @v4hn @mikeferguson
+*	@davetcoleman @v4hn @rhaschke 
 
 # The lines below correspond to directories with a package.xml file and the
 # maintainers specified in that file
@@ -36,40 +36,44 @@
 
 /moveit_plugins/moveit_controller_manager_example/	@v4hn
 
-/moveit_core/	@davetcoleman @v4hn @mikeferguson
+/moveit_core/	@davetcoleman @v4hn @mlautman
 
 /moveit_commander/	@v4hn @rhaschke
 
-/moveit/	@davetcoleman @mikeferguson @v4hn @rhaschke @IanTheEngineer @130s
+/moveit/	@130s
 
-/moveit_kinematics/	@davetcoleman @gavanderhoorn @jrgnicho
+/moveit_kinematics/	@rhaschke @gavanderhoorn @jrgnicho
 
 /moveit_experimental/	@AndyZe
 
-/moveit_ros/perception/	@mikeferguson
+/moveit_ros/perception/	@mikeferguson @jonbinney
+--
 
-/moveit_ros/manipulation/	@v4hn @mikeferguson
 
-/moveit_ros/benchmarks/	@davetcoleman
 
-/moveit_ros/planning_interface/	@mikeferguson @v4hn
+
+/moveit_ros/manipulation/	@v4hn @felixvd 
+
+/moveit_ros/benchmarks/	@davetcoleman @MohmadAyman 
+
+/moveit_ros/planning_interface/	@mintar @rhaschke 
 
 /moveit_ros/robot_interaction/	@mikeferguson @rhaschke
 
-/moveit_ros/planning/	@mikeferguson @v4hn
+/moveit_ros/planning/	@henningkayser @v4hn
 
-/moveit_ros/warehouse/	@mikeferguson
+/moveit_ros/warehouse/	@mikeferguson @dg-shadow 
 
-/moveit_ros/move_group/	@mikeferguson @v4hn
+/moveit_ros/move_group/	@IanTheEngineer @v4hn
 
-/moveit_ros/visualization/	@jonbinney @mikeferguson
+/moveit_ros/visualization/	@jonbinney @christian-rauch 
 
-/moveit_setup_assistant/	@davetcoleman @rhaschke
+/moveit_setup_assistant/	@davetcoleman @rhaschke @MohmadAyman 
 
 /moveit_planners/ompl/	@BryceStevenWilley @zkingston
 
-/moveit_planners/chomp/chomp_interface/	@sachinchitta @davetcoleman
+/moveit_planners/chomp/chomp_interface/    @raghavendersahdev @knorth55 @bmagyar
 
-/moveit_planners/chomp/chomp_optimizer_adapter/	@raghavendersahdev
+/moveit_planners/chomp/chomp_optimizer_adapter/	@raghavendersahdev @knorth55 @bmagyar
 
-/moveit_planners/chomp/chomp_motion_planner/	@sachinchitta
+/moveit_planners/chomp/chomp_motion_planner/	@raghavendersahdev @knorth55 @bmagyar

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@
 # The lines below correspond to directories with a package.xml file and the
 # maintainers specified in that file
 
-/moveit_plugins/moveit_ros_control_interface/	@ipa-mdl
+/moveit_plugins/moveit_ros_control_interface/	@ipa-mdl @bmagyar
 
 /moveit_plugins/moveit_fake_controller_manager/	@v4hn @rhaschke
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,17 @@
-# This is a comment.
+# MoveIt! is a large project with pull requests being created often. In order
+# to ensure quick review turn around time from our maintainer team, we're
+# leveraging an automated "triage" approach to auto-assign reviews to new pull
+# requests. If you already know who should review your PR, then you can assign
+# them manually. Otherwise, this code owners file will help assign reviewers
+# and reduce the amount of email received by maintainers having to "Watch" the
+# entire repository.
+
+# When a PR is finished being created ("Create Pull Request" is clicked), the
+# codeowner of each file in the PR will be added to the list of reviewers.
+# Code owners are maintainers who are familiar with certain parts of the code,
+# and thus more likely to review a PR relating to them. Being a code owner
+# does not imply authorship, control or ownership in a legal sense.
+
 # Each line in this file is a file pattern followed by one or more
 # @github_usernames and/or e-mail addresses corresponding to users with write
 # permissions for the repository.
@@ -10,61 +23,53 @@
 # The users below will be the default owners for everything in the repository.
 # Unless a line further in this file matches, all of the users here will be
 # requested for review when someone opens a pull request.
-*	dave@picknik.ai me@v4hn.de mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+*	@davetcoleman @v4hn @mikeferguson
 
 # The lines below correspond to directories with a package.xml file and the
 # maintainers specified in that file
 
-/moveit_runtime/	gm130s@gmail.com
+/moveit_plugins/moveit_ros_control_interface/	@ipa-mdl
 
-/moveit_plugins/moveit_plugins/	me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_plugins/moveit_fake_controller_manager/	@v4hn
 
-/moveit_plugins/moveit_ros_control_interface/	mathias.luedtke@ipa.fraunhofer.de moveit_releasers@googlegroups.com
+/moveit_plugins/moveit_simple_controller_manager/	@mikeferguson @v4hn
 
-/moveit_plugins/moveit_fake_controller_manager/	me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_plugins/moveit_controller_manager_example/	@v4hn
 
-/moveit_plugins/moveit_simple_controller_manager/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_core/	@davetcoleman @v4hn @mikeferguson
 
-/moveit_plugins/moveit_controller_manager_example/	me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_commander/	@v4hn @rhaschke
 
-/moveit_core/	dave@picknik.ai me@v4hn.de mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+/moveit/	@davetcoleman @mikeferguson @v4hn @rhaschke @IanTheEngineer @130s
 
-/moveit_commander/	me@v4hn.de rhaschke@techfak.uni-bielefeld.de moveit_releasers@googlegroups.com
+/moveit_kinematics/	@davetcoleman @gavanderhoorn @jrgnicho
 
-/moveit/	dave@picknik.ai mferguson@fetchrobotics.com me@v4hn.de rhaschke@techfak.uni-bielefeld.de imcmahon01@gmail.com 130s@2000.jukuin.keio.ac.jp
+/moveit_experimental/	@AndyZe
 
-/moveit_kinematics/	dave@picknik.ai g.a.vanderhoorn@tudelft.nl jorge.nicho@swri.org moveit_releasers@googlegroups.com
+/moveit_ros/perception/	@mikeferguson
 
-/moveit_experimental/	moveit_releasers@googlegroups.com
+/moveit_ros/manipulation/	@v4hn @mikeferguson
 
-/moveit_ros/perception/	mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+/moveit_ros/benchmarks/	@davetcoleman
 
-/moveit_ros/manipulation/	me@v4hn.de mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+/moveit_ros/planning_interface/	@mikeferguson @v4hn
 
-/moveit_ros/benchmarks/	dave@picknik.ai moveit_releasers@googlegroups.com
+/moveit_ros/robot_interaction/	@mikeferguson @rhaschke
 
-/moveit_ros/moveit_ros/	mferguson@fetchrobotics.com me@v4hn.de dave@picknik.ai moveit_releasers@googlegroups.com
+/moveit_ros/planning/	@mikeferguson @v4hn
 
-/moveit_ros/planning_interface/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_ros/warehouse/	@mikeferguson
 
-/moveit_ros/robot_interaction/	mferguson@fetchrobotics.com rhaschke@techfak.uni-bielefeld.de moveit_releasers@googlegroups.com
+/moveit_ros/move_group/	@mikeferguson @v4hn
 
-/moveit_ros/planning/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_ros/visualization/	@jonbinney @mikeferguson
 
-/moveit_ros/warehouse/	mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+/moveit_setup_assistant/	@davetcoleman @rhaschke
 
-/moveit_ros/move_group/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+/moveit_planners/ompl/	@BryceStevenWilley @zkingston
 
-/moveit_ros/visualization/	jon.binney@gmail.com mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+/moveit_planners/chomp/chomp_interface/	@sachinchitta @davetcoleman
 
-/moveit_setup_assistant/	dave@picknik.ai rhaschke@techfak.uni-bielefeld.de moveit_releasers@googlegroups.com
+/moveit_planners/chomp/chomp_optimizer_adapter/	@raghavendersahdev
 
-/moveit_planners/ompl/	dave@picknik.ai moveit_releasers@googlegroups.com
-
-/moveit_planners/moveit_planners/	dave@picknik.ai moveit_releasers@googlegroups.com
-
-/moveit_planners/chomp/chomp_interface/	chitt@live.in dave@picknik.ai moveit_releasers@googlegroups.com
-
-/moveit_planners/chomp/chomp_optimizer_adapter/	raghavendersahdev@gmail.com moveit_releasers@googlegroups.com
-
-/moveit_planners/chomp/chomp_motion_planner/	chitt@live.in moveit_releasers@googlegroups.com
+/moveit_planners/chomp/chomp_motion_planner/	@sachinchitta

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,10 +47,6 @@
 /moveit_experimental/	@AndyZe
 
 /moveit_ros/perception/	@mikeferguson @jonbinney
---
-
-
-
 
 /moveit_ros/manipulation/	@v4hn @felixvd 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,13 +30,13 @@
 
 /moveit_plugins/moveit_ros_control_interface/	@ipa-mdl
 
-/moveit_plugins/moveit_fake_controller_manager/	@v4hn
+/moveit_plugins/moveit_fake_controller_manager/	@v4hn @rhaschke
 
 /moveit_plugins/moveit_simple_controller_manager/	@mikeferguson @v4hn
 
 /moveit_plugins/moveit_controller_manager_example/	@v4hn
 
-/moveit_core/	@davetcoleman @v4hn @mlautman
+/moveit_core/	@davetcoleman @rhaschke @v4hn @mlautman
 
 /moveit_commander/	@v4hn @rhaschke @willcbaker
 
@@ -56,13 +56,13 @@
 
 /moveit_ros/robot_interaction/	@mikeferguson @rhaschke
 
-/moveit_ros/planning/	@henningkayser @v4hn
+/moveit_ros/planning/	@henningkayser @v4hn @rhaschke 
 
 /moveit_ros/warehouse/	@mikeferguson @dg-shadow 
 
-/moveit_ros/move_group/	@IanTheEngineer @v4hn
+/moveit_ros/move_group/	@rhaschke @IanTheEngineer @v4hn
 
-/moveit_ros/visualization/	@jonbinney @christian-rauch 
+/moveit_ros/visualization/	@rhaschke @jonbinney @christian-rauch 
 
 /moveit_setup_assistant/	@davetcoleman @rhaschke @MohmadAyman 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,7 +68,7 @@
 
 /moveit_planners/ompl/	@BryceStevenWilley @zkingston
 
-/moveit_planners/chomp/chomp_interface/    @raghavendersahdev @knorth55 @bmagyar
+/moveit_planners/chomp/chomp_interface/ @raghavendersahdev @knorth55 @bmagyar
 
 /moveit_planners/chomp/chomp_optimizer_adapter/	@raghavendersahdev @knorth55 @bmagyar
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,70 @@
+# This is a comment.
+# Each line in this file is a file pattern followed by one or more
+# @github_usernames and/or e-mail addresses corresponding to users with write
+# permissions for the repository.
+# https://help.github.com/en/articles/about-code-owners
+
+# Order is important; the user(s) in the last matching pattern here for a file will
+# be that file's owner(s).
+
+# The users below will be the default owners for everything in the repository.
+# Unless a line further in this file matches, all of the users here will be
+# requested for review when someone opens a pull request.
+*	dave@picknik.ai me@v4hn.de mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+
+# The lines below correspond to directories with a package.xml file and the
+# maintainers specified in that file
+
+/moveit_runtime/	gm130s@gmail.com
+
+/moveit_plugins/moveit_plugins/	me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_plugins/moveit_ros_control_interface/	mathias.luedtke@ipa.fraunhofer.de moveit_releasers@googlegroups.com
+
+/moveit_plugins/moveit_fake_controller_manager/	me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_plugins/moveit_simple_controller_manager/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_plugins/moveit_controller_manager_example/	me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_core/	dave@picknik.ai me@v4hn.de mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+
+/moveit_commander/	me@v4hn.de rhaschke@techfak.uni-bielefeld.de moveit_releasers@googlegroups.com
+
+/moveit/	dave@picknik.ai mferguson@fetchrobotics.com me@v4hn.de rhaschke@techfak.uni-bielefeld.de imcmahon01@gmail.com 130s@2000.jukuin.keio.ac.jp
+
+/moveit_kinematics/	dave@picknik.ai g.a.vanderhoorn@tudelft.nl jorge.nicho@swri.org moveit_releasers@googlegroups.com
+
+/moveit_experimental/	moveit_releasers@googlegroups.com
+
+/moveit_ros/perception/	mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+
+/moveit_ros/manipulation/	me@v4hn.de mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+
+/moveit_ros/benchmarks/	dave@picknik.ai moveit_releasers@googlegroups.com
+
+/moveit_ros/moveit_ros/	mferguson@fetchrobotics.com me@v4hn.de dave@picknik.ai moveit_releasers@googlegroups.com
+
+/moveit_ros/planning_interface/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_ros/robot_interaction/	mferguson@fetchrobotics.com rhaschke@techfak.uni-bielefeld.de moveit_releasers@googlegroups.com
+
+/moveit_ros/planning/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_ros/warehouse/	mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+
+/moveit_ros/move_group/	mferguson@fetchrobotics.com me@v4hn.de moveit_releasers@googlegroups.com
+
+/moveit_ros/visualization/	jon.binney@gmail.com mferguson@fetchrobotics.com moveit_releasers@googlegroups.com
+
+/moveit_setup_assistant/	dave@picknik.ai rhaschke@techfak.uni-bielefeld.de moveit_releasers@googlegroups.com
+
+/moveit_planners/ompl/	dave@picknik.ai moveit_releasers@googlegroups.com
+
+/moveit_planners/moveit_planners/	dave@picknik.ai moveit_releasers@googlegroups.com
+
+/moveit_planners/chomp/chomp_interface/	chitt@live.in dave@picknik.ai moveit_releasers@googlegroups.com
+
+/moveit_planners/chomp/chomp_optimizer_adapter/	raghavendersahdev@gmail.com moveit_releasers@googlegroups.com
+
+/moveit_planners/chomp/chomp_motion_planner/	chitt@live.in moveit_releasers@googlegroups.com

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,7 +38,7 @@
 
 /moveit_core/	@davetcoleman @v4hn @mlautman
 
-/moveit_commander/	@v4hn @rhaschke
+/moveit_commander/	@v4hn @rhaschke @willcbaker
 
 /moveit/	@130s
 


### PR DESCRIPTION
### Description

This adds a CODEOWNERS file as described [here](https://help.github.com/en/articles/about-code-owners) which will automatically assign reviewer(s) according to its rules. Each line in this file is a file pattern followed by one or more github usernames, github teamnames, or e-mail addresses affiliated with a github account. These users/teams must have write permission to the repository.

Order is important; the user(s) in the last matching pattern in CODEOWNERS for a file will be that file's owner(s). For each file in a PR, its owner(s) will be added as reviewers.

This CODEOWNERS file was generated by assigning files under a package.xml to the maintainer e-mails listed in that package.xml. The default owners for files not matching any pattern is the maintainer e-mail list in moveit_core's package.xml.