### PR TITLE
Fcl as a Plugin

### DIFF
--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIB
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 add_library(collision_detector_fcl_plugin src/collision_detector_fcl_plugin_loader.cpp)
-set_target_properties(collision_detector_fcl_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+set_target_properties(collision_detector_fcl_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(collision_detector_fcl_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME})
 
 
@@ -20,6 +20,8 @@ install(TARGETS ${MOVEIT_LIB_NAME} collision_detector_fcl_plugin
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+install(FILES ../collision_detector_fcl_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -10,7 +10,12 @@ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_V
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
-install(TARGETS ${MOVEIT_LIB_NAME}
+add_library(collision_detector_fcl_plugin src/collision_detector_fcl_plugin_loader.cpp)
+set_target_properties(collision_detector_fcl_plugin PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+target_link_libraries(collision_detector_fcl_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME})
+
+
+install(TARGETS ${MOVEIT_LIB_NAME} collision_detector_fcl_plugin
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
@@ -1,0 +1,19 @@
+/*
+ * collision_detector_fcl_plugin_loader.h
+ */
+
+#ifndef MOVEIT_COLLISION_DETECTION_FCL_COLLISION_DETECTOR_FCL_PLUGIN_LOADER_H_
+#define MOVEIT_COLLISION_DETECTION_FCL_COLLISION_DETECTOR_FCL_PLUGIN_LOADER_H_
+
+#include <moveit/collision_detection/collision_plugin.h>
+#include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
+
+namespace collision_detection
+{
+class CollisionDetectorFCLPluginLoader : public CollisionPlugin
+{
+public:
+  virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const;
+};
+}
+#endif  // MOVEIT_COLLISION_DETECTION_FCL_COLLISION_DETECTOR_FCL_PLUGIN_LOADER_H_

--- a/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
@@ -1,0 +1,14 @@
+#include <moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h>
+#include <pluginlib/class_list_macros.h>
+
+namespace collision_detection
+{
+bool CollisionDetectorFCLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene,
+                                                     bool exclusive) const
+{
+  scene->setActiveCollisionDetector(CollisionDetectorAllocatorFCL::create(), exclusive);
+  return true;
+}
+}
+
+PLUGINLIB_EXPORT_CLASS(collision_detection::CollisionDetectorFCLPluginLoader, collision_detection::CollisionPlugin)

--- a/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
@@ -3,8 +3,7 @@
 
 namespace collision_detection
 {
-bool CollisionDetectorFCLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene,
-                                                     bool exclusive) const
+bool CollisionDetectorFCLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const
 {
   scene->setActiveCollisionDetector(CollisionDetectorAllocatorFCL::create(), exclusive);
   return true;

--- a/moveit_core/collision_detector_fcl_description.xml
+++ b/moveit_core/collision_detector_fcl_description.xml
@@ -1,0 +1,8 @@
+<library path="lib/libcollision_detector_fcl_plugin">
+  <class name="FCL" type="collision_detection::CollisionDetectorFCLPluginLoader"
+  base_class_type="collision_detection::CollisionPlugin">
+    <description>
+      FCL Collision Detector, default for MoveIt.
+    </description>
+  </class>
+</library>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -54,4 +54,8 @@
   <test_depend>orocos_kdl</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>code_coverage</test_depend>
+
+  <export>
+    <moveit_core plugin="${prefix}/collision_detector_fcl_description.xml"/>
+  </export>
 </package>


### PR DESCRIPTION
### Description

I mentioned at the maintainer's meeting that I had once made the FCL collision detector a plugin, as opposed to its currently hardcoded state. This is the simple change to make that happen, and gets us one step closer to being able to easily use different collision detectors, like [Bullet](https://github.com/bulletphysics/bullet3), in MoveIt.

To actually make this affect anything, you have to set the `collision_detector` param of the move group. In the generated `move_group.launch`, you can add 
```
<param name="collision_detector" value="FCL"/>
``` 
right after `jiggle_fraction` to use it. Then the plugin loader loads it [as seen here](
https://github.com/ros-planning/moveit/blob/822a991e0ea4f713fe672e3e337d7f0702bcc224/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp#L116).
(This doesn't really make a difference, as the planning scene always [loads the FCL plugin by default](https://github.com/BryceStevenWilley/moveit/blob/d1b2fcf4e5622212d620ecde9f2935eed507a7e0/moveit_core/planning_scene/src/planning_scene.cpp#L173), but it's a step.)

Future changes should eventually make the collision detector a parameter in all of the generated `move_group` launch files. If desired, I could do that now, but it would take a while for me to figure out the MSA.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
