### PR TITLE
MSA: re-add missing build dependencies

### DIFF
--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -18,6 +18,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>libogre-dev</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
+
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_visualization</depend>


### PR DESCRIPTION
Address #1371. Re-add some missing build dependencies removed in #1341.