### PR TITLE
WIP: fix chomp issues

### DIFF
--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -166,7 +166,8 @@ public:
   {
     // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
     // variable which is then used by CHOMP for optimization of the computed trajectory
-    bool solved = planner(ps, req, res);
+    if (!planner(ps, req, res))
+      return false;
 
     // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
@@ -216,7 +217,7 @@ public:
       res.planning_time_ = res_detailed.processing_time_[0];
     }
 
-    return solved;
+    return planning_success;
   }
 
 private:


### PR DESCRIPTION
This is an attempt to fix various chomp issues.
* 1st one is to fix a segfault when the main planner fails. In this case `res.trajectory_` is `NULL`.

Open issues:
* plan + exec behaves differently (fails) than separate plan and execute (when triggered from rviz plugin)
  When running plan+exec, the initial RobotState seems to be undefined, while it is defined otherwise.
