### PR TITLE
Document release in MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,8 @@
 
 API changes in MoveIt! releases
 
+## ROS Noetic (upcoming changes in master)
+
 ## ROS Melodic
 
 - Migration to ``tf2`` API.


### PR DESCRIPTION
Make it clear that future migration notes go in a new section
