### PR TITLE
fix more warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - ROS_REPO=ros
     - UPSTREAM_WORKSPACE=moveit.rosinstall
     - TEST_BLACKLIST=moveit_ros_perception  # mesh_filter_test fails due to broken Mesa OpenGL
+    - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-unused-function"
     - WARNINGS_OK=false
   matrix:
     - TEST="clang-format catkin_lint"
@@ -31,6 +32,7 @@ matrix: # Add a separate config to the matrix, using clang as compiler
     - compiler: clang
       env: ROS_REPO=ros-shadow-fixed
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+           CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 
   fast_finish: true  # finish, even if allow-failure-tests still running
   allow_failures:

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -95,7 +95,7 @@ public:
     centers.push_back(std::uniform_int_distribution<size_t>{ 0, data.size() - 1 }(generator_));
     for (unsigned i = 1; i < k; ++i)
     {
-      unsigned ind;
+      unsigned ind = 0;
       const _T& center = data[centers[i - 1]];
       double maxDist = -std::numeric_limits<double>::infinity();
       for (unsigned j = 0; j < data.size(); ++j)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -46,7 +46,7 @@ namespace cached_ik_kinematics_plugin
 IKCache::IKCache()
 {
   // set distance function for nearest-neighbor queries
-  ik_nn_.setDistanceFunction([this](const IKEntry* entry1, const IKEntry* entry2) {
+  ik_nn_.setDistanceFunction([](const IKEntry* entry1, const IKEntry* entry2) {
     double dist = 0.;
     for (unsigned int i = 0; i < entry1->first.size(); ++i)
       dist += entry1->first[i].distance(entry2->first[i]);

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -78,9 +78,8 @@ int main(int argc, char* argv[])
   robot_state::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
   collision_detection::CollisionRequest collision_request;
   collision_detection::CollisionResult collision_result;
-  std::vector<double> joint_values;
   std::chrono::duration<double> ik_time(0);
-  std::chrono::time_point<std::chrono::system_clock> start, end;
+  std::chrono::time_point<std::chrono::system_clock> start;
   std::vector<robot_state::JointModelGroup*> groups;
   std::vector<std::string> end_effectors;
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/measure_ik_call_cost.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
   collision_detection::CollisionRequest collision_request;
   collision_detection::CollisionResult collision_result;
   std::vector<double> joint_values;
-  std::chrono::duration<double> ik_time;
+  std::chrono::duration<double> ik_time(0);
   std::chrono::time_point<std::chrono::system_clock> start, end;
   std::vector<robot_state::JointModelGroup*> groups;
   std::vector<std::string> end_effectors;

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast.h
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast.h
@@ -92,7 +92,7 @@ public:
   virtual const std::vector<int>& GetFree() const = 0;
 
   /// \brief the dof of the solution
-  virtual const int GetDOF() const = 0;
+  virtual int GetDOF() const = 0;
 };
 
 /// \brief manages all the solutions
@@ -206,7 +206,7 @@ public:
   {
     return _vfree;
   }
-  virtual const int GetDOF() const
+  virtual int GetDOF() const
   {
     return static_cast<int>(_vbasesol.size());
   }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -58,9 +58,10 @@ ChainIkSolverVelMimicSVD::ChainIkSolverVelMimicSVD(const Chain& chain,
   , jac_reduced_(svd_.cols())
 {
   assert(mimic_joints_.size() == chain.getNrOfJoints());
+#ifndef NDEBUG
   for (const auto& item : mimic_joints)
     assert(item.map_index < chain_.getNrOfJoints());
-
+#endif
   svd_.setThreshold(threshold);
 }
 

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -413,7 +413,9 @@ static void parseVector(XmlRpc::XmlRpcValue& vec, std::vector<double>& values, s
 {
   ASSERT_EQ(vec.getType(), XmlRpc::XmlRpcValue::TypeArray);
   if (num != 0)
-    ASSERT_EQ(vec.size(), num);
+  {
+    ASSERT_EQ(static_cast<size_t>(vec.size()), num);
+  }
   values.reserve(vec.size());
   values.clear();
   for (int i = 0; i < vec.size(); ++i)

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -291,11 +291,11 @@ public:
   std::vector<double> consistency_limits_;
   double timeout_;
   double tolerance_;
-  int num_fk_tests_;
-  int num_ik_cb_tests_;
-  int num_ik_tests_;
-  int num_ik_multiple_tests_;
-  int num_nearest_ik_tests_;
+  unsigned int num_fk_tests_;
+  unsigned int num_ik_cb_tests_;
+  unsigned int num_ik_tests_;
+  unsigned int num_ik_multiple_tests_;
+  unsigned int num_nearest_ik_tests_;
 };
 
 #define EXPECT_NEAR_POSES(lhs, rhs, near)                                                                              \
@@ -416,7 +416,7 @@ static void parseVector(XmlRpc::XmlRpcValue& vec, std::vector<double>& values, s
     ASSERT_EQ(vec.size(), num);
   values.reserve(vec.size());
   values.clear();
-  for (size_t i = 0; i < vec.size(); ++i)
+  for (int i = 0; i < vec.size(); ++i)
     values.push_back(parseDouble(vec[i]));
 }
 static bool parseGoal(const std::string& name, XmlRpc::XmlRpcValue& value, Eigen::Isometry3d& goal, std::string& desc)
@@ -509,7 +509,7 @@ TEST_F(KinematicsTest, unitIK)
      - pos.y: -0.1
        joints: [0, 0, 0, 0, 0, 0]
   */
-  for (size_t i = 0; i < tests.size(); ++i)
+  for (int i = 0; i < tests.size(); ++i)
   {
     goal = initial;  // reset goal to initial
     ground_truth.clear();

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
@@ -77,8 +77,8 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
   : mean_(mean)
   , covariance_(covariance)
   , covariance_cholesky_(covariance_.llt().matrixL())
-  , normal_dist_(0.0, 1.0)
   , rng_()
+  , normal_dist_(0.0, 1.0)
   , gaussian_(rng_, normal_dist_)
 {
   rng_.seed(rand());

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -126,10 +126,8 @@ void ChompOptimizer::initialize()
   const std::vector<const moveit::core::JointModel*> joint_models = joint_model_group_->getActiveJointModels();
   for (size_t i = 0; i < joint_models.size(); i++)
   {
-    const moveit::core::JointModel* model = joint_models[i];
     double joint_cost = 1.0;
-    const std::string& joint_name = model->getName();
-    // nh.param("joint_costs/" + joint_name, joint_cost, 1.0);
+    // nh.param("joint_costs/" + joint_models[i]->getName(), joint_cost, 1.0);
     std::vector<double> derivative_costs(3);
     derivative_costs[0] = joint_cost * parameters_->smoothness_cost_velocity_;
     derivative_costs[1] = joint_cost * parameters_->smoothness_cost_acceleration_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
@@ -80,7 +80,6 @@ public:
   void project(const ompl::base::State* state, OMPLProjection projection) const override;
 
 private:
-  const ModelBasedPlanningContext* planning_context_;
   std::vector<unsigned int> variables_;
 };
 }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -225,7 +225,7 @@ protected:
   unsigned int minimum_waypoint_count_;
 
 private:
-  MOVEIT_CLASS_FORWARD(CachedContexts);
+  MOVEIT_STRUCT_FORWARD(CachedContexts);
   CachedContextsPtr cached_contexts_;
 };
 }

--- a/moveit_planners/ompl/ompl_interface/src/detail/projection_evaluators.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/projection_evaluators.cpp
@@ -76,7 +76,7 @@ void ompl_interface::ProjectionEvaluatorLinkPose::project(const ompl::base::Stat
 
 ompl_interface::ProjectionEvaluatorJointValue::ProjectionEvaluatorJointValue(const ModelBasedPlanningContext* pc,
                                                                              std::vector<unsigned int> variables)
-  : ompl::base::ProjectionEvaluator(pc->getOMPLStateSpace()), planning_context_(pc), variables_(std::move(variables))
+  : ompl::base::ProjectionEvaluator(pc->getOMPLStateSpace()), variables_(std::move(variables))
 {
 }
 

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -164,7 +164,7 @@ void FollowJointTrajectoryControllerHandle::configure(XmlRpc::XmlRpcValue& confi
   }
   else if (isArray(config))  // or an array of JointTolerance msgs
   {
-    for (size_t i = 0; i < config.size(); ++i)
+    for (int i = 0; i < config.size(); ++i)
     {
       control_msgs::JointTolerance& tol = getTolerance(tolerances, config[i]["name"]);
       for (ToleranceVariables var : { POSITION, VELOCITY, ACCELERATION })

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -51,7 +51,7 @@
 
 namespace pick_place
 {
-MOVEIT_CLASS_FORWARD(ManipulationPlanSharedData);
+MOVEIT_STRUCT_FORWARD(ManipulationPlanSharedData);
 
 struct ManipulationPlanSharedData
 {
@@ -81,7 +81,7 @@ struct ManipulationPlanSharedData
   ros::WallTime timeout_;
 };
 
-MOVEIT_CLASS_FORWARD(ManipulationPlan);
+MOVEIT_STRUCT_FORWARD(ManipulationPlan);
 
 struct ManipulationPlan
 {

--- a/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
+++ b/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
@@ -62,7 +62,7 @@ MOVEIT_CLASS_FORWARD(TrajectoryExecutionManager);
 
 namespace move_group
 {
-MOVEIT_CLASS_FORWARD(MoveGroupContext);
+MOVEIT_STRUCT_FORWARD(MoveGroupContext);
 
 struct MoveGroupContext
 {

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/filter_job.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/filter_job.h
@@ -56,6 +56,8 @@ public:
   Job() : done_(false)
   {
   }
+  virtual ~Job() = default;
+
   inline void wait() const;
   virtual void execute() = 0;
   inline void cancel();

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
@@ -160,14 +160,14 @@ public:
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \return width of frame buffer in pixels
    */
-  const unsigned getWidth() const;
+  unsigned getWidth() const;
 
   /**
    * \brief returns the height of the frame buffer objects in pixels
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \return height of frame buffer in pixels
    */
-  const unsigned getHeight() const;
+  unsigned getHeight() const;
 
   /**
    * \brief set the size of fram buffers

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -440,12 +440,12 @@ GLuint mesh_filter::GLRenderer::getDepthTexture() const
   return depth_id_;
 }
 
-const unsigned mesh_filter::GLRenderer::getWidth() const
+unsigned mesh_filter::GLRenderer::getWidth() const
 {
   return width_;
 }
 
-const unsigned mesh_filter::GLRenderer::getHeight() const
+unsigned mesh_filter::GLRenderer::getHeight() const
 {
   return height_;
 }

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -247,8 +247,8 @@ SemanticWorld::generatePlacePoses(const object_recognition_msgs::Table& chosen_t
 
   Eigen::Quaterniond rotation(object_orientation.x, object_orientation.y, object_orientation.z, object_orientation.w);
   Eigen::Isometry3d object_pose(rotation);
-  double min_distance_from_edge;
-  double height_above_table;
+  double min_distance_from_edge = 0;
+  double height_above_table = 0;
 
   if (object_shape->type == shapes::MESH)
   {

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -641,7 +641,7 @@ protected:
       lock_.reset(new SingleUnlock(planning_scene_monitor_.get(), read_only));
   }
 
-  MOVEIT_CLASS_FORWARD(SingleUnlock);
+  MOVEIT_STRUCT_FORWARD(SingleUnlock);
 
   // we use this struct so that lock/unlock are called only once
   // even if the LockedPlanningScene instance is copied around

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -50,9 +50,9 @@ MOVEIT_CLASS_FORWARD(InteractionHandler);
 MOVEIT_CLASS_FORWARD(RobotInteraction);
 MOVEIT_CLASS_FORWARD(KinematicOptionsMap);
 
-class EndEffectorInteraction;
-class JointInteraction;
-class GenericInteraction;
+struct EndEffectorInteraction;
+struct JointInteraction;
+struct GenericInteraction;
 
 /// Function type for notifying client of RobotState changes.
 ///

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -95,8 +95,8 @@ void parseStart(std::istream& in, planning_scene_monitor::PlanningSceneMonitor* 
 void parseLinkConstraint(std::istream& in, planning_scene_monitor::PlanningSceneMonitor* psm,
                          moveit_warehouse::ConstraintsStorage* cs)
 {
-  Eigen::Translation3d pos;
-  Eigen::Quaterniond rot;
+  Eigen::Translation3d pos(Eigen::Vector3d::Zero());
+  Eigen::Quaterniond rot(Eigen::Quaterniond::Identity());
 
   bool have_position = false;
   bool have_orientation = false;


### PR DESCRIPTION
Having the warnings check enabled in Travis and motivated by [warnings on gentoo](https://answers.ros.org/question/317202/moveit-segfaults-due-to-eigen/?answer=317607#post-id-317607), I increased the warning level for the whole build (previously we only used extended warnings for moveit_core) and fixed the corresponding warnings.