### PR TITLE
Fix alignment of Eigen transforms

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -91,7 +91,7 @@ void RobotState::allocMemory()
                     sizeof(Eigen::Isometry3d),
                 "sizeof(Eigen::Isometry3d) should be a multiple of EIGEN_MAX_ALIGN_BYTES");
 
-  unsigned int extra_alignment_bytes = EIGEN_MAX_ALIGN_BYTES - 1;
+  constexpr unsigned int extra_alignment_bytes = EIGEN_MAX_ALIGN_BYTES - 1;
   // memory for the dirty joint transforms
   const int nr_doubles_for_dirty_joint_transforms =
       1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -87,17 +87,25 @@ RobotState::~RobotState()
 
 void RobotState::allocMemory()
 {
+  static_assert((sizeof(Eigen::Isometry3d) / EIGEN_MAX_ALIGN_BYTES) * EIGEN_MAX_ALIGN_BYTES ==
+                    sizeof(Eigen::Isometry3d),
+                "sizeof(Eigen::Isometry3d) should be a multiple of EIGEN_MAX_ALIGN_BYTES");
+
+  unsigned int extra_alignment_bytes = EIGEN_MAX_ALIGN_BYTES - 1;
   // memory for the dirty joint transforms
   const int nr_doubles_for_dirty_joint_transforms =
       1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));
   const size_t bytes =
       sizeof(Eigen::Isometry3d) * (robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
                                    robot_model_->getLinkGeometryCount()) +
-      sizeof(double) * (robot_model_->getVariableCount() * 3 + nr_doubles_for_dirty_joint_transforms) + 15;
+      sizeof(double) * (robot_model_->getVariableCount() * 3 + nr_doubles_for_dirty_joint_transforms) +
+      extra_alignment_bytes;
   memory_ = malloc(bytes);
 
-  // make the memory for transforms align at 16 bytes
-  variable_joint_transforms_ = reinterpret_cast<Eigen::Isometry3d*>(((uintptr_t)memory_ + 15) & ~(uintptr_t)0x0F);
+  // make the memory for transforms align at EIGEN_MAX_ALIGN_BYTES
+  // https://eigen.tuxfamily.org/dox/classEigen_1_1aligned__allocator.html
+  variable_joint_transforms_ = reinterpret_cast<Eigen::Isometry3d*>(((uintptr_t)memory_ + extra_alignment_bytes) &
+                                                                    ~(uintptr_t)extra_alignment_bytes);
   global_link_transforms_ = variable_joint_transforms_ + robot_model_->getJointModelCount();
   global_collision_body_transforms_ = global_link_transforms_ + robot_model_->getLinkModelCount();
   dirty_joint_transforms_ =


### PR DESCRIPTION
As pointed out at [ROS answers](https://answers.ros.org/question/317202/moveit-segfaults-due-to-eigen), the memory alignment of RobotState variables is not sufficient for new AVX support in Eigen, which requires 32- or even 64-byte alignment instead of the default 16-byte alignment.

This PR makes the alignment dependent on the corresponding variable `EIGEN_MAX_ALIGN_BYTES`.
https://eigen.tuxfamily.org/dox/classEigen_1_1aligned__allocator.html
