### PR TITLE
Fixed to handle normal robot urdf paths

### DIFF
--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection.cpp
@@ -57,7 +57,7 @@ class FclCollisionDetectionTester : public testing::Test
 protected:
   void SetUp() override
   {
-    robot_model_ = moveit::core::loadTestingRobotModel("pr2_description");
+    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
     robot_model_ok_ = static_cast<bool>(robot_model_);
     kinect_dae_resource_ = "package://moveit_resources/pr2_description/urdf/meshes/sensors/kinect_v0/kinect.dae";
 

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -72,7 +72,7 @@ protected:
 
   void SetUp() override
   {
-    robot_model_ = moveit::core::loadTestingRobotModel("pr2_description");
+    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
 
     pr2_kinematics_plugin_right_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);
     pr2_kinematics_plugin_right_arm_->initialize(*robot_model_, "right_arm", "torso_lift_link", { "r_wrist_roll_link" },

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -46,7 +46,7 @@ class LoadPlanningModelsPr2 : public testing::Test
 protected:
   void SetUp() override
   {
-    robot_model_ = moveit::core::loadTestingRobotModel("pr2_description");
+    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
   }
 
   void TearDown() override

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -48,7 +48,7 @@ class LoadPlanningModelsPr2 : public testing::Test
 protected:
   void SetUp() override
   {
-    robot_model_ = moveit::core::loadTestingRobotModel("pr2_description");
+    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
   };
 
   void TearDown() override

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -86,7 +86,7 @@ TEST_F(TestAABB, TestPR2)
 {
   // Contains a link with mesh geometry that is not centered
 
-  robot_state::RobotState pr2_state = this->loadModel("pr2_description");
+  robot_state::RobotState pr2_state = this->loadModel("pr2");
 
   const Eigen::Vector3d& extentsBaseFootprint = pr2_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin();
   // values taken from moveit_resources/pr2_description/urdf/robot.xml

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -44,7 +44,7 @@
 #include <moveit/utils/robot_model_test_utils.h>
 
 // Static variables used in all tests
-moveit::core::RobotModelConstPtr rmodel = moveit::core::loadTestingRobotModel("pr2_description");
+moveit::core::RobotModelConstPtr rmodel = moveit::core::loadTestingRobotModel("pr2");
 robot_trajectory::RobotTrajectory trajectory(rmodel, "right_arm");
 
 // Initialize one-joint, 3 points exactly the same.

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -54,23 +54,26 @@ namespace moveit
 namespace core
 {
 /** \brief Loads a robot from moveit_resources.
- * \param[in] robot_name The name of the robot package in moveit_resources to load.
- *            For example, "panda_description", or "fanuc_description".
+ * \param[in] robot_name The name of the robot in moveit_resources to load.
+ *            This should be the prefix to many of the robot packages.
+ *            For example, "pr2", "panda", or "fanuc".
  * \returns a RobotModel constructed from robot_name's URDF and SRDF.
  */
 moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name);
 
 /** \brief Loads a URDF Model Interface from moveit_resources.
- * \param[in] robot_name The name of the robot package in moveit_resources to load.
- *            For example, "panda_description", or "fanuc_description".
+ * \param[in] robot_name The name of the robot in moveit_resources to load.
+ *            This should be the prefix to many of the robot packages.
+ *            For example, "panda", or "fanuc".
  * \returns a ModelInterface constructed from robot_name's URDF.
  */
 urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name);
 
 /** \brief Loads an SRDF Model from moveit_resources.
- * \param[in] robot_name The name of the robot package in moveit_resources to load.
- *            For example, "panda_description", or "fanuc_description".
- * \returns an SRDF Model constructed from robot_names' URDF and SRDF.
+ * \param[in] robot_name The name of the robot in moveit_resources to load.
+ *            This should be the prefix to many of the robot packages.
+ *            For example, "pr2", "panda", or "fanuc".
+ * \returns an SRDF Model constructed from robot_name's URDF and SRDF.
  */
 srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name);
 

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -64,7 +64,7 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name)
 /** \brief Loads a URDF Model Interface from moveit_resources.
  * \param[in] robot_name The name of the robot in moveit_resources to load.
  *            This should be the prefix to many of the robot packages.
- *            For example, "panda", or "fanuc".
+ *            For example, "pr2", "panda", or "fanuc".
  * \returns a ModelInterface constructed from robot_name's URDF.
  */
 urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name);

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -60,7 +60,7 @@ urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
   std::string urdf_path;
   if (robot_name == "pr2")
   {
-    urdf_path = (res_path / (robot_name + "_description") / "urdf/robot.xml").string();
+    urdf_path = (res_path / "pr2_description/urdf/robot.xml").string();
   }
   else
   {
@@ -83,7 +83,7 @@ srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
   std::string srdf_path;
   if (robot_name == "pr2")
   {
-    srdf_path = (res_path / (robot_name + "_description") / "srdf/robot.xml").string();
+    srdf_path = (res_path / "pr2_description/srdf/robot.xml").string();
   }
   else
   {

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -57,7 +57,16 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name)
 urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 {
   boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
-  urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDFFile((res_path / robot_name / "urdf/robot.xml").string());
+  std::string urdf_path;
+  if (robot_name == "pr2")
+  {
+    urdf_path = (res_path / (robot_name + "_description") / "urdf/robot.xml").string();
+  }
+  else
+  {
+    urdf_path = (res_path / (robot_name + "_description") / "urdf" / (robot_name + ".urdf")).string();
+  }
+  urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDFFile(urdf_path);
   if (urdf_model == nullptr)
   {
     ROS_ERROR_NAMED(LOGNAME, "Cannot find URDF for %s. Make sure moveit_resources/your robot description is installed",
@@ -71,7 +80,16 @@ srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
   boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
   urdf::ModelInterfaceSharedPtr urdf_model = loadModelInterface(robot_name);
   srdf::ModelSharedPtr srdf_model(new srdf::Model());
-  srdf_model->initFile(*urdf_model, (res_path / robot_name / "srdf/robot.xml").string());
+  std::string srdf_path;
+  if (robot_name == "pr2")
+  {
+    srdf_path = (res_path / (robot_name + "_description") / "srdf/robot.xml").string();
+  }
+  else
+  {
+    srdf_path = (res_path / (robot_name + "_moveit_config") / "config" / (robot_name + ".srdf")).string();
+  }
+  srdf_model->initFile(*urdf_model, srdf_path);
   return srdf_model;
 }
 


### PR DESCRIPTION
### Description

Addresses #1386. 

Fixes the fact robot URDF and SRDF paths were hardcoded to the non-standard PR2 locations. Now uses the PR2 as a non-standard if case, and uses the newer normal locations of URDF in `<robot>_description/urdf/<robot>.urdf` and SRDF in `<robot>_moveit_config/config/<robot>.srdf`.
 
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
