### PR TITLE
Feat simple moveit controller manager

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -316,6 +316,7 @@ public:
    * @param YAML Emitter - yaml emitter used to write the config to the ROS controllers yaml file
    * @param vector<ROSControlConfig> - a copy of ROS controllers config which will be modified in the function
    */
+  bool outputFollowJointTrajectoryYAML(const std::string& file_path);
   void outputFollowJointTrajectoryYAML(YAML::Emitter& emitter,
                                        std::vector<ROSControlConfig>& ros_controllers_config_output);
 

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -312,7 +312,7 @@ public:
   bool outputFakeControllersYAML(const std::string& file_path);
 
   /**
-   * Helper function for writing follow joint trajectory ROS controllers to ros_controllers.yaml
+   * Helper function for setting configuration for the controllers given by its namesake function
    * @param YAML Emitter - yaml emitter used to write the config to the ROS controllers yaml file
    * @param vector<ROSControlConfig> - a copy of ROS controllers config which will be modified in the function
    */

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -731,6 +731,29 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
   return planner_des;
 }
 
+bool MoveItConfigData::outputFollowJointTrajectoryYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  addDefaultControllers();
+  std::vector<ROSControlConfig>& ros_controllers_config_output = getROSControllers();
+  outputFollowJointTrajectoryYAML(emitter, ros_controllers_config_output);
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    ROS_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
 // ******************************************************************************************
 // Helper function to write the FollowJointTrajectory for each planning group to ros_controller.yaml,
 // and erases the controller that have been written, to avoid mixing between FollowJointTrajectory

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -923,9 +923,6 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
       emitter << YAML::EndMap;
     }
 
-    // Writes Follow Joint Trajectory ROS controllers to ros_controller.yaml
-    outputFollowJointTrajectoryYAML(emitter, ros_controllers_config_output);
-
     for (std::vector<ROSControlConfig>::const_iterator controller_it = ros_controllers_config_output.begin();
          controller_it != ros_controllers_config_output.end(); ++controller_it)
     {

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -300,6 +300,14 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.write_on_changes = MoveItConfigData::GROUPS;
   gen_files_.push_back(file);
 
+  // controllers.yaml --------------------------------------------------------------------------------------
+  file.file_name_ = "controllers.yaml";
+  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.description_ = "Creates configurations for FollowJointTrajectory.";
+  file.gen_func_ = boost::bind(&MoveItConfigData::outputFollowJointTrajectoryYAML, config_data_, _1);
+  file.write_on_changes = MoveItConfigData::GROUPS;
+  gen_files_.push_back(file);
+
   // ros_controllers.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "ros_controllers.yaml";
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
@@ -1,10 +1,18 @@
 <launch>
+  <!-- The argument for specifying robot type -->
+  <arg name="robot_name" default="[ROBOT_NAME]" />
 
-  <!-- loads moveit_controller_manager on the parameter server which is taken as argument 
-    if no argument is passed, moveit_simple_controller_manager will be set -->
+  <!-- The robot config argument -->
+  <arg name="robot_config" value="$(arg robot_name)_config" />
+
+  <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
   <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
 
-  <!-- loads ros_controllers to the param server -->
-  <rosparam file="$(find [GENERATED_PACKAGE_NAME])/config/ros_controllers.yaml"/>
+  <!-- Flag indicating whether the controller manager should be used or not -->
+  <arg name="use_controller_manager" default="true" />
+  <param name="use_controller_manager" value="$(arg use_controller_manager)" />
+
+  <!-- The rest of the params are specific to this plugin -->
+  <rosparam file="$(find [GENERATED_PACKAGE_NAME])/config/controllers.yaml"/>
 </launch>


### PR DESCRIPTION

Follow up of #1140.
Currently the moveit config package generated by the Setup Assistant was not ready to use because of the missing controller configurations on the MoveIt! side. The PR generates a default `controllers.yaml` file along and sets the default `SimpleMoveItControllerManager`, which can be used within MoveIt! to communicate with `ros_control` or with the robot driver.

- f968db15ac6600af400c2044fd1dc8d5eafc2b5c - Currently `moveit_setup_assistant` generates an empty [`moveit_controller_manager.launch.xml`](https://github.com/ros-planning/moveit/blob/melodic-devel/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml). I see this has been done in https://github.com/ros-planning/moveit/pull/1051, but it also does many other things like launching Gazebo.   

- c171dc9e531c5e8dd5f5c2fcd94ce7d03a22acc0 - Generates `controller.yaml` (MoveIt! specific, which would be loaded in the launch file above), with default `FollowJointTrajectory` action interface

- 19c13b7a48190260e188c2d4810271cbb1d8a722 - Introduced in https://github.com/ros-planning/moveit/pull/951, but this is specific to MoveIt!. The `controller_list` will be needed irrespective of `ros_control` or not.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
