### PR TITLE
cleanup python PlanningSceneInterface

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -88,7 +88,8 @@ class PlanningSceneInterface(object):
         """
         Add a cylinder to the planning scene
         """
-        self._pub_co.publish(self.__make_cylinder(name, pose, height, radius))
+        co = self.__make_cylinder(name, pose, height, radius)
+        self.__submit(co, attach=False)
 
     def add_mesh(self, name, pose, filename, size=(1, 1, 1)):
         """

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -150,7 +150,7 @@ class PlanningSceneInterface(object):
         co.operation = CollisionObject.REMOVE
         if name is not None:
             co.id = name
-        self.__submit(co, attach=True)
+        self.__submit(co, attach=False)
 
     def remove_attached_object(self, link, name=None):
         """


### PR DESCRIPTION
This augments #789.

* `CollisionObject` in `remove_world_object` requires `__submit()` with `attach=False`
* Use new `__submit()` API for `add_cylinder()` as well. This was missing due to two parallel PRs