### PR TITLE
remove MessageFilter for /collision_object messages

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1740,6 +1740,12 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     return false;
   }
 
+  if (!getTransforms().canTransform(object.header.frame_id))
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Unknown frame: " << object.header.frame_id);
+    return false;
+  }
+
   // replace the object if ADD is specified instead of APPEND
   if (object.operation == moveit_msgs::CollisionObject::ADD && world_->hasObject(object.id))
     world_->removeObject(object.id);

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -39,9 +39,7 @@
 
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
-#include <tf2_ros/message_filter.h>
 #include <tf2_ros/buffer.h>
-#include <message_filters/subscriber.h>
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
@@ -419,10 +417,6 @@ protected:
   /** @brief Callback for a new collision object msg*/
   void collisionObjectCallback(const moveit_msgs::CollisionObjectConstPtr& obj);
 
-  /** @brief Callback for a new collision object msg that failed to pass the TF filter */
-  void collisionObjectFailTFCallback(const moveit_msgs::CollisionObjectConstPtr& obj,
-                                     tf2_ros::filter_failure_reasons::FilterFailureReason reason);
-
   /** @brief Callback for a new planning scene world*/
   void newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr& world);
 
@@ -500,9 +494,7 @@ protected:
   ros::Subscriber planning_scene_world_subscriber_;
 
   ros::Subscriber attached_collision_object_subscriber_;
-
-  std::unique_ptr<message_filters::Subscriber<moveit_msgs::CollisionObject> > collision_object_subscriber_;
-  std::unique_ptr<tf2_ros::MessageFilter<moveit_msgs::CollisionObject> > collision_object_filter_;
+  ros::Subscriber collision_object_subscriber_;
 
   // include a octomap monitor
   std::unique_ptr<occupancy_map_monitor::OccupancyMapMonitor> octomap_monitor_;


### PR DESCRIPTION
Due to a typo, I was trying to create a CollisionObject with an undefined frame_id. Interestingly, MoveIt just silently ignored this message on the `/collision_object` topic.

After a while of debugging, it turned out that the PlanningSceneMonitor employs a MessageFilter, which caches messages if the pose cannot be transformed into the planning frame.
But, as the (1024-elem) cache is never cleared (except if new messages arrive, which is not so often for CollisionObject messages), objects with invalid frames were silently ignored.

This PR removes the MessageFilter and adds a corresponding error message in `PlanningScene::processCollisionObjectAdd`.

This will have the side effect, that TF messages arriving after the CollisionObject message will not be considered anymore for resolving.