### PR TITLE
small fixes to chomp planner

### DIFF
--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -22,29 +22,29 @@ CHOMPPlanningContext::~CHOMPPlanningContext() = default;
 
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {
-  moveit_msgs::MotionPlanDetailedResponse res2;
-  if (chomp_interface_->solve(planning_scene_, request_, chomp_interface_->getParams(), res2))
+  moveit_msgs::MotionPlanDetailedResponse res_msg;
+  if (chomp_interface_->solve(planning_scene_, request_, chomp_interface_->getParams(), res_msg))
   {
     res.trajectory_.resize(1);
     res.trajectory_[0] =
         robot_trajectory::RobotTrajectoryPtr(new robot_trajectory::RobotTrajectory(robot_model_, getGroupName()));
 
     moveit::core::RobotState start_state(robot_model_);
-    robot_state::robotStateMsgToRobotState(res2.trajectory_start, start_state);
-    res.trajectory_[0]->setRobotTrajectoryMsg(start_state, res2.trajectory[0]);
+    robot_state::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
+    res.trajectory_[0]->setRobotTrajectoryMsg(start_state, res_msg.trajectory[0]);
 
     trajectory_processing::IterativeParabolicTimeParameterization itp;
     itp.computeTimeStamps(*res.trajectory_[0], request_.max_velocity_scaling_factor,
                           request_.max_acceleration_scaling_factor);
 
     res.description_.push_back("plan");
-    res.processing_time_ = res2.processing_time;
-    res.error_code_ = res2.error_code;
+    res.processing_time_ = res_msg.processing_time;
+    res.error_code_ = res_msg.error_code;
     return true;
   }
   else
   {
-    res.error_code_ = res2.error_code;
+    res.error_code_ = res_msg.error_code;
     return false;
   }
 }

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -33,10 +33,6 @@ bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse&
     robot_state::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
     res.trajectory_[0]->setRobotTrajectoryMsg(start_state, res_msg.trajectory[0]);
 
-    trajectory_processing::IterativeParabolicTimeParameterization itp;
-    itp.computeTimeStamps(*res.trajectory_[0], request_.max_velocity_scaling_factor,
-                          request_.max_acceleration_scaling_factor);
-
     res.description_.push_back("plan");
     res.processing_time_ = res_msg.processing_time;
     res.error_code_ = res_msg.error_code;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -50,6 +50,7 @@ public:
   ChompPlanner();
   virtual ~ChompPlanner(){};
 
+  // TODO: switch API from moveit_msgs to MotionPlanRequest / MotionPlanDetailedResponse
   bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::MotionPlanRequest& req,
              const ChompParameters& params, moveit_msgs::MotionPlanDetailedResponse& res) const;
 };

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -67,7 +67,7 @@ ChompOptimizer::ChompOptimizer(ChompTrajectory* trajectory, const planning_scene
   std::vector<std::string> cd_names;
   planning_scene->getCollisionDetectorNames(cd_names);
 
-  ROS_INFO_STREAM("The following collision detectors are active in the planning scene.");
+  ROS_INFO_STREAM("The following collision detectors are available in the planning scene.");
   for (std::size_t i = 0; i < cd_names.size(); i++)
   {
     ROS_INFO_STREAM(cd_names[i]);


### PR DESCRIPTION
Tracking down a `Found empty JointState message` from the chomp planner, I stumbled over some smaller issues. This PR
- introduces a (slightly) more verbose variable name to distinguish a MotionPlanResponse (res) from its message counterpart
- removes explicit time parameterization from the chomp planner (time parameterization is configured in the planning pipeline)
- adds a TODO to switch the API of `ChompPlanner::solve` to use real planning_interface datatypes (instead of their moveit_msgs counterparts). This will save some unnecessary serializations. As far as I can see, both usages in chomp_optimizer_adapter and chomp_interface, actually use native types originally. @bmagyar, what do you think of this idea?
Fixing this, will finally resolve the error message, as this one comes from deserializing an empty RobotState msg.