### PR TITLE
fixing the test utilities in moveit core

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -117,6 +117,7 @@ catkin_package(
     moveit_kinematics_metrics
     moveit_dynamics_solver
     moveit_utils
+    moveit_test_utils
     ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     eigen_stl_containers

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -64,7 +64,8 @@ protected:
   {
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file(ros::package::getPath("moveit_resources") + "/pr2_description/urdf/robot.xml", std::fstream::in);
+    std::fstream xml_file(ros::package::getPath("moveit_resources") + "/pr2_description/urdf/robot.xml",
+                          std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -79,7 +80,8 @@ protected:
     }
     else
       urdf_ok_ = false;
-    srdf_ok_ = srdf_model_->initFile(*urdf_model_, ros::package::getPath("moveit_resources") + "/pr2_description/srdf/robot.xml");
+    srdf_ok_ = srdf_model_->initFile(*urdf_model_,
+                                     ros::package::getPath("moveit_resources") + "/pr2_description/srdf/robot.xml");
 
     robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
 

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -52,6 +52,8 @@
 #include <ctype.h>
 #include <boost/filesystem.hpp>
 
+#include <ros/package.h>
+
 typedef collision_detection::CollisionWorldDistanceField DefaultCWorldType;
 typedef collision_detection::CollisionRobotDistanceField DefaultCRobotType;
 
@@ -62,7 +64,7 @@ protected:
   {
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file(MOVEIT_TEST_RESOURCES_DIR "/pr2_description/urdf/robot.xml", std::fstream::in);
+    std::fstream xml_file(ros::package::getPath("moveit_resources") + "/pr2_description/urdf/robot.xml", std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -77,7 +79,7 @@ protected:
     }
     else
       urdf_ok_ = false;
-    srdf_ok_ = srdf_model_->initFile(*urdf_model_, MOVEIT_TEST_RESOURCES_DIR "/pr2_description/srdf/robot.xml");
+    srdf_ok_ = srdf_model_->initFile(*urdf_model_, ros::package::getPath("moveit_resources") + "/pr2_description/srdf/robot.xml");
 
     robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
 

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -47,9 +47,9 @@
   <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
+  <depend>moveit_resources</depend>
 
   <test_depend>angles</test_depend>
-  <test_depend>moveit_resources</test_depend>
   <test_depend>tf2_kdl</test_depend>
   <test_depend>orocos_kdl</test_depend>
   <test_depend>rosunit</test_depend>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -47,8 +47,8 @@
   <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
-  <depend>moveit_resources</depend>
 
+  <test_depend>moveit_resources</test_depend>
   <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
   <test_depend>orocos_kdl</test_depend>

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -44,7 +44,6 @@
 #include <moveit_resources/config.h>
 #include <ros/package.h>
 
-
 // This function needs to return void so the gtest FAIL() macro inside
 // it works right.
 void loadModelFile(std::string filename, std::string& file_content)

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -42,12 +42,14 @@
 #include <string>
 #include <boost/filesystem/path.hpp>
 #include <moveit_resources/config.h>
+#include <ros/package.h>
+
 
 // This function needs to return void so the gtest FAIL() macro inside
 // it works right.
 void loadModelFile(std::string filename, std::string& file_content)
 {
-  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+  boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
   std::string xml_string;
   std::fstream xml_file((res_path / filename).string().c_str(), std::fstream::in);
   EXPECT_TRUE(xml_file.is_open());

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -44,13 +44,14 @@
 #include <geometric_shapes/shapes.h>
 #include <moveit/profiler/profiler.h>
 #include <moveit_resources/config.h>
+#include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
 protected:
   void SetUp() override
   {
-    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+    boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
 
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -1,35 +1,30 @@
 set(MOVEIT_LIB_NAME moveit_utils)
 
+find_package(moveit_resources REQUIRED)
+include_directories(${moveit_resources_INCLUDE_DIRS})
+
 add_library(${MOVEIT_LIB_NAME}
   src/lexical_casts.cpp
   src/xmlrpc_casts.cpp
 )
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-install(TARGETS ${MOVEIT_LIB_NAME}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-if(CATKIN_ENABLE_TESTING)
-  set(MOVEIT_TEST_LIB_NAME moveit_test_utils)
-  add_library(${MOVEIT_TEST_LIB_NAME}
-    src/robot_model_test_utils.cpp)
+set(MOVEIT_TEST_LIB_NAME moveit_test_utils)
+add_library(${MOVEIT_TEST_LIB_NAME}
+  src/robot_model_test_utils.cpp
+)
+add_dependencies(${MOVEIT_TEST_LIB_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${MOVEIT_TEST_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+set_target_properties(${MOVEIT_TEST_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-  add_dependencies(${MOVEIT_TEST_LIB_NAME} ${catkin_EXPORTED_TARGETS})
-
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
-  target_link_libraries(${MOVEIT_TEST_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
-
-  set_target_properties(${MOVEIT_TEST_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-
-  install(TARGETS ${MOVEIT_TEST_LIB_NAME}
-          LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-          ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-endif()
-
+install(
+  TARGETS
+    ${MOVEIT_LIB_NAME}
+    ${MOVEIT_TEST_LIB_NAME}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(MOVEIT_LIB_NAME moveit_utils)
 
-find_package(moveit_resources REQUIRED)
-include_directories(${moveit_resources_INCLUDE_DIRS})
-
 add_library(${MOVEIT_LIB_NAME}
   src/lexical_casts.cpp
   src/xmlrpc_casts.cpp

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -38,7 +38,9 @@
 #include <boost/algorithm/string_regex.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <geometry_msgs/Pose.h>
+
 #include "moveit/utils/robot_model_test_utils.h"
+#include <ros/package.h>
 
 namespace moveit
 {
@@ -56,7 +58,7 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name)
 
 urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 {
-  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+  boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
   std::string urdf_path;
   if (robot_name == "pr2")
   {
@@ -77,7 +79,7 @@ urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 
 srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
 {
-  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+  boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
   urdf::ModelInterfaceSharedPtr urdf_model = loadModelInterface(robot_name);
   srdf::ModelSharedPtr srdf_model(new srdf::Model());
   std::string srdf_path;

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -45,13 +45,14 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include <boost/filesystem/path.hpp>
+#include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
 protected:
   void SetUp() override
   {
-    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+    boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
 
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -44,6 +44,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <moveit_resources/config.h>
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#include <ros/package.h>
 
 // This tests writing/parsing of ros_controller.yaml
 class MoveItConfigData : public testing::Test
@@ -51,7 +52,7 @@ class MoveItConfigData : public testing::Test
 protected:
   void SetUp() override
   {
-    boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+    boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
@@ -79,7 +80,7 @@ protected:
 
 TEST_F(MoveItConfigData, ReadingControllers)
 {
-  boost::filesystem::path res_path(MOVEIT_TEST_RESOURCES_DIR);
+  boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
 
   // Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data;


### PR DESCRIPTION
This fixes an issue with the test utils where it was only getting built during testing and wasn't being exported as a library. 

This enables https://github.com/ros-planning/moveit_tutorials/pull/295 to build and run as expected