### PR TITLE
fix #1409: remove obsolete moveit_resources/config.h

### DIFF
--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -40,7 +40,6 @@
 #include <moveit/collision_distance_field/collision_distance_field_types.h>
 #include <moveit/collision_distance_field/collision_robot_distance_field.h>
 #include <moveit/collision_distance_field/collision_world_distance_field.h>
-#include <moveit_resources/config.h>
 
 #include <geometric_shapes/shape_operations.h>
 #include <urdf_parser/urdf_parser.h>

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -41,7 +41,6 @@
 #include <sstream>
 #include <string>
 #include <boost/filesystem/path.hpp>
-#include <moveit_resources/config.h>
 #include <ros/package.h>
 
 // This function needs to return void so the gtest FAIL() macro inside

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -40,7 +40,6 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem/path.hpp>
 #include <moveit/profiler/profiler.h>
-#include <moveit_resources/config.h>
 #include <moveit/utils/robot_model_test_utils.h>
 
 class LoadPlanningModelsPr2 : public testing::Test

--- a/moveit_core/robot_state/test/robot_state_benchmark.cpp
+++ b/moveit_core/robot_state/test/robot_state_benchmark.cpp
@@ -33,7 +33,6 @@
 *********************************************************************/
 
 /* Author: Robert Haschke */
-#include <moveit_resources/config.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/utils/robot_model_test_utils.h>

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -33,7 +33,6 @@
 *********************************************************************/
 
 /* Author: Ioan Sucan */
-#include <moveit_resources/config.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/utils/robot_model_test_utils.h>

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -37,7 +37,6 @@
 #include <moveit/robot_model/aabb.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
-#include <moveit_resources/config.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
 #include <boost/filesystem.hpp>

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -43,7 +43,6 @@
 #include <boost/filesystem/path.hpp>
 #include <geometric_shapes/shapes.h>
 #include <moveit/profiler/profiler.h>
-#include <moveit_resources/config.h>
 #include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -45,7 +45,6 @@
 #include <urdf/model.h>
 #include <fstream>
 #include <boost/filesystem/path.hpp>
-#include <moveit_resources/config.h>
 #include <moveit/robot_model/robot_model.h>
 #include <geometry_msgs/Pose.h>
 

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -36,7 +36,6 @@
 
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
 #include <moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h>
-#include <moveit_resources/config.h>
 
 #include <urdf_parser/urdf_parser.h>
 

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -42,7 +42,6 @@
 #include <string>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <moveit_resources/config.h>
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
 #include <ros/package.h>
 


### PR DESCRIPTION
This fixes #1409, which lifted libmoveit_test_utils to the default build. To this end, @mlautman removed the need to access `MOVEIT_TEST_RESOURCES_DIR` from moveit_resources/config.h, but he missed to remove the include from all sources, causing this issue: https://github.com/ros-planning/moveit_robots/issues/74#issuecomment-475852651.