### PR TITLE
Normalize quaternions when adding new or moving collision objects (#1119)

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -982,7 +982,9 @@ private:
   bool processCollisionObjectAdd(const moveit_msgs::CollisionObject& object);
   bool processCollisionObjectRemove(const moveit_msgs::CollisionObject& object);
   bool processCollisionObjectMove(const moveit_msgs::CollisionObject& object);
-  void normalizeObjectOrientation(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out);
+
+  /* convert Pose msg to Eigen::Isometry, normalizing the quaternion part if necessary. */
+  static void poseMsgToEigen(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out);
 
   MOVEIT_STRUCT_FORWARD(CollisionDetector);
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -982,6 +982,7 @@ private:
   bool processCollisionObjectAdd(const moveit_msgs::CollisionObject& object);
   bool processCollisionObjectRemove(const moveit_msgs::CollisionObject& object);
   bool processCollisionObjectMove(const moveit_msgs::CollisionObject& object);
+  void normalizeObjectOrientation(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out);
 
   MOVEIT_STRUCT_FORWARD(CollisionDetector);
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -983,7 +983,7 @@ private:
   bool processCollisionObjectRemove(const moveit_msgs::CollisionObject& object);
   bool processCollisionObjectMove(const moveit_msgs::CollisionObject& object);
 
-  /* convert Pose msg to Eigen::Isometry, normalizing the quaternion part if necessary. */
+  /** convert Pose msg to Eigen::Isometry, normalizing the quaternion part if necessary. */
   static void poseMsgToEigen(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out);
 
   MOVEIT_STRUCT_FORWARD(CollisionDetector);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1817,7 +1817,6 @@ bool PlanningScene::processCollisionObjectMove(const moveit_msgs::CollisionObjec
     for (std::size_t i = 0; i < object.primitive_poses.size(); ++i)
     {
       Eigen::Isometry3d object_pose;
-      tf2::fromMsg(object.primitive_poses[i], object_pose);
       PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1751,8 +1751,14 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     shapes::Shape* s = shapes::constructShapeFromMsg(object.primitives[i]);
     if (s)
     {
-      Eigen::Isometry3d object_pose;
-      tf2::fromMsg(object.primitive_poses[i], object_pose);
+      Eigen::Quaterniond object_orientation;
+      tf2::fromMsg(object.primitive_poses[i].orientation, object_orientation);
+      Eigen::Translation3d object_translation(object.primitive_poses[i].position.x,
+                                              object.primitive_poses[i].position.y,
+                                              object.primitive_poses[i].position.z);
+      object_orientation.normalize();
+      Eigen::Isometry3d object_pose(object_translation * object_orientation);
+
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1761,8 +1767,14 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     shapes::Shape* s = shapes::constructShapeFromMsg(object.meshes[i]);
     if (s)
     {
-      Eigen::Isometry3d object_pose;
-      tf2::fromMsg(object.mesh_poses[i], object_pose);
+      Eigen::Quaterniond object_orientation;
+      tf2::fromMsg(object.primitive_poses[i].orientation, object_orientation);
+      Eigen::Translation3d object_translation(object.primitive_poses[i].position.x,
+                                              object.primitive_poses[i].position.y,
+                                              object.primitive_poses[i].position.z);
+      object_orientation.normalize();
+      Eigen::Isometry3d object_pose(object_translation * object_orientation);
+
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1771,8 +1783,14 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     shapes::Shape* s = shapes::constructShapeFromMsg(object.planes[i]);
     if (s)
     {
-      Eigen::Isometry3d object_pose;
-      tf2::fromMsg(object.plane_poses[i], object_pose);
+      Eigen::Quaterniond object_orientation;
+      tf2::fromMsg(object.primitive_poses[i].orientation, object_orientation);
+      Eigen::Translation3d object_translation(object.primitive_poses[i].position.x,
+                                              object.primitive_poses[i].position.y,
+                                              object.primitive_poses[i].position.z);
+      object_orientation.normalize();
+      Eigen::Isometry3d object_pose(object_translation * object_orientation);
+
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1713,6 +1713,16 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
   return false;
 }
 
+void PlanningScene::normalizeObjectOrientation(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out)
+{
+  Eigen::Translation3d translation(msg.position.x, msg.position.y, msg.position.z);
+  Eigen::Quaterniond quaternion(msg.orientation.w, msg.orientation.x, msg.orientation.y, msg.orientation.z);
+
+  quaternion.normalize();
+
+  out = translation * quaternion;
+}
+
 bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject& object)
 {
   if (object.primitives.empty() && object.meshes.empty() && object.planes.empty())
@@ -1751,14 +1761,8 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     shapes::Shape* s = shapes::constructShapeFromMsg(object.primitives[i]);
     if (s)
     {
-      Eigen::Quaterniond object_orientation;
-      tf2::fromMsg(object.primitive_poses[i].orientation, object_orientation);
-      Eigen::Translation3d object_translation(object.primitive_poses[i].position.x,
-                                              object.primitive_poses[i].position.y,
-                                              object.primitive_poses[i].position.z);
-      object_orientation.normalize();
-      Eigen::Isometry3d object_pose(object_translation * object_orientation);
-
+      Eigen::Isometry3d object_pose;
+      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1767,14 +1771,8 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     shapes::Shape* s = shapes::constructShapeFromMsg(object.meshes[i]);
     if (s)
     {
-      Eigen::Quaterniond object_orientation;
-      tf2::fromMsg(object.primitive_poses[i].orientation, object_orientation);
-      Eigen::Translation3d object_translation(object.primitive_poses[i].position.x,
-                                              object.primitive_poses[i].position.y,
-                                              object.primitive_poses[i].position.z);
-      object_orientation.normalize();
-      Eigen::Isometry3d object_pose(object_translation * object_orientation);
-
+      Eigen::Isometry3d object_pose;
+      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1783,14 +1781,8 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     shapes::Shape* s = shapes::constructShapeFromMsg(object.planes[i]);
     if (s)
     {
-      Eigen::Quaterniond object_orientation;
-      tf2::fromMsg(object.primitive_poses[i].orientation, object_orientation);
-      Eigen::Translation3d object_translation(object.primitive_poses[i].position.x,
-                                              object.primitive_poses[i].position.y,
-                                              object.primitive_poses[i].position.z);
-      object_orientation.normalize();
-      Eigen::Isometry3d object_pose(object_translation * object_orientation);
-
+      Eigen::Isometry3d object_pose;
+      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1713,7 +1713,7 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
   return false;
 }
 
-void PlanningScene::normalizeObjectOrientation(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out)
+void PlanningScene::poseMsgToEigen(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out)
 {
   Eigen::Translation3d translation(msg.position.x, msg.position.y, msg.position.z);
   Eigen::Quaterniond quaternion(msg.orientation.w, msg.orientation.x, msg.orientation.y, msg.orientation.z);
@@ -1760,7 +1760,7 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     if (s)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
+      PlanningScene::poseMsgToEigen(object.primitive_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1770,7 +1770,7 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     if (s)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.mesh_poses[i], object_pose);
+      PlanningScene::poseMsgToEigen(object.mesh_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1780,7 +1780,7 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     if (s)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.plane_poses[i], object_pose);
+      PlanningScene::poseMsgToEigen(object.plane_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1817,19 +1817,19 @@ bool PlanningScene::processCollisionObjectMove(const moveit_msgs::CollisionObjec
     for (std::size_t i = 0; i < object.primitive_poses.size(); ++i)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
+      PlanningScene::poseMsgToEigen(object.primitive_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }
     for (std::size_t i = 0; i < object.mesh_poses.size(); ++i)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.mesh_poses[i], object_pose);
+      PlanningScene::poseMsgToEigen(object.mesh_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }
     for (std::size_t i = 0; i < object.plane_poses.size(); ++i)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.plane_poses[i], object_pose);
+      PlanningScene::poseMsgToEigen(object.plane_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1717,9 +1717,7 @@ void PlanningScene::normalizeObjectOrientation(const geometry_msgs::Pose& msg, E
 {
   Eigen::Translation3d translation(msg.position.x, msg.position.y, msg.position.z);
   Eigen::Quaterniond quaternion(msg.orientation.w, msg.orientation.x, msg.orientation.y, msg.orientation.z);
-
   quaternion.normalize();
-
   out = translation * quaternion;
 }
 
@@ -1772,7 +1770,7 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     if (s)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
+      PlanningScene::normalizeObjectOrientation(object.mesh_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1782,7 +1780,7 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
     if (s)
     {
       Eigen::Isometry3d object_pose;
-      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
+      PlanningScene::normalizeObjectOrientation(object.plane_poses[i], object_pose);
       world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
     }
   }
@@ -1820,18 +1818,19 @@ bool PlanningScene::processCollisionObjectMove(const moveit_msgs::CollisionObjec
     {
       Eigen::Isometry3d object_pose;
       tf2::fromMsg(object.primitive_poses[i], object_pose);
+      PlanningScene::normalizeObjectOrientation(object.primitive_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }
     for (std::size_t i = 0; i < object.mesh_poses.size(); ++i)
     {
       Eigen::Isometry3d object_pose;
-      tf2::fromMsg(object.mesh_poses[i], object_pose);
+      PlanningScene::normalizeObjectOrientation(object.mesh_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }
     for (std::size_t i = 0; i < object.plane_poses.size(); ++i)
     {
       Eigen::Isometry3d object_pose;
-      tf2::fromMsg(object.plane_poses[i], object_pose);
+      PlanningScene::normalizeObjectOrientation(object.plane_poses[i], object_pose);
       new_poses.push_back(t * object_pose);
     }
 


### PR DESCRIPTION
Fixes #1119.

### Description
As proposed in #1119 I implemented quaternion normalization when adding a new collision object and also when providing a new pose (move operation). Instead of using `tf2::fromMsg` as before I wrote a new function which includes orientation normalization and replaced it in the appropriate spots.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches