### PR TITLE
Update rosinstall for master branches

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -15,11 +15,11 @@
 - git:
     local-name: moveit_visual_tools
     uri: https://github.com/ros-planning/moveit_visual_tools.git
-    version: melodic-devel
+    version: master
 - git:
     local-name: rviz_visual_tools
     uri: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: melodic-devel
+    version: master
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
@@ -31,4 +31,4 @@
 - git:
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
-    version: melodic-devel
+    version: master


### PR DESCRIPTION
The tutorials are broken in local build because lack of master branch from source install.