### PR TITLE
automatically source moveit workspace

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -28,3 +28,7 @@ RUN catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_B
     # Status rate is limited so that just enough info is shown to keep Docker from timing out,
     # but not too much such that the Docker log gets too long (another form of timeout)
     catkin build --limit-status-rate 0.001 --no-notify
+
+COPY ./docker_entrypoint.sh /
+ENTRYPOINT ["/docker_entrypoint.sh"]
+CMD ["bash"]

--- a/.docker/source/docker_entrypoint.sh
+++ b/.docker/source/docker_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/root/ws_moveit/devel/setup.bash"
+exec "$@"


### PR DESCRIPTION
### Description

This automatically sources the moveit workspace when you run docker so that moveit_ci can build against the source build

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
