### PR TITLE
Detaching attached collision object bugfix

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1657,8 +1657,6 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       const EigenSTL::vector_Isometry3d& poses = attached_body->getGlobalCollisionBodyTransforms();
       const std::string& name = attached_body->getName();
 
-      robot_state_->clearAttachedBody(name);
-
       if (world_->hasObject(name))
         ROS_WARN_NAMED(LOGNAME,
                        "The collision world already has an object with the same name as the body about to be detached. "
@@ -1670,6 +1668,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         ROS_DEBUG_NAMED(LOGNAME, "Detached object '%s' from link '%s' and added it back in the collision world",
                         name.c_str(), object.link_name.c_str());
       }
+
+      robot_state_->clearAttachedBody(name);
     }
     if (!attached_bodies.empty() || object.object.id.empty())
       return true;


### PR DESCRIPTION
### Description

Detaching an attached collision object can cause segfaults in melodic. 

The segfault was found running Melodic on 18.04 

In this method, `attached_body` is a raw pointer to an `AttachedBody` in `robot_state_`. 
The planning scene saves the `attached_body`'s `shapes_` vector with `const std::vector<shapes::ShapeConstPtr>& shapes = attached_body->getShapes();`. However, when `robot_state_->clearAttachedBody(name)` is called, it deletes the `AttachedBody` causing the underlying `ShapeConstPtr`s to be freed. Then when `world_->addToObject(name, shapes, poses)` is called, it segfaults as the data in the `shapes_` vector is no longer available. 

By moving `world_->addToObject(name, shapes, poses)` before`robot_state_->clearAttachedBody(name)`, we create another shared pointer to the same underlying data in the shapes vector so that when `robot_state_->clearAttachedBody(name)` is called,  it does not free the `ShapeConstPtr`s. 

Another fix would be to use `const std::vector<shapes::ShapeConstPtr> shapes = attached_body->getShapes();` instead of `const std::vector<shapes::ShapeConstPtr>& shapes = attached_body->getShapes();` but I think this fix is better

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
