### PR TITLE
Add named frames to CollisionObjects (v2)

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -46,6 +46,7 @@
 #include <boost/function.hpp>
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_vector_container.h>
+#include <moveit/transforms/transforms.h>
 
 namespace shapes
 {
@@ -105,6 +106,12 @@ public:
      *
      * @copydetails shapes_ */
     EigenSTL::vector_Isometry3d shape_poses_;
+
+    /** \brief Transforms to subframes on the object.
+     *  Use them to define points of interest on an object to plan with
+     *  (e.g. screwdriver/tip, kettle/spout, mug/base).
+     */
+    moveit::core::FixedTransformsMap subframe_poses_;
   };
 
   /** \brief Get the list of Object ids */
@@ -138,6 +145,20 @@ public:
 
   /** \brief Check if a particular object exists in the collision world*/
   bool hasObject(const std::string& object_id) const;
+
+  /** \brief Check if an object or subframe with given name exists in the collision world.
+   * A subframe name needs to be prefixed with the object's name separated by a slash. */
+  bool knowsTransform(const std::string& name) const;
+
+  /** \brief Get the transform to an object or subframe with given name.
+   * If name does not exist, a std::runtime_error is thrown.
+   * A subframe name needs to be prefixed with the object's name separated by a slash. */
+  const Eigen::Isometry3d& getTransform(const std::string& name) const;
+
+  /** \brief Get the transform to an object or subframe with given name.
+   * If name does not exist, returns an identity transform and sets frame_found to false.
+   * A subframe name needs to be prefixed with the object's name separated by a slash. */
+  const Eigen::Isometry3d& getTransform(const std::string& name, bool& frame_found) const;
 
   /** \brief Add shapes to an object in the map.
    * This function makes repeated calls to addToObjectInternal() to add the
@@ -174,6 +195,9 @@ public:
    * Object, the memory is freed.
    * Returns true on success and false if no such object was found. */
   bool removeObject(const std::string& object_id);
+
+  /** \brief Set subframes on an object. */
+  bool setSubframesOfObject(const std::string& object_id, const moveit::core::FixedTransformsMap& subframe_poses);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -201,6 +201,19 @@ moveit_msgs::Constraints constructGoalConstraints(const std::string& link_name,
  * @return was the construction successful?
  */
 bool constructConstraints(XmlRpc::XmlRpcValue& params, moveit_msgs::Constraints& constraints);
-}
 
+/**
+ * \brief Resolves frames used in constraints to links in the robot model.
+ *
+ * The link_name field of a constraint is changed from the name of an object's frame or subframe
+ * to the name of the robot link that the object is attached to.
+ *
+ * This is used in a planning request adapter which ensures that the planning problem is defined
+ * properly (the attached objects' frames are not known to the planner).
+ *
+ * @param [in] state The RobotState used to resolve frames.
+ * @param [in] constraints The constraint to resolve.
+ */
+bool resolveConstraintFrames(const robot_state::RobotState& state, moveit_msgs::Constraints& constraints);
+}
 #endif

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -528,3 +528,56 @@ bool constructConstraints(XmlRpc::XmlRpcValue& params, moveit_msgs::Constraints&
   return collectConstraints(params["constraints"], constraints);
 }
 }  // namespace kinematic_constraints
+
+bool kinematic_constraints::resolveConstraintFrames(const robot_state::RobotState& state,
+                                                    moveit_msgs::Constraints& constraints)
+{
+  for (auto& c : constraints.position_constraints)
+  {
+    bool frame_found;
+    const moveit::core::LinkModel* robot_link;
+    const Eigen::Isometry3d& transform = state.getFrameInfo(c.link_name, robot_link, frame_found);
+    if (!frame_found)
+      return false;
+
+    // If the frame of the constraint is not part of the robot link model (but is an
+    // attached body or subframe instead), the constraint needs to be expressed in
+    // the frame of a robot link.
+    if (c.link_name != robot_link->getName())
+    {
+      Eigen::Vector3d pos_in_link_frame,
+          pos_in_original_frame(c.target_point_offset.x, c.target_point_offset.y, c.target_point_offset.z);
+
+      pos_in_link_frame = transform * pos_in_original_frame;
+      c.link_name = robot_link->getName();
+      c.target_point_offset.x = pos_in_link_frame[0];
+      c.target_point_offset.y = pos_in_link_frame[1];
+      c.target_point_offset.z = pos_in_link_frame[2];
+    }
+  }
+  for (auto& c : constraints.orientation_constraints)
+  {
+    bool frame_found;
+    const moveit::core::LinkModel* robot_link;
+    const Eigen::Isometry3d& transform = state.getFrameInfo(c.link_name, robot_link, frame_found);
+    if (!frame_found)
+      return false;
+
+    // If the frame of the constraint is not part of the robot link model (but is an
+    // attached body or subframe instead), the constraint needs to be expressed in
+    // the frame of a robot link.
+    if (c.link_name != robot_link->getName())
+    {
+      Eigen::Quaterniond q_body_to_link(transform.inverse().rotation());
+      Eigen::Quaterniond q_target(c.orientation.w, c.orientation.x, c.orientation.y, c.orientation.z);
+      Eigen::Quaterniond q_in_link = q_body_to_link * q_target;
+
+      c.link_name = robot_link->getName();
+      c.orientation.x = q_in_link.x();
+      c.orientation.y = q_in_link.y();
+      c.orientation.z = q_in_link.z();
+      c.orientation.w = q_in_link.w();
+    }
+  }
+  return true;
+}

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -74,9 +74,9 @@ public:
     if (Transforms::isFixedFrame(frame))
       return true;
     if (frame[0] == '/')
-      return knowsObject(frame.substr(1));
+      return knowsObjectFrame(frame.substr(1));
     else
-      return knowsObject(frame);
+      return knowsObjectFrame(frame);
   }
 
   const Eigen::Isometry3d& getTransform(const std::string& from_frame) const override
@@ -85,14 +85,10 @@ public:
   }
 
 private:
-  bool knowsObject(const std::string& object_id) const
+  // Returns true if frame_id is the name of an object or the name of a subframe on an object
+  bool knowsObjectFrame(const std::string& frame_id) const
   {
-    if (scene_->getWorld()->hasObject(object_id))
-    {
-      collision_detection::World::ObjectConstPtr obj = scene_->getWorld()->getObject(object_id);
-      return obj->shape_poses_.size() == 1;
-    }
-    return false;
+    return scene_->getWorld()->knowsTransform(frame_id);
   }
 
   const PlanningScene* scene_;
@@ -1884,23 +1880,16 @@ const Eigen::Isometry3d& PlanningScene::getFrameTransform(const robot_state::Rob
 {
   if (!frame_id.empty() && frame_id[0] == '/')
     // Recursively call itself without the slash in front of frame name
-    // TODO: minor cleanup, but likely getFrameTransform(state, frame_id.substr(1)); can be used, but requires further
-    // testing
     return getFrameTransform(frame_id.substr(1));
-  if (state.knowsFrameTransform(frame_id))
-    return state.getFrameTransform(frame_id);
-  if (getWorld()->hasObject(frame_id))
-  {
-    collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(frame_id);
-    if (obj->shape_poses_.size() > 1)
-    {
-      ROS_WARN_NAMED(LOGNAME, "More than one shapes in object '%s'. Using first one to decide transform",
-                     frame_id.c_str());
-      return obj->shape_poses_[0];
-    }
-    else if (obj->shape_poses_.size() == 1)
-      return obj->shape_poses_[0];
-  }
+
+  bool frame_found;
+  const Eigen::Isometry3d& t1 = state.getFrameTransform(frame_id, &frame_found);
+  if (frame_found)
+    return t1;
+
+  const Eigen::Isometry3d& t2 = getWorld()->getTransform(frame_id, frame_found);
+  if (frame_found)
+    return t2;
   return getTransforms().Transforms::getTransform(frame_id);
 }
 
@@ -1913,14 +1902,11 @@ bool PlanningScene::knowsFrameTransform(const robot_state::RobotState& state, co
 {
   if (!frame_id.empty() && frame_id[0] == '/')
     return knowsFrameTransform(frame_id.substr(1));
+
   if (state.knowsFrameTransform(frame_id))
     return true;
-
-  collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(frame_id);
-  if (obj)
-  {
-    return obj->shape_poses_.size() == 1;
-  }
+  if (getWorld()->knowsTransform(frame_id))
+    return true;
   return getTransforms().Transforms::canTransform(frame_id);
 }
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1654,7 +1654,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         trajectory_msgs::JointTrajectory detach_posture =
             object.detach_posture.joint_names.empty() ? ab->getDetachPosture() : object.detach_posture;
 
-        std::set<std::string> touch_links = std::move(ab->getTouchLinks());
+        std::set<std::string> touch_links = ab->getTouchLinks();
         touch_links.insert(std::make_move_iterator(object.touch_links.begin()),
                            std::make_move_iterator(object.touch_links.end()));
 

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -226,17 +226,19 @@ public:
     return getRootLink()->getName();
   }
 
-  /** \brief Check if a link exists. Return true if it does. */
+  /** \brief Check if a link exists. Return true if it does.
+   *
+   * If this is followed by a call to getLinkModel(), better use the latter with the has_link argument */
   bool hasLinkModel(const std::string& name) const;
 
   /** \brief Get a link by its name. Output error and return NULL when the link is missing. */
-  const LinkModel* getLinkModel(const std::string& link) const;
+  const LinkModel* getLinkModel(const std::string& link, bool* has_link = nullptr) const;
 
   /** \brief Get a link by its index. Output error and return NULL when the link is missing. */
   const LinkModel* getLinkModel(int index) const;
 
   /** \brief Get a link by its name. Output error and return NULL when the link is missing. */
-  LinkModel* getLinkModel(const std::string& link);
+  LinkModel* getLinkModel(const std::string& link, bool* has_link = nullptr);
 
   /** \brief Get the latest link upwards the kinematic tree, which is only connected via fixed joints
    *

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1106,9 +1106,9 @@ JointModel* RobotModel::getJointModel(const std::string& name)
   return nullptr;
 }
 
-const LinkModel* RobotModel::getLinkModel(const std::string& name) const
+const LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link) const
 {
-  return const_cast<RobotModel*>(this)->getLinkModel(name);
+  return const_cast<RobotModel*>(this)->getLinkModel(name, has_link);
 }
 
 const LinkModel* RobotModel::getLinkModel(int index) const
@@ -1122,12 +1122,18 @@ const LinkModel* RobotModel::getLinkModel(int index) const
   return link_model_vector_[index];
 }
 
-LinkModel* RobotModel::getLinkModel(const std::string& name)
+LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link)
 {
+  if (has_link)
+    *has_link = true;  // Start out optimistic
   LinkModelMap::const_iterator it = link_model_map_.find(name);
   if (it != link_model_map_.end())
     return it->second;
-  ROS_ERROR_NAMED(LOGNAME, "Link '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
+
+  if (has_link)
+    *has_link = false;  // Report failure via argument
+  else                  // Otherwise print error
+    ROS_ERROR_NAMED(LOGNAME, "Link '%s' not found in model '%s'", name.c_str(), model_name_.c_str());
   return nullptr;
 }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -40,6 +40,7 @@
 
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/attached_body.h>
+#include <moveit/transforms/transforms.h>
 #include <moveit/macros/deprecation.h>
 #include <sensor_msgs/JointState.h>
 #include <visualization_msgs/MarkerArray.h>
@@ -1545,6 +1546,8 @@ as the new values that correspond to the group */
    * @param attach_trans The desired transform between this link and the attached body
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
+   * @param detach_posture The posture of the gripper when placing the object
+   * @param subframe_poses Transforms to points of interest on the object (can be used as end effector link)
    *
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
@@ -1554,9 +1557,10 @@ as the new values that correspond to the group */
    * corresponding object from that world to avoid having collisions
    * detected against it. */
   void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
+                  const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                   const std::string& link_name,
-                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory());
+                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+                  const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
@@ -1564,6 +1568,8 @@ as the new values that correspond to the group */
    * @param attach_trans The desired transform between this link and the attached body
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
+   * @param detach_posture The posture of the gripper when placing the object
+   * @param subframe_poses Transforms to points of interest on the object (can be used as end effector link)
    *
    * This only adds the given body to this RobotState
    * instance.  It does not change anything about other
@@ -1573,12 +1579,13 @@ as the new values that correspond to the group */
    * corresponding object from that world to avoid having collisions
    * detected against it. */
   void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Isometry3d& attach_trans, const std::vector<std::string>& touch_links,
+                  const EigenSTL::vector_Isometry3d& shape_poses, const std::vector<std::string>& touch_links,
                   const std::string& link_name,
-                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory())
+                  const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
+                  const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap())
   {
     std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
-    attachBody(id, shapes, attach_trans, touch_links_set, link_name, detach_posture);
+    attachBody(id, shapes, shape_poses, touch_links_set, link_name, detach_posture, subframe_poses);
   }
 
   /** \brief Get all bodies attached to the model corresponding to this state */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1639,11 +1639,22 @@ as the new values that correspond to the group */
     return *rng_;
   }
 
-  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id */
-  const Eigen::Isometry3d& getFrameTransform(const std::string& frame_id);
+  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id
+   *
+   * If frame_id was not found, \e frame_found is set to false and an identity transform is returned */
+  const Eigen::Isometry3d& getFrameTransform(const std::string& frame_id, bool* frame_found = nullptr);
 
-  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id */
-  const Eigen::Isometry3d& getFrameTransform(const std::string& frame_id) const;
+  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id
+   *
+   * If frame_id was not found, \e frame_found is set to false and an identity transform is returned */
+  const Eigen::Isometry3d& getFrameTransform(const std::string& frame_id, bool* frame_found = nullptr) const;
+
+  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id
+   *
+   * If this frame is attached to a robot link, the link pointer is returned in \e robot_link.
+   * If frame_id was not found, \e frame_found is set to false and an identity transform is returned */
+  const Eigen::Isometry3d& getFrameInfo(const std::string& frame_id, const LinkModel*& robot_link,
+                                        bool& frame_found) const;
 
   /** \brief Check if a transformation matrix from the model frame to frame \e frame_id is known */
   bool knowsFrameTransform(const std::string& frame_id) const;

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -36,27 +36,33 @@
 
 #include <moveit/robot_state/attached_body.h>
 #include <geometric_shapes/shapes.h>
+#include <boost/algorithm/string/predicate.hpp>
 
-moveit::core::AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id,
-                                         const std::vector<shapes::ShapeConstPtr>& shapes,
-                                         const EigenSTL::vector_Isometry3d& attach_trans,
-                                         const std::set<std::string>& touch_links,
-                                         const trajectory_msgs::JointTrajectory& detach_posture)
+namespace moveit
+{
+namespace core
+{
+AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id,
+                           const std::vector<shapes::ShapeConstPtr>& shapes,
+                           const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
+                           const trajectory_msgs::JointTrajectory& detach_posture,
+                           const FixedTransformsMap& subframe_poses)
   : parent_link_model_(parent_link_model)
   , id_(id)
   , shapes_(shapes)
   , attach_trans_(attach_trans)
   , touch_links_(touch_links)
   , detach_posture_(detach_posture)
+  , subframe_poses_(subframe_poses)
 {
   global_collision_body_transforms_.resize(attach_trans.size());
   for (Eigen::Isometry3d& global_collision_body_transform : global_collision_body_transforms_)
     global_collision_body_transform.setIdentity();
 }
 
-moveit::core::AttachedBody::~AttachedBody() = default;
+AttachedBody::~AttachedBody() = default;
 
-void moveit::core::AttachedBody::setScale(double scale)
+void AttachedBody::setScale(double scale)
 {
   for (shapes::ShapeConstPtr& shape : shapes_)
   {
@@ -73,7 +79,7 @@ void moveit::core::AttachedBody::setScale(double scale)
   }
 }
 
-void moveit::core::AttachedBody::setPadding(double padding)
+void AttachedBody::setPadding(double padding)
 {
   for (shapes::ShapeConstPtr& shape : shapes_)
   {
@@ -88,4 +94,31 @@ void moveit::core::AttachedBody::setPadding(double padding)
       shape.reset(copy);
     }
   }
+}
+
+const Eigen::Isometry3d& AttachedBody::getSubframeTransform(const std::string& frame_name, bool* found) const
+{
+  if (boost::starts_with(frame_name, id_) && frame_name[id_.length()] == '/')
+  {
+    auto it = subframe_poses_.find(frame_name.substr(id_.length() + 1));
+    if (it != subframe_poses_.end())
+    {
+      if (found)
+        *found = true;
+      return it->second;
+    }
+  }
+  static const Eigen::Isometry3d IDENTITY_TRANSFORM = Eigen::Isometry3d::Identity();
+  if (found)
+    *found = false;
+  return IDENTITY_TRANSFORM;
+}
+
+bool AttachedBody::hasSubframeTransform(const std::string& frame_name) const
+{
+  bool found;
+  getSubframeTransform(frame_name, &found);
+  return found;
+}
+}
 }

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -120,5 +120,5 @@ bool AttachedBody::hasSubframeTransform(const std::string& frame_name) const
   getSubframeTransform(frame_name, &found);
   return found;
 }
-}
-}
+}  // namespace core
+}  // namespace moveit

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -216,6 +216,15 @@ static void _attachedBodyToMsg(const AttachedBody& attached_body, moveit_msgs::A
       sv.addToObject(sm, p);
     }
   }
+  aco.object.subframe_names.clear();
+  aco.object.subframe_poses.clear();
+  for (auto frame_pair : attached_body.getSubframeTransforms())
+  {
+    aco.object.subframe_names.push_back(frame_pair.first);
+    geometry_msgs::Pose pose;
+    pose = tf2::toMsg(frame_pair.second);
+    aco.object.subframe_poses.push_back(pose);
+  }
 }
 
 static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::AttachedCollisionObject& aco, RobotState& state)
@@ -240,6 +249,12 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
       if (aco.object.planes.size() != aco.object.plane_poses.size())
       {
         ROS_ERROR_NAMED(LOGNAME, "Number of planes does not match number of poses in collision object message");
+        return;
+      }
+
+      if (aco.object.subframe_poses.size() != aco.object.subframe_names.size())
+      {
+        ROS_ERROR_NAMED(LOGNAME, "Number of subframe poses does not match number of subframe names in message");
         return;
       }
 
@@ -284,7 +299,16 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           }
         }
 
-        // transform poses to link frame
+        moveit::core::FixedTransformsMap subframe_poses;
+        for (std::size_t i = 0; i < aco.object.subframe_poses.size(); ++i)
+        {
+          Eigen::Isometry3d p;
+          tf2::fromMsg(aco.object.subframe_poses[i], p);
+          std::string name = aco.object.subframe_names[i];
+          subframe_poses[name] = p;
+        }
+
+        // Transform shape poses and subframes to link frame
         if (!Transforms::sameFrame(aco.object.header.frame_id, aco.link_name))
         {
           bool frame_found = false;
@@ -305,6 +329,8 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           Eigen::Isometry3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
           for (Eigen::Isometry3d& pose : poses)
             pose = t * pose;
+          for (auto& subframe_pose : subframe_poses)
+            subframe_pose.second = t * subframe_pose.second;
         }
 
         if (shapes.empty())
@@ -316,7 +342,8 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
             ROS_DEBUG_NAMED(LOGNAME, "The robot state already had an object named '%s' attached to link '%s'. "
                                      "The object was replaced.",
                             aco.object.id.c_str(), aco.link_name.c_str());
-          state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture);
+          state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture,
+                           subframe_poses);
           ROS_DEBUG_NAMED(LOGNAME, "Attached object '%s' to link '%s'", aco.object.id.c_str(), aco.link_name.c_str());
         }
       }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -169,7 +169,8 @@ void RobotState::copyFrom(const RobotState& other)
   clearAttachedBodies();
   for (const std::pair<const std::string, AttachedBody*>& it : other.attached_body_map_)
     attachBody(it.second->getName(), it.second->getShapes(), it.second->getFixedTransforms(),
-               it.second->getTouchLinks(), it.second->getAttachedLinkName(), it.second->getDetachPosture());
+               it.second->getTouchLinks(), it.second->getAttachedLinkName(), it.second->getDetachPosture(),
+               it.second->getSubframeTransforms());
 }
 
 bool RobotState::checkJointTransforms(const JointModel* joint) const
@@ -886,15 +887,12 @@ void RobotState::attachBody(AttachedBody* attached_body)
 }
 
 void RobotState::attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                            const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
-                            const std::string& link, const trajectory_msgs::JointTrajectory& detach_posture)
+                            const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
+                            const std::string& link, const trajectory_msgs::JointTrajectory& detach_posture,
+                            const moveit::core::FixedTransformsMap& subframe_poses)
 {
   const LinkModel* l = robot_model_->getLinkModel(link);
-  AttachedBody* ab = new AttachedBody(l, id, shapes, attach_trans, touch_links, detach_posture);
-  attached_body_map_[id] = ab;
-  ab->computeTransform(getGlobalLinkTransform(l));
-  if (attached_body_update_callback_)
-    attached_body_update_callback_(ab, true);
+  attachBody(new AttachedBody(l, id, shapes, shape_poses, touch_links, detach_posture, subframe_poses));
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies) const
@@ -1000,31 +998,42 @@ const Eigen::Isometry3d& RobotState::getFrameTransform(const std::string& frame_
   static const Eigen::Isometry3d IDENTITY_TRANSFORM = Eigen::Isometry3d::Identity();
   if (frame_id == robot_model_->getModelFrame())
     return IDENTITY_TRANSFORM;
+  // Check if frame is in robot links
   if (robot_model_->hasLinkModel(frame_id))
   {
     const LinkModel* lm = robot_model_->getLinkModel(frame_id);
     return global_link_transforms_[lm->getLinkIndex()];
   }
+
+  // Check names of the attached bodies
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(frame_id);
-  if (jt == attached_body_map_.end())
+  if (jt != attached_body_map_.end())
   {
-    ROS_ERROR_NAMED(LOGNAME, "Transform from frame '%s' to frame '%s' is not known "
-                             "('%s' should be a link name or an attached body's id).",
-                    frame_id.c_str(), robot_model_->getModelFrame().c_str(), frame_id.c_str());
-    return IDENTITY_TRANSFORM;
+    const EigenSTL::vector_Isometry3d& tf = jt->second->getGlobalCollisionBodyTransforms();
+    if (tf.empty())
+    {
+      ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' has no geometry associated to it. No transform to return.",
+                      frame_id.c_str());
+      return IDENTITY_TRANSFORM;
+    }
+    if (tf.size() > 1)
+      ROS_DEBUG_NAMED(LOGNAME, "There are multiple geometries associated to attached body '%s'. "
+                               "Returning the transform for the first one.",
+                      frame_id.c_str());
+    return tf[0];
   }
-  const EigenSTL::vector_Isometry3d& tf = jt->second->getGlobalCollisionBodyTransforms();
-  if (tf.empty())
+
+  // Check if an AttachedBody has a subframe with name frame_id
+  for (const std::pair<std::string, AttachedBody*>& body : attached_body_map_)
   {
-    ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' has no geometry associated to it. No transform to return.",
-                    frame_id.c_str());
-    return IDENTITY_TRANSFORM;
+    bool found;
+    const auto& transform = body.second->getSubframeTransform(frame_id, &found);
+    if (found)
+      return transform;
   }
-  if (tf.size() > 1)
-    ROS_DEBUG_NAMED(LOGNAME, "There are multiple geometries associated to attached body '%s'. "
-                             "Returning the transform for the first one.",
-                    frame_id.c_str());
-  return tf[0];
+
+  ROS_DEBUG_NAMED(LOGNAME, "getFrameTransform() did not find a frame with name %s.", frame_id.c_str());
+  return IDENTITY_TRANSFORM;
 }
 
 bool RobotState::knowsFrameTransform(const std::string& frame_id) const
@@ -1033,8 +1042,19 @@ bool RobotState::knowsFrameTransform(const std::string& frame_id) const
     return knowsFrameTransform(frame_id.substr(1));
   if (robot_model_->hasLinkModel(frame_id))
     return true;
+
+  // Check if an AttachedBody with name frame_id exists
   std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(frame_id);
-  return it != attached_body_map_.end() && !it->second->getGlobalCollisionBodyTransforms().empty();
+  if (it != attached_body_map_.end())
+    return !it->second->getGlobalCollisionBodyTransforms().empty();
+
+  // Check if an AttachedBody has a subframe with name frame_id
+  for (const std::pair<std::string, AttachedBody*>& body : attached_body_map_)
+  {
+    if (body.second->hasSubframeTransform(frame_id))
+      return true;
+  }
+  return false;
 }
 
 void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std::vector<std::string>& link_names,
@@ -1530,15 +1550,15 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
       {
         if (hasAttachedBody(pose_frame))
         {
-          const AttachedBody* ab = getAttachedBody(pose_frame);
-          const EigenSTL::vector_Isometry3d& ab_trans = ab->getFixedTransforms();
+          const AttachedBody* body = getAttachedBody(pose_frame);
+          const EigenSTL::vector_Isometry3d& ab_trans = body->getFixedTransforms();
           if (ab_trans.size() != 1)
           {
             ROS_ERROR_NAMED(LOGNAME, "Cannot use an attached body "
                                      "with multiple geometries as a reference frame.");
             return false;
           }
-          pose_frame = ab->getAttachedLinkName();
+          pose_frame = body->getAttachedLinkName();
           pose = pose * ab_trans[0].inverse();
         }
         if (pose_frame != solver_tip_frame)
@@ -1742,14 +1762,14 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
     {
       if (hasAttachedBody(pose_frame))
       {
-        const AttachedBody* ab = getAttachedBody(pose_frame);
-        const EigenSTL::vector_Isometry3d& ab_trans = ab->getFixedTransforms();
+        const AttachedBody* body = getAttachedBody(pose_frame);
+        const EigenSTL::vector_Isometry3d& ab_trans = body->getFixedTransforms();
         if (ab_trans.size() != 1)
         {
           ROS_ERROR_NAMED(LOGNAME, "Cannot use an attached body with multiple geometries as a reference frame.");
           return false;
         }
-        pose_frame = ab->getAttachedLinkName();
+        pose_frame = body->getAttachedLinkName();
         pose = pose * ab_trans[0].inverse();
       }
       if (pose_frame != solver_tip_frame)

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -8,7 +8,9 @@ set(SOURCE_FILES
   src/fix_workspace_bounds.cpp
   src/add_time_parameterization.cpp
   src/add_iterative_spline_parameterization.cpp
-  src/add_time_optimal_parameterization.cpp)
+  src/add_time_optimal_parameterization.cpp
+  src/resolve_constraint_frames.cpp
+  )
 
 add_library(${MOVEIT_LIB_NAME} ${SOURCE_FILES})
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -1,0 +1,72 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Haschke */
+
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <class_loader/class_loader.hpp>
+#include <ros/ros.h>
+
+namespace default_planner_request_adapters
+{
+class ResolveConstraintFrames : public planning_request_adapter::PlanningRequestAdapter
+{
+public:
+  ResolveConstraintFrames() : planning_request_adapter::PlanningRequestAdapter()
+  {
+  }
+
+  std::string getDescription() const override
+  {
+    return "Resolve constraint frames to robot links";
+  }
+
+  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
+                    std::vector<std::size_t>& added_path_index) const override
+  {
+    ROS_DEBUG("Running '%s'", getDescription().c_str());
+    planning_interface::MotionPlanRequest modified = req;
+    kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), modified.path_constraints);
+    for (moveit_msgs::Constraints& constraint : modified.goal_constraints)
+      kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), constraint);
+    return planner(planning_scene, modified, res);
+  }
+};
+
+}  // namespace default_planner_request_adapters
+
+CLASS_LOADER_REGISTER_CLASS(default_planner_request_adapters::ResolveConstraintFrames,
+                            planning_request_adapter::PlanningRequestAdapter);

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -25,6 +25,12 @@
     </description>
   </class>
 
+  <class name="default_planner_request_adapters/ResolveConstraintFrames" type="default_planner_request_adapters::ResolveConstraintFrames" base_class_type="planning_request_adapter::PlanningRequestAdapter">
+    <description>
+      Resolves constraints that are defined in collision objects or subframes to robot links, because the former are not known to the planner.
+    </description>
+  </class>
+
   <class name="default_planner_request_adapters/AddTimeParameterization" type="default_planner_request_adapters::AddTimeParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
     </description>

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -402,10 +402,11 @@ public:
                                                moveit::core::GroupStateValidityCallbackFn(), o);
       else
       {
-        if (c->knowsFrameTransform(frame))
+        // transform the pose into the model frame, then do IK
+        bool frame_found;
+        const Eigen::Isometry3d& t = getTargetRobotState().getFrameTransform(frame, &frame_found);
+        if (frame_found)
         {
-          // transform the pose first if possible, then do IK
-          const Eigen::Isometry3d& t = getTargetRobotState().getFrameTransform(frame);
           Eigen::Isometry3d p;
           tf2::fromMsg(eef_pose, p);
           return getTargetRobotState().setFromIK(getJointModelGroup(), t * p, eef, 0.0,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -781,7 +781,7 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       known_collision_objects_[item->type()].first = item_text;
       robot_state::AttachedBody* new_ab = new robot_state::AttachedBody(
           ab->getAttachedLink(), known_collision_objects_[item->type()].first, ab->getShapes(),
-          ab->getFixedTransforms(), ab->getTouchLinks(), ab->getDetachPosture());
+          ab->getFixedTransforms(), ab->getTouchLinks(), ab->getDetachPosture(), ab->getSubframeTransforms());
       cs.clearAttachedBody(ab->getName());
       cs.attachBody(new_ab);
     }

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -5,11 +5,14 @@
 
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
-				       default_planner_request_adapters/FixWorkspaceBounds
-				       default_planner_request_adapters/FixStartStateBounds
-				       default_planner_request_adapters/FixStartStateCollision
-				       default_planner_request_adapters/FixStartStatePathConstraints" />
+  <arg name="planning_adapters"
+       value="default_planner_request_adapters/FixWorkspaceBounds
+              default_planner_request_adapters/FixStartStateBounds
+              default_planner_request_adapters/FixStartStateCollision
+              default_planner_request_adapters/FixStartStatePathConstraints
+              default_planner_request_adapters/ResolveConstraintFrames
+              default_planner_request_adapters/AddTimeParameterization"
+              />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
 


### PR DESCRIPTION
### Description

This PR supercedes #1060 and implements #1041. It includes all the changes requested in the last thread and now targets the correct branch. It requires [this PR](https://github.com/ros-planning/moveit_msgs/pull/50) to `moveit_msgs`.

In short, this PR adds subframes to CollisionObjects so that one can write "move the tip of object A to somewhere on object B". In the animation below, the cylinder tip is moved to each side of the box in this manner:

![simplescreenrecorder-2019-04-17_10 08 11](https://user-images.githubusercontent.com/4535737/56265284-1b861600-6124-11e9-8bfd-9b02d00700d2.gif)

I made a test package [here](https://github.com/felixvd/moveit_tutorials/tree/add-named-frames), which you can run with `rosrun moveit_tutorials subframes_tutorial`. You can reproduce the animation above by entering the numbers 2, 3, 4, 5.

**Small changelog:**  
I added a version of `getFrameTransform` to `robot_state.cpp` which combines the previous `getFrameTransform` and `knowsFrameTransform`, so that retrieval of a frame does not require two subsequent searches. I also added `getFrameInfo`, which returns the name of the robot link that a CollisionObject or named frame is attached to. This is used for changing the frames of constraints in `validateConstraintFrames`, because only links that are part of the link model can be used for motion planning.

I included the changes to the rest of the codebase where the new `getFrameTransform` would be used. I can take them out and start a separate PR for that, but they did not seem to cause issues.

**Last questions:**  
- [x] (Changed) Is the static variable I added [here](https://github.com/ros-planning/moveit/pull/1439/files#diff-15d4dc0e9e1eee143f7576803dfe8ea2R998) and [here](https://github.com/ros-planning/moveit/pull/1439/files#diff-8aac12a54166575f8df07630635ac4ffR1967) used correctly? I was stumped on how to return a reference correctly in a case like this. I suspect this is not thread-safe. Would appreciate a check from @rhaschke and/or whoever feels confident.
- [x] (fixed by using a reference) I made `getFrameTransform` forward to `getFrameInfo`, discarding the robot link returned by `getFrameInfo`. Should the functions be kept separate? I am not sure if makes a big difference performance-wise. The difference is one string copy.
- [x] Naming 1: In https://github.com/ros-planning/moveit_msgs/pull/50, @henningkayser proposed `subframe_ids` and `subframe_poses` instead of `frame_names` and `named_frame_poses`. Is "subframe" misleading? 
- [x] (Done) Naming 2: Another suggestion is to change the name of the `GetConstraintValidity` service. I am not opposed, it is only used internally anyway. `validateConstraintFrames` is the current version.

The Travis build will fail because moveit_msgs is affected. Before merging, I will remove the simple Rviz visualization of the named frames (the red dots in the animation). The visualization will have to be part of a PR addressing #1122 .

Would love to get this merged ASAP, because the GSoC project will affect this area of the code significantly. Thanks for reviewing!

@v4hn @davetcoleman 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
