### PR TITLE
Add allowCollisions/disallowCollisions to planning scene interface

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -318,11 +318,11 @@ class MoveGroupCommander(object):
         self._g.set_random_target()
 
     def get_named_targets(self):
-        """ Get a list of all the names of joint configurations."""
+        """ Get a list of all the names of joint configuration targets."""
         return self._g.get_named_targets()
 
     def set_named_target(self, name):
-        """ Set a joint configuration by name. The name can be a name previlusy remembered with remember_joint_values() or a configuration specified in the SRDF. """
+        """ Set a joint configuration target by name. The name can be a name previously remembered with remember_joint_values(), or a configuration specified in the SRDF. """
         if not self._g.set_named_target(name):
             raise MoveItCommanderException("Unable to set target %s. Is the target within bounds?" % name)
 
@@ -389,7 +389,7 @@ class MoveGroupCommander(object):
         return self._g.get_known_constraints()
 
     def get_path_constraints(self):
-        """ Get the acutal path constraints in form of a moveit_msgs.msgs.Constraints """
+        """ Get the current path constraints in form of a moveit_msgs.msgs.Constraints """
         c = Constraints()
         c_str = self._g.get_path_constraints()
         conversions.msg_from_string(c, c_str)
@@ -406,11 +406,11 @@ class MoveGroupCommander(object):
                 raise MoveItCommanderException("Unable to set path constraints " + value)
 
     def clear_path_constraints(self):
-        """ Specify that no path constraints are to be used during motion planning """
+        """ Remove current path constraints used during motion planning """
         self._g.clear_path_constraints()
 
     def get_trajectory_constraints(self):
-        """ Get the actual trajectory constraints in form of a moveit_msgs.msgs.Constraints """
+        """ Get the current trajectory constraints in form of a moveit_msgs.msgs.Constraints """
         c = Constraints()
         c_str = self._g.get_trajectory_constraints()
         conversions.msg_from_string(c, c_str)
@@ -427,7 +427,7 @@ class MoveGroupCommander(object):
                 raise MoveItCommanderException("Unable to set trajectory constraints " + value)
 
     def clear_trajectory_constraints(self):
-        """ Specify that no trajectory constraints are to be used during motion planning """
+        """ Remove current trajectory constraints used during motion planning """
         self._g.clear_trajectory_constraints()
 
     def set_constraints_database(self, host, port):
@@ -435,11 +435,11 @@ class MoveGroupCommander(object):
         self._g.set_constraints_database(host, port)
 
     def set_planning_time(self, seconds):
-        """ Specify the amount of time to be used for motion planning. """
+        """ Specify the maximum amount of time to be allowed for motion planning. """
         self._g.set_planning_time(seconds)
 
     def get_planning_time(self):
-        """ Specify the amount of time to be used for motion planning. """
+        """ Get the maximum amount of time to be allowed for motion planning. """
         return self._g.get_planning_time()
 
     def set_planner_id(self, planner_id):

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -106,7 +106,9 @@ class PlanningSceneInterface(object):
         self.__submit(co, attach=False)
 
     def add_plane(self, name, pose, normal=(0, 0, 1), offset=0):
-        """ Add a plane to the planning scene """
+        """ 
+        Add a plane to the planning scene 
+        """
         co = CollisionObject()
         co.operation = CollisionObject.ADD
         co.id = name
@@ -119,6 +121,9 @@ class PlanningSceneInterface(object):
         self.__submit(co, attach=False)
 
     def attach_mesh(self, link, name, pose=None, filename='', size=(1, 1, 1), touch_links=[]):
+        """
+        Attach a mesh to the robot as a collision object at the specified link. touch_links are excluded from collision with the object.
+        """
         aco = AttachedCollisionObject()
         if (pose is not None) and filename:
             aco.object = self.__make_mesh(name, pose, filename, size)
@@ -131,6 +136,9 @@ class PlanningSceneInterface(object):
         self.__submit(aco, attach=True)
 
     def attach_box(self, link, name, pose=None, size=(1, 1, 1), touch_links=[]):
+        """
+        Attach a box to the robot as a collision object at the specified link. touch_links are excluded from collision with the object.
+        """
         aco = AttachedCollisionObject()
         if pose is not None:
             aco.object = self.__make_box(name, pose, size)
@@ -145,7 +153,7 @@ class PlanningSceneInterface(object):
 
     def remove_world_object(self, name=None):
         """
-        Remove an object from planning scene, or all if no name is provided
+        Remove an object from planning scene, or all objects if no name is provided
         """
         co = CollisionObject()
         co.operation = CollisionObject.REMOVE

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -221,6 +221,37 @@ class PlanningSceneInterface(object):
             aobjs[key] = msg
         return aobjs
 
+    def allow_collisions(self, object_list_1, object_list_2 = []):
+        """
+        Allows collisions between/for objects or robot links. If object_list_2 is empty, the objects in object_list_1 will be allowed
+        to collide with all objects in the scene (including the robot and environment).
+
+        This function is meant for use cases such as "Allow collision between robot gripper and table".
+        """
+        return self._psi.allow_collisions(object_list_1, object_list_2)
+    
+    def disallow_collisions(self, object_list_1, object_list_2 = []):
+        """
+        Disallows (enables) collisions between/for objects or robot links. If object_list_2 is empty, the objects in object_list_1 will
+        have collision checking enabled for all other objects in the scene (including the robot and environment and
+        grippers that it might be inside of (!)).
+
+        This function is meant for use cases such as "Disllow collision between robot gripper and table".
+        """
+        return self._psi.disallow_collisions(object_list_1, object_list_2)
+    
+    def set_collisions(self, set_to_allow, object_list_1, object_list_2 = []):
+        """
+        Sets the allowed collision matrix between/for objects or robot links. If object_list_2 is empty, the objects in
+        object_list_1 will have their collisions set to allowed/disallowed for all other objects in the scene (including
+        the robot and environment and gripper links they might be in contact with).
+
+        set_to_allow should be True or False.
+
+        This function is meant for use cases such as "Allow/disallow collision between robot gripper and table".
+        """
+        return self._psi.set_collisions(set_to_allow, object_list_1, object_list_2)
+
     @staticmethod
     def __make_existing(name):
         """

--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -138,6 +138,48 @@ public:
       consider using `applyCollisionObjects` instead. */
   void removeCollisionObjects(const std::vector<std::string>& object_ids) const;
 
+  /** \brief Allow or disallow collisions for a set of links or between two sets. */
+  void setCollisions(bool set_to_allow, const std::vector<std::string>& link_group_1,
+                     const std::vector<std::string>& link_group_2 = std::vector<std::string>());
+  void setCollisions(bool set_to_allow, const std::string& link_name_1,
+                     const std::vector<std::string>& link_group_2 = std::vector<std::string>());
+  void setCollisions(bool set_to_allow, const std::string& link_name_1, const std::string& link_name_2 = "");
+
+  /** \brief Allow or disallow collisions for links or groups of links.
+  * This sets the AllowedCollisionMatrix of the PlanningScene.
+  * If the second argument is empty, the collision behavior is set between the link(s) in the first argument
+  * and all other objects in the world. Supplying both arguments only sets collision behavior between the two.
+  * If two link groups are supplied, the collision behavior is set between all the links of group 1 and all the links of
+  * group 2.
+  *
+  * E.g. allowCollisions("gripper_wrist_link", "table_base_link") allows collisions between
+  * the table and the wrist link of your gripper. You will want to add the other gripper links as well.
+ */
+  void allowCollisions(const std::string& link_name_1, const std::string& link_name_2 = "")
+  {
+    setCollisions(true, link_name_1, link_name_2);
+  }
+  void allowCollisions(const std::vector<std::string>& link_group_1, const std::string& link_name_2 = "")
+  {
+    setCollisions(true, link_name_2, link_group_1);
+  }
+  void allowCollisions(const std::vector<std::string>& link_group_1, const std::vector<std::string>& link_group_2)
+  {
+    setCollisions(true, link_group_1, link_group_2);
+  }
+  void disallowCollisions(const std::string& link_name_1, const std::string& link_name_2 = "")
+  {
+    setCollisions(false, link_name_1, link_name_2);
+  }
+  void disallowCollisions(const std::vector<std::string>& link_group_1, const std::string& link_name_2 = "")
+  {
+    setCollisions(false, link_name_2, link_group_1);
+  }
+  void disallowCollisions(const std::vector<std::string>& link_group_1, const std::vector<std::string>& link_group_2)
+  {
+    setCollisions(false, link_group_1, link_group_2);
+  }
+
   /**@}*/
 
 private:

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -110,6 +110,116 @@ public:
     py_bindings_tools::deserializeMsg(ps_str, ps_msg);
     return applyPlanningScene(ps_msg);
   }
+
+  bool applyCollisionObjectPython1(const std::string& co_str)
+  {
+    moveit_msgs::CollisionObject co_msg;
+    py_bindings_tools::deserializeMsg(co_str, co_msg);
+    return applyCollisionObject(co_msg);
+  }
+
+  bool applyCollisionObjectPython2(const std::string& co_str, const std::string& color_str)
+  {
+    moveit_msgs::CollisionObject co_msg;
+    py_bindings_tools::deserializeMsg(co_str, co_msg);
+    std_msgs::ColorRGBA color_msg;
+    py_bindings_tools::deserializeMsg(color_str, color_msg);
+    return applyCollisionObject(co_msg, color_msg);
+  }
+
+  bool applyCollisionObjectsPython(const bp::list& co_string_list, const bp::list& color_string_list)
+  {
+    int l = bp::len(co_string_list);
+    std::vector<moveit_msgs::CollisionObject> co_msgs(l);
+    std::vector<moveit_msgs::ObjectColor> color_msgs(l);
+    // TODO felixvd: Check for empty color vector?
+    for (int i = 0; i < l; ++i)
+    {
+      py_bindings_tools::deserializeMsg(bp::extract<std::string>(co_string_list[i]), co_msgs[i]);
+      py_bindings_tools::deserializeMsg(bp::extract<std::string>(color_string_list[i]), color_msgs[i]);
+    }
+    return applyCollisionObjects(co_msgs, color_msgs);
+  }
+
+  void addCollisionObjectsPython(const bp::list& collision_objects, const bp::list& object_colors) const
+  {
+    int l = bp::len(collision_objects);
+    std::vector<moveit_msgs::CollisionObject> co_msgs(l);
+    std::vector<moveit_msgs::ObjectColor> color_msgs(l);
+    // TODO felixvd: Check for empty color vector?
+    for (int i = 0; i < l; ++i)
+    {
+      py_bindings_tools::deserializeMsg(bp::extract<std::string>(collision_objects[i]), co_msgs[i]);
+      py_bindings_tools::deserializeMsg(bp::extract<std::string>(object_colors[i]), color_msgs[i]);
+    }
+    addCollisionObjects(co_msgs, color_msgs);
+  }
+
+  void removeCollisionObjectsPython(const bp::list& object_ids) const
+  {
+    removeCollisionObjects(py_bindings_tools::stringFromList(object_ids));
+  }
+
+  bool applyAttachedCollisionObjectPython(const std::string& attached_collision_object)
+  {
+    moveit_msgs::AttachedCollisionObject aco_msg;
+    py_bindings_tools::deserializeMsg(attached_collision_object, aco_msg);
+    return applyAttachedCollisionObject(aco_msg);
+  }
+
+  bool applyAttachedCollisionObjectsPython(const bp::list& attached_collision_objects)
+  {
+    int l = bp::len(attached_collision_objects);
+    std::vector<moveit_msgs::AttachedCollisionObject> aco_msgs(l);
+    for (int i = 0; i < l; ++i)
+    {
+      py_bindings_tools::deserializeMsg(bp::extract<std::string>(attached_collision_objects[i]), aco_msgs[i]);
+    }
+    return applyAttachedCollisionObjects(aco_msgs);
+  }
+
+  bool allowCollisionsPython1(const std::string& link_name_1, const std::string& link_name_2)
+  {
+    return allowCollisions(link_name_1, link_name_2);
+  }
+
+  bool allowCollisionsPython2(const bp::list& link_group_1, const std::string& link_name_2)
+  {
+    return allowCollisions(py_bindings_tools::stringFromList(link_group_1), link_name_2);
+  }
+
+  bool allowCollisionsPython3(const bp::list& link_group_1, const bp::list& link_group_2)
+  {
+    return allowCollisions(py_bindings_tools::stringFromList(link_group_1),
+                           py_bindings_tools::stringFromList(link_group_2));
+  }
+
+  bool disallowCollisionsPython1(const std::string& link_name_1, const std::string& link_name_2)
+  {
+    return disallowCollisions(link_name_1, link_name_2);
+  }
+
+  bool disallowCollisionsPython2(const bp::list& link_group_1, const std::string& link_name_2)
+  {
+    return disallowCollisions(py_bindings_tools::stringFromList(link_group_1), link_name_2);
+  }
+
+  bool disallowCollisionsPython3(const bp::list& link_group_1, const bp::list& link_group_2)
+  {
+    return disallowCollisions(py_bindings_tools::stringFromList(link_group_1),
+                              py_bindings_tools::stringFromList(link_group_2));
+  }
+
+  bool setCollisionsPython1(bool set_to_allow, bp::list& link_group_1, bp::list& link_group_2)
+  {
+    return setCollisions(set_to_allow, py_bindings_tools::stringFromList(link_group_1),
+                         py_bindings_tools::stringFromList(link_group_2));
+  }
+
+  bool setCollisionsPython2(bool set_to_allow, const std::string& link_name_1, bp::list& link_group_2)
+  {
+    return setCollisions(set_to_allow, link_name_1, py_bindings_tools::stringFromList(link_group_2));
+  }
 };
 
 static void wrap_planning_scene_interface()
@@ -124,6 +234,23 @@ static void wrap_planning_scene_interface()
   planning_scene_class.def("get_objects", &PlanningSceneInterfaceWrapper::getObjectsPython);
   planning_scene_class.def("get_attached_objects", &PlanningSceneInterfaceWrapper::getAttachedObjectsPython);
   planning_scene_class.def("apply_planning_scene", &PlanningSceneInterfaceWrapper::applyPlanningScenePython);
+  planning_scene_class.def("apply_collision_object", &PlanningSceneInterfaceWrapper::applyCollisionObjectPython1);
+  planning_scene_class.def("apply_collision_object", &PlanningSceneInterfaceWrapper::applyCollisionObjectPython2);
+  planning_scene_class.def("apply_collision_objects", &PlanningSceneInterfaceWrapper::applyCollisionObjectsPython);
+  planning_scene_class.def("add_collision_objects", &PlanningSceneInterfaceWrapper::addCollisionObjectsPython);
+  planning_scene_class.def("remove_collision_object", &PlanningSceneInterfaceWrapper::removeCollisionObjectsPython);
+  planning_scene_class.def("apply_attached_collision_object",
+                           &PlanningSceneInterfaceWrapper::applyAttachedCollisionObjectPython);
+  planning_scene_class.def("apply_attached_collision_objects",
+                           &PlanningSceneInterfaceWrapper::applyAttachedCollisionObjectsPython);
+  planning_scene_class.def("allow_collisions", &PlanningSceneInterfaceWrapper::allowCollisionsPython1);
+  planning_scene_class.def("allow_collisions", &PlanningSceneInterfaceWrapper::allowCollisionsPython2);
+  planning_scene_class.def("allow_collisions", &PlanningSceneInterfaceWrapper::allowCollisionsPython3);
+  planning_scene_class.def("disallow_collisions", &PlanningSceneInterfaceWrapper::disallowCollisionsPython1);
+  planning_scene_class.def("disallow_collisions", &PlanningSceneInterfaceWrapper::disallowCollisionsPython2);
+  planning_scene_class.def("disallow_collisions", &PlanningSceneInterfaceWrapper::disallowCollisionsPython3);
+  planning_scene_class.def("set_collisions", &PlanningSceneInterfaceWrapper::setCollisionsPython1);
+  planning_scene_class.def("set_collisions", &PlanningSceneInterfaceWrapper::setCollisionsPython2);
 }
 }  // namespace planning_interface
 }  // namespace moveit


### PR DESCRIPTION
### Description

Adds some convenience methods to planning_scene_interface that were mentioned as examples in #1123 : `allowCollisions`, `disallowCollisions` and `setCollisions`. The functions do what you expect them to, and they have comments and python bindings. I fixed typos and clarified some comments on the side, but I am too lazy to open another PR for that.

Cherry-pick to melodic would be useful. I wrote these changes for a project that was running on Kinetic, so they should work there as well.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] Extended the tutorials / documentation, if necessary (should be updated automatically)
- [X] Document API changes relevant to the user in the moveit/MIGRATION.md notes (only new functions are added)
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html) (I don't know how to write tests :( )
- [X] Decide if this should be cherry-picked to other current ROS branches
- [X] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
