### PR TITLE
Add user warning to planning pipeline when multiple constraints are set and planning fails

### DIFF
--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -339,6 +339,26 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     display_path_publisher_.publish(disp);
   }
 
+  if (!solved)
+  {
+    // This should alert the user if planning failed because of contradicting constraints.
+    // Could be checked more thoroughly, but it is probably not worth going to that length.
+    bool stacked_constraints = false;
+    if (req.goal_constraints.size() > 1 || req.path_constraints.joint_constraints.size() > 1 ||
+        req.path_constraints.position_constraints.size() > 1 || req.path_constraints.orientation_constraints.size() > 1)
+      stacked_constraints = true;
+    for (auto constraint : req.goal_constraints)
+    {
+      if (constraint.joint_constraints.size() > 1 || constraint.position_constraints.size() > 1 ||
+          constraint.orientation_constraints.size() > 1)
+        stacked_constraints = true;
+    }
+    if (stacked_constraints)
+      ROS_WARN("More than one constraint is set. If your move_group does not have multiple end effectors/arms, this is "
+               "unusual. Are you using a move_group_interface and forgetting to call clearPoseTargets() or "
+               "equivalent?");
+  }
+
   return solved && valid;
 }
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -344,13 +344,12 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     // This should alert the user if planning failed because of contradicting constraints.
     // Could be checked more thoroughly, but it is probably not worth going to that length.
     bool stacked_constraints = false;
-    if (req.goal_constraints.size() > 1 || req.path_constraints.joint_constraints.size() > 1 ||
-        req.path_constraints.position_constraints.size() > 1 || req.path_constraints.orientation_constraints.size() > 1)
+    if (req.goal_constraints.size() > 1 || req.path_constraints.position_constraints.size() > 1 ||
+        req.path_constraints.orientation_constraints.size() > 1)
       stacked_constraints = true;
     for (auto constraint : req.goal_constraints)
     {
-      if (constraint.joint_constraints.size() > 1 || constraint.position_constraints.size() > 1 ||
-          constraint.orientation_constraints.size() > 1)
+      if (constraint.position_constraints.size() > 1 || constraint.orientation_constraints.size() > 1)
         stacked_constraints = true;
     }
     if (stacked_constraints)


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit/issues/1048. When I had [this problem](https://answers.ros.org/question/299979/moveit-plan-fails-after-attaching-an-object-but-not-from-rviz-or-after-restarting-requesting-node/), I would have appreciated a more helpful error message. @v4hn requested a PR, so I made this.

The summary of the ROS answers post is that I forgot to call `clearPoseTargets` after changing the end effector link of the `move_group`, so that constraints were active on multiple links of the robot. I added an error message that displays if planning fails and multiple constraints are set.

You can test that the message fires correctly by adding the lines below in [this part](https://github.com/ros-planning/moveit_tutorials/blob/master/doc/move_group_interface/src/move_group_interface_tutorial.cpp#L126) of the tutorial:

```
  geometry_msgs::Pose target_pose2;
  target_pose2.orientation.w = 1.0;
  target_pose2.position.x = 0.28;
  target_pose2.position.y = 0.2;
  target_pose2.position.z = 0.5;
  move_group.setEndEffectorLink("panda_link7");
  move_group.setPoseTarget(target_pose2);
```

This is simple enough to be cherry-picked to both kinetic and melodic.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes (not needed)
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html) (I am not sure this is required)
- [X] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
