### PR TITLE
[Python wrapper] Added custom time limit for wait_for_servers in MoveGroupInterface

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -64,10 +64,11 @@ public:
   // ROSInitializer is constructed first, and ensures ros::init() was called, if
   // needed
   MoveGroupInterfaceWrapper(const std::string& group_name, const std::string& robot_description,
-                            const std::string& ns = "")
+                            const std::string& ns = "",
+                            double wait_for_servers = 5.0)
     : py_bindings_tools::ROScppInitializer()
     , MoveGroupInterface(Options(group_name, robot_description, ros::NodeHandle(ns)),
-                         std::shared_ptr<tf2_ros::Buffer>(), ros::WallDuration(5, 0))
+                         std::shared_ptr<tf2_ros::Buffer>(), ros::WallDuration(wait_for_servers))
   {
   }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -64,8 +64,7 @@ public:
   // ROSInitializer is constructed first, and ensures ros::init() was called, if
   // needed
   MoveGroupInterfaceWrapper(const std::string& group_name, const std::string& robot_description,
-                            const std::string& ns = "",
-                            double wait_for_servers = 5.0)
+                            const std::string& ns = "", double wait_for_servers = 5.0)
     : py_bindings_tools::ROScppInitializer()
     , MoveGroupInterface(Options(group_name, robot_description, ros::NodeHandle(ns)),
                          std::shared_ptr<tf2_ros::Buffer>(), ros::WallDuration(wait_for_servers))


### PR DESCRIPTION
### Description

* Retained current hard-coded 5 second limit
* Used double to conform to python accessible API instead of `ros::WallDuration(int, int)`
* API is extended, remains conformant to previous releases

Would be nice if this was applied to Kinetic, Lunar and Melodic (all distros maintained next month)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
