### PR TITLE
Fix IKFastPlugin initialization. Fixes #1448

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -375,6 +375,7 @@ bool IKFastKinematicsPlugin::computeRelativeTransform(const std::string& from, c
 {
   RobotStatePtr robot_state;
   robot_state.reset(new RobotState(robot_model_));
+  robot_state->setToDefaultValues();
 
   auto* from_link = robot_state->getLinkModel(from);
   auto* to_link = robot_state->getLinkModel(to);


### PR DESCRIPTION
- initialize values of RobotState in computeRelativeTransform()
- add tolerance for comparison to identity

### Description

see #1448

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
