### PR TITLE
Clarify "id" parameter in RobotState & collision world

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -111,7 +111,7 @@ public:
   std::vector<std::string> getObjectIds() const;
 
   /** \brief Get a particular object */
-  ObjectConstPtr getObject(const std::string& id) const;
+  ObjectConstPtr getObject(const std::string& object_id) const;
 
   /** iterator over the objects in the world. */
   typedef std::map<std::string, ObjectPtr>::const_iterator const_iterator;
@@ -137,28 +137,29 @@ public:
   }
 
   /** \brief Check if a particular object exists in the collision world*/
-  bool hasObject(const std::string& id) const;
+  bool hasObject(const std::string& object_id) const;
 
   /** \brief Add shapes to an object in the map.
    * This function makes repeated calls to addToObjectInternal() to add the
    * shapes one by one.
    *  \note This function does NOT call the addToObject() variant that takes
    * a single shape and a single pose as input. */
-  void addToObject(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+  void addToObject(const std::string& object_id, const std::vector<shapes::ShapeConstPtr>& shapes,
                    const EigenSTL::vector_Isometry3d& poses);
 
   /** \brief Add a shape to an object.
    * If the object already exists, this call will add the shape to the object
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
-  void addToObject(const std::string& id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose);
+  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose);
 
   /** \brief Update the pose of a shape in an object. Shape equality is
    * verified by comparing pointers. Returns true on success. */
-  bool moveShapeInObject(const std::string& id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose);
+  bool moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
+                         const Eigen::Isometry3d& pose);
 
   /** \brief Move all shapes in an object according to the given transform specified in world frame */
-  bool moveObject(const std::string& id, const Eigen::Isometry3d& transform);
+  bool moveObject(const std::string& object_id, const Eigen::Isometry3d& transform);
 
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the
@@ -166,13 +167,13 @@ public:
    * exist) if this was the last shape in the object.
    * Returns true on success and false if the object did not exist or did not
    * contain the shape. */
-  bool removeShapeFromObject(const std::string& id, const shapes::ShapeConstPtr& shape);
+  bool removeShapeFromObject(const std::string& object_id, const shapes::ShapeConstPtr& shape);
 
   /** \brief Remove a particular object.
    * If there are no external pointers to the corresponding instance of
    * Object, the memory is freed.
    * Returns true on success and false if no such object was found. */
-  bool removeObject(const std::string& id);
+  bool removeObject(const std::string& object_id);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -116,9 +116,9 @@ std::vector<std::string> World::getObjectIds() const
   return id;
 }
 
-World::ObjectConstPtr World::getObject(const std::string& id) const
+World::ObjectConstPtr World::getObject(const std::string& object_id) const
 {
-  auto it = objects_.find(id);
+  auto it = objects_.find(object_id);
   if (it == objects_.end())
     return ObjectConstPtr();
   else
@@ -131,14 +131,15 @@ void World::ensureUnique(ObjectPtr& obj)
     obj.reset(new Object(*obj));
 }
 
-bool World::hasObject(const std::string& id) const
+bool World::hasObject(const std::string& object_id) const
 {
-  return objects_.find(id) != objects_.end();
+  return objects_.find(object_id) != objects_.end();
 }
 
-bool World::moveShapeInObject(const std::string& id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose)
+bool World::moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
+                              const Eigen::Isometry3d& pose)
 {
-  auto it = objects_.find(id);
+  auto it = objects_.find(object_id);
   if (it != objects_.end())
   {
     unsigned int n = it->second->shapes_.size();
@@ -155,9 +156,9 @@ bool World::moveShapeInObject(const std::string& id, const shapes::ShapeConstPtr
   return false;
 }
 
-bool World::moveObject(const std::string& id, const Eigen::Isometry3d& transform)
+bool World::moveObject(const std::string& object_id, const Eigen::Isometry3d& transform)
 {
-  auto it = objects_.find(id);
+  auto it = objects_.find(object_id);
   if (it == objects_.end())
     return false;
   if (transform.isApprox(Eigen::Isometry3d::Identity()))
@@ -171,9 +172,9 @@ bool World::moveObject(const std::string& id, const Eigen::Isometry3d& transform
   return true;
 }
 
-bool World::removeShapeFromObject(const std::string& id, const shapes::ShapeConstPtr& shape)
+bool World::removeShapeFromObject(const std::string& object_id, const shapes::ShapeConstPtr& shape)
 {
-  auto it = objects_.find(id);
+  auto it = objects_.find(object_id);
   if (it != objects_.end())
   {
     unsigned int n = it->second->shapes_.size();
@@ -199,9 +200,9 @@ bool World::removeShapeFromObject(const std::string& id, const shapes::ShapeCons
   return false;
 }
 
-bool World::removeObject(const std::string& id)
+bool World::removeObject(const std::string& object_id)
 {
-  auto it = objects_.find(id);
+  auto it = objects_.find(object_id);
   if (it != objects_.end())
   {
     notify(it->second, DESTROY);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -85,11 +85,11 @@ public:
   }
 
 private:
-  bool knowsObject(const std::string& id) const
+  bool knowsObject(const std::string& object_id) const
   {
-    if (scene_->getWorld()->hasObject(id))
+    if (scene_->getWorld()->hasObject(object_id))
     {
-      collision_detection::World::ObjectConstPtr obj = scene_->getWorld()->getObject(id);
+      collision_detection::World::ObjectConstPtr obj = scene_->getWorld()->getObject(object_id);
       return obj->shape_poses_.size() == 1;
     }
     return false;
@@ -1859,97 +1859,99 @@ bool PlanningScene::processCollisionObjectMove(const moveit_msgs::CollisionObjec
   return false;
 }
 
-const Eigen::Isometry3d& PlanningScene::getFrameTransform(const std::string& id) const
+const Eigen::Isometry3d& PlanningScene::getFrameTransform(const std::string& frame_id) const
 {
-  return getFrameTransform(getCurrentState(), id);
+  return getFrameTransform(getCurrentState(), frame_id);
 }
 
-const Eigen::Isometry3d& PlanningScene::getFrameTransform(const std::string& id)
+const Eigen::Isometry3d& PlanningScene::getFrameTransform(const std::string& frame_id)
 {
   if (getCurrentState().dirtyLinkTransforms())
-    return getFrameTransform(getCurrentStateNonConst(), id);
+    return getFrameTransform(getCurrentStateNonConst(), frame_id);
   else
-    return getFrameTransform(getCurrentState(), id);
+    return getFrameTransform(getCurrentState(), frame_id);
 }
 
 const Eigen::Isometry3d& PlanningScene::getFrameTransform(const robot_state::RobotState& state,
-                                                          const std::string& id) const
+                                                          const std::string& frame_id) const
 {
-  if (!id.empty() && id[0] == '/')
+  if (!frame_id.empty() && frame_id[0] == '/')
     // Recursively call itself without the slash in front of frame name
-    // TODO: minor cleanup, but likely getFrameTransform(state, id.substr(1)); can be used, but requires further testing
-    return getFrameTransform(id.substr(1));
-  if (state.knowsFrameTransform(id))
-    return state.getFrameTransform(id);
-  if (getWorld()->hasObject(id))
+    // TODO: minor cleanup, but likely getFrameTransform(state, frame_id.substr(1)); can be used, but requires further
+    // testing
+    return getFrameTransform(frame_id.substr(1));
+  if (state.knowsFrameTransform(frame_id))
+    return state.getFrameTransform(frame_id);
+  if (getWorld()->hasObject(frame_id))
   {
-    collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(id);
+    collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(frame_id);
     if (obj->shape_poses_.size() > 1)
     {
-      ROS_WARN_NAMED(LOGNAME, "More than one shapes in object '%s'. Using first one to decide transform", id.c_str());
+      ROS_WARN_NAMED(LOGNAME, "More than one shapes in object '%s'. Using first one to decide transform",
+                     frame_id.c_str());
       return obj->shape_poses_[0];
     }
     else if (obj->shape_poses_.size() == 1)
       return obj->shape_poses_[0];
   }
-  return getTransforms().Transforms::getTransform(id);
+  return getTransforms().Transforms::getTransform(frame_id);
 }
 
-bool PlanningScene::knowsFrameTransform(const std::string& id) const
+bool PlanningScene::knowsFrameTransform(const std::string& frame_id) const
 {
-  return knowsFrameTransform(getCurrentState(), id);
+  return knowsFrameTransform(getCurrentState(), frame_id);
 }
 
-bool PlanningScene::knowsFrameTransform(const robot_state::RobotState& state, const std::string& id) const
+bool PlanningScene::knowsFrameTransform(const robot_state::RobotState& state, const std::string& frame_id) const
 {
-  if (!id.empty() && id[0] == '/')
-    return knowsFrameTransform(id.substr(1));
-  if (state.knowsFrameTransform(id))
+  if (!frame_id.empty() && frame_id[0] == '/')
+    return knowsFrameTransform(frame_id.substr(1));
+  if (state.knowsFrameTransform(frame_id))
     return true;
 
-  collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(id);
+  collision_detection::World::ObjectConstPtr obj = getWorld()->getObject(frame_id);
   if (obj)
   {
     return obj->shape_poses_.size() == 1;
   }
-  return getTransforms().Transforms::canTransform(id);
+  return getTransforms().Transforms::canTransform(frame_id);
 }
 
-bool PlanningScene::hasObjectType(const std::string& id) const
+bool PlanningScene::hasObjectType(const std::string& object_id) const
 {
   if (object_types_)
-    if (object_types_->find(id) != object_types_->end())
+    if (object_types_->find(object_id) != object_types_->end())
       return true;
   if (parent_)
-    return parent_->hasObjectType(id);
+    return parent_->hasObjectType(object_id);
   return false;
 }
 
-const object_recognition_msgs::ObjectType& PlanningScene::getObjectType(const std::string& id) const
+const object_recognition_msgs::ObjectType& PlanningScene::getObjectType(const std::string& object_id) const
 {
   if (object_types_)
   {
-    ObjectTypeMap::const_iterator it = object_types_->find(id);
+    ObjectTypeMap::const_iterator it = object_types_->find(object_id);
     if (it != object_types_->end())
       return it->second;
   }
   if (parent_)
-    return parent_->getObjectType(id);
+    return parent_->getObjectType(object_id);
   static const object_recognition_msgs::ObjectType EMPTY;
   return EMPTY;
 }
 
-void PlanningScene::setObjectType(const std::string& id, const object_recognition_msgs::ObjectType& type)
+void PlanningScene::setObjectType(const std::string& object_id, const object_recognition_msgs::ObjectType& type)
 {
   if (!object_types_)
     object_types_.reset(new ObjectTypeMap());
-  (*object_types_)[id] = type;
+  (*object_types_)[object_id] = type;
 }
 
-void PlanningScene::removeObjectType(const std::string& id)
+void PlanningScene::removeObjectType(const std::string& object_id)
 {
   if (object_types_)
-    object_types_->erase(id);
+    object_types_->erase(object_id);
 }
 
 void PlanningScene::getKnownObjectTypes(ObjectTypeMap& kc) const
@@ -1962,26 +1964,26 @@ void PlanningScene::getKnownObjectTypes(ObjectTypeMap& kc) const
       kc[it->first] = it->second;
 }
 
-bool PlanningScene::hasObjectColor(const std::string& id) const
+bool PlanningScene::hasObjectColor(const std::string& object_id) const
 {
   if (object_colors_)
-    if (object_colors_->find(id) != object_colors_->end())
+    if (object_colors_->find(object_id) != object_colors_->end())
       return true;
   if (parent_)
-    return parent_->hasObjectColor(id);
+    return parent_->hasObjectColor(object_id);
   return false;
 }
 
-const std_msgs::ColorRGBA& PlanningScene::getObjectColor(const std::string& id) const
+const std_msgs::ColorRGBA& PlanningScene::getObjectColor(const std::string& object_id) const
 {
   if (object_colors_)
   {
-    ObjectColorMap::const_iterator it = object_colors_->find(id);
+    ObjectColorMap::const_iterator it = object_colors_->find(object_id);
     if (it != object_colors_->end())
       return it->second;
   }
   if (parent_)
-    return parent_->getObjectColor(id);
+    return parent_->getObjectColor(object_id);
   static const std_msgs::ColorRGBA EMPTY;
   return EMPTY;
 }
@@ -1996,22 +1998,22 @@ void PlanningScene::getKnownObjectColors(ObjectColorMap& kc) const
       kc[it->first] = it->second;
 }
 
-void PlanningScene::setObjectColor(const std::string& id, const std_msgs::ColorRGBA& color)
+void PlanningScene::setObjectColor(const std::string& object_id, const std_msgs::ColorRGBA& color)
 {
-  if (id.empty())
+  if (object_id.empty())
   {
-    ROS_ERROR_NAMED(LOGNAME, "Cannot set color of object with empty id.");
+    ROS_ERROR_NAMED(LOGNAME, "Cannot set color of object with empty object_id.");
     return;
   }
   if (!object_colors_)
     object_colors_.reset(new ObjectColorMap());
-  (*object_colors_)[id] = color;
+  (*object_colors_)[object_id] = color;
 }
 
-void PlanningScene::removeObjectColor(const std::string& id)
+void PlanningScene::removeObjectColor(const std::string& object_id)
 {
   if (object_colors_)
-    object_colors_->erase(id);
+    object_colors_->erase(object_id);
 }
 
 bool PlanningScene::isStateColliding(const moveit_msgs::RobotState& state, const std::string& group, bool verbose) const

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1632,14 +1632,14 @@ as the new values that correspond to the group */
     return *rng_;
   }
 
-  /** \brief Get the transformation matrix from the model frame to the frame identified by \e id */
-  const Eigen::Isometry3d& getFrameTransform(const std::string& id);
+  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id */
+  const Eigen::Isometry3d& getFrameTransform(const std::string& frame_id);
 
-  /** \brief Get the transformation matrix from the model frame to the frame identified by \e id */
-  const Eigen::Isometry3d& getFrameTransform(const std::string& id) const;
+  /** \brief Get the transformation matrix from the model frame to the frame identified by \e frame_id */
+  const Eigen::Isometry3d& getFrameTransform(const std::string& frame_id) const;
 
-  /** \brief Check if a transformation matrix from the model frame to frame \e id is known */
-  bool knowsFrameTransform(const std::string& id) const;
+  /** \brief Check if a transformation matrix from the model frame to frame \e frame_id is known */
+  bool knowsFrameTransform(const std::string& frame_id) const;
 
   /** @brief Get a MarkerArray that fully describes the robot markers for a given robot.
    *  @param arr The returned marker array

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -985,55 +985,55 @@ bool RobotState::clearAttachedBody(const std::string& id)
     return false;
 }
 
-const Eigen::Isometry3d& RobotState::getFrameTransform(const std::string& id)
+const Eigen::Isometry3d& RobotState::getFrameTransform(const std::string& frame_id)
 {
   updateLinkTransforms();
-  return static_cast<const RobotState*>(this)->getFrameTransform(id);
+  return static_cast<const RobotState*>(this)->getFrameTransform(frame_id);
 }
 
-const Eigen::Isometry3d& RobotState::getFrameTransform(const std::string& id) const
+const Eigen::Isometry3d& RobotState::getFrameTransform(const std::string& frame_id) const
 {
-  if (!id.empty() && id[0] == '/')
-    return getFrameTransform(id.substr(1));
+  if (!frame_id.empty() && frame_id[0] == '/')
+    return getFrameTransform(frame_id.substr(1));
   BOOST_VERIFY(checkLinkTransforms());
 
   static const Eigen::Isometry3d IDENTITY_TRANSFORM = Eigen::Isometry3d::Identity();
-  if (id == robot_model_->getModelFrame())
+  if (frame_id == robot_model_->getModelFrame())
     return IDENTITY_TRANSFORM;
-  if (robot_model_->hasLinkModel(id))
+  if (robot_model_->hasLinkModel(frame_id))
   {
-    const LinkModel* lm = robot_model_->getLinkModel(id);
+    const LinkModel* lm = robot_model_->getLinkModel(frame_id);
     return global_link_transforms_[lm->getLinkIndex()];
   }
-  std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(id);
+  std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(frame_id);
   if (jt == attached_body_map_.end())
   {
     ROS_ERROR_NAMED(LOGNAME, "Transform from frame '%s' to frame '%s' is not known "
-                             "('%s' should be a link name or an attached body id).",
-                    id.c_str(), robot_model_->getModelFrame().c_str(), id.c_str());
+                             "('%s' should be a link name or an attached body's id).",
+                    frame_id.c_str(), robot_model_->getModelFrame().c_str(), frame_id.c_str());
     return IDENTITY_TRANSFORM;
   }
   const EigenSTL::vector_Isometry3d& tf = jt->second->getGlobalCollisionBodyTransforms();
   if (tf.empty())
   {
     ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' has no geometry associated to it. No transform to return.",
-                    id.c_str());
+                    frame_id.c_str());
     return IDENTITY_TRANSFORM;
   }
   if (tf.size() > 1)
     ROS_DEBUG_NAMED(LOGNAME, "There are multiple geometries associated to attached body '%s'. "
                              "Returning the transform for the first one.",
-                    id.c_str());
+                    frame_id.c_str());
   return tf[0];
 }
 
-bool RobotState::knowsFrameTransform(const std::string& id) const
+bool RobotState::knowsFrameTransform(const std::string& frame_id) const
 {
-  if (!id.empty() && id[0] == '/')
-    return knowsFrameTransform(id.substr(1));
-  if (robot_model_->hasLinkModel(id))
+  if (!frame_id.empty() && frame_id[0] == '/')
+    return knowsFrameTransform(frame_id.substr(1));
+  if (robot_model_->hasLinkModel(frame_id))
     return true;
-  std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
+  std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(frame_id);
   return it != attached_body_map_.end() && !it->second->getGlobalCollisionBodyTransforms().empty();
 }
 


### PR DESCRIPTION
### Description

This makes some parameters in the robot state and collision world clearer, as requested by @mlautman in #1060, in a separate PR as requested by @rhaschke in #1439. This PR changes nothing except the internal names.

Can be cherry-picked to kinetic and melodic.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Decide if this should be cherry-picked to other current ROS branches