### PR TITLE
docker: remove CATKIN_WS, define ROS_UNDERLAY

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -6,9 +6,8 @@ MAINTAINER Dave Coleman dave@picknik.ai
 
 ENV TERM xterm
 
-# Setup catkin workspace
-ENV CATKIN_WS=/root/ws_moveit
-WORKDIR $CATKIN_WS
+# Setup (temporary) ROS workspace
+WORKDIR /root/ws_moveit
 
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers

--- a/.docker/experimental/Dockerfile
+++ b/.docker/experimental/Dockerfile
@@ -1,7 +1,7 @@
-# moveit/moveit:melodic-experimental
+# moveit/moveit:master-experimental
 # Based on a moveit source install, adds the mongo driver and the warehouse packages
 
-FROM moveit/moveit:melodic-source
+FROM moveit/moveit:master-source
 
 # installing mongocxx driver for the warehouse
 RUN git clone -b 26compat https://github.com/mongodb/mongo-cxx-driver.git && \

--- a/.docker/experimental/Dockerfile
+++ b/.docker/experimental/Dockerfile
@@ -3,10 +3,6 @@
 
 FROM moveit/moveit:melodic-source
 
-ENV CATKIN_WS=/root/ws_moveit
-RUN mkdir -p $CATKIN_WS/src
-WORKDIR $CATKIN_WS/src
-
 # installing mongocxx driver for the warehouse
 RUN git clone -b 26compat https://github.com/mongodb/mongo-cxx-driver.git && \
     apt-get update -qq && \
@@ -22,7 +18,4 @@ RUN wstool set -yu warehouse_ros_mongo --git https://github.com/ros-planning/war
     wstool set -yu warehouse_ros --git https://github.com/ros-planning/warehouse_ros.git -v jade-devel
 
 # build the workspace
-RUN cd $CATKIN_WS && \
-    source /root/ws_moveit/devel/setup.bash && \
-    catkin init  && \
-    catkin build
+RUN catkin build --limit-status-rate 0.001 --no-notify

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,12 +4,12 @@
 FROM moveit/moveit:master-ci-shadow-fixed
 MAINTAINER Dave Coleman dave@picknik.ai
 
+ENV ROS_UNDERLAY /root/ws_moveit/install
+WORKDIR $ROS_UNDERLAY/../src
+
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 RUN \
-    mkdir src && \
-    cd src && \
-    #
     # Download moveit source so that we can get necessary dependencies
     wstool init . https://raw.githubusercontent.com/ros-planning/moveit/master/moveit.rosinstall && \
     #
@@ -22,9 +22,9 @@ RUN \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
 
-# Configure catkin workspace, but do not build because Docker times out
 ENV PYTHONIOENCODING UTF-8
-RUN catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+RUN cd .. && \
+    catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     # Status rate is limited so that just enough info is shown to keep Docker from timing out,
     # but not too much such that the Docker log gets too long (another form of timeout)
     catkin build --limit-status-rate 0.001 --no-notify


### PR DESCRIPTION
To enable https://github.com/ros-planning/moveit_ci/pull/62, define `ROS_UNDERLAY` in the source container. The `CATKIN_WS` environment variable is not used anymore by `moveit_ci` and is thus removed.
