### PR TITLE
Add MoveIt Task Constructor to main rosinstall, for integration testing

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -32,3 +32,7 @@
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
     version: master
+- git:
+    local-name: moveit_task_constructor
+    uri: https://github.com/ros-planning/moveit_task_constructor.git
+    version: master


### PR DESCRIPTION
We would like to start using the MTC in all our clients, and migrate away from the difficult to use planning pipeline. See also https://github.com/ros-planning/moveit_task_constructor/pull/88

