### PR TITLE
Allow subclassing of point_containment_filter::ShapeMask.

### DIFF
--- a/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -69,7 +69,7 @@ public:
   ShapeMask(const TransformCallback& transform_callback = TransformCallback());
 
   /** \brief Destructor to clean up */
-  ~ShapeMask();
+  virtual ~ShapeMask();
 
   ShapeHandle addShape(const shapes::ShapeConstPtr& shape, double scale = 1.0, double padding = 0.0);
   void removeShape(ShapeHandle handle);
@@ -91,7 +91,7 @@ public:
       It is assumed the point is in the frame corresponding to the TransformCallback */
   int getMaskContainment(const Eigen::Vector3d& pt) const;
 
-private:
+protected:
   struct SeeShape
   {
     SeeShape()
@@ -116,17 +116,20 @@ private:
     }
   };
 
+  TransformCallback transform_callback_;
+
+  /** \brief Protects, bodies_ and bspheres_. All public methods acquire this mutex for their whole duration. */
+  mutable boost::mutex shapes_lock_;
+  std::set<SeeShape, SortBodies> bodies_;
+  std::vector<bodies::BoundingSphere> bspheres_;
+
+private:
   /** \brief Free memory. */
   void freeMemory();
 
-  TransformCallback transform_callback_;
   ShapeHandle next_handle_;
   ShapeHandle min_handle_;
-
-  mutable boost::mutex shapes_lock_;
-  std::set<SeeShape, SortBodies> bodies_;
   std::map<ShapeHandle, std::set<SeeShape, SortBodies>::iterator> used_handles_;
-  std::vector<bodies::BoundingSphere> bspheres_;
 };
 }
 


### PR DESCRIPTION
### Description

Just made ShapeMask members protected, so that users can subclass it and make use of the existing data members and private classes.

This of course means making the C++ API public and saying it is stable.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
