### PR TITLE
fix moveit_commander

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -496,7 +496,7 @@ class MoveGroupCommander(object):
         elif joints is not None:
             try:
                 self.set_joint_value_target(self.get_remembered_joint_values()[joints])
-            except MoveItCommanderException:
+            except TypeError:
                 self.set_joint_value_target(joints)
         if wait:
             return self._g.move()


### PR DESCRIPTION
d649771a65 introduced the wrong exception to handle in go(), causing some tutorials to fail: https://github.com/ros-planning/moveit_tutorials/issues/301. This PR catches the correct exception (TypeError).