### PR TITLE
Make warning display check more sensible

### DIFF
--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -344,8 +344,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     // This should alert the user if planning failed because of contradicting constraints.
     // Could be checked more thoroughly, but it is probably not worth going to that length.
     bool stacked_constraints = false;
-    if (req.goal_constraints.size() > 1 || req.path_constraints.position_constraints.size() > 1 ||
-        req.path_constraints.orientation_constraints.size() > 1)
+    if (req.path_constraints.position_constraints.size() > 1 || req.path_constraints.orientation_constraints.size() > 1)
       stacked_constraints = true;
     for (auto constraint : req.goal_constraints)
     {


### PR DESCRIPTION
Removes the check as requested by @rhaschke in #1443 which was merged too early.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)