### PR TITLE
Sudden stop for critical issues, filtered deceleration otherwise

### DIFF
--- a/moveit_experimental/jog_arm/config/sia5_simulated_config.yaml
+++ b/moveit_experimental/jog_arm/config/sia5_simulated_config.yaml
@@ -8,7 +8,7 @@ scale: # Only used if command_in_type=="unitless"
 cartesian_command_in_topic: jog_arm_server/delta_jog_cmds # Topic for xyz commands
 joint_command_in_topic: jog_arm_server/joint_delta_jog_cmds # Topic for angle commands
 command_frame: base_link  # If incoming cmds have no frame, this is the default
-incoming_command_timeout: 5  # Stop jogging if X seconds elapse without a new cmd
+incoming_command_timeout: 0.5  # Stop jogging if X seconds elapse without a new cmd
 joint_topic: joint_states
 move_group_name: arm  # Often 'manipulator' or 'arm'
 lower_singularity_threshold: 15  # Start decelerating when the condition number hits this (close to singularity). Larger --> closer to singularity

--- a/moveit_experimental/jog_arm/include/jog_arm/jog_arm_data.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_arm_data.h
@@ -75,7 +75,7 @@ struct JogArmShared
   trajectory_msgs::JointTrajectory outgoing_command;
 
   // Timestamp of incoming commands
-  ros::Time incoming_cmd_stamp = ros::Time(0.);
+  ros::Time latest_nonzero_cmd_stamp = ros::Time(0.);
 
   // Indicates no collision, etc, so outgoing commands can be sent
   bool ok_to_publish = false;

--- a/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
@@ -66,7 +66,7 @@ protected:
 
   bool cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared& shared_variables, pthread_mutex_t& mutex);
 
-  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables);
+  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables, pthread_mutex_t& mutex);
 
   // Parse the incoming joint msg for the joints of our MoveGroup
   bool updateJoints();
@@ -83,8 +83,9 @@ protected:
   // Reset the data stored in low-pass filters so the trajectory won't jump when jogging is resumed.
   void resetVelocityFilters();
 
-  // Avoid a singularity or other issue. Is handled differently for position vs. velocity control.
-  void halt(trajectory_msgs::JointTrajectory& jt_traj);
+  // Suddenly halt for a joint limit or other critical issue.
+  // Is handled differently for position vs. velocity control.
+  void suddenHalt(trajectory_msgs::JointTrajectory& jt_traj);
 
   void publishWarning(bool active) const;
 

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_calcs.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_calcs.cpp
@@ -128,10 +128,8 @@ JogCalcs::JogCalcs(const JogArmParameters parameters, JogArmShared& shared_varia
     pthread_mutex_lock(&mutex);
     bool zero_cartesian_cmd_flag = shared_variables.zero_cartesian_cmd_flag;
     bool zero_joint_cmd_flag = shared_variables.zero_joint_cmd_flag;
-    pthread_mutex_unlock(&mutex);
 
     // Pull data from the shared variables.
-    pthread_mutex_lock(&mutex);
     incoming_jts_ = shared_variables.joints;
     pthread_mutex_unlock(&mutex);
 

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_calcs.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_calcs.cpp
@@ -168,8 +168,10 @@ JogCalcs::JogCalcs(const JogArmParameters parameters, JogArmShared& shared_varia
     // Skip publishing if the command is stale and outgoing velocities are all nearly zero.
     // (It takes some time for the low-pass velocity filters to settle at zero.)
     pthread_mutex_lock(&mutex);
-    bool skip_publication = shared_variables.command_is_stale &&
-        (std::all_of(outgoing_command_.points[0].velocities.begin(), outgoing_command_.points[0].velocities.end(), [](double i){return i < 0.000001;}));
+    bool skip_publication =
+        shared_variables.command_is_stale &&
+        (std::all_of(outgoing_command_.points[0].velocities.begin(), outgoing_command_.points[0].velocities.end(),
+                     [](double i) { return i < 0.000001; }));
     pthread_mutex_unlock(&mutex);
 
     // Send the newest target joints

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
@@ -137,12 +137,12 @@ JogROSInterface::JogROSInterface()
     }
     else if (shared_variables_.command_is_stale)
     {
-      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, "Stale command. "
+      ROS_WARN_STREAM_THROTTLE_NAMED(10, LOGNAME, "Stale command. "
                                                  "Try a larger 'incoming_command_timeout' parameter?");
     }
     else
     {
-      ROS_DEBUG_STREAM_THROTTLE_NAMED(2, LOGNAME, "All-zero command. Doing nothing.");
+      ROS_DEBUG_STREAM_THROTTLE_NAMED(10, LOGNAME, "All-zero command. Doing nothing.");
     }
 
     pthread_mutex_unlock(&shared_variables_mutex_);
@@ -189,7 +189,7 @@ void JogROSInterface::deltaCartesianCmdCB(const geometry_msgs::TwistStampedConst
     shared_variables_.command_deltas.header.frame_id = ros_parameters_.command_frame;
   }
 
-  // Check if input is all zeros. Flag it if so to skip calculations/publication
+  // Check if input is all zeros. Flag it if so to skip calculations/publication after num_halt_msgs_to_publish
   shared_variables_.zero_cartesian_cmd_flag = shared_variables_.command_deltas.twist.linear.x == 0.0 &&
                                               shared_variables_.command_deltas.twist.linear.y == 0.0 &&
                                               shared_variables_.command_deltas.twist.linear.z == 0.0 &&

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
@@ -138,7 +138,7 @@ JogROSInterface::JogROSInterface()
     else if (shared_variables_.command_is_stale)
     {
       ROS_WARN_STREAM_THROTTLE_NAMED(10, LOGNAME, "Stale command. "
-                                                 "Try a larger 'incoming_command_timeout' parameter?");
+                                                  "Try a larger 'incoming_command_timeout' parameter?");
     }
     else
     {

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
@@ -104,7 +104,7 @@ JogROSInterface::JogROSInterface()
     trajectory_msgs::JointTrajectory outgoing_command = shared_variables_.outgoing_command;
 
     // Check for stale cmds
-    if ((ros::Time::now() - shared_variables_.incoming_cmd_stamp) <
+    if ((ros::Time::now() - shared_variables_.latest_nonzero_cmd_stamp) <
         ros::Duration(ros_parameters_.incoming_command_timeout))
     {
       // Mark that incoming commands are not stale
@@ -197,7 +197,10 @@ void JogROSInterface::deltaCartesianCmdCB(const geometry_msgs::TwistStampedConst
                                               shared_variables_.command_deltas.twist.angular.y == 0.0 &&
                                               shared_variables_.command_deltas.twist.angular.z == 0.0;
 
-  shared_variables_.incoming_cmd_stamp = msg->header.stamp;
+  if (!shared_variables_.zero_cartesian_cmd_flag)
+  {
+    shared_variables_.latest_nonzero_cmd_stamp = msg->header.stamp;
+  }
   pthread_mutex_unlock(&shared_variables_mutex_);
 }
 
@@ -215,7 +218,10 @@ void JogROSInterface::deltaJointCmdCB(const control_msgs::JointJogConstPtr& msg)
   };
   shared_variables_.zero_joint_cmd_flag = all_zeros;
 
-  shared_variables_.incoming_cmd_stamp = msg->header.stamp;
+  if (!shared_variables_.zero_joint_cmd_flag)
+  {
+    shared_variables_.latest_nonzero_cmd_stamp = msg->header.stamp;
+  }
   pthread_mutex_unlock(&shared_variables_mutex_);
 }
 


### PR DESCRIPTION
### Description

A suddenHalt() function for critical issues like joint limits. Otherwise, decelerations are low-pass filtered.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
