### PR TITLE
Fix several Chomp issues

### DIFF
--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -55,7 +55,7 @@ public:
 
   CHOMPPlanningContext(const std::string& name, const std::string& group, const robot_model::RobotModelConstPtr& model);
 
-  ~CHOMPPlanningContext() override;
+  ~CHOMPPlanningContext() override = default;
 
   void initialize();
 

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -20,27 +20,7 @@ CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::s
 
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {
-  moveit_msgs::MotionPlanDetailedResponse res_msg;
-  if (chomp_interface_->solve(planning_scene_, request_, chomp_interface_->getParams(), res_msg))
-  {
-    res.trajectory_.resize(1);
-    res.trajectory_[0] =
-        robot_trajectory::RobotTrajectoryPtr(new robot_trajectory::RobotTrajectory(robot_model_, getGroupName()));
-
-    moveit::core::RobotState start_state(robot_model_);
-    robot_state::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
-    res.trajectory_[0]->setRobotTrajectoryMsg(start_state, res_msg.trajectory[0]);
-
-    res.description_.push_back("plan");
-    res.processing_time_ = res_msg.processing_time;
-    res.error_code_ = res_msg.error_code;
-    return true;
-  }
-  else
-  {
-    res.error_code_ = res_msg.error_code;
-    return false;
-  }
+  return chomp_interface_->solve(planning_scene_, request_, chomp_interface_->getParams(), res);
 }
 
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanResponse& res)

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -18,8 +18,6 @@ CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::s
   chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface());
 }
 
-CHOMPPlanningContext::~CHOMPPlanningContext() = default;
-
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {
   moveit_msgs::MotionPlanDetailedResponse res_msg;

--- a/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
+++ b/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
@@ -93,7 +93,7 @@ TEST_F(CHOMPMoveitTest, noStartState)
   move_group_.setJointValueTarget(std::vector<double>({ 0.2, 0.2 }));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
-  EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::INVALID_ROBOT_STATE);
+  EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::SUCCESS);
 }
 
 TEST_F(CHOMPMoveitTest, collisionAtEndOfPath)

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -38,8 +38,8 @@
 #define _CHOMP_PLANNER_H_
 
 #include <chomp_motion_planner/chomp_parameters.h>
-#include <moveit_msgs/MotionPlanDetailedResponse.h>
-#include <moveit_msgs/MotionPlanRequest.h>
+#include <moveit/planning_interface/planning_request.h>
+#include <moveit/planning_interface/planning_response.h>
 #include <moveit/planning_scene/planning_scene.h>
 
 namespace chomp
@@ -50,9 +50,9 @@ public:
   ChompPlanner() = default;
   virtual ~ChompPlanner() = default;
 
-  // TODO: switch API from moveit_msgs to MotionPlanRequest / MotionPlanDetailedResponse
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::MotionPlanRequest& req,
-             const ChompParameters& params, moveit_msgs::MotionPlanDetailedResponse& res) const;
+  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+             const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
+             planning_interface::MotionPlanDetailedResponse& res) const;
 };
 }
 

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -47,8 +47,8 @@ namespace chomp
 class ChompPlanner
 {
 public:
-  ChompPlanner();
-  virtual ~ChompPlanner(){};
+  ChompPlanner() = default;
+  virtual ~ChompPlanner() = default;
 
   // TODO: switch API from moveit_msgs to MotionPlanRequest / MotionPlanDetailedResponse
   bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::MotionPlanRequest& req,

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -135,7 +135,7 @@ public:
    * produced by OMPL) and puts it into the appropriate trajectory format required for CHOMP
    * @param res
    */
-  bool fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res);
+  bool fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory);
 
   /**
    * This function assigns the chomp_trajectory row / robot pose at index 'chomp_trajectory_point' obtained from input
@@ -145,9 +145,8 @@ public:
    * @param trajectory_msgs_point index of the input trajectory_msg's point to get joint values from
    * @param chomp_trajectory_point index of the chomp_trajectory's point to get joint values from
    */
-  void assignCHOMPTrajectoryPointFromInputTrajectoryPoint(moveit_msgs::RobotTrajectory trajectory_msg,
-                                                          size_t num_joints_trajectory, size_t trajectory_msgs_point,
-                                                          size_t chomp_trajectory_point);
+  void assignCHOMPTrajectoryPointFromInputTrajectoryPoint(const robot_trajectory::RobotTrajectory& trajectory,
+                                                          size_t trajectory_point_index, size_t chomp_trajectory_point);
 
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -64,7 +64,7 @@ public:
   /**
    * \brief Constructs a trajectory for a given robot model, number of trajectory points, and discretization
    */
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, unsigned int num_points, double discretization,
+  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, size_t num_points, double discretization,
                   const std::string& group_name);
 
   /**
@@ -81,9 +81,9 @@ public:
    */
   virtual ~ChompTrajectory() = default;
 
-  double& operator()(int traj_point, int joint);
+  double& operator()(size_t traj_point, size_t joint);
 
-  double operator()(int traj_point, int joint) const;
+  double operator()(size_t traj_point, size_t joint) const;
 
   Eigen::MatrixXd::RowXpr getTrajectoryPoint(int traj_point);
 
@@ -92,17 +92,17 @@ public:
   /**
    * \brief Gets the number of points in the trajectory
    */
-  int getNumPoints() const;
+  size_t getNumPoints() const;
 
   /**
    * \brief Gets the number of points (that are free to be optimized) in the trajectory
    */
-  int getNumFreePoints() const;
+  size_t getNumFreePoints() const;
 
   /**
    * \brief Gets the number of joints in each trajectory point
    */
-  int getNumJoints() const;
+  size_t getNumJoints() const;
 
   /**
    * \brief Gets the discretization time interval of the trajectory
@@ -146,8 +146,8 @@ public:
    * @param chomp_trajectory_point index of the chomp_trajectory's point to get joint values from
    */
   void assignCHOMPTrajectoryPointFromInputTrajectoryPoint(moveit_msgs::RobotTrajectory trajectory_msg,
-                                                          int num_joints_trajectory, int trajectory_msgs_point,
-                                                          int chomp_trajectory_point);
+                                                          size_t num_joints_trajectory, size_t trajectory_msgs_point,
+                                                          size_t chomp_trajectory_point);
 
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
@@ -155,17 +155,17 @@ public:
    * (Everything before the start and after the end index is considered fixed)
    * The values default to 1 and getNumPoints()-2
    */
-  void setStartEndIndex(int start_index, int end_index);
+  void setStartEndIndex(size_t start_index, size_t end_index);
 
   /**
    * \brief Gets the start index
    */
-  int getStartIndex() const;
+  size_t getStartIndex() const;
 
   /**
    * \brief Gets the end index
    */
-  int getEndIndex() const;
+  size_t getEndIndex() const;
 
   /**
    * \brief Gets the entire trajectory matrix
@@ -180,7 +180,7 @@ public:
   /**
    * \brief Gets the block of free (optimizable) trajectory for a single joint
    */
-  Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> getFreeJointTrajectoryBlock(int joint);
+  Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> getFreeJointTrajectoryBlock(size_t joint);
 
   /**
    * \brief Updates the full trajectory (*this) from the group trajectory
@@ -190,41 +190,38 @@ public:
   /**
    * \brief Gets the index in the full trajectory which was copied to this group trajectory
    */
-  int getFullTrajectoryIndex(int i) const;
+  size_t getFullTrajectoryIndex(size_t i) const;
 
   /**
    * \brief Gets the joint velocities at the given trajectory point
    */
   template <typename Derived>
-  void getJointVelocities(int traj_point, Eigen::MatrixBase<Derived>& velocities);
+  void getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived>& velocities);
 
   double getDuration() const;
 
 private:
   void init(); /**< \brief Allocates memory for the trajectory */
 
-  std::string planning_group_name_; /**< Planning group that this trajectory corresponds to, if any */
-  int num_points_;                  /**< Number of points in the trajectory */
-  int num_joints_;                  /**< Number of joints in each trajectory point */
-  double discretization_;           /**< Discretization of the trajectory */
-  double duration_;                 /**< Duration of the trajectory */
-  Eigen::MatrixXd trajectory_;      /**< Storage for the actual trajectory */
-  int start_index_; /**< Start index (inclusive) of trajectory to be optimized (everything before it will not be
-                       modified) */
-  int end_index_; /**< End index (inclusive) of trajectory to be optimized (everything after it will not be modified) */
-  std::vector<int> full_trajectory_index_; /**< If this is a "group" trajectory, the index from the original traj which
-                                              each
-                                              element here was copied */
+  std::string planning_group_name_;  //< Planning group that this trajectory corresponds to, if any
+  size_t num_points_;                //< Number of points in the trajectory
+  size_t num_joints_;                //< Number of joints in each trajectory point
+  double discretization_;            //< Discretization of the trajectory
+  double duration_;                  //< Duration of the trajectory
+  Eigen::MatrixXd trajectory_;       //< Storage for the actual trajectory
+  size_t start_index_;  // Start index (inclusive) of trajectory to be optimized (everything before will be ignored)
+  size_t end_index_;    //< End index (inclusive) of trajectory to be optimized (everything after will be ignored)
+  std::vector<size_t> full_trajectory_index_;  //< If this is a "group" trajectory, the indeces from the original traj
 };
 
 ///////////////////////// inline functions follow //////////////////////
 
-inline double& ChompTrajectory::operator()(int traj_point, int joint)
+inline double& ChompTrajectory::operator()(size_t traj_point, size_t joint)
 {
   return trajectory_(traj_point, joint);
 }
 
-inline double ChompTrajectory::operator()(int traj_point, int joint) const
+inline double ChompTrajectory::operator()(size_t traj_point, size_t joint) const
 {
   return trajectory_(traj_point, joint);
 }
@@ -239,17 +236,17 @@ inline Eigen::MatrixXd::ColXpr ChompTrajectory::getJointTrajectory(int joint)
   return trajectory_.col(joint);
 }
 
-inline int ChompTrajectory::getNumPoints() const
+inline size_t ChompTrajectory::getNumPoints() const
 {
   return num_points_;
 }
 
-inline int ChompTrajectory::getNumFreePoints() const
+inline size_t ChompTrajectory::getNumFreePoints() const
 {
   return (end_index_ - start_index_) + 1;
 }
 
-inline int ChompTrajectory::getNumJoints() const
+inline size_t ChompTrajectory::getNumJoints() const
 {
   return num_joints_;
 }
@@ -259,18 +256,18 @@ inline double ChompTrajectory::getDiscretization() const
   return discretization_;
 }
 
-inline void ChompTrajectory::setStartEndIndex(int start_index, int end_index)
+inline void ChompTrajectory::setStartEndIndex(size_t start_index, size_t end_index)
 {
   start_index_ = start_index;
   end_index_ = end_index;
 }
 
-inline int ChompTrajectory::getStartIndex() const
+inline size_t ChompTrajectory::getStartIndex() const
 {
   return start_index_;
 }
 
-inline int ChompTrajectory::getEndIndex() const
+inline size_t ChompTrajectory::getEndIndex() const
 {
   return end_index_;
 }
@@ -286,18 +283,18 @@ inline Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> ChompTrajec
 }
 
 inline Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic>
-ChompTrajectory::getFreeJointTrajectoryBlock(int joint)
+ChompTrajectory::getFreeJointTrajectoryBlock(size_t joint)
 {
   return trajectory_.block(start_index_, joint, getNumFreePoints(), 1);
 }
 
-inline int ChompTrajectory::getFullTrajectoryIndex(int i) const
+inline size_t ChompTrajectory::getFullTrajectoryIndex(size_t i) const
 {
   return full_trajectory_index_[i];
 }
 
 template <typename Derived>
-void ChompTrajectory::getJointVelocities(int traj_point, Eigen::MatrixBase<Derived>& velocities)
+void ChompTrajectory::getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived>& velocities)
 {
   velocities.setZero();
   double invTime = 1.0 / discretization_;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -64,7 +64,7 @@ public:
   /**
    * \brief Constructs a trajectory for a given robot model, number of trajectory points, and discretization
    */
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, int num_points, double discretization,
+  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, unsigned int num_points, double discretization,
                   const std::string& group_name);
 
   /**
@@ -88,8 +88,6 @@ public:
   Eigen::MatrixXd::RowXpr getTrajectoryPoint(int traj_point);
 
   Eigen::MatrixXd::ColXpr getJointTrajectory(int joint);
-
-  void overwriteTrajectory(const trajectory_msgs::JointTrajectory& traj);
 
   /**
    * \brief Gets the number of points in the trajectory

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -79,7 +79,7 @@ public:
   /**
    * \brief Destructor
    */
-  virtual ~ChompTrajectory();
+  virtual ~ChompTrajectory() = default;
 
   double& operator()(int traj_point, int joint);
 

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
@@ -52,23 +52,13 @@ static const double DIFF_RULES[3][DIFF_RULE_LENGTH] = {
   { 0, 1 / 12.0, -17 / 12.0, 46 / 12.0, -46 / 12.0, 17 / 12.0, -1 / 12.0 }  // jerk
 };
 
-static inline void jointStateToArray(const moveit::core::RobotModelConstPtr& robot_model,
-                                     const sensor_msgs::JointState& joint_state, const std::string& planning_group_name,
+static inline void robotStateToArray(const moveit::core::RobotState& state, const std::string& planning_group_name,
                                      Eigen::MatrixXd::RowXpr joint_array)
 {
-  const moveit::core::JointModelGroup* group = robot_model->getJointModelGroup(planning_group_name);
-  std::vector<const moveit::core::JointModel*> models = group->getActiveJointModels();
-
-  for (unsigned int i = 0; i < joint_state.position.size(); i++)
-  {
-    for (size_t j = 0; j < models.size(); j++)
-    {
-      if (models[j]->getName() == joint_state.name[i])
-      {
-        joint_array(0, j) = joint_state.position[i];
-      }
-    }
-  }
+  const moveit::core::JointModelGroup* group = state.getJointModelGroup(planning_group_name);
+  size_t joint_index = 0;
+  for (const moveit::core::JointModel* jm : group->getActiveJointModels())
+    joint_array[joint_index++] = state.getVariablePosition(jm->getFirstVariableIndex());
 }
 
 // copied from geometry/angles/angles.h

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -322,7 +322,7 @@ bool ChompOptimizer::optimize()
   {
     ros::WallTime for_time = ros::WallTime::now();
     performForwardKinematics();
-    ROS_INFO_STREAM("Forward kinematics took " << (ros::WallTime::now() - for_time));
+    ROS_DEBUG_STREAM("Forward kinematics took " << (ros::WallTime::now() - for_time));
     double c_cost = getCollisionCost();
     double s_cost = getSmoothnessCost();
     double cost = c_cost + s_cost;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -540,10 +540,10 @@ bool ChompOptimizer::isCurrentTrajectoryMeshToMeshCollisionFree() const
   moveit_msgs::RobotTrajectory traj;
   traj.joint_trajectory.joint_names = joint_names_;
 
-  for (int i = 0; i < group_trajectory_.getNumPoints(); i++)
+  for (size_t i = 0; i < group_trajectory_.getNumPoints(); i++)
   {
     trajectory_msgs::JointTrajectoryPoint point;
-    for (int j = 0; j < group_trajectory_.getNumJoints(); j++)
+    for (size_t j = 0; j < group_trajectory_.getNumJoints(); j++)
     {
       point.positions.push_back(best_group_trajectory_(i, j));
     }
@@ -1014,7 +1014,7 @@ void ChompOptimizer::setRobotStateFromPoint(ChompTrajectory& group_trajectory, i
 
   std::vector<double> joint_states;
   joint_states.reserve(group_trajectory.getNumJoints());
-  for (int j = 0; j < group_trajectory.getNumJoints(); j++)
+  for (size_t j = 0; j < group_trajectory.getNumJoints(); j++)
     joint_states.emplace_back(point(0, j));
 
   state_.setJointGroupPositions(planning_group_, joint_states);

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -43,8 +43,6 @@
 
 namespace chomp
 {
-ChompPlanner::ChompPlanner() = default;
-
 bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
                          const moveit_msgs::MotionPlanRequest& req, const chomp::ChompParameters& params,
                          moveit_msgs::MotionPlanDetailedResponse& res) const

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -237,7 +237,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   create_time = ros::WallTime::now();
   // assume that the trajectory is now optimized, fill in the output structure:
 
-  ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %d joints", trajectory.getNumJoints());
+  ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %zd joints", trajectory.getNumJoints());
 
   res.trajectory.resize(1);
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -47,6 +47,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
                          const moveit_msgs::MotionPlanRequest& req, const chomp::ChompParameters& params,
                          moveit_msgs::MotionPlanDetailedResponse& res) const
 {
+  ros::WallTime start_time = ros::WallTime::now();
   if (!planning_scene)
   {
     ROS_ERROR_STREAM_NAMED("chomp_planner", "No planning scene initialized.");
@@ -54,51 +55,46 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     return false;
   }
 
-  if (req.start_state.joint_state.position.empty())
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Start state is empty");
-    res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
-    return false;
-  }
+  // get the specified start state
+  robot_state::RobotState start_state = planning_scene->getCurrentState();
+  robot_state::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
 
-  if (not planning_scene->getRobotModel()->satisfiesPositionBounds(req.start_state.joint_state.position.data()))
+  if (!start_state.satisfiesBounds())
   {
     ROS_ERROR_STREAM_NAMED("chomp_planner", "Start state violates joint limits");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
 
-  ros::WallTime start_time = ros::WallTime::now();
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
+  robotStateToArray(start_state, req.group_name, trajectory.getTrajectoryPoint(0));
 
-  jointStateToArray(planning_scene->getRobotModel(), req.start_state.joint_state, req.group_name,
-                    trajectory.getTrajectoryPoint(0));
-
-  if (req.goal_constraints.empty())
+  if (req.goal_constraints.size() != 1)
   {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "No goal constraints specified!");
+    ROS_ERROR_NAMED("chomp_planner", "Expecting exactly one goal constraint, got: %zd", req.goal_constraints.size());
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
 
-  if (req.goal_constraints[0].joint_constraints.empty())
+  if (req.goal_constraints[0].joint_constraints.empty() || !req.goal_constraints[0].position_constraints.empty() ||
+      !req.goal_constraints[0].orientation_constraints.empty())
   {
     ROS_ERROR_STREAM("Only joint-space goals are supported");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
 
-  int goal_index = trajectory.getNumPoints() - 1;
-  trajectory.getTrajectoryPoint(goal_index) = trajectory.getTrajectoryPoint(0);
-  sensor_msgs::JointState js;
+  const size_t goal_index = trajectory.getNumPoints() - 1;
+  robot_state::RobotState goal_state(start_state);
   for (const moveit_msgs::JointConstraint& joint_constraint : req.goal_constraints[0].joint_constraints)
+    goal_state.setVariablePosition(joint_constraint.joint_name, joint_constraint.position);
+  if (!goal_state.satisfiesBounds())
   {
-    js.name.push_back(joint_constraint.joint_name);
-    js.position.push_back(joint_constraint.position);
-    ROS_INFO_STREAM_NAMED("chomp_planner", "Setting joint " << joint_constraint.joint_name << " to position "
-                                                            << joint_constraint.position);
+    ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal state violates joint limits");
+    res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
+    return false;
   }
-  jointStateToArray(planning_scene->getRobotModel(), js, req.group_name, trajectory.getTrajectoryPoint(goal_index));
+  robotStateToArray(goal_state, req.group_name, trajectory.getTrajectoryPoint(goal_index));
 
   const moveit::core::JointModelGroup* model_group =
       planning_scene->getRobotModel()->getJointModelGroup(req.group_name);
@@ -119,19 +115,6 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
         (trajectory)(goal_index, i) = start + shortestAngularDistance(start, end);
       }
     }
-  }
-
-  const std::vector<std::string>& active_joint_names = model_group->getActiveJointModelNames();
-  const Eigen::MatrixXd goal_state = trajectory.getTrajectoryPoint(goal_index);
-  moveit::core::RobotState goal_robot_state = planning_scene->getCurrentState();
-  goal_robot_state.setVariablePositions(
-      active_joint_names, std::vector<double>(goal_state.data(), goal_state.data() + active_joint_names.size()));
-
-  if (not goal_robot_state.satisfiesBounds())
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal state violates joint limits");
-    res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
-    return false;
   }
 
   // fill in an initial trajectory based on user choice from the chomp_config.yaml file
@@ -157,10 +140,6 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
                  (params.trajectory_initialization_method_).c_str());
 
   // optimize!
-  moveit::core::RobotState start_state(planning_scene->getCurrentState());
-  moveit::core::robotStateMsgToRobotState(req.start_state, start_state);
-  start_state.update();
-
   ros::WallTime create_time = ros::WallTime::now();
 
   int replan_count = 0;
@@ -241,7 +220,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   res.trajectory.resize(1);
 
-  res.trajectory[0].joint_trajectory.joint_names = active_joint_names;
+  res.trajectory[0].joint_trajectory.joint_names = model_group->getActiveJointModelNames();
 
   res.trajectory[0].joint_trajectory.header = req.start_state.joint_state.header;  // @TODO this is probably a hack
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -97,34 +97,6 @@ ChompTrajectory::ChompTrajectory(const ChompTrajectory& source_traj, const std::
   }
 }
 
-ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
-                                 const trajectory_msgs::JointTrajectory& traj)
-  : planning_group_name_(group_name)
-{
-  const moveit::core::JointModelGroup* model_group = robot_model->getJointModelGroup(planning_group_name_);
-  num_points_ = traj.points.size();
-  num_joints_ = model_group->getActiveJointModels().size();
-  assert(num_points_ > 2);
-
-  double discretization = (traj.points[1].time_from_start - traj.points[0].time_from_start).toSec();
-  double discretization2 = (traj.points[2].time_from_start - traj.points[1].time_from_start).toSec();
-  if (fabs(discretization2 - discretization) > .001)
-  {
-    ROS_WARN_STREAM("Trajectory Discretization not constant " << discretization << " " << discretization2);
-  }
-  discretization_ = discretization;
-
-  duration_ = (traj.points.back().time_from_start - traj.points[0].time_from_start).toSec();
-
-  start_index_ = 1;
-  end_index_ = num_points_ - 2;
-
-  init();
-
-  for (unsigned int i = 0; i < traj.points.size(); i++)
-    trajectory_.row(i) = Eigen::Map<Eigen::VectorXd>(traj.points[i].positions, num_joints_);
-}
-
 void ChompTrajectory::init()
 {
   trajectory_.resize(num_points_, num_joints_);

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -188,45 +188,39 @@ void ChompTrajectory::fillInMinJerk()
   }
 }
 
-bool ChompTrajectory::fillInFromTrajectory(moveit_msgs::MotionPlanDetailedResponse& res)
+bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory)
 {
-  // create a RobotTrajectory msg to obtain the trajectory from the MotionPlanDetailedResponse object
-  moveit_msgs::RobotTrajectory trajectory_msg = res.trajectory[0];
-
   // get the default number of points in the CHOMP trajectory
-  size_t num_chomp_trajectory_points = (*this).getNumPoints();
-  // get the number of points in the response trajectory obtained from OMPL
-  size_t num_response_points = trajectory_msg.joint_trajectory.points.size();
+  const size_t num_chomp_trajectory_points = (*this).getNumPoints();
+  // get the number of points in the input trajectory
+  const size_t num_input_points = trajectory.getWayPointCount();
 
   // check if input trajectory has less than two states (start and goal), function returns false if condition is true
-  if (num_response_points < 2)
+  if (num_input_points < 2)
     return false;
 
-  // get the number of joints for each robot state
-  size_t num_joints_trajectory = trajectory_msg.joint_trajectory.points[0].positions.size();
-
   // variables for populating the CHOMP trajectory with correct number of trajectory points
-  unsigned int repeated_factor = num_chomp_trajectory_points / num_response_points;
-  unsigned int repeated_balance_factor = num_chomp_trajectory_points % num_response_points;
+  const unsigned int repeated_factor = num_chomp_trajectory_points / num_input_points;
+  const unsigned int repeated_balance_factor = num_chomp_trajectory_points % num_input_points;
 
   // response_point_id stores the point at the stored index location.
   size_t response_point_id = 0;
-  if (num_chomp_trajectory_points >= num_response_points)
+  if (num_chomp_trajectory_points >= num_input_points)
   {
-    for (size_t i = 0; i < num_response_points; i++)
+    for (size_t i = 0; i < num_input_points; i++)
     {
       // following for loop repeats each OMPL trajectory pose/row 'repeated_factor' times; alternatively, there could
       // also be a linear interpolation between these points later if required
       for (unsigned int k = 0; k < repeated_factor; k++)
       {
-        assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory_msg, num_joints_trajectory, i, response_point_id);
+        assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory, i, response_point_id);
         response_point_id++;
       }
 
       // this populates the CHOMP trajectory row  for the remainder number of rows.
       if (i < repeated_balance_factor)
       {
-        assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory_msg, num_joints_trajectory, i, response_point_id);
+        assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory, i, response_point_id);
         response_point_id++;
       }  // end of if
     }    // end of for loop for loading in the trajectory poses/rows
@@ -235,27 +229,30 @@ bool ChompTrajectory::fillInFromTrajectory(moveit_msgs::MotionPlanDetailedRespon
   {
     // perform a decimation sampling in this block if the number of trajectory points in the MotionPlanDetailedResponse
     // res object is more than the number of points in the CHOMP trajectory
-    double decimation_sampling_factor = ((double)num_response_points) / ((double)num_chomp_trajectory_points);
+    const double decimation_sampling_factor = ((double)num_input_points) / ((double)num_chomp_trajectory_points);
 
     for (size_t i = 0; i < num_chomp_trajectory_points; i++)
     {
       size_t sampled_point = floor(i * decimation_sampling_factor);
-      assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory_msg, num_joints_trajectory, sampled_point, i);
+      assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory, sampled_point, i);
     }
   }  // end of else
   return true;
 }
 
-void ChompTrajectory::assignCHOMPTrajectoryPointFromInputTrajectoryPoint(moveit_msgs::RobotTrajectory trajectory_msg,
-                                                                         size_t num_joints_trajectory,
-                                                                         size_t trajectory_msgs_point_index,
-                                                                         size_t chomp_trajectory_point_index)
+void ChompTrajectory::assignCHOMPTrajectoryPointFromInputTrajectoryPoint(
+    const robot_trajectory::RobotTrajectory& trajectory, size_t trajectory_point_index,
+    size_t chomp_trajectory_point_index)
 {
-  // following loop iterates over all joints for a single robot pose, it assigns the corresponding input trajectory
-  // points into CHOMP trajectory points
-  for (size_t j = 0; j < num_joints_trajectory; j++)
-    (*this)(chomp_trajectory_point_index, j) =
-        trajectory_msg.joint_trajectory.points[trajectory_msgs_point_index].positions[j];
+  const robot_state::RobotState& source = trajectory.getWayPoint(trajectory_point_index);
+  Eigen::MatrixXd::RowXpr target = getTrajectoryPoint(chomp_trajectory_point_index);
+  assert(trajectory.getGroup()->getActiveJointModels().size() == static_cast<size_t>(target.cols()));
+  size_t joint_index = 0;
+  for (const robot_state::JointModel* jm : trajectory.getGroup()->getActiveJointModels())
+  {
+    assert(jm->getVariableCount() == 1);
+    target[joint_index++] = source.getVariablePosition(jm->getJointIndex());
+  }
 }
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -139,8 +139,6 @@ ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_m
   overwriteTrajectory(traj);
 }
 
-ChompTrajectory::~ChompTrajectory() = default;
-
 void ChompTrajectory::overwriteTrajectory(const trajectory_msgs::JointTrajectory& traj)
 {
   for (unsigned int i = 1; i <= traj.points.size(); i++)


### PR DESCRIPTION
This PR comprises several independent commits to improve the Chomp code, namely
- some code cleanup, reducing redundancy and explicit loops
- fix start state handling: 
  - An empty start state should be accepted. In this case, the current state should be used. Fixes #1452
  - Checking start state constraints was plain wrong, resulting in #1470.
- Avoid extra conversion from/to MotionPlanResponse _message_