### PR TITLE
update robot state transforms when initializing a planning scene

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -159,6 +159,7 @@ void PlanningScene::initialize()
 
   robot_state_.reset(new robot_state::RobotState(robot_model_));
   robot_state_->setToDefaultValues();
+  robot_state_->update();
 
   acm_.reset(new collision_detection::AllowedCollisionMatrix());
   // Use default collision operations in the SRDF to setup the acm


### PR DESCRIPTION
### Description

There was a bug in moveit_visual_tools where adding a collision object after initializing the planning scene resulting in the following error: `robot_state.cpp:998: const Isometry3d& moveit::core::RobotState::getFrameTransform(const string&) const: Assertion `checkLinkTransforms()' failed.`

This error is caused by the robot state in the planning scene holding dirty link transforms after initialization. 

This PR fixes the underlying issue


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
