### PR TITLE
TYPO: missing space

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -202,7 +202,7 @@ void FollowJointTrajectoryControllerHandle::controllerDoneCallback(
   else if (result->error_code == control_msgs::FollowJointTrajectoryResult::SUCCESSFUL)
     ROS_INFO_STREAM_NAMED(LOGNAME, "Controller " << name_ << " successfully finished");
   else
-    ROS_WARN_STREAM_NAMED(LOGNAME, "Controller " << name_ << "failed with error "
+    ROS_WARN_STREAM_NAMED(LOGNAME, "Controller " << name_ << " failed with error "
                                                  << errorCodeToMessage(result->error_code) << ": "
                                                  << result->error_string);
   finishControllerExecution(state);


### PR DESCRIPTION
### Description

follow_joint_trajectory_controller_handle: add missing space in warning
