### PR TITLE
Reduce scope of moveit.rosinstall

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -1,24 +1,24 @@
 # This file is intended for users who want to build MoveIt! from source.
 # Used with wstool, users can download source of all packages of MoveIt!.
 - git:
-    local-name: moveit
-    uri: https://github.com/ros-planning/moveit.git
-    version: master
-- git:
     local-name: moveit_msgs
     uri: https://github.com/ros-planning/moveit_msgs.git
     version: melodic-devel
 - git:
-    local-name: moveit_resources
-    uri: https://github.com/ros-planning/moveit_resources.git
-    version: master
+    local-name: geometric_shapes
+    uri: https://github.com/ros-planning/geometric_shapes.git
+    version: melodic-devel
 - git:
-    local-name: moveit_visual_tools
-    uri: https://github.com/ros-planning/moveit_visual_tools.git
+    local-name: moveit
+    uri: https://github.com/ros-planning/moveit.git
     version: master
 - git:
     local-name: rviz_visual_tools
     uri: https://github.com/PickNikRobotics/rviz_visual_tools
+    version: master
+- git:
+    local-name: moveit_visual_tools
+    uri: https://github.com/ros-planning/moveit_visual_tools.git
     version: master
 - git:
     local-name: moveit_tutorials

--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -21,14 +21,6 @@
     uri: https://github.com/PickNikRobotics/rviz_visual_tools
     version: master
 - git:
-    local-name: geometric_shapes
-    uri: https://github.com/ros-planning/geometric_shapes.git
-    version: melodic-devel
-- git:
-    local-name: srdfdom
-    uri: https://github.com/ros-planning/srdfdom.git
-    version: melodic-devel
-- git:
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
     version: master


### PR DESCRIPTION
We added these back when there were a lot of big changes happening in those repos, but I don't think we need them anymore. Or at least, for now.

This should speed up Travis builds.
