### PR TITLE
Change 2nd order Butterworth low pass filter to 1st order

### DIFF
--- a/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
@@ -45,6 +45,8 @@ namespace jog_arm
 /**
  * Class LowPassFilter - Filter a signal to soften jerks.
  * This is a first-order Butterworth low-pass filter.
+ * 
+ * TODO: Use ROS filters package (http://wiki.ros.org/filters, https://github.com/ros/filters)
  */
 class LowPassFilter
 {

--- a/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
@@ -44,8 +44,7 @@ namespace jog_arm
 {
 /**
  * Class LowPassFilter - Filter a signal to soften jerks.
- * This is a second-order Butterworth low-pass filter.
- * See https://ccrma.stanford.edu/~jos/filters/Example_Second_Order_Butterworth_Lowpass.html
+ * This is a first-order Butterworth low-pass filter.
  */
 class LowPassFilter
 {

--- a/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
@@ -55,8 +55,8 @@ public:
   void reset(double data);
 
 private:
-  double previous_measurements_[3] = { 0., 0., 0. };
-  double previous_filtered_measurements_[2] = { 0., 0. };
+  double previous_measurements_[2] = { 0., 0. };
+  double previous_filtered_measurement = 0.;
   // Larger filter_coeff-> more smoothing of jog commands, but more lag.
   // Rough plot, with cutoff frequency on the y-axis:
   // https://www.wolframalpha.com/input/?i=plot+arccot(c)

--- a/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
@@ -45,7 +45,7 @@ namespace jog_arm
 /**
  * Class LowPassFilter - Filter a signal to soften jerks.
  * This is a first-order Butterworth low-pass filter.
- * 
+ *
  * TODO: Use ROS filters package (http://wiki.ros.org/filters, https://github.com/ros/filters)
  */
 class LowPassFilter

--- a/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/low_pass_filter.h
@@ -56,7 +56,7 @@ public:
 
 private:
   double previous_measurements_[2] = { 0., 0. };
-  double previous_filtered_measurement = 0.;
+  double previous_filtered_measurement_ = 0.;
   // Larger filter_coeff-> more smoothing of jog commands, but more lag.
   // Rough plot, with cutoff frequency on the y-axis:
   // https://www.wolframalpha.com/input/?i=plot+arccot(c)

--- a/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
@@ -61,9 +61,8 @@ double LowPassFilter::filter(double new_measurement)
   previous_measurements_[0] = new_measurement;
 
   double new_filtered_msrmt =
-      (1. / (1. + filter_coeff_)) *
-      (previous_measurements_[1] + previous_measurements_[0] -
-       (-1. * filter_coeff_ + 1.) * previous_filtered_measurement);
+      (1. / (1. + filter_coeff_)) * (previous_measurements_[1] + previous_measurements_[0] -
+                                     (-1. * filter_coeff_ + 1.) * previous_filtered_measurement);
 
   // Store the new filtered measurement
   previous_filtered_measurement = new_filtered_msrmt;

--- a/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
@@ -38,7 +38,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <jog_arm/low_pass_filter.h>
-#include <cmath>
 
 namespace jog_arm
 {
@@ -61,9 +60,8 @@ double LowPassFilter::filter(double new_measurement)
   previous_measurements_[1] = previous_measurements_[0];
   previous_measurements_[0] = new_measurement;
 
-  double new_filtered_msrmt =
-      (1. / (1. + filter_coeff_ / (2 * M_PI))) * (previous_measurements_[1] + previous_measurements_[0] -
-                                     (-1. * filter_coeff_ / (2 * M_PI) + 1.) * previous_filtered_measurement_);
+  double new_filtered_msrmt = (1. / (1. + filter_coeff_)) * (previous_measurements_[1] + previous_measurements_[0] -
+                                                             (-filter_coeff_ + 1.) * previous_filtered_measurement_);
 
   // Store the new filtered measurement
   previous_filtered_measurement_ = new_filtered_msrmt;

--- a/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
@@ -51,7 +51,7 @@ void LowPassFilter::reset(double data)
   previous_measurements_[0] = data;
   previous_measurements_[1] = data;
 
-  previous_filtered_measurement = data;
+  previous_filtered_measurement_ = data;
 }
 
 double LowPassFilter::filter(double new_measurement)
@@ -62,10 +62,10 @@ double LowPassFilter::filter(double new_measurement)
 
   double new_filtered_msrmt =
       (1. / (1. + filter_coeff_)) * (previous_measurements_[1] + previous_measurements_[0] -
-                                     (-1. * filter_coeff_ + 1.) * previous_filtered_measurement);
+                                     (-1. * filter_coeff_ + 1.) * previous_filtered_measurement_);
 
   // Store the new filtered measurement
-  previous_filtered_measurement = new_filtered_msrmt;
+  previous_filtered_measurement_ = new_filtered_msrmt;
 
   return new_filtered_msrmt;
 }

--- a/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
@@ -50,27 +50,23 @@ void LowPassFilter::reset(double data)
 {
   previous_measurements_[0] = data;
   previous_measurements_[1] = data;
-  previous_measurements_[2] = data;
 
-  previous_filtered_measurements_[0] = data;
-  previous_filtered_measurements_[1] = data;
+  previous_filtered_measurement = data;
 }
 
 double LowPassFilter::filter(double new_measurement)
 {
   // Push in the new measurement
-  previous_measurements_[2] = previous_measurements_[1];
   previous_measurements_[1] = previous_measurements_[0];
   previous_measurements_[0] = new_measurement;
 
   double new_filtered_msrmt =
       (1. / (1. + filter_coeff_)) *
       (previous_measurements_[1] + previous_measurements_[0] -
-       (-1. * filter_coeff_ + 1.) * previous_filtered_measurements_[0]);
+       (-1. * filter_coeff_ + 1.) * previous_filtered_measurement);
 
   // Store the new filtered measurement
-  previous_filtered_measurements_[1] = previous_filtered_measurements_[0];
-  previous_filtered_measurements_[0] = new_filtered_msrmt;
+  previous_filtered_measurement = new_filtered_msrmt;
 
   return new_filtered_msrmt;
 }

--- a/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
@@ -64,10 +64,9 @@ double LowPassFilter::filter(double new_measurement)
   previous_measurements_[0] = new_measurement;
 
   double new_filtered_msrmt =
-      (1. / (1. + filter_coeff_ * filter_coeff_ + 1.414 * filter_coeff_)) *
-      (previous_measurements_[2] + 2. * previous_measurements_[1] + previous_measurements_[0] -
-       (filter_coeff_ * filter_coeff_ - 1.414 * filter_coeff_ + 1.) * previous_filtered_measurements_[1] -
-       (-2. * filter_coeff_ * filter_coeff_ + 2.) * previous_filtered_measurements_[0]);
+      (1. / (1. + filter_coeff_)) *
+      (previous_measurements_[1] + previous_measurements_[0] -
+       (-1. * filter_coeff_ + 1.) * previous_filtered_measurements_[0]);
 
   // Store the new filtered measurement
   previous_filtered_measurements_[1] = previous_filtered_measurements_[0];

--- a/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/low_pass_filter.cpp
@@ -38,6 +38,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <jog_arm/low_pass_filter.h>
+#include <cmath>
 
 namespace jog_arm
 {
@@ -61,8 +62,8 @@ double LowPassFilter::filter(double new_measurement)
   previous_measurements_[0] = new_measurement;
 
   double new_filtered_msrmt =
-      (1. / (1. + filter_coeff_)) * (previous_measurements_[1] + previous_measurements_[0] -
-                                     (-1. * filter_coeff_ + 1.) * previous_filtered_measurement_);
+      (1. / (1. + filter_coeff_ / (2 * M_PI))) * (previous_measurements_[1] + previous_measurements_[0] -
+                                     (-1. * filter_coeff_ / (2 * M_PI) + 1.) * previous_filtered_measurement_);
 
   // Store the new filtered measurement
   previous_filtered_measurement_ = new_filtered_msrmt;


### PR DESCRIPTION
### Description

Fixes Issue #1471 about filter overshooting by changing the 2nd order Butterworth low pass filter to 1st order.
