### PR TITLE
Add functions to set pick and place goal fields

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -313,14 +313,6 @@ public:
    * objects are allowed to touch the support surface */
   void setSupportSurfaceName(const std::string& name);
 
-  /** \brief For place operations, either the location of the object can be specified ( \e place_eef = false,
-   * this is the default ) or the location of the end effector ( \e place_eef = true ) */
-  void setPlaceEEF(const bool place_eef);
-
-  /** \brief For pick/place operations, specify whether collisions between the gripper and the support surface should
-   * be acceptable. By default, this is true */
-  void setAllowGripperSupportCollision(const bool allow_gripper_support_collision);
-
   /**
    * \name Setting a joint state target (goal)
    *

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -778,12 +778,12 @@ public:
   void constructMotionPlanRequest(moveit_msgs::MotionPlanRequest& request);
 
   /** \brief Build a PickupGoal for an object named \e object and store it in \e goal_out */
-  moveit_msgs::PickupGoal constructPickupGoal(const std::string& object, std::vector<moveit_msgs::Grasp>&& grasps,
+  moveit_msgs::PickupGoal constructPickupGoal(const std::string& object, std::vector<moveit_msgs::Grasp> grasps,
                                               bool plan_only);
 
   /** \brief Build a PlaceGoal for an object named \e object and store it in \e goal_out */
   moveit_msgs::PlaceGoal constructPlaceGoal(const std::string& object,
-                                            std::vector<moveit_msgs::PlaceLocation>&& locations, bool plan_only);
+                                            std::vector<moveit_msgs::PlaceLocation> locations, bool plan_only);
 
   /** \brief Convert a vector of PoseStamped to a vector of PlaceLocation */
   std::vector<moveit_msgs::PlaceLocation> posesToPlaceLocations(const std::vector<geometry_msgs::PoseStamped>& poses);
@@ -810,7 +810,7 @@ public:
   }
 
   /** \brief Pick up an object given possible grasp poses */
-  MoveItErrorCode pick(const std::string& object, std::vector<moveit_msgs::Grasp>&& grasps, bool plan_only = false)
+  MoveItErrorCode pick(const std::string& object, std::vector<moveit_msgs::Grasp> grasps, bool plan_only = false)
   {
     return pick(constructPickupGoal(object, std::move(grasps), plan_only));
   }
@@ -838,7 +838,7 @@ public:
   }
 
   /** \brief Place an object at one of the specified possible locations */
-  MoveItErrorCode place(const std::string& object, std::vector<moveit_msgs::PlaceLocation>&& locations,
+  MoveItErrorCode place(const std::string& object, std::vector<moveit_msgs::PlaceLocation> locations,
                         bool plan_only = false)
   {
     return place(constructPlaceGoal(object, std::move(locations), plan_only));

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -246,14 +246,14 @@ public:
   /** \brief Set a scaling factor for optionally reducing the maximum joint velocity.
       Allowed values are in (0,1]. The maximum joint velocity specified
       in the robot model is multiplied by the factor. If outside valid range
-      (imporantly, this includes it being set to 0.0), the factor is set to a
+      (importantly, this includes it being set to 0.0), the factor is set to a
       default value of 1.0 internally (i.e. maximum joint velocity) */
   void setMaxVelocityScalingFactor(double max_velocity_scaling_factor);
 
   /** \brief Set a scaling factor for optionally reducing the maximum joint acceleration.
       Allowed values are in (0,1]. The maximum joint acceleration specified
       in the robot model is multiplied by the factor. If outside valid range
-      (imporantly, this includes it being set to 0.0), the factor is set to a
+      (importantly, this includes it being set to 0.0), the factor is set to a
       default value of 1.0 internally (i.e. maximum joint acceleration) */
   void setMaxAccelerationScalingFactor(double max_acceleration_scaling_factor);
 
@@ -310,6 +310,14 @@ public:
   /** \brief For pick/place operations, the name of the support surface is used to specify the fact that attached
    * objects are allowed to touch the support surface */
   void setSupportSurfaceName(const std::string& name);
+
+  /** \brief For place operations, either the location of the object can be specified ( \e place_eef = false,
+   * this is the default ) or the location of the end effector ( \e place_eef = true ) */
+  void setPlaceEEF(const bool place_eef);
+
+  /** \brief For pick/place operations, specify whether collisions between the gripper and the support surface should
+   * be acceptable. By default, this is true */
+  void setAllowGripperSupportCollision(const bool allow_gripper_support_collision);
 
   /**
    * \name Setting a joint state target (goal)
@@ -958,7 +966,7 @@ private:
   class MoveGroupInterfaceImpl;
   MoveGroupInterfaceImpl* impl_;
 };
-}
-}
+}  // namespace planning_interface
+}  // namespace moveit
 
 #endif

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -47,6 +47,8 @@
 #include <moveit_msgs/Constraints.h>
 #include <moveit_msgs/Grasp.h>
 #include <moveit_msgs/PlaceLocation.h>
+#include <moveit_msgs/PickupGoal.h>
+#include <moveit_msgs/PlaceGoal.h>
 #include <moveit_msgs/MotionPlanRequest.h>
 #include <moveit_msgs/MoveGroupAction.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -783,6 +785,16 @@ public:
       in \e request */
   void constructMotionPlanRequest(moveit_msgs::MotionPlanRequest& request);
 
+  /** \brief Build a PickupGoal for an object named \e object and store it in \e goal_out
+
+      Any options previously set, e.g. with setSupportSurfaceName() or allowReplanning(), are used for the goal */
+  void constructPickupGoal(moveit_msgs::PickupGoal& goal_out, const std::string& object);
+
+  /** \brief Build a PlaceGoal for an object named \e object and store it in \e goal_out
+
+      Any options previously set, e.g. with setSupportSurfaceName() or allowReplanning(), are used for the goal */
+  void constructPlaceGoal(moveit_msgs::PlaceGoal& goal_out, const std::string& object);
+
   /**@}*/
 
   /**
@@ -803,6 +815,12 @@ public:
       if the vector is left empty this behaves like pick(const std::string &object) */
   MoveItErrorCode pick(const std::string& object, const std::vector<moveit_msgs::Grasp>& grasps,
                        bool plan_only = false);
+
+  /** \brief Pick up an object given a PickupGoal
+
+      Use as follows: first create the goal with constructPickupGoal(), then set \e possible_grasps and any other
+      desired variable in the goal, and finally pass it on to this function */
+  MoveItErrorCode pick(const moveit_msgs::PickupGoal& goal);
 
   /** \brief Pick up an object
 
@@ -827,6 +845,12 @@ public:
 
   /** \brief Place an object at one of the specified possible location */
   MoveItErrorCode place(const std::string& object, const geometry_msgs::PoseStamped& pose, bool plan_only = false);
+
+  /** \brief Place an object given a PlaceGoal
+
+      Use as follows: first create the goal with constructPlaceGoal(), then set \e place_locations and any other
+      desired variable in the goal, and finally pass it on to this function */
+  MoveItErrorCode place(const moveit_msgs::PlaceGoal& goal);
 
   /** \brief Given the name of an object in the planning scene, make
       the object attached to a link of the robot.  If no link name is
@@ -916,7 +940,7 @@ public:
     return remembered_joint_values_;
   }
 
-  /** \brief Forget the joint values remebered under \e name */
+  /** \brief Forget the joint values remembered under \e name */
   void forgetJointValues(const std::string& name);
 
   /**@}*/

--- a/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
@@ -68,7 +68,7 @@ void demoPick(moveit::planning_interface::MoveGroupInterface& group)
 
     grasps.push_back(g);
   }
-  group.pick("bubu", grasps);
+  group.pick("bubu", std::move(grasps));
 }
 
 void demoPlace(moveit::planning_interface::MoveGroupInterface& group)
@@ -98,7 +98,7 @@ void demoPlace(moveit::planning_interface::MoveGroupInterface& group)
 
     loc.push_back(g);
   }
-  group.place("bubu", loc);
+  group.place("bubu", std::move(loc));
 }
 
 void attachObject()

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -127,8 +127,6 @@ public:
     max_velocity_scaling_factor_ = 1.0;
     max_acceleration_scaling_factor_ = 1.0;
     initializing_constraints_ = false;
-    place_eef_ = false;
-    allow_gripper_support_collision_ = true;
 
     if (joint_model_group_->isChain())
       end_effector_link_ = joint_model_group_->getLinkModelNames().back();
@@ -524,19 +522,6 @@ public:
   void setSupportSurfaceName(const std::string& support_surface)
   {
     support_surface_ = support_surface;
-  }
-
-  void setPlaceEEF(bool place_eef)
-  {
-    place_eef_ = place_eef;
-    ROS_DEBUG_NAMED("move_group_interface", "Place EEF: %s", place_eef_ ? "yes" : "no");
-  }
-
-  void setAllowGripperSupportCollision(bool allow_gripper_support_collision)
-  {
-    allow_gripper_support_collision_ = allow_gripper_support_collision;
-    ROS_DEBUG_NAMED("move_group_interface", "Allow gripper support collision: %s",
-                    allow_gripper_support_collision ? "yes" : "no");
   }
 
   const std::string& getPoseReferenceFrame() const
@@ -1082,8 +1067,6 @@ public:
     goal.group_name = opt_.group_name_;
     goal.end_effector = getEndEffector();
     goal.support_surface_name = support_surface_;
-    if (!support_surface_.empty())
-      goal.allow_gripper_support_collision = allow_gripper_support_collision_;
 
     if (path_constraints_)
       goal.path_constraints = *path_constraints_;
@@ -1104,10 +1087,7 @@ public:
     moveit_msgs::PlaceGoal goal;
     goal.group_name = opt_.group_name_;
     goal.attached_object_name = object;
-    goal.place_eef = place_eef_;
     goal.support_surface_name = support_surface_;
-    if (!support_surface_.empty())
-      goal.allow_gripper_support_collision = allow_gripper_support_collision_;
 
     if (path_constraints_)
       goal.path_constraints = *path_constraints_;
@@ -1272,8 +1252,6 @@ private:
   std::string end_effector_link_;
   std::string pose_reference_frame_;
   std::string support_surface_;
-  bool allow_gripper_support_collision_;
-  bool place_eef_;
 
   // ROS communication
   ros::Publisher trajectory_event_publisher_;
@@ -2265,17 +2243,6 @@ double moveit::planning_interface::MoveGroupInterface::getPlanningTime() const
 void moveit::planning_interface::MoveGroupInterface::setSupportSurfaceName(const std::string& name)
 {
   impl_->setSupportSurfaceName(name);
-}
-
-void moveit::planning_interface::MoveGroupInterface::setPlaceEEF(const bool place_eef)
-{
-  impl_->setPlaceEEF(place_eef);
-}
-
-void moveit::planning_interface::MoveGroupInterface::setAllowGripperSupportCollision(
-    const bool allow_gripper_support_collision)
-{
-  impl_->setAllowGripperSupportCollision(allow_gripper_support_collision);
 }
 
 const std::string& moveit::planning_interface::MoveGroupInterface::getPlanningFrame() const

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1439,13 +1439,13 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 }
 
 moveit_msgs::PickupGoal moveit::planning_interface::MoveGroupInterface::constructPickupGoal(
-    const std::string& object, std::vector<moveit_msgs::Grasp>&& grasps, bool plan_only = false)
+    const std::string& object, std::vector<moveit_msgs::Grasp> grasps, bool plan_only = false)
 {
   return impl_->constructPickupGoal(object, std::move(grasps), plan_only);
 }
 
 moveit_msgs::PlaceGoal moveit::planning_interface::MoveGroupInterface::constructPlaceGoal(
-    const std::string& object, std::vector<moveit_msgs::PlaceLocation>&& locations, bool plan_only = false)
+    const std::string& object, std::vector<moveit_msgs::PlaceLocation> locations, bool plan_only = false)
 {
   return impl_->constructPlaceGoal(object, std::move(locations), plan_only);
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -174,8 +174,8 @@ public:
 
     plan_grasps_service_ = node_handle_.serviceClient<moveit_msgs::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 
-    ROS_INFO_STREAM_NAMED("move_group_interface",
-                          "Ready to take commands for planning group " << opt.group_name_ << ".");
+    ROS_INFO_STREAM_NAMED("move_group_interface", "Ready to take commands for planning group " << opt.group_name_
+                                                                                               << ".");
   }
 
   template <typename T>
@@ -711,8 +711,8 @@ public:
 
     if (objects.empty())
     {
-      ROS_ERROR_STREAM_NAMED("move_group_interface",
-                             "Asked for grasps for the object '" << object << "', but the object could not be found");
+      ROS_ERROR_STREAM_NAMED("move_group_interface", "Asked for grasps for the object '"
+                                                         << object << "', but the object could not be found");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME);
     }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -536,7 +536,7 @@ public:
   {
     allow_gripper_support_collision_ = allow_gripper_support_collision;
     ROS_DEBUG_NAMED("move_group_interface", "Allow gripper support collision: %s",
-                   allow_gripper_support_collision ? "yes" : "no");
+                    allow_gripper_support_collision ? "yes" : "no");
   }
 
   const std::string& getPoseReferenceFrame() const
@@ -1491,7 +1491,7 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 moveit::planning_interface::MoveItErrorCode
 moveit::planning_interface::MoveGroupInterface::pick(const moveit_msgs::PickupGoal& goal)
 {
-    return impl_->pick(goal);
+  return impl_->pick(goal);
 }
 
 moveit::planning_interface::MoveItErrorCode

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1065,6 +1065,8 @@ public:
     goal.end_effector = getEndEffector();
     goal.support_surface_name = support_surface_;
     goal.possible_grasps = std::move(grasps);
+    if (!support_surface_.empty())
+      goal.allow_gripper_support_collision = true;
 
     if (path_constraints_)
       goal.path_constraints = *path_constraints_;
@@ -1089,6 +1091,8 @@ public:
     goal.attached_object_name = object;
     goal.support_surface_name = support_surface_;
     goal.place_locations = std::move(locations);
+    if (!support_surface_.empty())
+      goal.allow_gripper_support_collision = true;
 
     if (path_constraints_)
       goal.path_constraints = *path_constraints_;

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -261,7 +261,7 @@ public:
   {
     std::vector<moveit_msgs::PlaceLocation> locations(1);
     py_bindings_tools::deserializeMsg(location_str, locations[0]);
-    return place(object_name, locations, plan_only) == MoveItErrorCode::SUCCESS;
+    return place(object_name, std::move(locations), plan_only) == MoveItErrorCode::SUCCESS;
   }
 
   bool placeAnywhere(const std::string& object_name, bool plan_only = false)
@@ -464,7 +464,7 @@ public:
     std::vector<moveit_msgs::Grasp> grasps(l);
     for (int i = 0; i < l; ++i)
       py_bindings_tools::deserializeMsg(bp::extract<std::string>(grasp_list[i]), grasps[i]);
-    return pick(object, grasps, plan_only).val;
+    return pick(object, std::move(grasps), plan_only).val;
   }
 
   void setPathConstraintsFromMsg(const std::string& constraints_str)


### PR DESCRIPTION
### Description

Add functions to set fields in the pick and place goals, namely `place_eef` and `allow_gripper_support_collision`. Also some minor formatting changes by clang-format.
See also issue #631
