### PR TITLE
Adding Bullet and Tesseract into MoveIt [WIP]

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -13,8 +13,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
   set(CMAKE_BUILD_TYPE Release)
@@ -55,6 +53,9 @@ COMPONENTS
   urdf
   visualization_msgs
   xmlrpcpp
+  tesseract_msgs
+  eigen_conversions
+  bullet3_ros
 )
 
 set(VERSION_FILE_PATH "${CATKIN_DEVEL_PREFIX}/include")
@@ -70,6 +71,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     backtrace/include
     collision_detection/include
     collision_detection_fcl/include
+    collision_detection_bullet/include
     constraint_samplers/include
     controller_manager/include
     distance_field/include
@@ -106,6 +108,7 @@ catkin_package(
     moveit_planning_interface
     moveit_collision_detection
     moveit_collision_detection_fcl
+    moveit_collision_detection_bullet
     moveit_kinematic_constraints
     moveit_planning_scene
     moveit_constraint_samplers
@@ -135,6 +138,9 @@ catkin_package(
     tf2_geometry_msgs
     trajectory_msgs
     visualization_msgs
+    tesseract_msgs
+    eigen_conversions
+    bullet3_ros
   DEPENDS
     Boost
     EIGEN3
@@ -155,8 +161,7 @@ if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
 endif()
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
-                           ${LIBFCL_INCLUDE_DIRS}
-                           )
+                           ${LIBFCL_INCLUDE_DIRS})
 
 #catkin_lint: ignore_once external_directory  (${VERSION_FILE_PATH})
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
@@ -195,6 +200,7 @@ add_subdirectory(robot_state)
 add_subdirectory(robot_trajectory)
 add_subdirectory(collision_detection)
 add_subdirectory(collision_detection_fcl)
+add_subdirectory(collision_detection_bullet)
 add_subdirectory(kinematic_constraints)
 add_subdirectory(planning_scene)
 add_subdirectory(constraint_samplers)

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -4,13 +4,10 @@ add_library(${MOVEIT_LIB_NAME}
   src/collision_common.cpp
   src/collision_robot_bt.cpp
   src/collision_world_bt.cpp
-  src/tesseract/bullet_discrete_simple_manager.cpp
-  src/tesseract/bullet_utils.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection
-    moveit_collision_detection_fcl ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 add_library(collision_detector_bullet_plugin src/collision_detector_bt_plugin_loader.cpp)
@@ -29,10 +26,4 @@ install(FILES ../collision_detector_bullet_description.xml DESTINATION ${CATKIN_
 if(CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   include_directories(${moveit_resources_INCLUDE_DIRS})
-
-  catkin_add_gtest(test_bullet_collision_detection test/test_bt_collision_detection.cpp)
-  target_link_libraries(test_bullet_collision_detection moveit_test_utils ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
-
-  catkin_add_gtest(test_bullet_collision_detection_panda test/test_bt_collision_detection_panda.cpp)
-  target_link_libraries(test_bullet_collision_detection_panda moveit_test_utils ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
 endif()

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -1,0 +1,38 @@
+set(MOVEIT_LIB_NAME moveit_collision_detection_bullet)
+
+add_library(${MOVEIT_LIB_NAME}
+  src/collision_common.cpp
+  src/collision_robot_bt.cpp
+  src/collision_world_bt.cpp
+  src/tesseract/bullet_discrete_simple_manager.cpp
+  src/tesseract/bullet_utils.cpp
+)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection
+    moveit_collision_detection_fcl ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
+
+add_library(collision_detector_bullet_plugin src/collision_detector_bt_plugin_loader.cpp)
+set_target_properties(collision_detector_bullet_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+target_link_libraries(collision_detector_bullet_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME})
+
+
+install(TARGETS ${MOVEIT_LIB_NAME} collision_detector_bullet_plugin
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+install(FILES ../collision_detector_bullet_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_resources REQUIRED)
+  include_directories(${moveit_resources_INCLUDE_DIRS})
+
+  catkin_add_gtest(test_bullet_collision_detection test/test_bt_collision_detection.cpp)
+  target_link_libraries(test_bullet_collision_detection moveit_test_utils ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+
+  catkin_add_gtest(test_bullet_collision_detection_panda test/test_bt_collision_detection_panda.cpp)
+  target_link_libraries(test_bullet_collision_detection_panda moveit_test_utils ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+endif()

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_common.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_common.h
@@ -1,0 +1,47 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#ifndef MOVEIT_COLLISION_DETECTION_BT_COLLISION_COMMON_
+#define MOVEIT_COLLISION_DETECTION_BT_COLLISION_COMMON_
+
+#include <moveit/collision_detection/world.h>
+#include <moveit/collision_detection/collision_world.h>
+
+namespace collision_detection
+{
+}
+
+#endif

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_allocator_bt.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_allocator_bt.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#ifndef MOVEIT_COLLISION_DETECTION_COLLISION_DETECTOR_BT_H_
+#define MOVEIT_COLLISION_DETECTION_COLLISION_DETECTOR_BT_H_
+
+#include <moveit/collision_detection/collision_detector_allocator.h>
+#include <moveit/collision_detection_bullet/collision_robot_bt.h>
+#include <moveit/collision_detection_bullet/collision_world_bt.h>
+
+namespace collision_detection
+{
+/** \brief An allocator for Bullet collision detectors */
+class CollisionDetectorAllocatorBt
+    : public CollisionDetectorAllocatorTemplate<CollisionWorldBt, CollisionRobotBt, CollisionDetectorAllocatorBt>
+{
+public:
+  static const std::string NAME;  // defined in collision_world_bt.cpp
+};
+}
+
+#endif

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_bt_plugin_loader.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_bt_plugin_loader.h
@@ -1,0 +1,51 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#ifndef MOVEIT_COLLISION_DETECTION_BT_COLLISION_DETECTOR_BT_PLUGIN_LOADER_H_
+#define MOVEIT_COLLISION_DETECTION_BT_COLLISION_DETECTOR_BT_PLUGIN_LOADER_H_
+
+#include <moveit/collision_detection/collision_plugin.h>
+#include <moveit/collision_detection_bullet/collision_detector_allocator_bt.h>
+
+namespace collision_detection
+{
+class CollisionDetectorBtPluginLoader : public CollisionPlugin
+{
+public:
+  virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const;
+};
+}
+#endif  // MOVEIT_COLLISION_DETECTION_BT_COLLISION_DETECTOR_BT_PLUGIN_LOADER_H_

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_robot_bt.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_robot_bt.h
@@ -38,6 +38,7 @@
 #define MOVEIT_COLLISION_DETECTION_BT_COLLISION_ROBOT_
 
 #include <moveit/collision_detection_bullet/collision_common.h>
+#include <moveit/collision_detection_bullet/tesseract/bullet_discrete_simple_manager.h>
 
 namespace collision_detection
 {
@@ -81,13 +82,23 @@ public:
                      const CollisionRobot& other_robot, const robot_state::RobotState& other_state) const override;
 
 protected:
+  /** \brief Updates the poses of the objects in the manager according to given robot state. */
+  void updateTransformsFromState(const robot_state::RobotState& state) const;
+
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
+
+  void addAttachedOjectsToManager(const robot_state::RobotState& state) const;
+
+  void getAttachedBodyObjects(const robot_state::AttachedBody* ab, std::vector<void*>& geoms) const;
 
   void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
                                 const AllowedCollisionMatrix* acm) const;
   void checkOtherCollisionHelper(const CollisionRequest& req, CollisionResult& res,
                                  const robot_state::RobotState& state, const CollisionRobot& other_robot,
                                  const robot_state::RobotState& other_state, const AllowedCollisionMatrix* acm) const;
+
+  /** @brief Bullet collision manager taken from tesseract*/
+  mutable tesseract::tesseract_bullet::BulletDiscreteSimpleManager bt_manager_;
 };
 }
 

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_robot_bt.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_robot_bt.h
@@ -1,0 +1,94 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#ifndef MOVEIT_COLLISION_DETECTION_BT_COLLISION_ROBOT_
+#define MOVEIT_COLLISION_DETECTION_BT_COLLISION_ROBOT_
+
+#include <moveit/collision_detection_bullet/collision_common.h>
+
+namespace collision_detection
+{
+class CollisionRobotBt : public CollisionRobot
+{
+  friend class CollisionWorldBt;
+
+public:
+  CollisionRobotBt(const robot_model::RobotModelConstPtr& robot_model, double padding = 0.0, double scale = 1.0);
+
+  CollisionRobotBt(const CollisionRobotBt& other);
+
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                          const robot_state::RobotState& state) const override;
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+                          const AllowedCollisionMatrix& acm) const override;
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state1,
+                          const robot_state::RobotState& state2) const override;
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state1,
+                          const robot_state::RobotState& state2, const AllowedCollisionMatrix& acm) const override;
+
+  void checkOtherCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+                           const CollisionRobot& other_robot,
+                           const robot_state::RobotState& other_state) const override;
+  void checkOtherCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+                           const CollisionRobot& other_robot, const robot_state::RobotState& other_state,
+                           const AllowedCollisionMatrix& acm) const override;
+  void checkOtherCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state1,
+                           const robot_state::RobotState& state2, const CollisionRobot& other_robot,
+                           const robot_state::RobotState& other_state1,
+                           const robot_state::RobotState& other_state2) const override;
+  void checkOtherCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state1,
+                           const robot_state::RobotState& state2, const CollisionRobot& other_robot,
+                           const robot_state::RobotState& other_state1, const robot_state::RobotState& other_state2,
+                           const AllowedCollisionMatrix& acm) const override;
+
+  void distanceSelf(const DistanceRequest& req, DistanceResult& res,
+                    const robot_state::RobotState& state) const override;
+
+  void distanceOther(const DistanceRequest& req, DistanceResult& res, const robot_state::RobotState& state,
+                     const CollisionRobot& other_robot, const robot_state::RobotState& other_state) const override;
+
+protected:
+  void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
+
+  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+                                const AllowedCollisionMatrix* acm) const;
+  void checkOtherCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                 const robot_state::RobotState& state, const CollisionRobot& other_robot,
+                                 const robot_state::RobotState& other_state, const AllowedCollisionMatrix* acm) const;
+};
+}
+
+#endif

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_world_bt.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_world_bt.h
@@ -1,0 +1,86 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#ifndef MOVEIT_COLLISION_DETECTION_BT_COLLISION_WORLD_BT_
+#define MOVEIT_COLLISION_DETECTION_BT_COLLISION_WORLD_BT_
+
+#include <moveit/collision_detection_bullet/collision_robot_bt.h>
+
+namespace collision_detection
+{
+class CollisionWorldBt : public CollisionWorld
+{
+public:
+  CollisionWorldBt();
+  explicit CollisionWorldBt(const WorldPtr& world);
+  CollisionWorldBt(const CollisionWorldBt& other, const WorldPtr& world);
+  ~CollisionWorldBt() override;
+
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const CollisionRobot& robot,
+                           const robot_state::RobotState& state) const override;
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const CollisionRobot& robot,
+                           const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const override;
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const CollisionRobot& robot,
+                           const robot_state::RobotState& state1, const robot_state::RobotState& state2) const override;
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const CollisionRobot& robot,
+                           const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                           const AllowedCollisionMatrix& acm) const override;
+  void checkWorldCollision(const CollisionRequest& req, CollisionResult& res,
+                           const CollisionWorld& other_world) const override;
+  void checkWorldCollision(const CollisionRequest& req, CollisionResult& res, const CollisionWorld& other_world,
+                           const AllowedCollisionMatrix& acm) const override;
+
+  void distanceRobot(const DistanceRequest& req, DistanceResult& res, const CollisionRobot& robot,
+                     const robot_state::RobotState& state) const override;
+
+  void distanceWorld(const DistanceRequest& req, DistanceResult& res, const CollisionWorld& world) const override;
+
+  void setWorld(const WorldPtr& world) override;
+
+protected:
+  void checkWorldCollisionHelper(const CollisionRequest& req, CollisionResult& res, const CollisionWorld& other_world,
+                                 const AllowedCollisionMatrix* acm) const;
+  void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res, const CollisionRobot& robot,
+                                 const robot_state::RobotState& state, const AllowedCollisionMatrix* acm) const;
+
+private:
+  void initialize();
+  void notifyObjectChange(const ObjectConstPtr& obj, World::Action action);
+  World::ObserverHandle observer_handle_;
+};
+}
+
+#endif

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_world_bt.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_world_bt.h
@@ -38,6 +38,9 @@
 #define MOVEIT_COLLISION_DETECTION_BT_COLLISION_WORLD_BT_
 
 #include <moveit/collision_detection_bullet/collision_robot_bt.h>
+#include <moveit/collision_detection_bullet/tesseract/bullet_discrete_simple_manager.h>
+
+#include <memory>
 
 namespace collision_detection
 {
@@ -75,6 +78,11 @@ protected:
                                  const AllowedCollisionMatrix* acm) const;
   void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res, const CollisionRobot& robot,
                                  const robot_state::RobotState& state, const AllowedCollisionMatrix* acm) const;
+
+  void addToManager(const World::Object* obj) const;
+  void updateManagedObject(const std::string& id);
+
+  mutable tesseract::tesseract_bullet::BulletDiscreteSimpleManager bt_manager_;
 
 private:
   void initialize();

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/basic_types.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/basic_types.h
@@ -1,0 +1,356 @@
+/**
+ * @file basic_types.h
+ * @brief The tesseract_core package types.
+ *
+ * @author Levi Armstrong
+ * @date April 15, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2013, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_CORE_BASIC_TYPES_H
+#define TESSERACT_CORE_BASIC_TYPES_H
+
+#include <moveit/collision_detection_bullet/tesseract/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <Eigen/StdVector>
+#include <geometric_shapes/shapes.h>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <map>
+#include <moveit/collision_detection/collision_common.h>
+TESSERACT_IGNORE_WARNINGS_POP
+
+namespace tesseract
+{
+template <typename T>
+using AlignedVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+template <typename Key, typename Value>
+using AlignedMap = std::map<Key, Value, std::less<Key>, Eigen::aligned_allocator<std::pair<const Key, Value>>>;
+
+template <typename Key, typename Value>
+using AlignedUnorderedMap = std::unordered_map<Key, Value, std::hash<Key>, std::equal_to<Key>,
+                                               Eigen::aligned_allocator<std::pair<const Key, Value>>>;
+
+using VectorIsometry3d = AlignedVector<Eigen::Isometry3d>;
+using VectorVector4d = AlignedVector<Eigen::Vector4d>;
+using VectorVector3d = std::vector<Eigen::Vector3d>;
+using TransformMap = AlignedMap<std::string, Eigen::Isometry3d>;
+
+typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> TrajArray;
+
+struct AllowedCollisionMatrix
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  virtual ~AllowedCollisionMatrix() = default;
+
+  /**
+   * @brief Disable collision between two collision objects
+   * @param obj1 Collision object name
+   * @param obj2 Collision object name
+   * @param reason The reason for disabling collison
+   */
+  virtual void addAllowedCollision(const std::string& link_name1, const std::string& link_name2,
+                                   const std::string& reason)
+  {
+    auto link_pair = makeOrderedLinkPair(link_name1, link_name2);
+    lookup_table_[link_pair] = reason;
+  }
+
+  /**
+   * @brief Remove disabled collision pair from allowed collision matrix
+   * @param obj1 Collision object name
+   * @param obj2 Collision object name
+   */
+  virtual void removeAllowedCollision(const std::string& link_name1, const std::string& link_name2)
+  {
+    auto link_pair = makeOrderedLinkPair(link_name1, link_name2);
+    lookup_table_.erase(link_pair);
+  }
+
+  /**
+   * @brief This checks if two links are allowed to be in collision
+   * @param link_name1 First link name
+   * @param link_name2 Second link anme
+   * @return True if allowed to be in collision, otherwise false
+   */
+  virtual bool isCollisionAllowed(const std::string& link_name1, const std::string& link_name2) const
+  {
+    auto link_pair = makeOrderedLinkPair(link_name1, link_name2);
+    return (lookup_table_.find(link_pair) != lookup_table_.end());
+  }
+
+  /**
+   * @brief Clears the list of allowed collisions, so that no collision will be
+   *        allowed.
+   */
+  void clearAllowedCollisions()
+  {
+    lookup_table_.clear();
+  }
+
+private:
+  typedef std::pair<const std::string, const std::string> LinkNamesPair;
+  struct PairHash
+  {
+    std::size_t operator()(const LinkNamesPair& pair) const
+    {
+      return std::hash<std::string>()(pair.first + pair.second);
+    }
+  };
+  typedef std::unordered_map<LinkNamesPair, std::string, PairHash> AllowedCollisionEntries;
+  AllowedCollisionEntries lookup_table_;
+
+  /**
+   * @brief Create a pair of strings, where the pair.first is always <= pair.second
+   * @param link_name1 First link name
+   * @param link_name2 Second link anme
+   * @return LinkNamesPair a lexicographically sorted pair of strings
+   */
+  static inline LinkNamesPair makeOrderedLinkPair(const std::string& link_name1, const std::string& link_name2)
+  {
+    if (link_name1 <= link_name2)
+      return std::make_pair(link_name1, link_name2);
+    else
+      return std::make_pair(link_name2, link_name1);
+  }
+
+public:
+  /**
+   * @brief Clears the list of allowed collisions
+   * @return AllowedCollisionEntries an unordered map containing all allowed
+   *         collision entries. The keys of the unordered map are a std::pair
+   *         of the link names in the allowed collision pair.
+   */
+  const AllowedCollisionEntries& getAllAllowedCollisions() const
+  {
+    return lookup_table_;
+  }
+};
+typedef std::shared_ptr<AllowedCollisionMatrix> AllowedCollisionMatrixPtr;
+typedef std::shared_ptr<const AllowedCollisionMatrix> AllowedCollisionMatrixConstPtr;
+
+/**
+ * @brief Should return true if contact allowed, otherwise false.
+ *
+ * Also the order of strings should not matter, the function should handled by the function.
+ */
+typedef std::function<bool(const std::string&, const std::string&)> IsContactAllowedFn;
+
+namespace CollisionObjectTypes
+{
+enum CollisionObjectType
+{
+  UseShapeType = 0, /**< @brief Infer the type from the type specified in the shapes::Shape class */
+
+  // These convert the meshes to custom collision objects
+  ConvexHull =
+      1, /**< @brief Use the mesh in shapes::Shape but make it a convex hulls collision object. (if not convex it will
+            be converted) */
+  MultiSphere = 2, /**< @brief Use the mesh and represent it by multiple spheres collision object */
+  SDF = 3          /**< @brief Use the mesh and rpresent it by a signed distance fields collision object */
+};
+}
+typedef CollisionObjectTypes::CollisionObjectType CollisionObjectType;
+typedef std::vector<CollisionObjectType> CollisionObjectTypeVector;
+
+namespace BodyTypes
+{
+enum BodyType
+{
+  ROBOT_LINK = 0,    /**< @brief These are links at the creation of the environment */
+  ROBOT_ATTACHED = 1 /**< @brief These are links that are added after initial creation */
+};
+}
+typedef BodyTypes::BodyType BodyType;
+
+namespace ContinouseCollisionTypes
+{
+enum ContinouseCollisionType
+{
+  CCType_None,
+  CCType_Time0,
+  CCType_Time1,
+  CCType_Between
+};
+}
+typedef ContinouseCollisionTypes::ContinouseCollisionType ContinouseCollisionType;
+
+namespace ContactTestTypes
+{
+enum ContactTestType
+{
+  FIRST = 0,   /**< Return at first contact for any pair of objects */
+  CLOSEST = 1, /**< Return the global minimum for a pair of objects */
+  ALL = 2,     /**< Return all contacts for a pair of objects */
+  LIMITED = 3  /**< Return limited set of contacts for a pair of objects */
+};
+}
+typedef ContactTestTypes::ContactTestType ContactTestType;
+
+struct ContactResult
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  double distance;
+  int type_id[2];
+  std::string link_names[2];
+  Eigen::Vector3d nearest_points[2];
+  Eigen::Vector3d normal;
+  Eigen::Vector3d cc_nearest_points[2];
+  double cc_time;
+  ContinouseCollisionType cc_type;
+
+  ContactResult()
+  {
+    clear();
+  }
+  /// Clear structure data
+  void clear()
+  {
+    distance = std::numeric_limits<double>::max();
+    nearest_points[0].setZero();
+    nearest_points[1].setZero();
+    link_names[0] = "";
+    link_names[1] = "";
+    type_id[0] = 0;
+    type_id[1] = 0;
+    normal.setZero();
+    cc_nearest_points[0].setZero();
+    cc_nearest_points[1].setZero();
+    cc_time = -1;
+    cc_type = ContinouseCollisionType::CCType_None;
+  }
+};
+typedef AlignedVector<ContactResult> ContactResultVector;
+typedef AlignedMap<std::pair<std::string, std::string>, ContactResultVector> ContactResultMap;
+
+/// Contact test data and query results information
+struct ContactTestData
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ContactTestData(const std::vector<std::string>& active, const double& contact_distance, const IsContactAllowedFn& fn,
+                  const ContactTestType& type, collision_detection::CollisionResult& res)
+    : active(active), contact_distance(contact_distance), fn(fn), type(type), res(res), done(false)
+  {
+  }
+
+  const std::vector<std::string>& active;
+  const double& contact_distance;
+  const IsContactAllowedFn& fn;
+  const ContactTestType& type;
+
+  /// Distance query results information
+  collision_detection::CollisionResult& res;
+
+  /// Indicate if search is finished
+  bool done;
+};
+
+static inline void moveContactResultsMapToContactResultsVector(ContactResultMap& contact_map,
+                                                               ContactResultVector& contact_vector)
+{
+  std::size_t size = 0;
+  for (const auto& contact : contact_map)
+    size += contact.second.size();
+
+  contact_vector.reserve(size);
+  for (auto& contact : contact_map)
+    std::move(contact.second.begin(), contact.second.end(), std::back_inserter(contact_vector));
+}
+
+/** @brief This holds a state of the environment */
+struct EnvState
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  std::unordered_map<std::string, double> joints;
+  TransformMap transforms;
+};
+typedef std::shared_ptr<EnvState> EnvStatePtr;
+typedef std::shared_ptr<const EnvState> EnvStateConstPtr;
+
+/**< @brief Information on how the object is attached to the environment */
+struct AttachedBodyInfo
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  AttachedBodyInfo() : transform(Eigen::Isometry3d::Identity())
+  {
+  }
+  std::string object_name;              /**< @brief The name of the AttachableObject being used */
+  std::string parent_link_name;         /**< @brief The name of the link to attach the body */
+  Eigen::Isometry3d transform;          /**< @brief The transform between parent link and object */
+  std::vector<std::string> touch_links; /**< @brief The names of links which the attached body is allowed to be in
+                                           contact with */
+};
+
+/** @brief Contains visual geometry data */
+struct VisualObjectGeometry
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  std::vector<shapes::ShapeConstPtr> shapes; /**< @brief The shape */
+  VectorIsometry3d shape_poses;              /**< @brief The pose of the shape */
+  VectorVector4d shape_colors;               /**< @brief (Optional) The shape color (R, G, B, A) */
+};
+
+/** @brief Contains visual geometry data */
+struct CollisionObjectGeometry : public VisualObjectGeometry
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  CollisionObjectTypeVector
+      collision_object_types; /**< @brief The collision object type. This is used by the collision libraries */
+};
+
+/** @brief Contains data about an attachable object */
+struct AttachableObject
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  std::string name;            /**< @brief The name of the attachable object (aka. link name and must be unique) */
+  VisualObjectGeometry visual; /**< @brief The objects visual geometry */
+  CollisionObjectGeometry collision; /**< @brief The objects collision geometry */
+};
+typedef std::shared_ptr<AttachableObject> AttachableObjectPtr;
+typedef std::shared_ptr<const AttachableObject> AttachableObjectConstPtr;
+
+/** @brief ObjectColorMap Stores Object color in a 4d vector as RGBA*/
+struct ObjectColor
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  VectorVector4d visual;
+  VectorVector4d collision;
+};
+typedef AlignedUnorderedMap<std::string, ObjectColor> ObjectColorMap;
+typedef std::shared_ptr<ObjectColorMap> ObjectColorMapPtr;
+typedef std::shared_ptr<const ObjectColorMap> ObjectColorMapConstPtr;
+typedef AlignedUnorderedMap<std::string, AttachedBodyInfo> AttachedBodyInfoMap;
+typedef std::unordered_map<std::string, AttachableObjectConstPtr> AttachableObjectConstPtrMap;
+}
+
+#endif  // TESSERACT_CORE_BASIC_TYPES_H

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/bullet_discrete_simple_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/bullet_discrete_simple_manager.h
@@ -1,0 +1,123 @@
+/**
+ * @file bullet_discrete_simple_manager.h
+ * @brief Tesseract ROS Bullet discrete simple collision manager.
+ *
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (BSD-2-Clause)
+ * @par
+ * All rights reserved.
+ * @par
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * @par
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * @par
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TESSERACT_COLLISION_BULLET_DISCRETE_SIMPLE_MANAGERS_H
+#define TESSERACT_COLLISION_BULLET_DISCRETE_SIMPLE_MANAGERS_H
+
+#include <moveit/collision_detection_bullet/tesseract/bullet_utils.h>
+#include <moveit/collision_detection_bullet/tesseract/discrete_contact_manager_base.h>
+#include <moveit/collision_detection_bullet/tesseract/macros.h>
+#include <moveit/collision_detection/collision_matrix.h>
+namespace tesseract
+{
+namespace tesseract_bullet
+{
+/** @brief A simple implementaiton of a bullet manager which does not use BHV */
+class BulletDiscreteSimpleManager : public DiscreteContactManagerBase
+{
+public:
+  BulletDiscreteSimpleManager();
+
+  DiscreteContactManagerBasePtr clone() const override;
+
+  bool addCollisionObject(const std::string& name, const int& mask_id, const std::vector<shapes::ShapeConstPtr>& shapes,
+                          const VectorIsometry3d& shape_poses, const CollisionObjectTypeVector& collision_object_types,
+                          bool enabled = true) override;
+
+  bool hasCollisionObject(const std::string& name) const override;
+
+  bool removeCollisionObject(const std::string& name) override;
+
+  bool enableCollisionObject(const std::string& name) override;
+
+  bool disableCollisionObject(const std::string& name) override;
+
+  void setCollisionObjectsTransform(const std::string& name, const Eigen::Isometry3d& pose) override;
+
+  void setCollisionObjectsTransform(const std::vector<std::string>& names, const VectorIsometry3d& poses) override;
+
+  void setCollisionObjectsTransform(const TransformMap& transforms) override;
+
+  void setActiveCollisionObjects(const std::vector<std::string>& names) override;
+
+  const std::vector<std::string>& getActiveCollisionObjects() const override;
+
+  void setContactDistanceThreshold(double contact_distance) override;
+
+  double getContactDistanceThreshold() const override;
+
+  void setIsContactAllowedFn(IsContactAllowedFn fn) override;
+
+  IsContactAllowedFn getIsContactAllowedFn() const override;
+
+  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
+
+  void contactTest(collision_detection::CollisionResult& collisions, const ContactTestType& type,
+                   const collision_detection::AllowedCollisionMatrix* acm,
+                   const collision_detection::CollisionRequest& req);
+
+  /**
+   * @brief A a bullet collision object to the manager
+   * @param cow The tesseract bullet collision object
+   */
+  void addCollisionObject(const COWPtr& cow);
+
+  /**
+   * @brief Return collision objects
+   * @return A map of collision objects <name, collision object>
+   */
+  const Link2Cow& getCollisionObjects() const;
+
+private:
+  std::vector<std::string> active_; /**< @brief A list of the active collision objects */
+  double contact_distance_;         /**< @brief The contact distance threshold */
+  IsContactAllowedFn fn_;           /**< @brief The is allowed collision function */
+
+  std::unique_ptr<btCollisionDispatcher> dispatcher_; /**< @brief The bullet collision dispatcher used for getting
+                                                         object to object collison algorithm */
+  btDispatcherInfo dispatch_info_;              /**< @brief The bullet collision dispatcher configuration information */
+  btDefaultCollisionConfiguration coll_config_; /**< @brief The bullet collision configuration */
+  Link2Cow link2cow_;        /**< @brief A map of all (static and active) collision objects being managed */
+  std::vector<COWPtr> cows_; /**< @brief A vector of collision objects (active followed by static) */
+};
+typedef std::shared_ptr<BulletDiscreteSimpleManager> BulletDiscreteSimpleManagerPtr;
+}
+}
+#endif  // TESSERACT_COLLISION_BULLET_DISCRETE_SIMPLE_MANAGERS_H

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/bullet_utils.h
@@ -1,0 +1,990 @@
+/**
+ * @file bullet_utils.h
+ * @brief Tesseract ROS Bullet environment utility function.
+ *
+ * @author John Schulman
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ * @copyright Copyright (c) 2013, John Schulman
+ *
+ * @par License
+ * Software License Agreement (BSD-2-Clause)
+ * @par
+ * All rights reserved.
+ * @par
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * @par
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * @par
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TESSERACT_COLLISION_BULLET_UTILS_H
+#define TESSERACT_COLLISION_BULLET_UTILS_H
+
+#include <moveit/collision_detection_bullet/tesseract/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <btBulletCollisionCommon.h>
+#include <geometric_shapes/mesh_operations.h>
+#include <ros/console.h>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <moveit/collision_detection_bullet/tesseract/basic_types.h>
+#include <moveit/collision_detection_bullet/tesseract/contact_checker_common.h>
+
+namespace tesseract
+{
+namespace tesseract_bullet
+{
+#define METERS
+
+const btScalar BULLET_MARGIN = 0.0f;
+const btScalar BULLET_SUPPORT_FUNC_TOLERANCE = 0.01f METERS;
+const btScalar BULLET_LENGTH_TOLERANCE = 0.001f METERS;
+const btScalar BULLET_EPSILON = 1e-3f;
+const btScalar BULLET_DEFAULT_CONTACT_DISTANCE = 0.05f;
+const bool BULLET_COMPOUND_USE_DYNAMIC_AABB = true;
+
+inline btVector3 convertEigenToBt(const Eigen::Vector3d& v)
+{
+  return btVector3(static_cast<btScalar>(v[0]), static_cast<btScalar>(v[1]), static_cast<btScalar>(v[2]));
+}
+
+inline Eigen::Vector3d convertBtToEigen(const btVector3& v)
+{
+  return Eigen::Vector3d(static_cast<double>(v.x()), static_cast<double>(v.y()), static_cast<double>(v.z()));
+}
+
+inline btQuaternion convertEigenToBt(const Eigen::Quaterniond& q)
+{
+  return btQuaternion(static_cast<btScalar>(q.x()), static_cast<btScalar>(q.y()), static_cast<btScalar>(q.z()),
+                      static_cast<btScalar>(q.w()));
+}
+
+inline btMatrix3x3 convertEigenToBt(const Eigen::Matrix3d& r)
+{
+  return btMatrix3x3(static_cast<btScalar>(r(0, 0)), static_cast<btScalar>(r(0, 1)), static_cast<btScalar>(r(0, 2)),
+                     static_cast<btScalar>(r(1, 0)), static_cast<btScalar>(r(1, 1)), static_cast<btScalar>(r(1, 2)),
+                     static_cast<btScalar>(r(2, 0)), static_cast<btScalar>(r(2, 1)), static_cast<btScalar>(r(2, 2)));
+}
+
+inline btTransform convertEigenToBt(const Eigen::Isometry3d& t)
+{
+  const Eigen::Matrix3d& rot = t.matrix().block<3, 3>(0, 0);
+  const Eigen::Vector3d& tran = t.translation();
+
+  return btTransform(convertEigenToBt(rot), convertEigenToBt(tran));
+}
+
+/**
+ * @brief This is a tesseract bullet collsion object.
+ *
+ * It is a wrapper around bullet's collision object which
+ * contains specific information related to tesseract
+ */
+class CollisionObjectWrapper : public btCollisionObject
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  CollisionObjectWrapper(const std::string& name, const int& type_id, const std::vector<shapes::ShapeConstPtr>& shapes,
+                         const VectorIsometry3d& shape_poses, const CollisionObjectTypeVector& collision_object_types);
+
+  short int m_collisionFilterGroup;
+  short int m_collisionFilterMask;
+  bool m_enabled;
+
+  /** @brief Get the collision object name */
+  const std::string& getName() const
+  {
+    return m_name;
+  }
+  /** @brief Get a user defined type */
+  const int& getTypeID() const
+  {
+    return m_type_id;
+  }
+  /** \brief Check if two CollisionObjectWrapper objects point to the same source object */
+  bool sameObject(const CollisionObjectWrapper& other) const
+  {
+    return m_name == other.m_name && m_type_id == other.m_type_id && m_shapes.size() == other.m_shapes.size() &&
+           m_shape_poses.size() == other.m_shape_poses.size() &&
+           std::equal(m_shapes.begin(), m_shapes.end(), other.m_shapes.begin()) &&
+           std::equal(m_shape_poses.begin(), m_shape_poses.end(), other.m_shape_poses.begin(),
+                      [](const Eigen::Isometry3d& t1, const Eigen::Isometry3d& t2) { return t1.isApprox(t2); });
+  }
+
+  /**
+   * @brief Get the collision objects axis aligned bounding box
+   * @param aabb_min The minimum point
+   * @param aabb_max The maximum point
+   */
+  void getAABB(btVector3& aabb_min, btVector3& aabb_max) const
+  {
+    getCollisionShape()->getAabb(getWorldTransform(), aabb_min, aabb_max);
+    const btScalar& d = getContactProcessingThreshold();
+    btVector3 contactThreshold(d, d, d);
+    aabb_min -= contactThreshold;
+    aabb_max += contactThreshold;
+  }
+
+  /**
+   * @brief This clones the collision objects but not the collision shape wich is const.
+   * @return Shared Pointer to the cloned collision object
+   */
+  std::shared_ptr<CollisionObjectWrapper> clone()
+  {
+    std::shared_ptr<CollisionObjectWrapper> clone_cow(
+        new CollisionObjectWrapper(m_name, m_type_id, m_shapes, m_shape_poses, m_collision_object_types, m_data));
+    clone_cow->setCollisionShape(getCollisionShape());
+    clone_cow->setWorldTransform(getWorldTransform());
+    clone_cow->m_collisionFilterGroup = m_collisionFilterGroup;
+    clone_cow->m_collisionFilterMask = m_collisionFilterMask;
+    clone_cow->m_enabled = m_enabled;
+    clone_cow->setBroadphaseHandle(nullptr);
+    return clone_cow;
+  }
+
+  template <class T>
+  void manage(T* t)
+  {  // manage memory of this object
+    m_data.push_back(std::shared_ptr<T>(t));
+  }
+  template <class T>
+  void manage(std::shared_ptr<T> t)
+  {
+    m_data.push_back(t);
+  }
+
+protected:
+  /** @brief This is a special constructor used by the clone method */
+  CollisionObjectWrapper(const std::string& name, const int& type_id, const std::vector<shapes::ShapeConstPtr>& shapes,
+                         const VectorIsometry3d& shape_poses, const CollisionObjectTypeVector& collision_object_types,
+                         const std::vector<std::shared_ptr<void>>& data);
+
+  std::string m_name;                                 /**< @brief The name of the collision object */
+  int m_type_id;                                      /**< @brief A user defined type id */
+  std::vector<shapes::ShapeConstPtr> m_shapes;        /**< @brief The shapes that define the collison object */
+  VectorIsometry3d m_shape_poses;                     /**< @brief The shpaes poses information */
+  CollisionObjectTypeVector m_collision_object_types; /**< @brief The shape collision object type to be used */
+
+  std::vector<std::shared_ptr<void>>
+      m_data; /**< @brief This manages the collision shape pointer so they get destroyed */
+};
+
+typedef CollisionObjectWrapper COW;
+typedef std::shared_ptr<CollisionObjectWrapper> COWPtr;
+typedef std::shared_ptr<const CollisionObjectWrapper> COWConstPtr;
+typedef std::map<std::string, COWPtr> Link2Cow;
+typedef std::map<std::string, COWConstPtr> Link2ConstCow;
+
+/** @brief This is a casted collision shape used for checking if an object is collision free between two transforms */
+struct CastHullShape : public btConvexShape
+{
+public:
+  btConvexShape* m_shape;
+  btTransform m_t01;
+
+  CastHullShape(btConvexShape* shape, const btTransform& t01) : m_shape(shape), m_t01(t01)
+  {
+    m_shapeType = CUSTOM_CONVEX_SHAPE_TYPE;
+  }
+
+  void updateCastTransform(const btTransform& t01)
+  {
+    m_t01 = t01;
+  }
+  btVector3 localGetSupportingVertex(const btVector3& vec) const override
+  {
+    btVector3 sv0 = m_shape->localGetSupportingVertex(vec);
+    btVector3 sv1 = m_t01 * m_shape->localGetSupportingVertex(vec * m_t01.getBasis());
+    return (vec.dot(sv0) > vec.dot(sv1)) ? sv0 : sv1;
+  }
+
+  // notice that the vectors should be unit length
+  void batchedUnitVectorGetSupportingVertexWithoutMargin(const btVector3* /*vectors*/,
+                                                         btVector3* /*supportVerticesOut*/,
+                                                         int /*numVectors*/) const override
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  /// getAabb's default implementation is brute force, expected derived classes to implement a fast dedicated version
+  void getAabb(const btTransform& t_w0, btVector3& aabbMin, btVector3& aabbMax) const override
+  {
+    m_shape->getAabb(t_w0, aabbMin, aabbMax);
+    btVector3 min1, max1;
+    m_shape->getAabb(t_w0 * m_t01, min1, max1);
+    aabbMin.setMin(min1);
+    aabbMax.setMax(max1);
+  }
+
+  void getAabbSlow(const btTransform& /*t*/, btVector3& /*aabbMin*/, btVector3& /*aabbMax*/) const override
+  {
+    throw std::runtime_error("shouldn't happen");
+  }
+
+  void setLocalScaling(const btVector3& /*scaling*/) override
+  {
+  }
+  const btVector3& getLocalScaling() const override
+  {
+    static btVector3 out(1, 1, 1);
+    return out;
+  }
+
+  void setMargin(btScalar /*margin*/) override
+  {
+  }
+  btScalar getMargin() const override
+  {
+    return 0;
+  }
+  int getNumPreferredPenetrationDirections() const override
+  {
+    return 0;
+  }
+  void getPreferredPenetrationDirection(int /*index*/, btVector3& /*penetrationVector*/) const override
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  void calculateLocalInertia(btScalar, btVector3&) const override
+  {
+    throw std::runtime_error("not implemented");
+  }
+  const char* getName() const override
+  {
+    return "CastHull";
+  }
+  btVector3 localGetSupportingVertexWithoutMargin(const btVector3& v) const override
+  {
+    return localGetSupportingVertex(v);
+  }
+};
+
+inline void GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, float& outsupport,
+                              btVector3& outpt)
+{
+  btVector3 ptSum(0, 0, 0);
+  float ptCount = 0;
+  float maxSupport = -1000;
+
+  const btPolyhedralConvexShape* pshape = dynamic_cast<const btPolyhedralConvexShape*>(shape);
+  if (pshape)
+  {
+    int nPts = pshape->getNumVertices();
+
+    for (int i = 0; i < nPts; ++i)
+    {
+      btVector3 pt;
+      pshape->getVertex(i, pt);
+
+      float sup = pt.dot(localNormal);
+      if (sup > maxSupport + BULLET_EPSILON)
+      {
+        ptCount = 1;
+        ptSum = pt;
+        maxSupport = sup;
+      }
+      else if (sup < maxSupport - BULLET_EPSILON)
+      {
+      }
+      else
+      {
+        ptCount += 1;
+        ptSum += pt;
+      }
+    }
+    outsupport = maxSupport;
+    outpt = ptSum / ptCount;
+  }
+  else
+  {
+    outpt = shape->localGetSupportingVertexWithoutMargin(localNormal);
+    outsupport = localNormal.dot(outpt);
+  }
+}
+
+/**
+ * @brief This is used to check if a collision check is required between the provided two collision objects
+ * @param cow1 The first collision object
+ * @param cow2 The second collision object
+ * @param acm  The contact allowed function pointer
+ * @param verbose Indicate if verbose information should be printed to the terminal
+ * @return True if the two collision objects should be checked for collision, otherwise false
+ */
+inline bool needsCollisionCheck(const COW& cow1, const COW& cow2, const IsContactAllowedFn acm, bool verbose = false)
+{
+  return cow1.m_enabled && cow2.m_enabled && (cow2.m_collisionFilterGroup & cow1.m_collisionFilterMask) &&
+         (cow1.m_collisionFilterGroup & cow2.m_collisionFilterMask) &&
+         !isContactAllowed(cow1.getName(), cow2.getName(), acm, verbose);
+}
+
+inline btScalar addDiscreteSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap,
+                                        const btCollisionObjectWrapper* colObj1Wrap, ContactTestData& collisions)
+{
+  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject()) != nullptr);
+  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject()) != nullptr);
+  const CollisionObjectWrapper* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());
+  const CollisionObjectWrapper* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());
+
+  ObjectPairKey pc = getObjectPairKey(cd0->getName(), cd1->getName());
+
+  const auto& it = collisions.res.contacts.find(pc);
+  bool found = (it != collisions.res.contacts.end());
+
+  //    size_t l = 0;
+  //    if (found)
+  //    {
+  //      l = it->second.size();
+  //      if (m_collisions.req->type == DistanceRequestType::LIMITED && l >= m_collisions.req->max_contacts_per_body)
+  //          return 0;
+
+  //    }
+
+  collision_detection::Contact contact;
+  contact.body_name_1 = cd0->getName();
+  contact.body_name_2 = cd1->getName();
+  contact.depth = static_cast<double>(cp.m_distance1);
+  contact.normal = convertBtToEigen(-1 * cp.m_normalWorldOnB);
+  contact.pos = convertBtToEigen(cp.m_positionWorldOnA);
+  switch (cd0->getTypeID())
+  {
+    case 0:
+      contact.body_type_1 = collision_detection::BodyType::ROBOT_LINK;
+      break;
+    case 1:
+      contact.body_type_1 = collision_detection::BodyType::ROBOT_ATTACHED;
+      break;
+    case 2:
+      contact.body_type_1 = collision_detection::BodyType::WORLD_OBJECT;
+      break;
+    default:
+      ROS_ERROR_STREAM("No known body type");
+  }
+
+  switch (cd1->getTypeID())
+  {
+    case 0:
+      contact.body_type_2 = collision_detection::BodyType::ROBOT_LINK;
+      break;
+    case 1:
+      contact.body_type_2 = collision_detection::BodyType::ROBOT_ATTACHED;
+      break;
+    case 2:
+      contact.body_type_2 = collision_detection::BodyType::WORLD_OBJECT;
+      break;
+    default:
+      ROS_ERROR_STREAM("No known body type");
+  }
+
+  // contact.body_type_1 = cd0->getTypeID();
+  // contact.body_type_2 = cd1->getTypeID();
+  // contact.nearest_points[2] = convertBtToEigen(cp.m_positionWorldOnB);
+
+  if (!processResult(collisions, contact, pc, found))
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+inline btScalar addCastSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int /*index0*/,
+                                    const btCollisionObjectWrapper* colObj1Wrap, int /*index1*/,
+                                    ContactTestData& collisions)
+{
+  return 1;
+}
+
+/** @brief This is copied directly out of BulletWorld */
+struct TesseractBridgedManifoldResult : public btManifoldResult
+{
+  btCollisionWorld::ContactResultCallback& m_resultCallback;
+
+  TesseractBridgedManifoldResult(const btCollisionObjectWrapper* obj0Wrap, const btCollisionObjectWrapper* obj1Wrap,
+                                 btCollisionWorld::ContactResultCallback& resultCallback)
+    : btManifoldResult(obj0Wrap, obj1Wrap), m_resultCallback(resultCallback)
+  {
+  }
+
+  virtual void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld,
+                               btScalar depth) override
+  {
+    bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
+    btVector3 pointA = pointInWorld + normalOnBInWorld * depth;
+    btVector3 localA;
+    btVector3 localB;
+    if (isSwapped)
+    {
+      localA = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+      localB = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+    }
+    else
+    {
+      localA = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+      localB = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+    }
+
+    btManifoldPoint newPt(localA, localB, normalOnBInWorld, depth);
+    newPt.m_positionWorldOnA = pointA;
+    newPt.m_positionWorldOnB = pointInWorld;
+
+    // BP mod, store contact triangles.
+    if (isSwapped)
+    {
+      newPt.m_partId0 = m_partId1;
+      newPt.m_partId1 = m_partId0;
+      newPt.m_index0 = m_index1;
+      newPt.m_index1 = m_index0;
+    }
+    else
+    {
+      newPt.m_partId0 = m_partId0;
+      newPt.m_partId1 = m_partId1;
+      newPt.m_index0 = m_index0;
+      newPt.m_index1 = m_index1;
+    }
+
+    // experimental feature info, for per-triangle material etc.
+    const btCollisionObjectWrapper* obj0Wrap = isSwapped ? m_body1Wrap : m_body0Wrap;
+    const btCollisionObjectWrapper* obj1Wrap = isSwapped ? m_body0Wrap : m_body1Wrap;
+    m_resultCallback.addSingleResult(newPt, obj0Wrap, newPt.m_partId0, newPt.m_index0, obj1Wrap, newPt.m_partId1,
+                                     newPt.m_index1);
+  }
+};
+
+/** @brief The BroadphaseContactResultCallback is used to report contact points */
+struct BroadphaseContactResultCallback
+{
+  ContactTestData& collisions_;
+  double contact_distance_;
+  bool verbose_;
+
+  BroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false)
+    : collisions_(collisions), contact_distance_(contact_distance), verbose_(verbose)
+  {
+  }
+
+  virtual ~BroadphaseContactResultCallback() = default;
+
+  virtual bool needsCollision(const CollisionObjectWrapper* cow0, const CollisionObjectWrapper* cow1) const
+  {
+    return !collisions_.done && needsCollisionCheck(*cow0, *cow1, collisions_.fn, verbose_);
+  }
+
+  virtual btScalar addSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int partId0,
+                                   int index0, const btCollisionObjectWrapper* colObj1Wrap, int partId1,
+                                   int index1) = 0;
+};
+
+struct DiscreteBroadphaseContactResultCallback : public BroadphaseContactResultCallback
+{
+  DiscreteBroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false)
+    : BroadphaseContactResultCallback(collisions, contact_distance, verbose)
+  {
+  }
+
+  btScalar addSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int /*partId0*/,
+                           int /*index0*/, const btCollisionObjectWrapper* colObj1Wrap, int /*partId1*/,
+                           int /*index1*/) override
+  {
+    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+      return 0;
+
+    return addDiscreteSingleResult(cp, colObj0Wrap, colObj1Wrap, collisions_);
+  }
+};
+
+struct CastBroadphaseContactResultCallback : public BroadphaseContactResultCallback
+{
+  CastBroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false)
+    : BroadphaseContactResultCallback(collisions, contact_distance, verbose)
+  {
+  }
+
+  btScalar addSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int /*partId0*/,
+                           int index0, const btCollisionObjectWrapper* colObj1Wrap, int /*partId1*/,
+                           int index1) override
+  {
+    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+      return 0;
+
+    return addCastSingleResult(cp, colObj0Wrap, index0, colObj1Wrap, index1, collisions_);
+  }
+};
+
+struct TesseractBroadphaseBridgedManifoldResult : public btManifoldResult
+{
+  BroadphaseContactResultCallback& result_callback_;
+
+  TesseractBroadphaseBridgedManifoldResult(const btCollisionObjectWrapper* obj0Wrap,
+                                           const btCollisionObjectWrapper* obj1Wrap,
+                                           BroadphaseContactResultCallback& result_callback)
+    : btManifoldResult(obj0Wrap, obj1Wrap), result_callback_(result_callback)
+  {
+  }
+
+  void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth) override
+  {
+    if (result_callback_.collisions_.done || depth > static_cast<btScalar>(result_callback_.contact_distance_))
+      return;
+
+    bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
+    btVector3 pointA = pointInWorld + normalOnBInWorld * depth;
+    btVector3 localA;
+    btVector3 localB;
+    if (isSwapped)
+    {
+      localA = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+      localB = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+    }
+    else
+    {
+      localA = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+      localB = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+    }
+
+    btManifoldPoint newPt(localA, localB, normalOnBInWorld, depth);
+    newPt.m_positionWorldOnA = pointA;
+    newPt.m_positionWorldOnB = pointInWorld;
+
+    // BP mod, store contact triangles.
+    if (isSwapped)
+    {
+      newPt.m_partId0 = m_partId1;
+      newPt.m_partId1 = m_partId0;
+      newPt.m_index0 = m_index1;
+      newPt.m_index1 = m_index0;
+    }
+    else
+    {
+      newPt.m_partId0 = m_partId0;
+      newPt.m_partId1 = m_partId1;
+      newPt.m_index0 = m_index0;
+      newPt.m_index1 = m_index1;
+    }
+
+    // experimental feature info, for per-triangle material etc.
+    const btCollisionObjectWrapper* obj0Wrap = isSwapped ? m_body1Wrap : m_body0Wrap;
+    const btCollisionObjectWrapper* obj1Wrap = isSwapped ? m_body0Wrap : m_body1Wrap;
+    result_callback_.addSingleResult(newPt, obj0Wrap, newPt.m_partId0, newPt.m_index0, obj1Wrap, newPt.m_partId1,
+                                     newPt.m_index1);
+  }
+};
+
+/**
+ * @brief This is copied directly out of BulletWorld
+ *
+ * This is currently not used but will remain because it is needed
+ * to check a collision object not in the broadphase to the broadphase
+ * which may eventually be exposed.
+*/
+struct TesseractSingleContactCallback : public btBroadphaseAabbCallback
+{
+  btCollisionObject* m_collisionObject;    /**< @brief The bullet collision object */
+  btCollisionDispatcher* m_dispatcher;     /**< @brief The bullet collision dispatcher used for getting object to object
+                                              collison algorithm */
+  const btDispatcherInfo& m_dispatch_info; /**< @brief The bullet collision dispatcher configuration information */
+  btCollisionWorld::ContactResultCallback& m_resultCallback;
+
+  TesseractSingleContactCallback(btCollisionObject* collisionObject, btCollisionDispatcher* dispatcher,
+                                 const btDispatcherInfo& dispatch_info,
+                                 btCollisionWorld::ContactResultCallback& resultCallback)
+    : m_collisionObject(collisionObject)
+    , m_dispatcher(dispatcher)
+    , m_dispatch_info(dispatch_info)
+    , m_resultCallback(resultCallback)
+  {
+  }
+
+  bool process(const btBroadphaseProxy* proxy) override
+  {
+    btCollisionObject* collisionObject = static_cast<btCollisionObject*>(proxy->m_clientObject);
+    if (collisionObject == m_collisionObject)
+      return true;
+
+    if (m_resultCallback.needsCollision(collisionObject->getBroadphaseHandle()))
+    {
+      btCollisionObjectWrapper ob0(nullptr, m_collisionObject->getCollisionShape(), m_collisionObject,
+                                   m_collisionObject->getWorldTransform(), -1, -1);
+      btCollisionObjectWrapper ob1(nullptr, collisionObject->getCollisionShape(), collisionObject,
+                                   collisionObject->getWorldTransform(), -1, -1);
+
+      btCollisionAlgorithm* algorithm = m_dispatcher->findAlgorithm(&ob0, &ob1, nullptr, BT_CLOSEST_POINT_ALGORITHMS);
+      if (algorithm)
+      {
+        TesseractBridgedManifoldResult contactPointResult(&ob0, &ob1, m_resultCallback);
+        contactPointResult.m_closestPointDistanceThreshold = m_resultCallback.m_closestDistanceThreshold;
+
+        // discrete collision detection query
+        algorithm->processCollision(&ob0, &ob1, m_dispatch_info, &contactPointResult);
+
+        algorithm->~btCollisionAlgorithm();
+        m_dispatcher->freeCollisionAlgorithm(algorithm);
+      }
+    }
+    return true;
+  }
+};
+
+/**
+ * @brief A callback function that is called as part of the broadphase collision checking.
+ *
+ * If the AABB of two collision objects are overlapping the processOverlap method is called
+ * and they are checked for collision/distance and the results are stored in collision_.
+ */
+class TesseractCollisionPairCallback : public btOverlapCallback
+{
+  const btDispatcherInfo& dispatch_info_;
+  btCollisionDispatcher* dispatcher_;
+  BroadphaseContactResultCallback& results_callback_;
+
+public:
+  TesseractCollisionPairCallback(const btDispatcherInfo& dispatchInfo, btCollisionDispatcher* dispatcher,
+                                 BroadphaseContactResultCallback& results_callback)
+    : dispatch_info_(dispatchInfo), dispatcher_(dispatcher), results_callback_(results_callback)
+  {
+  }
+
+  ~TesseractCollisionPairCallback() override = default;
+
+  bool processOverlap(btBroadphasePair& pair) override
+  {
+    if (results_callback_.collisions_.done)
+      return false;
+
+    const CollisionObjectWrapper* cow0 = static_cast<const CollisionObjectWrapper*>(pair.m_pProxy0->m_clientObject);
+    const CollisionObjectWrapper* cow1 = static_cast<const CollisionObjectWrapper*>(pair.m_pProxy1->m_clientObject);
+
+    if (results_callback_.needsCollision(cow0, cow1))
+    {
+      btCollisionObjectWrapper obj0Wrap(nullptr, cow0->getCollisionShape(), cow0, cow0->getWorldTransform(), -1, -1);
+      btCollisionObjectWrapper obj1Wrap(nullptr, cow1->getCollisionShape(), cow1, cow1->getWorldTransform(), -1, -1);
+
+      // dispatcher will keep algorithms persistent in the collision pair
+      if (!pair.m_algorithm)
+      {
+        pair.m_algorithm = dispatcher_->findAlgorithm(&obj0Wrap, &obj1Wrap, nullptr, BT_CLOSEST_POINT_ALGORITHMS);
+      }
+
+      if (pair.m_algorithm)
+      {
+        TesseractBroadphaseBridgedManifoldResult contactPointResult(&obj0Wrap, &obj1Wrap, results_callback_);
+        contactPointResult.m_closestPointDistanceThreshold = static_cast<btScalar>(results_callback_.contact_distance_);
+
+        // discrete collision detection query
+        pair.m_algorithm->processCollision(&obj0Wrap, &obj1Wrap, dispatch_info_, &contactPointResult);
+      }
+    }
+    return false;
+  }
+};
+
+btCollisionShape* createShapePrimitive(const shapes::ShapeConstPtr& geom,
+                                       const CollisionObjectType& collision_object_type, CollisionObjectWrapper* cow);
+
+/**
+ * @brief Update a collision objects filters
+ * @param active A list of active collision objects
+ * @param cow The collision object to update.
+ * @param continuous Indicate if the object is a continuous collision object.
+ *
+ * Currently continuous collision objects can only be checked against static objects. Continuous to Continuous
+ * collision checking is currently not supports. TODO LEVI: Add support for Continuous to Continuous collision checking.
+ */
+inline void updateCollisionObjectFilters(const std::vector<std::string>& active, COW& cow, bool continuous)
+{
+  cow.m_collisionFilterGroup = btBroadphaseProxy::KinematicFilter;
+
+  if (!isLinkActive(active, cow.getName()))
+  {
+    cow.m_collisionFilterGroup = btBroadphaseProxy::StaticFilter;
+  }
+
+  if (cow.m_collisionFilterGroup == btBroadphaseProxy::StaticFilter)
+  {
+    cow.m_collisionFilterMask = btBroadphaseProxy::KinematicFilter;
+  }
+  else
+  {
+    (continuous) ? (cow.m_collisionFilterMask = btBroadphaseProxy::StaticFilter) :
+                   (cow.m_collisionFilterMask = btBroadphaseProxy::StaticFilter | btBroadphaseProxy::KinematicFilter);
+  }
+
+  if (cow.getBroadphaseHandle())
+  {
+    cow.getBroadphaseHandle()->m_collisionFilterGroup = cow.m_collisionFilterGroup;
+    cow.getBroadphaseHandle()->m_collisionFilterMask = cow.m_collisionFilterMask;
+  }
+}
+
+inline COWPtr createCollisionObject(const std::string& name, const int& type_id,
+                                    const std::vector<shapes::ShapeConstPtr>& shapes,
+                                    const VectorIsometry3d& shape_poses,
+                                    const CollisionObjectTypeVector& collision_object_types, bool enabled = true)
+{
+  // dont add object that does not have geometry
+  if (shapes.empty() || shape_poses.empty() || (shapes.size() != shape_poses.size()))
+  {
+    ROS_DEBUG("ignoring link %s", name.c_str());
+    return nullptr;
+  }
+
+  COWPtr new_cow(new COW(name, type_id, shapes, shape_poses, collision_object_types));
+
+  new_cow->m_enabled = enabled;
+  new_cow->setContactProcessingThreshold(BULLET_DEFAULT_CONTACT_DISTANCE);
+
+  ROS_DEBUG("Created collision object for link %s", new_cow->getName().c_str());
+  return new_cow;
+}
+
+struct DiscreteCollisionCollector : public btCollisionWorld::ContactResultCallback
+{
+  ContactTestData& collisions_;
+  const COWPtr cow_;
+  double contact_distance_;
+  bool verbose_;
+
+  DiscreteCollisionCollector(ContactTestData& collisions, const COWPtr cow, double contact_distance,
+                             bool verbose = false)
+    : collisions_(collisions), cow_(cow), contact_distance_(contact_distance), verbose_(verbose)
+  {
+    m_closestDistanceThreshold = static_cast<btScalar>(contact_distance);
+    m_collisionFilterGroup = cow->m_collisionFilterGroup;
+    m_collisionFilterMask = cow->m_collisionFilterMask;
+  }
+
+  btScalar addSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int /*partId0*/,
+                           int /*index0*/, const btCollisionObjectWrapper* colObj1Wrap, int /*partId1*/,
+                           int /*index1*/) override
+  {
+    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+    {
+      ROS_DEBUG_STREAM("Not close enough for collision with " << cp.m_distance1);
+      return 0;
+    }
+
+    ROS_DEBUG_STREAM("We have a collision with " << cp.m_distance1);
+    return addDiscreteSingleResult(cp, colObj0Wrap, colObj1Wrap, collisions_);
+  }
+
+  bool needsCollision(btBroadphaseProxy* proxy0) const override
+  {
+    return !collisions_.done &&
+           needsCollisionCheck(*cow_, *(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)), collisions_.fn,
+                               verbose_);
+  }
+};
+
+struct CastCollisionCollector : public btCollisionWorld::ContactResultCallback
+{
+  ContactTestData& collisions_;
+  const COWPtr cow_;
+  double contact_distance_;
+  bool verbose_;
+
+  CastCollisionCollector(ContactTestData& collisions, const COWPtr cow, double contact_distance, bool verbose = false)
+    : collisions_(collisions), cow_(cow), contact_distance_(contact_distance), verbose_(verbose)
+  {
+    m_closestDistanceThreshold = static_cast<btScalar>(contact_distance);
+    m_collisionFilterGroup = cow->m_collisionFilterGroup;
+    m_collisionFilterMask = cow->m_collisionFilterMask;
+  }
+
+  btScalar addSingleResult(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int /*partId0*/,
+                           int index0, const btCollisionObjectWrapper* colObj1Wrap, int /*partId1*/,
+                           int index1) override
+  {
+    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+      return 0;
+
+    return addCastSingleResult(cp, colObj0Wrap, index0, colObj1Wrap, index1, collisions_);
+  }
+
+  bool needsCollision(btBroadphaseProxy* proxy0) const override
+  {
+    return !collisions_.done &&
+           needsCollisionCheck(*cow_, *(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)), collisions_.fn,
+                               verbose_);
+  }
+};
+
+inline COWPtr makeCastCollisionObject(const COWPtr& cow)
+{
+  COWPtr new_cow = cow->clone();
+
+  btTransform tf;
+  tf.setIdentity();
+
+  if (btBroadphaseProxy::isConvex(new_cow->getCollisionShape()->getShapeType()))
+  {
+    assert(dynamic_cast<btConvexShape*>(new_cow->getCollisionShape()) != nullptr);
+    btConvexShape* convex = static_cast<btConvexShape*>(new_cow->getCollisionShape());
+    assert(convex->getShapeType() !=
+           CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if the collision object is already a cast collision object
+
+    CastHullShape* shape = new CastHullShape(convex, tf);
+    assert(shape != nullptr);
+
+    new_cow->manage(shape);
+    new_cow->setCollisionShape(shape);
+  }
+  else if (btBroadphaseProxy::isCompound(new_cow->getCollisionShape()->getShapeType()))
+  {
+    assert(dynamic_cast<btCompoundShape*>(new_cow->getCollisionShape()) != nullptr);
+    btCompoundShape* compound = static_cast<btCompoundShape*>(new_cow->getCollisionShape());
+    btCompoundShape* new_compound =
+        new btCompoundShape(BULLET_COMPOUND_USE_DYNAMIC_AABB, compound->getNumChildShapes());
+
+    for (int i = 0; i < compound->getNumChildShapes(); ++i)
+    {
+      if (btBroadphaseProxy::isConvex(compound->getChildShape(i)->getShapeType()))
+      {
+        btConvexShape* convex = static_cast<btConvexShape*>(compound->getChildShape(i));
+        assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if already a cast collision object
+
+        btTransform geomTrans = compound->getChildTransform(i);
+
+        btCollisionShape* subshape = new CastHullShape(convex, tf);
+        assert(subshape != nullptr);
+
+        new_cow->manage(subshape);
+        subshape->setMargin(BULLET_MARGIN);
+        new_compound->addChildShape(geomTrans, subshape);
+      }
+      else if (btBroadphaseProxy::isCompound(compound->getChildShape(i)->getShapeType()))
+      {
+        btCompoundShape* second_compound = static_cast<btCompoundShape*>(compound->getChildShape(i));
+        btCompoundShape* new_second_compound =
+            new btCompoundShape(BULLET_COMPOUND_USE_DYNAMIC_AABB, second_compound->getNumChildShapes());
+        for (int j = 0; j < second_compound->getNumChildShapes(); ++j)
+        {
+          assert(!btBroadphaseProxy::isCompound(second_compound->getChildShape(j)->getShapeType()));
+          assert(dynamic_cast<btConvexShape*>(second_compound->getChildShape(j)) != nullptr);
+
+          btConvexShape* convex = static_cast<btConvexShape*>(second_compound->getChildShape(j));
+          assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if already a cast collision object
+
+          btTransform geomTrans = second_compound->getChildTransform(j);
+
+          btCollisionShape* subshape = new CastHullShape(convex, tf);
+          assert(subshape != nullptr);
+
+          new_cow->manage(subshape);
+          subshape->setMargin(BULLET_MARGIN);
+          new_second_compound->addChildShape(geomTrans, subshape);
+        }
+
+        btTransform geomTrans = compound->getChildTransform(i);
+
+        new_cow->manage(new_second_compound);
+        new_second_compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to
+                                                        // have no effect when positive
+                                                        // but has an effect when
+                                                        // negative
+
+        new_compound->addChildShape(geomTrans, new_second_compound);
+      }
+      else
+      {
+        throw std::runtime_error("I can only collision check convex shapes and compound shapes made of convex shapes");
+      }
+    }
+
+    new_compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to
+                                             // have no effect when positive
+                                             // but has an effect when
+                                             // negative
+    new_cow->manage(new_compound);
+    new_cow->setCollisionShape(new_compound);
+    new_cow->setWorldTransform(cow->getWorldTransform());
+  }
+  else
+  {
+    throw std::runtime_error("I can only collision check convex shapes and compound shapes made of convex shapes");
+  }
+
+  return new_cow;
+}
+
+/**
+ * @brief Update the Broadphase AABB for the input collision object
+ * @param cow The collision objects
+ * @param broadphase The bullet broadphase interface
+ * @param dispatcher The bullet collision dispatcher
+ */
+inline void updateBroadphaseAABB(const COWPtr& cow, const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                 const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  // Calculate the aabb
+  btVector3 aabb_min, aabb_max;
+  cow->getAABB(aabb_min, aabb_max);
+
+  // Update the broadphase aabb
+  assert(cow->getBroadphaseHandle() != nullptr);
+  broadphase->setAabb(cow->getBroadphaseHandle(), aabb_min, aabb_max, dispatcher.get());
+}
+
+/**
+ * @brief Remove the collision object from broadphase
+ * @param cow The collision objects
+ * @param broadphase The bullet broadphase interface
+ * @param dispatcher The bullet collision dispatcher
+ */
+inline void removeCollisionObjectFromBroadphase(const COWPtr& cow,
+                                                const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                                const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  btBroadphaseProxy* bp = cow->getBroadphaseHandle();
+  if (bp)
+  {
+    // only clear the cached algorithms
+    broadphase->getOverlappingPairCache()->cleanProxyFromPairs(bp, dispatcher.get());
+    broadphase->destroyProxy(bp, dispatcher.get());
+    cow->setBroadphaseHandle(nullptr);
+  }
+}
+
+/**
+ * @brief Add the collision object to broadphase
+ * @param cow The collision objects
+ * @param broadphase The bullet broadphase interface
+ * @param dispatcher The bullet collision dispatcher
+ */
+inline void addCollisionObjectToBroadphase(const COWPtr& cow, const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                           const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  btVector3 aabb_min, aabb_max;
+  cow->getAABB(aabb_min, aabb_max);
+
+  // Add the active collision object to the broadphase
+  int type = cow->getCollisionShape()->getShapeType();
+  cow->setBroadphaseHandle(broadphase->createProxy(aabb_min, aabb_max, type, cow.get(), cow->m_collisionFilterGroup,
+                                                   cow->m_collisionFilterMask, dispatcher.get()));
+}
+}
+}
+#endif  // TESSERACT_COLLISION_BULLET_UTILS_H

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/contact_checker_common.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/contact_checker_common.h
@@ -1,0 +1,302 @@
+/**
+ * @file contact_checker_common.h
+ * @brief This is a collection of common methods
+ *
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COLLISION_CONTACT_CHECKER_COMMON_H
+#define TESSERACT_COLLISION_CONTACT_CHECKER_COMMON_H
+
+#include <moveit/collision_detection_bullet/tesseract/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <LinearMath/btConvexHullComputer.h>
+#include <cstdio>
+#include <Eigen/Geometry>
+#include <fstream>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <moveit/collision_detection_bullet/tesseract/basic_types.h>
+#include <moveit/collision_detection/collision_common.h>
+
+namespace tesseract
+{
+typedef std::pair<std::string, std::string> ObjectPairKey;
+
+/**
+ * @brief Get a key for two object to search the collision matrix
+ * @param obj1 First collision object name
+ * @param obj2 Second collision object name
+ * @return The collision pair key
+ */
+inline ObjectPairKey getObjectPairKey(const std::string& obj1, const std::string& obj2)
+{
+  return obj1 < obj2 ? std::make_pair(obj1, obj2) : std::make_pair(obj2, obj1);
+}
+
+/**
+ * @brief This will check if a link is active provided a list. If the list is empty the link is considered active.
+ * @param active List of active link names
+ * @param name The name of link to check if it is active.
+ */
+inline bool isLinkActive(const std::vector<std::string>& active, const std::string& name)
+{
+  return active.empty() || (std::find(active.begin(), active.end(), name) != active.end());
+}
+
+/**
+ * @brief Determine if contact is allowed between two objects.
+ * @param name1 The name of the first object
+ * @param name2 The name of the second object
+ * @param acm The contact allowed function
+ * @param verbose If true print debug informaton
+ * @return True if contact is allowed between the two object, otherwise false.
+ */
+inline bool isContactAllowed(const std::string& name1, const std::string& name2, const IsContactAllowedFn acm,
+                             bool verbose = false)
+{
+  // do not distance check geoms part of the same object / link / attached body
+  if (name1 == name2)
+    return true;
+
+  if (acm != nullptr && acm(name1, name2))
+  {
+    if (verbose)
+    {
+      ROS_DEBUG("Collision between '%s' and '%s' is allowed. No contacts are computed.", name1.c_str(), name2.c_str());
+    }
+    return true;
+  }
+
+  if (verbose)
+  {
+    ROS_DEBUG("Actually checking collisions between %s and %s", name1.c_str(), name2.c_str());
+  }
+
+  return false;
+}
+
+inline collision_detection::Contact* processResult(ContactTestData& cdata, collision_detection::Contact& contact,
+                                                   const std::pair<std::string, std::string>& key, bool found)
+{
+  if (!found)
+  {
+    std::vector<collision_detection::Contact> data;
+    if (cdata.type == ContactTestType::FIRST)
+    {
+      data.emplace_back(contact);
+      ROS_INFO_STREAM("Contact btw " << key.first << " and " << key.second << " dist: " << contact.depth);
+      cdata.done = true;
+    }
+    else
+    {
+      data.reserve(100);  // TODO: Need better way to initialize this
+      data.emplace_back(contact);
+    }
+
+    return &(cdata.res.contacts.insert(std::make_pair(key, data)).first->second.back());
+  }
+  else
+  {
+    assert(cdata.type != ContactTestType::FIRST);
+    std::vector<collision_detection::Contact>& dr = cdata.res.contacts[key];
+    if (cdata.type == ContactTestType::ALL)
+    {
+      dr.emplace_back(contact);
+      return &(dr.back());
+    }
+    else if (cdata.type == ContactTestType::CLOSEST)
+    {
+      if (contact.depth < dr[0].depth)
+      {
+        dr[0] = contact;
+        return &(dr[0]);
+      }
+    }
+    //    else if (cdata.cdata.condition == DistanceRequestType::LIMITED)
+    //    {
+    //      assert(dr.size() < cdata.req->max_contacts_per_body);
+    //      dr.emplace_back(contact);
+    //      return &(dr.back());
+    //    }
+  }
+
+  return nullptr;
+}
+
+/**
+ * @brief Create a convex hull from vertices using Bullet Convex Hull Computer
+ * @param (Output) vertices A vector of vertices
+ * @param (Output) faces The first values indicates the number of vertices that define the face followed by the vertice
+ * index
+ * @param (input) input A vector of point to create a convex hull from
+ * @param (input) shrink If positive, the convex hull is shrunken by that amount (each face is moved by "shrink" length
+ *                units towards the center along its normal).
+ * @param (input) shrinkClamp If positive, "shrink" is clamped to not exceed "shrinkClamp * innerRadius", where
+ *                "innerRadius" is the minimum distance of a face to the center of the convex hull.
+ * @return The number of faces. If less than zero an error occured when trying to create the convex hull
+ */
+inline int createConvexHull(VectorVector3d& vertices, std::vector<int>& faces, const VectorVector3d& input,
+                            double shrink = -1, double shrinkClamp = -1)
+{
+  vertices.clear();
+  faces.clear();
+
+  btConvexHullComputer conv;
+  btAlignedObjectArray<btVector3> points;
+  points.reserve(static_cast<int>(input.size()));
+  for (const auto& v : input)
+  {
+    points.push_back(btVector3(static_cast<btScalar>(v[0]), static_cast<btScalar>(v[1]), static_cast<btScalar>(v[2])));
+  }
+
+  btScalar val = conv.compute(&points[0].getX(), sizeof(btVector3), points.size(), static_cast<btScalar>(shrink),
+                              static_cast<btScalar>(shrinkClamp));
+  if (val < 0)
+  {
+    ROS_ERROR("Failed to create convex hull");
+    return -1;
+  }
+
+  int num_verts = conv.vertices.size();
+  vertices.reserve(static_cast<size_t>(num_verts));
+  for (int i = 0; i < num_verts; i++)
+  {
+    btVector3& v = conv.vertices[i];
+    vertices.push_back(Eigen::Vector3d(v.getX(), v.getY(), v.getZ()));
+  }
+
+  int num_faces = conv.faces.size();
+  faces.reserve(static_cast<size_t>(3 * num_faces));
+  for (int i = 0; i < num_faces; i++)
+  {
+    std::vector<int> face;
+    face.reserve(3);
+
+    const btConvexHullComputer::Edge* sourceEdge = &(conv.edges[conv.faces[i]]);
+    int a = sourceEdge->getSourceVertex();
+    face.push_back(a);
+
+    int b = sourceEdge->getTargetVertex();
+    face.push_back(b);
+
+    const btConvexHullComputer::Edge* edge = sourceEdge->getNextEdgeOfFace();
+    int c = edge->getTargetVertex();
+    face.push_back(c);
+
+    edge = edge->getNextEdgeOfFace();
+    c = edge->getTargetVertex();
+    while (c != a)
+    {
+      face.push_back(c);
+
+      edge = edge->getNextEdgeOfFace();
+      c = edge->getTargetVertex();
+    }
+    faces.push_back(static_cast<int>(face.size()));
+    faces.insert(faces.end(), face.begin(), face.end());
+  }
+
+  return num_faces;
+}
+
+/**
+ * @brief Write a simple ply file given vertices and faces
+ * @param path The file path
+ * @param vertices A vector of vertices
+ * @param faces The first values indicates the number of vertices that define the face followed by the vertice index
+ * @param num_faces The number of faces
+ * @return False if failed to write file, otherwise true
+ */
+inline bool writeSimplePlyFile(const std::string& path, const VectorVector3d& vertices, const std::vector<int>& faces,
+                               int num_faces)
+{
+  //  ply
+  //  format ascii 1.0           { ascii/binary, format version number }
+  //  comment made by Greg Turk  { comments keyword specified, like all lines }
+  //  comment this file is a cube
+  //  element vertex 8           { define "vertex" element, 8 of them in file }
+  //  property float x           { vertex contains float "x" coordinate }
+  //  property float y           { y coordinate is also a vertex property }
+  //  property float z           { z coordinate, too }
+  //  element face 6             { there are 6 "face" elements in the file }
+  //  property list uchar int vertex_index { "vertex_indices" is a list of ints }
+  //  end_header                 { delimits the end of the header }
+  //  0 0 0                      { start of vertex list }
+  //  0 0 1
+  //  0 1 1
+  //  0 1 0
+  //  1 0 0
+  //  1 0 1
+  //  1 1 1
+  //  1 1 0
+  //  4 0 1 2 3                  { start of face list }
+  //  4 7 6 5 4
+  //  4 0 4 5 1
+  //  4 1 5 6 2
+  //  4 2 6 7 3
+  //  4 3 7 4 0
+  std::ofstream myfile;
+  myfile.open(path);
+  if (myfile.fail())
+  {
+    ROS_ERROR("Failed to open file: %s", path.c_str());
+    return false;
+  }
+
+  myfile << "ply\n";
+  myfile << "format ascii 1.0\n";
+  myfile << "comment made by tesseract\n";
+  myfile << "element vertex " << vertices.size() << "\n";
+  myfile << "property double x\n";
+  myfile << "property double y\n";
+  myfile << "property double z\n";
+  myfile << "element face " << num_faces << "\n";
+  myfile << "property list uchar uint vertex_indices\n";
+  myfile << "end_header\n";
+
+  // Add vertices
+  for (const auto& v : vertices)
+  {
+    myfile << std::fixed << std::setprecision(std::numeric_limits<double>::digits10 + 1) << v[0] << " " << v[1] << " "
+           << v[2] << "\n";
+  }
+
+  // Add faces
+  size_t idx = 0;
+  for (size_t i = 0; i < static_cast<size_t>(num_faces); ++i)
+  {
+    size_t num_vert = static_cast<size_t>(faces[idx]);
+    for (size_t j = 0; j < num_vert; ++j)
+    {
+      myfile << faces[idx] << " ";
+      ++idx;
+    }
+    myfile << faces[idx] << "\n";
+    ++idx;
+  }
+
+  myfile.close();
+  return true;
+}
+}
+
+#endif  // TESSERACT_COLLISION_CONTACT_CHECKER_COMMON_H

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/discrete_contact_manager_base.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/discrete_contact_manager_base.h
@@ -1,0 +1,156 @@
+/**
+ * @file discrete_contact_manager_base.h
+ * @brief This is the discrete contact manager base class
+ *
+ * It should be used to perform discrete contact checking.
+ *
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COLLISION_DISCRETE_CONTACT_MANAGER_BASE_H
+#define TESSERACT_COLLISION_DISCRETE_CONTACT_MANAGER_BASE_H
+
+#include <moveit/collision_detection_bullet/tesseract/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <geometric_shapes/shapes.h>
+#include <memory>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <moveit/collision_detection_bullet/tesseract/basic_types.h>
+
+namespace tesseract
+{
+class DiscreteContactManagerBase
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  virtual ~DiscreteContactManagerBase() = default;
+  /**
+   * @brief Clone the manager
+   *
+   * This is to be used for multi threaded application. A user should
+   * make a cone for each thread.
+   */
+  virtual std::shared_ptr<DiscreteContactManagerBase> clone() const = 0;
+
+  /**
+   * @brief Add a object to the checker
+   * @param name            The name of the object, must be unique.
+   * @param mask_id         User defined id which gets stored in the results structure.
+   * @param shapes          A vector of shapes that make up the collision object.
+   * @param shape_poses     A vector of poses for each shape, must be same length as shapes
+   * @param shape_types     A vector of shape types for encode the collision object. If the vector is of length 1 it is
+   * used for all shapes.
+   * @param collision_object_types A int identifying a conversion mode for the object. (ex. convert meshes to
+   * convex_hulls)
+   * @return true if successfully added, otherwise false.
+   */
+  virtual bool addCollisionObject(const std::string& name, const int& mask_id,
+                                  const std::vector<shapes::ShapeConstPtr>& shapes, const VectorIsometry3d& shape_poses,
+                                  const CollisionObjectTypeVector& collision_object_types, bool enabled = true) = 0;
+
+  /**
+   * @brief Find if a collision object already exists
+   * @param name The name of the collision object
+   * @return true if it exists, otherwise false.
+   */
+  virtual bool hasCollisionObject(const std::string& name) const = 0;
+
+  /**
+   * @brief Remove an object from the checker
+   * @param name The name of the object
+   * @return true if successfully removed, otherwise false.
+   */
+  virtual bool removeCollisionObject(const std::string& name) = 0;
+
+  /**
+   * @brief Enable an object
+   * @param name The name of the object
+   */
+  virtual bool enableCollisionObject(const std::string& name) = 0;
+
+  /**
+   * @brief Disable an object
+   * @param name The name of the object
+   */
+  virtual bool disableCollisionObject(const std::string& name) = 0;
+
+  /**
+   * @brief Set a single collision object's tansforms
+   * @param name The name of the object
+   * @param pose The tranformation in world
+   */
+  virtual void setCollisionObjectsTransform(const std::string& name, const Eigen::Isometry3d& pose) = 0;
+
+  /**
+   * @brief Set a series of collision object's tranforms
+   * @param names The name of the object
+   * @param poses The tranformation in world
+   */
+  virtual void setCollisionObjectsTransform(const std::vector<std::string>& names, const VectorIsometry3d& poses) = 0;
+
+  /**
+   * @brief Set a series of collision object's tranforms
+   * @param transforms A transform map <name, pose>
+   */
+  virtual void setCollisionObjectsTransform(const TransformMap& transforms) = 0;
+
+  /**
+   * @brief Set which collision objects can move
+   * @param names A vector of collision object names
+   */
+  virtual void setActiveCollisionObjects(const std::vector<std::string>& names) = 0;
+
+  /**
+   * @brief Get which collision objects can move
+   * @return A list of collision object names
+   */
+  virtual const std::vector<std::string>& getActiveCollisionObjects() const = 0;
+
+  /**
+   * @brief Set the contact distance threshold for which collision should be considered.
+   * @param contact_distance The contact distance
+   */
+  virtual void setContactDistanceThreshold(double contact_distance) = 0;
+
+  /**
+   * @brief Get the contact distance threshold
+   * @return The contact distance
+   */
+  virtual double getContactDistanceThreshold() const = 0;
+
+  /** @brief Set the active function for determining if two links are allowed to be in collision */
+  virtual void setIsContactAllowedFn(IsContactAllowedFn fn) = 0;
+
+  /** @brief Get the active function for determining if two links are allowed to be in collision */
+  virtual IsContactAllowedFn getIsContactAllowedFn() const = 0;
+
+  /**
+   * @brief Perform a contact test for all objects based
+   * @param collisions The Contact results data
+   */
+  virtual void contactTest(ContactResultMap& collisions, const ContactTestType& type) = 0;
+};
+typedef std::shared_ptr<DiscreteContactManagerBase> DiscreteContactManagerBasePtr;
+typedef std::shared_ptr<const DiscreteContactManagerBase> DiscreteContactManagerBaseConstPtr;
+}
+#endif  // TESSERACT_COLLISION_DISCRETE_CONTACT_MANAGER_BASE_H

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/macros.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/macros.h
@@ -1,0 +1,39 @@
+/**
+ * @file macros.h
+ * @brief The tesseract_core package macros.
+ *
+ * @author Levi Armstrong
+ * @date April 15, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2013, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_CORE_MACROS_H
+#define TESSERACT_CORE_MACROS_H
+#define TESSERACT_IGNORE_WARNINGS_PUSH                                                                                 \
+  _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wall\"")                                           \
+      _Pragma("GCC diagnostic ignored \"-Wint-to-pointer-cast\"")                                                      \
+          _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                                                     \
+              _Pragma("GCC diagnostic ignored \"-Wsuggest-override\"")                                                 \
+                  _Pragma("GCC diagnostic ignored \"-Wconversion\"")                                                   \
+                      _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")                                         \
+                          _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+
+#define TESSERACT_IGNORE_WARNINGS_POP _Pragma("GCC diagnostic pop")
+
+#endif  // TESSERACT_CORE_MACROS_H

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/ros_tesseract_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/tesseract/ros_tesseract_utils.h
@@ -1,0 +1,714 @@
+/**
+ * @file ros_tesseract_utils.h
+ * @brief Tesseract ROS utility functions.
+ *
+ * @author Levi Armstrong
+ * @date April 15, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2013, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_ROS_UTILS_H
+#define TESSERACT_ROS_UTILS_H
+
+#include <moveit/collision_detection_bullet/tesseract/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <octomap_msgs/conversions.h>
+#include <geometric_shapes/shape_messages.h>
+#include <geometric_shapes/shapes.h>
+#include <geometric_shapes/shape_operations.h>
+#include <std_msgs/Int32.h>
+#include <eigen_conversions/eigen_msg.h>
+#include <ros/console.h>
+#include <trajectory_msgs/JointTrajectory.h>
+#include <tesseract_msgs/TesseractState.h>
+#include <tesseract_msgs/ContactResultVector.h>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <moveit/collision_detection_bullet/tesseract/basic_types.h>
+
+namespace tesseract
+{
+namespace tesseract_ros
+{
+static inline bool isMsgEmpty(const sensor_msgs::JointState& msg)
+{
+  return msg.name.empty() && msg.position.empty() && msg.velocity.empty() && msg.effort.empty();
+}
+
+static inline bool isMsgEmpty(const sensor_msgs::MultiDOFJointState& msg)
+{
+  return msg.joint_names.empty() && msg.transforms.empty() && msg.twist.empty() && msg.wrench.empty();
+}
+
+static inline bool isIdentical(const shapes::Shape& shape1, const shapes::Shape& shape2)
+{
+  if (shape1.type != shape2.type)
+    return false;
+
+  switch (shape1.type)
+  {
+    case shapes::BOX:
+    {
+      const shapes::Box& s1 = static_cast<const shapes::Box&>(shape1);
+      const shapes::Box& s2 = static_cast<const shapes::Box&>(shape2);
+
+      for (unsigned i = 0; i < 3; ++i)
+        if (std::abs(s1.size[i] - s2.size[i]) > std::numeric_limits<double>::epsilon())
+          return false;
+
+      break;
+    }
+    case shapes::SPHERE:
+    {
+      const shapes::Sphere& s1 = static_cast<const shapes::Sphere&>(shape1);
+      const shapes::Sphere& s2 = static_cast<const shapes::Sphere&>(shape2);
+
+      if (std::abs(s1.radius - s2.radius) > std::numeric_limits<double>::epsilon())
+        return false;
+
+      break;
+    }
+    case shapes::CYLINDER:
+    {
+      const shapes::Cylinder& s1 = static_cast<const shapes::Cylinder&>(shape1);
+      const shapes::Cylinder& s2 = static_cast<const shapes::Cylinder&>(shape2);
+
+      if (std::abs(s1.radius - s2.radius) > std::numeric_limits<double>::epsilon())
+        return false;
+
+      if (std::abs(s1.length - s2.length) > std::numeric_limits<double>::epsilon())
+        return false;
+
+      break;
+    }
+    case shapes::CONE:
+    {
+      const shapes::Cone& s1 = static_cast<const shapes::Cone&>(shape1);
+      const shapes::Cone& s2 = static_cast<const shapes::Cone&>(shape2);
+
+      if (std::abs(s1.radius - s2.radius) > std::numeric_limits<double>::epsilon())
+        return false;
+
+      if (std::abs(s1.length - s2.length) > std::numeric_limits<double>::epsilon())
+        return false;
+
+      break;
+    }
+    case shapes::MESH:
+    {
+      const shapes::Mesh& s1 = static_cast<const shapes::Mesh&>(shape1);
+      const shapes::Mesh& s2 = static_cast<const shapes::Mesh&>(shape2);
+
+      if (s1.vertex_count != s2.vertex_count)
+        return false;
+
+      if (s1.triangle_count != s2.triangle_count)
+        return false;
+
+      break;
+    }
+    case shapes::OCTREE:
+    {
+      const shapes::OcTree& s1 = static_cast<const shapes::OcTree&>(shape1);
+      const shapes::OcTree& s2 = static_cast<const shapes::OcTree&>(shape2);
+
+      if (s1.octree->getTreeType() != s2.octree->getTreeType())
+        return false;
+
+      if (s1.octree->size() != s2.octree->size())
+        return false;
+
+      if (s1.octree->getTreeDepth() != s2.octree->getTreeDepth())
+        return false;
+
+      if (s1.octree->memoryUsage() != s2.octree->memoryUsage())
+        return false;
+
+      if (s1.octree->memoryFullGrid() != s2.octree->memoryFullGrid())
+        return false;
+
+      break;
+    }
+    default:
+      ROS_ERROR("This geometric shape type (%d) is not supported", static_cast<int>(shape1.type));
+      return false;
+  }
+
+  return true;
+}
+
+static inline bool isIdentical(const AttachableObject& ao1, const AttachableObject& ao2)
+{
+  if (ao1.name != ao2.name)
+    return false;
+
+  // Check Collision
+  if (ao1.collision.collision_object_types.size() != ao2.collision.collision_object_types.size())
+    return false;
+
+  if (ao1.collision.shapes.size() != ao2.collision.shapes.size())
+    return false;
+
+  for (unsigned i = 0; i < ao1.collision.shapes.size(); ++i)
+  {
+    if (!isIdentical(*ao1.collision.shapes[i], *ao2.collision.shapes[i]))
+      return false;
+  }
+
+  if (ao1.collision.shape_colors.size() != ao2.collision.shape_colors.size())
+    return false;
+
+  for (unsigned i = 0; i < ao1.collision.shape_colors.size(); ++i)
+  {
+    for (unsigned j = 0; j < 4; ++j)
+    {
+      if (std::abs(ao1.collision.shape_colors[i][j] - ao2.collision.shape_colors[i][j]) >
+          std::numeric_limits<double>::epsilon())
+        return false;
+    }
+  }
+
+  // Check Visual
+  if (ao1.visual.shapes.size() != ao2.visual.shapes.size())
+    return false;
+
+  for (unsigned i = 0; i < ao1.visual.shapes.size(); ++i)
+  {
+    if (!isIdentical(*ao1.visual.shapes[i], *ao2.visual.shapes[i]))
+      return false;
+  }
+
+  if (ao1.visual.shape_colors.size() != ao2.visual.shape_colors.size())
+    return false;
+
+  for (unsigned i = 0; i < ao1.visual.shape_colors.size(); ++i)
+  {
+    for (unsigned j = 0; j < 4; ++j)
+    {
+      if (std::abs(ao1.visual.shape_colors[i][j] - ao2.visual.shape_colors[i][j]) >
+          std::numeric_limits<double>::epsilon())
+        return false;
+    }
+  }
+
+  return true;
+}
+
+static inline void attachableObjectToAttachableObjectMsg(tesseract_msgs::AttachableObject& ao_msg,
+                                                         const AttachableObject& ao)
+{
+  ao_msg.operation = tesseract_msgs::AttachableObject::ADD;
+  ao_msg.name = ao.name;
+
+  // Visual Geometry
+  for (auto i = 0u; i < ao.visual.shapes.size(); ++i)
+  {
+    if (ao.visual.shapes[i]->type == shapes::MESH)
+    {
+      shapes::ShapeMsg shape_msg;
+      shapes::constructMsgFromShape(ao.visual.shapes[i].get(), shape_msg);
+      ao_msg.visual.meshes.push_back(boost::get<shape_msgs::Mesh>(shape_msg));
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.visual.shape_poses[i], pose);
+      ao_msg.visual.mesh_poses.push_back(pose);
+
+      if (!ao.visual.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.visual.shape_colors[i](0));
+        color.g = static_cast<float>(ao.visual.shape_colors[i](1));
+        color.b = static_cast<float>(ao.visual.shape_colors[i](2));
+        color.a = static_cast<float>(ao.visual.shape_colors[i](3));
+        ao_msg.visual.mesh_colors.push_back(color);
+      }
+    }
+    else if (ao.visual.shapes[i]->type == shapes::OCTREE)
+    {
+      octomap_msgs::Octomap octomap_msg;
+      const shapes::OcTree* o = static_cast<const shapes::OcTree*>(ao.visual.shapes[i].get());
+      octomap_msgs::fullMapToMsg(*o->octree, octomap_msg);
+      ao_msg.visual.octomaps.push_back(octomap_msg);
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.visual.shape_poses[i], pose);
+      ao_msg.visual.octomap_poses.push_back(pose);
+
+      if (!ao.visual.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.visual.shape_colors[i](0));
+        color.g = static_cast<float>(ao.visual.shape_colors[i](1));
+        color.b = static_cast<float>(ao.visual.shape_colors[i](2));
+        color.a = static_cast<float>(ao.visual.shape_colors[i](3));
+        ao_msg.visual.octomap_colors.push_back(color);
+      }
+    }
+    else if (ao.visual.shapes[i]->type == shapes::PLANE)
+    {
+      shapes::ShapeMsg shape_msg;
+      shapes::constructMsgFromShape(ao.visual.shapes[i].get(), shape_msg);
+      ao_msg.visual.planes.push_back(boost::get<shape_msgs::Plane>(shape_msg));
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.visual.shape_poses[i], pose);
+      ao_msg.visual.plane_poses.push_back(pose);
+
+      if (!ao.visual.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.visual.shape_colors[i](0));
+        color.g = static_cast<float>(ao.visual.shape_colors[i](1));
+        color.b = static_cast<float>(ao.visual.shape_colors[i](2));
+        color.a = static_cast<float>(ao.visual.shape_colors[i](3));
+        ao_msg.visual.plane_colors.push_back(color);
+      }
+    }
+    else
+    {
+      shapes::ShapeMsg shape_msg;
+      shapes::constructMsgFromShape(ao.visual.shapes[i].get(), shape_msg);
+      ao_msg.visual.primitives.push_back(boost::get<shape_msgs::SolidPrimitive>(shape_msg));
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.visual.shape_poses[i], pose);
+      ao_msg.visual.primitive_poses.push_back(pose);
+
+      if (!ao.visual.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.visual.shape_colors[i](0));
+        color.g = static_cast<float>(ao.visual.shape_colors[i](1));
+        color.b = static_cast<float>(ao.visual.shape_colors[i](2));
+        color.a = static_cast<float>(ao.visual.shape_colors[i](3));
+        ao_msg.visual.primitive_colors.push_back(color);
+      }
+    }
+  }
+
+  // Collision Geometry
+  for (auto i = 0u; i < ao.collision.shapes.size(); ++i)
+  {
+    if (ao.collision.shapes[i]->type == shapes::MESH)
+    {
+      shapes::ShapeMsg shape_msg;
+      shapes::constructMsgFromShape(ao.collision.shapes[i].get(), shape_msg);
+      ao_msg.collision.meshes.push_back(boost::get<shape_msgs::Mesh>(shape_msg));
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.collision.shape_poses[i], pose);
+      ao_msg.collision.mesh_poses.push_back(pose);
+
+      if (!ao.collision.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.collision.shape_colors[i](0));
+        color.g = static_cast<float>(ao.collision.shape_colors[i](1));
+        color.b = static_cast<float>(ao.collision.shape_colors[i](2));
+        color.a = static_cast<float>(ao.collision.shape_colors[i](3));
+        ao_msg.collision.mesh_colors.push_back(color);
+      }
+
+      std_msgs::Int32 cot;
+      cot.data = ao.collision.collision_object_types[i];
+      ao_msg.collision.mesh_collision_object_types.push_back(cot);
+    }
+    else if (ao.collision.shapes[i]->type == shapes::OCTREE)
+    {
+      octomap_msgs::Octomap octomap_msg;
+      const shapes::OcTree* o = static_cast<const shapes::OcTree*>(ao.collision.shapes[i].get());
+      octomap_msgs::fullMapToMsg(*o->octree, octomap_msg);
+      ao_msg.collision.octomaps.push_back(octomap_msg);
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.collision.shape_poses[i], pose);
+      ao_msg.collision.octomap_poses.push_back(pose);
+
+      if (!ao.collision.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.collision.shape_colors[i](0));
+        color.g = static_cast<float>(ao.collision.shape_colors[i](1));
+        color.b = static_cast<float>(ao.collision.shape_colors[i](2));
+        color.a = static_cast<float>(ao.collision.shape_colors[i](3));
+        ao_msg.collision.octomap_colors.push_back(color);
+      }
+
+      std_msgs::Int32 cot;
+      cot.data = ao.collision.collision_object_types[i];
+      ao_msg.collision.octomap_collision_object_types.push_back(cot);
+    }
+    else if (ao.collision.shapes[i]->type == shapes::PLANE)
+    {
+      shapes::ShapeMsg shape_msg;
+      shapes::constructMsgFromShape(ao.collision.shapes[i].get(), shape_msg);
+      ao_msg.collision.planes.push_back(boost::get<shape_msgs::Plane>(shape_msg));
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.collision.shape_poses[i], pose);
+      ao_msg.collision.plane_poses.push_back(pose);
+
+      if (!ao.collision.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.collision.shape_colors[i](0));
+        color.g = static_cast<float>(ao.collision.shape_colors[i](1));
+        color.b = static_cast<float>(ao.collision.shape_colors[i](2));
+        color.a = static_cast<float>(ao.collision.shape_colors[i](3));
+        ao_msg.collision.plane_colors.push_back(color);
+      }
+
+      std_msgs::Int32 cot;
+      cot.data = ao.collision.collision_object_types[i];
+      ao_msg.collision.plane_collision_object_types.push_back(cot);
+    }
+    else
+    {
+      shapes::ShapeMsg shape_msg;
+      shapes::constructMsgFromShape(ao.collision.shapes[i].get(), shape_msg);
+      ao_msg.collision.primitives.push_back(boost::get<shape_msgs::SolidPrimitive>(shape_msg));
+
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(ao.collision.shape_poses[i], pose);
+      ao_msg.collision.primitive_poses.push_back(pose);
+
+      if (!ao.collision.shape_colors.empty())
+      {
+        std_msgs::ColorRGBA color;
+        color.r = static_cast<float>(ao.collision.shape_colors[i](0));
+        color.g = static_cast<float>(ao.collision.shape_colors[i](1));
+        color.b = static_cast<float>(ao.collision.shape_colors[i](2));
+        color.a = static_cast<float>(ao.collision.shape_colors[i](3));
+        ao_msg.collision.primitive_colors.push_back(color);
+      }
+
+      std_msgs::Int32 cot;
+      cot.data = ao.collision.collision_object_types[i];
+      ao_msg.collision.primitive_collision_object_types.push_back(cot);
+    }
+  }
+}
+
+static inline void attachableObjectToAttachableObjectMsg(tesseract_msgs::AttachableObjectPtr ao_msg,
+                                                         const AttachableObject& ao)
+{
+  attachableObjectToAttachableObjectMsg(*ao_msg, ao);
+}
+
+static inline void attachableObjectMsgToAttachableObject(AttachableObject& ao,
+                                                         const tesseract_msgs::AttachableObject& ao_msg)
+{
+  ao.name = ao_msg.name;
+
+  // Visual Geometry
+  for (auto i = 0u; i < ao_msg.visual.primitives.size(); ++i)
+  {
+    shapes::ShapePtr shape(shapes::constructShapeFromMsg(ao_msg.visual.primitives[i]));
+    ao.visual.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.visual.primitive_poses[i], pose);
+    ao.visual.shape_poses.push_back(pose);
+
+    if (!ao_msg.visual.primitive_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.visual.primitive_colors[i];
+      ao.visual.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+  }
+
+  for (auto i = 0u; i < ao_msg.visual.meshes.size(); ++i)
+  {
+    shapes::ShapePtr shape(shapes::constructShapeFromMsg(ao_msg.visual.meshes[i]));
+    ao.visual.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.visual.mesh_poses[i], pose);
+    ao.visual.shape_poses.push_back(pose);
+
+    if (!ao_msg.visual.mesh_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.visual.mesh_colors[i];
+      ao.visual.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+  }
+
+  for (auto i = 0u; i < ao_msg.visual.planes.size(); ++i)
+  {
+    shapes::ShapePtr shape(shapes::constructShapeFromMsg(ao_msg.visual.planes[i]));
+    ao.visual.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.visual.plane_poses[i], pose);
+    ao.visual.shape_poses.push_back(pose);
+
+    if (!ao_msg.visual.plane_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.visual.plane_colors[i];
+      ao.visual.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+  }
+
+  for (auto i = 0u; i < ao_msg.visual.octomaps.size(); ++i)
+  {
+    std::shared_ptr<octomap::OcTree> om(
+        static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(ao_msg.visual.octomaps[i])));
+    shapes::ShapePtr shape(new shapes::OcTree(om));
+    ao.visual.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.visual.octomap_poses[i], pose);
+    ao.visual.shape_poses.push_back(pose);
+
+    if (!ao_msg.visual.octomap_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.visual.octomap_colors[i];
+      ao.visual.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+  }
+
+  // Collision Geometry
+  for (auto i = 0u; i < ao_msg.collision.primitives.size(); ++i)
+  {
+    shapes::ShapePtr shape(shapes::constructShapeFromMsg(ao_msg.collision.primitives[i]));
+    ao.collision.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.collision.primitive_poses[i], pose);
+    ao.collision.shape_poses.push_back(pose);
+
+    if (!ao_msg.collision.primitive_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.collision.primitive_colors[i];
+      ao.collision.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+
+    ao.collision.collision_object_types.push_back(
+        (CollisionObjectType)ao_msg.collision.primitive_collision_object_types[i].data);
+  }
+
+  for (auto i = 0u; i < ao_msg.collision.meshes.size(); ++i)
+  {
+    shapes::ShapePtr shape(shapes::constructShapeFromMsg(ao_msg.collision.meshes[i]));
+    ao.collision.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.collision.mesh_poses[i], pose);
+    ao.collision.shape_poses.push_back(pose);
+
+    if (!ao_msg.collision.mesh_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.collision.mesh_colors[i];
+      ao.collision.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+
+    ao.collision.collision_object_types.push_back(
+        (CollisionObjectType)ao_msg.collision.mesh_collision_object_types[i].data);
+  }
+
+  for (auto i = 0u; i < ao_msg.collision.planes.size(); ++i)
+  {
+    shapes::ShapePtr shape(shapes::constructShapeFromMsg(ao_msg.collision.planes[i]));
+    ao.collision.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.collision.plane_poses[i], pose);
+    ao.collision.shape_poses.push_back(pose);
+
+    if (!ao_msg.collision.plane_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.collision.plane_colors[i];
+      ao.collision.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+
+    ao.collision.collision_object_types.push_back(
+        (CollisionObjectType)ao_msg.collision.plane_collision_object_types[i].data);
+  }
+
+  for (auto i = 0u; i < ao_msg.collision.octomaps.size(); ++i)
+  {
+    std::shared_ptr<octomap::OcTree> om(
+        static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(ao_msg.collision.octomaps[i])));
+    shapes::ShapePtr shape(new shapes::OcTree(om));
+    ao.collision.shapes.push_back(shape);
+
+    Eigen::Isometry3d pose;
+    tf::poseMsgToEigen(ao_msg.collision.octomap_poses[i], pose);
+    ao.collision.shape_poses.push_back(pose);
+
+    if (!ao_msg.collision.octomap_colors.empty())
+    {
+      const std_msgs::ColorRGBA& c = ao_msg.collision.octomap_colors[i];
+      ao.collision.shape_colors.push_back(Eigen::Vector4d(c.r, c.g, c.b, c.a));
+    }
+
+    ao.collision.collision_object_types.push_back(
+        (CollisionObjectType)ao_msg.collision.octomap_collision_object_types[i].data);
+  }
+}
+
+static inline void attachableObjectMsgToAttachableObject(AttachableObjectPtr ao,
+                                                         const tesseract_msgs::AttachableObject& ao_msg)
+{
+  attachableObjectMsgToAttachableObject(*ao, ao_msg);
+}
+
+static inline void attachedBodyInfoToAttachedBodyInfoMsg(tesseract_msgs::AttachedBodyInfo& ab_info_msg,
+                                                         const AttachedBodyInfo& ab_info)
+{
+  ab_info_msg.operation = tesseract_msgs::AttachedBodyInfo::ADD;
+  ab_info_msg.object_name = ab_info.object_name;
+  ab_info_msg.parent_link_name = ab_info.parent_link_name;
+  tf::poseEigenToMsg(ab_info.transform, ab_info_msg.transform);
+  ab_info_msg.touch_links = ab_info.touch_links;
+}
+
+static inline void attachedBodyInfoToAttachedBodyInfoMsg(tesseract_msgs::AttachedBodyInfoPtr ab_info_msg,
+                                                         const AttachedBodyInfo& ab_info)
+{
+  attachedBodyInfoToAttachedBodyInfoMsg(*ab_info_msg, ab_info);
+}
+
+static inline void attachedBodyInfoMsgToAttachedBodyInfo(AttachedBodyInfo& ab_info,
+                                                         const tesseract_msgs::AttachedBodyInfo& body)
+{
+  ab_info.object_name = body.object_name;
+  ab_info.parent_link_name = body.parent_link_name;
+  tf::poseMsgToEigen(body.transform, ab_info.transform);
+  ab_info.touch_links = body.touch_links;
+}
+
+static inline void tesseractContactResultToContactResultMsg(tesseract_msgs::ContactResult& contact_result_msg,
+                                                            const tesseract::ContactResult& contact_result,
+                                                            const ros::Time& stamp = ros::Time::now())
+{
+  contact_result_msg.stamp = stamp;
+  contact_result_msg.distance = contact_result.distance;
+  contact_result_msg.link_names[0] = contact_result.link_names[0];
+  contact_result_msg.link_names[1] = contact_result.link_names[1];
+  contact_result_msg.normal.x = contact_result.normal[0];
+  contact_result_msg.normal.y = contact_result.normal[1];
+  contact_result_msg.normal.z = contact_result.normal[2];
+  contact_result_msg.nearest_points[0].x = contact_result.nearest_points[0][0];
+  contact_result_msg.nearest_points[0].y = contact_result.nearest_points[0][1];
+  contact_result_msg.nearest_points[0].z = contact_result.nearest_points[0][2];
+  contact_result_msg.nearest_points[1].x = contact_result.nearest_points[1][0];
+  contact_result_msg.nearest_points[1].y = contact_result.nearest_points[1][1];
+  contact_result_msg.nearest_points[1].z = contact_result.nearest_points[1][2];
+  contact_result_msg.cc_time = contact_result.cc_time;
+  contact_result_msg.cc_nearest_points[0].x = contact_result.cc_nearest_points[0][0];
+  contact_result_msg.cc_nearest_points[0].y = contact_result.cc_nearest_points[0][1];
+  contact_result_msg.cc_nearest_points[0].z = contact_result.cc_nearest_points[0][2];
+  contact_result_msg.cc_nearest_points[1].x = contact_result.cc_nearest_points[1][0];
+  contact_result_msg.cc_nearest_points[1].y = contact_result.cc_nearest_points[1][1];
+  contact_result_msg.cc_nearest_points[1].z = contact_result.cc_nearest_points[1][2];
+
+  contact_result_msg.type_id[0] = static_cast<char>(contact_result.type_id[0]);
+  contact_result_msg.type_id[1] = static_cast<char>(contact_result.type_id[1]);
+
+  if (contact_result.cc_type == ContinouseCollisionTypes::CCType_Time0)
+    contact_result_msg.cc_type = 1;
+  else if (contact_result.cc_type == ContinouseCollisionTypes::CCType_Time1)
+    contact_result_msg.cc_type = 2;
+  else if (contact_result.cc_type == ContinouseCollisionTypes::CCType_Between)
+    contact_result_msg.cc_type = 3;
+  else
+    contact_result_msg.cc_type = 0;
+}
+
+static inline void tesseractContactResultToContactResultMsg(tesseract_msgs::ContactResultPtr contact_result_msg,
+                                                            const tesseract::ContactResult& contact_result,
+                                                            const ros::Time& stamp = ros::Time::now())
+{
+  tesseractContactResultToContactResultMsg(*contact_result_msg, contact_result, stamp);
+}
+
+static inline void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
+                                               const urdf::LinkConstSharedPtr urdf_link, bool active)
+{
+  // recursively get all active links
+  if (active)
+  {
+    active_links.push_back(urdf_link->name);
+    for (std::size_t i = 0; i < urdf_link->child_links.size(); ++i)
+    {
+      getActiveLinkNamesRecursive(active_links, urdf_link->child_links[i], active);
+    }
+  }
+  else
+  {
+    for (std::size_t i = 0; i < urdf_link->child_links.size(); ++i)
+    {
+      const urdf::LinkConstSharedPtr child_link = urdf_link->child_links[i];
+      if ((child_link->parent_joint) && (child_link->parent_joint->type != urdf::Joint::FIXED))
+        getActiveLinkNamesRecursive(active_links, child_link, true);
+      else
+        getActiveLinkNamesRecursive(active_links, child_link, active);
+    }
+  }
+}
+
+inline shapes::ShapePtr constructShape(const urdf::Geometry* geom)
+{
+  shapes::Shape* result = nullptr;
+  switch (geom->type)
+  {
+    case urdf::Geometry::SPHERE:
+      result = new shapes::Sphere(static_cast<const urdf::Sphere*>(geom)->radius);
+      break;
+    case urdf::Geometry::BOX:
+    {
+      urdf::Vector3 dim = static_cast<const urdf::Box*>(geom)->dim;
+      result = new shapes::Box(dim.x, dim.y, dim.z);
+    }
+    break;
+    case urdf::Geometry::CYLINDER:
+      result = new shapes::Cylinder(static_cast<const urdf::Cylinder*>(geom)->radius,
+                                    static_cast<const urdf::Cylinder*>(geom)->length);
+      break;
+    case urdf::Geometry::MESH:
+    {
+      const urdf::Mesh* mesh = static_cast<const urdf::Mesh*>(geom);
+      if (!mesh->filename.empty())
+      {
+        Eigen::Vector3d scale(mesh->scale.x, mesh->scale.y, mesh->scale.z);
+        shapes::Mesh* m = shapes::createMeshFromResource(mesh->filename, scale);
+        result = m;
+      }
+    }
+    break;
+    default:
+      ROS_ERROR("Unknown geometry type: %d", static_cast<int>(geom->type));
+      break;
+  }
+
+  return shapes::ShapePtr(result);
+}
+
+inline Eigen::Isometry3d urdfPose2Eigen(const urdf::Pose& pose)
+{
+  Eigen::Quaterniond q(pose.rotation.w, pose.rotation.x, pose.rotation.y, pose.rotation.z);
+  Eigen::Isometry3d result;
+  result.translation() = Eigen::Vector3d(pose.position.x, pose.position.y, pose.position.z);
+  result.linear() = q.toRotationMatrix();
+  return result;
+}
+}
+}
+#endif  // TESSERACT_ROS_UTILS_H

--- a/moveit_core/collision_detection_bullet/src/collision_common.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_common.cpp
@@ -1,0 +1,42 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#include <moveit/collision_detection_bullet/collision_common.h>
+#include <geometric_shapes/shapes.h>
+
+namespace collision_detection
+{
+}  // namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_common.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_common.cpp
@@ -39,4 +39,6 @@
 
 namespace collision_detection
 {
+// TODO: Enable group functionality with active components like in FCL
+
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_detector_bt_plugin_loader.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_detector_bt_plugin_loader.cpp
@@ -1,0 +1,49 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#include <moveit/collision_detection_bullet/collision_detector_bt_plugin_loader.h>
+#include <pluginlib/class_list_macros.h>
+
+namespace collision_detection
+{
+bool CollisionDetectorBtPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const
+{
+  scene->setActiveCollisionDetector(CollisionDetectorAllocatorBt::create(), exclusive);
+  return true;
+}
+}
+
+PLUGINLIB_EXPORT_CLASS(collision_detection::CollisionDetectorBtPluginLoader, collision_detection::CollisionPlugin)

--- a/moveit_core/collision_detection_bullet/src/collision_robot_bt.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_robot_bt.cpp
@@ -35,16 +35,91 @@
 /* Author: Jens Petit */
 
 #include <moveit/collision_detection_bullet/collision_robot_bt.h>
+#include <moveit/collision_detection_bullet/tesseract/ros_tesseract_utils.h>
 
 namespace collision_detection
 {
 CollisionRobotBt::CollisionRobotBt(const robot_model::RobotModelConstPtr& model, double padding, double scale)
   : CollisionRobot(model, padding, scale)
 {
+  for (const auto& link : robot_model_->getURDF()->links_)
+  {
+    if (link.second->collision_array.size() > 0)
+    {
+      const std::vector<urdf::CollisionSharedPtr>& col_array =
+          link.second->collision_array.empty() ? std::vector<urdf::CollisionSharedPtr>(1, link.second->collision) :
+                                                 link.second->collision_array;
+
+      std::vector<shapes::ShapeConstPtr> shapes;
+      tesseract::VectorIsometry3d shape_poses;
+      tesseract::CollisionObjectTypeVector collision_object_types;
+
+      for (std::size_t i = 0; i < col_array.size(); ++i)
+      {
+        if (col_array[i] && col_array[i]->geometry)
+        {
+          shapes::ShapeConstPtr s = tesseract::tesseract_ros::constructShape(col_array[i]->geometry.get());
+          if (s)
+          {
+            shapes.push_back(s);
+            shape_poses.push_back(tesseract::tesseract_ros::urdfPose2Eigen(col_array[i]->origin));
+
+            if (s->type == shapes::MESH)
+              collision_object_types.push_back(tesseract::CollisionObjectType::ConvexHull);
+            else
+              collision_object_types.push_back(tesseract::CollisionObjectType::UseShapeType);
+          }
+        }
+      }
+      bt_manager_.addCollisionObject(link.second->name, BodyType::ROBOT_LINK, shapes, shape_poses,
+                                     collision_object_types, true);
+    }
+  }
 }
 
 CollisionRobotBt::CollisionRobotBt(const CollisionRobotBt& other) : CollisionRobot(other)
 {
+  const CollisionRobotBt& other_bt = dynamic_cast<const CollisionRobotBt&>(other);
+  tesseract::DiscreteContactManagerBasePtr test = other_bt.bt_manager_.clone();
+
+  // TODO: use clone method of manager
+  for (const auto& cow : other_bt.bt_manager_.getCollisionObjects())
+  {
+    tesseract::tesseract_bullet::COWPtr new_cow = cow.second->clone();
+    new_cow->setWorldTransform(cow.second->getWorldTransform());
+
+    new_cow->setContactProcessingThreshold(static_cast<btScalar>(other_bt.bt_manager_.getContactDistanceThreshold()));
+    bt_manager_.addCollisionObject(new_cow);
+
+    bt_manager_.setActiveCollisionObjects(other_bt.bt_manager_.getActiveCollisionObjects());
+    bt_manager_.setContactDistanceThreshold(other_bt.bt_manager_.getContactDistanceThreshold());
+    bt_manager_.setIsContactAllowedFn(other_bt.bt_manager_.getIsContactAllowedFn());
+  }
+}
+
+void CollisionRobotBt::getAttachedBodyObjects(const robot_state::AttachedBody* ab, std::vector<void*>& geoms) const
+{
+  // TODO: Rewrite for using bullet add alll shapes to a single bullet COW. use geoms as output!
+  const std::vector<shapes::ShapeConstPtr>& shapes = ab->getShapes();
+  for (std::size_t i = 0; i < shapes.size(); ++i)
+  {
+  }
+}
+
+void CollisionRobotBt::addAttachedOjectsToManager(const robot_state::RobotState& state) const
+{
+  // TODO: add attached objects to the manager with correct flags using Bullet
+  std::vector<const robot_state::AttachedBody*> ab;
+  state.getAttachedBodies(ab);
+  for (auto& body : ab)
+  {
+    std::vector<void*> objs;
+    getAttachedBodyObjects(body, objs);
+    const EigenSTL::vector_Isometry3d& ab_t = body->getGlobalCollisionBodyTransforms();
+    for (std::size_t k = 0; k < objs.size(); ++k)
+    {
+    }
+  }
 }
 
 void CollisionRobotBt::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
@@ -77,6 +152,20 @@ void CollisionRobotBt::checkSelfCollisionHelper(const CollisionRequest& req, Col
                                                 const robot_state::RobotState& state,
                                                 const AllowedCollisionMatrix* acm) const
 {
+  updateTransformsFromState(state);
+  bt_manager_.contactTest(res, tesseract::ContactTestType::ALL, acm, req);
+
+  if (req.distance)
+  {
+    DistanceRequest dreq;
+    DistanceResult dres;
+
+    dreq.group_name = req.group_name;
+    dreq.acm = acm;
+    dreq.enableGroup(getRobotModel());
+    distanceSelf(dreq, dres, state);
+    res.distance = dres.minimum_distance.distance;
+  }
 }
 
 void CollisionRobotBt::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
@@ -124,6 +213,20 @@ void CollisionRobotBt::checkOtherCollisionHelper(const CollisionRequest& req, Co
 
 void CollisionRobotBt::updatedPaddingOrScaling(const std::vector<std::string>& links)
 {
+  // TODO: add for bullet manager -> iterate through each input link and then construct new object
+  // out of the geometry from the robot
+  for (const auto& link : links)
+  {
+    const robot_model::LinkModel* lmodel = robot_model_->getLinkModel(link);
+    if (lmodel)
+    {
+      for (std::size_t j = 0; j < lmodel->getShapes().size(); ++j)
+      {
+      }
+    }
+    else
+      ROS_ERROR_NAMED("collision_detection.bullet", "Updating padding or scaling for unknown link: '%s'", link.c_str());
+  }
 }
 
 void CollisionRobotBt::distanceSelf(const DistanceRequest& req, DistanceResult& res,
@@ -137,6 +240,17 @@ void CollisionRobotBt::distanceOther(const DistanceRequest& req, DistanceResult&
                                      const robot_state::RobotState& other_state) const
 {
   ROS_ERROR_NAMED("collision_detection.bullet", "Collision distance to other not implemented yet.");
+}
+
+void CollisionRobotBt::updateTransformsFromState(const robot_state::RobotState& state) const
+{
+  // updating link positions with the current robot state
+  for (auto& link : bt_manager_.getCollisionObjects())
+  {
+    // select the first of the transformations for each link (composed of multiple shapes...)
+    // TODO: further investigate if this brings problems
+    bt_manager_.setCollisionObjectsTransform(link.first, state.getCollisionBodyTransform(link.first, 0));
+  }
 }
 
 }  // end of namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_robot_bt.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_robot_bt.cpp
@@ -1,0 +1,142 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#include <moveit/collision_detection_bullet/collision_robot_bt.h>
+
+namespace collision_detection
+{
+CollisionRobotBt::CollisionRobotBt(const robot_model::RobotModelConstPtr& model, double padding, double scale)
+  : CollisionRobot(model, padding, scale)
+{
+}
+
+CollisionRobotBt::CollisionRobotBt(const CollisionRobotBt& other) : CollisionRobot(other)
+{
+}
+
+void CollisionRobotBt::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                          const robot_state::RobotState& state) const
+{
+  checkSelfCollisionHelper(req, res, state, nullptr);
+}
+
+void CollisionRobotBt::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                          const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const
+{
+  checkSelfCollisionHelper(req, res, state, &acm);
+}
+
+void CollisionRobotBt::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                          const robot_state::RobotState& state1,
+                                          const robot_state::RobotState& state2) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet continuous collision checking not yet implemented");
+}
+
+void CollisionRobotBt::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                          const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                          const AllowedCollisionMatrix& acm) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet continuous collision checking not yet implemented");
+}
+
+void CollisionRobotBt::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                const robot_state::RobotState& state,
+                                                const AllowedCollisionMatrix* acm) const
+{
+}
+
+void CollisionRobotBt::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const robot_state::RobotState& state, const CollisionRobot& other_robot,
+                                           const robot_state::RobotState& other_state) const
+{
+  checkOtherCollisionHelper(req, res, state, other_robot, other_state, nullptr);
+}
+
+void CollisionRobotBt::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const robot_state::RobotState& state, const CollisionRobot& other_robot,
+                                           const robot_state::RobotState& other_state,
+                                           const AllowedCollisionMatrix& acm) const
+{
+  checkOtherCollisionHelper(req, res, state, other_robot, other_state, &acm);
+}
+
+void CollisionRobotBt::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                           const CollisionRobot& other_robot,
+                                           const robot_state::RobotState& other_state1,
+                                           const robot_state::RobotState& other_state2) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet continuous collision checking not yet implemented");
+}
+
+void CollisionRobotBt::checkOtherCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                           const CollisionRobot& other_robot,
+                                           const robot_state::RobotState& other_state1,
+                                           const robot_state::RobotState& other_state2,
+                                           const AllowedCollisionMatrix& acm) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet continuous collision checking not yet implemented");
+}
+
+void CollisionRobotBt::checkOtherCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                 const robot_state::RobotState& state,
+                                                 const CollisionRobot& other_robot,
+                                                 const robot_state::RobotState& other_state,
+                                                 const AllowedCollisionMatrix* acm) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Other collision not implemented yet.");
+}
+
+void CollisionRobotBt::updatedPaddingOrScaling(const std::vector<std::string>& links)
+{
+}
+
+void CollisionRobotBt::distanceSelf(const DistanceRequest& req, DistanceResult& res,
+                                    const robot_state::RobotState& state) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Collision distance to self not implemented yet.");
+}
+
+void CollisionRobotBt::distanceOther(const DistanceRequest& req, DistanceResult& res,
+                                     const robot_state::RobotState& state, const CollisionRobot& other_robot,
+                                     const robot_state::RobotState& other_state) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Collision distance to other not implemented yet.");
+}
+
+}  // end of namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_world_bt.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_world_bt.cpp
@@ -1,0 +1,155 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#include <moveit/collision_detection_bullet/collision_world_bt.h>
+#include <moveit/collision_detection_bullet/collision_detector_allocator_bt.h>
+
+#include <boost/bind.hpp>
+
+namespace collision_detection
+{
+const std::string CollisionDetectorAllocatorBt::NAME("Bullet");
+
+CollisionWorldBt::CollisionWorldBt() : CollisionWorld()
+{
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionWorldBt::notifyObjectChange, this, _1, _2));
+}
+
+CollisionWorldBt::CollisionWorldBt(const WorldPtr& world) : CollisionWorld(world)
+{
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionWorldBt::notifyObjectChange, this, _1, _2));
+  getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
+}
+
+CollisionWorldBt::CollisionWorldBt(const CollisionWorldBt& other, const WorldPtr& world) : CollisionWorld(other, world)
+{
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionWorldBt::notifyObjectChange, this, _1, _2));
+}
+
+CollisionWorldBt::~CollisionWorldBt()
+{
+  getWorld()->removeObserver(observer_handle_);
+}
+
+void CollisionWorldBt::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const CollisionRobot& robot, const robot_state::RobotState& state) const
+{
+  checkRobotCollisionHelper(req, res, robot, state, nullptr);
+}
+
+void CollisionWorldBt::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const CollisionRobot& robot, const robot_state::RobotState& state,
+                                           const AllowedCollisionMatrix& acm) const
+{
+  checkRobotCollisionHelper(req, res, robot, state, &acm);
+}
+
+void CollisionWorldBt::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const CollisionRobot& robot, const robot_state::RobotState& state1,
+                                           const robot_state::RobotState& state2) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet continuous collision checking not yet implemented");
+}
+
+void CollisionWorldBt::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const CollisionRobot& robot, const robot_state::RobotState& state1,
+                                           const robot_state::RobotState& state2,
+                                           const AllowedCollisionMatrix& acm) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet continuous collision checking not yet implemented");
+}
+
+void CollisionWorldBt::checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                 const CollisionRobot& robot, const robot_state::RobotState& state,
+                                                 const AllowedCollisionMatrix* acm) const
+{
+}
+
+void CollisionWorldBt::checkWorldCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const CollisionWorld& other_world) const
+{
+  checkWorldCollisionHelper(req, res, other_world, nullptr);
+}
+
+void CollisionWorldBt::checkWorldCollision(const CollisionRequest& req, CollisionResult& res,
+                                           const CollisionWorld& other_world, const AllowedCollisionMatrix& acm) const
+{
+  checkWorldCollisionHelper(req, res, other_world, &acm);
+}
+
+void CollisionWorldBt::checkWorldCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                 const CollisionWorld& other_world,
+                                                 const AllowedCollisionMatrix* acm) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet checking with other world not implemented yet.");
+}
+
+void CollisionWorldBt::setWorld(const WorldPtr& world)
+{
+  if (world == getWorld())
+    return;
+
+  // turn off notifications about old world
+  getWorld()->removeObserver(observer_handle_);
+
+  CollisionWorld::setWorld(world);
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionWorldBt::notifyObjectChange, this, _1, _2));
+
+  // get notifications any objects already in the new world
+  getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
+}
+
+void CollisionWorldBt::notifyObjectChange(const ObjectConstPtr& obj, World::Action action)
+{
+}
+
+void CollisionWorldBt::distanceRobot(const DistanceRequest& req, DistanceResult& res, const CollisionRobot& robot,
+                                     const robot_state::RobotState& state) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet checking with other world not implemented yet.");
+}
+
+void CollisionWorldBt::distanceWorld(const DistanceRequest& req, DistanceResult& res, const CollisionWorld& world) const
+{
+  ROS_ERROR_NAMED("collision_detection.bullet", "Bullet checking with other world not implemented yet.");
+}
+
+}  // end of namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_world_bt.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_world_bt.cpp
@@ -36,8 +36,10 @@
 
 #include <moveit/collision_detection_bullet/collision_world_bt.h>
 #include <moveit/collision_detection_bullet/collision_detector_allocator_bt.h>
+#include <moveit/collision_detection_bullet/tesseract/ros_tesseract_utils.h>
 
 #include <boost/bind.hpp>
+#include <bullet/btBulletCollisionCommon.h>
 
 namespace collision_detection
 {
@@ -58,6 +60,8 @@ CollisionWorldBt::CollisionWorldBt(const WorldPtr& world) : CollisionWorld(world
 
 CollisionWorldBt::CollisionWorldBt(const CollisionWorldBt& other, const WorldPtr& world) : CollisionWorld(other, world)
 {
+  // TODO add copy constructor for new manager
+
   // request notifications about changes to new world
   observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionWorldBt::notifyObjectChange, this, _1, _2));
 }
@@ -99,6 +103,35 @@ void CollisionWorldBt::checkRobotCollisionHelper(const CollisionRequest& req, Co
                                                  const CollisionRobot& robot, const robot_state::RobotState& state,
                                                  const AllowedCollisionMatrix* acm) const
 {
+  const CollisionRobotBt& robot_bt = dynamic_cast<const CollisionRobotBt&>(robot);
+
+  robot_bt.updateTransformsFromState(state);
+
+  tesseract::tesseract_bullet::Link2Cow link2cow;
+  link2cow = robot_bt.bt_manager_.getCollisionObjects();
+
+  for (const auto& cow : link2cow)
+  {
+    if (!bt_manager_.hasCollisionObject(cow.first))
+    {
+      bt_manager_.addCollisionObject(cow.second);
+      ROS_DEBUG_STREAM("Added " << cow.first << " to the bullet manager from robot");
+    }
+  }
+
+  bt_manager_.contactTest(res, tesseract::ContactTestType::ALL, acm, req);
+
+  if (req.distance)
+  {
+    DistanceRequest dreq;
+    DistanceResult dres;
+
+    dreq.group_name = req.group_name;
+    dreq.acm = acm;
+    dreq.enableGroup(robot.getRobotModel());
+    distanceRobot(dreq, dres, robot, state);
+    res.distance = dres.minimum_distance.distance;
+  }
 }
 
 void CollisionWorldBt::checkWorldCollision(const CollisionRequest& req, CollisionResult& res,
@@ -120,6 +153,50 @@ void CollisionWorldBt::checkWorldCollisionHelper(const CollisionRequest& req, Co
   ROS_ERROR_NAMED("collision_detection.bullet", "Bullet checking with other world not implemented yet.");
 }
 
+void CollisionWorldBt::addToManager(const World::Object* obj) const
+{
+  tesseract::CollisionObjectTypeVector collision_object_types;
+
+  for (auto shape : obj->shapes_)
+  {
+    if (shape->type == shapes::MESH)
+      collision_object_types.push_back(tesseract::CollisionObjectType::ConvexHull);
+    else
+      collision_object_types.push_back(tesseract::CollisionObjectType::UseShapeType);
+  }
+
+  // TODO: Mask id -> 0 what exactly do with it
+  bt_manager_.addCollisionObject(obj->id_, 0, obj->shapes_, obj->shape_poses_, collision_object_types, true);
+}
+
+void CollisionWorldBt::updateManagedObject(const std::string& id)
+{
+  // we have three cases: 1) the object is part of the manager and not of world --> delete it
+  //                      2) the object is not in the manager, therefore register to manager,
+  //                      3) the object is in the manager then delete and add the modified
+
+  if (getWorld()->hasObject(id))
+  {
+    auto it = getWorld()->find(id);
+    if (bt_manager_.hasCollisionObject(id))
+    {
+      bt_manager_.removeCollisionObject(id);
+      addToManager(it->second.get());
+    }
+    else
+    {
+      addToManager(it->second.get());
+    }
+  }
+  else
+  {
+    if (bt_manager_.hasCollisionObject(id))
+    {
+      bt_manager_.removeCollisionObject(id);
+    }
+  }
+}
+
 void CollisionWorldBt::setWorld(const WorldPtr& world)
 {
   if (world == getWorld())
@@ -139,6 +216,14 @@ void CollisionWorldBt::setWorld(const WorldPtr& world)
 
 void CollisionWorldBt::notifyObjectChange(const ObjectConstPtr& obj, World::Action action)
 {
+  if (action == World::DESTROY)
+  {
+    bt_manager_.removeCollisionObject(obj->id_);
+  }
+  else
+  {
+    updateManagedObject(obj->id_);
+  }
 }
 
 void CollisionWorldBt::distanceRobot(const DistanceRequest& req, DistanceResult& res, const CollisionRobot& robot,

--- a/moveit_core/collision_detection_bullet/src/tesseract/bullet_discrete_simple_manager.cpp
+++ b/moveit_core/collision_detection_bullet/src/tesseract/bullet_discrete_simple_manager.cpp
@@ -1,0 +1,369 @@
+/**
+ * @file bullet_discrete_simple_manager.cpp
+ * @brief Tesseract ROS Bullet Discrete Simple Manager implementation.
+ *
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (BSD-2-Clause)
+ * @par
+ * All rights reserved.
+ * @par
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * @par
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * @par
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "moveit/collision_detection_bullet/tesseract/bullet_discrete_simple_manager.h"
+
+namespace tesseract
+{
+namespace tesseract_bullet
+{
+BulletDiscreteSimpleManager::BulletDiscreteSimpleManager()
+{
+  dispatcher_.reset(new btCollisionDispatcher(&coll_config_));
+
+  dispatcher_->registerCollisionCreateFunc(
+      BOX_SHAPE_PROXYTYPE, BOX_SHAPE_PROXYTYPE,
+      coll_config_.getCollisionAlgorithmCreateFunc(CONVEX_SHAPE_PROXYTYPE, CONVEX_SHAPE_PROXYTYPE));
+
+  dispatcher_->setDispatcherFlags(dispatcher_->getDispatcherFlags() &
+                                  ~btCollisionDispatcher::CD_USE_RELATIVE_CONTACT_BREAKING_THRESHOLD);
+
+  contact_distance_ = 0;
+}
+
+DiscreteContactManagerBasePtr BulletDiscreteSimpleManager::clone() const
+{
+  BulletDiscreteSimpleManagerPtr manager(new BulletDiscreteSimpleManager());
+
+  for (const auto& cow : link2cow_)
+  {
+    COWPtr new_cow = cow.second->clone();
+
+    assert(new_cow->getCollisionShape());
+    assert(new_cow->getCollisionShape()->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);
+
+    new_cow->setWorldTransform(cow.second->getWorldTransform());
+
+    new_cow->setContactProcessingThreshold(static_cast<btScalar>(contact_distance_));
+    manager->addCollisionObject(new_cow);
+  }
+
+  manager->setActiveCollisionObjects(active_);
+  manager->setContactDistanceThreshold(contact_distance_);
+  manager->setIsContactAllowedFn(fn_);
+
+  return manager;
+}
+
+bool BulletDiscreteSimpleManager::addCollisionObject(const std::string& name, const int& mask_id,
+                                                     const std::vector<shapes::ShapeConstPtr>& shapes,
+                                                     const VectorIsometry3d& shape_poses,
+                                                     const CollisionObjectTypeVector& collision_object_types,
+                                                     bool enabled)
+{
+  COWPtr new_cow = createCollisionObject(name, mask_id, shapes, shape_poses, collision_object_types, enabled);
+  if (new_cow != nullptr)
+  {
+    addCollisionObject(new_cow);
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool BulletDiscreteSimpleManager::hasCollisionObject(const std::string& name) const
+{
+  return (link2cow_.find(name) != link2cow_.end());
+}
+
+bool BulletDiscreteSimpleManager::removeCollisionObject(const std::string& name)
+{
+  auto it = link2cow_.find(name);
+  if (it != link2cow_.end())
+  {
+    cows_.erase(std::find(cows_.begin(), cows_.end(), it->second));
+    link2cow_.erase(name);
+    return true;
+  }
+
+  return false;
+}
+
+bool BulletDiscreteSimpleManager::enableCollisionObject(const std::string& name)
+{
+  auto it = link2cow_.find(name);
+  if (it != link2cow_.end())
+  {
+    it->second->m_enabled = true;
+    return true;
+  }
+  return false;
+}
+
+bool BulletDiscreteSimpleManager::disableCollisionObject(const std::string& name)
+{
+  auto it = link2cow_.find(name);
+  if (it != link2cow_.end())
+  {
+    it->second->m_enabled = false;
+    return true;
+  }
+  return false;
+}
+
+void BulletDiscreteSimpleManager::setCollisionObjectsTransform(const std::string& name, const Eigen::Isometry3d& pose)
+{
+  // TODO: Find a way to remove this check. Need to store information in Tesseract EnvState indicating transforms with
+  // geometry
+  auto it = link2cow_.find(name);
+  if (it != link2cow_.end())
+    it->second->setWorldTransform(convertEigenToBt(pose));
+}
+
+void BulletDiscreteSimpleManager::setCollisionObjectsTransform(const std::vector<std::string>& names,
+                                                               const VectorIsometry3d& poses)
+{
+  assert(names.size() == poses.size());
+  for (auto i = 0u; i < names.size(); ++i)
+    setCollisionObjectsTransform(names[i], poses[i]);
+}
+
+void BulletDiscreteSimpleManager::setCollisionObjectsTransform(const TransformMap& transforms)
+{
+  for (const auto& transform : transforms)
+    setCollisionObjectsTransform(transform.first, transform.second);
+}
+
+void BulletDiscreteSimpleManager::setActiveCollisionObjects(const std::vector<std::string>& names)
+{
+  active_ = names;
+  cows_.clear();
+  cows_.reserve(link2cow_.size());
+
+  for (auto& co : link2cow_)
+  {
+    COWPtr& cow = co.second;
+
+    updateCollisionObjectFilters(active_, *cow, false);
+
+    // Update collision object vector
+    if (cow->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
+      cows_.insert(cows_.begin(), cow);
+    else
+      cows_.push_back(cow);
+  }
+}
+
+const std::vector<std::string>& BulletDiscreteSimpleManager::getActiveCollisionObjects() const
+{
+  return active_;
+}
+void BulletDiscreteSimpleManager::setContactDistanceThreshold(double contact_distance)
+{
+  contact_distance_ = contact_distance;
+
+  for (auto& co : link2cow_)
+    co.second->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
+}
+
+double BulletDiscreteSimpleManager::getContactDistanceThreshold() const
+{
+  return contact_distance_;
+}
+void BulletDiscreteSimpleManager::setIsContactAllowedFn(IsContactAllowedFn fn)
+{
+  fn_ = fn;
+}
+IsContactAllowedFn BulletDiscreteSimpleManager::getIsContactAllowedFn() const
+{
+  return fn_;
+}
+void BulletDiscreteSimpleManager::contactTest(ContactResultMap& collisions, const ContactTestType& type)
+{
+  ROS_ERROR_STREAM("Not implemented, superseeded by adapted version for moveit");
+}
+
+void BulletDiscreteSimpleManager::contactTest(collision_detection::CollisionResult& collisions,
+                                              const ContactTestType& type,
+                                              const collision_detection::AllowedCollisionMatrix* acm,
+                                              const collision_detection::CollisionRequest& req)
+{
+  ContactTestData cdata(active_, contact_distance_, fn_, type, collisions);
+
+  ROS_DEBUG_STREAM("Printing all cows");
+  for (auto& cow : cows_)
+  {
+    ROS_DEBUG_STREAM(cow->getName());
+  }
+
+  for (auto cow1_iter = cows_.begin(); cow1_iter != (cows_.end() - 1); cow1_iter++)
+  {
+    const COWPtr& cow1 = *cow1_iter;
+
+    ROS_DEBUG_STREAM("On COW " << cow1->getName());
+
+    if (cow1->m_collisionFilterGroup != btBroadphaseProxy::KinematicFilter)
+    {
+      break;
+    }
+
+    if (!cow1->m_enabled)
+    {
+      continue;
+    }
+
+    btVector3 min_aabb[2], max_aabb[2];
+    cow1->getAABB(min_aabb[0], max_aabb[0]);
+
+    btCollisionObjectWrapper obA(nullptr, cow1->getCollisionShape(), cow1.get(), cow1->getWorldTransform(), -1, -1);
+
+    DiscreteCollisionCollector cc(cdata, cow1, static_cast<double>(cow1->getContactProcessingThreshold()));
+
+    collision_detection::AllowedCollision::Type allowed_type;
+    for (auto cow2_iter = cow1_iter + 1; cow2_iter != cows_.end(); cow2_iter++)
+    {
+      assert(!cdata.done);
+
+      const COWPtr& cow2 = *cow2_iter;
+      cow2->getAABB(min_aabb[1], max_aabb[1]);
+
+      if (acm)
+      {
+        if (acm->getEntry(cow1->getName(), cow2->getName(), allowed_type))
+        {
+          if (allowed_type == collision_detection::AllowedCollision::Type::NEVER)
+          {
+            ROS_DEBUG_STREAM("Not allowed entry in ACM found, collision check between " << cow1->getName() << " and "
+                                                                                        << cow2->getName());
+          }
+          else
+          {
+            ROS_DEBUG_STREAM("Entry in ACM found, skipping collision check as allowed " << cow1->getName() << " and "
+                                                                                        << cow2->getName());
+            continue;
+          }
+        }
+        else
+        {
+          ROS_DEBUG_STREAM("No entry in ACM found, collision check between " << cow1->getName() << " and "
+                                                                             << cow2->getName());
+        }
+      }
+      else
+      {
+        ROS_DEBUG_STREAM("No ACM, collision check between " << cow1->getName() << " and " << cow2->getName());
+      }
+
+      bool aabb_check = (min_aabb[0][0] <= max_aabb[1][0] && max_aabb[0][0] >= min_aabb[1][0]) &&
+                        (min_aabb[0][1] <= max_aabb[1][1] && max_aabb[0][1] >= min_aabb[1][1]) &&
+                        (min_aabb[0][2] <= max_aabb[1][2] && max_aabb[0][2] >= min_aabb[1][2]);
+
+      if (aabb_check)
+      {
+        bool needs_collision = needsCollisionCheck(*cow1, *cow2, fn_, false);
+
+        if (needs_collision)
+        {
+          ROS_DEBUG_STREAM("Check will execute, cdata: done, " << (cdata.done ? "true | " : "false | ")
+                                                               << cow1->getName() << " | " << cow2->getName());
+
+          btCollisionObjectWrapper obB(nullptr, cow2->getCollisionShape(), cow2.get(), cow2->getWorldTransform(), -1,
+                                       -1);
+
+          btCollisionAlgorithm* algorithm =
+              dispatcher_->findAlgorithm(&obA, &obB, nullptr, BT_CLOSEST_POINT_ALGORITHMS);
+          assert(algorithm != nullptr);
+
+          if (algorithm)
+          {
+            TesseractBridgedManifoldResult contactPointResult(&obA, &obB, cc);
+            contactPointResult.m_closestPointDistanceThreshold = cc.m_closestDistanceThreshold;
+
+            // discrete collision detection query
+            algorithm->processCollision(&obA, &obB, dispatch_info_, &contactPointResult);
+
+            algorithm->~btCollisionAlgorithm();
+            dispatcher_->freeCollisionAlgorithm(algorithm);
+          }
+          else
+          {
+            ROS_ERROR_STREAM("Could not find right algorithm for objects!");
+          }
+        }
+      }
+
+      if (collisions.contacts.size() >= req.max_contacts)
+      {
+        if (!req.cost)
+        {
+          cdata.done = true;
+        }
+        ROS_INFO_NAMED("collision_detection.fcl",
+                       "Collision checking is considered complete (collision was found and %u contacts are stored)",
+                       (unsigned int)collisions.contact_count);
+      }
+
+      if (cdata.done)
+      {
+        break;
+      }
+    }
+    if (cdata.done)
+    {
+      break;
+    }
+  }
+
+  collisions.collision = !collisions.contacts.empty();
+  collisions.contact_count = collisions.contacts.size();
+
+  ROS_DEBUG_STREAM((collisions.collision ? "In" : "No") << " collision with " << collisions.contact_count << " collisio"
+                                                                                                             "ns");
+}
+
+void BulletDiscreteSimpleManager::addCollisionObject(const COWPtr& cow)
+{
+  link2cow_[cow->getName()] = cow;
+
+  if (cow->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
+    cows_.insert(cows_.begin(), cow);
+  else
+    cows_.push_back(cow);
+}
+
+const Link2Cow& BulletDiscreteSimpleManager::getCollisionObjects() const
+{
+  return link2cow_;
+}
+}
+}

--- a/moveit_core/collision_detection_bullet/src/tesseract/bullet_utils.cpp
+++ b/moveit_core/collision_detection_bullet/src/tesseract/bullet_utils.cpp
@@ -1,0 +1,347 @@
+/**
+ * @file bullet_utils.cpp
+ * @brief Tesseract ROS Bullet environment utility function.
+ *
+ * @author John Schulman
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ * @copyright Copyright (c) 2013, John Schulman
+ *
+ * @par License
+ * Software License Agreement (BSD-2-Clause)
+ * @par
+ * All rights reserved.
+ * @par
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * @par
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * @par
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "moveit/collision_detection_bullet/tesseract/bullet_utils.h"
+
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.h>
+#include <BulletCollision/CollisionShapes/btShapeHull.h>
+#include <BulletCollision/Gimpact/btGImpactShape.h>
+#include <boost/thread/mutex.hpp>
+#include <geometric_shapes/shapes.h>
+#include <memory>
+#include <octomap/octomap.h>
+#include <ros/console.h>
+TESSERACT_IGNORE_WARNINGS_POP
+
+namespace tesseract
+{
+namespace tesseract_bullet
+{
+btCollisionShape* createShapePrimitive(const shapes::Box* geom, const CollisionObjectType& collision_object_type)
+{
+  assert(collision_object_type == CollisionObjectType::UseShapeType);
+  const double* size = geom->size;
+  btScalar a = static_cast<btScalar>(size[0] / 2);
+  btScalar b = static_cast<btScalar>(size[1] / 2);
+  btScalar c = static_cast<btScalar>(size[2] / 2);
+
+  return (new btBoxShape(btVector3(a, b, c)));
+}
+
+btCollisionShape* createShapePrimitive(const shapes::Sphere* geom, const CollisionObjectType& collision_object_type)
+{
+  assert(collision_object_type == CollisionObjectType::UseShapeType);
+  return (new btSphereShape(static_cast<btScalar>(geom->radius)));
+}
+
+btCollisionShape* createShapePrimitive(const shapes::Cylinder* geom, const CollisionObjectType& collision_object_type)
+{
+  assert(collision_object_type == CollisionObjectType::UseShapeType);
+  btScalar r = static_cast<btScalar>(geom->radius);
+  btScalar l = static_cast<btScalar>(geom->length / 2);
+  return (new btCylinderShapeZ(btVector3(r, r, l)));
+}
+
+btCollisionShape* createShapePrimitive(const shapes::Cone* geom, const CollisionObjectType& collision_object_type)
+{
+  assert(collision_object_type == CollisionObjectType::UseShapeType);
+  btScalar r = static_cast<btScalar>(geom->radius);
+  btScalar l = static_cast<btScalar>(geom->length);
+  return (new btConeShapeZ(r, l));
+}
+
+btCollisionShape* createShapePrimitive(const shapes::Mesh* geom, const CollisionObjectType& collision_object_type,
+                                       CollisionObjectWrapper* cow)
+{
+  assert(collision_object_type == CollisionObjectType::UseShapeType ||
+         collision_object_type == CollisionObjectType::ConvexHull || collision_object_type == CollisionObjectType::SDF);
+
+  if (geom->vertex_count > 0 && geom->triangle_count > 0)
+  {
+    // convert the mesh to the assigned collision object type
+    switch (collision_object_type)
+    {
+      case CollisionObjectType::ConvexHull:
+      {
+        // Create a convex hull shape to approximate Trimesh
+        tesseract::VectorVector3d input;
+        tesseract::VectorVector3d vertices;
+        std::vector<int> faces;
+
+        input.reserve(geom->vertex_count);
+        for (unsigned int i = 0; i < geom->vertex_count; ++i)
+          input.push_back(Eigen::Vector3d(geom->vertices[3 * i], geom->vertices[3 * i + 1], geom->vertices[3 * i + 2]));
+
+        if (tesseract::createConvexHull(vertices, faces, input) < 0)
+          return nullptr;
+
+        btConvexHullShape* subshape = new btConvexHullShape();
+        for (const auto& v : vertices)
+          subshape->addPoint(
+              btVector3(static_cast<btScalar>(v[0]), static_cast<btScalar>(v[1]), static_cast<btScalar>(v[2])));
+
+        return subshape;
+      }
+      case CollisionObjectType::UseShapeType:
+      {
+        btCompoundShape* compound =
+            new btCompoundShape(BULLET_COMPOUND_USE_DYNAMIC_AABB, static_cast<int>(geom->triangle_count));
+        compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to have no
+                                             // effect when positive but has an
+                                             // effect when negative
+
+        for (unsigned i = 0; i < geom->triangle_count; ++i)
+        {
+          btVector3 v[3];
+          for (unsigned x = 0; x < 3; ++x)
+          {
+            unsigned idx = geom->triangles[3 * i + x];
+            for (unsigned y = 0; y < 3; ++y)
+            {
+              v[x][y] = static_cast<btScalar>(geom->vertices[3 * idx + y]);
+            }
+          }
+
+          btCollisionShape* subshape = new btTriangleShapeEx(v[0], v[1], v[2]);
+          if (subshape != nullptr)
+          {
+            cow->manage(subshape);
+            subshape->setMargin(BULLET_MARGIN);
+            btTransform geomTrans;
+            geomTrans.setIdentity();
+            compound->addChildShape(geomTrans, subshape);
+          }
+        }
+
+        return compound;
+      }
+      default:
+      {
+        ROS_ERROR("This bullet shape type (%d) is not supported for geometry meshs",
+                  static_cast<int>(collision_object_type));
+        return nullptr;
+      }
+    }
+  }
+  ROS_ERROR("The mesh is empty!");
+  return nullptr;
+}
+
+btCollisionShape* createShapePrimitive(const shapes::OcTree* geom, const CollisionObjectType& collision_object_type,
+                                       CollisionObjectWrapper* cow)
+{
+  assert(collision_object_type == CollisionObjectType::UseShapeType ||
+         collision_object_type == CollisionObjectType::ConvexHull ||
+         collision_object_type == CollisionObjectType::SDF ||
+         collision_object_type == CollisionObjectType::MultiSphere);
+
+  btCompoundShape* subshape =
+      new btCompoundShape(BULLET_COMPOUND_USE_DYNAMIC_AABB, static_cast<int>(geom->octree->size()));
+  double occupancy_threshold = geom->octree->getOccupancyThres();
+
+  // convert the mesh to the assigned collision object type
+  switch (collision_object_type)
+  {
+    case CollisionObjectType::UseShapeType:
+    {
+      for (auto it = geom->octree->begin(static_cast<unsigned char>(geom->octree->getTreeDepth())),
+                end = geom->octree->end();
+           it != end; ++it)
+      {
+        if (it->getOccupancy() >= occupancy_threshold)
+        {
+          double size = it.getSize();
+          btTransform geomTrans;
+          geomTrans.setIdentity();
+          geomTrans.setOrigin(btVector3(static_cast<btScalar>(it.getX()), static_cast<btScalar>(it.getY()),
+                                        static_cast<btScalar>(it.getZ())));
+          btScalar l = static_cast<btScalar>(size / 2);
+          btBoxShape* childshape = new btBoxShape(btVector3(l, l, l));
+          childshape->setMargin(BULLET_MARGIN);
+          cow->manage(childshape);
+
+          subshape->addChildShape(geomTrans, childshape);
+        }
+      }
+      return subshape;
+    }
+    case CollisionObjectType::MultiSphere:
+    {
+      for (auto it = geom->octree->begin(static_cast<unsigned char>(geom->octree->getTreeDepth())),
+                end = geom->octree->end();
+           it != end; ++it)
+      {
+        if (it->getOccupancy() >= occupancy_threshold)
+        {
+          double size = it.getSize();
+          btTransform geomTrans;
+          geomTrans.setIdentity();
+          geomTrans.setOrigin(btVector3(static_cast<btScalar>(it.getX()), static_cast<btScalar>(it.getY()),
+                                        static_cast<btScalar>(it.getZ())));
+          btSphereShape* childshape =
+              new btSphereShape(static_cast<btScalar>(std::sqrt(2 * ((size / 2) * (size / 2)))));
+          childshape->setMargin(BULLET_MARGIN);
+          cow->manage(childshape);
+
+          subshape->addChildShape(geomTrans, childshape);
+        }
+      }
+      return subshape;
+    }
+    default:
+    {
+      ROS_ERROR("This bullet shape type (%d) is not supported for geometry octree",
+                static_cast<int>(collision_object_type));
+      return nullptr;
+    }
+  }
+}
+
+btCollisionShape* createShapePrimitive(const shapes::ShapeConstPtr& geom,
+                                       const CollisionObjectType& collision_object_type, CollisionObjectWrapper* cow)
+{
+  switch (geom->type)
+  {
+    case shapes::BOX:
+    {
+      return createShapePrimitive(static_cast<const shapes::Box*>(geom.get()), collision_object_type);
+    }
+    case shapes::SPHERE:
+    {
+      return createShapePrimitive(static_cast<const shapes::Sphere*>(geom.get()), collision_object_type);
+    }
+    case shapes::CYLINDER:
+    {
+      return createShapePrimitive(static_cast<const shapes::Cylinder*>(geom.get()), collision_object_type);
+    }
+    case shapes::CONE:
+    {
+      return createShapePrimitive(static_cast<const shapes::Cone*>(geom.get()), collision_object_type);
+    }
+    case shapes::MESH:
+    {
+      return createShapePrimitive(static_cast<const shapes::Mesh*>(geom.get()), collision_object_type, cow);
+    }
+    case shapes::OCTREE:
+    {
+      return createShapePrimitive(static_cast<const shapes::OcTree*>(geom.get()), collision_object_type, cow);
+    }
+    default:
+    {
+      ROS_ERROR("This geometric shape type (%d) is not supported using BULLET yet", static_cast<int>(geom->type));
+      return nullptr;
+    }
+  }
+}
+
+CollisionObjectWrapper::CollisionObjectWrapper(const std::string& name, const int& type_id,
+                                               const std::vector<shapes::ShapeConstPtr>& shapes,
+                                               const VectorIsometry3d& shape_poses,
+                                               const CollisionObjectTypeVector& collision_object_types)
+  : m_name(name)
+  , m_type_id(type_id)
+  , m_shapes(shapes)
+  , m_shape_poses(shape_poses)
+  , m_collision_object_types(collision_object_types)
+{
+  assert(!shapes.empty());
+  assert(!shape_poses.empty());
+  assert(!collision_object_types.empty());
+  assert(!name.empty());
+  assert(shapes.size() == shape_poses.size());
+  assert(shapes.size() == collision_object_types.size());
+
+  m_collisionFilterGroup = btBroadphaseProxy::KinematicFilter;
+  m_collisionFilterMask = btBroadphaseProxy::StaticFilter | btBroadphaseProxy::KinematicFilter;
+
+  if (shapes.size() == 1 && m_shape_poses[0].matrix().isIdentity())
+  {
+    btCollisionShape* shape = createShapePrimitive(m_shapes[0], collision_object_types[0], this);
+    shape->setMargin(BULLET_MARGIN);
+    manage(shape);
+    setCollisionShape(shape);
+  }
+  else
+  {
+    btCompoundShape* compound =
+        new btCompoundShape(BULLET_COMPOUND_USE_DYNAMIC_AABB, static_cast<int>(m_shapes.size()));
+    manage(compound);
+    compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to have no
+                                         // effect when positive but has an
+                                         // effect when negative
+    setCollisionShape(compound);
+
+    for (std::size_t j = 0; j < m_shapes.size(); ++j)
+    {
+      btCollisionShape* subshape = createShapePrimitive(m_shapes[j], collision_object_types[j], this);
+      if (subshape != nullptr)
+      {
+        manage(subshape);
+        subshape->setMargin(BULLET_MARGIN);
+        btTransform geomTrans = convertEigenToBt(m_shape_poses[j]);
+        compound->addChildShape(geomTrans, subshape);
+      }
+    }
+  }
+
+  btTransform trans;
+  trans.setIdentity();
+  setWorldTransform(trans);
+}
+
+CollisionObjectWrapper::CollisionObjectWrapper(const std::string& name, const int& type_id,
+                                               const std::vector<shapes::ShapeConstPtr>& shapes,
+                                               const VectorIsometry3d& shape_poses,
+                                               const CollisionObjectTypeVector& collision_object_types,
+                                               const std::vector<std::shared_ptr<void>>& data)
+  : m_name(name)
+  , m_type_id(type_id)
+  , m_shapes(shapes)
+  , m_shape_poses(shape_poses)
+  , m_collision_object_types(collision_object_types)
+  , m_data(data)
+{
+}
+}
+}

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -47,6 +47,9 @@
   <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
+  <depend>tesseract_msgs</depend>
+  <depend>eigen_conversions</depend>
+  <depend>bullet3_ros</depend>
 
   <test_depend>moveit_resources</test_depend>
   <test_depend>angles</test_depend>


### PR DESCRIPTION
### Description
This PR is a follow up to #1499 and fills the empty template with a bullet collision checker using the ported tesseract code. Tesseract is integrated into MoveIt except `tesseract_msgs` packages and `bullet3_ros`.

This is just a current snapshot and not anywhere near a final version. The tesseract code will be further reduced and dismantled.

**Building this requires [my branch of tesseract](https://github.com/j-petit/tesseract/tree/tesseract_reduced) to be in the catkin workspace.**
