### PR TITLE
docker: rosdep update --include-eol-distros

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -30,7 +30,7 @@ RUN wstool init . && \
         ros-$ROS_DISTRO-rosbash \
         ros-$ROS_DISTRO-rospack && \
     # Download all dependencies of MoveIt!
-    rosdep update && \
+    rosdep update --include-eol-distros && \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     # Remove the source code from this container. TODO: in the future we may want to keep this here for further optimization of later containers
     cd .. && \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -20,7 +20,7 @@ RUN wstool init . && \
 RUN apt-get -qq update && \
     apt-get -qq install -y \
         wget && \
-    rosdep update && \
+    rosdep update --include-eol-distros && \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Because [ROS Indigo has reached EOL in April 2019](http://wiki.ros.org/Distributions), `rosdep update` doesn't pull any package information for Indigo anymore and our [docker images fail to build](https://cloud.docker.com/u/moveit/repository/docker/moveit/moveit/builds).
To fix this, I added the option `--include-eol-distros` to these calls.
Alternatively, we should disable and remove Indigo docker images. However, I think there might be still many people using these Indigo branches.