### PR TITLE
ikfast: fix ROS apt-key in OpenRAVE docker image

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
@@ -88,9 +88,11 @@ function build_docker_image {
    echo "Building docker image"
    cat <<EOF > $TMP_DIR/Dockerfile
 FROM personalrobotics/ros-openrave
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python-pip && \
-    apt-get install -y --no-install-recommends build-essential liblapack-dev ros-indigo-collada-urdf && \
+# Update ROS keys (https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454)
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 && \
+    apt-key del 421C365BD9FF1F717815A3895523BAEEB01FA116 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python-pip build-essential liblapack-dev ros-indigo-collada-urdf && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 # enforce a specific version of sympy, which is known to work with OpenRave
 RUN pip install sympy==0.7.1


### PR DESCRIPTION
Due to new [ROS GPG keys](https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454), the IKFast generator tool [fails in Travis](https://travis-ci.org/ros-planning/moveit/jobs/543158027). Hence, we need to update the keys used in the corresponding docker image as well.

Needs to be back-ported to Melodic.