### PR TITLE
[Python wrapper] add acceleration_scaling_factor to retime_trajectory

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -578,10 +578,10 @@ class MoveGroupCommander(object):
         """ Set the support surface name for a place operation """
         self._g.set_support_surface_name(value)
 
-    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor):
+    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor=1.0, acceleration_scaling_factor=1.0):
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
-        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor)
+        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor, acceleration_scaling_factor)
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)
         return traj_out

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -489,7 +489,7 @@ public:
   }
 
   std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
-                               double velocity_scaling_factor)
+                               double velocity_scaling_factor, double acceleration_scaling_factor)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -505,7 +505,7 @@ public:
 
       // Do the actual retiming
       trajectory_processing::IterativeParabolicTimeParameterization time_param;
-      time_param.computeTimeStamps(traj_obj, velocity_scaling_factor);
+      time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
 
       // Convert the retimed trajectory back into a message
       traj_obj.getRobotTrajectoryMsg(traj_msg);


### PR DESCRIPTION
### Description
- Add `acceleration_scaling_factor` argument to the `retime_trajectory` method of Python MoveGroupCommander.
- Set default value of `velocity_scaling_factor` and `acceleration_scaling_factor` to 1. Same with raw C++ function:
https://github.com/ros-planning/moveit/blob/master/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h#L55-L56 

Example code:
```python
plan_retimed = self.move_group.retime_trajectory(
    reference_state, plan,
    # velocity_scaling_factor=1.0, # can be omitted if 1.0
    acceleration_scaling_factor=0.1) # this argument becomes supported by this PR.
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
