### PR TITLE
Select time parametrization algorithm in retime_trajectory

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -578,10 +578,10 @@ class MoveGroupCommander(object):
         """ Set the support surface name for a place operation """
         self._g.set_support_surface_name(value)
 
-    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor):
+    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor=1.0, acceleration_scaling_factor=1.0):
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
-        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor)
+        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor, acceleration_scaling_factor)
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)
         return traj_out

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -578,10 +578,10 @@ class MoveGroupCommander(object):
         """ Set the support surface name for a place operation """
         self._g.set_support_surface_name(value)
 
-    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor=1.0, acceleration_scaling_factor=1.0):
+    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor=1.0, acceleration_scaling_factor=1.0, algorithm="iterative_time_parameterization"):
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
-        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor, acceleration_scaling_factor)
+        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor, acceleration_scaling_factor, algorithm)
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)
         return traj_out

--- a/moveit_commander/test/CMakeLists.txt
+++ b/moveit_commander/test/CMakeLists.txt
@@ -4,4 +4,5 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest(python_moveit_commander.test)
   add_rostest(python_moveit_commander_ns.test)
+  add_rostest(python_time_parameterization.test)
 endif()

--- a/moveit_commander/test/python_time_parameterization.py
+++ b/moveit_commander/test/python_time_parameterization.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2012, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Masaki Murooka (JSK Robotics Lab, The University of Tokyo)
+
+import unittest
+import numpy as np
+import rospy
+import rostest
+import os
+
+from moveit_commander import RobotCommander
+
+
+class PythonTimeParameterizationTest(unittest.TestCase):
+    PLANNING_GROUP = "manipulator"
+
+    @classmethod
+    def setUpClass(self):
+        self.commander = RobotCommander("robot_description")
+        self.group = self.commander.get_group(self.PLANNING_GROUP)
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def plan(self):
+        start_pose = self.group.get_current_pose().pose
+        goal_pose = self.group.get_current_pose().pose
+        goal_pose.position.z -= 0.1
+        (plan, fraction) = self.group.compute_cartesian_path([start_pose, goal_pose], 0.005, 0.0)
+        self.assertEqual(fraction, 1.0, "Cartesian path plan failed")
+        return plan
+
+    def time_parameterization(self, plan, algorithm):
+        ref_state = self.commander.get_current_state()
+        retimed_plan = self.group.retime_trajectory(
+            ref_state, plan,
+            velocity_scaling_factor=0.1,
+            acceleration_scaling_factor=0.1,
+            algorithm=algorithm)
+        return retimed_plan
+
+
+    def test_plan_and_time_parameterization(self):
+        plan = self.plan()
+        retimed_plan = self.time_parameterization(plan, "iterative_time_parameterization")
+        self.assertTrue(len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid")
+        retimed_plan = self.time_parameterization(plan, "iterative_spline_parameterization")
+        self.assertTrue(len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid")
+        retimed_plan = self.time_parameterization(plan, "time_optimal_trajectory_generation")
+        self.assertTrue(len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid")
+        retimed_plan = self.time_parameterization(plan, "")
+        self.assertTrue(len(retimed_plan.joint_trajectory.points) == 0, "Invalid retime algorithm")
+
+if __name__ == '__main__':
+    PKGNAME = 'moveit_ros_planning_interface'
+    NODENAME = 'moveit_test_python_time_parameterization'
+    rospy.init_node(NODENAME)
+    rostest.rosrun(PKGNAME, NODENAME, PythonTimeParameterizationTest)
+
+    # suppress cleanup segfault
+    os._exit(0)

--- a/moveit_commander/test/python_time_parameterization.test
+++ b/moveit_commander/test/python_time_parameterization.test
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <test pkg="moveit_commander" type="python_time_parameterization.py" test-name="python_time_parameterization"
+        time-limit="300" args=""/>
+</launch>

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -41,6 +41,8 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/iterative_spline_parameterization.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -489,7 +491,8 @@ public:
   }
 
   std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
-                               double velocity_scaling_factor, double acceleration_scaling_factor)
+                               double velocity_scaling_factor, double acceleration_scaling_factor,
+                               std::string algorithm)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -504,8 +507,26 @@ public:
       traj_obj.setRobotTrajectoryMsg(ref_state_obj, traj_msg);
 
       // Do the actual retiming
-      trajectory_processing::IterativeParabolicTimeParameterization time_param;
-      time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+      if (algorithm == "iterative_time_parameterization")
+      {
+        trajectory_processing::IterativeParabolicTimeParameterization time_param;
+        time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+      }
+      else if (algorithm == "iterative_spline_parameterization")
+      {
+        trajectory_processing::IterativeSplineParameterization time_param;
+        time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+      }
+      else if (algorithm == "time_optimal_trajectory_generation")
+      {
+        trajectory_processing::TimeOptimalTrajectoryGeneration time_param;
+        time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
+      }
+      else
+      {
+        ROS_ERROR_STREAM_NAMED("move_group_py", "Unknown time parameterization algorithm: " << algorithm);
+        return py_bindings_tools::serializeMsg(moveit_msgs::RobotTrajectory());
+      }
 
       // Convert the retimed trajectory back into a message
       traj_obj.getRobotTrajectoryMsg(traj_msg);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -489,7 +489,7 @@ public:
   }
 
   std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
-                               double velocity_scaling_factor)
+                               double velocity_scaling_factor, double acceleration_scaling_factor)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -505,7 +505,7 @@ public:
 
       // Do the actual retiming
       trajectory_processing::IterativeParabolicTimeParameterization time_param;
-      time_param.computeTimeStamps(traj_obj, velocity_scaling_factor);
+      time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
 
       // Convert the retimed trajectory back into a message
       traj_obj.getRobotTrajectoryMsg(traj_msg);


### PR DESCRIPTION
### Description

Enable to select Time Parametrization Algorithm via `algorithm` argument in `retime_trajectory` method of Python MoveGroupCommander.

Ref: Time Parametrization Algorithms:
http://docs.ros.org/melodic/api/moveit_tutorials/html/doc/time_parameterization/time_parameterization_tutorial.html#time-parameterization-algorithms

Example use case:
https://github.com/mmurooka/moveit_tutorials/blob/time-parametrization-tutorial-master/demo_rs007n/scripts/demo_adept_motion_rs007n.py#L93-L102

（This PR contains https://github.com/ros-planning/moveit/pull/1506 .）

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
