### PR TITLE
MoveIt benchmark improvements

### DIFF
--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -158,6 +158,13 @@ protected:
                                       const std::vector<planning_interface::MotionPlanDetailedResponse>& responses,
                                       const std::vector<bool>& solved);
 
+  /// Helper function used by computeAveragePathSimilarities() for computing a heuristic distance metric between two
+  /// robot trajectories. This function aligns both trajectories in a greedy fashion and computes the mean waypoint
+  /// distance averaged over all aligned waypoints. Using a greedy approach is more efficient than dynamic time warping,
+  /// and seems to be sufficient for similar trajectories.
+  bool computeTrajectoryDistance(const robot_trajectory::RobotTrajectory& traj_first,
+                                 const robot_trajectory::RobotTrajectory& traj_second, double& result_distance);
+
   virtual void writeOutput(const BenchmarkRequest& brequest, const std::string& start_time, double benchmark_duration);
 
   void shiftConstraintsByOffset(moveit_msgs::Constraints& constraints, const std::vector<double>& offset);

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -141,6 +141,14 @@ protected:
   virtual bool initializeBenchmarks(const BenchmarkOptions& opts, moveit_msgs::PlanningScene& scene_msg,
                                     std::vector<BenchmarkRequest>& queries);
 
+  virtual bool loadBenchmarkQueryData(const BenchmarkOptions& opts,
+                                      moveit_msgs::PlanningScene& scene_msg,
+                                      std::vector<StartState>& start_states,
+                                      std::vector<PathConstraints>& path_constraints,
+                                      std::vector<PathConstraints>& goal_constraints,
+                                      std::vector<TrajectoryConstraints>& traj_constraints,
+                                      std::vector<BenchmarkRequest>& queries);
+
   virtual void collectMetrics(PlannerRunData& metrics, const planning_interface::MotionPlanDetailedResponse& mp_res,
                               bool solved, double total_time);
 

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -152,6 +152,10 @@ protected:
   virtual void collectMetrics(PlannerRunData& metrics, const planning_interface::MotionPlanDetailedResponse& mp_res,
                               bool solved, double total_time);
 
+  void computeResultPathSimilarity(PlannerBenchmarkData& planner_data,
+                                   const std::vector<planning_interface::MotionPlanDetailedResponse>& mp_res,
+                                   const std::vector<bool>& solved);
+
   virtual void writeOutput(const BenchmarkRequest& brequest, const std::string& start_time, double benchmark_duration);
 
   void shiftConstraintsByOffset(moveit_msgs::Constraints& constraints, const std::vector<double>& offset);

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -141,8 +141,8 @@ protected:
   virtual bool initializeBenchmarks(const BenchmarkOptions& opts, moveit_msgs::PlanningScene& scene_msg,
                                     std::vector<BenchmarkRequest>& queries);
 
-  virtual bool loadBenchmarkQueryData(const BenchmarkOptions& opts,
-                                      moveit_msgs::PlanningScene& scene_msg,
+  /// Initialize benchmark query data from start states and constraints
+  virtual bool loadBenchmarkQueryData(const BenchmarkOptions& opts, moveit_msgs::PlanningScene& scene_msg,
                                       std::vector<StartState>& start_states,
                                       std::vector<PathConstraints>& path_constraints,
                                       std::vector<PathConstraints>& goal_constraints,
@@ -152,6 +152,7 @@ protected:
   virtual void collectMetrics(PlannerRunData& metrics, const planning_interface::MotionPlanDetailedResponse& mp_res,
                               bool solved, double total_time);
 
+  /// Computes a similarity measure for all trajectories of an experiment and writes the result to planner_data metrics
   void computeResultPathSimilarity(PlannerBenchmarkData& planner_data,
                                    const std::vector<planning_interface::MotionPlanDetailedResponse>& mp_res,
                                    const std::vector<bool>& solved);

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -152,10 +152,11 @@ protected:
   virtual void collectMetrics(PlannerRunData& metrics, const planning_interface::MotionPlanDetailedResponse& mp_res,
                               bool solved, double total_time);
 
-  /// Computes a similarity measure for all trajectories of an experiment and writes the result to planner_data metrics
-  void computeResultPathSimilarity(PlannerBenchmarkData& planner_data,
-                                   const std::vector<planning_interface::MotionPlanDetailedResponse>& mp_res,
-                                   const std::vector<bool>& solved);
+  /// Compute the similarity of each (final) trajectory to all other (final) trajectories in the experiment and write
+  /// the results to planner_data metrics
+  void computeAveragePathSimilarities(PlannerBenchmarkData& planner_data,
+                                      const std::vector<planning_interface::MotionPlanDetailedResponse>& responses,
+                                      const std::vector<bool>& solved);
 
   virtual void writeOutput(const BenchmarkRequest& brequest, const std::string& start_time, double benchmark_duration);
 

--- a/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
+++ b/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
@@ -112,7 +112,7 @@ def readBenchmarkLog(dbname, filenames):
 
     # create all tables if they don't already exist
     c.executescript("""CREATE TABLE IF NOT EXISTS experiments
-        (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(512),
+        (id INTEGER PRIMARY KEY ON CONFLICT REPLACE AUTOINCREMENT, name VARCHAR(512),
         totaltime REAL, timelimit REAL, memorylimit REAL, runcount INTEGER,
         version VARCHAR(128), hostname VARCHAR(1024), cpuinfo TEXT,
         date DATETIME, seed INTEGER, setup TEXT);
@@ -129,6 +129,18 @@ def readBenchmarkLog(dbname, filenames):
         CREATE TABLE IF NOT EXISTS progress
         (runid INTEGER, time REAL, PRIMARY KEY (runid, time),
         FOREIGN KEY (runid) REFERENCES runs(id) ON DELETE CASCADE)""")
+
+    # add placeholder entry for all_experiments
+    allExperimentsName = "all_experiments"
+    allExperimentsValues = {
+        "totaltime": 0.0, "timelimit": 0.0, "memorylimit": 0.0, "runcount": 0, "version": "0.0.0",
+        "hostname": "",   "cpuinfo": "",    "date": 0,          "seed": 0,     "setup": ""
+    }
+    addAllExperiments = len(filenames) > 0
+    if addAllExperiments:
+        c.execute('INSERT INTO experiments VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
+                  (None, allExperimentsName) + tuple(allExperimentsValues.values()))
+        allExperimentsId = c.lastrowid
 
     for filename in filenames:
         print('Processing ' + filename)
@@ -155,7 +167,9 @@ def readBenchmarkLog(dbname, filenames):
         nrruns = -1
         if nrrunsOrNone != None:
             nrruns = int(nrrunsOrNone)
+            allExperimentsValues['runcount'] += nrruns
         totaltime = float(readRequiredLogValue("total time", logfile, 0, {-3 : "collect", -2 : "the", -1 : "data"}))
+        allExperimentsValues['totaltime'] += totaltime
         numEnums = 0
         numEnumsOrNone = readOptionalLogValue(logfile, 0, {-2 : "enum"})
         if numEnumsOrNone != None:
@@ -213,13 +227,17 @@ def readBenchmarkLog(dbname, filenames):
             numRuns = int(logfile.readline().split()[0])
             runIds = []
             for j in range(numRuns):
-                values = tuple([experimentId, plannerId] + \
-                    [None if len(x) == 0 or x == 'nan' or x == 'inf' else x
-                    for x in logfile.readline().split('; ')[:-1]])
+                runValues = [None if len(x) == 0 or x == 'nan' or x == 'inf' else x
+                    for x in logfile.readline().split('; ')[:-1]]
+                values = tuple([experimentId, plannerId] + runValues)
                 c.execute(insertFmtStr, values)
                 # extract primary key of each run row so we can reference them
                 # in the planner progress data table if needed
                 runIds.append(c.lastrowid)
+                # add all run data to all_experiments
+                if addAllExperiments:
+                    values = tuple([allExperimentsId, plannerId] + runValues)
+                    c.execute(insertFmtStr, values)
 
             nextLine = logfile.readline().strip()
 
@@ -259,6 +277,14 @@ def readBenchmarkLog(dbname, filenames):
 
                 logfile.readline()
         logfile.close()
+
+    if addAllExperiments:
+        updateString = "UPDATE experiments SET"
+        for i, (key, val) in enumerate(allExperimentsValues.items()):
+            if i > 0: updateString += ","
+            updateString += " " + str(key) + "='" + str(val) + "'"
+        updateString += "WHERE id='" + str(allExperimentsId) + "'"
+        c.execute(updateString)
     conn.commit()
     c.close()
 
@@ -543,7 +569,7 @@ if __name__ == "__main__":
     if len(args) == 0:
 	parser.error("No arguments were provided. Please provide full path of log file")
 
-    if len(args) == 1:
+    if len(args) > 0:
         readBenchmarkLog(options.dbname, args)
         # If we update the database, we recompute the views as well
         options.view = True

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -901,6 +901,15 @@ void BenchmarkExecutor::collectMetrics(PlannerRunData& metrics,
       metrics["path_" + mp_res.description_[j] + "_clearance REAL"] = moveit::core::toString(clearance);
       metrics["path_" + mp_res.description_[j] + "_smoothness REAL"] = moveit::core::toString(smoothness);
       metrics["path_" + mp_res.description_[j] + "_time REAL"] = moveit::core::toString(mp_res.processing_time_[j]);
+
+      if (j == mp_res.trajectory_.size() - 1)
+      {
+        metrics["final_path_correct BOOLEAN"] = boost::lexical_cast<std::string>(correct);
+        metrics["final_path_length REAL"] = moveit::core::toString(traj_len);
+        metrics["final_path_clearance REAL"] = moveit::core::toString(clearance);
+        metrics["final_path_smoothness REAL"] = moveit::core::toString(smoothness);
+        metrics["final_path_time REAL"] = moveit::core::toString(mp_res.processing_time_[j]);
+      }
       process_time -= mp_res.processing_time_[j];
     }
     if (process_time <= 0.0)


### PR DESCRIPTION
I'm working on extending the benchmark interface and measurement functions with the following goals/items:

**Simplify setting up a benchmark without warehouse (f20c07e)**
With the current implementation this would require overriding the function `initializeBenchmarks()`.
I added another virtual function `loadBenchmarkQueryData()` that allows initializing the planning scene and constraints only without the need to create the BenchmarkRequests as well.

**Compare results across experiments (8ae9a25, 11ad204)**
Currently the results are stored in separate log files which can be written to a database file storing the result of a single experiment. I extended the python script to accept multiple log files and to write all benchmarks into the same file. Also I added a pseudo experiment all_experiments which can be used for compare (and plot in PlannerArena) the measurements across all experiments. Another issue I attempted to fix is that STOMP (and possibly other planners) don't use the same naming convention for detailed plan descriptions, leading to different entry names.

**Measure planner repeatability (4724870)**
This measure should represent the similarity of subsequent results from the same query. In particular this should include a scalar distance function (or propability function) that describes how one trajectory is distinct from the set of all solutions. Right now I added a rather simple approach which is based on iterating over trajectory pairs and computing the average distance of the closest waypoints and then. Suggestions for more sophisticated (and efficient) approaches are welcome.