### PR TITLE
Improve Travis config for clang-tidy-fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix: # Add a separate config to the matrix, using clang as compiler
     # add a config to the matrix using clang as compiler and also test ikfast plugin creation
     - compiler: clang
       env: ROS_REPO=ros-shadow-fixed
-           TEST=clang-tidy-fix
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - WARNINGS_OK=false
   matrix:
     - TEST="clang-format catkin_lint"
-    - TEST=clang-tidy-fix
     - ROS_DISTRO=melodic
     - ROS_DISTRO=kinetic
 
@@ -32,6 +31,7 @@ matrix: # Add a separate config to the matrix, using clang as compiler
     - compiler: clang
       env: ROS_REPO=ros-shadow-fixed
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+           TEST=clang-tidy-fix
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 
   fast_finish: true  # finish, even if allow-failure-tests still running

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix: # Add a separate config to the matrix, using clang as compiler
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 
   fast_finish: true  # finish, even if allow-failure-tests still running
-  allow_failures:
-    - env: TEST=clang-tidy-fix  # need to fix clang-tidy issues
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ matrix: # Add a separate config to the matrix, using clang as compiler
     # add a config to the matrix using clang as compiler and also test ikfast plugin creation
     - compiler: clang
       env: ROS_REPO=ros-shadow-fixed
-           BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
            TEST=clang-tidy-fix
+           BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 
   fast_finish: true  # finish, even if allow-failure-tests still running


### PR DESCRIPTION
- Couple clang-tidy-fix to clang-based build to avoid spurious warnings
- Require clang-tidy-fix to pass