### PR TITLE
Add get_jacobian_matrix to moveit_commander (#1501)

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -585,3 +585,8 @@ class MoveGroupCommander(object):
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)
         return traj_out
+
+    def get_jacobian_matrix(self, joint_values):
+        """ Get the jacobian matrix of the group as a list"""
+        return self._g.get_jacobian_matrix(joint_values)
+

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -94,6 +94,7 @@ class PythonMoveitCommanderTest(unittest.TestCase):
     def test_planning_scene_interface(self):
         planning_scene = PlanningSceneInterface()
 
+
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'
     NODENAME = 'moveit_test_python_moveit_commander'

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
+  eigenpy
   roscpp
   actionlib
   rospy

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -47,6 +47,7 @@
 #include <tf2_ros/buffer.h>
 
 #include <boost/python.hpp>
+#include <eigenpy/eigenpy.hpp>
 #include <memory>
 #include <Python.h>
 
@@ -520,10 +521,22 @@ public:
       return "";
     }
   }
+
+  Eigen::MatrixXd getJacobianMatrixPython(bp::list& joint_values)
+  {
+    std::vector<double> v = py_bindings_tools::doubleFromList(joint_values);
+    robot_state::RobotState state(getRobotModel());
+    state.setToDefaultValues();
+    auto group = state.getJointModelGroup(getName());
+    state.setJointGroupPositions(group, v);
+    return state.getJacobian(group);
+  }
 };
 
 static void wrap_move_group_interface()
 {
+  eigenpy::enableEigenPy();
+
   bp::class_<MoveGroupInterfaceWrapper, boost::noncopyable> MoveGroupInterfaceClass(
       "MoveGroupInterface", bp::init<std::string, std::string, bp::optional<std::string>>());
 
@@ -653,6 +666,7 @@ static void wrap_move_group_interface()
   MoveGroupInterfaceClass.def("get_named_targets", &MoveGroupInterfaceWrapper::getNamedTargetsPython);
   MoveGroupInterfaceClass.def("get_named_target_values", &MoveGroupInterfaceWrapper::getNamedTargetValuesPython);
   MoveGroupInterfaceClass.def("get_current_state_bounded", &MoveGroupInterfaceWrapper::getCurrentStateBoundedPython);
+  MoveGroupInterfaceClass.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython);
 }
 }  // namespace planning_interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -33,6 +33,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>python</depend>
+  <depend>eigenpy</depend>
 
   <build_depend>eigen</build_depend>
 

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -56,6 +56,18 @@ class PythonMoveGroupTest(unittest.TestCase):
         plan3 = self.plan(current)
         self.assertTrue(self.group.execute(plan3))
 
+    def test_get_jacobian_matrix(self):
+        current = self.group.get_current_joint_values()
+        result = self.group.get_jacobian_matrix(current)
+        # Value check by known value at the initial pose
+        expected = np.array([[ 0.  ,  0.8 , -0.2 ,  0.  ,  0.  ,  0.  ],
+                             [ 0.89,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ],
+                             [ 0.  , -0.74,  0.74,  0.  ,  0.1 ,  0.  ],
+                             [ 0.  ,  0.  ,  0.  , -1.  ,  0.  , -1.  ],
+                             [ 0.  ,  1.  , -1.  ,  0.  , -1.  ,  0.  ],
+                             [ 1.  ,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ]])
+        self.assertTrue(np.allclose(result, expected))
+
 
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'


### PR DESCRIPTION
This is a cherry-pick of #1501 from Kinetic. If Travis passes, melodic-devel can be fast-forwarded.