### PR TITLE
Cleanup move_group capabilities

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -37,28 +37,31 @@
 #include "apply_planning_scene_service_capability.h"
 #include <moveit/move_group/capability_names.h>
 
-move_group::ApplyPlanningSceneService::ApplyPlanningSceneService() : MoveGroupCapability("ApplyPlanningSceneService")
+namespace move_group
+{
+ApplyPlanningSceneService::ApplyPlanningSceneService() : MoveGroupCapability("ApplyPlanningSceneService")
 {
 }
 
-void move_group::ApplyPlanningSceneService::initialize()
+void ApplyPlanningSceneService::initialize()
 {
   service_ = root_node_handle_.advertiseService(APPLY_PLANNING_SCENE_SERVICE_NAME,
                                                 &ApplyPlanningSceneService::applyScene, this);
 }
 
-bool move_group::ApplyPlanningSceneService::applyScene(moveit_msgs::ApplyPlanningScene::Request& req,
-                                                       moveit_msgs::ApplyPlanningScene::Response& res)
+bool ApplyPlanningSceneService::applyScene(moveit_msgs::ApplyPlanningScene::Request& req,
+                                           moveit_msgs::ApplyPlanningScene::Response& res)
 {
   if (!context_->planning_scene_monitor_)
   {
-    ROS_ERROR("Cannot apply PlanningScene as no scene is monitored.");
+    ROS_ERROR_NAMED(getName(), "Cannot apply PlanningScene as no scene is monitored.");
     return true;
   }
   context_->planning_scene_monitor_->updateFrameTransforms();
   res.success = context_->planning_scene_monitor_->newPlanningSceneMessage(req.scene);
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::ApplyPlanningSceneService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -46,19 +46,6 @@
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
-move_group::MoveGroupCartesianPathService::MoveGroupCartesianPathService()
-  : MoveGroupCapability("CartesianPathService"), display_computed_paths_(true)
-{
-}
-
-void move_group::MoveGroupCartesianPathService::initialize()
-{
-  display_path_ = node_handle_.advertise<moveit_msgs::DisplayTrajectory>(
-      planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC, 10, true);
-  cartesian_path_service_ = root_node_handle_.advertiseService(CARTESIAN_PATH_SERVICE_NAME,
-                                                               &MoveGroupCartesianPathService::computeService, this);
-}
-
 namespace
 {
 bool isStateValid(const planning_scene::PlanningScene* planning_scene,
@@ -72,10 +59,25 @@ bool isStateValid(const planning_scene::PlanningScene* planning_scene,
 }
 }  // namespace
 
-bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath::Request& req,
-                                                               moveit_msgs::GetCartesianPath::Response& res)
+namespace move_group
 {
-  ROS_INFO("Received request to compute Cartesian path");
+MoveGroupCartesianPathService::MoveGroupCartesianPathService()
+  : MoveGroupCapability("CartesianPathService"), display_computed_paths_(true)
+{
+}
+
+void MoveGroupCartesianPathService::initialize()
+{
+  display_path_ = node_handle_.advertise<moveit_msgs::DisplayTrajectory>(
+      planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC, 10, true);
+  cartesian_path_service_ = root_node_handle_.advertiseService(CARTESIAN_PATH_SERVICE_NAME,
+                                                               &MoveGroupCartesianPathService::computeService, this);
+}
+
+bool MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath::Request& req,
+                                                   moveit_msgs::GetCartesianPath::Response& res)
+{
+  ROS_INFO_NAMED(getName(), "Received request to compute Cartesian path");
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   robot_state::RobotState start_state =
@@ -107,7 +109,7 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
           tf2::fromMsg(p.pose, waypoints[i]);
         else
         {
-          ROS_ERROR("Error encountered transforming waypoints to frame '%s'", default_frame.c_str());
+          ROS_ERROR_NAMED(getName(), "Error encountered transforming waypoints to frame '%s'", default_frame.c_str());
           ok = false;
           break;
         }
@@ -118,8 +120,8 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
     {
       if (req.max_step < std::numeric_limits<double>::epsilon())
       {
-        ROS_ERROR("Maximum step to take between consecutive configrations along Cartesian path was not specified (this "
-                  "value needs to be > 0)");
+        ROS_ERROR_NAMED(getName(), "Maximum step to take between consecutive configrations along Cartesian path"
+                                   "was not specified (this value needs to be > 0)");
         res.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
       }
       else
@@ -140,10 +142,10 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
                 kset->empty() ? nullptr : kset.get(), _1, _2, _3);
           }
           bool global_frame = !robot_state::Transforms::sameFrame(link_name, req.header.frame_id);
-          ROS_INFO("Attempting to follow %u waypoints for link '%s' using a step of %lf m and jump threshold %lf (in "
-                   "%s reference frame)",
-                   (unsigned int)waypoints.size(), link_name.c_str(), req.max_step, req.jump_threshold,
-                   global_frame ? "global" : "link");
+          ROS_INFO_NAMED(getName(), "Attempting to follow %u waypoints for link '%s' using a step of %lf m "
+                                    "and jump threshold %lf (in %s reference frame)",
+                         (unsigned int)waypoints.size(), link_name.c_str(), req.max_step, req.jump_threshold,
+                         global_frame ? "global" : "link");
           std::vector<robot_state::RobotStatePtr> traj;
           res.fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
               &start_state, jmg, traj, start_state.getLinkModel(link_name), waypoints, global_frame,
@@ -160,8 +162,8 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
           time_param.computeTimeStamps(rt, 1.0);
 
           rt.getRobotTrajectoryMsg(res.solution);
-          ROS_INFO("Computed Cartesian path with %u points (followed %lf%% of requested trajectory)",
-                   (unsigned int)traj.size(), res.fraction * 100.0);
+          ROS_INFO_NAMED(getName(), "Computed Cartesian path with %u points (followed %lf%% of requested trajectory)",
+                         (unsigned int)traj.size(), res.fraction * 100.0);
           if (display_computed_paths_ && rt.getWayPointCount() > 0)
           {
             moveit_msgs::DisplayTrajectory disp;
@@ -182,6 +184,8 @@ bool move_group::MoveGroupCartesianPathService::computeService(moveit_msgs::GetC
 
   return true;
 }
+
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupCartesianPathService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -91,7 +91,7 @@ void MoveGroupExecuteTrajectoryAction::executePathCallback(const moveit_msgs::Ex
 void MoveGroupExecuteTrajectoryAction::executePath(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
                                                    moveit_msgs::ExecuteTrajectoryResult& action_res)
 {
-  ROS_INFO_NAMED(capability_name_, "Execution request received");
+  ROS_INFO_NAMED(getName(), "Execution request received");
 
   context_->trajectory_execution_manager_->clear();
   if (context_->trajectory_execution_manager_->push(goal->trajectory))
@@ -115,7 +115,7 @@ void MoveGroupExecuteTrajectoryAction::executePath(const moveit_msgs::ExecuteTra
     {
       action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
     }
-    ROS_INFO_STREAM_NAMED(capability_name_, "Execution completed: " << status.asString());
+    ROS_INFO_STREAM_NAMED(getName(), "Execution completed: " << status.asString());
   }
   else
   {

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
@@ -38,19 +38,21 @@
 #include <moveit/trajectory_execution_manager/trajectory_execution_manager.h>
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupExecuteService::MoveGroupExecuteService()
+namespace move_group
+{
+MoveGroupExecuteService::MoveGroupExecuteService()
   : MoveGroupCapability("ExecuteTrajectoryService")
   , callback_queue_()
   , spinner_(1 /* spinner threads */, &callback_queue_)
 {
 }
 
-move_group::MoveGroupExecuteService::~MoveGroupExecuteService()
+MoveGroupExecuteService::~MoveGroupExecuteService()
 {
   spinner_.stop();
 }
 
-void move_group::MoveGroupExecuteService::initialize()
+void MoveGroupExecuteService::initialize()
 {
   // We need to serve each service request in a thread independent of the main spinner thread.
   // Otherwise, a synchronous execution request (i.e. waiting for the execution to finish) would block
@@ -64,13 +66,13 @@ void move_group::MoveGroupExecuteService::initialize()
   spinner_.start();
 }
 
-bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::ExecuteKnownTrajectory::Request& req,
-                                                                   moveit_msgs::ExecuteKnownTrajectory::Response& res)
+bool MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::ExecuteKnownTrajectory::Request& req,
+                                                       moveit_msgs::ExecuteKnownTrajectory::Response& res)
 {
-  ROS_INFO("Received new trajectory execution service request...");
+  ROS_INFO_NAMED(getName(), "Received new trajectory execution service request...");
   if (!context_->trajectory_execution_manager_)
   {
-    ROS_ERROR("Cannot execute trajectory since ~allow_trajectory_execution was set to false");
+    ROS_ERROR_NAMED(getName(), "Cannot execute trajectory since ~allow_trajectory_execution was set to false");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
     return true;
   }
@@ -93,11 +95,11 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
         res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
       else
         res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
-      ROS_INFO_STREAM("Execution completed: " << es.asString());
+      ROS_INFO_STREAM_NAMED(getName(), "Execution completed: " << es.asString());
     }
     else
     {
-      ROS_INFO("Trajectory was successfully forwarded to the controller");
+      ROS_INFO_NAMED(getName(), "Trajectory was successfully forwarded to the controller");
       res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     }
   }
@@ -107,6 +109,7 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
   }
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupExecuteService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.cpp
@@ -37,19 +37,20 @@
 #include "get_planning_scene_service_capability.h"
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupGetPlanningSceneService::MoveGroupGetPlanningSceneService()
-  : MoveGroupCapability("GetPlanningSceneService")
+namespace move_group
+{
+MoveGroupGetPlanningSceneService::MoveGroupGetPlanningSceneService() : MoveGroupCapability("GetPlanningSceneService")
 {
 }
 
-void move_group::MoveGroupGetPlanningSceneService::initialize()
+void MoveGroupGetPlanningSceneService::initialize()
 {
   get_scene_service_ = root_node_handle_.advertiseService(
       GET_PLANNING_SCENE_SERVICE_NAME, &MoveGroupGetPlanningSceneService::getPlanningSceneService, this);
 }
 
-bool move_group::MoveGroupGetPlanningSceneService::getPlanningSceneService(moveit_msgs::GetPlanningScene::Request& req,
-                                                                           moveit_msgs::GetPlanningScene::Response& res)
+bool MoveGroupGetPlanningSceneService::getPlanningSceneService(moveit_msgs::GetPlanningScene::Request& req,
+                                                               moveit_msgs::GetPlanningScene::Response& res)
 {
   if (req.components.components & moveit_msgs::PlanningSceneComponents::TRANSFORMS)
     context_->planning_scene_monitor_->updateFrameTransforms();
@@ -61,6 +62,7 @@ bool move_group::MoveGroupGetPlanningSceneService::getPlanningSceneService(movei
 
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupGetPlanningSceneService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -40,11 +40,13 @@
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupKinematicsService::MoveGroupKinematicsService() : MoveGroupCapability("KinematicsService")
+namespace move_group
+{
+MoveGroupKinematicsService::MoveGroupKinematicsService() : MoveGroupCapability("KinematicsService")
 {
 }
 
-void move_group::MoveGroupKinematicsService::initialize()
+void MoveGroupKinematicsService::initialize()
 {
   fk_service_ =
       root_node_handle_.advertiseService(FK_SERVICE_NAME, &MoveGroupKinematicsService::computeFKService, this);
@@ -66,9 +68,9 @@ bool isIKSolutionValid(const planning_scene::PlanningScene* planning_scene,
 }
 }  // namespace
 
-void move_group::MoveGroupKinematicsService::computeIK(
-    moveit_msgs::PositionIKRequest& req, moveit_msgs::RobotState& solution, moveit_msgs::MoveItErrorCodes& error_code,
-    robot_state::RobotState& rs, const robot_state::GroupStateValidityCallbackFn& constraint) const
+void MoveGroupKinematicsService::computeIK(moveit_msgs::PositionIKRequest& req, moveit_msgs::RobotState& solution,
+                                           moveit_msgs::MoveItErrorCodes& error_code, robot_state::RobotState& rs,
+                                           const robot_state::GroupStateValidityCallbackFn& constraint) const
 {
   const robot_state::JointModelGroup* jmg = rs.getJointModelGroup(req.group_name);
   if (jmg)
@@ -140,8 +142,8 @@ void move_group::MoveGroupKinematicsService::computeIK(
     error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
 }
 
-bool move_group::MoveGroupKinematicsService::computeIKService(moveit_msgs::GetPositionIK::Request& req,
-                                                              moveit_msgs::GetPositionIK::Response& res)
+bool MoveGroupKinematicsService::computeIKService(moveit_msgs::GetPositionIK::Request& req,
+                                                  moveit_msgs::GetPositionIK::Response& res)
 {
   context_->planning_scene_monitor_->updateFrameTransforms();
 
@@ -169,12 +171,12 @@ bool move_group::MoveGroupKinematicsService::computeIKService(moveit_msgs::GetPo
   return true;
 }
 
-bool move_group::MoveGroupKinematicsService::computeFKService(moveit_msgs::GetPositionFK::Request& req,
-                                                              moveit_msgs::GetPositionFK::Response& res)
+bool MoveGroupKinematicsService::computeFKService(moveit_msgs::GetPositionFK::Request& req,
+                                                  moveit_msgs::GetPositionFK::Response& res)
 {
   if (req.fk_link_names.empty())
   {
-    ROS_ERROR("No links specified for FK request");
+    ROS_ERROR_NAMED(getName(), "No links specified for FK request");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME;
     return true;
   }
@@ -210,6 +212,7 @@ bool move_group::MoveGroupKinematicsService::computeFKService(moveit_msgs::GetPo
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME;
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupKinematicsService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -43,12 +43,14 @@
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupMoveAction::MoveGroupMoveAction()
+namespace move_group
+{
+MoveGroupMoveAction::MoveGroupMoveAction()
   : MoveGroupCapability("MoveAction"), move_state_(IDLE), preempt_requested_{ false }
 {
 }
 
-void move_group::MoveGroupMoveAction::initialize()
+void MoveGroupMoveAction::initialize()
 {
   // start the move action server
   move_action_server_.reset(new actionlib::SimpleActionServer<moveit_msgs::MoveGroupAction>(
@@ -57,7 +59,7 @@ void move_group::MoveGroupMoveAction::initialize()
   move_action_server_->start();
 }
 
-void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
+void MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
 {
   setMoveState(PLANNING);
   // before we start planning, ensure that we have the latest robot state received...
@@ -68,8 +70,9 @@ void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::Mov
   if (goal->planning_options.plan_only || !context_->allow_trajectory_execution_)
   {
     if (!goal->planning_options.plan_only)
-      ROS_WARN("This instance of MoveGroup is not allowed to execute trajectories but the goal request has plan_only "
-               "set to false. Only a motion plan will be computed anyway.");
+      ROS_WARN_NAMED(getName(), "This instance of MoveGroup is not allowed to execute trajectories "
+                                "but the goal request has plan_only set to false. "
+                                "Only a motion plan will be computed anyway.");
     executeMoveCallbackPlanOnly(goal, action_res);
   }
   else
@@ -93,11 +96,11 @@ void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::Mov
   preempt_requested_ = false;
 }
 
-void move_group::MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const moveit_msgs::MoveGroupGoalConstPtr& goal,
-                                                                        moveit_msgs::MoveGroupResult& action_res)
+void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const moveit_msgs::MoveGroupGoalConstPtr& goal,
+                                                            moveit_msgs::MoveGroupResult& action_res)
 {
-  ROS_INFO("Combined planning and execution request received for MoveGroup action. Forwarding to planning and "
-           "execution pipeline.");
+  ROS_INFO_NAMED(getName(), "Combined planning and execution request received for MoveGroup action. "
+                            "Forwarding to planning and execution pipeline.");
 
   if (planning_scene::PlanningScene::isEmpty(goal->planning_options.planning_scene_diff))
   {
@@ -110,7 +113,7 @@ void move_group::MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const mo
                                      kinematic_constraints::mergeConstraints(goal->request.goal_constraints[i],
                                                                              goal->request.path_constraints)))
       {
-        ROS_INFO("Goal constraints are already satisfied. No need to plan or execute any motions");
+        ROS_INFO_NAMED(getName(), "Goal constraints are already satisfied. No need to plan or execute any motions");
         action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
         return;
       }
@@ -144,7 +147,7 @@ void move_group::MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const mo
   plan_execution::ExecutableMotionPlan plan;
   if (preempt_requested_)
   {
-    ROS_INFO("Preempt requested before the goal is planned and executed.");
+    ROS_INFO_NAMED(getName(), "Preempt requested before the goal is planned and executed.");
     action_res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
     return;
   }
@@ -157,15 +160,13 @@ void move_group::MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const mo
   action_res.error_code = plan.error_code_;
 }
 
-void move_group::MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_msgs::MoveGroupGoalConstPtr& goal,
-                                                                  moveit_msgs::MoveGroupResult& action_res)
+void MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_msgs::MoveGroupGoalConstPtr& goal,
+                                                      moveit_msgs::MoveGroupResult& action_res)
 {
-  ROS_INFO("Planning request received for MoveGroup action. Forwarding to planning pipeline.");
+  ROS_INFO_NAMED(getName(), "Planning request received for MoveGroup action. Forwarding to planning pipeline.");
 
-  planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);  // lock the scene so that it
-                                                                                            // does not modify the world
-                                                                                            // representation while
-                                                                                            // diff() is called
+  // lock the scene so that it does not modify the world representation while diff() is called
+  planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
   const planning_scene::PlanningSceneConstPtr& the_scene =
       (planning_scene::PlanningScene::isEmpty(goal->planning_options.planning_scene_diff)) ?
           static_cast<const planning_scene::PlanningSceneConstPtr&>(lscene) :
@@ -174,7 +175,7 @@ void move_group::MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_m
 
   if (preempt_requested_)
   {
-    ROS_INFO("Preempt requested before the goal is planned.");
+    ROS_INFO_NAMED(getName(), "Preempt requested before the goal is planned.");
     action_res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
     return;
   }
@@ -185,7 +186,7 @@ void move_group::MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_m
   }
   catch (std::exception& ex)
   {
-    ROS_ERROR("Planning pipeline threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED(getName(), "Planning pipeline threw an exception: %s", ex.what());
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
 
@@ -194,8 +195,8 @@ void move_group::MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_m
   action_res.planning_time = res.planning_time_;
 }
 
-bool move_group::MoveGroupMoveAction::planUsingPlanningPipeline(const planning_interface::MotionPlanRequest& req,
-                                                                plan_execution::ExecutableMotionPlan& plan)
+bool MoveGroupMoveAction::planUsingPlanningPipeline(const planning_interface::MotionPlanRequest& req,
+                                                    plan_execution::ExecutableMotionPlan& plan)
 {
   setMoveState(PLANNING);
 
@@ -208,7 +209,7 @@ bool move_group::MoveGroupMoveAction::planUsingPlanningPipeline(const planning_i
   }
   catch (std::exception& ex)
   {
-    ROS_ERROR("Planning pipeline threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED(getName(), "Planning pipeline threw an exception: %s", ex.what());
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
   if (res.trajectory_)
@@ -221,28 +222,29 @@ bool move_group::MoveGroupMoveAction::planUsingPlanningPipeline(const planning_i
   return solved;
 }
 
-void move_group::MoveGroupMoveAction::startMoveExecutionCallback()
+void MoveGroupMoveAction::startMoveExecutionCallback()
 {
   setMoveState(MONITOR);
 }
 
-void move_group::MoveGroupMoveAction::startMoveLookCallback()
+void MoveGroupMoveAction::startMoveLookCallback()
 {
   setMoveState(LOOK);
 }
 
-void move_group::MoveGroupMoveAction::preemptMoveCallback()
+void MoveGroupMoveAction::preemptMoveCallback()
 {
   preempt_requested_ = true;
   context_->plan_execution_->stop();
 }
 
-void move_group::MoveGroupMoveAction::setMoveState(MoveGroupState state)
+void MoveGroupMoveAction::setMoveState(MoveGroupState state)
 {
   move_state_ = state;
   move_feedback_.state = stateToStr(state);
   move_action_server_->publishFeedback(move_feedback_);
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupMoveAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -38,20 +38,22 @@
 #include <moveit/planning_pipeline/planning_pipeline.h>
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupPlanService::MoveGroupPlanService() : MoveGroupCapability("MotionPlanService")
+namespace move_group
+{
+MoveGroupPlanService::MoveGroupPlanService() : MoveGroupCapability("MotionPlanService")
 {
 }
 
-void move_group::MoveGroupPlanService::initialize()
+void MoveGroupPlanService::initialize()
 {
   plan_service_ =
       root_node_handle_.advertiseService(PLANNER_SERVICE_NAME, &MoveGroupPlanService::computePlanService, this);
 }
 
-bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotionPlan::Request& req,
-                                                          moveit_msgs::GetMotionPlan::Response& res)
+bool MoveGroupPlanService::computePlanService(moveit_msgs::GetMotionPlan::Request& req,
+                                              moveit_msgs::GetMotionPlan::Response& res)
 {
-  ROS_INFO("Received new planning service request...");
+  ROS_INFO_NAMED(getName(), "Received new planning service request...");
   // before we start planning, ensure that we have the latest robot state received...
   if (static_cast<bool>(req.motion_plan_request.start_state.is_diff))
     context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
@@ -66,12 +68,13 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
   }
   catch (std::exception& ex)
   {
-    ROS_ERROR("Planning pipeline threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED(getName(), "Planning pipeline threw an exception: %s", ex.what());
     res.motion_plan_response.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
   }
 
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupPlanService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
@@ -38,11 +38,13 @@
 #include <moveit/planning_pipeline/planning_pipeline.h>
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupQueryPlannersService::MoveGroupQueryPlannersService() : MoveGroupCapability("QueryPlannersService")
+namespace move_group
+{
+MoveGroupQueryPlannersService::MoveGroupQueryPlannersService() : MoveGroupCapability("QueryPlannersService")
 {
 }
 
-void move_group::MoveGroupQueryPlannersService::initialize()
+void MoveGroupQueryPlannersService::initialize()
 {
   query_service_ = root_node_handle_.advertiseService(QUERY_PLANNERS_SERVICE_NAME,
                                                       &MoveGroupQueryPlannersService::queryInterface, this);
@@ -53,8 +55,8 @@ void move_group::MoveGroupQueryPlannersService::initialize()
                                                     &MoveGroupQueryPlannersService::setParams, this);
 }
 
-bool move_group::MoveGroupQueryPlannersService::queryInterface(moveit_msgs::QueryPlannerInterfaces::Request& req,
-                                                               moveit_msgs::QueryPlannerInterfaces::Response& res)
+bool MoveGroupQueryPlannersService::queryInterface(moveit_msgs::QueryPlannerInterfaces::Request& req,
+                                                   moveit_msgs::QueryPlannerInterfaces::Response& res)
 {
   const planning_interface::PlannerManagerPtr& planner_interface = context_->planning_pipeline_->getPlannerManager();
   if (planner_interface)
@@ -69,8 +71,8 @@ bool move_group::MoveGroupQueryPlannersService::queryInterface(moveit_msgs::Quer
   return true;
 }
 
-bool move_group::MoveGroupQueryPlannersService::getParams(moveit_msgs::GetPlannerParams::Request& req,
-                                                          moveit_msgs::GetPlannerParams::Response& res)
+bool MoveGroupQueryPlannersService::getParams(moveit_msgs::GetPlannerParams::Request& req,
+                                              moveit_msgs::GetPlannerParams::Response& res)
 {
   const planning_interface::PlannerManagerPtr& planner_interface = context_->planning_pipeline_->getPlannerManager();
   if (planner_interface)
@@ -100,8 +102,8 @@ bool move_group::MoveGroupQueryPlannersService::getParams(moveit_msgs::GetPlanne
   return true;
 }
 
-bool move_group::MoveGroupQueryPlannersService::setParams(moveit_msgs::SetPlannerParams::Request& req,
-                                                          moveit_msgs::SetPlannerParams::Response& res)
+bool MoveGroupQueryPlannersService::setParams(moveit_msgs::SetPlannerParams::Request& req,
+                                              moveit_msgs::SetPlannerParams::Response& res)
 {
   const planning_interface::PlannerManagerPtr& planner_interface = context_->planning_pipeline_->getPlannerManager();
   if (req.params.keys.size() != req.params.values.size())
@@ -124,6 +126,7 @@ bool move_group::MoveGroupQueryPlannersService::setParams(moveit_msgs::SetPlanne
   }
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupQueryPlannersService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -40,19 +40,20 @@
 #include <moveit/collision_detection/collision_tools.h>
 #include <moveit/move_group/capability_names.h>
 
-move_group::MoveGroupStateValidationService::MoveGroupStateValidationService()
-  : MoveGroupCapability("StateValidationService")
+namespace move_group
+{
+MoveGroupStateValidationService::MoveGroupStateValidationService() : MoveGroupCapability("StateValidationService")
 {
 }
 
-void move_group::MoveGroupStateValidationService::initialize()
+void MoveGroupStateValidationService::initialize()
 {
   validity_service_ = root_node_handle_.advertiseService(STATE_VALIDITY_SERVICE_NAME,
                                                          &MoveGroupStateValidationService::computeService, this);
 }
 
-bool move_group::MoveGroupStateValidationService::computeService(moveit_msgs::GetStateValidity::Request& req,
-                                                                 moveit_msgs::GetStateValidity::Response& res)
+bool MoveGroupStateValidationService::computeService(moveit_msgs::GetStateValidity::Request& req,
+                                                     moveit_msgs::GetStateValidity::Response& res)
 {
   planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
   robot_state::RobotState rs = ls->getCurrentState();
@@ -119,6 +120,7 @@ bool move_group::MoveGroupStateValidationService::computeService(moveit_msgs::Ge
 
   return true;
 }
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupStateValidationService, move_group::MoveGroupCapability)


### PR DESCRIPTION
- use namespace definition to reduce verboseness of individual method signatures
- use capability name for ROS console messages
