### PR TITLE
KDL IK solver: fix handling of mimic joints (#1490)

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -31,12 +31,10 @@ namespace
 unsigned int countMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimic>& mimic_joints)
 {
   unsigned int num_mimic = 0;
-  unsigned int index = 0;
   for (const auto& item : mimic_joints)
   {
-    if (item.map_index != index)
+    if (!item.active)
       ++num_mimic;
-    ++index;
   }
   return num_mimic;
 }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -511,7 +511,7 @@ int KDLKinematicsPlugin::CartToJnt(KDL::ChainIkSolverVelMimicSVD& ik_solver, con
 void KDLKinematicsPlugin::clipToJointLimits(const KDL::JntArray& q, KDL::JntArray& q_delta,
                                             Eigen::ArrayXd& weighting) const
 {
-  weighting.setOnes(q_delta.rows());
+  weighting.setOnes();
   for (std::size_t i = 0; i < q.rows(); ++i)
   {
     const double delta_max = joint_max_(i) - q(i);


### PR DESCRIPTION
Backport of #1490 .
The code that originally introduced the problem was merged in melodic-devel.

- correctly count mimic joints
- don't resize extra_joint_weights vector

Fixes an issue introduced in 5bedb7a31db8ab4ac7e474de762e5dfc42ad4d13.
