### PR TITLE
Replace eigenpy with boost::python::numpy

### DIFF
--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
-  eigenpy
   roscpp
   actionlib
   rospy
@@ -30,9 +29,9 @@ find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIR
 
 find_package(Boost REQUIRED)
 if(Boost_VERSION LESS 106700)
-  set(BOOST_PYTHON_COMPONENT python)
+  set(BOOST_PYTHON_COMPONENT python numpy)
 elseif()
-  set(BOOST_PYTHON_COMPONENT python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+  set(BOOST_PYTHON_COMPONENT python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} numpy${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
 endif()
 
 find_package(Boost REQUIRED COMPONENTS

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -33,7 +33,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>python</depend>
-  <depend>eigenpy</depend>
+  <depend>boost</depend>
 
   <build_depend>eigen</build_depend>
 


### PR DESCRIPTION
#1501 used `eigenpy` to directly return the Jacobian matrix from C++ to python as an Eigen::MatrixXd.
Unfortunately, using `eigenpy`, I experienced strange behaviour of `numpy`: `flatten()` didn't work on arrays anymore (https://github.com/stack-of-tasks/eigenpy/issues/63). Removing `eigenpy` solved the issue immediately.
As a work-around (and to get rid of this extra dependency), I replaced `eigenpy` with plain `numpy`.
@7675t, please review.