### PR TITLE
Fix chomp adapter

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -138,12 +138,11 @@ public:
   bool fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory);
 
   /**
-   * This function assigns the chomp_trajectory row / robot pose at index 'chomp_trajectory_point' obtained from input
-   * trajectory_msgs at index 'trajectory_msgs_point'
-   * @param trajectory_msg the input trajectory_msg
-   * @param num_joints_trajectory number of joints in the given robot trajectory
-   * @param trajectory_msgs_point index of the input trajectory_msg's point to get joint values from
-   * @param chomp_trajectory_point index of the chomp_trajectory's point to get joint values from
+   * \brief This function assigns the given \a source RobotState to the row at index \a chomp_trajectory_point
+   *
+   * @param source The source RobotState
+   * @param chomp_trajectory_point index of the chomp_trajectory's point (row)
+   * @param group  JointModelGroup determining the joints to copy
    */
   void assignCHOMPTrajectoryPointFromRobotState(const moveit::core::RobotState& source, size_t chomp_trajectory_point,
                                                 const moveit::core::JointModelGroup* group);

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -145,8 +145,8 @@ public:
    * @param trajectory_msgs_point index of the input trajectory_msg's point to get joint values from
    * @param chomp_trajectory_point index of the chomp_trajectory's point to get joint values from
    */
-  void assignCHOMPTrajectoryPointFromInputTrajectoryPoint(const robot_trajectory::RobotTrajectory& trajectory,
-                                                          size_t trajectory_point_index, size_t chomp_trajectory_point);
+  void assignCHOMPTrajectoryPointFromRobotState(const moveit::core::RobotState& source, size_t chomp_trajectory_point,
+                                                const moveit::core::JointModelGroup* group);
 
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -353,15 +353,13 @@ bool ChompOptimizer::optimize()
     {
       best_group_trajectory_ = group_trajectory_.getTrajectory();
       best_group_trajectory_cost_ = cost;
+      last_improvement_iteration_ = iteration_;
     }
-    else
+    else if (cost < best_group_trajectory_cost_)
     {
-      if (cost < best_group_trajectory_cost_)
-      {
-        best_group_trajectory_ = group_trajectory_.getTrajectory();
-        best_group_trajectory_cost_ = cost;
-        last_improvement_iteration_ = iteration_;
-      }
+      best_group_trajectory_ = group_trajectory_.getTrajectory();
+      best_group_trajectory_cost_ = cost;
+      last_improvement_iteration_ = iteration_;
     }
     calculateSmoothnessIncrements();
     calculateCollisionIncrements();

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -198,8 +198,16 @@ bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajecto
   const size_t max_input_index = trajectory.getWayPointCount() - 1;
 
   const robot_model::JointModelGroup* group = trajectory.getGroup();
+  robot_state::RobotState interpolated(trajectory.getRobotModel());
   for (size_t i = 0; i <= max_output_index; i++)
-    assignCHOMPTrajectoryPointFromRobotState(trajectory.getWayPoint(i * max_input_index / max_output_index), i, group);
+  {
+    double fraction = static_cast<double>(i * max_input_index) / max_output_index;
+    size_t prev_idx = std::trunc(fraction);  // integer part
+    fraction = fraction - prev_idx;          // fractional part
+    size_t next_idx = prev_idx == max_input_index ? prev_idx : prev_idx + 1;
+    trajectory.getWayPoint(prev_idx).interpolate(trajectory.getWayPoint(next_idx), fraction, interpolated, group);
+    assignCHOMPTrajectoryPointFromRobotState(interpolated, i, group);
+  }
   return true;
 }
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -194,7 +194,7 @@ bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajecto
   if (trajectory.getWayPointCount() < 2)
     return false;
 
-  const size_t max_output_index = (*this).getNumPoints() - 1;
+  const size_t max_output_index = getNumPoints() - 1;
   const size_t max_input_index = trajectory.getWayPointCount() - 1;
 
   const robot_model::JointModelGroup* group = trajectory.getGroup();
@@ -202,9 +202,9 @@ bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajecto
   for (size_t i = 0; i <= max_output_index; i++)
   {
     double fraction = static_cast<double>(i * max_input_index) / max_output_index;
-    size_t prev_idx = std::trunc(fraction);  // integer part
-    fraction = fraction - prev_idx;          // fractional part
-    size_t next_idx = prev_idx == max_input_index ? prev_idx : prev_idx + 1;
+    const size_t prev_idx = std::trunc(fraction);  // integer part
+    fraction = fraction - prev_idx;                // fractional part
+    const size_t next_idx = prev_idx == max_input_index ? prev_idx : prev_idx + 1;
     trajectory.getWayPoint(prev_idx).interpolate(trajectory.getWayPoint(next_idx), fraction, interpolated, group);
     assignCHOMPTrajectoryPointFromRobotState(interpolated, i, group);
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -190,68 +190,30 @@ void ChompTrajectory::fillInMinJerk()
 
 bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory)
 {
-  // get the default number of points in the CHOMP trajectory
-  const size_t num_chomp_trajectory_points = (*this).getNumPoints();
-  // get the number of points in the input trajectory
-  const size_t num_input_points = trajectory.getWayPointCount();
-
   // check if input trajectory has less than two states (start and goal), function returns false if condition is true
-  if (num_input_points < 2)
+  if (trajectory.getWayPointCount() < 2)
     return false;
 
-  // variables for populating the CHOMP trajectory with correct number of trajectory points
-  const unsigned int repeated_factor = num_chomp_trajectory_points / num_input_points;
-  const unsigned int repeated_balance_factor = num_chomp_trajectory_points % num_input_points;
+  const size_t max_output_index = (*this).getNumPoints() - 1;
+  const size_t max_input_index = trajectory.getWayPointCount() - 1;
 
-  // response_point_id stores the point at the stored index location.
-  size_t response_point_id = 0;
-  if (num_chomp_trajectory_points >= num_input_points)
-  {
-    for (size_t i = 0; i < num_input_points; i++)
-    {
-      // following for loop repeats each OMPL trajectory pose/row 'repeated_factor' times; alternatively, there could
-      // also be a linear interpolation between these points later if required
-      for (unsigned int k = 0; k < repeated_factor; k++)
-      {
-        assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory, i, response_point_id);
-        response_point_id++;
-      }
-
-      // this populates the CHOMP trajectory row  for the remainder number of rows.
-      if (i < repeated_balance_factor)
-      {
-        assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory, i, response_point_id);
-        response_point_id++;
-      }  // end of if
-    }    // end of for loop for loading in the trajectory poses/rows
-  }
-  else
-  {
-    // perform a decimation sampling in this block if the number of trajectory points in the MotionPlanDetailedResponse
-    // res object is more than the number of points in the CHOMP trajectory
-    const double decimation_sampling_factor = ((double)num_input_points) / ((double)num_chomp_trajectory_points);
-
-    for (size_t i = 0; i < num_chomp_trajectory_points; i++)
-    {
-      size_t sampled_point = floor(i * decimation_sampling_factor);
-      assignCHOMPTrajectoryPointFromInputTrajectoryPoint(trajectory, sampled_point, i);
-    }
-  }  // end of else
+  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  for (size_t i = 0; i <= max_output_index; i++)
+    assignCHOMPTrajectoryPointFromRobotState(trajectory.getWayPoint(i * max_input_index / max_output_index), i, group);
   return true;
 }
 
-void ChompTrajectory::assignCHOMPTrajectoryPointFromInputTrajectoryPoint(
-    const robot_trajectory::RobotTrajectory& trajectory, size_t trajectory_point_index,
-    size_t chomp_trajectory_point_index)
+void ChompTrajectory::assignCHOMPTrajectoryPointFromRobotState(const robot_state::RobotState& source,
+                                                               size_t chomp_trajectory_point_index,
+                                                               const robot_model::JointModelGroup* group)
 {
-  const robot_state::RobotState& source = trajectory.getWayPoint(trajectory_point_index);
   Eigen::MatrixXd::RowXpr target = getTrajectoryPoint(chomp_trajectory_point_index);
-  assert(trajectory.getGroup()->getActiveJointModels().size() == static_cast<size_t>(target.cols()));
+  assert(group->getActiveJointModels().size() == static_cast<size_t>(target.cols()));
   size_t joint_index = 0;
-  for (const robot_state::JointModel* jm : trajectory.getGroup()->getActiveJointModels())
+  for (const robot_state::JointModel* jm : group->getActiveJointModels())
   {
     assert(jm->getVariableCount() == 1);
-    target[joint_index++] = source.getVariablePosition(jm->getJointIndex());
+    target[joint_index++] = source.getVariablePosition(jm->getFirstVariableIndex());
   }
 }
 

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -187,7 +187,7 @@ public:
     if (planning_success)
     {
       res.trajectory_ = res_detailed.trajectory_[0];
-      res.planning_time_ = res_detailed.processing_time_[0];
+      res.planning_time_ += res_detailed.processing_time_[0];
     }
     res.error_code_ = res_detailed.error_code_;
 


### PR DESCRIPTION
Looks like #1473 introduced a new chomp issue: Initializing the chomp trajectory from an OMPL trajectory (when used as an adapter), was using the wrong function to access joint positions.
This fixes https://github.com/ros-planning/moveit/issues/1452#issuecomment-504662578.
Additionally, the new trajectory is interpolated to yield smooth results also when the initialized solution is returned.