### PR TITLE
remove (unused) TrajectoryMonitor from PlanExecution

### DIFF
--- a/moveit_ros/planning/plan_execution/cfg/PlanExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/plan_execution/cfg/PlanExecutionDynamicReconfigure.cfg
@@ -4,6 +4,5 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("max_replan_attempts", int_t, 1, "Set the maximum number of times a sensor can be pointed to parts of the environment doring a motion plan", 5, 0, 1000)
-gen.add("record_trajectory_state_frequency", double_t, 6, "The frequency at which to record states when monitoring trajectories", 10.0, 1.0, 1000.0)
 
 exit(gen.generate(PACKAGE, PACKAGE, "PlanExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -103,20 +103,6 @@ public:
     return trajectory_execution_manager_;
   }
 
-  double getTrajectoryStateRecordingFrequency() const
-  {
-    if (trajectory_monitor_)
-      return trajectory_monitor_->getSamplingFrequency();
-    else
-      return 0.0;
-  }
-
-  void setTrajectoryStateRecordingFrequency(double freq)
-  {
-    if (trajectory_monitor_)
-      trajectory_monitor_->setSamplingFrequency(freq);
-  }
-
   void setMaxReplanAttempts(unsigned int attempts)
   {
     default_max_replan_attempts_ = attempts;
@@ -152,7 +138,6 @@ private:
   ros::NodeHandle node_handle_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
-  planning_scene_monitor::TrajectoryMonitorPtr trajectory_monitor_;
 
   unsigned int default_max_replan_attempts_;
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -61,7 +61,6 @@ private:
   void dynamicReconfigureCallback(PlanExecutionDynamicReconfigureConfig& config, uint32_t level)
   {
     owner_->setMaxReplanAttempts(config.max_replan_attempts);
-    owner_->setTrajectoryStateRecordingFrequency(config.record_trajectory_state_frequency);
   }
 
   PlanExecution* owner_;
@@ -390,14 +389,6 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
     }
   }
 
-  if (!trajectory_monitor_ && planning_scene_monitor_->getStateMonitor())
-    trajectory_monitor_.reset(
-        new planning_scene_monitor::TrajectoryMonitor(planning_scene_monitor_->getStateMonitor()));
-
-  // start recording trajectory states
-  if (trajectory_monitor_)
-    trajectory_monitor_->startTrajectoryMonitor();
-
   // start a trajectory execution thread
   trajectory_execution_manager_->execute(
       boost::bind(&PlanExecution::doneWithTrajectoryExecution, this, _1),
@@ -438,10 +429,6 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
                                      "Possibly the node is about to shut down.");
     trajectory_execution_manager_->stopExecution();
   }
-
-  // stop recording trajectory states
-  if (trajectory_monitor_)
-    trajectory_monitor_->stopTrajectoryMonitor();
 
   // decide return value
   if (path_became_invalid_)


### PR DESCRIPTION
As pointed out in #1526, TrajectoryMonitor in PlanExecution leaks memory and is not used at all.
That's why I suggest to remove it.