### PR TITLE
Benchmark planning pipelines instead of plugins only

### DIFF
--- a/moveit_ros/benchmarks/README.md
+++ b/moveit_ros/benchmarks/README.md
@@ -2,4 +2,4 @@
 
 This package provides methods to benchmark motion planning algorithms and aggregate/plot statistics. Results can be viewed in [Planner Arena](http://plannerarena.org/).
 
-For more information and usage example please see [moveit tutorials](http://docs.ros.org/indigo/api/moveit_tutorials/html/doc/benchmarking_tutorial.html).
+For more information and usage example please see [moveit tutorials](https://ros-planning.github.io/moveit_tutorials/doc/benchmarking/benchmarking_tutorial.html).

--- a/moveit_ros/benchmarks/examples/demo1.yaml
+++ b/moveit_ros/benchmarks/examples/demo1.yaml
@@ -18,8 +18,8 @@ benchmark_config:
         output_directory: /tmp/moveit_benchmarks/
         queries: Pick1
         start_states: Start1
-    planners:
-        - plugin: ompl_interface/OMPLPlanner
+    planning_pipelines:
+        - name: ompl
           planners:
             - RRTConnectkConfigDefault
             - BKPIECEkConfigDefault

--- a/moveit_ros/benchmarks/examples/demo2.yaml
+++ b/moveit_ros/benchmarks/examples/demo2.yaml
@@ -18,12 +18,12 @@ benchmark_config:
         output_directory: /home/benchmarks/
         queries: .*
         start_states: .*
-    planners:
-        - plugin: ompl_interface/OMPLPlanner
+    planning_pipelines:
+        - name: ompl
           planners:
             - RRTConnectkConfigDefault
             - BKPIECEkConfigDefault
             - KPIECEkConfigDefault
-        - plugin: my_plugin_ns/my_plugin
+        - name: my_pipeline
           planners:
             - MyPlanner

--- a/moveit_ros/benchmarks/examples/demo_fanuc.launch
+++ b/moveit_ros/benchmarks/examples/demo_fanuc.launch
@@ -8,7 +8,7 @@
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark" file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 

--- a/moveit_ros/benchmarks/examples/demo_obstacles.yaml
+++ b/moveit_ros/benchmarks/examples/demo_obstacles.yaml
@@ -18,7 +18,7 @@ benchmark_config:
         output_directory: /tmp/moveit_benchmarks/
         queries: .*
         start_states: .*
-    planning_pipeline:
+    planning_pipelines:
         - name: ompl
           planners:
             - RRTConnectkConfigDefault

--- a/moveit_ros/benchmarks/examples/demo_obstacles.yaml
+++ b/moveit_ros/benchmarks/examples/demo_obstacles.yaml
@@ -18,16 +18,16 @@ benchmark_config:
         output_directory: /tmp/moveit_benchmarks/
         queries: .*
         start_states: .*
-    planners:
-        - plugin: ompl_interface/OMPLPlanner
+    planning_pipeline:
+        - name: ompl
           planners:
             - RRTConnectkConfigDefault
             - BKPIECEkConfigDefault
             - KPIECEkConfigDefault
-        - plugin: chomp_interface/CHOMPPlanner
+        - name: chomp
           planners:
             - CHOMP
-        - plugin: stomp_moveit/StompPlannerManager
+        - name: stomp
           planners:
             - STOMP
 

--- a/moveit_ros/benchmarks/examples/demo_panda.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda.launch
@@ -8,7 +8,7 @@
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
@@ -8,15 +8,15 @@
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/chomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="chomp" />
   </include>
 
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/stomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="stomp" />
   </include>
 

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.yaml
@@ -18,16 +18,16 @@ benchmark_config:
         output_directory: /tmp/moveit_benchmarks/
         queries: .*
         start_states: .*
-    planners:
-        - plugin: ompl_interface/OMPLPlanner
+    planning_pipelines:
+        - name: ompl
           planners:
             - RRTConnectkConfigDefault
             - BKPIECEkConfigDefault
             - KPIECEkConfigDefault
-        - plugin: chomp_interface/CHOMPPlanner
+        - name: chomp
           planners:
             - CHOMP
-        - plugin: stomp_moveit/StompPlannerManager
+        - name: stomp
           planners:
             - STOMP
 

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
@@ -8,15 +8,15 @@
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/chomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="chomp" />
   </include>
 
-  <include ns="moveit_run_benchmark" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/stomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="stomp" />
   </include>
 

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkExecutor.h
@@ -46,7 +46,7 @@
 #include <moveit/warehouse/state_storage.h>
 #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/warehouse/trajectory_constraints_storage.h>
-#include <moveit/planning_interface/planning_interface.h>
+#include <moveit/planning_pipeline/planning_pipeline.h>
 #include <warehouse_ros/database_loader.h>
 #include <pluginlib/class_loader.hpp>
 
@@ -213,8 +213,7 @@ protected:
 
   BenchmarkOptions options_;
 
-  std::shared_ptr<pluginlib::ClassLoader<planning_interface::PlannerManager>> planner_plugin_loader_;
-  std::map<std::string, planning_interface::PlannerManagerPtr> planner_interfaces_;
+  std::map<std::string, planning_pipeline::PlanningPipelinePtr> planning_pipelines_;
 
   std::vector<PlannerBenchmarkData> benchmark_data_;
 

--- a/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkOptions.h
+++ b/moveit_ros/benchmarks/include/moveit/benchmarks/BenchmarkOptions.h
@@ -69,8 +69,8 @@ public:
   const std::string& getPathConstraintRegex() const;
   const std::string& getTrajectoryConstraintRegex() const;
   void getGoalOffsets(std::vector<double>& offsets) const;
-  const std::map<std::string, std::vector<std::string>>& getPlannerConfigurations() const;
-  void getPlannerPluginList(std::vector<std::string>& plugin_list) const;
+  const std::map<std::string, std::vector<std::string>>& getPlanningPipelineConfigurations() const;
+  void getPlanningPipelineNames(std::vector<std::string>& planning_pipeline_names) const;
 
   const std::string& getWorkspaceFrameID() const;
   const moveit_msgs::WorkspaceParameters& getWorkspaceParameters() const;
@@ -104,7 +104,7 @@ protected:
   double goal_offsets[6];
 
   /// planner configurations
-  std::map<std::string, std::vector<std::string>> planners_;
+  std::map<std::string, std::vector<std::string>> planning_pipelines_;
 
   moveit_msgs::WorkspaceParameters workspace_;
 };

--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -142,16 +142,16 @@ void BenchmarkOptions::getGoalOffsets(std::vector<double>& offsets) const
   memcpy(&offsets[0], goal_offsets, 6 * sizeof(double));
 }
 
-const std::map<std::string, std::vector<std::string>>& BenchmarkOptions::getPlannerConfigurations() const
+const std::map<std::string, std::vector<std::string>>& BenchmarkOptions::getPlanningPipelineConfigurations() const
 {
-  return planners_;
+  return planning_pipelines_;
 }
 
-void BenchmarkOptions::getPlannerPluginList(std::vector<std::string>& plugin_list) const
+void BenchmarkOptions::getPlanningPipelineNames(std::vector<std::string>& planning_pipeline_names) const
 {
-  plugin_list.clear();
-  for (const std::pair<const std::string, std::vector<std::string>>& planner : planners_)
-    plugin_list.push_back(planner.first);
+  planning_pipeline_names.clear();
+  for (const std::pair<const std::string, std::vector<std::string>>& planning_pipeline : planning_pipelines_)
+    planning_pipeline_names.push_back(planning_pipeline.first);
 }
 
 const std::string& BenchmarkOptions::getWorkspaceFrameID() const
@@ -237,48 +237,48 @@ void BenchmarkOptions::readWorkspaceParameters(ros::NodeHandle& nh)
 
 void BenchmarkOptions::readPlannerConfigs(ros::NodeHandle& nh)
 {
-  planners_.clear();
+  planning_pipelines_.clear();
 
-  XmlRpc::XmlRpcValue planner_configs;
-  if (nh.getParam("benchmark_config/planners", planner_configs))
+  XmlRpc::XmlRpcValue pipeline_configs;
+  if (nh.getParam("benchmark_config/planning_pipelines", pipeline_configs))
   {
-    if (planner_configs.getType() != XmlRpc::XmlRpcValue::TypeArray)
+    if (pipeline_configs.getType() != XmlRpc::XmlRpcValue::TypeArray)
     {
-      ROS_ERROR("Expected a list of planner configurations to benchmark");
+      ROS_ERROR("Expected a list of planning pipeline configurations to benchmark");
       return;
     }
 
-    for (int i = 0; i < planner_configs.size(); ++i)  // NOLINT(modernize-loop-convert)
+    for (int i = 0; i < pipeline_configs.size(); ++i)  // NOLINT(modernize-loop-convert)
     {
-      if (planner_configs[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+      if (pipeline_configs[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
       {
-        ROS_WARN("Improper YAML type for planner configurations");
+        ROS_WARN("Improper YAML type for planning pipeline configurations");
         continue;
       }
-      if (!planner_configs[i].hasMember("plugin") || !planner_configs[i].hasMember("planners"))
+      if (!pipeline_configs[i].hasMember("name") || !pipeline_configs[i].hasMember("planners"))
       {
         ROS_WARN("Malformed YAML for planner configurations");
         continue;
       }
 
-      if (planner_configs[i]["planners"].getType() != XmlRpc::XmlRpcValue::TypeArray)
+      if (pipeline_configs[i]["planners"].getType() != XmlRpc::XmlRpcValue::TypeArray)
       {
         ROS_WARN("Expected a list of planners to benchmark");
         continue;
       }
 
-      const std::string plugin = planner_configs[i]["plugin"];
-      ROS_INFO("Reading in planner names for plugin '%s'", plugin.c_str());
+      const std::string pipeline_name = pipeline_configs[i]["name"];
+      ROS_INFO("Reading in planner names for planning pipeline '%s'", pipeline_name.c_str());
 
       std::vector<std::string> planners;
-      planners.reserve(planner_configs[i]["planners"].size());
-      for (int j = 0; j < planner_configs[i]["planners"].size(); ++j)
-        planners.emplace_back(planner_configs[i]["planners"][j]);
+      planners.reserve(pipeline_configs[i]["planners"].size());
+      for (int j = 0; j < pipeline_configs[i]["planners"].size(); ++j)
+        planners.emplace_back(pipeline_configs[i]["planners"][j]);
 
       for (std::size_t j = 0; j < planners.size(); ++j)
         ROS_INFO("  [%lu]: %s", j, planners[j].c_str());
 
-      planners_[plugin] = planners;
+      planning_pipelines_[pipeline_name] = planners;
     }
   }
 }

--- a/moveit_ros/benchmarks/src/RunBenchmark.cpp
+++ b/moveit_ros/benchmarks/src/RunBenchmark.cpp
@@ -51,9 +51,9 @@ int main(int argc, char** argv)
   // Setup benchmark server
   moveit_ros_benchmarks::BenchmarkExecutor server;
 
-  std::vector<std::string> plugins;
-  opts.getPlannerPluginList(plugins);
-  server.initialize(plugins);
+  std::vector<std::string> planning_pipelines;
+  opts.getPlanningPipelineNames(planning_pipelines);
+  server.initialize(planning_pipelines);
 
   // Running benchmarks
   if (!server.runBenchmarks(opts))


### PR DESCRIPTION
Based on #1510 and #1530 this adds support for running benchmarks on full planning pipelines.
This only requires minor changes in the configuration, in particular specifying pipeline namespaces in the launch files and using this names instead of plugin identifiers inside the yaml files.
If approved, I will add appropriate changes for the tutorial.

Please review the last commit bc689be only. All other changes are included from #1510.
