### PR TITLE
link moveit_robot_model from moveit_test_utils

### DIFF
--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(${MOVEIT_TEST_LIB_NAME}
   src/robot_model_test_utils.cpp
 )
 add_dependencies(${MOVEIT_TEST_LIB_NAME} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${MOVEIT_TEST_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_TEST_LIB_NAME} moveit_robot_model ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(${MOVEIT_TEST_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 install(


### PR DESCRIPTION
The library internally creates RobotModel objects
and thus should link the constructor.

---

I just tried to build a fresh current master workspace on Lunar-Linux with clang++ and hit this error:

```
Errors     << moveit_ros_planning:make ros/melodic/moveit/logs/moveit_ros_planning/build.make.001.log
/usr/bin/ld: ros/melodic/moveit/install/lib/libmoveit_test_utils.so: undefined reference to `moveit::core::RobotModel::RobotModel(std::shared_ptr<urdf::ModelInterface> const&, std::shared_ptr<srdf::Model const> const&)'
/usr/bin/ld: ros/melodic/moveit/install/lib/libmoveit_test_utils.so: undefined reference to `moveit::core::RobotModel::~RobotModel()'
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [planning_scene_monitor/CMakeFiles/demo_scene.dir/build.make:248: ros/melodic/moveit/devel/.private/moveit_ros_planning/lib/moveit_ros_planning/demo_scene] Error 1
make[1]: *** [CMakeFiles/Makefile2:3183: planning_scene_monitor/CMakeFiles/demo_scene.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:141: all] Error 2
```

(1) This request simply links libmoveit_robot_model from libmoveit_test_utils.so. Both reside in the same ROS package, so the library can be referenced by literal name here. I seem to recall a debate on whether this link is necessary or not but I can't find it anymore.

(2) It does not really make any sense that a binary like `moveit_ros_planning/demo_scene` links the tests lib to begin with. But it is probably pulled in as a general library dependency of `moveit_core`. The concrete so-link might be related to me not using a Debian-based linux distribution.