### PR TITLE
backport #1538 trajectory recording / memory leak

### DIFF
--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
@@ -73,7 +73,7 @@ struct ExecutableMotionPlan
 
   std::vector<ExecutableTrajectory> plan_components_;
 
-  // The trace of the trajectory recorded during execution
+  /// The trace of the trajectory recorded during execution
   robot_trajectory::RobotTrajectoryPtr executed_trajectory_;
 
   /// An error code reflecting what went wrong (if anything)

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -441,7 +441,12 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
 
   // stop recording trajectory states
   if (trajectory_monitor_)
+  {
     trajectory_monitor_->stopTrajectoryMonitor();
+    plan.executed_trajectory_ =
+        std::make_shared<robot_trajectory::RobotTrajectory>(planning_scene_monitor_->getRobotModel(), "");
+    trajectory_monitor_->swapTrajectory(*plan.executed_trajectory_);
+  }
 
   // decide return value
   if (path_became_invalid_)


### PR DESCRIPTION
This backports #1538 to fix the associated memory leak.

Do we want to backport the re-enabled feature to send tracked trajectories in Result messages also to kinetic-devel? Alternatively, we could [disable recording](https://github.com/ros-planning/moveit/pull/1528) there to avoid potential performance losses.