### PR TITLE
TrajectoryMonitor: zero sampling frequency disables recording

### DIFF
--- a/moveit_ros/planning/plan_execution/cfg/PlanExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/plan_execution/cfg/PlanExecutionDynamicReconfigure.cfg
@@ -4,6 +4,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("max_replan_attempts", int_t, 1, "Set the maximum number of times a sensor can be pointed to parts of the environment doring a motion plan", 5, 0, 1000)
-gen.add("record_trajectory_state_frequency", double_t, 6, "The frequency at which to record states when monitoring trajectories", 10.0, 1.0, 1000.0)
+gen.add("record_trajectory_state_frequency", double_t, 6, "The frequency at which to record states when monitoring trajectories", 0.0, 0.0, 1000.0)
 
 exit(gen.generate(PACKAGE, PACKAGE, "PlanExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -391,8 +391,13 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
   }
 
   if (!trajectory_monitor_ && planning_scene_monitor_->getStateMonitor())
-    trajectory_monitor_.reset(
-        new planning_scene_monitor::TrajectoryMonitor(planning_scene_monitor_->getStateMonitor()));
+  {
+    // Pass current value of reconfigurable parameter plan_execution/record_trajectory_state_frequency
+    double sampling_frequency = 0.0;
+    node_handle_.getParam("plan_execution/record_trajectory_state_frequency", sampling_frequency);
+    trajectory_monitor_ = std::make_shared<planning_scene_monitor::TrajectoryMonitor>(
+        planning_scene_monitor_->getStateMonitor(), sampling_frequency);
+  }
 
   // start recording trajectory states
   if (trajectory_monitor_)

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -57,7 +57,7 @@ class TrajectoryMonitor
 public:
   /** @brief Constructor.
    */
-  TrajectoryMonitor(const CurrentStateMonitorConstPtr& state_monitor, double sampling_frequency = 5.0);
+  TrajectoryMonitor(const CurrentStateMonitorConstPtr& state_monitor, double sampling_frequency = 0.0);
 
   ~TrajectoryMonitor();
 

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -40,6 +40,8 @@
 #include <limits>
 #include <memory>
 
+static const std::string LOGNAME = "TrajectoryMonitor";
+
 planning_scene_monitor::TrajectoryMonitor::TrajectoryMonitor(const CurrentStateMonitorConstPtr& state_monitor,
                                                              double sampling_frequency)
   : current_state_monitor_(state_monitor)
@@ -57,9 +59,8 @@ planning_scene_monitor::TrajectoryMonitor::~TrajectoryMonitor()
 void planning_scene_monitor::TrajectoryMonitor::setSamplingFrequency(double sampling_frequency)
 {
   if (sampling_frequency <= std::numeric_limits<double>::epsilon())
-    ROS_ERROR("The sampling frequency for trajectory states should be positive");
-  else
-    sampling_frequency_ = sampling_frequency;
+    ROS_INFO_NAMED(LOGNAME, "Disabling trajectory recording");
+  sampling_frequency_ = sampling_frequency;
 }
 
 bool planning_scene_monitor::TrajectoryMonitor::isActive() const
@@ -69,10 +70,10 @@ bool planning_scene_monitor::TrajectoryMonitor::isActive() const
 
 void planning_scene_monitor::TrajectoryMonitor::startTrajectoryMonitor()
 {
-  if (!record_states_thread_)
+  if (sampling_frequency_ > std::numeric_limits<double>::epsilon() && !record_states_thread_)
   {
     record_states_thread_.reset(new boost::thread(boost::bind(&TrajectoryMonitor::recordStates, this)));
-    ROS_DEBUG("Started trajectory monitor");
+    ROS_DEBUG_NAMED(LOGNAME, "Started trajectory monitor");
   }
 }
 
@@ -83,7 +84,7 @@ void planning_scene_monitor::TrajectoryMonitor::stopTrajectoryMonitor()
     std::unique_ptr<boost::thread> copy;
     copy.swap(record_states_thread_);
     copy->join();
-    ROS_DEBUG("Stopped trajectory monitor");
+    ROS_DEBUG_NAMED(LOGNAME, "Stopped trajectory monitor");
   }
 }
 

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -45,7 +45,7 @@ static const std::string LOGNAME = "TrajectoryMonitor";
 planning_scene_monitor::TrajectoryMonitor::TrajectoryMonitor(const CurrentStateMonitorConstPtr& state_monitor,
                                                              double sampling_frequency)
   : current_state_monitor_(state_monitor)
-  , sampling_frequency_(5.0)
+  , sampling_frequency_(sampling_frequency)
   , trajectory_(current_state_monitor_->getRobotModel(), "")
 {
   setSamplingFrequency(sampling_frequency);
@@ -58,6 +58,9 @@ planning_scene_monitor::TrajectoryMonitor::~TrajectoryMonitor()
 
 void planning_scene_monitor::TrajectoryMonitor::setSamplingFrequency(double sampling_frequency)
 {
+  if (sampling_frequency != sampling_frequency_)
+    return;  // silently return if nothing changes
+
   if (sampling_frequency <= std::numeric_limits<double>::epsilon())
     ROS_INFO_NAMED(LOGNAME, "Disabling trajectory recording");
   else

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -60,6 +60,8 @@ void planning_scene_monitor::TrajectoryMonitor::setSamplingFrequency(double samp
 {
   if (sampling_frequency <= std::numeric_limits<double>::epsilon())
     ROS_INFO_NAMED(LOGNAME, "Disabling trajectory recording");
+  else
+    ROS_DEBUG_NAMED(LOGNAME, "Setting trajectory sampling frequency to %.1f", sampling_frequency);
   sampling_frequency_ = sampling_frequency;
 }
 


### PR DESCRIPTION
Implements https://github.com/ros-planning/moveit/pull/1538#issuecomment-508770275.
@v4hn, should we disable the monitoring by default in `PlanExecution`?