### PR TITLE
Adapt eigenpy to upcoming third-party re-release

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -27,5 +27,5 @@
 # Temporary for running CI to test new EigenPy
 - git:
     local-name: eigenpy
-    uri: https://github.com/wxmerkt/eigenpy.git
-    version: wxm-update-eigenpy-for-3rd-party-release
+    uri: https://github.com/stack-of-tasks/eigenpy.git
+    version: devel

--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -24,3 +24,8 @@
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
     version: master
+# Temporary for running CI to test new EigenPy
+- git:
+    local-name: eigenpy
+    uri: https://github.com/wxmerkt/eigenpy.git
+    version: wxm-update-eigenpy-for-3rd-party-release

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -75,7 +75,6 @@ catkin_package(
     tf2_geometry_msgs
   DEPENDS
     EIGEN3
-    eigenpy
 )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -19,12 +19,14 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
-  eigenpy
   roscpp
   actionlib
   rospy
   rosconsole
 )
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(eigenpy eigenpy REQUIRED)
 
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
@@ -73,10 +75,12 @@ catkin_package(
     tf2_geometry_msgs
   DEPENDS
     EIGEN3
+    eigenpy
 )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
+                    ${eigenpy_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS})
 
 include_directories(SYSTEM

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -33,8 +33,8 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>python</depend>
-  <depend>eigenpy</depend>
 
+  <build_depend>eigenpy</build_depend>
   <build_depend>eigen</build_depend>
 
   <test_depend>moveit_resources</test_depend>


### PR DESCRIPTION
This is a test to trigger CI to see whether a fixed 3rd-party-released package with a fixed pkg-config would resolve the issues raised in #1536.