### PR TITLE
WIP: Implement CostConvergenceTerminationCondition for OMPL* planners

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <ompl/base/PlannerTerminationCondition.h>
+namespace ompl_interface
+{
+namespace ob = ompl::base;
+class CostConvergenceTerminationCondition : public ob::PlannerTerminationCondition
+{
+public:
+  CostConvergenceTerminationCondition(size_t solutions_window = 10, double convergence_threshold = 0.9)
+    : ob::PlannerTerminationCondition([] { return false; })
+    , solutions_window_(solutions_window)
+    , convergence_threshold_(convergence_threshold)
+  {
+    std::cout << " test" << std::endl;
+  }
+
+  // Compute the running average cost of the last solutions (solution_window) and terminate if the cost of a
+  // new solution is higher than convergence_threshold times the average cost.
+  void processNewSolution(const std::vector<const ob::State*>& solution_states, const ob::Cost solution_cost)
+  {
+    ++solutions_;
+    size_t solutions = std::min(solutions_, solutions_window_);
+    double new_cost = ((solutions - 1) * average_cost_ + solution_cost.value()) / solutions;
+    double cost_ratio = average_cost_ / new_cost;
+    average_cost_ = new_cost;
+    if (solutions == solutions_window_ && cost_ratio > convergence_threshold_)
+    {
+      std::cout << "Optimizing planner converged after " << solutions_ << " solutions" << std::endl;
+      terminate();
+    }
+  }
+
+private:
+  double average_cost_;
+  size_t solutions_ = 0;
+
+  const size_t solutions_window_;
+  const double convergence_threshold_;
+};
+}

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
@@ -1,4 +1,40 @@
-#include <iostream>
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, PickNik LLC
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of PickNik LLC nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Henning Kayser */
+/* Description: A termination condition for early-stopping OMPL* planners based on cost-convergence. */
+
 #include <ompl/base/PlannerTerminationCondition.h>
 namespace ompl_interface
 {
@@ -11,7 +47,6 @@ public:
     , solutions_window_(solutions_window)
     , convergence_threshold_(convergence_threshold)
   {
-    std::cout << " test" << std::endl;
   }
 
   // Compute the running average cost of the last solutions (solution_window) and terminate if the cost of a
@@ -21,11 +56,12 @@ public:
     ++solutions_;
     size_t solutions = std::min(solutions_, solutions_window_);
     double new_cost = ((solutions - 1) * average_cost_ + solution_cost.value()) / solutions;
-    double cost_ratio = average_cost_ / new_cost;
+    double cost_ratio = new_cost / average_cost_;
     average_cost_ = new_cost;
     if (solutions == solutions_window_ && cost_ratio > convergence_threshold_)
     {
-      std::cout << "Optimizing planner converged after " << solutions_ << " solutions" << std::endl;
+      ROS_DEBUG_NAMED("cost_convergence_termination_condition",
+                      "Cost of optimizing planner converged after %lu solutions", solutions_);
       terminate();
     }
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -318,6 +318,8 @@ protected:
   virtual void useConfig();
   virtual ob::GoalPtr constructGoal();
 
+  ob::PlannerTerminationCondition getPlannerTerminationCondition(
+      double timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& ptc_or = nullptr);
   void registerTerminationCondition(const ob::PlannerTerminationCondition& ptc);
   void unregisterTerminationCondition();
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -319,7 +319,7 @@ protected:
   virtual ob::GoalPtr constructGoal();
 
   ob::PlannerTerminationCondition getPlannerTerminationCondition(
-      double timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& ptc_or = nullptr);
+      double ptc_timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& alternative_ptc = nullptr);
   void registerTerminationCondition(const ob::PlannerTerminationCondition& ptc);
   void unregisterTerminationCondition();
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -729,11 +729,11 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
 }
 
 ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContext::getPlannerTerminationCondition(
-    double timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& ptc_or)
+    double ptc_timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& alternative_ptc)
 {
-  ob::PlannerTerminationCondition ptc = ob::timedPlannerTerminationCondition(timeout);
-  if (ptc_or)
-    return ob::plannerOrTerminationCondition(ptc, *ptc_or);
+  ob::PlannerTerminationCondition ptc = ob::timedPlannerTerminationCondition(ptc_timeout);
+  if (alternative_ptc)
+    return ob::plannerOrTerminationCondition(ptc, *alternative_ptc);
   else
     return ptc;
 }


### PR DESCRIPTION
This implements a simple convergence-based termination condition that lets OMPL* planners terminate early if the solutions don't increase by a certain margin. In the long run I would like to add support for custom termination conditions and of course be able to configure them. Non-optimizing planners won't be affected by this at all.

Also, I realize that this should probably be optional but I wanted to open this for review anyway.