### PR TITLE
Handeye calibration rviz gui plugin [WIP]

### DIFF
--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -25,6 +25,8 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning_interface
   moveit_ros_robot_interaction
   moveit_ros_warehouse
+  moveit_visual_tools
+  image_geometry
   object_recognition_msgs
   pluginlib
   rosconsole
@@ -69,16 +71,19 @@ catkin_package(
     moveit_robot_state_rviz_plugin_core
     moveit_rviz_plugin_render_tools
     moveit_trajectory_rviz_plugin_core
+    moveit_handeye_calibration_rviz_plugin_core
   INCLUDE_DIRS
     motion_planning_rviz_plugin/include
     planning_scene_rviz_plugin/include
     robot_state_rviz_plugin/include
     rviz_plugin_render_tools/include
     trajectory_rviz_plugin/include
+    handeye_calibration_rviz_plugin/include
   CATKIN_DEPENDS
     moveit_ros_planning_interface
     moveit_ros_robot_interaction
     object_recognition_msgs
+    moveit_visual_tools
   DEPENDS
     EIGEN3
 )
@@ -91,6 +96,7 @@ include_directories(rviz_plugin_render_tools/include
                     planning_scene_rviz_plugin/include
                     motion_planning_rviz_plugin/include
                     trajectory_rviz_plugin/include
+                    handeye_calibration_rviz_plugin/include
                     ${Boost_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS})
 
@@ -103,12 +109,14 @@ add_subdirectory(robot_state_rviz_plugin)
 add_subdirectory(planning_scene_rviz_plugin)
 add_subdirectory(motion_planning_rviz_plugin)
 add_subdirectory(trajectory_rviz_plugin)
+add_subdirectory(handeye_calibration_rviz_plugin)
 
 install(FILES
   motion_planning_rviz_plugin_description.xml
   trajectory_rviz_plugin_description.xml
   planning_scene_rviz_plugin_description.xml
   robot_state_rviz_plugin_description.xml
+  handeye_calibration_rviz_plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/CMakeLists.txt
@@ -1,0 +1,37 @@
+find_package(OpenCV REQUIRED) 
+
+set(HEADERS
+  include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h
+  include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
+  include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
+  include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+)
+
+#catkin_lint: ignore_once missing_directory
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# Plugin Source
+set(SOURCE_FILES
+  src/handeye_calibration_gui.cpp
+  src/handeye_target_widget.cpp
+  src/handeye_context_widget.cpp
+  src/handeye_control_widget.cpp
+)
+
+set(MOVEIT_LIB_NAME moveit_handeye_calibration_rviz_plugin)
+add_library(${MOVEIT_LIB_NAME}_core ${SOURCE_FILES} ${HEADERS})
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+target_link_libraries(${MOVEIT_LIB_NAME}_core
+  moveit_rviz_plugin_render_tools
+  moveit_planning_scene_rviz_plugin_core
+  ${catkin_LIBRARIES} ${OpenCV_LIBS} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+
+add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+install(TARGETS ${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h
@@ -1,0 +1,85 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
+#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATION_GUI_
+
+// qt
+
+// ros
+#include <rviz_visual_tools/tf_visual_tools.h>
+
+// local
+#include <moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h>
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#endif
+
+namespace moveit_rviz_plugin
+{
+class HandEyeCalibrationGui : public rviz::Panel
+{
+  Q_OBJECT
+public:
+  explicit HandEyeCalibrationGui(QWidget* parent = 0);
+  ~HandEyeCalibrationGui() override;
+
+  virtual void load(const rviz::Config& config);
+  virtual void save(rviz::Config config) const;
+
+private:
+  // ******************************************************************************************
+  // Qt Components
+  // ******************************************************************************************
+
+  TargetTabWidget* tab_target_;
+  ContextTabWidget* tab_context_;
+  ControlTabWidget* tab_control_;
+
+  // ******************************************************************************************
+  // Ros Components
+  // ******************************************************************************************
+
+  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
+};
+
+}  // namedist moveit_rviz_plugin
+
+#endif

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h
@@ -1,0 +1,249 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CONTEXT_WIDGET_
+#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CONTEXT_WIDGET_
+
+// qt
+#include <QLabel>
+#include <QWidget>
+#include <QSlider>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QGroupBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QRadioButton>
+
+// ros
+#include <shape_msgs/Mesh.h>
+#include <rviz/frame_manager.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <rviz_visual_tools/tf_visual_tools.h>
+#include <rviz_visual_tools/rviz_visual_tools.h>
+#include <image_geometry/pinhole_camera_model.h>
+#include <moveit_visual_tools/moveit_visual_tools.h>
+#include <moveit/handeye_calibration_solver/handeye_solver_base.h>
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#endif
+
+namespace rvt = rviz_visual_tools;
+namespace mhc = moveit_handeye_calibration;
+
+namespace moveit_rviz_plugin
+{
+enum FRAME_SOURCE
+{
+  ROBOT_FRAME = 0,
+  CAMERA_FRAME = 1,
+  ENVIRONMENT_FRAME = 2
+};
+
+// **************************************************
+// Custom QComboBox for frame name
+// **************************************************
+class TFFrameNameComboBox : public QComboBox
+{
+  Q_OBJECT
+public:
+  TFFrameNameComboBox(FRAME_SOURCE source = ROBOT_FRAME, QWidget* parent = 0) : QComboBox(parent), frame_source_(source)
+  {
+    robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("robot_description"));
+    frame_manager_.reset(new rviz::FrameManager());
+  }
+
+  ~TFFrameNameComboBox()
+  {
+    robot_model_loader_.reset();
+  }
+
+  bool hasFrame(const std::string& frame_name);
+
+protected:
+  void mousePressEvent(QMouseEvent* event);
+
+private:
+  FRAME_SOURCE frame_source_;
+  std::unique_ptr<rviz::FrameManager> frame_manager_;
+  robot_model_loader::RobotModelLoaderConstPtr robot_model_loader_;
+};
+
+// **************************************************
+// Custom slider class
+// **************************************************
+class SliderWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  SliderWidget(QWidget* parent, std::string name, double min, double max);
+
+  ~SliderWidget() override = default;
+
+  double getValue();
+
+  void setValue(double value);
+
+  QLabel* label_;
+  QSlider* slider_;
+  QLineEdit* edit_;
+
+private Q_SLOTS:
+
+  // Called when the slider is changed
+  void changeValue(int value);
+
+  // Called when the edit box is changed
+  void changeSlider();
+
+Q_SIGNALS:
+
+  // Indicate value when slider widget changed
+  void valueChanged(double value);
+
+private:
+  // Max & min position
+  double max_position_;
+  double min_position_;
+};
+
+class ContextTabWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit ContextTabWidget(QWidget* parent = Q_NULLPTR);
+  ~ContextTabWidget()
+  {
+    camera_info_.reset();
+    visual_tools_.reset();
+    tf_tools_.reset();
+  }
+
+  void loadWidget(const rviz::Config& config);
+  void saveWidget(rviz::Config& config);
+  void setTFTool(rviz_visual_tools::TFVisualToolsPtr& tf_pub);
+
+  void updateAllMarkers();
+
+  void updateFOVPose();
+
+  static shape_msgs::Mesh getCameraFOVMesh(const sensor_msgs::CameraInfo& camera_info, double maxdist);
+
+  visualization_msgs::Marker getCameraFOVMarker(const Eigen::Isometry3d& pose, const shape_msgs::Mesh& mesh,
+                                                rvt::colors color, double alpha, std::string frame_id);
+
+  visualization_msgs::Marker getCameraFOVMarker(const geometry_msgs::Pose& pose, const shape_msgs::Mesh& mesh,
+                                                rvt::colors color, double alpha, std::string frame_id);
+
+  void setCameraPose(double tx, double ty, double tz, double rx, double ry, double rz);
+
+public Q_SLOTS:
+
+  void setCameraInfo(sensor_msgs::CameraInfo camera_info);
+
+  void setOpticalFrame(const std::string& frame_id);
+
+  void updateCameraPose(double tx, double ty, double tz, double rx, double ry, double rz);
+
+private Q_SLOTS:
+
+  // Called when the sensor_mount_type_ changed
+  void updateSensorMountType(int index);
+
+  // Called when the TFFrameNameComboBox changed
+  void updateFrameName(int index);
+
+  // Called when the slider of initial camera pose guess changed
+  void updateCameraMarkerPose(double value);
+
+  // Called when the fov_on_off_ button toggled
+  void fovOnOffBtnToggled(bool checked);
+
+Q_SIGNALS:
+
+  void sensorMountTypeChanged(int index);
+
+  void frameNameChanged(std::map<std::string, std::string> names);
+
+private:
+  // **************************************************************
+  // Qt components
+  // **************************************************************
+
+  // Calibration algorithm, sensor mount type area
+  QComboBox* sensor_mount_type_;
+
+  // Frame selection area
+  std::map<std::string, TFFrameNameComboBox*> frames_;
+
+  // FOV setting area
+  QRadioButton* fov_on_off_;
+  SliderWidget* fov_alpha_;
+
+  // Initial camera pose
+  std::map<std::string, SliderWidget*> guess_pose_;
+
+  // **************************************************************
+  // Variables
+  // **************************************************************
+
+  sensor_msgs::CameraInfoPtr camera_info_;
+
+  // Transform from camera to robot base or end-effector
+  Eigen::Isometry3d camera_pose_;
+
+  std::string optical_frame_;
+
+  // Transform from camera to fov
+  Eigen::Isometry3d fov_pose_;
+
+  // **************************************************************
+  // Ros components
+  // **************************************************************
+
+  moveit_visual_tools::MoveItVisualToolsPtr visual_tools_;
+  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+};
+
+}  // namespace moveit_rviz_plugin
+
+#endif

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h
@@ -1,0 +1,242 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THEsensorPoseUpdate
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATE_WIDGET_
+#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_CALIBRATE_WIDGET_
+
+// qt
+#include <QFile>
+#include <QLabel>
+#include <QString>
+#include <QTreeView>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QTextStream>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QtConcurrent/QtConcurrent>
+#include <QStandardItemModel>
+
+// ros
+#include <tf2_eigen/tf2_eigen.h>
+#include <pluginlib/class_loader.hpp>
+#include <tf2_ros/transform_listener.h>
+#include <rviz_visual_tools/tf_visual_tools.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <moveit/handeye_calibration_solver/handeye_solver_base.h>
+#include <moveit/background_processing/background_processing.h>
+#include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#endif
+
+#include <yaml-cpp/yaml.h>
+
+namespace mhc = moveit_handeye_calibration;
+
+namespace moveit_rviz_plugin
+{
+class ProgressBarWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  ProgressBarWidget(QWidget* parent, int min = 0, int max = 0, int value = 0);
+
+  ~ProgressBarWidget() override = default;
+
+  void setMax(int value);
+  void setMin(int value);
+  void setValue(int value);
+  int getValue();
+
+  QLabel* name_label_;
+  QLabel* value_label_;
+  QLabel* max_label_;
+  QProgressBar* bar_;
+};
+
+class ControlTabWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit ControlTabWidget(QWidget* parent = Q_NULLPTR);
+  ~ControlTabWidget()
+  {
+    tf_tools_.reset();
+    tf_buffer_.reset();
+    solver_.reset();
+    solver_plugins_loader_.reset();
+    move_group_.reset();
+    planning_scene_monitor_.reset();
+  }
+
+  void loadWidget(const rviz::Config& config);
+  void saveWidget(rviz::Config& config);
+
+  void setTFTool(rviz_visual_tools::TFVisualToolsPtr& tf_pub);
+
+  void addPoseSampleToTreeView(const geometry_msgs::TransformStamped& cTo, const geometry_msgs::TransformStamped& bTe,
+                               int id);
+
+  bool loadSolverPlugin(std::vector<std::string>& plugins);
+
+  bool createSolverInstance(const std::string& plugin_name);
+
+  void fillSolverTypes(const std::vector<std::string>& plugins);
+
+  std::string parseSolverName(const std::string& solver_name, char delimiter);
+
+  bool takeTranformSamples();
+
+  bool solveCameraRobotPose();
+
+  bool frameNamesEmpty();
+
+  bool checkJointStates();
+
+  void computePlan();
+
+  void computeExecution();
+
+Q_SIGNALS:
+
+  void sensorPoseUpdate(double x, double y, double z, double rx, double ry, double rz);
+
+public Q_SLOTS:
+
+  void UpdateSensorMountType(int index);
+
+  void updateFrameNames(std::map<std::string, std::string> names);
+
+private Q_SLOTS:
+
+  void takeSampleBtnClicked(bool clicked);
+
+  void resetSampleBtnClicked(bool clicked);
+
+  void saveCameraPoseBtnClicked(bool clicked);
+
+  void planningGroupNameChanged(const QString& text);
+
+  void saveJointStateBtnClicked(bool clicked);
+
+  void loadJointStateBtnClicked(bool clicked);
+
+  void autoPlanBtnClicked(bool clicked);
+
+  void autoExecuteBtnClicked(bool clicked);
+
+  void autoSkipBtnClicked(bool clicked);
+
+  void planFinished();
+
+  void executeFinished();
+
+private:
+  // **************************************************************
+  // Qt components
+  // **************************************************************
+
+  QTreeView* sample_tree_view_;
+  QStandardItemModel* tree_view_model_;
+
+  QComboBox* calibration_solver_;
+
+  // Load & save pose samples and joint goals
+  QPushButton* save_joint_state_btn_;
+  QPushButton* load_joint_state_btn_;
+  QPushButton* save_camera_pose_btn_;
+
+  // Manual calibration
+  QPushButton* take_sample_btn_;
+  QPushButton* reset_sample_btn_;
+
+  // Auto calibration
+  QComboBox* group_name_;
+  QPushButton* auto_plan_btn_;
+  QPushButton* auto_execute_btn_;
+  QPushButton* auto_skip_btn_;
+
+  // Progress of finished joint states for auto calibration
+  ProgressBarWidget* auto_progress_;
+
+  QFutureWatcher<void>* plan_watcher_;
+  QFutureWatcher<void>* execution_watcher_;
+
+  // **************************************************************
+  // Variables
+  // **************************************************************
+
+  mhc::SENSOR_MOUNT_TYPE sensor_mount_type_;
+  std::map<std::string, std::string> frame_names_;
+  // Transform samples
+  std::vector<Eigen::Isometry3d> effector_wrt_world_;
+  std::vector<Eigen::Isometry3d> object_wrt_sensor_;
+  std::string from_frame_tag_;
+  Eigen::Isometry3d camera_robot_pose_;
+  std::vector<std::vector<double>> joint_states_;
+  std::vector<std::string> joint_names_;
+  bool auto_started_;
+  bool planning_res_;
+
+  // **************************************************************
+  // Ros components
+  // **************************************************************
+
+  ros::NodeHandle nh_;
+  // ros::CallbackQueue callback_queue_;
+  // ros::AsyncSpinner spinner_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rviz_visual_tools::TFVisualToolsPtr tf_tools_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_handeye_calibration::HandEyeSolverBase>> solver_plugins_loader_;
+  pluginlib::UniquePtr<moveit_handeye_calibration::HandEyeSolverBase> solver_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+  moveit::planning_interface::MoveGroupInterfacePtr move_group_;
+  moveit::planning_interface::MoveGroupInterface::PlanPtr current_plan_;
+};
+
+}  // namespace moveit_rviz_plugin
+#endif

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/include/moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h
@@ -1,0 +1,205 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#ifndef MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_TARGET_WIDGET_
+#define MOVEIT_HANDEYE_CALIBRATION_RVIZ_PLUGIN_HANDEYE_TARGET_WIDGET_
+
+// qt
+#include <QSet>
+#include <QLabel>
+#include <QString>
+#include <QLineEdit>
+#include <QGroupBox>
+#include <QComboBox>
+#include <QMetaType>
+#include <QTabWidget>
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QMessageBox>
+#include <QFileDialog>
+
+// opencv
+#include <opencv2/aruco.hpp>
+#include <opencv2/opencv.hpp>
+
+// ros
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/JointState.h>
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
+
+#include <pluginlib/class_loader.hpp>
+#include <rviz_visual_tools/tf_visual_tools.h>
+#include <moveit/handeye_calibration_target/handeye_target_base.h>
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#endif
+
+Q_DECLARE_METATYPE(sensor_msgs::CameraInfo);
+Q_DECLARE_METATYPE(std::string);
+
+namespace moveit_rviz_plugin
+{
+// **************************************************
+// Custom QComboBox for image and camera_info topic
+// **************************************************
+class RosTopicComboBox : public QComboBox
+{
+  Q_OBJECT
+public:
+  explicit RosTopicComboBox(QWidget* parent = Q_NULLPTR) : QComboBox(parent)
+  {
+  }
+  ~RosTopicComboBox() = default;
+
+  void addMsgsFilterType(QString msgs_type);
+
+  bool hasTopic(const QString& topic_name);
+
+  bool getFilteredTopics();
+
+protected:
+  void mousePressEvent(QMouseEvent* event);
+
+  QSet<QString> message_types_;
+  QSet<QString> image_topics_;
+};
+
+class TargetTabWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit TargetTabWidget(QWidget* parent = Q_NULLPTR);
+  ~TargetTabWidget()
+  {
+    target_.reset();
+    target_plugins_loader_.reset();
+    camera_info_.reset();
+  }
+
+  void loadWidget(const rviz::Config& config);
+  void saveWidget(rviz::Config& config);
+
+  bool loadTargetPlugin();
+
+  bool createTargetInstance(const std::string& plugin_name);
+
+  void fillDictionaryIds(std::string id = "");
+
+  void imageCallback(const sensor_msgs::ImageConstPtr& msg);
+
+  void cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg);
+
+private Q_SLOTS:
+
+  // Called when the current item of target_type_ changed
+  void targetTypeComboboxChanged(const QString& text);
+
+  // Called when the create_target_btn clicked
+  void createTargetImageBtnClicked(bool clicked);
+
+  // Called when the save_target_btn clicked
+  void saveTargetImageBtnClicked(bool clicked);
+
+  // Called when the intrinsic or real params of the target changed
+  void targetParamsSet(const QString& text = "");
+
+  // Called when the item of image_topic_field_ combobox is selected
+  void imageTopicComboboxChanged(const QString& topic);
+
+  // Called when the item of camera_info_topic_field_ combobox is selected
+  void cameraInfoComboBoxChanged(const QString& topic);
+
+Q_SIGNALS:
+
+  void cameraInfoChanged(sensor_msgs::CameraInfo msg);
+
+  void opticalFrameChanged(const std::string& frame_id);
+
+private:
+  // **************************************************************
+  // Qt components
+  // **************************************************************
+
+  // Target intrinsic params
+  QComboBox* target_type_;
+  QComboBox* dictionary_id_;
+  std::map<std::string, QLineEdit*> target_params_;
+
+  // Target 3D pose recognition
+  RosTopicComboBox* image_topic_;
+  RosTopicComboBox* camera_info_topic_;
+  std::map<std::string, RosTopicComboBox*> ros_topics_;
+  std::map<std::string, QLineEdit*> target_real_dims_;
+
+  // Target Image display, create and save
+  QLabel* target_display_label_;
+  QPushButton* create_target_btn_;
+  QPushButton* save_target_btn_;
+
+  // **************************************************************
+  // Variables
+  // **************************************************************
+
+  cv::Mat target_image_;
+
+  std::string optical_frame_;
+
+  sensor_msgs::CameraInfoPtr camera_info_;
+
+  // **************************************************************
+  // Ros components
+  // **************************************************************
+  ros::NodeHandle nh_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_handeye_calibration::HandEyeTargetBase> > target_plugins_loader_;
+  pluginlib::UniquePtr<moveit_handeye_calibration::HandEyeTargetBase> target_;
+  image_transport::ImageTransport it_;
+  image_transport::Subscriber image_sub_;
+  image_transport::Publisher image_pub_;
+  ros::Subscriber camerainfo_sub_;
+  // tf broadcaster
+  tf2_ros::TransformBroadcaster tf_pub_;
+};
+
+}  // namedist moveit_rviz_plugin
+
+#endif

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_calibration_gui.cpp
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_calibration_gui.cpp
@@ -1,0 +1,109 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h>
+
+#include <Eigen/Geometry>
+#include <cmath>
+
+namespace moveit_rviz_plugin
+{
+HandEyeCalibrationGui::HandEyeCalibrationGui(QWidget* parent) : rviz::Panel(parent)
+{
+  setMinimumSize(695, 460);
+  // Basic widget container
+  QVBoxLayout* layout = new QVBoxLayout();
+  setLayout(layout);
+
+  // Description
+  QLabel* description = new QLabel(this);
+  description->setText(QString("Configure the position and orientation of your 3D sensors to work with Moveit!"));
+  description->setWordWrap(true);
+  description->setMinimumWidth(1);
+  layout->addWidget(description);
+
+  // Tab menu ------------------------------------------------------------
+  QTabWidget* tabs = new QTabWidget(this);
+  tab_target_ = new TargetTabWidget();
+
+  tf_tools_.reset(new rviz_visual_tools::TFVisualTools(250));
+
+  tab_context_ = new ContextTabWidget();
+  tab_context_->setTFTool(tf_tools_);
+  connect(tab_target_, SIGNAL(cameraInfoChanged(sensor_msgs::CameraInfo)), tab_context_,
+          SLOT(setCameraInfo(sensor_msgs::CameraInfo)));
+  connect(tab_target_, SIGNAL(opticalFrameChanged(const std::string&)), tab_context_,
+          SLOT(setOpticalFrame(const std::string&)));
+
+  tab_control_ = new ControlTabWidget();
+  tab_control_->setTFTool(tf_tools_);
+  connect(tab_context_, SIGNAL(sensorMountTypeChanged(int)), tab_control_, SLOT(UpdateSensorMountType(int)));
+  connect(tab_context_, SIGNAL(frameNameChanged(std::map<std::string, std::string>)), tab_control_,
+          SLOT(updateFrameNames(std::map<std::string, std::string>)));
+  connect(tab_control_, SIGNAL(sensorPoseUpdate(double, double, double, double, double, double)), tab_context_,
+          SLOT(updateCameraPose(double, double, double, double, double, double)));
+
+  tabs->addTab(tab_target_, "Target");
+  tabs->addTab(tab_context_, "Context");
+  tabs->addTab(tab_control_, "Calibrate");
+  layout->addWidget(tabs);
+
+  ROS_INFO_STREAM("handeye calibration gui created.");
+}
+
+HandEyeCalibrationGui::~HandEyeCalibrationGui() = default;
+
+void HandEyeCalibrationGui::save(rviz::Config config) const
+{
+  tab_target_->saveWidget(config);
+  tab_context_->saveWidget(config);
+  tab_control_->saveWidget(config);
+  rviz::Panel::save(config);
+}
+
+// Load all configuration data for this panel from the given Config object.
+void HandEyeCalibrationGui::load(const rviz::Config& config)
+{
+  rviz::Panel::load(config);
+
+  tab_target_->loadWidget(config);
+  tab_context_->loadWidget(config);
+  tab_control_->loadWidget(config);
+
+  ROS_INFO_STREAM("handeye calibration gui loaded.");
+}
+
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_context_widget.cpp
@@ -1,0 +1,553 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#include <moveit/handeye_calibration_rviz_plugin/handeye_context_widget.h>
+#include <math.h>
+
+namespace moveit_rviz_plugin
+{
+const std::string LOGNAME = "handeye_context_widget";
+
+void TFFrameNameComboBox::mousePressEvent(QMouseEvent* event)
+{
+  std::vector<std::string> names;
+  frame_manager_->update();
+  frame_manager_->getTF2BufferPtr()->_getFrameStrings(names);
+
+  clear();
+  addItem(QString(""));
+  if (robot_model_loader_->getModel())  // Ensure that robot is brought up
+  {
+    const std::vector<std::string>& robot_links = robot_model_loader_->getModel()->getLinkModelNames();
+    for (const std::string& name : names)
+    {
+      auto it = std::find(robot_links.begin(), robot_links.end(), name);
+      size_t index = name.find("camera");
+
+      if (frame_source_ == ROBOT_FRAME)
+        if (it != robot_links.end())
+          addItem(QString(name.c_str()));
+
+      if (frame_source_ == CAMERA_FRAME)
+        if (index != std::string::npos)
+          addItem(QString(name.c_str()));
+
+      if (frame_source_ == ENVIRONMENT_FRAME)
+        if (it == robot_links.end() && index == std::string::npos)
+          addItem(QString(name.c_str()));
+    }
+  }
+  showPopup();
+}
+
+bool TFFrameNameComboBox::hasFrame(const std::string& frame_name)
+{
+  std::vector<std::string> names;
+  frame_manager_->update();
+  frame_manager_->getTF2BufferPtr()->_getFrameStrings(names);
+
+  auto it = std::find(names.begin(), names.end(), frame_name);
+  return it != names.end();
+}
+
+SliderWidget::SliderWidget(QWidget* parent, std::string name, double min, double max)
+  : QWidget(parent), min_position_(min), max_position_(max)
+{
+  QHBoxLayout* row = new QHBoxLayout(this);
+  row->setContentsMargins(0, 10, 0, 10);
+
+  // QLabel init
+  label_ = new QLabel(QString(name.c_str()), this);
+  label_->setContentsMargins(0, 0, 0, 0);
+  row->addWidget(label_);
+
+  // QSlider init
+  slider_ = new QSlider(Qt::Horizontal, this);
+  slider_->setSingleStep(100);
+  slider_->setPageStep(100);
+  slider_->setTickInterval(1000);
+  slider_->setContentsMargins(0, 0, 0, 0);
+  row->addWidget(slider_);
+
+  slider_->setMaximum(max_position_ * 10000);
+  slider_->setMinimum(min_position_ * 10000);
+
+  connect(slider_, SIGNAL(valueChanged(int)), this, SLOT(changeValue(int)));
+
+  // QLineEdit init
+  edit_ = new QLineEdit(this);
+  edit_->setMinimumWidth(62);
+  edit_->setContentsMargins(0, 0, 0, 0);
+  connect(edit_, SIGNAL(editingFinished()), this, SLOT(changeSlider()));
+  row->addWidget(edit_);
+
+  this->setLayout(row);
+}
+
+double SliderWidget::getValue()
+{
+  return edit_->text().toDouble();
+}
+
+void SliderWidget::setValue(double value)
+{
+  if (min_position_ > value || value > max_position_)
+  {
+    value = (min_position_ > value) ? min_position_ : max_position_;
+  }
+  edit_->setText(QString("%1").arg(value, 0, 'f', 4));
+  slider_->setSliderPosition(value * 10000);
+}
+
+void SliderWidget::changeValue(int value)
+{
+  const double double_value = double(value) / 10000;
+
+  // Set textbox
+  edit_->setText(QString("%1").arg(double_value, 0, 'f', 4));
+
+  // Send event to parent widget
+  Q_EMIT valueChanged(double_value);
+}
+
+void SliderWidget::changeSlider()
+{
+  // Get joint value
+  double value = edit_->text().toDouble();
+
+  setValue(value);
+
+  // Send event to parent widget
+  Q_EMIT valueChanged(value);
+}
+
+ContextTabWidget::ContextTabWidget(QWidget* parent) : QWidget(parent), tf_listener_(tf_buffer_)
+{
+  // Context setting tab ----------------------------------------------------
+  QHBoxLayout* layout = new QHBoxLayout();
+  this->setLayout(layout);
+  QVBoxLayout* layout_left = new QVBoxLayout();
+  layout->addLayout(layout_left);
+  QVBoxLayout* layout_right = new QVBoxLayout();
+  layout->addLayout(layout_right);
+
+  // Sensor mount type area and fov area
+  QGroupBox* group_left_top = new QGroupBox("General Setting", this);
+  layout_left->addWidget(group_left_top);
+  QFormLayout* layout_left_top = new QFormLayout();
+  group_left_top->setLayout(layout_left_top);
+
+  sensor_mount_type_ = new QComboBox();
+  sensor_mount_type_->addItem("Eye-to-Hand");
+  sensor_mount_type_->addItem("Eye-in-hand");
+  layout_left_top->addRow("Sensor Mount Type", sensor_mount_type_);
+  connect(sensor_mount_type_, SIGNAL(activated(int)), this, SLOT(updateSensorMountType(int)));
+
+  // Frame name selection area
+  QGroupBox* frame_group = new QGroupBox("Frames Selection", this);
+  layout_left->addWidget(frame_group);
+  QFormLayout* frame_layout = new QFormLayout();
+  frame_group->setLayout(frame_layout);
+
+  frames_.insert(std::make_pair("sensor", new TFFrameNameComboBox(CAMERA_FRAME)));
+  frame_layout->addRow("Sensor Frame:", frames_["sensor"]);
+
+  frames_.insert(std::make_pair("object", new TFFrameNameComboBox(ENVIRONMENT_FRAME)));
+  frame_layout->addRow("Object Frame:", frames_["object"]);
+
+  frames_.insert(std::make_pair("eef", new TFFrameNameComboBox(ROBOT_FRAME)));
+  frame_layout->addRow("End-Effector Frame:", frames_["eef"]);
+
+  frames_.insert(std::make_pair("base", new TFFrameNameComboBox(ROBOT_FRAME)));
+  frame_layout->addRow("Robot Base Frame:", frames_["base"]);
+
+  for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
+    connect(frame.second, SIGNAL(activated(int)), this, SLOT(updateFrameName(int)));
+
+  // FOV area
+  QGroupBox* fov_group = new QGroupBox("FOV", this);
+  layout_left->addWidget(fov_group);
+  QFormLayout* fov_layout = new QFormLayout();
+  fov_group->setLayout(fov_layout);
+
+  fov_alpha_ = new SliderWidget(this, "Transparency", 0, 1);
+  fov_alpha_->setValue(0.5);
+  fov_layout->addRow(fov_alpha_);
+  connect(fov_alpha_, SIGNAL(valueChanged(double)), this, SLOT(updateCameraMarkerPose(double)));
+
+  fov_on_off_ = new QRadioButton();
+  fov_on_off_->setChecked(true);
+  fov_layout->addRow("ON/OFF", fov_on_off_);
+  connect(fov_on_off_, SIGNAL(toggled(bool)), this, SLOT(fovOnOffBtnToggled(bool)));
+
+  // Camera Pose initial guess area
+  QGroupBox* pose_group = new QGroupBox("Camera Pose Inital Guess", this);
+  pose_group->setMinimumWidth(300);
+  layout_right->addWidget(pose_group);
+  QFormLayout* pose_layout = new QFormLayout();
+  pose_group->setLayout(pose_layout);
+
+  guess_pose_.insert(std::make_pair("Tx", new SliderWidget(this, "TranslX", -2.0, 2.0)));
+  pose_layout->addRow(guess_pose_["Tx"]);
+
+  guess_pose_.insert(std::make_pair("Ty", new SliderWidget(this, "TranslY", -2.0, 2.0)));
+  pose_layout->addRow(guess_pose_["Ty"]);
+
+  guess_pose_.insert(std::make_pair("Tz", new SliderWidget(this, "TranslZ", -2.0, 2.0)));
+  pose_layout->addRow(guess_pose_["Tz"]);
+
+  guess_pose_.insert(std::make_pair("Rx", new SliderWidget(this, "RotateX", -M_PI, M_PI)));
+  pose_layout->addRow(guess_pose_["Rx"]);
+
+  guess_pose_.insert(std::make_pair("Ry", new SliderWidget(this, "RotateY", -M_PI, M_PI)));
+  pose_layout->addRow(guess_pose_["Ry"]);
+
+  guess_pose_.insert(std::make_pair("Rz", new SliderWidget(this, "RotateZ", -M_PI, M_PI)));
+  pose_layout->addRow(guess_pose_["Rz"]);
+
+  for (std::pair<const std::string, SliderWidget*>& dim : guess_pose_)
+  {
+    dim.second->setValue(0);
+    connect(dim.second, SIGNAL(valueChanged(double)), this, SLOT(updateCameraMarkerPose(double)));
+  }
+
+  // Variable Initialization
+  camera_pose_ = Eigen::Isometry3d::Identity();
+  fov_pose_ = Eigen::Quaterniond(0.5, -0.5, 0.5, -0.5);
+  fov_pose_.translate(Eigen::Vector3d(0.0149, 0.0325, 0.0125));
+
+  camera_info_.reset(new sensor_msgs::CameraInfo());
+
+  visual_tools_.reset(new moveit_visual_tools::MoveItVisualTools("world"));
+  visual_tools_->enableFrameLocking(true);
+  visual_tools_->setAlpha(1.0);
+  visual_tools_->setLifetime(0.0);
+  visual_tools_->trigger();
+}
+
+void ContextTabWidget::loadWidget(const rviz::Config& config)
+{
+  int index;
+  if (config.mapGetInt("sensor_mount_type", &index))
+    sensor_mount_type_->setCurrentIndex(index);
+
+  Q_EMIT sensorMountTypeChanged(index);
+
+  for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
+  {
+    QString frame_name;
+    if (config.mapGetString(frame.first.c_str(), &frame_name))
+    {
+      frame.second->clear();
+      if (!frame_name.isEmpty() && frame.second->hasFrame(frame_name.toStdString()))
+        frame.second->addItem(frame_name);
+    }
+  }
+
+  float alpha;
+  if (config.mapGetFloat("fov_transparent", &alpha))
+    fov_alpha_->setValue(alpha);
+
+  bool fov_enabled;
+  if (config.mapGetBool("fov_on_off", &fov_enabled))
+    fov_on_off_->setChecked(fov_enabled);
+
+  for (std::pair<const std::string, SliderWidget*>& dim : guess_pose_)
+  {
+    float value;
+    if (config.mapGetFloat(dim.first.c_str(), &value))
+      dim.second->setValue(value);
+  }
+  updateAllMarkers();
+
+  std::map<std::string, std::string> names;
+  for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
+    names.insert(std::make_pair(frame.first, frame.second->currentText().toStdString()));
+
+  Q_EMIT frameNameChanged(names);
+}
+
+void ContextTabWidget::saveWidget(rviz::Config& config)
+{
+  config.mapSetValue("sensor_mount_type", sensor_mount_type_->currentIndex());
+
+  for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
+    config.mapSetValue(frame.first.c_str(), frame.second->currentText());
+
+  config.mapSetValue("fov_transparent", fov_alpha_->getValue());
+  config.mapSetValue("fov_on_off", fov_on_off_->isChecked());
+
+  for (std::pair<const std::string, SliderWidget*>& dim : guess_pose_)
+    config.mapSetValue(dim.first.c_str(), dim.second->getValue());
+}
+
+void ContextTabWidget::setTFTool(rviz_visual_tools::TFVisualToolsPtr& tf_pub)
+{
+  tf_tools_ = tf_pub;
+}
+
+void ContextTabWidget::updateAllMarkers()
+{
+  if (visual_tools_ && tf_tools_)
+  {
+    visual_tools_->deleteAllMarkers();
+    tf_tools_->clearAllTransforms();
+
+    QString from_frame("");
+    mhc::SENSOR_MOUNT_TYPE setup = static_cast<mhc::SENSOR_MOUNT_TYPE>(sensor_mount_type_->currentIndex());
+
+    switch (setup)
+    {
+      case mhc::EYE_TO_HAND:
+        from_frame = frames_["base"]->currentText();
+        break;
+      case mhc::EYE_IN_HAND:
+        from_frame = frames_["eef"]->currentText();
+        break;
+      default:
+        ROS_ERROR_STREAM_NAMED(LOGNAME, "Error sensor mount type.");
+        break;
+    }
+
+    if (!from_frame.isEmpty())
+    {
+      for (std::pair<const std::string, TFFrameNameComboBox*> frame : frames_)
+      {
+        // Publish selected frame axis
+        const std::string& frame_id = frame.second->currentText().toStdString();
+        if (!frame_id.empty())
+        {
+          visual_tools_->setBaseFrame(frame_id);
+          visual_tools_->setAlpha(1.0);
+          visual_tools_->publishAxisLabeled(Eigen::Isometry3d::Identity(), frame_id);
+        }
+      }
+
+      // Publish camera and fov marker
+      QString to_frame = frames_["sensor"]->currentText();
+      if (!to_frame.isEmpty())
+      {
+        // // Get camera pose guess
+        setCameraPose(guess_pose_["Tx"]->getValue(), guess_pose_["Ty"]->getValue(), guess_pose_["Tz"]->getValue(),
+                      guess_pose_["Rx"]->getValue(), guess_pose_["Ry"]->getValue(), guess_pose_["Rz"]->getValue());
+
+        // Publish new transform from robot base or end-effector to sensor frame
+        tf_tools_->publishTransform(camera_pose_, from_frame.toStdString(), to_frame.toStdString());
+
+        // Publish new FOV marker
+        shape_msgs::Mesh mesh = getCameraFOVMesh(*camera_info_, 1.5);
+        if (fov_on_off_->isChecked())
+        {
+          visual_tools_->setBaseFrame(to_frame.toStdString());
+          visual_tools_->setAlpha(fov_alpha_->getValue());
+          visual_tools_->publishMesh(fov_pose_, mesh, rvt::YELLOW, 1.0, "fov", 1);
+        }
+      }
+    }
+
+    visual_tools_->trigger();
+  }
+  else
+    ROS_ERROR("Visual or TF tool is NULL.");
+}
+
+void ContextTabWidget::updateFOVPose()
+{
+  QString sensor_frame = frames_["sensor"]->currentText();
+  geometry_msgs::TransformStamped tf_msg;
+  if (!optical_frame_.empty() && !sensor_frame.isEmpty())
+  {
+    try
+    {
+      // Get FOV pose W.R.T sensor frame
+      tf_msg = tf_buffer_.lookupTransform(sensor_frame.toStdString(), optical_frame_, ros::Time(0));
+      fov_pose_ = tf2::transformToEigen(tf_msg);
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "FOV pose from '" << sensor_frame.toStdString() << "' to '" << optical_frame_
+                                                        << "' is:"
+                                                        << "\nTranslation:\n"
+                                                        << fov_pose_.translation() << "\nRotation:\n"
+                                                        << fov_pose_.rotation());
+    }
+    catch (tf2::TransformException& e)
+    {
+      ROS_WARN_STREAM("TF exception: " << e.what());
+    }
+  }
+}
+
+shape_msgs::Mesh ContextTabWidget::getCameraFOVMesh(const sensor_msgs::CameraInfo& camera_info, double max_dist)
+{
+  shape_msgs::Mesh mesh;
+  image_geometry::PinholeCameraModel camera_model;
+  camera_model.fromCameraInfo(camera_info);
+  double delta_x = camera_model.getDeltaX(camera_info.width / 2, max_dist);
+  double delta_y = camera_model.getDeltaY(camera_info.height / 2, max_dist);
+
+  std::vector<double> x_cords = { -delta_x, delta_x };
+  std::vector<double> y_cords = { -delta_y, delta_y };
+
+  // Get corners
+  mesh.vertices.clear();
+  // Add the first corner at origin of the optical frame
+  mesh.vertices.push_back(geometry_msgs::Point());
+
+  // Add the four corners at bottom
+  for (const double& x_it : x_cords)
+    for (const double& y_it : y_cords)
+    {
+      geometry_msgs::Point vertex;
+      // Check in case camera info is not valid
+      if (std::isfinite(x_it) && std::isfinite(y_it) && std::isfinite(max_dist))
+      {
+        vertex.x = x_it;
+        vertex.y = y_it;
+        vertex.z = max_dist;
+      }
+      mesh.vertices.push_back(vertex);
+    }
+
+  // Get surface triangles
+  mesh.triangles.resize(4);
+  mesh.triangles[0].vertex_indices = { 0, 1, 2 };
+  mesh.triangles[1].vertex_indices = { 0, 2, 4 };
+  mesh.triangles[2].vertex_indices = { 0, 4, 3 };
+  mesh.triangles[3].vertex_indices = { 0, 3, 1 };
+  return mesh;
+}
+
+visualization_msgs::Marker ContextTabWidget::getCameraFOVMarker(const Eigen::Isometry3d& pose,
+                                                                const shape_msgs::Mesh& mesh, rvt::colors color,
+                                                                double alpha, std::string frame_id)
+{
+  return getCameraFOVMarker(rvt::RvizVisualTools::convertPose(pose), mesh, color, alpha, frame_id);
+}
+
+visualization_msgs::Marker ContextTabWidget::getCameraFOVMarker(const geometry_msgs::Pose& pose,
+                                                                const shape_msgs::Mesh& mesh, rvt::colors color,
+                                                                double alpha, std::string frame_id)
+{
+  visualization_msgs::Marker marker;
+  marker.header.frame_id = frame_id;
+  marker.ns = "camera_fov";
+  marker.id = 0;
+  marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
+  marker.action = visualization_msgs::Marker::ADD;
+  marker.lifetime = ros::Duration(0.0);
+  visual_tools_->setAlpha(alpha);
+  marker.color = visual_tools_->getColor(color);
+  marker.pose = pose;
+  marker.scale.x = 1.0;
+  marker.scale.y = 1.0;
+  marker.scale.z = 1.0;
+
+  marker.points.clear();
+  for (const shape_msgs::MeshTriangle& triangle : mesh.triangles)
+    for (const uint32_t& index : triangle.vertex_indices)
+      marker.points.push_back(mesh.vertices[index]);
+
+  return marker;
+}
+
+void ContextTabWidget::setCameraPose(double tx, double ty, double tz, double rx, double ry, double rz)
+{
+  camera_pose_.setIdentity();
+  camera_pose_ = visual_tools_->convertFromXYZRPY(tx, ty, tz, rx, ry, rz, rviz_visual_tools::XYZ);
+}
+
+void ContextTabWidget::setCameraInfo(sensor_msgs::CameraInfo camera_info)
+{
+  camera_info_->header = camera_info.header;
+  camera_info_->height = camera_info.height;
+  camera_info_->width = camera_info.width;
+  camera_info_->distortion_model = camera_info.distortion_model;
+  camera_info_->D = camera_info.D;
+  camera_info_->K = camera_info.K;
+  camera_info_->R = camera_info.R;
+  camera_info_->P = camera_info.P;
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Camera info changed: " << *camera_info_);
+}
+
+void ContextTabWidget::setOpticalFrame(const std::string& frame_id)
+{
+  optical_frame_ = frame_id;
+  updateFOVPose();
+}
+
+void ContextTabWidget::updateCameraPose(double tx, double ty, double tz, double rx, double ry, double rz)
+{
+  // setCameraPose(tx, ty, tz, rx, ry, rz);
+  guess_pose_["Tx"]->setValue(tx);
+  guess_pose_["Ty"]->setValue(ty);
+  guess_pose_["Tz"]->setValue(tz);
+  guess_pose_["Rx"]->setValue(rx);
+  guess_pose_["Ry"]->setValue(ry);
+  guess_pose_["Rz"]->setValue(rz);
+  updateCameraMarkerPose(0);
+}
+
+void ContextTabWidget::updateSensorMountType(int index)
+{
+  for (std::pair<const std::string, SliderWidget*> dim : guess_pose_)
+    dim.second->setValue(0);
+
+  updateAllMarkers();
+
+  Q_EMIT sensorMountTypeChanged(index);
+}
+
+void ContextTabWidget::updateFrameName(int index)
+{
+  updateAllMarkers();
+  updateFOVPose();
+
+  std::map<std::string, std::string> names;
+  for (std::pair<const std::string, TFFrameNameComboBox*>& frame : frames_)
+    names.insert(std::make_pair(frame.first, frame.second->currentText().toStdString()));
+
+  Q_EMIT frameNameChanged(names);
+}
+
+void ContextTabWidget::updateCameraMarkerPose(double value)
+{
+  updateAllMarkers();
+}
+
+void ContextTabWidget::fovOnOffBtnToggled(bool checked)
+{
+  updateAllMarkers();
+}
+
+}  // namgespace moveit_rviz_plugin

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_control_widget.cpp
@@ -1,0 +1,828 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#include <moveit/handeye_calibration_rviz_plugin/handeye_control_widget.h>
+
+namespace moveit_rviz_plugin
+{
+const std::string LOGNAME = "handeye_control_widget";
+
+ProgressBarWidget::ProgressBarWidget(QWidget* parent, int min, int max, int value) : QWidget(parent)
+{
+  QHBoxLayout* row = new QHBoxLayout(this);
+  row->setContentsMargins(0, 10, 0, 10);
+
+  // QLabel init
+  name_label_ = new QLabel("joint_state:", this);
+  name_label_->setContentsMargins(0, 0, 0, 0);
+  row->addWidget(name_label_);
+
+  value_label_ = new QLabel(QString::number(value), this);
+  value_label_->setContentsMargins(0, 0, 0, 0);
+  row->addWidget(value_label_);
+
+  // QProgressBar init
+  bar_ = new QProgressBar(this);
+  bar_->setTextVisible(true);
+  bar_->setMinimum(min);
+  bar_->setMaximum(max);
+  bar_->setValue(value);
+  bar_->setContentsMargins(0, 0, 0, 0);
+  row->addWidget(bar_);
+
+  max_label_ = new QLabel(QString::number(max), this);
+  max_label_->setContentsMargins(0, 0, 0, 0);
+  row->addWidget(max_label_);
+
+  this->setLayout(row);
+}
+
+void ProgressBarWidget::setMax(int value)
+{
+  bar_->setMaximum(value);
+  max_label_->setText(QString::number(value));
+}
+
+void ProgressBarWidget::setMin(int value)
+{
+  bar_->setMinimum(value);
+}
+
+void ProgressBarWidget::setValue(int value)
+{
+  bar_->setValue(value);
+  value_label_->setText(QString::number(value));
+}
+
+int ProgressBarWidget::getValue()
+{
+  return bar_->value();
+}
+
+ControlTabWidget::ControlTabWidget(QWidget* parent)
+  : QWidget(parent)
+  , tf_buffer_(new tf2_ros::Buffer())
+  , tf_listener_(*tf_buffer_)
+  , sensor_mount_type_(mhc::EYE_TO_HAND)
+  , solver_plugins_loader_(nullptr)
+  , solver_(nullptr)
+  , move_group_(nullptr)
+  , camera_robot_pose_(Eigen::Isometry3d::Identity())
+  , auto_started_(false)
+  , planning_res_(false)
+// spinner_(0, &callback_queue_)
+{
+  QVBoxLayout* layout = new QVBoxLayout();
+  this->setLayout(layout);
+
+  QHBoxLayout* calib_layout = new QHBoxLayout();
+  layout->addLayout(calib_layout);
+
+  // Calibration progress
+  auto_progress_ = new ProgressBarWidget(this);
+  layout->addWidget(auto_progress_);
+
+  // Pose sample tree view area
+  QGroupBox* sample_group = new QGroupBox("Pose_sample");
+  sample_group->setMinimumWidth(280);
+  calib_layout->addWidget(sample_group);
+  QVBoxLayout* sample_layout = new QVBoxLayout();
+  sample_group->setLayout(sample_layout);
+
+  sample_tree_view_ = new QTreeView(this);
+  sample_tree_view_->setAutoScroll(true);
+  sample_tree_view_->setAlternatingRowColors(true);
+  tree_view_model_ = new QStandardItemModel(sample_tree_view_);
+  sample_tree_view_->setModel(tree_view_model_);
+  sample_tree_view_->setHeaderHidden(true);
+  sample_tree_view_->setIndentation(10);
+  sample_layout->addWidget(sample_tree_view_);
+
+  // Setting area
+  QVBoxLayout* layout_right = new QVBoxLayout();
+  calib_layout->addLayout(layout_right);
+
+  QGroupBox* setting_group = new QGroupBox("Setting");
+  layout_right->addWidget(setting_group);
+  QFormLayout* setting_layout = new QFormLayout();
+  setting_group->setLayout(setting_layout);
+
+  calibration_solver_ = new QComboBox();
+  setting_layout->addRow("AX=XB Solver", calibration_solver_);
+
+  group_name_ = new QComboBox();
+  connect(group_name_, SIGNAL(activated(const QString&)), this, SLOT(planningGroupNameChanged(const QString&)));
+  setting_layout->addRow("Planning Group", group_name_);
+
+  load_joint_state_btn_ = new QPushButton("Load Joint States");
+  connect(load_joint_state_btn_, SIGNAL(clicked(bool)), this, SLOT(loadJointStateBtnClicked(bool)));
+  setting_layout->addRow(load_joint_state_btn_);
+
+  save_joint_state_btn_ = new QPushButton("Save Joint states");
+  connect(save_joint_state_btn_, SIGNAL(clicked(bool)), this, SLOT(saveJointStateBtnClicked(bool)));
+  setting_layout->addRow(save_joint_state_btn_);
+
+  save_camera_pose_btn_ = new QPushButton("Save Camera Pose");
+  connect(save_camera_pose_btn_, SIGNAL(clicked(bool)), this, SLOT(saveCameraPoseBtnClicked(bool)));
+  setting_layout->addRow(save_camera_pose_btn_);
+
+  // Manual calibration area
+  QGroupBox* manual_cal_group = new QGroupBox("Manual Calibration");
+  layout_right->addWidget(manual_cal_group);
+  QHBoxLayout* control_cal_layout = new QHBoxLayout();
+  manual_cal_group->setLayout(control_cal_layout);
+
+  take_sample_btn_ = new QPushButton("Take Sample");
+  take_sample_btn_->setMinimumHeight(35);
+  connect(take_sample_btn_, SIGNAL(clicked(bool)), this, SLOT(takeSampleBtnClicked(bool)));
+  control_cal_layout->addWidget(take_sample_btn_);
+
+  reset_sample_btn_ = new QPushButton("Reset Sample");
+  reset_sample_btn_->setMinimumHeight(35);
+  connect(reset_sample_btn_, SIGNAL(clicked(bool)), this, SLOT(resetSampleBtnClicked(bool)));
+  control_cal_layout->addWidget(reset_sample_btn_);
+
+  // Auto calibration area
+  QGroupBox* auto_cal_group = new QGroupBox("Auto Calibration");
+  layout_right->addWidget(auto_cal_group);
+  QVBoxLayout* auto_cal_layout = new QVBoxLayout();
+  auto_cal_group->setLayout(auto_cal_layout);
+
+  QHBoxLayout* auto_btns_layout = new QHBoxLayout();
+  auto_cal_layout->addLayout(auto_btns_layout);
+  auto_plan_btn_ = new QPushButton("Plan");
+  auto_plan_btn_->setMinimumHeight(35);
+  auto_plan_btn_->setToolTip("Start or resume auto calibration process");
+  connect(auto_plan_btn_, SIGNAL(clicked(bool)), this, SLOT(autoPlanBtnClicked(bool)));
+  auto_btns_layout->addWidget(auto_plan_btn_);
+
+  auto_execute_btn_ = new QPushButton("Execute");
+  auto_execute_btn_->setMinimumHeight(35);
+  auto_execute_btn_->setToolTip("Pause the auto calibration process");
+  connect(auto_execute_btn_, SIGNAL(clicked(bool)), this, SLOT(autoExecuteBtnClicked(bool)));
+  auto_btns_layout->addWidget(auto_execute_btn_);
+
+  auto_skip_btn_ = new QPushButton("Skip");
+  auto_skip_btn_->setMinimumHeight(35);
+  auto_skip_btn_->setToolTip("Skip the current robot state target");
+  connect(auto_skip_btn_, SIGNAL(clicked(bool)), this, SLOT(autoSkipBtnClicked(bool)));
+  auto_btns_layout->addWidget(auto_skip_btn_);
+
+  // Initialize handeye solver plugins
+  std::vector<std::string> plugins;
+  if (loadSolverPlugin(plugins))
+    fillSolverTypes(plugins);
+
+  // Fill in available planning group names
+  planning_scene_monitor_.reset(
+      new planning_scene_monitor::PlanningSceneMonitor("robot_description", tf_buffer_, "planning_scene_monitor"));
+  if (planning_scene_monitor_)
+  {
+    planning_scene_monitor_->startSceneMonitor("move_group/monitored_planning_scene");
+    std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
+    if (planning_scene_monitor_->requestPlanningSceneState(service_name))
+    {
+      const robot_model::RobotModelConstPtr& kmodel = planning_scene_monitor_->getRobotModel();
+      for (const std::string& group_name : kmodel->getJointModelGroupNames())
+        group_name_->addItem(group_name.c_str());
+      if (!group_name_->currentText().isEmpty())
+        try
+        {
+          moveit::planning_interface::MoveGroupInterface::Options opt(group_name_->currentText().toStdString());
+          opt.node_handle_ = nh_;
+          move_group_.reset(
+              new moveit::planning_interface::MoveGroupInterface(opt, tf_buffer_, ros::WallDuration(30, 0)));
+        }
+        catch (std::exception& ex)
+        {
+          ROS_ERROR_NAMED(LOGNAME, "%s", ex.what());
+        }
+    }
+  }
+
+  // Set plan and execution watcher
+  plan_watcher_ = new QFutureWatcher<void>(this);
+  connect(plan_watcher_, &QFutureWatcher<void>::finished, this, &ControlTabWidget::planFinished);
+
+  execution_watcher_ = new QFutureWatcher<void>(this);
+  connect(execution_watcher_, &QFutureWatcher<void>::finished, this, &ControlTabWidget::executeFinished);
+}
+
+void ControlTabWidget::loadWidget(const rviz::Config& config)
+{
+  QString group_name;
+  config.mapGetString("group", &group_name);
+  if (!group_name.isEmpty() && planning_scene_monitor_)
+  {
+    const std::vector<std::string> groups = planning_scene_monitor_->getRobotModel()->getJointModelGroupNames();
+    std::vector<std::string>::const_iterator it = std::find(groups.begin(), groups.end(), group_name.toStdString());
+    if (it != groups.end())
+    {
+      group_name_->setCurrentText(group_name);
+      Q_EMIT group_name_->activated(group_name);
+    }
+  }
+}
+
+void ControlTabWidget::saveWidget(rviz::Config& config)
+{
+  config.mapSetValue("solver", calibration_solver_->currentText());
+  config.mapSetValue("group", group_name_->currentText());
+}
+
+bool ControlTabWidget::loadSolverPlugin(std::vector<std::string>& plugins)
+{
+  if (!solver_plugins_loader_)
+  {
+    try
+    {
+      solver_plugins_loader_.reset(new pluginlib::ClassLoader<moveit_handeye_calibration::HandEyeSolverBase>(
+          "moveit_ros_perception", "moveit_handeye_calibration::HandEyeSolverBase"));
+    }
+    catch (pluginlib::PluginlibException& ex)
+    {
+      QMessageBox::warning(this, tr("Exception while creating handeye solver plugin loader "), tr(ex.what()));
+      return false;
+    }
+  }
+
+  // Get available plugins
+  plugins = solver_plugins_loader_->getDeclaredClasses();
+  return !plugins.empty();
+}
+
+bool ControlTabWidget::createSolverInstance(const std::string& plugin_name)
+{
+  try
+  {
+    solver_ = solver_plugins_loader_->createUniqueInstance(plugin_name);
+    solver_->initialize();
+  }
+  catch (pluginlib::PluginlibException& ex)
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Exception while loading handeye solver plugin: " << plugin_name << ex.what());
+    solver_ = nullptr;
+  }
+
+  return solver_ != nullptr;
+}
+
+void ControlTabWidget::fillSolverTypes(const std::vector<std::string>& plugins)
+{
+  for (const std::string& plugin : plugins)
+    if (!plugin.empty() && createSolverInstance(plugin))
+    {
+      const std::vector<std::string>& solvers = solver_->getSolverNames();
+      for (const std::string& solver : solvers)
+      {
+        std::string solver_name = plugin + "/" + solver;  // solver name format is "plugin_name/solver_name"
+        calibration_solver_->addItem(tr(solver_name.c_str()));
+      }
+    }
+}
+
+std::string ControlTabWidget::parseSolverName(const std::string& solver_name, char delimiter)
+{
+  std::vector<std::string> tokens;
+  std::string token;
+  std::istringstream tokenStream(solver_name);
+  while (std::getline(tokenStream, token, delimiter))
+  {
+    tokens.push_back(token);
+  }
+  return tokens.back();
+}
+
+bool ControlTabWidget::takeTranformSamples()
+{
+  // Store the pair of two tf transforms and calculate camera_robot pose
+  try
+  {
+    geometry_msgs::TransformStamped cTo;
+    geometry_msgs::TransformStamped bTe;
+
+    // Get the transform of the object w.r.t the camera
+    cTo = tf_buffer_->lookupTransform(frame_names_["sensor"], frame_names_["object"], ros::Time(0));
+
+    // Get the transform of the end-effector w.r.t the robot base
+    bTe = tf_buffer_->lookupTransform(frame_names_["base"], frame_names_["eef"], ros::Time(0));
+
+    // save the pose samples
+    effector_wrt_world_.push_back(tf2::transformToEigen(bTe));
+    object_wrt_sensor_.push_back(tf2::transformToEigen(cTo));
+
+    ControlTabWidget::addPoseSampleToTreeView(cTo, bTe, effector_wrt_world_.size());
+  }
+  catch (tf2::TransformException& e)
+  {
+    ROS_WARN("TF exception: %s", e.what());
+    return false;
+  }
+
+  return true;
+}
+
+bool ControlTabWidget::solveCameraRobotPose()
+{
+  if (solver_ && !calibration_solver_->currentText().isEmpty())
+  {
+    bool res = solver_->solve(effector_wrt_world_, object_wrt_sensor_, sensor_mount_type_,
+                              parseSolverName(calibration_solver_->currentText().toStdString(), '/'));
+    if (res)
+    {
+      camera_robot_pose_ = solver_->getCameraRobotPose();
+
+      // Update camera pose guess in context tab
+      Eigen::Vector3d t = camera_robot_pose_.translation();
+      Eigen::Vector3d r = camera_robot_pose_.rotation().eulerAngles(0, 1, 2);
+      Q_EMIT sensorPoseUpdate(t[0], t[1], t[2], r[0], r[1], r[2]);
+
+      // Publish camera pose tf
+      std::string& from_frame = frame_names_[from_frame_tag_];
+      std::string& to_frame = frame_names_["sensor"];
+      if (!from_frame.empty() && !to_frame.empty())
+      {
+        tf_tools_->clearAllTransforms();
+        return tf_tools_->publishTransform(camera_robot_pose_, from_frame, to_frame);
+      }
+      else
+      {
+        ROS_ERROR_STREAM_NAMED(LOGNAME, "Invalid key used for reading the frame names.");
+        return false;
+      }
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "No available handeye calibration solver instance.");
+    return false;
+  }
+}
+
+bool ControlTabWidget::frameNamesEmpty()
+{
+  // All of four frame names needed for getting the pair of two tf transforms
+  if (frame_names_["sensor"].empty() || frame_names_["object"].empty() || frame_names_["base"].empty() ||
+      frame_names_["eef"].empty())
+  {
+    QMessageBox::warning(this, tr("Empty Frame Name"), tr("At least one of the four frame names is empty."));
+    return true;
+  }
+  return false;
+}
+
+bool ControlTabWidget::checkJointStates()
+{
+  if (joint_names_.empty() || joint_states_.empty())
+    return false;
+
+  for (const std::vector<double>& state : joint_states_)
+    if (state.size() != joint_names_.size())
+      return false;
+
+  return true;
+}
+
+void ControlTabWidget::setTFTool(rviz_visual_tools::TFVisualToolsPtr& tf_pub)
+{
+  tf_tools_ = tf_pub;
+}
+
+void ControlTabWidget::addPoseSampleToTreeView(const geometry_msgs::TransformStamped& cTo,
+                                               const geometry_msgs::TransformStamped& bTe, int id)
+{
+  std::string item_name = "Sample " + std::to_string(id);
+  QStandardItem* parent = new QStandardItem(QString(item_name.c_str()));
+  tree_view_model_->appendRow(parent);
+
+  std::ostringstream ss;
+
+  QStandardItem* child_1 = new QStandardItem("bTe");
+  ss << bTe.transform;
+  child_1->appendRow(new QStandardItem(ss.str().c_str()));
+  parent->appendRow(child_1);
+
+  QStandardItem* child_2 = new QStandardItem("cTo");
+  ss.str("");
+  ss << cTo.transform;
+  child_2->appendRow(new QStandardItem(ss.str().c_str()));
+  parent->appendRow(child_2);
+}
+
+void ControlTabWidget::UpdateSensorMountType(int index)
+{
+  if (0 <= index && index <= 1)
+  {
+    sensor_mount_type_ = static_cast<mhc::SENSOR_MOUNT_TYPE>(index);
+    switch (sensor_mount_type_)
+    {
+      case mhc::EYE_TO_HAND:
+        from_frame_tag_ = "base";
+        break;
+      case mhc::EYE_IN_HAND:
+        from_frame_tag_ = "eef";
+        break;
+      default:
+        ROS_ERROR_STREAM_NAMED(LOGNAME, "Error sensor mount type.");
+        break;
+    }
+  }
+}
+
+void ControlTabWidget::updateFrameNames(std::map<std::string, std::string> names)
+{
+  frame_names_ = names;
+  ROS_DEBUG("Frame names changed:");
+  for (const std::pair<const std::string, std::string>& name : frame_names_)
+    ROS_DEBUG_STREAM(name.first << " : " << name.second);
+}
+
+void ControlTabWidget::takeSampleBtnClicked(bool clicked)
+{
+  if (frameNamesEmpty() || !takeTranformSamples())
+    return;
+
+  if (effector_wrt_world_.size() == object_wrt_sensor_.size() && effector_wrt_world_.size() > 4)
+    if (!solveCameraRobotPose())
+      return;
+
+  // Save the joint values of current robot state
+  if (planning_scene_monitor_)
+  {
+    planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now(), 0.1);
+    const planning_scene_monitor::LockedPlanningSceneRO& ps =
+        planning_scene_monitor::LockedPlanningSceneRO(planning_scene_monitor_);
+    if (ps)
+    {
+      const robot_state::RobotState& state = ps->getCurrentState();
+      const moveit::core::JointModelGroup* jmg = state.getJointModelGroup(group_name_->currentText().toStdString());
+      const std::vector<std::string>& names = jmg->getActiveJointModelNames();
+      if (joint_names_.size() != names.size() || joint_names_ != names)
+      {
+        joint_names_.clear();
+        joint_states_.clear();
+      }
+      std::vector<double> state_joint_values;
+      state.copyJointGroupPositions(jmg, state_joint_values);
+      if (names.size() == state_joint_values.size())
+      {
+        joint_names_ = names;
+        joint_states_.push_back(state_joint_values);
+        auto_progress_->setMax(joint_states_.size());
+      }
+    }
+  }
+}
+
+void ControlTabWidget::resetSampleBtnClicked(bool clicked)
+{
+  // Clear recorded transforms
+  effector_wrt_world_.clear();
+  object_wrt_sensor_.clear();
+  tree_view_model_->clear();
+
+  // Clear recorded joint states
+  joint_states_.clear();
+  auto_progress_->setMax(0);
+  auto_progress_->setValue(0);
+}
+
+void ControlTabWidget::saveCameraPoseBtnClicked(bool clicked)
+{
+  std::string& from_frame = frame_names_[from_frame_tag_];
+  std::string& to_frame = frame_names_["sensor"];
+
+  if (from_frame.empty() || to_frame.empty())
+  {
+    QMessageBox::warning(this, tr("Empty Frame Name"), tr("Make sure you have set correct frame names."));
+    return;
+  }
+
+  QString file_name =
+      QFileDialog::getSaveFileName(this, tr("Save Camera Robot Pose"), "", tr("Target File (*.launch);;All Files (*)"));
+
+  if (file_name.isEmpty())
+    return;
+
+  if (!file_name.endsWith(".launch"))
+    file_name += ".launch";
+
+  QFile file(file_name);
+  if (!file.open(QIODevice::WriteOnly))
+  {
+    QMessageBox::warning(this, tr("Unable to open file"), file.errorString());
+    return;
+  }
+
+  QTextStream out(&file);
+
+  Eigen::Vector3d t = camera_robot_pose_.translation();
+  Eigen::Vector3d r = camera_robot_pose_.rotation().eulerAngles(0, 1, 2);
+  std::stringstream ss;
+  ss << "<launch>\n";
+  ss << "<node pkg=\"tf2_ros\" type=\"static_transform_publisher\" name=\"camera_link_broadcaster\"\n";
+  ss << "      args=\"" << t[0] << " " << t[1] << " " << t[2] << " " << r[0] << " " << r[1] << " " << r[2] << " "
+     << from_frame << " " << to_frame << "\" />\n";
+  ss << "</launch>";
+  out << ss.str().c_str();
+}
+
+void ControlTabWidget::planningGroupNameChanged(const QString& text)
+{
+  if (!text.isEmpty())
+  {
+    if (move_group_ && move_group_->getName() == text.toStdString())
+      return;
+
+    try
+    {
+      moveit::planning_interface::MoveGroupInterface::Options opt(group_name_->currentText().toStdString());
+      opt.node_handle_ = nh_;
+      move_group_.reset(new moveit::planning_interface::MoveGroupInterface(opt, tf_buffer_, ros::WallDuration(30, 0)));
+
+      // Clear the joint values aligning with other group
+      joint_states_.clear();
+      auto_progress_->setMax(0);
+    }
+    catch (const std::exception& e)
+    {
+      ROS_ERROR_NAMED(LOGNAME, "%s", e.what());
+    }
+  }
+  else
+  {
+    QMessageBox::warning(this, tr("Invalid Group Name"), "Group name is empty");
+  }
+}
+
+void ControlTabWidget::saveJointStateBtnClicked(bool clicked)
+{
+  if (!checkJointStates())
+  {
+    QMessageBox::warning(this, tr("Error"), tr("No joint states or joint state dosen't match joint names."));
+    return;
+  }
+
+  QString file_name =
+      QFileDialog::getSaveFileName(this, tr("Save Joint States"), "", tr("Target File (*.yaml);;All Files (*)"));
+
+  if (file_name.isEmpty())
+    return;
+
+  if (!file_name.endsWith(".yaml"))
+    file_name += ".yaml";
+
+  QFile file(file_name);
+  if (!file.open(QIODevice::WriteOnly))
+  {
+    QMessageBox::warning(this, tr("Unable to open file"), file.errorString());
+    return;
+  }
+
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  // Joint Names
+  emitter << YAML::Key << "joint_names";
+  emitter << YAML::Value << YAML::BeginSeq;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+    emitter << YAML::Value << joint_names_[i];
+  emitter << YAML::EndSeq;
+
+  // Joint Values
+  emitter << YAML::Key << "joint_values";
+  emitter << YAML::Value << YAML::BeginSeq;
+  for (size_t i = 0; i < joint_states_.size(); ++i)
+  {
+    emitter << YAML::BeginSeq;
+    for (size_t j = 0; j < joint_states_[i].size(); ++j)
+      emitter << YAML::Value << joint_states_[i][j];
+    emitter << YAML::EndSeq;
+  }
+  emitter << YAML::EndSeq;
+
+  emitter << YAML::EndMap;
+
+  QTextStream out(&file);
+  out << emitter.c_str();
+}
+
+void ControlTabWidget::loadJointStateBtnClicked(bool clicked)
+{
+  QString file_name =
+      QFileDialog::getOpenFileName(this, tr("Load Joint States"), "", tr("Target File (*.yaml);;All Files (*)"));
+
+  if (file_name.isEmpty() || !file_name.endsWith(".yaml"))
+    return;
+
+  QFile file(file_name);
+  if (!file.open(QIODevice::ReadOnly))
+  {
+    QMessageBox::warning(this, tr("Unable to open file"), file.errorString());
+    return;
+  }
+
+  // Begin parsing
+  try
+  {
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Load joint states from file: " << file_name.toStdString().c_str());
+    YAML::Node doc = YAML::LoadFile(file_name.toStdString());
+    if (!doc.IsMap())
+      return;
+
+    // Read joint names
+    const YAML::Node& names = doc["joint_names"];
+    if (!names.IsNull() && names.IsSequence())
+    {
+      joint_names_.clear();
+      for (YAML::const_iterator it = names.begin(); it != names.end(); ++it)
+        joint_names_.push_back(it->as<std::string>());
+    }
+    else
+    {
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Can't find 'joint_names' in the openned file.");
+      return;
+    }
+
+    // Read joint values
+    const YAML::Node& values = doc["joint_values"];
+    if (!values.IsNull() && values.IsSequence())
+    {
+      joint_states_.clear();
+      for (YAML::const_iterator state_it = values.begin(); state_it != values.end(); ++state_it)
+      {
+        std::vector<double> jv;
+        if (!state_it->IsNull() && state_it->IsSequence())
+          for (YAML::const_iterator joint_it = state_it->begin(); joint_it != state_it->end(); ++joint_it)
+            jv.push_back(joint_it->as<double>());
+        if (jv.size() == joint_names_.size())
+          joint_states_.push_back(jv);
+      }
+    }
+    else
+    {
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Can't find 'joint_values' in the openned file.");
+      return;
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, e.what());
+    return;
+  }
+
+  if (joint_states_.size() > 0)
+  {
+    auto_progress_->setMax(joint_states_.size());
+    auto_progress_->setValue(0);
+  }
+  ROS_INFO_STREAM_NAMED(LOGNAME, "Loaded and parsed: " << file_name.toStdString());
+}
+
+void ControlTabWidget::autoPlanBtnClicked(bool clicked)
+{
+  auto_plan_btn_->setEnabled(false);
+  plan_watcher_->setFuture(QtConcurrent::run(this, &ControlTabWidget::computePlan));
+}
+
+void ControlTabWidget::computePlan()
+{
+  planning_res_ = true;
+  int max = auto_progress_->bar_->maximum();
+
+  if (max != joint_states_.size() || auto_progress_->getValue() == max)
+  {
+    planning_res_ = false;
+    return;
+  }
+
+  if (!checkJointStates())
+  {
+    planning_res_ = false;
+    return;
+  }
+
+  if (!planning_scene_monitor_)
+  {
+    planning_res_ = false;
+    return;
+  }
+
+  if (!move_group_ || move_group_->getActiveJoints() != joint_names_)
+  {
+    planning_res_ = false;
+    return;
+  }
+
+  // Get current joint state as start state
+  robot_state::RobotStatePtr start_state = move_group_->getCurrentState();
+  planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now(), 0.1);
+  const planning_scene_monitor::LockedPlanningSceneRO& ps =
+      planning_scene_monitor::LockedPlanningSceneRO(planning_scene_monitor_);
+  if (ps)
+    start_state.reset(new robot_state::RobotState(ps->getCurrentState()));
+
+  // Plan motion to the recorded joint state target
+  if (auto_progress_->getValue() < joint_states_.size())
+  {
+    move_group_->setStartState(*start_state);
+    move_group_->setJointValueTarget(joint_states_[auto_progress_->getValue()]);
+    move_group_->setMaxVelocityScalingFactor(0.5);
+    move_group_->setMaxAccelerationScalingFactor(0.5);
+    current_plan_.reset(new moveit::planning_interface::MoveGroupInterface::Plan());
+    planning_res_ = (move_group_->plan(*current_plan_) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+    if (planning_res_)
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "Planning succeed.");
+    else
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Planning failed.");
+  }
+}
+
+void ControlTabWidget::autoExecuteBtnClicked(bool clicked)
+{
+  if (plan_watcher_->isRunning())
+  {
+    plan_watcher_->waitForFinished();
+  }
+
+  auto_execute_btn_->setEnabled(false);
+  execution_watcher_->setFuture(QtConcurrent::run(this, &ControlTabWidget::computeExecution));
+}
+
+void ControlTabWidget::computeExecution()
+{
+  if (move_group_ && current_plan_)
+    planning_res_ = (move_group_->execute(*current_plan_) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  if (planning_res_)
+  {
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Execution succeed.");
+  }
+  else
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Execution failed.");
+}
+
+void ControlTabWidget::planFinished()
+{
+  auto_plan_btn_->setEnabled(true);
+  if (!planning_res_)
+    QMessageBox::warning(this, tr("Error"),
+                         tr("Please check if move_group is started or there are recorded joint states."));
+  ROS_DEBUG_NAMED(LOGNAME, "Plan finished");
+}
+
+void ControlTabWidget::executeFinished()
+{
+  auto_execute_btn_->setEnabled(true);
+  if (planning_res_)
+  {
+    auto_progress_->setValue(auto_progress_->getValue() + 1);
+    if (!frameNamesEmpty())
+      takeTranformSamples();
+
+    if (effector_wrt_world_.size() == object_wrt_sensor_.size() && effector_wrt_world_.size() > 4)
+      solveCameraRobotPose();
+  }
+  ROS_DEBUG_NAMED(LOGNAME, "Execution finished");
+}
+
+void ControlTabWidget::autoSkipBtnClicked(bool clicked)
+{
+  auto_progress_->setValue(auto_progress_->getValue() + 1);
+}
+
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/handeye_target_widget.cpp
@@ -1,0 +1,538 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#include <moveit/handeye_calibration_rviz_plugin/handeye_target_widget.h>
+
+namespace moveit_rviz_plugin
+{
+const std::string LOGNAME = "handeye_target_widget";
+
+void RosTopicComboBox::addMsgsFilterType(QString msgs_type)
+{
+  message_types_.insert(msgs_type);
+}
+
+bool RosTopicComboBox::hasTopic(const QString& topic_name)
+{
+  getFilteredTopics();
+  return image_topics_.contains(topic_name);
+}
+
+bool RosTopicComboBox::getFilteredTopics()
+{
+  // Get all topic names
+  ros::master::V_TopicInfo ros_topic_vec;
+  if (ros::master::getTopics(ros_topic_vec))
+  {
+    image_topics_.clear();
+    // Filter out the topic names with specific topic type
+    for (const ros::master::TopicInfo& topic_info : ros_topic_vec)
+    {
+      if (message_types_.contains(QString(topic_info.datatype.c_str())))
+      {
+        image_topics_.insert(QString(topic_info.name.c_str()));
+      }
+    }
+  }
+
+  clear();
+  addItem(QString(""));
+  for (const QString& topic : image_topics_)
+  {
+    addItem(topic);
+  }
+
+  return !image_topics_.isEmpty();
+}
+
+void RosTopicComboBox::mousePressEvent(QMouseEvent* event)
+{
+  getFilteredTopics();
+  showPopup();
+}
+
+TargetTabWidget::TargetTabWidget(QWidget* parent)
+  : QWidget(parent), nh_("~"), it_(nh_), target_plugins_loader_(nullptr), target_(nullptr)
+{
+  // Target setting tab area -----------------------------------------------
+  QHBoxLayout* layout = new QHBoxLayout();
+  this->setLayout(layout);
+  QVBoxLayout* layout_left = new QVBoxLayout();
+  layout->addLayout(layout_left);
+
+  // Target creation area
+  QGroupBox* group_left_top = new QGroupBox("Target_Intrinsic_Params", this);
+  layout_left->addWidget(group_left_top);
+  QFormLayout* layout_left_top = new QFormLayout();
+  group_left_top->setLayout(layout_left_top);
+
+  target_type_ = new QComboBox();
+  connect(target_type_, SIGNAL(activated(const QString&)), this, SLOT(targetTypeComboboxChanged(const QString&)));
+  layout_left_top->addRow("Target Type", target_type_);
+
+  dictionary_id_ = new QComboBox();
+  layout_left_top->addRow("Dictionary", dictionary_id_);
+
+  target_params_.clear();
+  target_params_.insert(std::make_pair("markers_x", new QLineEdit()));
+  target_params_.insert(std::make_pair("markers_y", new QLineEdit()));
+  target_params_.insert(std::make_pair("marker_size", new QLineEdit()));
+  target_params_.insert(std::make_pair("marker_dist", new QLineEdit()));
+  target_params_.insert(std::make_pair("marker_border", new QLineEdit()));
+
+  target_params_["markers_x"]->setText(QString("4"));
+  target_params_["markers_x"]->setValidator(new QIntValidator(1, 50));
+  layout_left_top->addRow("Num_Markers_X", target_params_["markers_x"]);
+
+  target_params_["markers_y"]->setText(QString("5"));
+  target_params_["markers_y"]->setValidator(new QIntValidator(1, 50));
+  layout_left_top->addRow("Num_Markers_Y", target_params_["markers_y"]);
+
+  target_params_["marker_size"]->setText(QString("200"));
+  target_params_["marker_size"]->setValidator(new QIntValidator(100, 1000));
+  layout_left_top->addRow("Marker_Size_(pixels)", target_params_["marker_size"]);
+
+  target_params_["marker_dist"]->setText(QString("20"));
+  target_params_["marker_dist"]->setValidator(new QIntValidator(10, 200));
+  layout_left_top->addRow("Marker_Dist_(pixels)", target_params_["marker_dist"]);
+
+  target_params_["marker_border"]->setText(QString("1"));
+  target_params_["marker_border"]->setValidator(new QIntValidator(1, 4));
+  layout_left_top->addRow("Marker_Border_(bits)", target_params_["marker_border"]);
+
+  // Target 3D pose recognition area
+  QGroupBox* group_left_bottom = new QGroupBox("Target_Pose_Recognition", this);
+  layout_left->addWidget(group_left_bottom);
+  QFormLayout* layout_left_bottom = new QFormLayout();
+  group_left_bottom->setLayout(layout_left_bottom);
+
+  ros_topics_.insert(std::make_pair("image_topic", new RosTopicComboBox(this)));
+  ros_topics_["image_topic"]->addMsgsFilterType("sensor_msgs/Image");
+  layout_left_bottom->addRow("Image Topic", ros_topics_["image_topic"]);
+  connect(ros_topics_["image_topic"], SIGNAL(activated(const QString&)), this,
+          SLOT(imageTopicComboboxChanged(const QString&)));
+
+  ros_topics_.insert(std::make_pair("camera_info_topic", new RosTopicComboBox(this)));
+  ros_topics_["camera_info_topic"]->addMsgsFilterType("sensor_msgs/CameraInfo");
+  layout_left_bottom->addRow("CameraInfo Topic", ros_topics_["camera_info_topic"]);
+  connect(ros_topics_["camera_info_topic"], SIGNAL(activated(const QString&)), this,
+          SLOT(cameraInfoComboBoxChanged(const QString&)));
+
+  target_real_dims_.insert(std::make_pair("marker_size_real", new QLineEdit()));
+  target_real_dims_.insert(std::make_pair("marker_dist_real", new QLineEdit()));
+
+  target_real_dims_["marker_size_real"]->setText("0.0256");
+  target_real_dims_["marker_size_real"]->setValidator(new QDoubleValidator(0, 2, 4));
+  layout_left_bottom->addRow("Marker Size (m)", target_real_dims_["marker_size_real"]);
+
+  target_real_dims_["marker_dist_real"]->setText("0.0066");
+  target_real_dims_["marker_dist_real"]->setValidator(new QDoubleValidator(0, 2, 4));
+  layout_left_bottom->addRow("Marker Dist (m)", target_real_dims_["marker_dist_real"]);
+
+  // Target image dislay, create and save area
+  QGroupBox* group_right = new QGroupBox("Target_Create_Save", this);
+  group_right->setMinimumWidth(330);
+  layout->addWidget(group_right);
+  QVBoxLayout* layout_right = new QVBoxLayout();
+  group_right->setLayout(layout_right);
+
+  target_display_label_ = new QLabel();
+  target_display_label_->setAlignment(Qt::AlignHCenter);
+  layout_right->addWidget(target_display_label_);
+
+  QPushButton* create_target_btn = new QPushButton("Create Target");
+  layout_right->addWidget(create_target_btn);
+  connect(create_target_btn, SIGNAL(clicked(bool)), this, SLOT(createTargetImageBtnClicked(bool)));
+
+  QPushButton* save_target_btn = new QPushButton("Save Target");
+  layout_right->addWidget(save_target_btn);
+  connect(save_target_btn, SIGNAL(clicked(bool)), this, SLOT(saveTargetImageBtnClicked(bool)));
+
+  // Load target availible plugins
+  if (loadTargetPlugin() && createTargetInstance(target_type_->currentText().toStdString()))
+    fillDictionaryIds();
+
+  // Initialize image publisher
+  image_pub_ = it_.advertise("/handeye_calibration/target_detection", 1);
+
+  // Initialize camera info dada
+  camera_info_.reset(new sensor_msgs::CameraInfo());
+
+  // Register custom types
+  qRegisterMetaType<sensor_msgs::CameraInfo>();
+  qRegisterMetaType<std::string>();
+}
+
+void TargetTabWidget::loadWidget(const rviz::Config& config)
+{
+  if (target_type_->count() > 0)
+  {
+    QString type;
+    if (config.mapGetString("target_type", &type) && target_type_->findText(type, Qt::MatchCaseSensitive) != -1)
+      target_type_->setCurrentText(type);
+
+    createTargetInstance(target_type_->currentText().toStdString());
+
+    QString dict_name;
+    config.mapGetString("dictionary", &dict_name);
+    fillDictionaryIds(dict_name.toStdString());
+  }
+
+  int param_int;
+  for (const std::pair<const std::string, QLineEdit*>& param : target_params_)
+    if (config.mapGetInt(param.first.c_str(), &param_int))
+      param.second->setText(std::to_string(param_int).c_str());
+
+  for (const std::pair<const std::string, RosTopicComboBox*>& topic : ros_topics_)
+  {
+    QString topic_name;
+    if (config.mapGetString(topic.first.c_str(), &topic_name))
+    {
+      if (topic.second->hasTopic(topic_name))
+      {
+        topic.second->setCurrentText(topic_name);
+        try
+        {
+          if (!topic.first.compare("image_topic"))
+          {
+            image_sub_.shutdown();
+            image_sub_ = it_.subscribe(topic_name.toStdString(), 1, &TargetTabWidget::imageCallback, this);
+          }
+
+          if (!topic.first.compare("camera_info_topic"))
+          {
+            camerainfo_sub_.shutdown();
+            camerainfo_sub_ = nh_.subscribe(topic_name.toStdString(), 1, &TargetTabWidget::cameraInfoCallback, this);
+          }
+        }
+        catch (const image_transport::TransportLoadException& e)
+        {
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Subscribe to " << topic_name.toStdString() << " fail: " << e.what());
+        }
+      }
+    }
+  }
+
+  for (const std::pair<const std::string, QLineEdit*>& param : target_real_dims_)
+  {
+    float param_double;
+    if (config.mapGetFloat(param.first.c_str(), &param_double))
+      param.second->setText(std::to_string(param_double).c_str());
+  }
+}
+
+void TargetTabWidget::saveWidget(rviz::Config& config)
+{
+  config.mapSetValue("target_type", target_type_->currentText());
+  config.mapSetValue("dictionary", dictionary_id_->currentText());
+  for (const std::pair<const std::string, QLineEdit*>& param : target_params_)
+    config.mapSetValue(param.first.c_str(), param.second->text().toInt());
+
+  for (const std::pair<const std::string, RosTopicComboBox*>& topic : ros_topics_)
+    config.mapSetValue(topic.first.c_str(), topic.second->currentText());
+
+  for (const std::pair<const std::string, QLineEdit*>& param : target_real_dims_)
+    config.mapSetValue(param.first.c_str(), param.second->text().toDouble());
+}
+
+bool TargetTabWidget::loadTargetPlugin()
+{
+  if (!target_plugins_loader_)
+  {
+    try
+    {
+      target_plugins_loader_.reset(new pluginlib::ClassLoader<moveit_handeye_calibration::HandEyeTargetBase>(
+          "moveit_ros_perception", "moveit_handeye_calibration::HandEyeTargetBase"));
+    }
+    catch (pluginlib::PluginlibException& ex)
+    {
+      QMessageBox::warning(this, tr("Exception while creating handeye target plugin loader "), tr(ex.what()));
+      return false;
+    }
+  }
+
+  // Get target classes
+  const std::vector<std::string>& classes = target_plugins_loader_->getDeclaredClasses();
+
+  target_type_->clear();
+  if (classes.empty())
+  {
+    QMessageBox::warning(this, tr("Missing target plugins"), "No MoveIt handeye calibration target plugin found.");
+    return false;
+  }
+
+  for (const std::string& it : classes)
+    target_type_->addItem(tr(it.c_str()));
+
+  return true;
+}
+
+bool TargetTabWidget::createTargetInstance(const std::string& plugin_name)
+{
+  if (plugin_name.empty())
+    return false;
+
+  try
+  {
+    target_ = target_plugins_loader_->createUniqueInstance(plugin_name);
+    target_->initialize(target_params_["markers_x"]->text().toInt(), target_params_["markers_y"]->text().toInt(),
+                        target_params_["marker_size"]->text().toInt(), target_params_["marker_dist"]->text().toInt(),
+                        target_params_["marker_border"]->text().toInt(), dictionary_id_->currentText().toStdString(),
+                        target_real_dims_["marker_size_real"]->text().toDouble(),
+                        target_real_dims_["marker_dist_real"]->text().toDouble());
+  }
+  catch (pluginlib::PluginlibException& ex)
+  {
+    QMessageBox::warning(this, tr("Exception while loading a handeye target plugin"), tr(ex.what()));
+    target_ = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+void TargetTabWidget::fillDictionaryIds(std::string id)
+{
+  if (target_)
+  {
+    // Get dictionary ids
+    const std::vector<std::string>& ids = target_->getDictionaryIds();
+    dictionary_id_->clear();
+    for (const std::string& id : ids)
+    {
+      dictionary_id_->addItem(tr(id.c_str()));
+    }
+
+    // Check if 'id' exists in the list
+    if (!id.empty())
+    {
+      auto it = std::find(ids.begin(), ids.end(), id);
+      if (it != ids.end())
+        dictionary_id_->setCurrentText(QString(id.c_str()));
+    }
+  }
+}
+
+void TargetTabWidget::imageCallback(const sensor_msgs::ImageConstPtr& msg)
+{
+  targetParamsSet();
+
+  // Depth image format `16UC1` cannot be converted to `MONO8`
+  if (msg->encoding == "16UC1")
+    return;
+
+  std::string frame_id = msg->header.frame_id;
+  if (!frame_id.empty())
+  {
+    if (optical_frame_.compare(frame_id))
+    {
+      optical_frame_ = frame_id;
+      Q_EMIT opticalFrameChanged(optical_frame_);
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Image msg has empty frame_id.");
+    return;
+  }
+
+  if (msg->data.empty())
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Image msg has empty data.");
+    return;
+  }
+
+  cv_bridge::CvImagePtr cv_ptr;
+  try
+  {
+    cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::MONO8);
+
+    sensor_msgs::ImagePtr pub_msg;
+    if (target_ && target_->detectTargetPose(cv_ptr->image))
+    {
+      pub_msg = cv_bridge::CvImage(std_msgs::Header(), "rgb8", cv_ptr->image).toImageMsg();
+
+      geometry_msgs::TransformStamped tf2_msg = target_->getTransformStamped(optical_frame_);
+      tf_pub_.sendTransform(tf2_msg);
+    }
+    else
+    {
+      pub_msg = cv_bridge::CvImage(std_msgs::Header(), "mono8", cv_ptr->image).toImageMsg();
+    }
+    image_pub_.publish(pub_msg);
+  }
+  catch (cv_bridge::Exception& e)
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "cv_bridge exception: " << e.what());
+  }
+  catch (cv::Exception& e)
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "cv exception: " << e.what());
+  }
+}
+
+void TargetTabWidget::cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg)
+{
+  if (target_)
+  {
+    if (msg->height > 0 && msg->width > 0 && !msg->K.empty() && !msg->D.empty())
+    {
+      if (msg->K != camera_info_->K || msg->P != camera_info_->P)
+      {
+        ROS_DEBUG("Received camera info.");
+        camera_info_->header = msg->header;
+        camera_info_->height = msg->height;
+        camera_info_->width = msg->width;
+        camera_info_->distortion_model = msg->distortion_model;
+        camera_info_->D = msg->D;
+        camera_info_->K = msg->K;
+        camera_info_->R = msg->R;
+        camera_info_->P = msg->P;
+        target_->setCameraIntrinsicParams(camera_info_);
+        Q_EMIT cameraInfoChanged(*camera_info_);
+      }
+    }
+  }
+}
+
+void TargetTabWidget::targetTypeComboboxChanged(const QString& text)
+{
+  if (!text.isEmpty())
+  {
+    if (createTargetInstance(text.toStdString()))
+    {
+      fillDictionaryIds();
+    }
+  }
+}
+
+void TargetTabWidget::createTargetImageBtnClicked(bool clicked)
+{
+  if (target_)
+  {
+    targetParamsSet();
+    target_->createTargetImage(target_image_);
+  }
+  else
+    QMessageBox::warning(this, tr("Fail to create a target image."), "No available target plugin.");
+
+  if (!target_image_.empty())
+  {
+    // Show target image
+    QImage qimage(target_image_.data, target_image_.cols, target_image_.rows, QImage::Format_Grayscale8);
+    if (target_image_.cols > target_image_.rows)
+      qimage = qimage.scaledToWidth(320, Qt::SmoothTransformation);
+    else
+      qimage = qimage.scaledToHeight(260, Qt::SmoothTransformation);
+    target_display_label_->setPixmap(QPixmap::fromImage(qimage));
+  }
+}
+
+void TargetTabWidget::targetParamsSet(const QString& text)
+{
+  if (target_)
+  {
+    target_->setTargetIntrinsicParams(
+        target_params_["markers_x"]->text().toInt(), target_params_["markers_y"]->text().toInt(),
+        target_params_["marker_size"]->text().toInt(), target_params_["marker_dist"]->text().toInt(),
+        target_params_["marker_border"]->text().toInt(), dictionary_id_->currentText().toStdString());
+    target_->setTargetDimension(target_real_dims_["marker_size_real"]->text().toDouble(),
+                                target_real_dims_["marker_dist_real"]->text().toDouble());
+  }
+}
+
+void TargetTabWidget::saveTargetImageBtnClicked(bool clicked)
+{
+  if (target_image_.empty())
+  {
+    QMessageBox::warning(this, tr("Unable to save image"), tr("Please create a target at first."));
+    return;
+  }
+
+  QString fileName =
+      QFileDialog::getSaveFileName(this, tr("Save Target Image"), "", tr("Target Image (*.png);;All Files (*)"));
+
+  if (fileName.isEmpty())
+    return;
+
+  if (!fileName.endsWith(".png"))
+    fileName += ".png";
+
+  QFile file(fileName);
+  if (!file.open(QIODevice::WriteOnly))
+  {
+    QMessageBox::warning(this, tr("Unable to open file"), file.errorString());
+    return;
+  }
+
+  if (!cv::imwrite(cv::String(fileName.toStdString()), target_image_))
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Error OpenCV saving image.");
+}
+
+void TargetTabWidget::imageTopicComboboxChanged(const QString& topic)
+{
+  image_sub_.shutdown();
+  if (!topic.isNull() and !topic.isEmpty())
+  {
+    try
+    {
+      image_sub_ = it_.subscribe(topic.toStdString(), 1, &TargetTabWidget::imageCallback, this);
+    }
+    catch (image_transport::TransportLoadException& e)
+    {
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Subscribe to image topic: " << topic.toStdString() << " failed. " << e.what());
+    }
+  }
+}
+
+void TargetTabWidget::cameraInfoComboBoxChanged(const QString& topic)
+{
+  camerainfo_sub_.shutdown();
+  if (!topic.isNull() and !topic.isEmpty())
+  {
+    try
+    {
+      camerainfo_sub_ = nh_.subscribe(topic.toStdString(), 1, &TargetTabWidget::cameraInfoCallback, this);
+    }
+    catch (ros::Exception& e)
+    {
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Subscribe to camera info topic: " << topic.toStdString() << " failed. "
+                                                                         << e.what());
+    }
+  }
+}
+
+}  // namedist moveit_rviz_plugin

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin/src/plugin_init.cpp
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019,  Intel Corporation.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Yu Yan */
+
+#include <class_loader/class_loader.hpp>
+#include <moveit/handeye_calibration_rviz_plugin/handeye_calibration_gui.h>
+
+CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::HandEyeCalibrationGui, rviz::Panel)

--- a/moveit_ros/visualization/handeye_calibration_rviz_plugin_description.xml
+++ b/moveit_ros/visualization/handeye_calibration_rviz_plugin_description.xml
@@ -1,0 +1,7 @@
+<library path="libmoveit_handeye_calibration_rviz_plugin">
+  <class name="moveit_rviz_plugin/HandEyeCalibration" type="moveit_rviz_plugin::HandEyeCalibrationGui" base_class_type="rviz::Panel">
+    <description>
+      Gui widget for the hand-eye calibration.
+    </description>
+  </class>
+</library>

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -25,6 +25,7 @@
   <build_depend>libogre-dev</build_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
+  <build_depend>image_geometry</build_depend>
 
   <depend>geometric_shapes</depend>
   <depend>interactive_markers</depend>
@@ -32,6 +33,7 @@
   <depend>moveit_ros_perception</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_ros_warehouse</depend>
+  <depend>moveit_visual_tools</depend>
   <depend>object_recognition_msgs</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
   <depend>rosconsole</depend>
@@ -47,6 +49,7 @@
     <rviz plugin="${prefix}/planning_scene_rviz_plugin_description.xml"/>
     <rviz plugin="${prefix}/motion_planning_rviz_plugin_description.xml"/>
     <rviz plugin="${prefix}/trajectory_rviz_plugin_description.xml"/>
+    <rviz plugin="${prefix}/handeye_calibration_rviz_plugin_description.xml"/>
   </export>
 
 </package>


### PR DESCRIPTION
### Description

In [issue#1070](https://github.com/ros-planning/moveit/issues/1070), we proposed creating an easy to use and extensible hand-eye calibration tool for MoveIt. Some screenshots of this tool can be found in the [reference](https://github.com/ros-planning/moveit/issues/1070#issuecomment-510752941). This tool contains three plugins:

- **Rviz GUI plugin** [This PR](https://github.com/ros-planning/moveit/pull/1560)(Set parameters, make calibration control and call the other two plugins. Change moveit_ros_visualization)
- Default Target plugin [PR#1558](https://github.com/ros-planning/moveit/pull/1558)(Create target image and detect target pose. Change moveit_ros_perception)
- Default Solver plugin [PR#1559](https://github.com/ros-planning/moveit/pull/1559)(Solve the camera pose w.r.t robot arm from the collected transform samples. Change moveit_ros_perception)

They are separated into three PRs. This PR intends to add a rviz plugin that is in charge of the interaction of the calibration process. This plugin has one panel widget and three tab widgets:

- Target tab widget: is used to set target parameters, load target plugins, select Image and CameraInfo topics and publish target pose detection results.
- Context tab widget: is used to choose the sensor mount type (eye-in-hand or eye-to-hand), set the initial guess pose of a camera.
- Control tab widget: is used to load handeye solver plugin, config planning group name of move_group, make manual calibration and auto calibration, save camera-robot pose, save and load joint states.

This PR should not be merged before [PR#1558](https://github.com/ros-planning/moveit/pull/1558) and [PR#1559](https://github.com/ros-planning/moveit/pull/1559) are merged.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference]()
- [x] Include a screenshot if changing a GUI
- [ ] Created tests, which fail without this PR [reference]()
