### PR TITLE
Get joint model names from joint_model_group_

### DIFF
--- a/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
@@ -42,7 +42,6 @@
 
 #include <jog_arm/jog_arm_data.h>
 #include <jog_arm/low_pass_filter.h>
-#include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <std_msgs/Bool.h>
@@ -54,13 +53,11 @@ namespace jog_arm
 class JogCalcs
 {
 public:
-  JogCalcs(const JogArmParameters parameters, JogArmShared& shared_variables, pthread_mutex_t& mutex,
+  JogCalcs(const JogArmParameters& parameters, JogArmShared& shared_variables, pthread_mutex_t& mutex,
            const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
 
 protected:
   ros::NodeHandle nh_;
-
-  moveit::planning_interface::MoveGroupInterface move_group_;
 
   sensor_msgs::JointState incoming_jts_;
 

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_calcs.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_calcs.cpp
@@ -42,9 +42,9 @@
 namespace jog_arm
 {
 // Constructor for the class that handles jogging calculations
-JogCalcs::JogCalcs(const JogArmParameters parameters, JogArmShared& shared_variables, pthread_mutex_t& mutex,
+JogCalcs::JogCalcs(const JogArmParameters& parameters, JogArmShared& shared_variables, pthread_mutex_t& mutex,
                    const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr)
-  : move_group_(parameters.move_group_name), tf_listener_(tf_buffer_), parameters_(parameters)
+  : tf_listener_(tf_buffer_), parameters_(parameters)
 {
   // Publish collision status
   warning_pub_ = nh_.advertise<std_msgs::Bool>(parameters_.warning_topic, 1);
@@ -72,7 +72,7 @@ JogCalcs::JogCalcs(const JogArmParameters parameters, JogArmShared& shared_varia
 
   resetVelocityFilters();
 
-  jt_state_.name = move_group_.getJointNames();
+  jt_state_.name = joint_model_group_->getVariableNames();
   num_joints_ = jt_state_.name.size();
   jt_state_.position.resize(num_joints_);
   jt_state_.velocity.resize(num_joints_);


### PR DESCRIPTION
Remove dependence on move_group action server by getting the joint model names through joint_model_group_ instead.

### Description

closes #1563

Uses joint_model_group_ instead of MoveGroupInterface to get joint names
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
