### PR TITLE
[Windows][master] remove GCC extension and alternative operator usage.

### DIFF
--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -41,7 +41,9 @@
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/function.hpp>
-#include <cxxabi.h>
+#if !defined(_MSC_VER)
+  #include <cxxabi.h>
+#endif
 
 /** \brief Generic interface to adapting motion planning requests */
 namespace planning_request_adapter
@@ -72,7 +74,11 @@ public:
     std::string adapter_name = typeid(*this).name();
     // Try to demangle the name
     int status;
+#if defined(_MSC_VER)
+    std::string demangled_name = adapter_name;
+#else
     std::string demangled_name = abi::__cxa_demangle(adapter_name.c_str(), NULL, NULL, &status);
+#endif
     if (status == 0)
       adapter_name = demangled_name;
     ROS_WARN_NAMED("planning_request_adapter", "Implementation of function initialize() is missing from '%s'."

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -73,7 +73,7 @@ public:
     // Get name of derived adapter
     std::string adapter_name = typeid(*this).name();
     // Try to demangle the name
-     int status = 1;
+    int status = 1;
 #if defined(_MSC_VER)
     std::string demangled_name = adapter_name;
 #else

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -73,7 +73,7 @@ public:
     // Get name of derived adapter
     std::string adapter_name = typeid(*this).name();
     // Try to demangle the name
-    int status;
+     int status = 1;
 #if defined(_MSC_VER)
     std::string demangled_name = adapter_name;
 #else

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -42,7 +42,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/function.hpp>
 #if !defined(_MSC_VER)
-  #include <cxxabi.h>
+#include <cxxabi.h>
 #endif
 
 /** \brief Generic interface to adapting motion planning requests */

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1231,7 +1231,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     const JointModel* pjm = link->getParentJointModel();
     if (pjm->getVariableCount() > 0)
     {
-      if (not group->hasJointModel(pjm->getName()))
+      if (!group->hasJointModel(pjm->getName()))
       {
         link = pjm->getParentLinkModel();
         continue;

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -120,14 +120,14 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
     return;
   }
   // First link should already be added.
-  if (not urdf_model_->getLink(link_names[0]))
+  if (!urdf_model_->getLink(link_names[0]))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_names[0].c_str());
     is_valid_ = false;
     return;
   }
 
-  if (not joint_origins.empty() && link_names.size() - 1 != joint_origins.size())
+  if (!joint_origins.empty() && link_names.size() - 1 != joint_origins.size())
   {
     ROS_ERROR_NAMED(LOGNAME, "There should be one more link (%zu) than there are joint origins (%zu)",
                     link_names.size(), joint_origins.size());
@@ -152,7 +152,7 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
     joint->name = link_names[i - 1] + "-" + link_names[i] + "-joint";
     // Default to Identity transform for origins.
     joint->parent_to_joint_origin_transform.clear();
-    if (not joint_origins.empty())
+    if (!joint_origins.empty())
     {
       geometry_msgs::Pose o = joint_origins[i - 1];
       joint->parent_to_joint_origin_transform.position = urdf::Vector3(o.position.x, o.position.y, o.position.z);
@@ -197,7 +197,7 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
 void RobotModelBuilder::addInertial(const std::string& link_name, double mass, geometry_msgs::Pose origin, double ixx,
                                     double ixy, double ixz, double iyy, double iyz, double izz)
 {
-  if (not urdf_model_->getLink(link_name))
+  if (!urdf_model_->getLink(link_name))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_name.c_str());
     is_valid_ = false;
@@ -260,7 +260,7 @@ void RobotModelBuilder::addCollisionMesh(const std::string& link_name, const std
 void RobotModelBuilder::addLinkCollision(const std::string& link_name, const urdf::CollisionSharedPtr& collision,
                                          geometry_msgs::Pose origin)
 {
-  if (not urdf_model_->getLink(link_name))
+  if (!urdf_model_->getLink(link_name))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_name.c_str());
     is_valid_ = false;
@@ -278,7 +278,7 @@ void RobotModelBuilder::addLinkCollision(const std::string& link_name, const urd
 void RobotModelBuilder::addLinkVisual(const std::string& link_name, const urdf::VisualSharedPtr& vis,
                                       geometry_msgs::Pose origin)
 {
-  if (not urdf_model_->getLink(link_name))
+  if (!urdf_model_->getLink(link_name))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_name.c_str());
     is_valid_ = false;
@@ -290,7 +290,7 @@ void RobotModelBuilder::addLinkVisual(const std::string& link_name, const urdf::
 
   urdf::LinkSharedPtr link;
   urdf_model_->getLink(link_name, link);
-  if (not link->visual_array.empty())
+  if (!link->visual_array.empty())
   {
     link->visual_array.push_back(vis);
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -155,7 +155,7 @@ void ChompTrajectory::fillInMinJerk()
 
   // calculate the spline coefficients for each joint:
   // (these are for the special case of zero start and end vel and acc)
-  double coeff[num_joints_][6];
+  std::vector<double[6]> coeff(num_joints_);
   for (size_t i = 0; i < num_joints_; i++)
   {
     double x0 = (*this)(start_index, i);

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -443,20 +443,20 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
         continue;
       joint_time_[joint] = latest_common_time;
 
-      double new_values[joint->getStateSpaceDimension()];
+      std::vector<double> new_values(joint->getStateSpaceDimension());
       const robot_model::LinkModel* link = joint->getChildLinkModel();
       if (link->jointOriginTransformIsIdentity())
-        joint->computeVariablePositions(tf2::transformToEigen(transf), new_values);
+        joint->computeVariablePositions(tf2::transformToEigen(transf), new_values.data());
       else
         joint->computeVariablePositions(link->getJointOriginTransform().inverse() * tf2::transformToEigen(transf),
-                                        new_values);
+                                        new_values.data());
 
-      if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
+      if (joint->distance(new_values.data(), robot_state_.getJointPositions(joint)) > 1e-5)
       {
         changes = true;
       }
 
-      robot_state_.setJointPositions(joint, new_values);
+      robot_state_.setJointPositions(joint, new_values.data());
       update = true;
     }
   }


### PR DESCRIPTION
This change is to replace the `gcc` extension and alternative operator usage.

* Replace alternative operator with [`primary tokens`](https://en.cppreference.com/w/cpp/language/operator_alternative).
* Replace `variable length array` with `std::vector`.
* Don't do `abi::__cxa_demangle` when it is using `MSVC` toolchain.