### PR TITLE
Fix clang-tidy error in move_group_interface

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -486,7 +486,7 @@ public:
 
   std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
                                double velocity_scaling_factor, double acceleration_scaling_factor,
-                               std::string algorithm)
+                               const std::string& algorithm)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;


### PR DESCRIPTION
Fixes [Travis breakage on master](https://travis-ci.org/ros-planning/moveit/jobs/563596256) from https://github.com/ros-planning/moveit/pull/1508/files

it looks like the PR got through Travis because this was committed to melodic first, then cherry-picked to master...

@rhaschke do we have easier clang-tidy tests on melodic than master branch? this would indicate we need to target all PRs to master first, then.