### PR TITLE
Update occupancy grid when loaded from file

### DIFF
--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -329,6 +329,9 @@ bool OccupancyMapMonitor::loadMapCallback(moveit_msgs::LoadMap::Request& request
     response.success = false;
   }
   tree_->unlockWrite();
+  if (response.success){
+    tree_->triggerUpdateCallback();
+  }
 
   return true;
 }

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -329,9 +329,9 @@ bool OccupancyMapMonitor::loadMapCallback(moveit_msgs::LoadMap::Request& request
     response.success = false;
   }
   tree_->unlockWrite();
-  if (response.success){
+
+  if (response.success)
     tree_->triggerUpdateCallback();
-  }
 
   return true;
 }


### PR DESCRIPTION
### Description

Trigger the octomap update when loaded through /move_group/load_map service

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [X] Include a screenshot if changing a GUI
- [X] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [X] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [X] Decide if this should be cherry-picked to other current ROS branches
- [X] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
