### PR TITLE
Add parameter to get_jacobian_matrix

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -596,7 +596,7 @@ class MoveGroupCommander(object):
         traj_out.deserialize(ser_traj_out)
         return traj_out
 
-    def get_jacobian_matrix(self, joint_values):
+    def get_jacobian_matrix(self, joint_values, reference_point_position=[0.0, 0.0, 0.0]):
         """ Get the jacobian matrix of the group as a list"""
-        return self._g.get_jacobian_matrix(joint_values)
+        return self._g.get_jacobian_matrix(joint_values, reference_point_position)
 

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -596,7 +596,7 @@ class MoveGroupCommander(object):
         traj_out.deserialize(ser_traj_out)
         return traj_out
 
-    def get_jacobian_matrix(self, joint_values, reference_point_position=[0.0, 0.0, 0.0]):
+    def get_jacobian_matrix(self, joint_values, reference_point_position=None):
         """ Get the jacobian matrix of the group as a list"""
-        return self._g.get_jacobian_matrix(joint_values, reference_point_position)
+        return self._g.get_jacobian_matrix(joint_values, [0.0, 0.0, 0.0] if reference_point_position is None else reference_point_position)
 

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -596,7 +596,7 @@ class MoveGroupCommander(object):
         traj_out.deserialize(ser_traj_out)
         return traj_out
 
-    def get_jacobian_matrix(self, joint_values, reference_point_position=None):
+    def get_jacobian_matrix(self, joint_values, reference_point=None):
         """ Get the jacobian matrix of the group as a list"""
-        return self._g.get_jacobian_matrix(joint_values, [0.0, 0.0, 0.0] if reference_point_position is None else reference_point_position)
+        return self._g.get_jacobian_matrix(joint_values, [0.0, 0.0, 0.0] if reference_point is None else reference_point)
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -536,14 +536,16 @@ public:
     }
   }
 
-  Eigen::MatrixXd getJacobianMatrixPython(bp::list& joint_values)
+  Eigen::MatrixXd getJacobianMatrixPython(bp::list& joint_values, bp::list& reference_point_position)
   {
-    std::vector<double> v = py_bindings_tools::doubleFromList(joint_values);
+    std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
+    std::vector<double> ref_point_pos_vector = py_bindings_tools::doubleFromList(reference_point_position);
+    Eigen::Vector3d ref_point_pos(ref_point_pos_vector.data());
     robot_state::RobotState state(getRobotModel());
     state.setToDefaultValues();
     auto group = state.getJointModelGroup(getName());
-    state.setJointGroupPositions(group, v);
-    return state.getJacobian(group);
+    state.setJointGroupPositions(group, joint_vals);
+    return state.getJacobian(group, ref_point_pos);
   }
 };
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -536,13 +536,20 @@ public:
     }
   }
 
-  Eigen::MatrixXd getJacobianMatrixPython(const bp::list& joint_values,
-                                          const bp::list& reference_point_position = bp::list())
+  Eigen::MatrixXd getJacobianMatrixPython1(const bp::list& joint_values)
+  {
+    const std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
+    robot_state::RobotState state(getRobotModel());
+    state.setToDefaultValues();
+    auto group = state.getJointModelGroup(getName());
+    state.setJointGroupPositions(group, joint_vals);
+    return state.getJacobian(group);
+  }
+
+  Eigen::MatrixXd getJacobianMatrixPython2(const bp::list& joint_values, const bp::list& reference_point_position)
   {
     const std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
     std::vector<double> ref_point_pos_vector = py_bindings_tools::doubleFromList(reference_point_position);
-    if (ref_point_pos_vector.size() == 0)
-      ref_point_pos_vector = { 0.0, 0.0, 0.0 };
     const Eigen::Vector3d ref_point_pos(ref_point_pos_vector.data());
 
     robot_state::RobotState state(getRobotModel());
@@ -689,7 +696,8 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("get_named_targets", &MoveGroupInterfaceWrapper::getNamedTargetsPython);
   move_group_interface_class.def("get_named_target_values", &MoveGroupInterfaceWrapper::getNamedTargetValuesPython);
   move_group_interface_class.def("get_current_state_bounded", &MoveGroupInterfaceWrapper::getCurrentStateBoundedPython);
-  move_group_interface_class.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython);
+  move_group_interface_class.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython1);
+  move_group_interface_class.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython2);
 }
 }  // namespace planning_interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -536,11 +536,15 @@ public:
     }
   }
 
-  Eigen::MatrixXd getJacobianMatrixPython(bp::list& joint_values, bp::list& reference_point_position)
+  Eigen::MatrixXd getJacobianMatrixPython(const bp::list& joint_values,
+                                          const bp::list& reference_point_position = bp::list())
   {
-    std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
+    const std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
     std::vector<double> ref_point_pos_vector = py_bindings_tools::doubleFromList(reference_point_position);
-    Eigen::Vector3d ref_point_pos(ref_point_pos_vector.data());
+    if (ref_point_pos_vector.size() == 0)
+      ref_point_pos_vector = { 0.0, 0.0, 0.0 };
+    const Eigen::Vector3d ref_point_pos(ref_point_pos_vector.data());
+
     robot_state::RobotState state(getRobotModel());
     state.setToDefaultValues();
     auto group = state.getJointModelGroup(getName());

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -536,29 +536,27 @@ public:
     }
   }
 
-  Eigen::MatrixXd getJacobianMatrixPython1(const bp::list& joint_values)
+  Eigen::MatrixXd getJacobianMatrixPython(const bp::list& joint_values,
+                                          const bp::object& reference_point = bp::object())
   {
-    const std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
-    robot_state::RobotState state(getRobotModel());
-    state.setToDefaultValues();
-    auto group = state.getJointModelGroup(getName());
-    state.setJointGroupPositions(group, joint_vals);
-    return state.getJacobian(group);
-  }
-
-  Eigen::MatrixXd getJacobianMatrixPython2(const bp::list& joint_values, const bp::list& reference_point_position)
-  {
-    const std::vector<double> joint_vals = py_bindings_tools::doubleFromList(joint_values);
-    std::vector<double> ref_point_pos_vector = py_bindings_tools::doubleFromList(reference_point_position);
-    const Eigen::Vector3d ref_point_pos(ref_point_pos_vector.data());
+    const std::vector<double> v = py_bindings_tools::doubleFromList(joint_values);
+    std::vector<double> ref;
+    if (reference_point.is_none())
+      ref = { 0.0, 0.0, 0.0 };
+    else
+      ref = py_bindings_tools::doubleFromList(reference_point);
+    if (ref.size() != 3)
+      throw std::invalid_argument("reference point needs to have 3 elements, got " + std::to_string(ref.size()));
 
     robot_state::RobotState state(getRobotModel());
     state.setToDefaultValues();
     auto group = state.getJointModelGroup(getName());
-    state.setJointGroupPositions(group, joint_vals);
-    return state.getJacobian(group, ref_point_pos);
+    state.setJointGroupPositions(group, v);
+    return state.getJacobian(group, Eigen::Map<Eigen::Vector3d>(&ref[0]));
   }
 };
+
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getJacobianMatrixOverloads, getJacobianMatrixPython, 1, 2)
 
 static void wrap_move_group_interface()
 {
@@ -696,8 +694,8 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("get_named_targets", &MoveGroupInterfaceWrapper::getNamedTargetsPython);
   move_group_interface_class.def("get_named_target_values", &MoveGroupInterfaceWrapper::getNamedTargetValuesPython);
   move_group_interface_class.def("get_current_state_bounded", &MoveGroupInterfaceWrapper::getCurrentStateBoundedPython);
-  move_group_interface_class.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython1);
-  move_group_interface_class.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython2);
+  move_group_interface_class.def("get_jacobian_matrix", &MoveGroupInterfaceWrapper::getJacobianMatrixPython,
+                                 getJacobianMatrixOverloads());
 }
 }  // namespace planning_interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -80,6 +80,13 @@ class PythonMoveGroupTest(unittest.TestCase):
                              [ 1.  ,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ]])
         self.assertTrue(np.allclose(result, expected))
 
+        result = self.group.get_jacobian_matrix(current, [1.0, 1.0, 1.0])
+        expected = np.array([[ 1.  ,  1.8 , -1.2 ,  0.  , -1.  ,  0.  ],
+                             [ 1.89,  0.  ,  0.  ,  1.  ,  0.  ,  1.  ],
+                             [ 0.  , -1.74,  1.74,  1.  ,  1.1 ,  1.  ],
+                             [ 0.  ,  0.  ,  0.  , -1.  ,  0.  , -1.  ],
+                             [ 0.  ,  1.  , -1.  ,  0.  , -1.  ,  0.  ],
+                             [ 1.  ,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ]])
 
 if __name__ == '__main__':
     PKGNAME = 'moveit_ros_planning_interface'


### PR DESCRIPTION
### Description

I needed to expose the `reference_point_position` parameter of the `getJacobian` function in Python, so I added it as an optional parameter. Tested on a UR5, worked as expected.

Can be cherry-picked to kinetic and melodic just like #1501, where the `get_jacobian_matrix` was added that this PR modifies.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] Decide if this should be cherry-picked to other current ROS branches
- [X] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
