### PR TITLE
Do not wait for command msg to start spinning in jog_arm

### DIFF
--- a/moveit_experimental/jog_arm/include/jog_arm/jog_arm_data.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_arm_data.h
@@ -86,7 +86,7 @@ struct JogArmParameters
   std::string move_group_name, joint_topic, cartesian_command_in_topic, command_frame, command_out_topic,
       planning_frame, warning_topic, joint_command_in_topic, command_in_type, command_out_type;
   double linear_scale, rotational_scale, joint_scale, lower_singularity_threshold, hard_stop_singularity_threshold,
-      collision_proximity_threshold, low_pass_filter_coeff, publish_period, publish_delay, incoming_command_timeout,
+      collision_proximity_threshold, low_pass_filter_coeff, publish_period, incoming_command_timeout,
       joint_limit_margin, collision_check_rate;
   int num_halt_msgs_to_publish;
   bool use_gazebo, check_collisions, publish_joint_positions, publish_joint_velocities, publish_joint_accelerations;

--- a/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
@@ -97,8 +97,7 @@ protected:
                             trajectory_msgs::JointTrajectory& new_jt_traj, const Eigen::VectorXd& delta_theta,
                             double singularity_scale);
 
-  trajectory_msgs::JointTrajectory composeOutgoingMessage(sensor_msgs::JointState& joint_state,
-                                                          const ros::Time& stamp) const;
+  trajectory_msgs::JointTrajectory composeOutgoingMessage(sensor_msgs::JointState& joint_state) const;
 
   void lowPassFilterVelocities(const Eigen::VectorXd& joint_vel);
 

--- a/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
@@ -62,7 +62,7 @@ protected:
 
   bool cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared& shared_variables, pthread_mutex_t& mutex);
 
-  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables, pthread_mutex_t& mutex);
+  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables);
 
   // Parse the incoming joint msg for the joints of our MoveGroup
   bool updateJoints();

--- a/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
+++ b/moveit_experimental/jog_arm/src/jog_arm/jog_ros_interface.cpp
@@ -87,8 +87,6 @@ JogROSInterface::JogROSInterface()
   // Wait for incoming topics to appear
   ROS_DEBUG_NAMED(LOGNAME, "Waiting for JointState topic");
   ros::topic::waitForMessage<sensor_msgs::JointState>(ros_parameters_.joint_topic);
-  ROS_DEBUG_NAMED(LOGNAME, "Waiting for Cartesian command topic");
-  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(ros_parameters_.cartesian_command_in_topic);
 
   // Wait for low pass filters to stabilize
   ROS_INFO_STREAM_NAMED(LOGNAME, "Waiting for low-pass filters to stabilize.");
@@ -251,7 +249,6 @@ bool JogROSInterface::readParameters(ros::NodeHandle& n)
   }
 
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/publish_period", ros_parameters_.publish_period);
-  error += !rosparam_shortcuts::get("", n, parameter_ns + "/publish_delay", ros_parameters_.publish_delay);
   error +=
       !rosparam_shortcuts::get("", n, parameter_ns + "/collision_check_rate", ros_parameters_.collision_check_rate);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/num_halt_msgs_to_publish",

--- a/moveit_experimental/jog_arm/test/arm_setup/config/jog_settings.yaml
+++ b/moveit_experimental/jog_arm/test/arm_setup/config/jog_settings.yaml
@@ -17,7 +17,6 @@ collision_proximity_threshold: 0.03 # Start decelerating when a collision is thi
 planning_frame: base_link  # The MoveIt planning frame. Often 'base_link'
 low_pass_filter_coeff: 2.  # Larger-> more smoothing to jog commands, but more lag.
 publish_period: 0.01  # 1/Nominal publish rate [seconds]
-publish_delay: 0.005  # delay between calculation and execution start of command
 collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 num_halt_msgs_to_publish: 1 # If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish
 # Publish boolean warnings to this topic


### PR DESCRIPTION
### Description
- Only wait for the message we try to smooth with the low-pass filter (JointState). This also allows the initial jog command to be of the JointJog type.
- Do not assume the command to be cartesian when the zero_joint_cmd_flag is set, could be a JointJog command with zero velocity
- valid_nonzero_command flag is set when either zero_cartesian_cmd_flag **or** zero_joint_cmd_flag is not set
- Remove unused publish_delay parameter



