### PR TITLE
Switch moveit_msgs to new 'master' branch

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -3,7 +3,7 @@
 - git:
     local-name: moveit_msgs
     uri: https://github.com/ros-planning/moveit_msgs.git
-    version: melodic-devel
+    version: master
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
I'm hoping we [make some changes to moveit_msgs](https://github.com/ros-planning/moveit_msgs/pull/46) soon, so I've just switched that repo to use a master branch instead.