### PR TITLE
fix clang-tidy warnings

### DIFF
--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -146,7 +146,7 @@ bool World::knowsTransform(const std::string& name) const
     return it->second->shape_poses_.size() == 1;
   else  // Then objects' subframes
   {
-    for (const std::pair<std::string, ObjectPtr>& object : objects_)
+    for (const auto& object : objects_)
     {
       // if "object name/" matches start of object_id, we found the matching object
       if (boost::starts_with(name, object.first) && name[object.first.length()] == '/')
@@ -174,7 +174,7 @@ const Eigen::Isometry3d& World::getTransform(const std::string& name, bool& fram
     return it->second->shape_poses_[0];
   else  // Search within subframes
   {
-    for (const std::pair<std::string, ObjectPtr>& object : objects_)
+    for (const auto& object : objects_)
     {
       // if "object name/" matches start of object_id, we found the matching object
       if (boost::starts_with(name, object.first) && name[object.first.length()] == '/')

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1049,7 +1049,7 @@ const Eigen::Isometry3d& RobotState::getFrameInfo(const std::string& frame_id, c
   }
 
   // Check if an AttachedBody has a subframe with name frame_id
-  for (const std::pair<std::string, AttachedBody*>& body : attached_body_map_)
+  for (const auto& body : attached_body_map_)
   {
     const auto& transform = body.second->getSubframeTransform(frame_id, &frame_found);
     if (frame_found)
@@ -1078,7 +1078,7 @@ bool RobotState::knowsFrameTransform(const std::string& frame_id) const
     return !it->second->getGlobalCollisionBodyTransforms().empty();
 
   // Check if an AttachedBody has a subframe with name frame_id
-  for (const std::pair<std::string, AttachedBody*>& body : attached_body_map_)
+  for (const auto& body : attached_body_map_)
   {
     if (body.second->hasSubframeTransform(frame_id))
       return true;

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
@@ -324,7 +324,7 @@ void mesh_filter::MeshFilterBase::doFilter(const void* sensor_data, const int en
   glUniform3f(padding_coefficients_id, padding_coefficients[0], padding_coefficients[1], padding_coefficients[2]);
 
   Eigen::Isometry3d transform;
-  for (const std::pair<MeshHandle, GLMeshPtr>& mesh : meshes_)
+  for (const auto& mesh : meshes_)
     if (transform_callback_(mesh.first, transform))
       mesh.second->render(transform);
 


### PR DESCRIPTION
clang-tidy issues [several warnings on Travis](https://travis-ci.org/ros-planning/moveit/jobs/569519848#L1360), e.g.:

```
/root/ros_ws/src/moveit/moveit_core/robot_state/src/robot_state.cpp:1052:8: warning: the type of the loop variable 'body' is different from the one returned by the iterator and generates an implicit conversion; you can either change the type to the matching one ('const std::pair<const std::__cxx11::basic_string<char>, moveit::core::AttachedBody *> &' but 'const auto&' is always a valid option) or remove the reference to make it explicit that you are creating a new value [performance-implicit-conversion-in-loop]
for (const std::pair<std::string, AttachedBody*>& body : attached_body_map_)
    ^
```

Although gcc and clang themselves don't complain, I would like to clean those warnings as well.
Looks like clang-tidy cannot match `std::__cxx11::basic_string<char>` to `std::string`.
Hence, I propose to replace the explicit type with `auto`.