### PR TITLE
psi: wait for services

### DIFF
--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -53,11 +53,14 @@ public:
   explicit PlanningSceneInterfaceImpl(const std::string& ns = "")
   {
     node_handle_ = ros::NodeHandle(ns);
+    planning_scene_diff_publisher_ = node_handle_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
     planning_scene_service_ =
         node_handle_.serviceClient<moveit_msgs::GetPlanningScene>(move_group::GET_PLANNING_SCENE_SERVICE_NAME);
     apply_planning_scene_service_ =
         node_handle_.serviceClient<moveit_msgs::ApplyPlanningScene>(move_group::APPLY_PLANNING_SCENE_SERVICE_NAME);
-    planning_scene_diff_publisher_ = node_handle_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
+
+    waitForService(planning_scene_service_);
+    waitForService(apply_planning_scene_service_);
   }
 
   std::vector<std::string> getKnownObjectNames(bool with_type)
@@ -249,6 +252,17 @@ public:
   }
 
 private:
+  void waitForService(ros::ServiceClient& srv)
+  {
+    ros::Duration time_before_warning(5.0);
+    srv.waitForExistence(time_before_warning);
+    if (!srv.exists())
+    {
+      ROS_WARN_STREAM_NAMED(LOGNAME, "service '" << srv.getService() << "' not advertised yet. Continue waiting...");
+      srv.waitForExistence();
+    }
+  }
+
   ros::NodeHandle node_handle_;
   ros::ServiceClient planning_scene_service_;
   ros::ServiceClient apply_planning_scene_service_;

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -45,6 +45,8 @@ namespace moveit
 {
 namespace planning_interface
 {
+static const std::string LOGNAME = "planning_scene_interface";
+
 class PlanningSceneInterface::PlanningSceneInterfaceImpl
 {
 public:
@@ -89,7 +91,7 @@ public:
     request.components.components = request.components.WORLD_OBJECT_GEOMETRY;
     if (!planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface", "Could not call planning scene service to get object names");
+      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object names");
       return result;
     }
 
@@ -133,7 +135,7 @@ public:
     request.components.components = request.components.WORLD_OBJECT_GEOMETRY;
     if (!planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface", "Could not call planning scene service to get object names");
+      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object names");
       return result;
     }
 
@@ -160,7 +162,7 @@ public:
     request.components.components = request.components.WORLD_OBJECT_GEOMETRY;
     if (!planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface", "Could not call planning scene service to get object geometries");
+      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object geometries");
       return result;
     }
 
@@ -184,8 +186,7 @@ public:
     request.components.components = request.components.ROBOT_STATE_ATTACHED_OBJECTS;
     if (!planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface",
-                     "Could not call planning scene service to get attached object geometries");
+      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get attached object geometries");
       return result;
     }
 
@@ -208,7 +209,7 @@ public:
     request.scene = planning_scene;
     if (!apply_planning_scene_service_.call(request, response))
     {
-      ROS_WARN_NAMED("planning_scene_interface", "Failed to call ApplyPlanningScene service");
+      ROS_WARN_NAMED(LOGNAME, "Failed to call ApplyPlanningScene service");
       return false;
     }
     return response.success;


### PR DESCRIPTION
Turns out, the `PlanningSceneInterface` never waited for its services to be available.
However, all but two functions of the class utilize this class (and fail if the service is not setup yet).

As the original goal of the `apply*` function family was to get rid of random `sleep` statements in the code base, I consider it important that there is no need to wait when using the class methods.