### PR TITLE
Use QDir::currentPath() rather than getenv("PWD")

### DIFF
--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -47,6 +47,7 @@
 #include <QCloseEvent>
 #include <QMessageBox>
 #include <QString>
+#include <QDir>
 #include <pluginlib/class_loader.hpp>  // for loading all avail kinematic planners
 // Rviz
 #include <rviz/render_panel.h>
@@ -113,13 +114,7 @@ SetupAssistantWidget::SetupAssistantWidget(QWidget* parent, const boost::program
   }
   else
   {
-    // Open the directory where the MSA was started from.
-    // cf. http://stackoverflow.com/a/7413516/577001
-    QString pwdir("");
-    char* pwd;
-    pwd = getenv("PWD");
-    pwdir.append(pwd);
-    start_screen_widget_->stack_path_->setPath(pwdir);
+    start_screen_widget_->stack_path_->setPath(QDir::currentPath());
   }
 
   // Add Navigation Buttons (but do not load widgets yet except start screen)


### PR DESCRIPTION
### Description

Use QDir::currentPath() rather than getenv("PWD")

Please see issue #1497 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
