### PR TITLE
Use standard cmake text for metapackages

### DIFF
--- a/moveit/CMakeLists.txt
+++ b/moveit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/moveit_planners/moveit_planners/CMakeLists.txt
+++ b/moveit_planners/moveit_planners/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_planners)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/moveit_plugins/moveit_plugins/CMakeLists.txt
+++ b/moveit_plugins/moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_plugins)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/moveit_ros/moveit_ros/CMakeLists.txt
+++ b/moveit_ros/moveit_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_ros)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/moveit_runtime/CMakeLists.txt
+++ b/moveit_runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_runtime)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit/issues/1619 

catkin_make requires very specific text in the metapackage cmakelists files. We broke that by upping the required cmake version. This just reverts that change.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
