### PR TITLE
pure virtual `planning_request_adapter::initialize()`

### DIFF
--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -40,9 +40,6 @@
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/function.hpp>
-#if !defined(_MSC_VER)
-#include <cxxabi.h>
-#endif
 
 /** \brief Generic interface to adapting motion planning requests */
 namespace planning_request_adapter
@@ -65,25 +62,9 @@ public:
   {
   }
 
-  /// Initialize parameters using the passed NodeHandle
-  // TODO - Make initialize() a pure virtual function in O-turtle
-  virtual void initialize(const ros::NodeHandle& node_handle)
-  {
-    // Get name of derived adapter
-    std::string adapter_name = typeid(*this).name();
-    // Try to demangle the name
-    int status = 1;
-#if defined(_MSC_VER)
-    std::string demangled_name = adapter_name;
-#else
-    std::string demangled_name = abi::__cxa_demangle(adapter_name.c_str(), NULL, NULL, &status);
-#endif
-    if (status == 0)
-      adapter_name = demangled_name;
-    ROS_WARN_NAMED("planning_request_adapter", "Implementation of function initialize() is missing from '%s'."
-                                               "Any parameters should be loaded from the passed NodeHandle.",
-                   adapter_name.c_str());
-  }
+  /** \brief Initialize parameters using the passed NodeHandle
+      if no initialization is needed, simply implement as empty */
+  virtual void initialize(const ros::NodeHandle& node_handle) = 0;
 
   /// Get a short string that identifies the planning request adapter
   virtual std::string getDescription() const


### PR DESCRIPTION
The method was introduced in #1530, together with [a TODO](https://github.com/ros-planning/moveit/pull/1530/files#diff-9247374d69dc34d55ae1a420105cd85dR68) to make it pure virtual "in O-turtle".

[A Windows-compatibility pr](https://github.com/ros-planning/moveit/pull/1583#discussion_r308193285) noticed that the current functionality is not available in Windows, as it uses `cxxabi.h`.
I would propose to either go for the pure virtual method directly or just implement an empty default implementation (apparently this was dismissed in #1530).