### PR TITLE
fix the invalid iterator issue

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -775,7 +775,7 @@ void MoveItConfigData::outputFollowJointTrajectoryYAML(YAML::Emitter& emitter,
             emitter << YAML::EndMap;
           }
         }
-        ros_controllers_config_output.erase(controller_it);
+        controller_it = ros_controllers_config_output.erase(controller_it);
         emitter << YAML::EndMap;
       }
       else


### PR DESCRIPTION
Signed-off-by: Daniel Wang <daniel.wang@canonical.com>

### Description

this pull request address https://github.com/ros-planning/moveit/issues/1578 to avoid `iterator controller_it` point to random elements
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
