### PR TITLE
(fix) moveit_commander python planning_scene_interface for attached obj

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -309,8 +309,8 @@ class PlanningSceneInterface(object):
     def __make_planning_scene_diff_req(collision_object, attach=False):
         scene = PlanningScene()
         scene.is_diff = True
+        scene.robot_state.is_diff = True
         if attach:
-            scene.robot_state.is_diff = True
             scene.robot_state.attached_collision_objects.append(collision_object)
         else:
             scene.world.collision_objects = [collision_object]

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -311,10 +311,9 @@ class PlanningSceneInterface(object):
         scene.is_diff = True
         scene.robot_state.is_diff = True
         if attach:
-            scene.robot_state.attached_collision_objects.append(collision_object)
+            scene.robot_state.attached_collision_objects = [collision_object]
         else:
             scene.world.collision_objects = [collision_object]
         planning_scene_diff_req = ApplyPlanningSceneRequest()
         planning_scene_diff_req.scene = scene
         return planning_scene_diff_req
-

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -69,7 +69,7 @@ class PlanningSceneInterface(object):
 
     def __submit(self, collision_object, attach=False):
         if self.__synchronous:
-            diff_req = self.__make_planning_scene_diff_req(collision_object)
+            diff_req = self.__make_planning_scene_diff_req(collision_object, attach)
             self._apply_planning_scene_diff.call(diff_req)
         else:
             if attach:
@@ -306,10 +306,15 @@ class PlanningSceneInterface(object):
         return co
 
     @staticmethod
-    def __make_planning_scene_diff_req(collision_object):
+    def __make_planning_scene_diff_req(collision_object, attach=False):
         scene = PlanningScene()
         scene.is_diff = True
-        scene.world.collision_objects = [collision_object]
+        if attach:
+            scene.robot_state.is_diff = True
+            scene.robot_state.attached_collision_objects.append(collision_object)
+        else:
+            scene.world.collision_objects = [collision_object]
         planning_scene_diff_req = ApplyPlanningSceneRequest()
         planning_scene_diff_req.scene = scene
         return planning_scene_diff_req
+


### PR DESCRIPTION

### Description

Moveit commander python planning_scene_interface crashed when we remove attached object, this was caused by the request function. Request was adding AttachedObjectCollision to the world collision object instead of robot state collision object.


[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
