### PR TITLE
Update newRobotStateCallback to use the new the DisplayRobotState msg

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -290,6 +290,8 @@ void RobotStateDisplay::changedRobotStateTopic()
   if (static_cast<bool>(robot_state_))
     robot_state_->setToDefaultValues();
   update_state_ = true;
+  robot_->setVisible(false);
+  setStatus(rviz::StatusProperty::Warn, "RobotState", "No msg received");
 
   robot_state_subscriber_ = root_nh_.subscribe(robot_state_topic_property_->getStdString(), 10,
                                                &RobotStateDisplay::newRobotStateCallback, this);
@@ -307,17 +309,24 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
     if (!planning_scene::PlanningScene::isEmpty(state_msg->state))
       robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
     setRobotHighlights(state_msg->highlight_links);
-    setStatus(rviz::StatusProperty::Ok, "RobotState", "");
   }
   catch (const moveit::Exception& e)
   {
     robot_state_->setToDefaultValues();
     setRobotHighlights(moveit_msgs::DisplayRobotState::_highlight_links_type());
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
+    robot_->setVisible(false);
     return;
   }
 
-  robot_->setVisible(!state_msg->hide);
+  if (robot_->isVisible() != !state_msg->hide)
+  {
+    robot_->setVisible(!state_msg->hide);
+    if (robot_->isVisible())
+      setStatus(rviz::StatusProperty::Ok, "RobotState", "");
+    else
+      setStatus(rviz::StatusProperty::Warn, "RobotState", "Hidden");
+  }
 
   update_state_ = true;
 }
@@ -371,13 +380,13 @@ void RobotStateDisplay::loadRobotModel()
     root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());
     root_link_name_property_->blockSignals(old_state);
     update_state_ = true;
-    setStatus(rviz::StatusProperty::Ok, "RobotState", "Planning Model Loaded Successfully");
+    setStatus(rviz::StatusProperty::Ok, "RobotModel", "Loaded successfully");
 
     changedEnableVisualVisible();
     changedEnableCollisionVisible();
   }
   else
-    setStatus(rviz::StatusProperty::Error, "RobotState", "No Planning Model Loaded");
+    setStatus(rviz::StatusProperty::Error, "RobotModel", "Loading failed");
 
   highlights_.clear();
 }

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -314,6 +314,9 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
     return;
   }
+
+  robot_->setVisible(!state_msg->hide);
+
   update_state_ = true;
 }
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -375,7 +375,6 @@ void RobotStateDisplay::loadRobotModel()
 
     changedEnableVisualVisible();
     changedEnableCollisionVisible();
-    robot_->setVisible(true);
   }
   else
     setStatus(rviz::StatusProperty::Error, "RobotState", "No Planning Model Loaded");

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/robot_state_rviz_plugin/robot_state_display.h>
 #include <moveit/robot_state/conversions.h>
+#include <moveit/planning_scene/planning_scene.h>
 
 #include <rviz/visualization_manager.h>
 #include <rviz/robot/robot.h>
@@ -303,7 +304,8 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
   try
   {
-    robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
+    if (!planning_scene::PlanningScene::isEmpty(state_msg->state))
+      robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
     setRobotHighlights(state_msg->highlight_links);
     setStatus(rviz::StatusProperty::Ok, "RobotState", "");
   }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -69,6 +69,11 @@ public:
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
 
+  bool isVisible() const
+  {
+    return visible_;
+  }
+
   /**
    * \brief Set the robot as a whole to be visible or not
    * @param visible Should we be visible?


### PR DESCRIPTION
### Description

This PR is related to [PR#56](https://github.com/ros-planning/moveit_visual_tools/pull/56)

So after updating the DisplayRobotState msg to include a new field [see](https://github.com/ros-planning/moveit_msgs/pull/55), and updating [MoveItVisualTools::hideRobot()](https://github.com/ros-planning/moveit_visual_tools/blob/master/src/moveit_visual_tools.cpp#L1528) to toggle the .hide rather than using a virtual_joint that moves the robot very far away location in Rviz; there's a need to add the feature in the Rviz Display,

I think that one solution could be by updating the robot visibility `robot_->setVisualVisible(!state_msg->hide)` inside [RobotStateDisplay::newRobotStateCallback](https://github.com/ros-planning/moveit/blob/2505cf4e4783386fc828553d60cd6f78accda4bb/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp#L297)

Another option is to change `enable_visual_visible_->setBool(!state_msg->hide)` directly but this option will change the checkmark, too.
![RVIZ_Soln#1](https://user-images.githubusercontent.com/16278108/63100978-d4e4e300-bf80-11e9-9b92-e7149e3563d2.png)


The current solution will not affect it
![RVIZ_Soln#2](https://user-images.githubusercontent.com/16278108/63099884-98b08300-bf7e-11e9-92ee-5894542ff39e.png)


I tested it with these launch files

`roslaunch moveit_visual_tools demo_rviz.launch`
`roslaunch moveit_visual_tools demo.launch`


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
