### PR TITLE
moveit::core::isEmpty

### DIFF
--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -67,7 +67,7 @@ moveit_msgs::Constraints mergeConstraints(const moveit_msgs::Constraints& first,
                                           const moveit_msgs::Constraints& second);
 
 /** \brief Check if any constraints were specified */
-bool isEmpty(const moveit_msgs::Constraints& constr);
+[[deprecated("Use moveit/utils/message_checks.h instead")]] bool isEmpty(const moveit_msgs::Constraints& constr);
 
 std::size_t countIndividualConstraints(const moveit_msgs::Constraints& constr);
 

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -38,6 +38,7 @@
 #include <geometric_shapes/solid_primitive_dims.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <moveit/utils/xmlrpc_casts.h>
+#include <moveit/utils/message_checks.h>
 
 using namespace moveit::core;
 
@@ -116,8 +117,7 @@ moveit_msgs::Constraints mergeConstraints(const moveit_msgs::Constraints& first,
 
 bool isEmpty(const moveit_msgs::Constraints& constr)
 {
-  return constr.position_constraints.empty() && constr.orientation_constraints.empty() &&
-         constr.visibility_constraints.empty() && constr.joint_constraints.empty();
+  return moveit::core::isEmpty(constr);
 }
 
 std::size_t countIndividualConstraints(const moveit_msgs::Constraints& constr)

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -953,14 +953,16 @@ public:
 
   /** \brief Check if a message includes any information about a planning scene, or it is just a default, empty message.
    */
-  static bool isEmpty(const moveit_msgs::PlanningScene& msg);
+  [[deprecated("Use moveit/utils/message_checks.h instead")]] static bool
+  isEmpty(const moveit_msgs::PlanningScene& msg);
 
   /** \brief Check if a message includes any information about a planning scene world, or it is just a default, empty
    * message. */
-  static bool isEmpty(const moveit_msgs::PlanningSceneWorld& msg);
+  [[deprecated("Use moveit/utils/message_checks.h instead")]] static bool
+  isEmpty(const moveit_msgs::PlanningSceneWorld& msg);
 
   /** \brief Check if a message includes any information about a robot state, or it is just a default, empty message. */
-  static bool isEmpty(const moveit_msgs::RobotState& msg);
+  [[deprecated("Use moveit/utils/message_checks.h instead")]] static bool isEmpty(const moveit_msgs::RobotState& msg);
 
   /** \brief Clone a planning scene. Even if the scene \e scene depends on a parent, the cloned scene will not. */
   static PlanningScenePtr clone(const PlanningSceneConstPtr& scene);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -43,6 +43,7 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/exceptions/exceptions.h>
 #include <moveit/robot_state/attached_body.h>
+#include <moveit/utils/message_checks.h>
 #include <octomap_msgs/conversions.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <memory>
@@ -96,25 +97,17 @@ private:
 
 bool PlanningScene::isEmpty(const moveit_msgs::PlanningScene& msg)
 {
-  return msg.name.empty() && msg.fixed_frame_transforms.empty() && msg.allowed_collision_matrix.entry_names.empty() &&
-         msg.link_padding.empty() && msg.link_scale.empty() && isEmpty(msg.robot_state) && isEmpty(msg.world);
+  return moveit::core::isEmpty(msg);
 }
 
 bool PlanningScene::isEmpty(const moveit_msgs::RobotState& msg)
 {
-  /* a state is empty if it includes no information and it is a diff; if the state is not a diff, then the implicit
-     information is
-     that the set of attached bodies is empty, so they must be cleared from the state to be updated */
-  return static_cast<bool>(msg.is_diff) && msg.multi_dof_joint_state.joint_names.empty() &&
-         msg.joint_state.name.empty() && msg.attached_collision_objects.empty() && msg.joint_state.position.empty() &&
-         msg.joint_state.velocity.empty() && msg.joint_state.effort.empty() &&
-         msg.multi_dof_joint_state.transforms.empty() && msg.multi_dof_joint_state.twist.empty() &&
-         msg.multi_dof_joint_state.wrench.empty();
+  return moveit::core::isEmpty(msg);
 }
 
 bool PlanningScene::isEmpty(const moveit_msgs::PlanningSceneWorld& msg)
 {
-  return msg.collision_objects.empty() && msg.octomap.octomap.data.empty();
+  return moveit::core::isEmpty(msg);
 }
 
 PlanningScene::PlanningScene(const robot_model::RobotModelConstPtr& robot_model,

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/utils/message_checks.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
 #include <sstream>
@@ -104,10 +105,10 @@ TEST(PlanningScene, LoadRestoreDiff)
 
   moveit_msgs::PlanningScene ps_msg;
   ps_msg.robot_state.is_diff = true;
-  EXPECT_TRUE(planning_scene::PlanningScene::isEmpty(ps_msg));
+  EXPECT_TRUE(moveit::core::isEmpty(ps_msg));
   ps->getPlanningSceneMsg(ps_msg);
   ps->setPlanningSceneMsg(ps_msg);
-  EXPECT_FALSE(planning_scene::PlanningScene::isEmpty(ps_msg));
+  EXPECT_FALSE(moveit::core::isEmpty(ps_msg));
   EXPECT_TRUE(world.hasObject("sphere"));
 
   planning_scene::PlanningScenePtr next = ps->diff();

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MOVEIT_LIB_NAME moveit_utils)
 add_library(${MOVEIT_LIB_NAME}
   src/lexical_casts.cpp
   src/xmlrpc_casts.cpp
+  src/message_checks.cpp
 )
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_core/utils/include/moveit/utils/message_checks.h
+++ b/moveit_core/utils/include/moveit/utils/message_checks.h
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Universitaet Hamburg.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael 'v4hn' Goerner */
+
+#pragma once
+
+/** \file empty_msgs.h
+ *  \brief Checks for empty MoveIt-related messages
+ *
+ */
+
+#include <moveit_msgs/PlanningScene.h>
+#include <moveit_msgs/PlanningSceneWorld.h>
+#include <moveit_msgs/RobotState.h>
+#include <moveit_msgs/Constraints.h>
+
+namespace moveit
+{
+namespace core
+{
+/** \brief Check if a message includes any information about a planning scene, or whether it is empty. */
+bool isEmpty(const moveit_msgs::PlanningScene& msg);
+
+/** \brief Check if a message includes any information about a planning scene world, or whether it is empty. */
+bool isEmpty(const moveit_msgs::PlanningSceneWorld& msg);
+
+/** \brief Check if a message includes any information about a robot state, or whether it is empty. */
+bool isEmpty(const moveit_msgs::RobotState& msg);
+
+/** \brief Check if a message specifies constraints */
+bool isEmpty(const moveit_msgs::Constraints& msg);
+}
+}

--- a/moveit_core/utils/src/message_checks.cpp
+++ b/moveit_core/utils/src/message_checks.cpp
@@ -1,0 +1,73 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Universitaet Hamburg.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Hamburg University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Michael Goerner */
+
+#include <moveit/utils/message_checks.h>
+
+namespace moveit
+{
+namespace core
+{
+bool isEmpty(const moveit_msgs::PlanningScene& msg)
+{
+  return msg.name.empty() && msg.fixed_frame_transforms.empty() && msg.allowed_collision_matrix.entry_names.empty() &&
+         msg.link_padding.empty() && msg.link_scale.empty() && isEmpty(msg.robot_state) && isEmpty(msg.world);
+}
+
+bool isEmpty(const moveit_msgs::PlanningSceneWorld& msg)
+{
+  return msg.collision_objects.empty() && msg.octomap.octomap.data.empty();
+}
+
+bool isEmpty(const moveit_msgs::RobotState& msg)
+{
+  /* a state is empty if it includes no information and it is a diff; if the state is not a diff, then the implicit
+     information is
+     that the set of attached bodies is empty, so they must be cleared from the state to be updated */
+  return static_cast<bool>(msg.is_diff) && msg.multi_dof_joint_state.joint_names.empty() &&
+         msg.joint_state.name.empty() && msg.attached_collision_objects.empty() && msg.joint_state.position.empty() &&
+         msg.joint_state.velocity.empty() && msg.joint_state.effort.empty() &&
+         msg.multi_dof_joint_state.transforms.empty() && msg.multi_dof_joint_state.twist.empty() &&
+         msg.multi_dof_joint_state.wrench.empty();
+}
+
+bool isEmpty(const moveit_msgs::Constraints& constr)
+{
+  return constr.position_constraints.empty() && constr.orientation_constraints.empty() &&
+         constr.visibility_constraints.empty() && constr.joint_constraints.empty();
+}
+
+}  // namespace core
+}  // namespace moveit

--- a/moveit_planners/ompl/ompl_interface/src/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/generate_state_database.cpp
@@ -42,6 +42,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 #include <moveit/kinematic_constraints/utils.h>
+#include <moveit/utils/message_checks.h>
 
 #include <boost/math/constants/constants.hpp>
 #include <sstream>
@@ -165,7 +166,7 @@ int main(int argc, char** argv)
     }
   }
 
-  if (kinematic_constraints::isEmpty(params.constraints))
+  if (moveit::core::isEmpty(params.constraints))
   {
     ROS_FATAL_NAMED(LOGNAME, "Abort. Constraint description is an empty set of constraints.");
     return 1;

--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -38,6 +38,7 @@
 #include <moveit/pick_place/reachable_valid_pose_filter.h>
 #include <moveit/pick_place/approach_and_translate_stage.h>
 #include <moveit/pick_place/plan_stage.h>
+#include <moveit/utils/message_checks.h>
 #include <ros/console.h>
 
 namespace pick_place
@@ -230,7 +231,7 @@ PickPlanPtr PickPlace::planPick(const planning_scene::PlanningSceneConstPtr& pla
 {
   PickPlanPtr p(new PickPlan(shared_from_this()));
 
-  if (planning_scene::PlanningScene::isEmpty(goal.planning_options.planning_scene_diff))
+  if (moveit::core::isEmpty(goal.planning_options.planning_scene_diff))
     p->plan(planning_scene, goal);
   else
     p->plan(planning_scene->diff(goal.planning_options.planning_scene_diff), goal);

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -39,6 +39,7 @@
 #include <moveit/pick_place/approach_and_translate_stage.h>
 #include <moveit/pick_place/plan_stage.h>
 #include <moveit/robot_state/conversions.h>
+#include <moveit/utils/message_checks.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <ros/console.h>
 
@@ -369,7 +370,7 @@ PlacePlanPtr PickPlace::planPlace(const planning_scene::PlanningSceneConstPtr& p
                                   const moveit_msgs::PlaceGoal& goal) const
 {
   PlacePlanPtr p(new PlacePlan(shared_from_this()));
-  if (planning_scene::PlanningScene::isEmpty(goal.planning_options.planning_scene_diff))
+  if (moveit::core::isEmpty(goal.planning_options.planning_scene_diff))
     p->plan(planning_scene, goal);
   else
     p->plan(planning_scene->diff(goal.planning_options.planning_scene_diff), goal);

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -36,7 +36,7 @@
 
 #include "cartesian_path_service_capability.h"
 #include <moveit/robot_state/conversions.h>
-#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/utils/message_checks.h>
 #include <moveit/collision_detection/collision_tools.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/move_group/capability_names.h>
@@ -131,7 +131,7 @@ bool MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath
           robot_state::GroupStateValidityCallbackFn constraint_fn;
           std::unique_ptr<planning_scene_monitor::LockedPlanningSceneRO> ls;
           std::unique_ptr<kinematic_constraints::KinematicConstraintSet> kset;
-          if (req.avoid_collisions || !kinematic_constraints::isEmpty(req.path_constraints))
+          if (req.avoid_collisions || !moveit::core::isEmpty(req.path_constraints))
           {
             ls.reset(new planning_scene_monitor::LockedPlanningSceneRO(context_->planning_scene_monitor_));
             kset.reset(new kinematic_constraints::KinematicConstraintSet((*ls)->getRobotModel()));

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -36,7 +36,7 @@
 
 #include "kinematics_service_capability.h"
 #include <moveit/robot_state/conversions.h>
-#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/utils/message_checks.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/move_group/capability_names.h>
 
@@ -148,7 +148,7 @@ bool MoveGroupKinematicsService::computeIKService(moveit_msgs::GetPositionIK::Re
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   // check if the planning scene needs to be kept locked; if so, call computeIK() in the scope of the lock
-  if (req.ik_request.avoid_collisions || !kinematic_constraints::isEmpty(req.ik_request.constraints))
+  if (req.ik_request.avoid_collisions || !moveit::core::isEmpty(req.ik_request.constraints))
   {
     planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
     kinematic_constraints::KinematicConstraintSet kset(ls->getRobotModel());

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -41,6 +41,7 @@
 #include <moveit/plan_execution/plan_with_sensing.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <moveit/kinematic_constraints/utils.h>
+#include <moveit/utils/message_checks.h>
 #include <moveit/move_group/capability_names.h>
 
 namespace move_group
@@ -102,7 +103,7 @@ void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const moveit_msgs::M
   ROS_INFO_NAMED(getName(), "Combined planning and execution request received for MoveGroup action. "
                             "Forwarding to planning and execution pipeline.");
 
-  if (planning_scene::PlanningScene::isEmpty(goal->planning_options.planning_scene_diff))
+  if (moveit::core::isEmpty(goal->planning_options.planning_scene_diff))
   {
     planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
     const robot_state::RobotState& current_state = lscene->getCurrentState();
@@ -122,10 +123,9 @@ void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const moveit_msgs::M
   plan_execution::PlanExecution::Options opt;
 
   const moveit_msgs::MotionPlanRequest& motion_plan_request =
-      planning_scene::PlanningScene::isEmpty(goal->request.start_state) ? goal->request :
-                                                                          clearRequestStartState(goal->request);
+      moveit::core::isEmpty(goal->request.start_state) ? goal->request : clearRequestStartState(goal->request);
   const moveit_msgs::PlanningScene& planning_scene_diff =
-      planning_scene::PlanningScene::isEmpty(goal->planning_options.planning_scene_diff.robot_state) ?
+      moveit::core::isEmpty(goal->planning_options.planning_scene_diff.robot_state) ?
           goal->planning_options.planning_scene_diff :
           clearSceneRobotState(goal->planning_options.planning_scene_diff);
 
@@ -168,7 +168,7 @@ void MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_msgs::MoveGro
   // lock the scene so that it does not modify the world representation while diff() is called
   planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
   const planning_scene::PlanningSceneConstPtr& the_scene =
-      (planning_scene::PlanningScene::isEmpty(goal->planning_options.planning_scene_diff)) ?
+      (moveit::core::isEmpty(goal->planning_options.planning_scene_diff)) ?
           static_cast<const planning_scene::PlanningSceneConstPtr&>(lscene) :
           lscene->diff(goal->planning_options.planning_scene_diff);
   planning_interface::MotionPlanResponse res;

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -36,7 +36,7 @@
 
 #include "state_validation_service_capability.h"
 #include <moveit/robot_state/conversions.h>
-#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/utils/message_checks.h>
 #include <moveit/collision_detection/collision_tools.h>
 #include <moveit/move_group/capability_names.h>
 
@@ -100,7 +100,7 @@ bool MoveGroupStateValidationService::computeService(moveit_msgs::GetStateValidi
   }
 
   // evaluate constraints
-  if (!kinematic_constraints::isEmpty(req.constraints))
+  if (!moveit::core::isEmpty(req.constraints))
   {
     kinematic_constraints::KinematicConstraintSet kset(ls->getRobotModel());
     kset.add(req.constraints, ls->getTransforms());

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -38,6 +38,7 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <moveit/collision_detection/collision_tools.h>
+#include <moveit/utils/message_checks.h>
 #include <boost/algorithm/string/join.hpp>
 
 #include <dynamic_reconfigure/server.h>
@@ -141,7 +142,7 @@ void plan_execution::PlanExecution::planAndExecute(ExecutableMotionPlan& plan, c
 void plan_execution::PlanExecution::planAndExecute(ExecutableMotionPlan& plan,
                                                    const moveit_msgs::PlanningScene& scene_diff, const Options& opt)
 {
-  if (planning_scene::PlanningScene::isEmpty(scene_diff))
+  if (moveit::core::isEmpty(scene_diff))
     planAndExecute(plan, opt);
   else
   {

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/utils/message_checks.h>
 #include <moveit/exceptions/exceptions.h>
 #include <moveit_msgs/GetPlanningScene.h>
 
@@ -565,13 +566,13 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningSc
     if (no_other_scene_upd)
     {
       upd = UPDATE_NONE;
-      if (!planning_scene::PlanningScene::isEmpty(scene.world))
+      if (!moveit::core::isEmpty(scene.world))
         upd = (SceneUpdateType)((int)upd | (int)UPDATE_GEOMETRY);
 
       if (!scene.fixed_frame_transforms.empty())
         upd = (SceneUpdateType)((int)upd | (int)UPDATE_TRANSFORMS);
 
-      if (!planning_scene::PlanningScene::isEmpty(scene.robot_state))
+      if (!moveit::core::isEmpty(scene.robot_state))
       {
         upd = (SceneUpdateType)((int)upd | (int)UPDATE_STATE);
         if (!scene.robot_state.attached_collision_objects.empty() || !static_cast<bool>(scene.robot_state.is_diff))

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/robot_state_rviz_plugin/robot_state_display.h>
 #include <moveit/robot_state/conversions.h>
-#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/utils/message_checks.h>
 
 #include <rviz/visualization_manager.h>
 #include <rviz/robot/robot.h>
@@ -306,7 +306,7 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
   try
   {
-    if (!planning_scene::PlanningScene::isEmpty(state_msg->state))
+    if (!moveit::core::isEmpty(state_msg->state))
       robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
     setRobotHighlights(state_msg->highlight_links);
   }


### PR DESCRIPTION
Builds on top of #1625 (although it could be isolated) and only consists of one commit.
I will rebase here once #1625 is merged.

[As pointed out by @davetcoleman](https://github.com/ros-planning/moveit/pull/1625#issuecomment-521980815) it seems weird to keep simple test functions like `isEmpty` within the full `PlanningScene` class.

This patch proposes to collect them in a new header in `moveit/utils/message_checks.h`.
Please review.