### PR TITLE
Add OMPL planner 'AnytimePathShortening'

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -41,6 +41,7 @@
 #include <set>
 #include <utility>
 
+#include <ompl/geometric/planners/AnytimePathShortening.h>
 #include <ompl/geometric/planners/rrt/RRT.h>
 #include <ompl/geometric/planners/rrt/pRRT.h>
 #include <ompl/geometric/planners/rrt/RRTConnect.h>
@@ -114,7 +115,6 @@ static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr& si,
   if (!new_name.empty())
     planner->setName(new_name);
   planner->params().setParams(spec.config_, true);
-  planner->setup();
   return planner;
 }
 }  // namespace
@@ -134,6 +134,10 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
 
 void ompl_interface::PlanningContextManager::registerDefaultPlanners()
 {
+  registerPlannerAllocator(                //
+      "geometric::AnytimePathShortening",  //
+      std::bind(&allocatePlanner<og::AnytimePathShortening>, std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3));
   registerPlannerAllocator(  //
       "geometric::RRT",      //
       std::bind(&allocatePlanner<og::RRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -68,6 +68,7 @@
 #include <ompl/geometric/planners/prm/LazyPRMstar.h>
 #include <ompl/geometric/planners/prm/SPARS.h>
 #include <ompl/geometric/planners/prm/SPARStwo.h>
+#include <ompl/base/goals/GoalState.h>
 
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h>
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
@@ -115,6 +116,10 @@ static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr& si,
   if (!new_name.empty())
     planner->setName(new_name);
   planner->params().setParams(spec.config_, true);
+  // Some planners (AnytimePathShortening) require problem and goal to be initialized before setup
+  planner->setProblemDefinition(std::make_shared<ob::ProblemDefinition>(si));
+  planner->getProblemDefinition()->setGoal(std::make_shared<ob::GoalState>(si));
+  planner->setup();
   return planner;
 }
 }  // namespace

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -546,6 +546,13 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
 {
   std::vector<OMPLPlannerDescription> planner_des;
 
+  OMPLPlannerDescription aps("AnytimePathShortening", "geometric");
+  aps.addParameter("shortcut", "true", "Attempt to shortcut all new solution paths");
+  aps.addParameter("hybridize", "true", "Compute hybrid solution trajectories");
+  aps.addParameter("max_hybrid_paths", "24", "Number of hybrid paths generated per iteration");
+  aps.addParameter("num_planners", "4", "The number of default planners to use for planning");
+  planner_des.push_back(aps);
+
   OMPLPlannerDescription sbl("SBL", "geometric");
   sbl.addParameter("range", "0.0", "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()");
   planner_des.push_back(sbl);


### PR DESCRIPTION
This adds [AnytimePathShortening](https://ompl.kavrakilab.org/classompl_1_1geometric_1_1AnytimePathShortening.html) to the OMPL planning plugin. APS is a planner optimizer that wraps multiple sampling-based planners and attempts to iteratively shortcut and hybridize the solution paths. If no planner algorithms are specified (as implemented here) APS uses RRTConnect as default planner.
APS should be run with `num_planning_attempts=1` since the planner instances already use multiple threads.