### PR TITLE
[windows][master] Use ros::Duration::sleep for portability.

### DIFF
--- a/moveit_ros/planning/planning_components_tools/src/display_random_state.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/display_random_state.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv)
       pub_scene.publish(psmsg);
       std::cout << psm.getPlanningScene()->getCurrentState() << std::endl;
 
-      sleep(1);
+      ros::Duration(1).sleep();
     }
   } while (nh.ok());
 

--- a/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
       else
         pub_scene.publish(ps_msg.world);
 
-      sleep(1);
+      ros::Duration(1).sleep();
     }
   }
   else

--- a/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
@@ -76,7 +76,7 @@ void sendKnife()
   co.primitive_poses[0].orientation.w = 1.0;
 
   pub_aco.publish(aco);
-  sleep(1);
+  ros::Duration(1).sleep();
   pub_aco.publish(aco);
   ROS_INFO("Object published.");
   ros::Duration(1.5).sleep();

--- a/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/demo.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
   moveit::planning_interface::MoveGroupInterface group(argc > 1 ? argv[1] : "right_arm");
   demoPlace(group);
 
-  sleep(2);
+  ros::Duration(2).sleep();
 
   return 0;
 }

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -561,7 +561,7 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const st
   while (!nh.ok() && steps < 4)
   {
     ROS_WARN("Waiting for node handle");
-    sleep(1);
+    ros::Duration(1).sleep();
     steps++;
     ros::spinOnce();
   }
@@ -610,7 +610,7 @@ bool StartScreenWidget::setSRDFFile(const std::string& srdf_string)
   while (!nh.ok() && steps < 4)
   {
     ROS_WARN("Waiting for node handle");
-    sleep(1);
+    ros::Duration(1).sleep();
     steps++;
     ros::spinOnce();
   }


### PR DESCRIPTION
In some code paths, it uses `POSIX` [`sleep`](http://pubs.opengroup.org/onlinepubs/009695399/functions/sleep.html). However, for `non-POSIX` systems, the `sleep` may not exist. This change is to use the abstract `ros::Duration::sleep` for portability.