### PR TITLE
[windows][master] Fallback readline usage to pyreadline for Windows.

### DIFF
--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -4,7 +4,10 @@ from __future__ import print_function
 
 import roslib
 import rospy
-import readline
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline # for Windows
 import sys
 import os
 import signal


### PR DESCRIPTION
For Python, `readline` is not available on Windows. This change is to fallback using [`pyreadline`](https://pypi.org/project/pyreadline/) instead.