### PR TITLE
Fix clang-tidy for unified collision environment

### DIFF
--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -64,7 +64,7 @@ public:
                             const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                                 std::map<std::string, std::vector<CollisionSphere>>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
-                            double size_z = DEFAULT_SIZE_Z, Eigen::Vector3d origin = Eigen::Vector3d(0, 0, 0),
+                            double size_z = DEFAULT_SIZE_Z, const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                             bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                             double resolution = DEFAULT_RESOLUTION,
                             double collision_tolerance = DEFAULT_COLLISION_TOLERANCE,
@@ -75,7 +75,7 @@ public:
                             const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                                 std::map<std::string, std::vector<CollisionSphere>>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
-                            double size_z = DEFAULT_SIZE_Z, Eigen::Vector3d origin = Eigen::Vector3d(0, 0, 0),
+                            double size_z = DEFAULT_SIZE_Z, const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                             bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                             double resolution = DEFAULT_RESOLUTION,
                             double collision_tolerance = DEFAULT_COLLISION_TOLERANCE,

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
@@ -56,7 +56,7 @@ public:
                      const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                          std::map<std::string, std::vector<CollisionSphere>>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
-                     Eigen::Vector3d origin = Eigen::Vector3d(0, 0, 0),
+                     const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                      bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                      double resolution = DEFAULT_RESOLUTION, double collision_tolerance = DEFAULT_COLLISION_TOLERANCE,
                      double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
@@ -66,7 +66,7 @@ public:
                      const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                          std::map<std::string, std::vector<CollisionSphere>>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
-                     Eigen::Vector3d origin = Eigen::Vector3d(0, 0, 0),
+                     const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                      bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                      double resolution = DEFAULT_RESOLUTION, double collision_tolerance = DEFAULT_COLLISION_TOLERANCE,
                      double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -55,7 +55,7 @@ const std::string collision_detection::CollisionDetectorAllocatorDistanceField::
 CollisionEnvDistanceField::CollisionEnvDistanceField(
     const robot_model::RobotModelConstPtr& robot_model,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
-    double size_z, Eigen::Vector3d origin, bool use_signed_distance_field, double resolution,
+    double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
   : CollisionEnv(robot_model)
 {
@@ -73,7 +73,7 @@ CollisionEnvDistanceField::CollisionEnvDistanceField(
 CollisionEnvDistanceField::CollisionEnvDistanceField(
     const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
-    double size_z, Eigen::Vector3d origin, bool use_signed_distance_field, double resolution,
+    double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
   : CollisionEnv(robot_model, world, padding, scale)
 {

--- a/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
@@ -45,24 +45,24 @@ const std::string collision_detection::CollisionDetectorAllocatorHybrid::NAME("H
 CollisionEnvHybrid::CollisionEnvHybrid(
     const robot_model::RobotModelConstPtr& robot_model,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
-    double size_z, Eigen::Vector3d origin, bool use_signed_distance_field, double resolution,
+    double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
   : CollisionEnvFCL(robot_model)
   , cenv_distance_(new collision_detection::CollisionEnvDistanceField(
-        robot_model, getWorld(), link_body_decompositions, size_x, size_y, size_z, std::move(origin),
-        use_signed_distance_field, resolution, collision_tolerance, max_propogation_distance, padding, scale))
+        robot_model, getWorld(), link_body_decompositions, size_x, size_y, size_z, origin, use_signed_distance_field,
+        resolution, collision_tolerance, max_propogation_distance, padding, scale))
 {
 }
 
 CollisionEnvHybrid::CollisionEnvHybrid(
     const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
-    double size_z, Eigen::Vector3d origin, bool use_signed_distance_field, double resolution,
+    double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
   : CollisionEnvFCL(robot_model, world, padding, scale)
   , cenv_distance_(new collision_detection::CollisionEnvDistanceField(
-        robot_model, getWorld(), link_body_decompositions, size_x, size_y, size_z, std::move(origin),
-        use_signed_distance_field, resolution, collision_tolerance, max_propogation_distance, padding, scale))
+        robot_model, getWorld(), link_body_decompositions, size_x, size_y, size_z, origin, use_signed_distance_field,
+        resolution, collision_tolerance, max_propogation_distance, padding, scale))
 {
 }
 


### PR DESCRIPTION
### Description
Travis fails due to `performance-unnecessary-value-param` which has been introduced through the new unified environment in #1584. This fixes the issue.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
