### PR TITLE
Handle the updated plan() function of MoveGroupCommander

### DIFF
--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -336,11 +336,11 @@ class MoveGroupCommandInterpreter(object):
                 if clist[1] == "rand" or clist[1] == "random":
                     vals = g.get_random_joint_values()
                     g.set_joint_value_target(vals)
-                    self._last_plan = g.plan()
+                    self._last_plan = g.plan()[1] # The trajectory msg
                 else:
                     try:
                         g.set_named_target(clist[1])
-                        self._last_plan = g.plan()
+                        self._last_plan = g.plan()[1] # The trajectory msg
                     except MoveItCommanderException as e:
                         return (MoveGroupInfoLevel.WARN, "Planning to " + clist[1] + ": " + str(e))
                     except:


### PR DESCRIPTION
### Description

After this [PR](https://github.com/ros-planning/moveit/pull/790) the MoveGroupCommander.plan() now returns [success, trajectory, planning_time, error_code] which leads to a run-time error when executing this [line](https://github.com/ros-planning/moveit/blob/master/moveit_commander/src/moveit_commander/interpreter.py#L349)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
