### PR TITLE
Migration notes for unified collision environment

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@ API changes in MoveIt releases
 - Moved the example package `moveit_controller_manager_example` into [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials)
 - Requests to `get_planning_scene` service without explicitly setting "components" now return full scene
 - `moveit_ros_plannning` no longer depends on `moveit_ros_perception`
-- `CollisionRobot` and `CollisionWorld` are combined into a single `CollisionEnv` class. This applies for all derived collision checkers as `FCL`, `ALL_VALID`, `HYBRID` and `DISTANCE_FIELD`. Consequently, `getCollisionRobot[Unpadded] / getCollisionWorld` functions are replaced through a `getCollisionEnv` in the planning scene and return the new combined environment. This unified collision environment provides the union of all member functions of `CollisionRobot` and `CollisionWorld`.
+- `CollisionRobot` and `CollisionWorld` are combined into a single `CollisionEnv` class. This applies for all derived collision checkers as `FCL`, `ALL_VALID`, `HYBRID` and `DISTANCE_FIELD`. Consequently, `getCollisionRobot[Unpadded] / getCollisionWorld` functions are replaced through a `getCollisionEnv` in the planning scene and return the new combined environment. This unified collision environment provides the union of all member functions of `CollisionRobot` and `CollisionWorld`. Note that calling `checkRobotCollision` of the `CollisionEnv` does not take a `CollisionRobot` as an argument anymore as it is implicitly contained in the `CollisionEnv`.
 
 ## ROS Melodic
 


### PR DESCRIPTION
One extra sentence for the migration notes added which states the fact that collision checks don't take a `CollisionRobot` as an argument anymore as it is implicitly contained in the new collision environment.