### PR TITLE
chomp: fix potential calculation

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -84,25 +84,21 @@ private:
   inline double getPotential(double field_distance, double radius, double clearence)
   {
     double d = field_distance - radius;
-    double potential = 0.0;
 
-    // three cases below:
-    if (d >= clearence)
+    if (d >= clearence)  // everything is fine
     {
-      potential = 0.0;
+      return 0.0;
     }
-    else if (d >= 0.0)
+    else if (d >= 0.0)  // transition phase, no collision yet
     {
       double diff = (d - clearence);
-      double gradient_magnitude = diff * clearence;  // (diff / clearance)
-      potential = 0.5 * gradient_magnitude * diff;
+      double gradient_magnitude = diff / clearence;
+      return 0.5 * gradient_magnitude * diff;  // 0.5 * (d - clearance)^2 / clearance
     }
-    else  // if d < 0.0
+    else  // d < 0.0: collision
     {
-      potential = -d + 0.5 * clearence;
+      return -d + 0.5 * clearence;  // linearly increase, starting from 0.5 * clearance
     }
-
-    return potential;
   }
   template <typename Derived>
   void getJacobian(int trajectoryPoint, Eigen::Vector3d& collision_point_pos, std::string& jointName,

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -91,7 +91,7 @@ private:
     }
     else if (d >= 0.0)  // transition phase, no collision yet
     {
-      double diff = (d - clearence);
+      const double diff = (d - clearence);
       double gradient_magnitude = diff / clearence;
       return 0.5 * gradient_magnitude * diff;  // 0.5 * (d - clearance)^2 / clearance
     }

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -92,7 +92,7 @@ private:
     else if (d >= 0.0)  // transition phase, no collision yet
     {
       const double diff = (d - clearence);
-      double gradient_magnitude = diff / clearence;
+      const double gradient_magnitude = diff / clearence;
       return 0.5 * gradient_magnitude * diff;  // 0.5 * (d - clearance)^2 / clearance
     }
     else  // d < 0.0: collision


### PR DESCRIPTION
Fix #1650. The potential is a piecewise function as follows:

![image](https://user-images.githubusercontent.com/5376030/63999277-63ba3980-cb03-11e9-9457-96faaaef8533.png)

To have a smooth transition at zero, we need
```c++
double gradient_magnitude = diff / clearance;
```
as was stated in the comment.
