### PR TITLE
depth_image_octomap_updater: correctly set properties of debug images

### DIFF
--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -394,33 +394,32 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
   {
     sensor_msgs::Image debug_msg;
     debug_msg.header = depth_msg->header;
-    debug_msg.height = depth_msg->height;
-    debug_msg.width = depth_msg->width;
+    debug_msg.height = h;
+    debug_msg.width = w;
+    debug_msg.is_bigendian = HOST_IS_BIG_ENDIAN;
     debug_msg.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-    debug_msg.is_bigendian = depth_msg->is_bigendian;
-    debug_msg.step = depth_msg->step;
+    debug_msg.step = w * sizeof(float);
     debug_msg.data.resize(img_size * sizeof(float));
     mesh_filter_->getModelDepth(reinterpret_cast<float*>(&debug_msg.data[0]));
     pub_model_depth_image_.publish(debug_msg, *info_msg);
 
     sensor_msgs::Image filtered_depth_msg;
     filtered_depth_msg.header = depth_msg->header;
-    filtered_depth_msg.height = depth_msg->height;
-    filtered_depth_msg.width = depth_msg->width;
+    filtered_depth_msg.height = h;
+    filtered_depth_msg.width = w;
+    filtered_depth_msg.is_bigendian = HOST_IS_BIG_ENDIAN;
     filtered_depth_msg.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-    filtered_depth_msg.is_bigendian = depth_msg->is_bigendian;
-    filtered_depth_msg.step = depth_msg->step;
+    filtered_depth_msg.step = w * sizeof(float);
     filtered_depth_msg.data.resize(img_size * sizeof(float));
-
     mesh_filter_->getFilteredDepth(reinterpret_cast<float*>(&filtered_depth_msg.data[0]));
     pub_filtered_depth_image_.publish(filtered_depth_msg, *info_msg);
 
     sensor_msgs::Image label_msg;
     label_msg.header = depth_msg->header;
-    label_msg.height = depth_msg->height;
-    label_msg.width = depth_msg->width;
+    label_msg.height = h;
+    label_msg.width = w;
+    label_msg.is_bigendian = HOST_IS_BIG_ENDIAN;
     label_msg.encoding = sensor_msgs::image_encodings::RGBA8;
-    label_msg.is_bigendian = depth_msg->is_bigendian;
     label_msg.step = w * sizeof(unsigned int);
     label_msg.data.resize(img_size * sizeof(unsigned int));
     mesh_filter_->getFilteredLabels(reinterpret_cast<unsigned int*>(&label_msg.data[0]));
@@ -430,22 +429,26 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
 
   if (!filtered_cloud_topic_.empty())
   {
-    static std::vector<float> filtered_data;
     sensor_msgs::Image filtered_msg;
     filtered_msg.header = depth_msg->header;
-    filtered_msg.height = depth_msg->height;
-    filtered_msg.width = depth_msg->width;
+    filtered_msg.height = h;
+    filtered_msg.width = w;
+    filtered_msg.is_bigendian = HOST_IS_BIG_ENDIAN;
     filtered_msg.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
-    filtered_msg.is_bigendian = depth_msg->is_bigendian;
-    filtered_msg.step = depth_msg->step;
+    filtered_msg.step = w * sizeof(unsigned short);
     filtered_msg.data.resize(img_size * sizeof(unsigned short));
+
+    // reuse float buffer across callbacks
+    static std::vector<float> filtered_data;
     if (filtered_data.size() < img_size)
       filtered_data.resize(img_size);
+
     mesh_filter_->getFilteredDepth(reinterpret_cast<float*>(&filtered_data[0]));
-    unsigned short* tmp_ptr = (unsigned short*)&filtered_msg.data[0];
+    unsigned short* msg_data = reinterpret_cast<unsigned short*>(&filtered_msg.data[0]);
     for (std::size_t i = 0; i < img_size; ++i)
     {
-      tmp_ptr[i] = (unsigned short)(filtered_data[i] * 1000 + 0.5);
+      // rescale depth to millimeter to work with `unsigned short`
+      msg_data[i] = static_cast<unsigned short>(filtered_data[i] * 1000 + 0.5);
     }
     pub_filtered_depth_image_.publish(filtered_msg, *info_msg);
   }


### PR DESCRIPTION
Cherry-pick of #1652 to `master`.

* calculate step width independent from input depth image

* Also set endianness based on the host system, as the data stems from local computation.

* depth updater: streamline Image properties

* depth updater: enhance readability for filtered image generation