### PR TITLE
depth_image_octomap_updater: reset depth transfer function to standard values

### DIFF
--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -182,7 +182,7 @@ void mesh_filter::GLRenderer::deleteFrameBuffers()
 
 void mesh_filter::GLRenderer::begin() const
 {
-  glPushAttrib(GL_VIEWPORT_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_POLYGON_BIT);
+  glPushAttrib(GL_VIEWPORT_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_POLYGON_BIT | GL_PIXEL_MODE_BIT);
   glBindFramebuffer(GL_FRAMEBUFFER, fbo_id_);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glViewport(0, 0, width_, height_);

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
@@ -382,8 +382,6 @@ void mesh_filter::MeshFilterBase::doFilter(const void* sensor_data, const int en
   glActiveTexture(GL_TEXTURE4);
   glBindTexture(GL_TEXTURE_2D, color_texture);
   glCallList(canvas_);
-  glPixelTransferf(GL_DEPTH_SCALE, 1.);
-  glPixelTransferf(GL_DEPTH_BIAS, 0.);
   depth_filter_->end();
 }
 

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
@@ -383,6 +383,8 @@ void mesh_filter::MeshFilterBase::doFilter(const void* sensor_data, const int en
   glBindTexture(GL_TEXTURE_2D, color_texture);
   glCallList(canvas_);
   depth_filter_->end();
+  glPixelTransferf(GL_DEPTH_SCALE, 1.);
+  glPixelTransferf(GL_DEPTH_BIAS, 0.);
 }
 
 void mesh_filter::MeshFilterBase::setPaddingOffset(float offset)

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
@@ -382,9 +382,9 @@ void mesh_filter::MeshFilterBase::doFilter(const void* sensor_data, const int en
   glActiveTexture(GL_TEXTURE4);
   glBindTexture(GL_TEXTURE_2D, color_texture);
   glCallList(canvas_);
-  depth_filter_->end();
   glPixelTransferf(GL_DEPTH_SCALE, 1.);
   glPixelTransferf(GL_DEPTH_BIAS, 0.);
+  depth_filter_->end();
 }
 
 void mesh_filter::MeshFilterBase::setPaddingOffset(float offset)


### PR DESCRIPTION
### Description

Currently, the pixel transfer function is set accordingly to the encoding of the input sensor data in the filtering step. This seems to be correct for rendering the sensor data only, but causes errors when rendering the robot model and when visualizing the filtered data and robot model as depth images.

This PR resets the pixel transfer function after sensor data has been rendered.

This also partially fixes #1109 and #374 for me (using Mesa OpenGL). Some tests still fail because of numerical inaccuracies.

As the mesh filter does depth calculations distributed over multiple places and, hence, is hard to debug, a review of this patch by someone who is more familiar with the mesh filter would be highly appreciated.

Examples:

Visualization of depth images without the PR (white: input depth image, yellow: filtered_cloud, red: model_depth) for floating point images. Z-scaling of the filtered cloud and the model_depth is wrong. The OctoMap (cubes) is scaled correctly as it does not employ the z-values but only the labels:

![float-wo-modifications-ps](https://user-images.githubusercontent.com/1028032/64528178-1e1e1d80-d308-11e9-8f7f-46520c2349d0.png)

Visualization of the same situation for an unsigned depth image (from a RealSense). The rendered model and the filtered cloud disappear due to the scaling:

![uint-wo-modifications](https://user-images.githubusercontent.com/1028032/64528202-2bd3a300-d308-11e9-9ec7-510e7d78e5ce.png)

Unsigned with my modifications:

![uint-w-modifications](https://user-images.githubusercontent.com/1028032/64528833-b8cb2c00-d309-11e9-8cdd-8817091830de.png)

When rendering the robot model robot model too close to the camera (cut by near clipping plane), the model's z-values are distributed over the depth buffer (unsigned image):

![uint-too-close](https://user-images.githubusercontent.com/1028032/64527640-c3d08d00-d306-11e9-859e-8256d8384851.png)

With the modification, model points behind the near clipping plane are rendered as expected:

![uint-too-close-modified](https://user-images.githubusercontent.com/1028032/64527652-ca5f0480-d306-11e9-9158-b88e033fac74.png)

Kind regards,
Matthias