### PR TITLE
Fix moveit.rosinstall

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -3,7 +3,7 @@
 - git:
     local-name: moveit
     uri: https://github.com/ros-planning/moveit.git
-    version: master
+    version: melodic-devel
 - git:
     local-name: moveit_msgs
     uri: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
The Melodic version of moveit.rosinstall should build the melodic-devel branch of MoveIt.
This fixes an issue introduced in #1369, which was [breaking docker source images recently](https://cloud.docker.com/u/moveit/repository/registry-1.docker.io/moveit/moveit/builds/0c5108f0-7cbc-4dbd-acba-26284211ef4e).