### PR TITLE
Add OMPL planner 'AnytimePathShortening', take #2

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -136,27 +136,27 @@ void ompl_interface::PlanningContextManager::registerDefaultPlanners()
 {
   registerPlannerAllocator("geometric::AnytimePathShortening", allocatePlanner<og::AnytimePathShortening>);
   registerPlannerAllocator("geometric::BFMT", allocatePlanner<og::BFMT>);
-  registerPlannerAllocator("geometric::BiEST",  allocatePlanner<og::BiEST>);
+  registerPlannerAllocator("geometric::BiEST", allocatePlanner<og::BiEST>);
   registerPlannerAllocator("geometric::BiTRRT", allocatePlanner<og::BiTRRT>);
   registerPlannerAllocator("geometric::BKPIECE", allocatePlanner<og::BKPIECE1>);
   registerPlannerAllocator("geometric::EST", allocatePlanner<og::EST>);
   registerPlannerAllocator("geometric::FMT", allocatePlanner<og::FMT>);
   registerPlannerAllocator("geometric::KPIECE", allocatePlanner<og::KPIECE1>);
-  registerPlannerAllocator("geometric::LazyPRM",allocatePlanner<og::LazyPRM>);
+  registerPlannerAllocator("geometric::LazyPRM", allocatePlanner<og::LazyPRM>);
   registerPlannerAllocator("geometric::LazyPRMstar", allocatePlanner<og::LazyPRMstar>);
   registerPlannerAllocator("geometric::LazyRRT", allocatePlanner<og::LazyRRT>);
   registerPlannerAllocator("geometric::LBKPIECE", allocatePlanner<og::LBKPIECE1>);
   registerPlannerAllocator("geometric::LBTRRT", allocatePlanner<og::LBTRRT>);
   registerPlannerAllocator("geometric::PDST", allocatePlanner<og::PDST>);
   registerPlannerAllocator("geometric::PRM", allocatePlanner<og::PRM>);
-  registerPlannerAllocator("geometric::PRMstar",allocatePlanner<og::PRMstar>);
-  registerPlannerAllocator("geometric::ProjEST",allocatePlanner<og::ProjEST>);
+  registerPlannerAllocator("geometric::PRMstar", allocatePlanner<og::PRMstar>);
+  registerPlannerAllocator("geometric::ProjEST", allocatePlanner<og::ProjEST>);
   registerPlannerAllocator("geometric::RRT", allocatePlanner<og::RRT>);
   registerPlannerAllocator("geometric::RRTConnect", allocatePlanner<og::RRTConnect>);
   registerPlannerAllocator("geometric::RRTstar", allocatePlanner<og::RRTstar>);
   registerPlannerAllocator("geometric::SBL", allocatePlanner<og::SBL>);
   registerPlannerAllocator("geometric::SPARS", allocatePlanner<og::SPARS>);
-  registerPlannerAllocator("geometric::SPARStwo",allocatePlanner<og::SPARStwo>);
+  registerPlannerAllocator("geometric::SPARStwo", allocatePlanner<og::SPARStwo>);
   registerPlannerAllocator("geometric::STRIDE", allocatePlanner<og::STRIDE>);
   registerPlannerAllocator("geometric::TRRT", allocatePlanner<og::TRRT>);
 }

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -41,6 +41,7 @@
 #include <set>
 #include <utility>
 
+#include <ompl/geometric/planners/AnytimePathShortening.h>
 #include <ompl/geometric/planners/rrt/RRT.h>
 #include <ompl/geometric/planners/rrt/pRRT.h>
 #include <ompl/geometric/planners/rrt/RRTConnect.h>
@@ -114,7 +115,6 @@ static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr& si,
   if (!new_name.empty())
     planner->setName(new_name);
   planner->params().setParams(spec.config_, true);
-  planner->setup();
   return planner;
 }
 }  // namespace
@@ -134,6 +134,10 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
 
 void ompl_interface::PlanningContextManager::registerDefaultPlanners()
 {
+  registerPlannerAllocator(                //
+      "geometric::AnytimePathShortening",  //
+      std::bind(&allocatePlanner<og::AnytimePathShortening>, std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3));
   registerPlannerAllocator(  //
       "geometric::RRT",      //
       std::bind(&allocatePlanner<og::RRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -134,83 +134,31 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
 
 void ompl_interface::PlanningContextManager::registerDefaultPlanners()
 {
-  registerPlannerAllocator(                //
-      "geometric::AnytimePathShortening",  //
-      std::bind(&allocatePlanner<og::AnytimePathShortening>, std::placeholders::_1, std::placeholders::_2,
-                std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::RRT",      //
-      std::bind(&allocatePlanner<og::RRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(     //
-      "geometric::RRTConnect",  //
-      std::bind(&allocatePlanner<og::RRTConnect>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::LazyRRT",  //
-      std::bind(&allocatePlanner<og::LazyRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::TRRT",     //
-      std::bind(&allocatePlanner<og::TRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::EST",      //
-      std::bind(&allocatePlanner<og::EST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::SBL",      //
-      std::bind(&allocatePlanner<og::SBL>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::KPIECE",   //
-      std::bind(&allocatePlanner<og::KPIECE1>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::BKPIECE",  //
-      std::bind(&allocatePlanner<og::BKPIECE1>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(   //
-      "geometric::LBKPIECE",  //
-      std::bind(&allocatePlanner<og::LBKPIECE1>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::RRTstar",  //
-      std::bind(&allocatePlanner<og::RRTstar>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::PRM",      //
-      std::bind(&allocatePlanner<og::PRM>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::PRMstar",  //
-      std::bind(&allocatePlanner<og::PRMstar>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::FMT",      //
-      std::bind(&allocatePlanner<og::FMT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::BFMT",     //
-      std::bind(&allocatePlanner<og::BFMT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::PDST",     //
-      std::bind(&allocatePlanner<og::PDST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::STRIDE",   //
-      std::bind(&allocatePlanner<og::STRIDE>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::BiTRRT",   //
-      std::bind(&allocatePlanner<og::BiTRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::LBTRRT",   //
-      std::bind(&allocatePlanner<og::LBTRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::BiEST",    //
-      std::bind(&allocatePlanner<og::BiEST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::ProjEST",  //
-      std::bind(&allocatePlanner<og::ProjEST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::LazyPRM",  //
-      std::bind(&allocatePlanner<og::LazyPRM>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(      //
-      "geometric::LazyPRMstar",  //
-      std::bind(&allocatePlanner<og::LazyPRMstar>, std::placeholders::_1, std::placeholders::_2,
-                std::placeholders::_3));
-  registerPlannerAllocator(  //
-      "geometric::SPARS",    //
-      std::bind(&allocatePlanner<og::SPARS>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-  registerPlannerAllocator(   //
-      "geometric::SPARStwo",  //
-      std::bind(&allocatePlanner<og::SPARStwo>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  registerPlannerAllocator("geometric::AnytimePathShortening", allocatePlanner<og::AnytimePathShortening>);
+  registerPlannerAllocator("geometric::BFMT", allocatePlanner<og::BFMT>);
+  registerPlannerAllocator("geometric::BiEST",  allocatePlanner<og::BiEST>);
+  registerPlannerAllocator("geometric::BiTRRT", allocatePlanner<og::BiTRRT>);
+  registerPlannerAllocator("geometric::BKPIECE", allocatePlanner<og::BKPIECE1>);
+  registerPlannerAllocator("geometric::EST", allocatePlanner<og::EST>);
+  registerPlannerAllocator("geometric::FMT", allocatePlanner<og::FMT>);
+  registerPlannerAllocator("geometric::KPIECE", allocatePlanner<og::KPIECE1>);
+  registerPlannerAllocator("geometric::LazyPRM",allocatePlanner<og::LazyPRM>);
+  registerPlannerAllocator("geometric::LazyPRMstar", allocatePlanner<og::LazyPRMstar>);
+  registerPlannerAllocator("geometric::LazyRRT", allocatePlanner<og::LazyRRT>);
+  registerPlannerAllocator("geometric::LBKPIECE", allocatePlanner<og::LBKPIECE1>);
+  registerPlannerAllocator("geometric::LBTRRT", allocatePlanner<og::LBTRRT>);
+  registerPlannerAllocator("geometric::PDST", allocatePlanner<og::PDST>);
+  registerPlannerAllocator("geometric::PRM", allocatePlanner<og::PRM>);
+  registerPlannerAllocator("geometric::PRMstar",allocatePlanner<og::PRMstar>);
+  registerPlannerAllocator("geometric::ProjEST",allocatePlanner<og::ProjEST>);
+  registerPlannerAllocator("geometric::RRT", allocatePlanner<og::RRT>);
+  registerPlannerAllocator("geometric::RRTConnect", allocatePlanner<og::RRTConnect>);
+  registerPlannerAllocator("geometric::RRTstar", allocatePlanner<og::RRTstar>);
+  registerPlannerAllocator("geometric::SBL", allocatePlanner<og::SBL>);
+  registerPlannerAllocator("geometric::SPARS", allocatePlanner<og::SPARS>);
+  registerPlannerAllocator("geometric::SPARStwo",allocatePlanner<og::SPARStwo>);
+  registerPlannerAllocator("geometric::STRIDE", allocatePlanner<og::STRIDE>);
+  registerPlannerAllocator("geometric::TRRT", allocatePlanner<og::TRRT>);
 }
 
 void ompl_interface::PlanningContextManager::registerDefaultStateSpaces()

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -27,7 +27,8 @@ find_package(catkin REQUIRED COMPONENTS
   urdf
   srdfdom
 )
-include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+find_package(ompl REQUIRED)
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${OMPL_INCLUDE_DIRS})
 
 # Qt Stuff
 if(rviz_QT_VERSION VERSION_LESS "5")

--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -21,6 +21,7 @@
   <build_depend>libogre-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
+  <build_depend>ompl</build_depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -546,6 +546,13 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
 {
   std::vector<OMPLPlannerDescription> planner_des;
 
+  OMPLPlannerDescription aps("AnytimePathShortening", "geometric");
+  aps.addParameter("shortcut", "true", "Attempt to shortcut all new solution paths");
+  aps.addParameter("hybridize", "true", "Compute hybrid solution trajectories");
+  aps.addParameter("max_hybrid_paths", "24", "Number of hybrid paths generated per iteration");
+  aps.addParameter("num_planners", "4", "The number of default planners to use for planning");
+  planner_des.push_back(aps);
+
   OMPLPlannerDescription sbl("SBL", "geometric");
   sbl.addParameter("range", "0.0", "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()");
   planner_des.push_back(sbl);

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -46,6 +46,9 @@
 #include <ros/console.h>
 #include <ros/package.h>  // for getting file path for loading images
 
+// OMPL version
+#include <ompl/config.h>
+
 namespace moveit_setup_assistant
 {
 // File system
@@ -551,9 +554,12 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
   aps.addParameter("hybridize", "true", "Compute hybrid solution trajectories");
   aps.addParameter("max_hybrid_paths", "24", "Number of hybrid paths generated per iteration");
   aps.addParameter("num_planners", "4", "The number of default planners to use for planning");
+#if OMPL_VERSION_VALUE >= 1005000
+  // This parameter was added in OMPL 1.5.0
   aps.addParameter("planners", "", "A comma-separated list of planner types (e.g., \"PRM,EST,RRTConnect\""
                                    "Optionally, planner parameters can be passed to change the default:"
                                    "\"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]\"");
+#endif
   planner_des.push_back(aps);
 
   OMPLPlannerDescription sbl("SBL", "geometric");

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -551,6 +551,9 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
   aps.addParameter("hybridize", "true", "Compute hybrid solution trajectories");
   aps.addParameter("max_hybrid_paths", "24", "Number of hybrid paths generated per iteration");
   aps.addParameter("num_planners", "4", "The number of default planners to use for planning");
+  aps.addParameter("planners", "", "A comma-separated list of planner types (e.g., \"PRM,EST,RRTConnect\""
+                                   "Optionally, planner parameters can be passed to change the default:"
+                                   "\"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]\"");
   planner_des.push_back(aps);
 
   OMPLPlannerDescription sbl("SBL", "geometric");


### PR DESCRIPTION
### Description

This builds on @henningkayser's PR #1629. Due to changes in OMPL, only that first commit of that other PR is now necessary. This PR requires OMPL to be built from source at the moment. I am planning to release a new version of OMPL soon, though. 

This PR allows you configure AnytimePathShortening like so in your ompl_planning.yaml:
```
planner_configs:
  AnytimePathShortening:
    type: geometric::AnytimePathShortening
    shortcut: true
    hybridize: true
    planners: PRM,PRM,PRM[max_nearest_neighbors=5],RRTConnect[goal_bias=.2],RRTConnect,BiEST,BiEST,BiEST
```

Note how several planning instances can be created, even multiple of the same type with different parameters.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
