### PR TITLE
Add docker documentation

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,3 +1,4 @@
 # MoveIt Docker Containers
 
-For more information see [Continuous Integration and Docker](http://moveit.ros.org/documentation/contributing/continuous_integration.html) documentation.
+
+For more information see the pages [Continuous Integration and Docker](http://moveit.ros.org/documentation/contributing/continuous_integration.html) and [Using Docker Containers with MoveIt](https://moveit.ros.org/install/docker/).

--- a/.docker/gui-docker
+++ b/.docker/gui-docker
@@ -1,17 +1,14 @@
 #!/bin/bash -u
 
 # This script is used to run a docker container with graphics support.
-# Documentation: https://moveit.ros.org/install/docker/
-# http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration
-
 # All arguments to this script except "-c <container_name>" will be appended to a docker run command.
 # If a container name is specified, and this container already exists, the container is re-entered,
 # which easily allows entering the same persistent container from multiple terminals.
+# See documentation for detailed examples: https://moveit.ros.org/install/docker/
 
 # Example commands:
 # ./gui-docker --rm -it moveit/moveit:master-source /bin/bash     # Run a (randomly named) container that is removed on exit
 # ./gui-docker -v ~/ros_ws:/root/ros_ws --rm -it moveit/moveit:master-source /bin/bash   # Same, but also link host volume ~/ros_ws to /root/ros_ws in the container
-# ./gui-docker -c container_name -v ~/ros_ws:/root/ros_ws moveit/moveit:master-source echo  # Create a persistent container that links host volume ~/ros_ws to /root/ros_ws
 # ./gui-docker -c container_name                                  # Start (or continue) an interactive bash in a moveit/moveit:master-source container
 # ./gui-docker                                                    # Same, but use the default container name "default_moveit_container"
 

--- a/.docker/gui-docker
+++ b/.docker/gui-docker
@@ -4,14 +4,15 @@
 # Documentation: https://moveit.ros.org/install/docker/
 # http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration
 
-# Runs and enters a persistent docker container with moveit installed by default.
-# All arguments to this script except "-c" will be appended to a docker run command.
+# All arguments to this script except "-c <container_name>" will be appended to a docker run command.
+# If a container name is specified, and this container already exists, the container is re-entered,
+# which easily allows to run persistent containers.
 
 # Example commands:
-# ./gui-docker
-# ./gui-docker -c different_container_name                              # To create a different persistent container
-# ./gui-docker --rm -it moveit/moveit:master-source /bin/bash           # To remove and recreate the container
-# ./gui-docker --volume="/home/your_user/dev/ws_moveit:/root/linked_ws_moveit" -it moveit/moveit:master-source /bin/bash      # To link a directory on your hard drive to the container
+# ./gui-docker --rm -it moveit/moveit:master-source /bin/bash     # Run a (randomly named) container that is removed on exit
+# ./gui-docker -v ~/ros_ws:/root/ros_ws --rm -it moveit/moveit:master-source /bin/bash   # Same, but also link host volume ~/ros_ws to /root/ros_ws
+# ./gui-docker -c different_container_name                        # Start (or continue) an interactive bash in a moveit/moveit:master-source container
+# ./gui-docker                                                    # Same, but use the default container name "default_moveit_container"
 
 function check_nvidia2() {
     # If we don't have an NVIDIA graphics card, bail out
@@ -84,7 +85,7 @@ function count_positional_args() {
 }
 
 if [ $# -eq 0 ] ; then
-   # If not options are specified at all, use the name "default_moveit_container"
+   # If no options are specified at all, use the name "default_moveit_container"
    CONTAINER_NAME=default_moveit_container
 else
   # Check for option -c or --container in first position

--- a/.docker/gui-docker
+++ b/.docker/gui-docker
@@ -6,13 +6,15 @@
 
 # All arguments to this script except "-c <container_name>" will be appended to a docker run command.
 # If a container name is specified, and this container already exists, the container is re-entered,
-# which easily allows to run persistent containers.
+# which easily allows entering the same persistent container from multiple terminals.
 
 # Example commands:
 # ./gui-docker --rm -it moveit/moveit:master-source /bin/bash     # Run a (randomly named) container that is removed on exit
-# ./gui-docker -v ~/ros_ws:/root/ros_ws --rm -it moveit/moveit:master-source /bin/bash   # Same, but also link host volume ~/ros_ws to /root/ros_ws
-# ./gui-docker -c different_container_name                        # Start (or continue) an interactive bash in a moveit/moveit:master-source container
+# ./gui-docker -v ~/ros_ws:/root/ros_ws --rm -it moveit/moveit:master-source /bin/bash   # Same, but also link host volume ~/ros_ws to /root/ros_ws in the container
+# ./gui-docker -c container_name                                  # Start (or continue) an interactive bash in a moveit/moveit:master-source container
 # ./gui-docker                                                    # Same, but use the default container name "default_moveit_container"
+# ./gui-docker -c container_name -v ~/ros_ws:/root/ros_ws -it moveit/moveit:master-source /bin/bash  # Same, but also link host volume ~/ros_ws to /root/ros_ws in the container
+
 
 function check_nvidia2() {
     # If we don't have an NVIDIA graphics card, bail out

--- a/.docker/gui-docker
+++ b/.docker/gui-docker
@@ -1,11 +1,17 @@
 #!/bin/bash -u
 
 # This script is used to run a docker container with graphics support.
+# Documentation: https://moveit.ros.org/install/docker/
 # http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration
 
-# All arguments to this script will be appended to a docker run command.
-# Example command line:
-# ./gui-docker -it --rm moveit/moveit:master-source /bin/bash
+# Runs and enters a persistent docker container with moveit installed by default.
+# All arguments to this script except "-c" will be appended to a docker run command.
+
+# Example commands:
+# ./gui-docker
+# ./gui-docker -c different_container_name                              # To create a different persistent container
+# ./gui-docker --rm -it moveit/moveit:master-source /bin/bash           # To remove and recreate the container
+# ./gui-docker --volume="/home/your_user/dev/ws_moveit:/root/linked_ws_moveit" -it moveit/moveit:master-source /bin/bash      # To link a directory on your hard drive to the container
 
 function check_nvidia2() {
     # If we don't have an NVIDIA graphics card, bail out
@@ -78,8 +84,8 @@ function count_positional_args() {
 }
 
 if [ $# -eq 0 ] ; then
-   # If not options are specified at all, just run the default_container
-   CONTAINER_NAME=default_container
+   # If not options are specified at all, use the name "default_moveit_container"
+   CONTAINER_NAME=default_moveit_container
 else
   # Check for option -c or --container in first position
   case "$1" in
@@ -91,7 +97,7 @@ else
          shift
       fi
       # Set default container name if still undefined
-      CONTAINER_NAME="${CONTAINER_NAME:-default_container}"
+      CONTAINER_NAME="${CONTAINER_NAME:-default_moveit_container}"
       ;;
   esac
 fi

--- a/.docker/gui-docker
+++ b/.docker/gui-docker
@@ -11,10 +11,9 @@
 # Example commands:
 # ./gui-docker --rm -it moveit/moveit:master-source /bin/bash     # Run a (randomly named) container that is removed on exit
 # ./gui-docker -v ~/ros_ws:/root/ros_ws --rm -it moveit/moveit:master-source /bin/bash   # Same, but also link host volume ~/ros_ws to /root/ros_ws in the container
+# ./gui-docker -c container_name -v ~/ros_ws:/root/ros_ws moveit/moveit:master-source echo  # Create a persistent container that links host volume ~/ros_ws to /root/ros_ws
 # ./gui-docker -c container_name                                  # Start (or continue) an interactive bash in a moveit/moveit:master-source container
 # ./gui-docker                                                    # Same, but use the default container name "default_moveit_container"
-# ./gui-docker -c container_name -v ~/ros_ws:/root/ros_ws -it moveit/moveit:master-source /bin/bash  # Same, but also link host volume ~/ros_ws to /root/ros_ws in the container
-
 
 function check_nvidia2() {
     # If we don't have an NVIDIA graphics card, bail out


### PR DESCRIPTION
### Description

While updating the Docker documentation ([this PR](https://github.com/ros-planning/moveit.ros.org/pull/282)) to include the changes from #1532, I noticed that that page should be referenced and made some minor changes that I believe are helpful when using this script.

The change from `default_container` to `default_moveit_container` is already part of the other PR, so it would be good if at least that bit was included. The name change is for clarity when listing containers via `docker ps -a`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers