### PR TITLE
fixing jog_arm segfault

### DIFF
--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -578,7 +578,7 @@ bool JogCalcs::checkIfJointsWithinURDFBounds(trajectory_msgs::JointTrajectory& n
                                                                               " velocity limit. Enforcing limit.");
 
       kinematic_state_->enforceVelocityBounds(joint);
-      for (std::size_t c = 0; c < new_jt_traj.points[0].velocities.size(); ++c)
+      for (std::size_t c = 0; c < new_jt_traj.joint_names.size(); ++c)
       {
         if (new_jt_traj.joint_names[c] == joint->getName())
         {


### PR DESCRIPTION
### Description
Fixes a segfault issue with jog_arm where the fix bounds method tries to access invalid indices inthe velocity vector. Not sure if this is the best way to fix this. @AndyZe 