### PR TITLE
Update version of occupancy_map_monitor

### DIFF
--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>moveit_ros_occupancy_map_monitor</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Components of MoveIt! connecting to occupancy map</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>


### PR DESCRIPTION
it is still at 1.0.1 while the old version from `moveit_ros_perception` is at 1.0.2 . This creates confusion