### PR TITLE
Code of conduct tweaks

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 Like the technical community as a whole, the MoveIt team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 
-Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few basic rules that we ask people to adhere to. This code applies equally to founders, mentors and those seeking help and guidance. 
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few basic rules that we ask people to adhere to. This code applies equally to maintainers, contributors, and those seeking help and guidance. 
 It applies to all kinds of communication, including discussions on GitHub (issue tracker, pull requests), MoveIt maintainer meetings and any other forums created by the project team, which the community uses for communication.
 
 - **Be friendly and patient.**
@@ -12,4 +12,4 @@ It applies to all kinds of communication, including discussions on GitHub (issue
 - **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. Treat others like you want to be treated.
 - **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and MoveIt is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we're different. The strength of MoveIt comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn't mean that they're wrong. Don't forget that it is human to err and blaming each other doesn't get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
-Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
+Original text courtesy of the [Django project](https://www.djangoproject.com/conduct/).


### PR DESCRIPTION
- Customize naming of people involved with the MoveIt project specifically. We don't really call anyone founders or mentors, rather just maintainers and contributors. This is a concept from a different community.
- Clarify that this CoC is based on Djangos, which is a fairly modified version of Speak Ups, and theirs is a fairly modified version of Fedora and Python's. So we should have a full chain of references.

follow up of https://github.com/ros-planning/moveit/pull/1684