### PR TITLE
plan_execution: refine logging for invalid paths

### DIFF
--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -141,7 +141,6 @@ public:
 
 private:
   void planAndExecuteHelper(ExecutableMotionPlan& plan, const Options& opt);
-  bool isRemainingPathValid(const ExecutableMotionPlan& plan);
   bool isRemainingPathValid(const ExecutableMotionPlan& plan, const std::pair<int, int>& path_segment);
 
   void planningSceneUpdatedCallback(const planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type);


### PR DESCRIPTION
This differentiates between checks caused by scene updates
and checks caused by changing trajectory components.