### PR TITLE
Specify retime_trajectory parameters as arguments.

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -499,7 +499,9 @@ public:
   py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
                                                  const py_bindings_tools::ByteString& traj_str,
                                                  double velocity_scaling_factor, double acceleration_scaling_factor,
-                                                 const std::string& algorithm)
+                                                 const std::string& algorithm, unsigned int max_iterations = 100,
+                                                 double max_time_change_per_it = 0.01, bool add_points = true,
+                                                 const double path_tolerance = 0.1, const double resample_dt = 0.1)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -517,17 +519,18 @@ public:
       // Do the actual retiming
       if (algorithm == "iterative_time_parameterization")
       {
-        trajectory_processing::IterativeParabolicTimeParameterization time_param;
+        trajectory_processing::IterativeParabolicTimeParameterization time_param(max_iterations,
+                                                                                 max_time_change_per_it);
         time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
       }
       else if (algorithm == "iterative_spline_parameterization")
       {
-        trajectory_processing::IterativeSplineParameterization time_param;
+        trajectory_processing::IterativeSplineParameterization time_param(add_points);
         time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
       }
       else if (algorithm == "time_optimal_trajectory_generation")
       {
-        trajectory_processing::TimeOptimalTrajectoryGeneration time_param;
+        trajectory_processing::TimeOptimalTrajectoryGeneration time_param(path_tolerance, resample_dt);
         time_param.computeTimeStamps(traj_obj, velocity_scaling_factor, acceleration_scaling_factor);
       }
       else


### PR DESCRIPTION
### Description

This PR makes it possible to specify retime_trajectory parameters as arguments in Python interface of move_group.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
