### PR TITLE
Add execution thread mutex.

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -320,6 +320,7 @@ private:
 
   boost::mutex execution_state_mutex_;
   boost::mutex continuous_execution_mutex_;
+  boost::mutex execution_thread_mutex_;
 
   boost::condition_variable continuous_execution_condition_;
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1171,8 +1171,7 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
 
       // wait for the execution thread to finish
       boost::mutex::scoped_lock lock(execution_thread_mutex_);
-
-      if (execution_thread_ != nullptr)
+      if (execution_thread_)
       {
         execution_thread_->join();
         execution_thread_.reset();
@@ -1184,12 +1183,11 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
     else
       execution_state_mutex_.unlock();
   }
-  else  // just in case we have some thread waiting to be joined from some point in the past, we
-        // join it now
+  else if (execution_thread_)  // just in case we have some thread waiting to be joined from some point in the past, we
+                               // join it now
   {
     boost::mutex::scoped_lock lock(execution_thread_mutex_);
-
-    if (execution_thread_ != nullptr)
+    if (execution_thread_)
     {
       execution_thread_->join();
       execution_thread_.reset();

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1184,8 +1184,8 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
     else
       execution_state_mutex_.unlock();
   }
-  else // just in case we have some thread waiting to be joined from some point in the past, we
-                               // join it now
+  else  // just in case we have some thread waiting to be joined from some point in the past, we
+        // join it now
   {
     boost::mutex::scoped_lock lock(execution_thread_mutex_);
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1170,13 +1170,13 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
       ROS_INFO_NAMED(name_, "Stopped trajectory execution.");
 
       // wait for the execution thread to finish
-      execution_thread_mutex_.lock();
+      boost::mutex::scoped_lock lock(execution_thread_mutex_);
+
       if (execution_thread_ != nullptr)
       {
         execution_thread_->join();
         execution_thread_.reset();
       }
-      execution_thread_mutex_.unlock();
 
       if (auto_clear)
         clear();
@@ -1184,16 +1184,16 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
     else
       execution_state_mutex_.unlock();
   }
-  else if (execution_thread_)  // just in case we have some thread waiting to be joined from some point in the past, we
+  else // just in case we have some thread waiting to be joined from some point in the past, we
                                // join it now
   {
-    execution_thread_mutex_.lock();
+    boost::mutex::scoped_lock lock(execution_thread_mutex_);
+
     if (execution_thread_ != nullptr)
     {
       execution_thread_->join();
       execution_thread_.reset();
     }
-    execution_thread_mutex_.unlock();
   }
 }
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1170,8 +1170,13 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
       ROS_INFO_NAMED(name_, "Stopped trajectory execution.");
 
       // wait for the execution thread to finish
-      execution_thread_->join();
-      execution_thread_.reset();
+      execution_thread_mutex_.lock();
+      if (execution_thread_ != nullptr)
+      {
+        execution_thread_->join();
+        execution_thread_.reset();
+      }
+      execution_thread_mutex_.unlock();
 
       if (auto_clear)
         clear();
@@ -1182,8 +1187,13 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
   else if (execution_thread_)  // just in case we have some thread waiting to be joined from some point in the past, we
                                // join it now
   {
-    execution_thread_->join();
-    execution_thread_.reset();
+    execution_thread_mutex_.lock();
+    if (execution_thread_ != nullptr)
+    {
+      execution_thread_->join();
+      execution_thread_.reset();
+    }
+    execution_thread_mutex_.unlock();
   }
 }
 


### PR DESCRIPTION
### Description
#1481  
My project was in huge need of canceling trajectory execution in quite often manner, over direct message via "stop" event on "/trajectory_execution_event" topic, or via move group interface `stop() ` method. I added one more mutex for protecting `execution_thread_` variable and it worked. Definitely it is not the optimal and the most elegant solution, but is quite effective. Long simulation period confirmed it has no memory leaks. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
