### PR TITLE
Configurable time parametrization method default cartesian path planner in moveit

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -1,36 +1,36 @@
-# Software License Agreement (BSD License)
+#Software License Agreement(BSD License)
 #
-# Copyright (c) 2012, Willow Garage, Inc.
-# All rights reserved.
+#Copyright(c) 2012, Willow Garage, Inc.
+#All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#Redistribution and use in source and binary forms, with or without
+#modification, are permitted provided that the following conditions
+#are met:
 #
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above
-#    copyright notice, this list of conditions and the following
-#    disclaimer in the documentation and/or other materials provided
-#    with the distribution.
-#  * Neither the name of Willow Garage, Inc. nor the names of its
-#    contributors may be used to endorse or promote products derived
-#    from this software without specific prior written permission.
+#* Redistributions of source code must retain the above copyright
+#notice, this list of conditions and the following disclaimer.
+#* Redistributions in binary form must reproduce the above
+#copyright notice, this list of conditions and the following
+#disclaimer in the documentation and / or other materials provided
+#with the distribution.
+#* Neither the name of Willow Garage, Inc.nor the names of its
+#contributors may be used to endorse or promote products derived
+#from this software without specific prior written permission.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#FOR A PARTICULAR PURPOSE ARE DISCLAIMED.IN NO EVENT SHALL THE
+#COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES(INCLUDING,
+#BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#LIABILITY, OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#POSSIBILITY OF SUCH DAMAGE.
 #
-# Author: Ioan Sucan, William Baker
+#Author : Ioan Sucan, William Baker
 
 from geometry_msgs.msg import Pose, PoseStamped
 from moveit_msgs.msg import RobotTrajectory, Grasp, PlaceLocation, Constraints, RobotState
@@ -292,8 +292,8 @@ class MoveGroupCommander(object):
         """ Get the current pose of the end effector, add value to the corresponding axis (0..5: X, Y, Z, R, P, Y) and set the new pose as the pose target """
         if len(end_effector_link) > 0 or self.has_end_effector_link():
             pose = self._g.get_current_pose(end_effector_link)
-            # by default we get orientation as a quaternion list
-            # if we are updating a rotation axis however, we convert the orientation to RPY
+#by default we get orientation as a quaternion list
+#if we are updating a rotation axis however, we convert the orientation to RPY
             if axis > 2:
                 (r, p, y) = tf.transformations.euler_from_quaternion(pose[3:])
                 pose = [pose[0], pose[1], pose[2], r, p, y]
@@ -495,27 +495,25 @@ class MoveGroupCommander(object):
 
         elif joints is not None:
             try:
-                self.set_joint_value_target(self.get_remembered_joint_values()[joints])
-            except TypeError:
-                self.set_joint_value_target(joints)
-        if wait:
-            return self._g.move()
-        else:
-            return self._g.async_move()
+                self
+  .set_joint_value_target(self.get_remembered_joint_values()[joints]) except TypeError
+      : self.set_joint_value_target(joints) if wait : return self._g.move() else : return self._g
+                                                                                       .async_move()
 
-    def plan(self, joints=None):
-        """ Return a tuple of the motion planning results such as
-            (success flag : boolean, trajectory message : RobotTrajectory,
-             planning time : float, error code : MoveitErrorCodes) """
-        if type(joints) is JointState:
-            self.set_joint_value_target(joints)
+                                                                                           def plan(self, joints = None)
+    : ""
+      " Return a tuple of the motion planning results such as
+    (success flag
+     : boolean, trajectory message
+     : RobotTrajectory, planning time
+     : float, error code
+     : MoveitErrorCodes) ""
+                         "
+    if type(joints) is JointState : self.set_joint_value_target(joints)
 
-        elif type(joints) is Pose:
-            self.set_pose_target(joints)
+                                        elif type(joints) is Pose : self.set_pose_target(joints)
 
-        elif joints is not None:
-            try:
-                self.set_joint_value_target(self.get_remembered_joint_values()[joints])
+                                                                        elif joints is not None : try : self.set_joint_value_target(self.get_remembered_joint_values()[joints])
             except MoveItCommanderException:
                 self.set_joint_value_target(joints)
 
@@ -599,4 +597,3 @@ class MoveGroupCommander(object):
     def get_jacobian_matrix(self, joint_values, reference_point=None):
         """ Get the jacobian matrix of the group as a list"""
         return self._g.get_jacobian_matrix(joint_values, [0.0, 0.0, 0.0] if reference_point is None else reference_point)
-

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -529,16 +529,16 @@ class MoveGroupCommander(object):
                 planning_time,
                 error_code)
 
-    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, avoid_collisions=True, path_constraints=None):
+    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, algorithm, avoid_collisions=True, path_constraints=None):
         """ Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. Configurations are computed for every eef_step meters; The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned. The return value is a tuple: a fraction of how much of the path was followed, the actual RobotTrajectory. """
         if path_constraints:
             if type(path_constraints) is Constraints:
                 constraints_str = conversions.msg_to_string(path_constraints)
             else:
                 raise MoveItCommanderException("Unable to set path constraints, unknown constraint type " + type(path_constraints))
-            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions, constraints_str)
+            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, algorithm, avoid_collisions, constraints_str)
         else:
-            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions)
+            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, algorithm, avoid_collisions)
 
         path = RobotTrajectory()
         path.deserialize(ser_path)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -45,6 +45,7 @@
 #include <moveit/robot_state/cartesian_interpolator.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <string>
 
 namespace
 {
@@ -158,9 +159,30 @@ bool MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath
 
           // time trajectory
           // \todo optionally compute timing to move the eef with constant speed
-          trajectory_processing::IterativeParabolicTimeParameterization time_param;
-          time_param.computeTimeStamps(rt, 1.0);
+          if(!req.algorithm.compare("IterativeparabolicParameterization"))
+          {
+            trajectory_processing::IterativeParabolicTimeParameterization time_param;
+            ROS_INFO_NAMED(getName(),"IterativeparabolicParameterization initialized");
+            time_param.computeTimeStamps(rt, 1.0);
+          }
+          else if(!req.algorithm.compare("IterativeSplineParameterization")){
+            trajectory_processing::IterativeSplineParameterization time_param;
+            ROS_INFO_NAMED(getName(),"IterativeSplineParameterization initialized");
+            time_param.computeTimeStamps(rt, 1.0);
+          
+        }
+        else if(!req.algorithm.compare("TimeOptimalTrajectoryGeneration")){
+            trajectory_processing::TimeOptimalTrajectoryGeneration time_param;
+            ROS_INFO_NAMED(getName(),"TimeOptimalTrajectoryGeneration initialized");
+            time_param.computeTimeStamps(rt, 1.0);
+        }
+        else{
+            trajectory_processing::IterativeParabolicTimeParameterization time_param;
+            ROS_WARN_NAMED(getName(),"Unknown Time parametrization algorithm specified. Setting it to default algorithm");
+            ROS_INFO_NAMED(getName(),"IterativeparabolicParameterization initialized");
+            time_param.computeTimeStamps(rt, 1.0);
 
+        }
           rt.getRobotTrajectoryMsg(res.solution);
           ROS_INFO_NAMED(getName(), "Computed Cartesian path with %u points (followed %lf%% of requested trajectory)",
                          (unsigned int)traj.size(), res.fraction * 100.0);

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -161,30 +161,32 @@ bool MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath
 
           // time trajectory
           // \todo optionally compute timing to move the eef with constant speed
-          if(!req.algorithm.compare("IterativeparabolicParameterization"))
+          if (!req.algorithm.compare("IterativeparabolicParameterization"))
           {
             trajectory_processing::IterativeParabolicTimeParameterization time_param;
-            ROS_INFO_NAMED(getName(),"IterativeparabolicParameterization initialized");
+            ROS_INFO_NAMED(getName(), "IterativeparabolicParameterization initialized");
             time_param.computeTimeStamps(rt, 1.0);
           }
-          else if(!req.algorithm.compare("IterativeSplineParameterization")){
+          else if (!req.algorithm.compare("IterativeSplineParameterization"))
+          {
             trajectory_processing::IterativeSplineParameterization time_param;
-            ROS_INFO_NAMED(getName(),"IterativeSplineParameterization initialized");
+            ROS_INFO_NAMED(getName(), "IterativeSplineParameterization initialized");
             time_param.computeTimeStamps(rt, 1.0);
-          
-        }
-        else if(!req.algorithm.compare("TimeOptimalTrajectoryGeneration")){
+          }
+          else if (!req.algorithm.compare("TimeOptimalTrajectoryGeneration"))
+          {
             trajectory_processing::TimeOptimalTrajectoryGeneration time_param;
-            ROS_INFO_NAMED(getName(),"TimeOptimalTrajectoryGeneration initialized");
+            ROS_INFO_NAMED(getName(), "TimeOptimalTrajectoryGeneration initialized");
             time_param.computeTimeStamps(rt, 1.0);
-        }
-        else{
+          }
+          else
+          {
             trajectory_processing::IterativeParabolicTimeParameterization time_param;
-            ROS_WARN_NAMED(getName(),"Unknown Time parametrization algorithm specified. Setting it to default algorithm");
-            ROS_INFO_NAMED(getName(),"IterativeparabolicParameterization initialized");
+            ROS_WARN_NAMED(getName(),
+                           "Unknown Time parametrization algorithm specified. Setting it to default algorithm");
+            ROS_INFO_NAMED(getName(), "IterativeparabolicParameterization initialized");
             time_param.computeTimeStamps(rt, 1.0);
-
-        }
+          }
           rt.getRobotTrajectoryMsg(res.solution);
           ROS_INFO_NAMED(getName(), "Computed Cartesian path with %u points (followed %lf%% of requested trajectory)",
                          (unsigned int)traj.size(), res.fraction * 100.0);

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -45,6 +45,8 @@
 #include <moveit/robot_state/cartesian_interpolator.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/iterative_spline_parameterization.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <string>
 
 namespace

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -742,8 +742,7 @@ public:
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
      waypoints.
       Return -1.0 in case of error. */
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
-                              const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold, const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = NULL);
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
@@ -758,8 +757,7 @@ public:
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
      waypoints.
       Return -1.0 in case of error. */
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
-                              const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory,
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold, const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory,
                               const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = NULL);
 

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -742,8 +742,9 @@ public:
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
      waypoints.
       Return -1.0 in case of error. */
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold, const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
-                              moveit_msgs::MoveItErrorCodes* error_code = NULL);
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
+                              const std::string& algorithm, moveit_msgs::RobotTrajectory& trajectory,
+                              bool avoid_collisions = true, moveit_msgs::MoveItErrorCodes* error_code = NULL);
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
@@ -757,7 +758,8 @@ public:
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
      waypoints.
       Return -1.0 in case of error. */
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold, const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory,
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
+                              const std::string& algorithm, moveit_msgs::RobotTrajectory& trajectory,
                               const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = NULL);
 

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -737,19 +737,20 @@ public:
       waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold
       is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK
      solutions).
+      Time parametrization technique can be set using this \e algorithm parameter.
       Collisions are avoided if \e avoid_collisions is set to true. If collisions cannot be avoided, the function fails.
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
      waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
+                              const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = NULL);
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
       waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold
       is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK
-     solutions).
+     solutions). Time parametrization technique can be set using this \e algorithm parameter.
       Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory,
      if they are not met, a partial solution will be returned.
       Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be
@@ -758,7 +759,7 @@ public:
      waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory& trajectory,
+                              const std::string& algorithm,moveit_msgs::RobotTrajectory& trajectory,
                               const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = NULL);
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -828,8 +828,10 @@ public:
     }
   }
 
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double step, double jump_threshold,const std::string& algorithm, moveit_msgs::RobotTrajectory& msg, const moveit_msgs::Constraints& path_constraints,
-                              bool avoid_collisions, moveit_msgs::MoveItErrorCodes& error_code)
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double step, double jump_threshold,
+                              const std::string& algorithm, moveit_msgs::RobotTrajectory& msg,
+                              const moveit_msgs::Constraints& path_constraints, bool avoid_collisions,
+                              moveit_msgs::MoveItErrorCodes& error_code)
   {
     moveit_msgs::GetCartesianPath::Request req;
     moveit_msgs::GetCartesianPath::Response res;
@@ -1471,16 +1473,18 @@ MoveItErrorCode MoveGroupInterface::place(const moveit_msgs::PlaceGoal& goal)
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
-                                                double jump_threshold, const std::string& algorithm, moveit_msgs::RobotTrajectory& trajectory,
-                                                bool avoid_collisions, moveit_msgs::MoveItErrorCodes* error_code)
+                                                double jump_threshold, const std::string& algorithm,
+                                                moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions,
+                                                moveit_msgs::MoveItErrorCodes* error_code)
 {
   moveit_msgs::Constraints path_constraints_tmp;
-  return computeCartesianPath(waypoints, eef_step, jump_threshold, algorithm, trajectory, path_constraints_tmp, avoid_collisions,
-                              error_code);
+  return computeCartesianPath(waypoints, eef_step, jump_threshold, algorithm, trajectory, path_constraints_tmp,
+                              avoid_collisions, error_code);
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
-                                                double jump_threshold, const std::string& algorithm, moveit_msgs::RobotTrajectory& trajectory,
+                                                double jump_threshold, const std::string& algorithm,
+                                                moveit_msgs::RobotTrajectory& trajectory,
                                                 const moveit_msgs::Constraints& path_constraints, bool avoid_collisions,
                                                 moveit_msgs::MoveItErrorCodes* error_code)
 {

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -845,7 +845,7 @@ public:
     req.waypoints = waypoints;
     req.max_step = step;
     req.jump_threshold = jump_threshold;
-    req.algorithm = algorithm
+    req.algorithm = algorithm;
     req.path_constraints = path_constraints;
     req.avoid_collisions = avoid_collisions;
     req.link_name = getEndEffectorLink();

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1471,28 +1471,28 @@ MoveItErrorCode MoveGroupInterface::place(const moveit_msgs::PlaceGoal& goal)
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
-                                                double jump_threshold, moveit_msgs::RobotTrajectory& trajectory,
+                                                double jump_threshold, const std::string& algorithm, moveit_msgs::RobotTrajectory& trajectory,
                                                 bool avoid_collisions, moveit_msgs::MoveItErrorCodes* error_code)
 {
   moveit_msgs::Constraints path_constraints_tmp;
-  return computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints_tmp, avoid_collisions,
+  return computeCartesianPath(waypoints, eef_step, jump_threshold, algorithm, trajectory, path_constraints_tmp, avoid_collisions,
                               error_code);
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
-                                                double jump_threshold, moveit_msgs::RobotTrajectory& trajectory,
+                                                double jump_threshold, const std::string& algorithm, moveit_msgs::RobotTrajectory& trajectory,
                                                 const moveit_msgs::Constraints& path_constraints, bool avoid_collisions,
                                                 moveit_msgs::MoveItErrorCodes* error_code)
 {
   if (error_code)
   {
-    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
+    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, algorithm, trajectory, path_constraints,
                                        avoid_collisions, *error_code);
   }
   else
   {
     moveit_msgs::MoveItErrorCodes error_code_tmp;
-    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
+    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, algorithm, trajectory, path_constraints,
                                        avoid_collisions, error_code_tmp);
   }
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -828,8 +828,7 @@ public:
     }
   }
 
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory& msg, const moveit_msgs::Constraints& path_constraints,
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double step, double jump_threshold,const std::string& algorithm, moveit_msgs::RobotTrajectory& msg, const moveit_msgs::Constraints& path_constraints,
                               bool avoid_collisions, moveit_msgs::MoveItErrorCodes& error_code)
   {
     moveit_msgs::GetCartesianPath::Request req;
@@ -846,6 +845,7 @@ public:
     req.waypoints = waypoints;
     req.max_step = step;
     req.jump_threshold = jump_threshold;
+    req.algorithm = algorithm
     req.path_constraints = path_constraints;
     req.avoid_collisions = avoid_collisions;
     req.link_name = getEndEffectorLink();

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -429,28 +429,32 @@ public:
   }
 
   bp::tuple computeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                       const std::string& algorithm,bool avoid_collisions)
+                                       const std::string& algorithm, bool avoid_collisions)
   {
     moveit_msgs::Constraints path_constraints_tmp;
-    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, algorithm, avoid_collisions, path_constraints_tmp);
+    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, algorithm, avoid_collisions,
+                                        path_constraints_tmp);
   }
 
   bp::tuple computeCartesianPathConstrainedPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                                  const std::string& algorithm, bool avoid_collisions, const std::string& path_constraints_str)
+                                                  const std::string& algorithm, bool avoid_collisions,
+                                                  const std::string& path_constraints_str)
   {
     moveit_msgs::Constraints path_constraints;
     py_bindings_tools::deserializeMsg(path_constraints_str, path_constraints);
-    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, algorithm, avoid_collisions, path_constraints);
+    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, algorithm, avoid_collisions,
+                                        path_constraints);
   }
 
   bp::tuple doComputeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                         const std::string& algorithm,bool avoid_collisions, const moveit_msgs::Constraints& path_constraints)
+                                         const std::string& algorithm, bool avoid_collisions,
+                                         const moveit_msgs::Constraints& path_constraints)
   {
     std::vector<geometry_msgs::Pose> poses;
     convertListToArrayOfPoses(waypoints, poses);
     moveit_msgs::RobotTrajectory trajectory;
-    double fraction =
-        computeCartesianPath(poses, eef_step, jump_threshold, algorithm, trajectory, path_constraints, avoid_collisions);
+    double fraction = computeCartesianPath(poses, eef_step, jump_threshold, algorithm, trajectory, path_constraints,
+                                           avoid_collisions);
     return bp::make_tuple(py_bindings_tools::serializeMsg(trajectory), fraction);
   }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -429,28 +429,28 @@ public:
   }
 
   bp::tuple computeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                       bool avoid_collisions)
+                                       const std::string& algorithm,bool avoid_collisions)
   {
     moveit_msgs::Constraints path_constraints_tmp;
-    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, avoid_collisions, path_constraints_tmp);
+    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, algorithm, avoid_collisions, path_constraints_tmp);
   }
 
   bp::tuple computeCartesianPathConstrainedPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                                  bool avoid_collisions, const std::string& path_constraints_str)
+                                                  const std::string& algorithm, bool avoid_collisions, const std::string& path_constraints_str)
   {
     moveit_msgs::Constraints path_constraints;
     py_bindings_tools::deserializeMsg(path_constraints_str, path_constraints);
-    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, avoid_collisions, path_constraints);
+    return doComputeCartesianPathPython(waypoints, eef_step, jump_threshold, algorithm, avoid_collisions, path_constraints);
   }
 
   bp::tuple doComputeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                         bool avoid_collisions, const moveit_msgs::Constraints& path_constraints)
+                                         const std::string& algorithm,bool avoid_collisions, const moveit_msgs::Constraints& path_constraints)
   {
     std::vector<geometry_msgs::Pose> poses;
     convertListToArrayOfPoses(waypoints, poses);
     moveit_msgs::RobotTrajectory trajectory;
     double fraction =
-        computeCartesianPath(poses, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
+        computeCartesianPath(poses, eef_step, jump_threshold, algorithm, trajectory, path_constraints, avoid_collisions);
     return bp::make_tuple(py_bindings_tools::serializeMsg(trajectory), fraction);
   }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -48,6 +48,8 @@
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
+#include "string"
+
 namespace moveit_rviz_plugin
 {
 void MotionPlanningFrame::planButtonClicked()
@@ -129,11 +131,12 @@ bool MotionPlanningFrame::computeCartesianPlan()
   double cart_step_size = 0.01;
   double cart_jump_thresh = 0.0;
   bool avoid_collisions = true;
+  std::string algorithm = "IterativeParabolicTimeParameterization";
 
   // compute trajectory
   moveit_msgs::RobotTrajectory trajectory;
   double fraction =
-      move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, trajectory, avoid_collisions);
+      move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, algorithm, trajectory, avoid_collisions);
 
   if (fraction >= 1.0)
   {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -135,8 +135,8 @@ bool MotionPlanningFrame::computeCartesianPlan()
 
   // compute trajectory
   moveit_msgs::RobotTrajectory trajectory;
-  double fraction =
-      move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, algorithm, trajectory, avoid_collisions);
+  double fraction = move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, algorithm,
+                                                      trajectory, avoid_collisions);
 
   if (fraction >= 1.0)
   {


### PR DESCRIPTION
### Description

This PR modifies the default cartesian path planning functionality of the moveit, allowing the user to specify the time parametrization method which is hard coded otherwise. The need for this functionality is reported in the   #[issue](https://github.com/ros-planning/moveit/issues/1708). In the issue referred, there was two possible approaches suggested to solve it. This PR deals with the second approach. And this method requires changes in the moveit_msgs package as well.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
