### PR TITLE
TrajectoryExecutionManager: protect access to execution_thread_

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -318,8 +318,8 @@ private:
   // thread used to execute trajectories using pushAndExecute()
   std::unique_ptr<boost::thread> continuous_execution_thread_;
 
-  boost::mutex execution_state_mutex_;
-  boost::mutex continuous_execution_mutex_;
+  boost::mutex execution_state_mutex_;       //< protect execution_complete_, active_handles_, execution_thread_
+  boost::mutex continuous_execution_mutex_;  //< protect continuous_execution_queue_
 
   boost::condition_variable continuous_execution_condition_;
 


### PR DESCRIPTION
As outlined in https://github.com/ros-planning/moveit/issues/1481#issuecomment-498731966
stopExecution() is accessed in parallel from several threads, all trying to join and reset
the execution_thread_. As the access was not correctly protected, this resulted in race
conditions and segfaults accessing a just released `execution_thread_`.

Fixes #1481.
Alternative to #1709: Instead of introducing yet another mutex, just reuse `execution_state_mutex_`, which protected the `execution_complete_` flag. As this flag is kind of synonymous to `execution_thread_ == nullptr`, reusing the same mutex makes sense to me.