### PR TITLE
remove opertunity for use after free

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_env_allvalid.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_env_allvalid.h
@@ -46,10 +46,10 @@ namespace collision_detection
 class CollisionEnvAllValid : public CollisionEnv
 {
 public:
-  CollisionEnvAllValid(const robot_model::RobotModelConstPtr& robot_model, double padding = 0.0, double scale = 1.0);
-  CollisionEnvAllValid(const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnvAllValid(const robot_model::RobotModelConstPtr robot_model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvAllValid(const robot_model::RobotModelConstPtr robot_model, const WorldPtr world, double padding = 0.0,
                        double scale = 1.0);
-  CollisionEnvAllValid(const CollisionEnv& other, const WorldPtr& world);
+  CollisionEnvAllValid(const CollisionEnv& other, const WorldPtr world);
 
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
                            const robot_state::RobotState& state) const override;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -247,7 +247,7 @@ struct DistanceRequest
   }
 
   /// Compute \e active_components_only_ based on \e req_
-  void enableGroup(const robot_model::RobotModelConstPtr& robot_model)
+  void enableGroup(const robot_model::RobotModelConstPtr robot_model)
   {
     if (robot_model->hasJointModelGroup(group_name))
       active_components_only = &robot_model->getJointModelGroup(group_name)->getUpdatedLinkModelsSet();

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -55,16 +55,16 @@ public:
   virtual const std::string& getName() const = 0;
 
   /** create a new CollisionWorld for checking collisions with the supplied world. */
-  virtual CollisionEnvPtr allocateEnv(const WorldPtr& world,
-                                      const robot_model::RobotModelConstPtr& robot_model) const = 0;
+  virtual CollisionEnvPtr allocateEnv(const WorldPtr world,
+                                      const robot_model::RobotModelConstPtr robot_model) const = 0;
 
   /** create a new CollisionWorld by copying an existing CollisionWorld of the same type.s
    * The world must be either the same world as used by \orig or a copy of that world which has not yet been modified.
    */
-  virtual CollisionEnvPtr allocateEnv(const CollisionEnvConstPtr& orig, const WorldPtr& world) const = 0;
+  virtual CollisionEnvPtr allocateEnv(const CollisionEnvConstPtr orig, const WorldPtr world) const = 0;
 
   /** create a new CollisionEnv given a robot_model with a new empty world */
-  virtual CollisionEnvPtr allocateEnv(const robot_model::RobotModelConstPtr& robot_model) const = 0;
+  virtual CollisionEnvPtr allocateEnv(const robot_model::RobotModelConstPtr robot_model) const = 0;
 };
 
 /** \brief Template class to make it easy to create an allocator for a specific CollisionWorld/CollisionRobot pair. */
@@ -77,17 +77,17 @@ public:
     return CollisionDetectorAllocatorType::NAME;
   }
 
-  CollisionEnvPtr allocateEnv(const WorldPtr& world, const robot_model::RobotModelConstPtr& robot_model) const override
+  CollisionEnvPtr allocateEnv(const WorldPtr world, const robot_model::RobotModelConstPtr robot_model) const override
   {
     return CollisionEnvPtr(new CollisionEnvType(robot_model, world));
   }
 
-  CollisionEnvPtr allocateEnv(const CollisionEnvConstPtr& orig, const WorldPtr& world) const override
+  CollisionEnvPtr allocateEnv(const CollisionEnvConstPtr orig, const WorldPtr world) const override
   {
     return CollisionEnvPtr(new CollisionEnvType(dynamic_cast<const CollisionEnvType&>(*orig), world));
   }
 
-  CollisionEnvPtr allocateEnv(const robot_model::RobotModelConstPtr& robot_model) const override
+  CollisionEnvPtr allocateEnv(const robot_model::RobotModelConstPtr robot_model) const override
   {
     return CollisionEnvPtr(new CollisionEnvType(robot_model));
   }

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -58,18 +58,18 @@ public:
    *  @param padding The padding to use for all objects/links on the robot
    *  @scale scale A common scaling to use for all objects/links on the robot
    */
-  CollisionEnv(const robot_model::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnv(const robot_model::RobotModelConstPtr model, double padding = 0.0, double scale = 1.0);
 
   /** @brief Constructor
    *  @param model A robot model to construct the collision robot from
    *  @param padding The padding to use for all objects/links on the robot
    *  @scale scale A common scaling to use for all objects/links on the robot
    */
-  CollisionEnv(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnv(const robot_model::RobotModelConstPtr model, const WorldPtr world, double padding = 0.0,
                double scale = 1.0);
 
   /** \brief Copy constructor */
-  CollisionEnv(const CollisionEnv& other, const WorldPtr& world);
+  CollisionEnv(const CollisionEnv& other, const WorldPtr world);
 
   virtual ~CollisionEnv()
   {
@@ -234,16 +234,16 @@ public:
   /** set the world to use.
    * This can be expensive unless the new and old world are empty.
    * Passing NULL will result in a new empty world being created. */
-  virtual void setWorld(const WorldPtr& world);
+  virtual void setWorld(const WorldPtr world);
 
   /** access the world geometry */
-  const WorldPtr& getWorld()
+  const WorldPtr getWorld()
   {
     return world_;
   }
 
   /** access the world geometry */
-  const WorldConstPtr& getWorld() const
+  const WorldConstPtr getWorld() const
   {
     return world_const_;
   }
@@ -252,7 +252,7 @@ public:
   typedef World::ObjectConstPtr ObjectConstPtr;
 
   /** @brief The kinematic model corresponding to this collision model*/
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_octomap_filter.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_octomap_filter.h
@@ -57,7 +57,7 @@ namespace collision_detection
  *  @param The iso-surface threshold value (0.5 is a reasonable default).
  *  @param The metaball radius, as a multiple of the octomap cell size (1.5 is a reasonable default)
  */
-int refineContactNormals(const World::ObjectConstPtr& object, CollisionResult& res,
+int refineContactNormals(const World::ObjectConstPtr object, CollisionResult& res,
                          double cell_bbx_search_distance = 1.0, double allowed_angle_divergence = 0.0,
                          bool estimate_depth = false, double iso_value = 0.5, double metaball_radius_multiple = 1.5);
 }

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
@@ -66,7 +66,7 @@ MOVEIT_CLASS_FORWARD(CollisionPlugin);
  *   class MyCollisionDetectionLoader : public CollisionPlugin
  *   {
  *   public:
- *     virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const
+ *     virtual bool initialize(const planning_scene::PlanningScenePtr scene, bool exclusive) const
  *     {
  *       scene->setActiveCollisionDetector(my_collision_checker::MyCollisionDetectorAllocator::create(), exclusive);
          return true;
@@ -87,7 +87,7 @@ public:
   /**
    * @brief This should be used to load your collision plugin.
    */
-  virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const = 0;
+  virtual bool initialize(const planning_scene::PlanningScenePtr scene, bool exclusive) const = 0;
 };
 
 }  // namespace collision_detection

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -171,11 +171,11 @@ public:
    * If the object already exists, this call will add the shape to the object
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
-  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose);
+  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr shape, const Eigen::Isometry3d& pose);
 
   /** \brief Update the pose of a shape in an object. Shape equality is
    * verified by comparing pointers. Returns true on success. */
-  bool moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
+  bool moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr shape,
                          const Eigen::Isometry3d& pose);
 
   /** \brief Move all shapes in an object according to the given transform specified in world frame */
@@ -187,7 +187,7 @@ public:
    * exist) if this was the last shape in the object.
    * Returns true on success and false if the object did not exist or did not
    * contain the shape. */
-  bool removeShapeFromObject(const std::string& object_id, const shapes::ShapeConstPtr& shape);
+  bool removeShapeFromObject(const std::string& object_id, const shapes::ShapeConstPtr shape);
 
   /** \brief Remove a particular object.
    * If there are no external pointers to the corresponding instance of
@@ -253,7 +253,7 @@ public:
     friend class World;
   };
 
-  typedef boost::function<void(const ObjectConstPtr&, Action)> ObserverCallbackFn;
+  typedef boost::function<void(const ObjectConstPtr, Action)> ObserverCallbackFn;
 
   /** \brief register a callback function for notification of changes.
    * \e callback will be called right after any change occurs to any Object.
@@ -270,7 +270,7 @@ public:
 
 private:
   /** notify all observers of a change */
-  void notify(const ObjectConstPtr&, Action);
+  void notify(const ObjectConstPtr, Action);
 
   /** send notification of change to all objects. */
   void notifyAll(Action action);
@@ -278,10 +278,10 @@ private:
   /** \brief Make sure that the object named \e id is known only to this
    * instance of the World. If the object is known outside of it, a
    * clone is made so that it can be safely modified later on. */
-  void ensureUnique(ObjectPtr& obj);
+  void ensureUnique(ObjectPtr obj);
 
   /* Add a shape with no checking */
-  virtual void addToObjectInternal(const ObjectPtr& obj, const shapes::ShapeConstPtr& shape,
+  virtual void addToObjectInternal(const ObjectPtr obj, const shapes::ShapeConstPtr shape,
                                    const Eigen::Isometry3d& pose);
 
   /** The objects maintained in the world */

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -53,7 +53,7 @@ public:
   WorldDiff();
 
   /** \brief Constructor */
-  WorldDiff(const WorldPtr& world);
+  WorldDiff(const WorldPtr world);
 
   /** \brief copy constructor. */
   WorldDiff(WorldDiff& other);
@@ -63,11 +63,11 @@ public:
   /** \brief Set which world to record.  Records all objects in old world (if
    * any) as DESTROYED and all objects in new world as CREATED and ADD_SHAPE
    * */
-  void setWorld(const WorldPtr& world);
+  void setWorld(const WorldPtr world);
 
   /** \brief Set which world to record.  Erases all previously recorded
    * changes.  */
-  void reset(const WorldPtr& world);
+  void reset(const WorldPtr world);
 
   /** \brief Turn off recording and erase all previously recorded changes. */
   void reset();
@@ -113,7 +113,7 @@ public:
 
 private:
   /** \brief Notification function */
-  void notify(const World::ObjectConstPtr&, World::Action);
+  void notify(const World::ObjectConstPtr, World::Action);
 
   /** keep changes in a map so they can be coalesced */
   std::map<std::string, World::Action> changes_;

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -152,7 +152,7 @@ struct CollisionData
   }
 
   /** \brief Compute \e active_components_only_ based on the joint group specified in \e req_ */
-  void enableGroup(const robot_model::RobotModelConstPtr& robot_model);
+  void enableGroup(const robot_model::RobotModelConstPtr robot_model);
 
   /** \brief The collision request passed by the user */
   const CollisionRequest* req_;
@@ -285,28 +285,28 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist);
 
 /** \brief Create new FCLGeometry object out of robot link model. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_model::LinkModel* link,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr shape, const robot_model::LinkModel* link,
                                             int shape_index);
 
 /** \brief Create new FCLGeometry object out of attached body. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_state::AttachedBody* ab,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr shape, const robot_state::AttachedBody* ab,
                                             int shape_index);
 
 /** \brief Create new FCLGeometry object out of a world object.
  *
  *  A world object always consists only of a single shape, therefore we don't need the \e shape_index. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const World::Object* obj);
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr shape, const World::Object* obj);
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of robot link model. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr shape, double scale, double padding,
                                             const robot_model::LinkModel* link, int shape_index);
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of an attached body. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr shape, double scale, double padding,
                                             const robot_state::AttachedBody* ab, int shape_index);
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of an world object. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr shape, double scale, double padding,
                                             const World::Object* obj);
 
 /** \brief Increases the counter of the caches which can trigger the cleaning of expired entries from them. */

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
@@ -44,6 +44,6 @@ namespace collision_detection
 class CollisionDetectorFCLPluginLoader : public CollisionPlugin
 {
 public:
-  virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const;
+  virtual bool initialize(const planning_scene::PlanningScenePtr scene, bool exclusive) const;
 };
 }

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -55,12 +55,12 @@ class CollisionEnvFCL : public CollisionEnv
 public:
   CollisionEnvFCL() = delete;
 
-  CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvFCL(const robot_model::RobotModelConstPtr model, double padding = 0.0, double scale = 1.0);
 
-  CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnvFCL(const robot_model::RobotModelConstPtr model, const WorldPtr world, double padding = 0.0,
                   double scale = 1.0);
 
-  CollisionEnvFCL(const CollisionEnvFCL& other, const WorldPtr& world);
+  CollisionEnvFCL(const CollisionEnvFCL& other, const WorldPtr world);
 
   ~CollisionEnvFCL() override;
 
@@ -92,7 +92,7 @@ public:
   virtual void distanceRobot(const DistanceRequest& req, DistanceResult& res,
                              const robot_state::RobotState& state) const override;
 
-  void setWorld(const WorldPtr& world) override;
+  void setWorld(const WorldPtr world) override;
 
 protected:
   /** \brief Updates the FCL collision geometry and objects saved in the CollisionRobotFCL members to reflect a new
@@ -156,7 +156,7 @@ protected:
 
 private:
   /** \brief Callback function executed for each change to the world environment */
-  void notifyObjectChange(const ObjectConstPtr& obj, World::Action action);
+  void notifyObjectChange(const ObjectConstPtr obj, World::Action action);
 
   World::ObserverHandle observer_handle_;
 };

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -165,7 +165,7 @@ struct DistanceFieldCacheEntry
   std::vector<std::vector<bool>> intra_group_collision_enabled_;
 };
 
-BodyDecompositionConstPtr getBodyDecompositionCacheEntry(const shapes::ShapeConstPtr& shape, double resolution);
+BodyDecompositionConstPtr getBodyDecompositionCacheEntry(const shapes::ShapeConstPtr shape, double resolution);
 
 PosedBodyPointDecompositionVectorPtr getCollisionObjectPointDecomposition(const collision_detection::World::Object& obj,
                                                                           double resolution);
@@ -176,6 +176,6 @@ PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const r
 PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const robot_state::AttachedBody* att,
                                                                        double resolution);
 
-void getBodySphereVisualizationMarkers(const GroupStateRepresentationPtr& gsr, const std::string& reference_frame,
+void getBodySphereVisualizationMarkers(const GroupStateRepresentationPtr gsr, const std::string& reference_frame,
                                        visualization_msgs::MarkerArray& body_marker_array);
 }

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -225,7 +225,7 @@ class BodyDecomposition
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  BodyDecomposition(const shapes::ShapeConstPtr& shape, double resolution, double padding = 0.01);
+  BodyDecomposition(const shapes::ShapeConstPtr shape, double resolution, double padding = 0.01);
 
   BodyDecomposition(const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& poses,
                     double resolution, double padding);
@@ -296,7 +296,7 @@ class PosedBodySphereDecomposition
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  PosedBodySphereDecomposition(const BodyDecompositionConstPtr& body_decomposition);
+  PosedBodySphereDecomposition(const BodyDecompositionConstPtr body_decomposition);
 
   const std::vector<CollisionSphere>& getCollisionSpheres() const
   {
@@ -343,9 +343,9 @@ class PosedBodyPointDecomposition
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  PosedBodyPointDecomposition(const BodyDecompositionConstPtr& body_decomposition);
+  PosedBodyPointDecomposition(const BodyDecompositionConstPtr body_decomposition);
 
-  PosedBodyPointDecomposition(const BodyDecompositionConstPtr& body_decomposition, const Eigen::Isometry3d& pose);
+  PosedBodyPointDecomposition(const BodyDecompositionConstPtr body_decomposition, const Eigen::Isometry3d& pose);
 
   PosedBodyPointDecomposition(const std::shared_ptr<const octomap::OcTree>& octree);
 
@@ -385,7 +385,7 @@ public:
     return sphere_radii_;
   }
 
-  void addToVector(PosedBodySphereDecompositionPtr& bd)
+  void addToVector(PosedBodySphereDecompositionPtr bd)
   {
     sphere_index_map_[decomp_vector_.size()] = collision_spheres_.size();
     decomp_vector_.push_back(bd);
@@ -454,7 +454,7 @@ public:
     return ret_points;
   }
 
-  void addToVector(PosedBodyPointDecompositionPtr& bd)
+  void addToVector(PosedBodyPointDecompositionPtr bd)
   {
     decomp_vector_.push_back(bd);
   }
@@ -505,8 +505,8 @@ struct ProximityInfo
   Eigen::Vector3d closest_gradient;
 };
 
-bool doBoundingSpheresIntersect(const PosedBodySphereDecompositionConstPtr& p1,
-                                const PosedBodySphereDecompositionConstPtr& p2);
+bool doBoundingSpheresIntersect(const PosedBodySphereDecompositionConstPtr p1,
+                                const PosedBodySphereDecompositionConstPtr p2);
 
 void getCollisionSphereMarkers(const std_msgs::ColorRGBA& color, const std::string& frame_id, const std::string& ns,
                                const ros::Duration& dur,

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -60,7 +60,7 @@ class CollisionEnvDistanceField : public CollisionEnv
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CollisionEnvDistanceField(const robot_model::RobotModelConstPtr& robot_model,
+  CollisionEnvDistanceField(const robot_model::RobotModelConstPtr robot_model,
                             const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                                 std::map<std::string, std::vector<CollisionSphere>>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
@@ -71,7 +71,7 @@ public:
                             double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                             double scale = 1.0);
 
-  CollisionEnvDistanceField(const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
+  CollisionEnvDistanceField(const robot_model::RobotModelConstPtr robot_model, const WorldPtr world,
                             const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                                 std::map<std::string, std::vector<CollisionSphere>>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
@@ -82,7 +82,7 @@ public:
                             double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                             double scale = 1.0);
 
-  CollisionEnvDistanceField(const CollisionEnvDistanceField& other, const WorldPtr& world);
+  CollisionEnvDistanceField(const CollisionEnvDistanceField& other, const WorldPtr world);
 
   void initialize(const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
                   const Eigen::Vector3d& size, const Eigen::Vector3d& origin, bool use_signed_distance_field,
@@ -92,7 +92,7 @@ public:
                           const moveit::core::RobotState& state) const override;
 
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          const moveit::core::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                          const moveit::core::RobotState& state, GroupStateRepresentationPtr gsr) const;
 
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                           const moveit::core::RobotState& state,
@@ -100,7 +100,7 @@ public:
 
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                           const moveit::core::RobotState& state, const collision_detection::AllowedCollisionMatrix& acm,
-                          GroupStateRepresentationPtr& gsr) const;
+                          GroupStateRepresentationPtr gsr) const;
 
   void createCollisionModelMarker(const moveit::core::RobotState& state,
                                   visualization_msgs::MarkerArray& model_markers) const;
@@ -148,26 +148,26 @@ public:
                       const robot_state::RobotState& state) const override;
 
   virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
-                              GroupStateRepresentationPtr& gsr) const;
+                              GroupStateRepresentationPtr gsr) const;
 
   void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
                       const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
-                              const AllowedCollisionMatrix& acm, GroupStateRepresentationPtr& gsr) const;
+                              const AllowedCollisionMatrix& acm, GroupStateRepresentationPtr gsr) const;
 
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
                            const robot_state::RobotState& state) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                                   const robot_state::RobotState& state, GroupStateRepresentationPtr gsr) const;
 
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
                            const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
                                    const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
-                                   GroupStateRepresentationPtr& gsr) const;
+                                   GroupStateRepresentationPtr gsr) const;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
                                    const robot_state::RobotState& state1, const robot_state::RobotState& state2,
@@ -194,7 +194,7 @@ public:
     ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
 
-  void setWorld(const WorldPtr& world) override;
+  void setWorld(const WorldPtr world) override;
 
   distance_field::DistanceFieldConstPtr getDistanceField() const
   {
@@ -207,33 +207,33 @@ public:
   }
 
   void getCollisionGradients(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
-                             const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
+                             const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr gsr) const;
 
   void getAllCollisions(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
-                        const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
+                        const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr gsr) const;
 
 protected:
-  bool getSelfProximityGradients(GroupStateRepresentationPtr& gsr) const;
+  bool getSelfProximityGradients(GroupStateRepresentationPtr gsr) const;
 
-  bool getIntraGroupProximityGradients(GroupStateRepresentationPtr& gsr) const;
+  bool getIntraGroupProximityGradients(GroupStateRepresentationPtr gsr) const;
 
   bool getSelfCollisions(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                         GroupStateRepresentationPtr& gsr) const;
+                         GroupStateRepresentationPtr gsr) const;
 
   bool getIntraGroupCollisions(const collision_detection::CollisionRequest& req,
-                               collision_detection::CollisionResult& res, GroupStateRepresentationPtr& gsr) const;
+                               collision_detection::CollisionResult& res, GroupStateRepresentationPtr gsr) const;
 
   void checkSelfCollisionHelper(const collision_detection::CollisionRequest& req,
                                 collision_detection::CollisionResult& res, const moveit::core::RobotState& state,
                                 const collision_detection::AllowedCollisionMatrix* acm,
-                                GroupStateRepresentationPtr& gsr) const;
+                                GroupStateRepresentationPtr gsr) const;
 
   void updateGroupStateRepresentationState(const moveit::core::RobotState& state,
-                                           GroupStateRepresentationPtr& gsr) const;
+                                           GroupStateRepresentationPtr gsr) const;
 
   void generateCollisionCheckingStructures(const std::string& group_name, const moveit::core::RobotState& state,
                                            const collision_detection::AllowedCollisionMatrix* acm,
-                                           GroupStateRepresentationPtr& gsr, bool generate_distance_field) const;
+                                           GroupStateRepresentationPtr gsr, bool generate_distance_field) const;
 
   DistanceFieldCacheEntryConstPtr
   getDistanceFieldCacheEntry(const std::string& group_name, const moveit::core::RobotState& state,
@@ -254,30 +254,30 @@ protected:
 
   PosedBodyPointDecompositionPtr getPosedLinkBodyPointDecomposition(const moveit::core::LinkModel* ls) const;
 
-  void getGroupStateRepresentation(const DistanceFieldCacheEntryConstPtr& dfce, const moveit::core::RobotState& state,
-                                   GroupStateRepresentationPtr& gsr) const;
+  void getGroupStateRepresentation(const DistanceFieldCacheEntryConstPtr dfce, const moveit::core::RobotState& state,
+                                   GroupStateRepresentationPtr gsr) const;
 
-  bool compareCacheEntryToState(const DistanceFieldCacheEntryConstPtr& dfce,
+  bool compareCacheEntryToState(const DistanceFieldCacheEntryConstPtr dfce,
                                 const moveit::core::RobotState& state) const;
 
-  bool compareCacheEntryToAllowedCollisionMatrix(const DistanceFieldCacheEntryConstPtr& dfce,
+  bool compareCacheEntryToAllowedCollisionMatrix(const DistanceFieldCacheEntryConstPtr dfce,
                                                  const collision_detection::AllowedCollisionMatrix& acm) const;
 
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override{};
 
   DistanceFieldCacheEntryWorldPtr generateDistanceFieldCacheEntryWorld();
 
-  void updateDistanceObject(const std::string& id, CollisionEnvDistanceField::DistanceFieldCacheEntryWorldPtr& dfce,
+  void updateDistanceObject(const std::string& id, CollisionEnvDistanceField::DistanceFieldCacheEntryWorldPtr dfce,
                             EigenSTL::vector_Vector3d& add_points, EigenSTL::vector_Vector3d& subtract_points);
 
   bool getEnvironmentCollisions(const CollisionRequest& req, CollisionResult& res,
-                                const distance_field::DistanceFieldConstPtr& env_distance_field,
-                                GroupStateRepresentationPtr& gsr) const;
+                                const distance_field::DistanceFieldConstPtr env_distance_field,
+                                GroupStateRepresentationPtr gsr) const;
 
-  bool getEnvironmentProximityGradients(const distance_field::DistanceFieldConstPtr& env_distance_field,
-                                        GroupStateRepresentationPtr& gsr) const;
+  bool getEnvironmentProximityGradients(const distance_field::DistanceFieldConstPtr env_distance_field,
+                                        GroupStateRepresentationPtr gsr) const;
 
-  static void notifyObjectChange(CollisionEnvDistanceField* self, const ObjectConstPtr& obj, World::Action action);
+  static void notifyObjectChange(CollisionEnvDistanceField* self, const ObjectConstPtr obj, World::Action action);
 
   Eigen::Vector3d size_;
   Eigen::Vector3d origin_;

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
@@ -52,7 +52,7 @@ class CollisionEnvHybrid : public collision_detection::CollisionEnvFCL
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CollisionEnvHybrid(const robot_model::RobotModelConstPtr& robot_model,
+  CollisionEnvHybrid(const robot_model::RobotModelConstPtr robot_model,
                      const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                          std::map<std::string, std::vector<CollisionSphere>>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
@@ -62,7 +62,7 @@ public:
                      double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                      double scale = 1.0);
 
-  CollisionEnvHybrid(const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
+  CollisionEnvHybrid(const robot_model::RobotModelConstPtr robot_model, const WorldPtr world,
                      const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                          std::map<std::string, std::vector<CollisionSphere>>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
@@ -72,7 +72,7 @@ public:
                      double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                      double scale = 1.0);
 
-  CollisionEnvHybrid(const CollisionEnvHybrid& other, const WorldPtr& world);
+  CollisionEnvHybrid(const CollisionEnvHybrid& other, const WorldPtr world);
 
   ~CollisionEnvHybrid() override
   {
@@ -93,7 +93,7 @@ public:
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                        collision_detection::CollisionResult& res, const robot_state::RobotState& state,
-                                       GroupStateRepresentationPtr& gsr) const;
+                                       GroupStateRepresentationPtr gsr) const;
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                        collision_detection::CollisionResult& res, const robot_state::RobotState& state,
@@ -102,7 +102,7 @@ public:
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                        collision_detection::CollisionResult& res, const robot_state::RobotState& state,
                                        const collision_detection::AllowedCollisionMatrix& acm,
-                                       GroupStateRepresentationPtr& gsr) const;
+                                       GroupStateRepresentationPtr gsr) const;
   const CollisionEnvDistanceFieldConstPtr getCollisionRobotDistanceField() const
   {
     return cenv_distance_;
@@ -112,35 +112,35 @@ public:
                                    const robot_state::RobotState& state) const;
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                                   const robot_state::RobotState& state, GroupStateRepresentationPtr gsr) const;
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
                                    const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const;
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
                                    const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
-                                   GroupStateRepresentationPtr& gsr) const;
+                                   GroupStateRepresentationPtr gsr) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
                                         const robot_state::RobotState& state) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                        const robot_state::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                                        const robot_state::RobotState& state, GroupStateRepresentationPtr gsr) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
                                         const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
                                         const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
-                                        GroupStateRepresentationPtr& gsr) const;
+                                        GroupStateRepresentationPtr gsr) const;
 
-  void setWorld(const WorldPtr& world) override;
+  void setWorld(const WorldPtr world) override;
 
   void getCollisionGradients(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
-                             const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
+                             const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr gsr) const;
 
   void getAllCollisions(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
-                        const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
+                        const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr gsr) const;
 
   const CollisionEnvDistanceFieldConstPtr getCollisionWorldDistanceField() const
   {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -72,7 +72,7 @@ public:
    * joint model group cannot be found in the kinematic model
    *
    */
-  ConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name);
+  ConstraintSampler(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name);
 
   virtual ~ConstraintSampler()
   {
@@ -115,7 +115,7 @@ public:
    *
    * @return The planning scene as a const ptr
    */
-  const planning_scene::PlanningSceneConstPtr& getPlanningScene() const
+  const planning_scene::PlanningSceneConstPtr getPlanningScene() const
   {
     return scene_;
   }

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
@@ -54,10 +54,10 @@ public:
   {
   }
 
-  virtual ConstraintSamplerPtr alloc(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
+  virtual ConstraintSamplerPtr alloc(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name,
                                      const moveit_msgs::Constraints& constr) = 0;
 
-  virtual bool canService(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
+  virtual bool canService(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name,
                           const moveit_msgs::Constraints& constr) const = 0;
 };
 }

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -68,7 +68,7 @@ public:
    *
    * @param sa The constraint sampler allocator that will be used
    */
-  void registerSamplerAllocator(const ConstraintSamplerAllocatorPtr& sa)
+  void registerSamplerAllocator(const ConstraintSamplerAllocatorPtr sa)
   {
     sampler_alloc_.push_back(sa);
   }
@@ -88,7 +88,7 @@ public:
    * @return An allocated ConstraintSamplerPtr,
    * or an empty pointer if none could be allocated
    */
-  ConstraintSamplerPtr selectSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
+  ConstraintSamplerPtr selectSampler(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name,
                                      const moveit_msgs::Constraints& constr) const;
 
   /**
@@ -134,7 +134,7 @@ public:
    * @return A valid \ref ConstraintSamplerPtr if one could be allocated, and otherwise an empty \ref
    *ConstraintSamplerPtr
    */
-  static ConstraintSamplerPtr selectDefaultSampler(const planning_scene::PlanningSceneConstPtr& scene,
+  static ConstraintSamplerPtr selectDefaultSampler(const planning_scene::PlanningSceneConstPtr scene,
                                                    const std::string& group_name,
                                                    const moveit_msgs::Constraints& constr);
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
@@ -41,16 +41,16 @@
 
 namespace constraint_samplers
 {
-void visualizeDistribution(const ConstraintSamplerPtr& sampler, const robot_state::RobotState& reference_state,
+void visualizeDistribution(const ConstraintSamplerPtr sampler, const robot_state::RobotState& reference_state,
                            const std::string& link_name, unsigned int sample_count,
                            visualization_msgs::MarkerArray& markers);
 
-void visualizeDistribution(const moveit_msgs::Constraints& constr, const planning_scene::PlanningSceneConstPtr& scene,
+void visualizeDistribution(const moveit_msgs::Constraints& constr, const planning_scene::PlanningSceneConstPtr scene,
                            const std::string& group, const std::string& link_name, unsigned int sample_count,
                            visualization_msgs::MarkerArray& markers);
 
-double countSamplesPerSecond(const ConstraintSamplerPtr& sampler, const robot_state::RobotState& reference_state);
+double countSamplesPerSecond(const ConstraintSamplerPtr sampler, const robot_state::RobotState& reference_state);
 
-double countSamplesPerSecond(const moveit_msgs::Constraints& constr, const planning_scene::PlanningSceneConstPtr& scene,
+double countSamplesPerSecond(const moveit_msgs::Constraints& constr, const planning_scene::PlanningSceneConstPtr scene,
                              const std::string& group);
 }

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -66,7 +66,7 @@ public:
    * joint model group cannot be found in the kinematic model
    *
    */
-  JointConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
+  JointConstraintSampler(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
   {
   }
@@ -251,7 +251,7 @@ struct IKSamplingPose
    *
    * @return
    */
-  IKSamplingPose(const kinematic_constraints::PositionConstraintPtr& pc);
+  IKSamplingPose(const kinematic_constraints::PositionConstraintPtr pc);
 
   /**
    * \brief Constructor that takes a pointer to a orientation constraint.
@@ -260,7 +260,7 @@ struct IKSamplingPose
    *
    * @return
    */
-  IKSamplingPose(const kinematic_constraints::OrientationConstraintPtr& oc);
+  IKSamplingPose(const kinematic_constraints::OrientationConstraintPtr oc);
 
   /**
    * \brief Constructor that takes a pointer to both position and orientation constraints.
@@ -270,8 +270,8 @@ struct IKSamplingPose
    *
    * @return
    */
-  IKSamplingPose(const kinematic_constraints::PositionConstraintPtr& pc,
-                 const kinematic_constraints::OrientationConstraintPtr& oc);
+  IKSamplingPose(const kinematic_constraints::PositionConstraintPtr pc,
+                 const kinematic_constraints::OrientationConstraintPtr oc);
 
   kinematic_constraints::PositionConstraintPtr position_constraint_; /**< \brief Holds the position constraint for
                                                                         sampling */
@@ -302,7 +302,7 @@ public:
    * joint model group cannot be found in the kinematic model
    *
    */
-  IKConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
+  IKConstraintSampler(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
   {
   }
@@ -386,7 +386,7 @@ public:
    *
    * @return The position constraint, or an empty shared_ptr if none has been specified
    */
-  const kinematic_constraints::PositionConstraintPtr& getPositionConstraint() const
+  const kinematic_constraints::PositionConstraintPtr getPositionConstraint() const
   {
     return sampling_pose_.position_constraint_;
   }
@@ -396,7 +396,7 @@ public:
    *
    * @return The orientation constraint, or an empty shared_ptr if none has been specified
    */
-  const kinematic_constraints::OrientationConstraintPtr& getOrientationConstraint() const
+  const kinematic_constraints::OrientationConstraintPtr getOrientationConstraint() const
   {
     return sampling_pose_.orientation_constraint_;
   }

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -94,7 +94,7 @@ public:
    *
    * @return
    */
-  UnionConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
+  UnionConstraintSampler(const planning_scene::PlanningSceneConstPtr scene, const std::string& group_name,
                          const std::vector<ConstraintSamplerPtr>& samplers);
 
   /**

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -167,7 +167,7 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 private:
-  void addJointToChainInfo(const urdf::JointConstSharedPtr& joint, moveit_msgs::KinematicSolverInfo& info);
+  void addJointToChainInfo(const urdf::JointConstSharedPtr joint, moveit_msgs::KinematicSolverInfo& info);
 
   bool checkJointLimits(const std::vector<double>& joint_values) const;
 

--- a/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
+++ b/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
@@ -66,7 +66,7 @@ public:
    * @param group_name The name of the group to compute stuff for
    * @return False if initialization failed
    */
-  DynamicsSolver(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
+  DynamicsSolver(const robot_model::RobotModelConstPtr robot_model, const std::string& group_name,
                  const geometry_msgs::Vector3& gravity_vector);
 
   /**
@@ -124,7 +124,7 @@ public:
    * @brief Get the kinematic model
    * @return kinematic model
    */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -92,7 +92,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  KinematicConstraint(const robot_model::RobotModelConstPtr& model);
+  KinematicConstraint(const robot_model::RobotModelConstPtr model);
   virtual ~KinematicConstraint();
 
   /** \brief Clear the stored constraint */
@@ -166,7 +166,7 @@ public:
    *
    * @return The kinematic model associated with this constraint
    */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -207,7 +207,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  JointConstraint(const robot_model::RobotModelConstPtr& model)
+  JointConstraint(const robot_model::RobotModelConstPtr model)
     : KinematicConstraint(model), joint_model_(NULL), joint_variable_index_(-1)
   {
     type_ = JOINT_CONSTRAINT;
@@ -355,7 +355,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  OrientationConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  OrientationConstraint(const robot_model::RobotModelConstPtr model) : KinematicConstraint(model), link_model_(NULL)
   {
     type_ = ORIENTATION_CONSTRAINT;
   }
@@ -512,7 +512,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  PositionConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  PositionConstraint(const robot_model::RobotModelConstPtr model) : KinematicConstraint(model), link_model_(NULL)
   {
     type_ = POSITION_CONSTRAINT;
   }
@@ -757,7 +757,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  VisibilityConstraint(const robot_model::RobotModelConstPtr& model);
+  VisibilityConstraint(const robot_model::RobotModelConstPtr model);
 
   /**
    * \brief Configure the constraint based on a
@@ -868,7 +868,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  KinematicConstraintSet(const robot_model::RobotModelConstPtr& model) : robot_model_(model)
+  KinematicConstraintSet(const robot_model::RobotModelConstPtr model) : robot_model_(model)
   {
   }
 

--- a/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
+++ b/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
@@ -52,7 +52,7 @@ class KinematicsMetrics
 {
 public:
   /** \brief Construct a KinematicsMetricss from a RobotModel */
-  KinematicsMetrics(const robot_model::RobotModelConstPtr& robot_model)
+  KinematicsMetrics(const robot_model::RobotModelConstPtr robot_model)
     : robot_model_(robot_model), penalty_multiplier_(0.0)
   {
   }

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -98,7 +98,7 @@ public:
   }
 
   /** \brief Get the planning scene associated to this planning context */
-  const planning_scene::PlanningSceneConstPtr& getPlanningScene() const
+  const planning_scene::PlanningSceneConstPtr getPlanningScene() const
   {
     return planning_scene_;
   }
@@ -110,7 +110,7 @@ public:
   }
 
   /** \brief Set the planning scene for this context */
-  void setPlanningScene(const planning_scene::PlanningSceneConstPtr& planning_scene);
+  void setPlanningScene(const planning_scene::PlanningSceneConstPtr planning_scene);
 
   /** \brief Set the planning request for this context */
   void setMotionPlanRequest(const MotionPlanRequest& request);
@@ -163,7 +163,7 @@ public:
   /// It is assumed that motion plans will be computed for the robot described by \e model and that any exposed ROS
   /// functionality
   /// or required ROS parameters are namespaced by \e ns
-  virtual bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& ns);
+  virtual bool initialize(const robot_model::RobotModelConstPtr model, const std::string& ns);
 
   /// Get \brief a short string that identifies the planning interface
   virtual std::string getDescription() const;
@@ -179,12 +179,12 @@ public:
   /// \param planning_scene A const planning scene to use for planning
   /// \param req The representation of the planning request
   /// \param error_code This is where the error is set if constructing the planning context fails
-  virtual PlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  virtual PlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr planning_scene,
                                                 const MotionPlanRequest& req,
                                                 moveit_msgs::MoveItErrorCodes& error_code) const = 0;
 
   /// \brief Calls the function above but ignores the error_code
-  PlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  PlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr planning_scene,
                                         const MotionPlanRequest& req) const;
 
   /// \brief Determine whether this plugin instance is able to represent this planning request

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -49,7 +49,7 @@ MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);
 class PlanningRequestAdapter
 {
 public:
-  typedef boost::function<bool(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  typedef boost::function<bool(const planning_scene::PlanningSceneConstPtr planning_scene,
                                const planning_interface::MotionPlanRequest& req,
                                planning_interface::MotionPlanResponse& res)>
       PlannerFn;
@@ -72,13 +72,13 @@ public:
     return "";
   }
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool adaptAndPlan(const planning_interface::PlannerManagerPtr planner,
+                    const planning_scene::PlanningSceneConstPtr planning_scene,
                     const planning_interface::MotionPlanRequest& req,
                     planning_interface::MotionPlanResponse& res) const;
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool adaptAndPlan(const planning_interface::PlannerManagerPtr planner,
+                    const planning_scene::PlanningSceneConstPtr planning_scene,
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& added_path_index) const;
 
@@ -87,7 +87,7 @@ public:
       needed. If the response is changed, the index values of the
       states added without planning are added to \e
       added_path_index */
-  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr planning_scene,
                             const planning_interface::MotionPlanRequest& req,
                             planning_interface::MotionPlanResponse& res,
                             std::vector<std::size_t>& added_path_index) const = 0;
@@ -101,18 +101,18 @@ public:
   {
   }
 
-  void addAdapter(const PlanningRequestAdapterConstPtr& adapter)
+  void addAdapter(const PlanningRequestAdapterConstPtr adapter)
   {
     adapters_.push_back(adapter);
   }
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool adaptAndPlan(const planning_interface::PlannerManagerPtr planner,
+                    const planning_scene::PlanningSceneConstPtr planning_scene,
                     const planning_interface::MotionPlanRequest& req,
                     planning_interface::MotionPlanResponse& res) const;
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool adaptAndPlan(const planning_interface::PlannerManagerPtr planner,
+                    const planning_scene::PlanningSceneConstPtr planning_scene,
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& added_path_index) const;
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -89,14 +89,14 @@ class PlanningScene : private boost::noncopyable, public std::enable_shared_from
 public:
   /** \brief construct using an existing RobotModel */
   PlanningScene(
-      const robot_model::RobotModelConstPtr& robot_model,
-      const collision_detection::WorldPtr& world = collision_detection::WorldPtr(new collision_detection::World()));
+      const robot_model::RobotModelConstPtr robot_model,
+      const collision_detection::WorldPtr world = collision_detection::WorldPtr(new collision_detection::World()));
 
   /** \brief construct using a urdf and srdf.
    * A RobotModel for the PlanningScene will be created using the urdf and srdf. */
   PlanningScene(
-      const urdf::ModelInterfaceSharedPtr& urdf_model, const srdf::ModelConstSharedPtr& srdf_model,
-      const collision_detection::WorldPtr& world = collision_detection::WorldPtr(new collision_detection::World()));
+      const urdf::ModelInterfaceSharedPtr urdf_model, const srdf::ModelConstSharedPtr srdf_model,
+      const collision_detection::WorldPtr world = collision_detection::WorldPtr(new collision_detection::World()));
 
   static const std::string OCTOMAP_NS;
   static const std::string DEFAULT_SCENE_NAME;
@@ -132,13 +132,13 @@ public:
   PlanningScenePtr diff(const moveit_msgs::PlanningScene& msg) const;
 
   /** \brief Get the parent scene (whith respect to which the diffs are maintained). This may be empty */
-  const PlanningSceneConstPtr& getParent() const
+  const PlanningSceneConstPtr getParent() const
   {
     return parent_;
   }
 
   /** \brief Get the kinematic model for which the planning scene is maintained */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     // the kinematic model does not change
     return robot_model_;
@@ -249,7 +249,7 @@ public:
    *   planning_scene->addCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
    *
    * */
-  void addCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator);
+  void addCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr allocator);
 
   /** \brief Set the type of collision detector to use.
    * Calls addCollisionDetector() to add it if it has not already been added.
@@ -260,7 +260,7 @@ public:
    * example: to use FCL collision call
    *   planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
    */
-  void setActiveCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+  void setActiveCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr allocator,
                                   bool exclusive = false);
 
   /** \brief Set the type of collision detector to use.
@@ -281,44 +281,44 @@ public:
   void getCollisionDetectorNames(std::vector<std::string>& names) const;
 
   /** \brief Get the representation of the world */
-  const collision_detection::WorldConstPtr& getWorld() const
+  const collision_detection::WorldConstPtr getWorld() const
   {
     // we always have a world representation
     return world_const_;
   }
 
   // brief Get the representation of the world
-  const collision_detection::WorldPtr& getWorldNonConst()
+  const collision_detection::WorldPtr getWorldNonConst()
   {
     // we always have a world representation
     return world_;
   }
 
   /** \brief Get the active collision environment */
-  const collision_detection::CollisionEnvConstPtr& getCollisionEnv() const
+  const collision_detection::CollisionEnvConstPtr getCollisionEnv() const
   {
     return active_collision_->getCollisionEnv();
   }
 
   /** \brief Get the active collision detector for the robot */
-  const collision_detection::CollisionEnvConstPtr& getCollisionEnvUnpadded() const
+  const collision_detection::CollisionEnvConstPtr getCollisionEnvUnpadded() const
   {
     return active_collision_->getCollisionEnvUnpadded();
   }
 
   /** \brief Get a specific collision detector for the world.  If not found return active CollisionWorld. */
-  const collision_detection::CollisionEnvConstPtr& getCollisionEnv(const std::string& collision_detector_name) const;
+  const collision_detection::CollisionEnvConstPtr getCollisionEnv(const std::string& collision_detector_name) const;
 
   /** \brief Get a specific collision detector for the unpadded robot.  If no found return active unpadded
    * CollisionRobot. */
-  const collision_detection::CollisionEnvConstPtr&
+  const collision_detection::CollisionEnvConstPtr
   getCollisionEnvUnpadded(const std::string& collision_detector_name) const;
 
   /** \brief Get the representation of the collision robot
    * This can be used to set padding and link scale on the active collision_robot.
    * NOTE: After modifying padding and scale on the active robot call
    * propogateRobotPadding() to copy it to all the other collision detectors. */
-  const collision_detection::CollisionEnvPtr& getCollisionEnvNonConst();
+  const collision_detection::CollisionEnvPtr getCollisionEnvNonConst();
 
   /** \brief Copy scale and padding from active CollisionRobot to other CollisionRobots.
    * This should be called after any changes are made to the scale or padding of the active
@@ -782,7 +782,7 @@ public:
   /** \brief If there is a parent specified for this scene, then the diffs with respect to that parent are applied to a
      specified planning scene, whatever
       that scene may be. If there is no parent specified, this function is a no-op. */
-  void pushDiffs(const PlanningScenePtr& scene);
+  void pushDiffs(const PlanningScenePtr scene);
 
   /** \brief Make sure that all the data maintained in this
       scene is local. All unmodified data is copied from the
@@ -954,19 +954,19 @@ public:
   [[deprecated("Use moveit/utils/message_checks.h instead")]] static bool isEmpty(const moveit_msgs::RobotState& msg);
 
   /** \brief Clone a planning scene. Even if the scene \e scene depends on a parent, the cloned scene will not. */
-  static PlanningScenePtr clone(const PlanningSceneConstPtr& scene);
+  static PlanningScenePtr clone(const PlanningSceneConstPtr scene);
 
 private:
   /* Private constructor used by the diff() methods. */
-  PlanningScene(const PlanningSceneConstPtr& parent);
+  PlanningScene(const PlanningSceneConstPtr parent);
 
   /* Initialize the scene.  This should only be called by the constructors.
    * Requires a valid robot_model_ */
   void initialize();
 
   /* helper function to create a RobotModel from a urdf/srdf. */
-  static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
-                                                     const srdf::ModelConstSharedPtr& srdf_model);
+  static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr urdf_model,
+                                                     const srdf::ModelConstSharedPtr srdf_model);
 
   /* Helper functions for processing collision objects */
   bool processCollisionObjectAdd(const moveit_msgs::CollisionObject& object);
@@ -990,11 +990,11 @@ private:
 
     CollisionDetectorConstPtr parent_;  // may be NULL
 
-    const collision_detection::CollisionEnvConstPtr& getCollisionEnv() const
+    const collision_detection::CollisionEnvConstPtr getCollisionEnv() const
     {
       return cenv_const_ ? cenv_const_ : parent_->getCollisionEnv();
     }
-    const collision_detection::CollisionEnvConstPtr& getCollisionEnvUnpadded() const
+    const collision_detection::CollisionEnvConstPtr getCollisionEnvUnpadded() const
     {
       return cenv_unpadded_const_ ? cenv_unpadded_const_ : parent_->getCollisionEnvUnpadded();
     }

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -531,7 +531,7 @@ public:
     return group_kinematics_.first.solver_instance_;
   }
 
-  const kinematics::KinematicsBasePtr& getSolverInstance()
+  const kinematics::KinematicsBasePtr getSolverInstance()
   {
     return group_kinematics_.first.solver_instance_;
   }

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -67,7 +67,7 @@ class RobotModel
 {
 public:
   /** \brief Construct a kinematic model from a parsed description and a list of planning groups */
-  RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model, const srdf::ModelConstSharedPtr& srdf_model);
+  RobotModel(const urdf::ModelInterfaceSharedPtr urdf_model, const srdf::ModelConstSharedPtr srdf_model);
 
   /** \brief Destructor. Clear all memory. */
   ~RobotModel();
@@ -94,13 +94,13 @@ public:
   }
 
   /** \brief Get the parsed URDF model */
-  const urdf::ModelInterfaceSharedPtr& getURDF() const
+  const urdf::ModelInterfaceSharedPtr getURDF() const
   {
     return urdf_;
   }
 
   /** \brief Get the parsed SRDF model */
-  const srdf::ModelConstSharedPtr& getSRDF() const
+  const srdf::ModelConstSharedPtr getSRDF() const
   {
     return srdf_;
   }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -85,7 +85,7 @@ class RobotState
 public:
   /** \brief A state can be constructed from a specified robot model. No values are initialized.
       Call setToDefaultValues() if a state needs to provide valid information. */
-  RobotState(const RobotModelConstPtr& robot_model);
+  RobotState(const RobotModelConstPtr robot_model);
   ~RobotState();
 
   /** \brief Copy constructor. */
@@ -95,7 +95,7 @@ public:
   RobotState& operator=(const RobotState& other);
 
   /** \brief Get the robot model this state is constructed for. */
-  const RobotModelConstPtr& getRobotModel() const
+  const RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -896,7 +896,7 @@ as the new values that correspond to the group */
    * @param solver - a kin solver whose base frame is important to us
    * @return true if no error
    */
-  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
+  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr solver);
 
   /**
    * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -52,11 +52,11 @@ MOVEIT_CLASS_FORWARD(RobotTrajectory);
 class RobotTrajectory
 {
 public:
-  RobotTrajectory(const robot_model::RobotModelConstPtr& robot_model, const std::string& group);
+  RobotTrajectory(const robot_model::RobotModelConstPtr robot_model, const std::string& group);
 
-  RobotTrajectory(const robot_model::RobotModelConstPtr& robot_model, const robot_model::JointModelGroup* group);
+  RobotTrajectory(const robot_model::RobotModelConstPtr robot_model, const robot_model::JointModelGroup* group);
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -90,17 +90,17 @@ public:
     return *waypoints_.front();
   }
 
-  robot_state::RobotStatePtr& getWayPointPtr(std::size_t index)
+  robot_state::RobotStatePtr getWayPointPtr(std::size_t index)
   {
     return waypoints_[index];
   }
 
-  robot_state::RobotStatePtr& getLastWayPointPtr()
+  robot_state::RobotStatePtr getLastWayPointPtr()
   {
     return waypoints_.back();
   }
 
-  robot_state::RobotStatePtr& getFirstWayPointPtr()
+  robot_state::RobotStatePtr getFirstWayPointPtr()
   {
     return waypoints_.front();
   }
@@ -153,7 +153,7 @@ public:
    * \param state - current robot state
    * \param dt - duration from previous
    */
-  void addSuffixWayPoint(const robot_state::RobotStatePtr& state, double dt)
+  void addSuffixWayPoint(const robot_state::RobotStatePtr state, double dt)
   {
     state->update();
     waypoints_.push_back(state);
@@ -165,7 +165,7 @@ public:
     addPrefixWayPoint(robot_state::RobotStatePtr(new robot_state::RobotState(state)), dt);
   }
 
-  void addPrefixWayPoint(const robot_state::RobotStatePtr& state, double dt)
+  void addPrefixWayPoint(const robot_state::RobotStatePtr state, double dt)
   {
     state->update();
     waypoints_.push_front(state);
@@ -177,7 +177,7 @@ public:
     insertWayPoint(index, robot_state::RobotStatePtr(new robot_state::RobotState(state)), dt);
   }
 
-  void insertWayPoint(std::size_t index, const robot_state::RobotStatePtr& state, double dt)
+  void insertWayPoint(std::size_t index, const robot_state::RobotStatePtr state, double dt)
   {
     state->update();
     waypoints_.insert(waypoints_.begin() + index, state);
@@ -255,7 +255,7 @@ public:
    *  @param The resulting robot state.
    *  @return True if state is valid, false otherwise (trajectory is empty).
    */
-  bool getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr& output_state) const;
+  bool getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr output_state) const;
 
 private:
   robot_model::RobotModelConstPtr robot_model_;

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -180,10 +180,10 @@ public:
 
 private:
   /** \brief Adds different collision geometries to a link. */
-  void addLinkCollision(const std::string& link_name, const urdf::CollisionSharedPtr& coll, geometry_msgs::Pose origin);
+  void addLinkCollision(const std::string& link_name, const urdf::CollisionSharedPtr coll, geometry_msgs::Pose origin);
 
   /** \brief Adds different visual geometries to a link. */
-  void addLinkVisual(const std::string& link_name, const urdf::VisualSharedPtr& vis, geometry_msgs::Pose origin);
+  void addLinkVisual(const std::string& link_name, const urdf::VisualSharedPtr vis, geometry_msgs::Pose origin);
 
   /// The URDF model, holds all of the URDF components of the robot added so far.
   urdf::ModelInterfaceSharedPtr urdf_model_;

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_distance_field_ros_helpers.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_distance_field_ros_helpers.h
@@ -43,7 +43,7 @@
 namespace collision_detection
 {
 static inline bool loadLinkBodySphereDecompositions(
-    ros::NodeHandle& nh, const planning_models::RobotModelConstPtr& robot_model,
+    ros::NodeHandle& nh, const planning_models::RobotModelConstPtr robot_model,
     std::map<std::string, std::vector<collision_detection::CollisionSphere> >& link_body_spheres)
 {
   if (!nh.hasParam("link_spheres"))

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_robot_distance_field_ros.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_robot_distance_field_ros.h
@@ -45,7 +45,7 @@ namespace collision_detection
 class CollisionRobotDistanceFieldROS : public CollisionRobotDistanceField
 {
 public:
-  CollisionRobotDistanceFieldROS(const planning_models::RobotModelConstPtr& robot_model, double size_x = DEFAULT_SIZE_X,
+  CollisionRobotDistanceFieldROS(const planning_models::RobotModelConstPtr robot_model, double size_x = DEFAULT_SIZE_X,
                                  double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
                                  bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                                  double resolution = DEFAULT_RESOLUTION,

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/hybrid_collision_robot_ros.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/hybrid_collision_robot_ros.h
@@ -45,7 +45,7 @@ namespace collision_detection
 class CollisionRobotHybridROS : public CollisionRobotHybrid
 {
 public:
-  CollisionRobotHybridROS(const planning_models::RobotModelConstPtr& robot_model, double size_x = DEFAULT_SIZE_X,
+  CollisionRobotHybridROS(const planning_models::RobotModelConstPtr robot_model, double size_x = DEFAULT_SIZE_X,
                           double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
                           bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
                           double resolution = DEFAULT_RESOLUTION,

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
@@ -102,8 +102,8 @@ public:
    *  @param opt Parameters needed for defining the cache workspace
    *  @return False if any error occured during initialization
    */
-  bool initialize(kinematics::KinematicsBaseConstPtr solver,
-                  const planning_models::RobotModelConstPtr kinematic_model, const KinematicsCache::Options& opt);
+  bool initialize(kinematics::KinematicsBaseConstPtr solver, const planning_models::RobotModelConstPtr kinematic_model,
+                  const KinematicsCache::Options& opt);
 
   /** @brief Return the instance of the kinematics solver */
   const kinematics::KinematicsBaseConstPtr getSolverInstance() const

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
@@ -102,17 +102,17 @@ public:
    *  @param opt Parameters needed for defining the cache workspace
    *  @return False if any error occured during initialization
    */
-  bool initialize(kinematics::KinematicsBaseConstPtr& solver,
-                  const planning_models::RobotModelConstPtr& kinematic_model, const KinematicsCache::Options& opt);
+  bool initialize(kinematics::KinematicsBaseConstPtr solver,
+                  const planning_models::RobotModelConstPtr kinematic_model, const KinematicsCache::Options& opt);
 
   /** @brief Return the instance of the kinematics solver */
-  const kinematics::KinematicsBaseConstPtr& getSolverInstance() const
+  const kinematics::KinematicsBaseConstPtr getSolverInstance() const
   {
     return kinematics_solver_;
   }
 
   /** @brief Return the instance of the kinematics model */
-  const planning_models::RobotModelConstPtr& getModelInstance() const
+  const planning_models::RobotModelConstPtr getModelInstance() const
   {
     return kinematic_model_;
   }

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
@@ -102,17 +102,17 @@ public:
    *  @param opt Parameters needed for defining the cache workspace
    *  @return False if any error occured during initialization
    */
-  bool initialize(kinematics::KinematicsBaseConstPtr& solver, const robot_model::RobotModelConstPtr& kinematic_model,
+  bool initialize(kinematics::KinematicsBaseConstPtr solver, const robot_model::RobotModelConstPtr kinematic_model,
                   const KinematicsCache::Options& opt);
 
   /** @brief Return the instance of the kinematics solver */
-  const kinematics::KinematicsBaseConstPtr& getSolverInstance() const
+  const kinematics::KinematicsBaseConstPtr getSolverInstance() const
   {
     return kinematics_solver_;
   }
 
   /** @brief Return the instance of the kinematics model */
-  const robot_model::RobotModelConstPtr& getModelInstance() const
+  const robot_model::RobotModelConstPtr getModelInstance() const
   {
     return kinematic_model_;
   }

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
@@ -74,7 +74,7 @@ public:
    * @param group_name The name of the group to configure this solver for
    * @return False if any error occurs
    */
-  KinematicsConstraintAware(const robot_model::RobotModelConstPtr& kinematic_model, const std::string& group_name);
+  KinematicsConstraintAware(const robot_model::RobotModelConstPtr kinematic_model, const std::string& group_name);
 
   /** @brief Solve the planning problem
    * @param planning_scene A const reference to the planning scene
@@ -82,7 +82,7 @@ public:
    * @param response The solution (if it exists)
    * @return False if group_name is invalid or ik fails
    */
-  bool getIK(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool getIK(const planning_scene::PlanningSceneConstPtr planning_scene,
              const kinematics_constraint_aware::KinematicsRequest& request,
              kinematics_constraint_aware::KinematicsResponse& response) const;
 
@@ -92,7 +92,7 @@ public:
    * @param response The solution (if it exists)
    * @return False if group_name is invalid or ik fails
    */
-  bool getIK(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool getIK(const planning_scene::PlanningSceneConstPtr planning_scene,
              const moveit_msgs::GetConstraintAwarePositionIK::Request& request,
              moveit_msgs::GetConstraintAwarePositionIK::Response& response) const;
 
@@ -101,27 +101,27 @@ public:
     return group_name_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return kinematic_model_;
   }
 
 private:
-  EigenSTL::vector_Isometry3d transformPoses(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  EigenSTL::vector_Isometry3d transformPoses(const planning_scene::PlanningSceneConstPtr planning_scene,
                                              const robot_state::RobotState& kinematic_state,
                                              const std::vector<geometry_msgs::PoseStamped>& poses,
                                              const std::string& target_frame) const;
 
-  bool convertServiceRequest(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool convertServiceRequest(const planning_scene::PlanningSceneConstPtr planning_scene,
                              const moveit_msgs::GetConstraintAwarePositionIK::Request& request,
                              kinematics_constraint_aware::KinematicsRequest& kinematics_request,
                              kinematics_constraint_aware::KinematicsResponse& kinematics_response) const;
 
-  geometry_msgs::Pose getTipFramePose(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  geometry_msgs::Pose getTipFramePose(const planning_scene::PlanningSceneConstPtr planning_scene,
                                       const robot_state::RobotState& kinematic_state, const geometry_msgs::Pose& pose,
                                       const std::string& link_name, unsigned int sub_group_index) const;
 
-  bool validityCallbackFn(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool validityCallbackFn(const planning_scene::PlanningSceneConstPtr planning_scene,
                           const kinematics_constraint_aware::KinematicsRequest& request,
                           kinematics_constraint_aware::KinematicsResponse& response,
                           robot_state::JointStateGroup* joint_state_group,

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -51,6 +51,6 @@ class CollisionCheckThread
 public:
   CollisionCheckThread(const moveit_jog_arm::JogArmParameters parameters,
                        moveit_jog_arm::JogArmShared& shared_variables, pthread_mutex_t& mutex,
-                       const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+                       const robot_model_loader::RobotModelLoaderPtr model_loader_ptr);
 };
 }

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -53,7 +53,7 @@ class JogCalcs
 {
 public:
   JogCalcs(const JogArmParameters& parameters, JogArmShared& shared_variables, pthread_mutex_t& mutex,
-           const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+           const robot_model_loader::RobotModelLoaderPtr model_loader_ptr);
 
 protected:
   ros::NodeHandle nh_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_ros_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_ros_interface.h
@@ -64,9 +64,9 @@ public:
 
 private:
   // ROS subscriber callbacks
-  void deltaCartesianCmdCB(const geometry_msgs::TwistStampedConstPtr& msg);
-  void deltaJointCmdCB(const control_msgs::JointJogConstPtr& msg);
-  void jointsCB(const sensor_msgs::JointStateConstPtr& msg);
+  void deltaCartesianCmdCB(const geometry_msgs::TwistStampedConstPtr msg);
+  void deltaJointCmdCB(const control_msgs::JointJogConstPtr msg);
+  void jointsCB(const sensor_msgs::JointStateConstPtr msg);
 
   bool readParameters(ros::NodeHandle& n);
 

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -52,7 +52,7 @@ public:
   void clear() override;
   bool terminate() override;
 
-  CHOMPPlanningContext(const std::string& name, const std::string& group, const robot_model::RobotModelConstPtr& model);
+  CHOMPPlanningContext(const std::string& name, const std::string& group, const robot_model::RobotModelConstPtr model);
 
   ~CHOMPPlanningContext() override = default;
 

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -53,7 +53,7 @@ namespace chomp
 class ChompOptimizer
 {
 public:
-  ChompOptimizer(ChompTrajectory* trajectory, const planning_scene::PlanningSceneConstPtr& planning_scene,
+  ChompOptimizer(ChompTrajectory* trajectory, const planning_scene::PlanningSceneConstPtr planning_scene,
                  const std::string& planning_group, const ChompParameters* parameters,
                  const moveit::core::RobotState& start_state);
 
@@ -122,7 +122,7 @@ private:
   unsigned int collision_free_iteration_;
 
   ChompTrajectory* full_trajectory_;
-  const moveit::core::RobotModelConstPtr& robot_model_;
+  const moveit::core::RobotModelConstPtr robot_model_;
   std::string planning_group_;
   const ChompParameters* parameters_;
   ChompTrajectory group_trajectory_;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -49,7 +49,7 @@ public:
   ChompPlanner() = default;
   virtual ~ChompPlanner() = default;
 
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene,
              const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
              planning_interface::MotionPlanDetailedResponse& res) const;
 };

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -57,13 +57,13 @@ public:
   /**
    * \brief Constructs a trajectory for a given robot model, trajectory duration, and discretization
    */
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, double duration, double discretization,
+  ChompTrajectory(const moveit::core::RobotModelConstPtr robot_model, double duration, double discretization,
                   const std::string& group_name);
 
   /**
    * \brief Constructs a trajectory for a given robot model, number of trajectory points, and discretization
    */
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, size_t num_points, double discretization,
+  ChompTrajectory(const moveit::core::RobotModelConstPtr robot_model, size_t num_points, double discretization,
                   const std::string& group_name);
 
   /**
@@ -72,7 +72,7 @@ public:
    */
   ChompTrajectory(const ChompTrajectory& source_traj, const std::string& group_name, int diff_rule_length);
 
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
+  ChompTrajectory(const moveit::core::RobotModelConstPtr robot_model, const std::string& group_name,
                   const trajectory_msgs::JointTrajectory& traj);
 
   /**

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/constraints_library.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/constraints_library.h
@@ -100,7 +100,7 @@ public:
     return constraint_msg_;
   }
 
-  const ompl::base::StateStoragePtr& getStateStorage() const
+  const ompl::base::StateStoragePtr getStateStorage() const
   {
     return state_storage_ptr_;
   }
@@ -171,27 +171,27 @@ public:
   ConstraintApproximationConstructionResults
   addConstraintApproximation(const moveit_msgs::Constraints& constr_sampling,
                              const moveit_msgs::Constraints& constr_hard, const std::string& group,
-                             const planning_scene::PlanningSceneConstPtr& scene,
+                             const planning_scene::PlanningSceneConstPtr scene,
                              const ConstraintApproximationConstructionOptions& options);
 
   ConstraintApproximationConstructionResults
   addConstraintApproximation(const moveit_msgs::Constraints& constr, const std::string& group,
-                             const planning_scene::PlanningSceneConstPtr& scene,
+                             const planning_scene::PlanningSceneConstPtr scene,
                              const ConstraintApproximationConstructionOptions& options);
 
   void printConstraintApproximations(std::ostream& out = std::cout) const;
   void clearConstraintApproximations();
 
-  void registerConstraintApproximation(const ConstraintApproximationPtr& approx)
+  void registerConstraintApproximation(const ConstraintApproximationPtr approx)
   {
     constraint_approximations_[approx->getName()] = approx;
   }
 
-  const ConstraintApproximationPtr& getConstraintApproximation(const moveit_msgs::Constraints& msg) const;
+  const ConstraintApproximationPtr getConstraintApproximation(const moveit_msgs::Constraints& msg) const;
 
 private:
   ompl::base::StateStoragePtr constructConstraintApproximation(
-      const ModelBasedPlanningContextPtr& pcontext, const moveit_msgs::Constraints& constr_sampling,
+      const ModelBasedPlanningContextPtr pcontext, const moveit_msgs::Constraints& constr_sampling,
       const moveit_msgs::Constraints& constr_hard, const ConstraintApproximationConstructionOptions& options,
       ConstraintApproximationConstructionResults& result);
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
@@ -49,12 +49,12 @@ typedef std::function<bool(const ompl::base::State*, const ompl::base::State*)> 
 
 struct ConstraintApproximation
 {
-  ConstraintApproximation(const planning_models::RobotModelConstPtr& kinematic_model, const std::string& group,
+  ConstraintApproximation(const planning_models::RobotModelConstPtr kinematic_model, const std::string& group,
                           const std::string& factory, const std::string& serialization, const std::string& filename,
-                          const ompl::base::StateStoragePtr& storage);
-  ConstraintApproximation(const planning_models::RobotModelConstPtr& kinematic_model, const std::string& group,
+                          const ompl::base::StateStoragePtr storage);
+  ConstraintApproximation(const planning_models::RobotModelConstPtr kinematic_model, const std::string& group,
                           const std::string& factory, const moveit_msgs::Constraints& msg, const std::string& filename,
-                          const ompl::base::StateStoragePtr& storage);
+                          const ompl::base::StateStoragePtr storage);
 
   void visualizeDistribution(const std::string& link_name, unsigned int count,
                              visualization_msgs::MarkerArray& arr) const;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/threadsafe_state_storage.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/threadsafe_state_storage.h
@@ -45,7 +45,7 @@ namespace ompl_interface
 class TSStateStorage
 {
 public:
-  TSStateStorage(const robot_model::RobotModelPtr& robot_model);
+  TSStateStorage(const robot_model::RobotModelPtr robot_model);
   TSStateStorage(const robot_state::RobotState& start_state);
   ~TSStateStorage();
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -56,7 +56,7 @@ MOVEIT_CLASS_FORWARD(ModelBasedPlanningContext);
 MOVEIT_CLASS_FORWARD(ConstraintsLibrary);
 
 struct ModelBasedPlanningContextSpecification;
-typedef std::function<ob::PlannerPtr(const ompl::base::SpaceInformationPtr& si, const std::string& name,
+typedef std::function<ob::PlannerPtr(const ompl::base::SpaceInformationPtr si, const std::string& name,
                                      const ModelBasedPlanningContextSpecification& spec)>
     ConfiguredPlannerAllocator;
 typedef std::function<ConfiguredPlannerAllocator(const std::string& planner_type)> ConfiguredPlannerSelector;
@@ -103,7 +103,7 @@ public:
     spec_.config_ = config;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return spec_.state_space_->getRobotModel();
   }
@@ -118,17 +118,17 @@ public:
     return complete_initial_robot_state_;
   }
 
-  const ModelBasedStateSpacePtr& getOMPLStateSpace() const
+  const ModelBasedStateSpacePtr getOMPLStateSpace() const
   {
     return spec_.state_space_;
   }
 
-  const og::SimpleSetupPtr& getOMPLSimpleSetup() const
+  const og::SimpleSetupPtr getOMPLSimpleSetup() const
   {
     return ompl_simple_setup_;
   }
 
-  og::SimpleSetupPtr& getOMPLSimpleSetup()
+  og::SimpleSetupPtr getOMPLSimpleSetup()
   {
     return ompl_simple_setup_;
   }
@@ -143,7 +143,7 @@ public:
     return ompl_benchmark_;
   }
 
-  const kinematic_constraints::KinematicConstraintSetPtr& getPathConstraints() const
+  const kinematic_constraints::KinematicConstraintSetPtr getPathConstraints() const
   {
     return path_constraints_;
   }
@@ -219,12 +219,12 @@ public:
     minimum_waypoint_count_ = mwc;
   }
 
-  const constraint_samplers::ConstraintSamplerManagerPtr& getConstraintSamplerManager()
+  const constraint_samplers::ConstraintSamplerManagerPtr getConstraintSamplerManager()
   {
     return spec_.constraint_sampler_manager_;
   }
 
-  void setConstraintSamplerManager(const constraint_samplers::ConstraintSamplerManagerPtr& csm)
+  void setConstraintSamplerManager(const constraint_samplers::ConstraintSamplerManagerPtr csm)
   {
     spec_.constraint_sampler_manager_ = csm;
   }
@@ -241,7 +241,7 @@ public:
                           const moveit_msgs::Constraints& path_constraints, moveit_msgs::MoveItErrorCodes* error);
   bool setPathConstraints(const moveit_msgs::Constraints& path_constraints, moveit_msgs::MoveItErrorCodes* error);
 
-  void setConstraintsApproximations(const ConstraintsLibraryConstPtr& constraints_library)
+  void setConstraintsApproximations(const ConstraintsLibraryConstPtr constraints_library)
   {
     spec_.constraints_library_ = constraints_library;
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -57,13 +57,13 @@ class OMPLInterface
 public:
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
    * NodeHandle */
-  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model, const ros::NodeHandle& nh = ros::NodeHandle("~"));
+  OMPLInterface(const robot_model::RobotModelConstPtr robot_model, const ros::NodeHandle& nh = ros::NodeHandle("~"));
 
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
      NodeHandle. However,
       planner configurations are used as specified in \e pconfig instead of reading them from the ROS parameter server
      */
-  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
+  OMPLInterface(const robot_model::RobotModelConstPtr robot_model,
                 const planning_interface::PlannerConfigurationMap& pconfig,
                 const ros::NodeHandle& nh = ros::NodeHandle("~"));
 
@@ -80,9 +80,9 @@ public:
     return context_manager_.getPlannerConfigurations();
   }
 
-  ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr planning_scene,
                                                   const planning_interface::MotionPlanRequest& req) const;
-  ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr planning_scene,
                                                   const planning_interface::MotionPlanRequest& req,
                                                   moveit_msgs::MoveItErrorCodes& error_code) const;
 
@@ -166,11 +166,11 @@ protected:
   /** @brief Load the additional plugins for sampling constraints */
   void loadConstraintSamplers();
 
-  void configureContext(const ModelBasedPlanningContextPtr& context) const;
+  void configureContext(const ModelBasedPlanningContextPtr context) const;
 
   /** \brief Configure the OMPL planning context for a new planning request */
   ModelBasedPlanningContextPtr prepareForSolve(const planning_interface::MotionPlanRequest& req,
-                                               const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                               const planning_scene::PlanningSceneConstPtr planning_scene,
                                                moveit_msgs::MoveItErrorCodes* error_code, unsigned int* attempts,
                                                double* timeout) const;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h
@@ -46,7 +46,7 @@ public:
   JointModelStateSpaceFactory();
 
   int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                          const robot_model::RobotModelConstPtr& robot_model) const override;
+                          const robot_model::RobotModelConstPtr robot_model) const override;
 
 protected:
   ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const override;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -51,13 +51,13 @@ typedef std::function<double(const ompl::base::State* state1, const ompl::base::
 
 struct ModelBasedStateSpaceSpecification
 {
-  ModelBasedStateSpaceSpecification(const robot_model::RobotModelConstPtr& robot_model,
+  ModelBasedStateSpaceSpecification(const robot_model::RobotModelConstPtr robot_model,
                                     const robot_model::JointModelGroup* jmg)
     : robot_model_(robot_model), joint_model_group_(jmg)
   {
   }
 
-  ModelBasedStateSpaceSpecification(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name)
+  ModelBasedStateSpaceSpecification(const robot_model::RobotModelConstPtr robot_model, const std::string& group_name)
     : robot_model_(robot_model), joint_model_group_(robot_model_->getJointModelGroup(group_name))
   {
     if (!joint_model_group_)
@@ -200,7 +200,7 @@ public:
 
   ompl::base::StateSamplerPtr allocDefaultStateSampler() const override;
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return spec_.robot_model_;
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
@@ -67,7 +67,7 @@ public:
       request \e req for group \e group. The group \e group must always be specified and takes precedence over \e
      req.group_name, which may be different */
   virtual int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                                  const robot_model::RobotModelConstPtr& robot_model) const = 0;
+                                  const robot_model::RobotModelConstPtr robot_model) const = 0;
 
 protected:
   virtual ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const = 0;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space_factory.h
@@ -46,7 +46,7 @@ public:
   PoseModelStateSpaceFactory();
 
   int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                          const robot_model::RobotModelConstPtr& robot_model) const override;
+                          const robot_model::RobotModelConstPtr robot_model) const override;
 
 protected:
   ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const override;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -135,7 +135,7 @@ public:
     minimum_waypoint_count_ = mwc;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -143,7 +143,7 @@ public:
   ModelBasedPlanningContextPtr getPlanningContext(const std::string& config,
                                                   const std::string& factory_type = "") const;
 
-  ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr planning_scene,
                                                   const planning_interface::MotionPlanRequest& req,
                                                   moveit_msgs::MoveItErrorCodes& error_code) const;
 
@@ -152,7 +152,7 @@ public:
     known_planners_[planner_id] = pa;
   }
 
-  void registerStateSpaceFactory(const ModelBasedStateSpaceFactoryPtr& factory)
+  void registerStateSpaceFactory(const ModelBasedStateSpaceFactoryPtr factory)
   {
     state_space_factories_[factory->getType()] = factory;
   }
@@ -170,7 +170,7 @@ public:
   ConfiguredPlannerSelector getPlannerSelector() const;
 
 protected:
-  typedef std::function<const ModelBasedStateSpaceFactoryPtr&(const std::string&)> StateSpaceFactoryTypeSelector;
+  typedef std::function<const ModelBasedStateSpaceFactoryPtr(const std::string&)> StateSpaceFactoryTypeSelector;
 
   ConfiguredPlannerAllocator plannerSelector(const std::string& planner) const;
 
@@ -182,9 +182,9 @@ protected:
                                                   const StateSpaceFactoryTypeSelector& factory_selector,
                                                   const moveit_msgs::MotionPlanRequest& req) const;
 
-  const ModelBasedStateSpaceFactoryPtr& getStateSpaceFactory1(const std::string& group_name,
+  const ModelBasedStateSpaceFactoryPtr getStateSpaceFactory1(const std::string& group_name,
                                                               const std::string& factory_type) const;
-  const ModelBasedStateSpaceFactoryPtr& getStateSpaceFactory2(const std::string& group_name,
+  const ModelBasedStateSpaceFactoryPtr getStateSpaceFactory2(const std::string& group_name,
                                                               const moveit_msgs::MotionPlanRequest& req) const;
 
   /** \brief The kinematic model for which motion plans are computed */

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -183,9 +183,9 @@ protected:
                                                   const moveit_msgs::MotionPlanRequest& req) const;
 
   const ModelBasedStateSpaceFactoryPtr getStateSpaceFactory1(const std::string& group_name,
-                                                              const std::string& factory_type) const;
+                                                             const std::string& factory_type) const;
   const ModelBasedStateSpaceFactoryPtr getStateSpaceFactory2(const std::string& group_name,
-                                                              const moveit_msgs::MotionPlanRequest& req) const;
+                                                             const moveit_msgs::MotionPlanRequest& req) const;
 
   /** \brief The kinematic model for which motion plans are computed */
   robot_model::RobotModelConstPtr robot_model_;

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/environment_chain3d.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/environment_chain3d.h
@@ -101,7 +101,7 @@ public:
   /**
    * @brief Default constructor
    */
-  EnvironmentChain3D(const planning_scene::PlanningSceneConstPtr& planning_scene);
+  EnvironmentChain3D(const planning_scene::PlanningSceneConstPtr planning_scene);
 
   /**
    * @brief Destructor
@@ -208,7 +208,7 @@ public:
    */
   virtual bool AreEquivalent(int StateID1, int StateID2);
 
-  bool setupForMotionPlan(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool setupForMotionPlan(const planning_scene::PlanningSceneConstPtr planning_scene,
                           const moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res,
                           const PlanningParameters& params);
 

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_interface.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_interface.h
@@ -44,14 +44,14 @@ namespace sbpl_interface
 class SBPLInterface
 {
 public:
-  SBPLInterface(const planning_models::RobotModelConstPtr& robot_model)
+  SBPLInterface(const planning_models::RobotModelConstPtr robot_model)
   {
   }
   virtual ~SBPLInterface()
   {
   }
 
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene,
              const moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res,
              const PlanningParameters& params) const;
 

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_interface.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_interface.h
@@ -51,9 +51,8 @@ public:
   {
   }
 
-  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene,
-             const moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res,
-             const PlanningParameters& params) const;
+  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene, const moveit_msgs::GetMotionPlan::Request& req,
+             moveit_msgs::GetMotionPlan::Response& res, const PlanningParameters& params) const;
 
   const PlanningStatistics& getLastPlanningStatistics() const
   {

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_meta_interface.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_meta_interface.h
@@ -50,8 +50,8 @@ public:
   {
   }
 
-  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene,
-             const moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res);
+  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene, const moveit_msgs::GetMotionPlan::Request& req,
+             moveit_msgs::GetMotionPlan::Response& res);
 
   const PlanningStatistics& getLastPlanningStatistics() const
   {

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_meta_interface.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_meta_interface.h
@@ -45,12 +45,12 @@ namespace sbpl_interface
 class SBPLMetaInterface
 {
 public:
-  SBPLMetaInterface(const planning_models::RobotModelConstPtr& robot_model);
+  SBPLMetaInterface(const planning_models::RobotModelConstPtr robot_model);
   virtual ~SBPLMetaInterface()
   {
   }
 
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene,
              const moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res);
 
   const PlanningStatistics& getLastPlanningStatistics() const
@@ -59,7 +59,7 @@ public:
   }
 
 protected:
-  void runSolver(bool use_first, const planning_scene::PlanningSceneConstPtr& planning_scene,
+  void runSolver(bool use_first, const planning_scene::PlanningSceneConstPtr planning_scene,
                  const moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res,
                  const PlanningParameters& params);
 

--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_interface.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_interface.h
@@ -54,7 +54,7 @@ public:
     return params_;
   }
 
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool solve(const planning_scene::PlanningSceneConstPtr planning_scene,
              const planning_interface::MotionPlanRequest& req, moveit_msgs::MotionPlanDetailedResponse& res);
 
 protected:
@@ -62,7 +62,7 @@ protected:
   void setTrajOptParams(sco::BasicTrustRegionSQPParameters& param);
   void setDefaultTrajOPtParams();
   void setProblemInfoParam(ProblemInfo& problem_info);
-  void setJointPoseTermInfoParams(JointPoseTermInfoPtr& jp, std::string name);
+  void setJointPoseTermInfoParams(JointPoseTermInfoPtr jp, std::string name);
   trajopt::DblVec extractStartJointValues(const planning_interface::MotionPlanRequest& req,
                                           const std::vector<std::string>& group_joint_names);
 

--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
@@ -13,7 +13,7 @@ class TrajOptPlanningContext : public planning_interface::PlanningContext
 {
 public:
   TrajOptPlanningContext(const std::string& name, const std::string& group,
-                         const robot_model::RobotModelConstPtr& model);
+                         const robot_model::RobotModelConstPtr model);
   ~TrajOptPlanningContext() override
   {
   }

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -66,11 +66,11 @@ protected:
                                                     const std::string& name);
 
   void controllerDoneCallback(const actionlib::SimpleClientGoalState& state,
-                              const control_msgs::FollowJointTrajectoryResultConstPtr& result);
+                              const control_msgs::FollowJointTrajectoryResultConstPtr result);
 
   void controllerActiveCallback();
 
-  void controllerFeedbackCallback(const control_msgs::FollowJointTrajectoryFeedbackConstPtr& feedback);
+  void controllerFeedbackCallback(const control_msgs::FollowJointTrajectoryFeedbackConstPtr feedback);
 
   control_msgs::FollowJointTrajectoryGoal goal_template_;
 };

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -170,7 +170,7 @@ public:
 
 private:
   void controllerDoneCallback(const actionlib::SimpleClientGoalState& state,
-                              const control_msgs::GripperCommandResultConstPtr& result)
+                              const control_msgs::GripperCommandResultConstPtr result)
   {
     if (state == actionlib::SimpleClientGoalState::ABORTED && allow_failure_)
       finishControllerExecution(actionlib::SimpleClientGoalState::SUCCEEDED);
@@ -183,7 +183,7 @@ private:
     ROS_DEBUG_STREAM_NAMED("GripperController", name_ << " started execution");
   }
 
-  void controllerFeedbackCallback(const control_msgs::GripperCommandFeedbackConstPtr& feedback)
+  void controllerFeedbackCallback(const control_msgs::GripperCommandFeedbackConstPtr feedback)
   {
   }
 

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.h
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.h
@@ -56,8 +56,7 @@ private:
   void executePickupCallback(const moveit_msgs::PickupGoalConstPtr goal);
   void executePlaceCallback(const moveit_msgs::PlaceGoalConstPtr goal);
 
-  void executePickupCallbackPlanOnly(const moveit_msgs::PickupGoalConstPtr goal,
-                                     moveit_msgs::PickupResult& action_res);
+  void executePickupCallbackPlanOnly(const moveit_msgs::PickupGoalConstPtr goal, moveit_msgs::PickupResult& action_res);
   void executePickupCallbackPlanAndExecute(const moveit_msgs::PickupGoalConstPtr goal,
                                            moveit_msgs::PickupResult& action_res);
 

--- a/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.h
+++ b/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.h
@@ -53,16 +53,16 @@ public:
   void initialize() override;
 
 private:
-  void executePickupCallback(const moveit_msgs::PickupGoalConstPtr& goal);
-  void executePlaceCallback(const moveit_msgs::PlaceGoalConstPtr& goal);
+  void executePickupCallback(const moveit_msgs::PickupGoalConstPtr goal);
+  void executePlaceCallback(const moveit_msgs::PlaceGoalConstPtr goal);
 
-  void executePickupCallbackPlanOnly(const moveit_msgs::PickupGoalConstPtr& goal,
+  void executePickupCallbackPlanOnly(const moveit_msgs::PickupGoalConstPtr goal,
                                      moveit_msgs::PickupResult& action_res);
-  void executePickupCallbackPlanAndExecute(const moveit_msgs::PickupGoalConstPtr& goal,
+  void executePickupCallbackPlanAndExecute(const moveit_msgs::PickupGoalConstPtr goal,
                                            moveit_msgs::PickupResult& action_res);
 
-  void executePlaceCallbackPlanOnly(const moveit_msgs::PlaceGoalConstPtr& goal, moveit_msgs::PlaceResult& action_res);
-  void executePlaceCallbackPlanAndExecute(const moveit_msgs::PlaceGoalConstPtr& goal,
+  void executePlaceCallbackPlanOnly(const moveit_msgs::PlaceGoalConstPtr goal, moveit_msgs::PlaceResult& action_res);
+  void executePlaceCallbackPlanAndExecute(const moveit_msgs::PlaceGoalConstPtr goal,
                                           moveit_msgs::PlaceResult& action_res);
 
   bool planUsingPickPlacePickup(const moveit_msgs::PickupGoal& goal, moveit_msgs::PickupResult* action_res,

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/approach_and_translate_stage.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/approach_and_translate_stage.h
@@ -45,10 +45,10 @@ namespace pick_place
 class ApproachAndTranslateStage : public ManipulationStage
 {
 public:
-  ApproachAndTranslateStage(const planning_scene::PlanningSceneConstPtr& scene,
-                            const collision_detection::AllowedCollisionMatrixConstPtr& collision_matrix);
+  ApproachAndTranslateStage(const planning_scene::PlanningSceneConstPtr scene,
+                            const collision_detection::AllowedCollisionMatrixConstPtr collision_matrix);
 
-  bool evaluate(const ManipulationPlanPtr& plan) const override;
+  bool evaluate(const ManipulationPlanPtr plan) const override;
 
 private:
   planning_scene::PlanningSceneConstPtr planning_scene_;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_pipeline.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_pipeline.h
@@ -66,9 +66,9 @@ public:
     empty_queue_callback_ = callback;
   }
 
-  ManipulationPipeline& addStage(const ManipulationStagePtr& next);
-  const ManipulationStagePtr& getFirstStage() const;
-  const ManipulationStagePtr& getLastStage() const;
+  ManipulationPipeline& addStage(const ManipulationStagePtr next);
+  const ManipulationStagePtr getFirstStage() const;
+  const ManipulationStagePtr getLastStage() const;
   void reset();
 
   void setVerbose(bool flag);
@@ -77,7 +77,7 @@ public:
   void start();
   void stop();
 
-  void push(const ManipulationPlanPtr& grasp);
+  void push(const ManipulationPlanPtr grasp);
   void clear();
 
   const std::vector<ManipulationPlanPtr>& getSuccessfulManipulationPlans() const

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -86,7 +86,7 @@ struct ManipulationPlan
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  ManipulationPlan(const ManipulationPlanSharedDataConstPtr& shared_data)
+  ManipulationPlan(const ManipulationPlanSharedDataConstPtr shared_data)
     : shared_data_(shared_data), processing_stage_(0)
   {
   }

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_stage.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_stage.h
@@ -75,7 +75,7 @@ public:
     signal_stop_ = true;
   }
 
-  virtual bool evaluate(const ManipulationPlanPtr& plan) const = 0;
+  virtual bool evaluate(const ManipulationPlanPtr plan) const = 0;
 
 protected:
   std::string name_;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
@@ -53,7 +53,7 @@ MOVEIT_CLASS_FORWARD(PickPlace);
 class PickPlacePlanBase
 {
 public:
-  PickPlacePlanBase(const PickPlaceConstPtr& pick_place, const std::string& name);
+  PickPlacePlanBase(const PickPlaceConstPtr pick_place, const std::string& name);
   ~PickPlacePlanBase();
 
   const std::vector<ManipulationPlanPtr>& getSuccessfulManipulationPlans() const
@@ -97,8 +97,8 @@ MOVEIT_CLASS_FORWARD(PickPlan);
 class PickPlan : public PickPlacePlanBase
 {
 public:
-  PickPlan(const PickPlaceConstPtr& pick_place);
-  bool plan(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::PickupGoal& goal);
+  PickPlan(const PickPlaceConstPtr pick_place);
+  bool plan(const planning_scene::PlanningSceneConstPtr planning_scene, const moveit_msgs::PickupGoal& goal);
 };
 
 MOVEIT_CLASS_FORWARD(PlacePlan);
@@ -106,8 +106,8 @@ MOVEIT_CLASS_FORWARD(PlacePlan);
 class PlacePlan : public PickPlacePlanBase
 {
 public:
-  PlacePlan(const PickPlaceConstPtr& pick_place);
-  bool plan(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::PlaceGoal& goal);
+  PlacePlan(const PickPlaceConstPtr pick_place);
+  bool plan(const planning_scene::PlanningSceneConstPtr planning_scene, const moveit_msgs::PlaceGoal& goal);
 };
 
 class PickPlace : private boost::noncopyable, public std::enable_shared_from_this<PickPlace>
@@ -119,37 +119,37 @@ public:
   // the amount of time (maximum) to wait for achieving a grasp posture
   static const double DEFAULT_GRASP_POSTURE_COMPLETION_DURATION;  // seconds
 
-  PickPlace(const planning_pipeline::PlanningPipelinePtr& planning_pipeline);
+  PickPlace(const planning_pipeline::PlanningPipelinePtr planning_pipeline);
 
-  const constraint_samplers::ConstraintSamplerManagerPtr& getConstraintsSamplerManager() const
+  const constraint_samplers::ConstraintSamplerManagerPtr getConstraintsSamplerManager() const
   {
     return constraint_sampler_manager_loader_->getConstraintSamplerManager();
   }
 
-  const planning_pipeline::PlanningPipelinePtr& getPlanningPipeline() const
+  const planning_pipeline::PlanningPipelinePtr getPlanningPipeline() const
   {
     return planning_pipeline_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return planning_pipeline_->getRobotModel();
   }
 
   /** \brief Plan the sequence of motions that perform a pickup action */
-  PickPlanPtr planPick(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  PickPlanPtr planPick(const planning_scene::PlanningSceneConstPtr planning_scene,
                        const moveit_msgs::PickupGoal& goal) const;
 
   /** \brief Plan the sequence of motions that perform a placement action */
-  PlacePlanPtr planPlace(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  PlacePlanPtr planPlace(const planning_scene::PlanningSceneConstPtr planning_scene,
                          const moveit_msgs::PlaceGoal& goal) const;
 
   void displayComputedMotionPlans(bool flag);
   void displayProcessedGrasps(bool flag);
 
-  void visualizePlan(const ManipulationPlanPtr& plan) const;
+  void visualizePlan(const ManipulationPlanPtr plan) const;
 
-  void visualizeGrasp(const ManipulationPlanPtr& plan) const;
+  void visualizeGrasp(const ManipulationPlanPtr plan) const;
 
   void visualizeGrasps(const std::vector<ManipulationPlanPtr>& plans) const;
 

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/plan_stage.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/plan_stage.h
@@ -45,12 +45,12 @@ namespace pick_place
 class PlanStage : public ManipulationStage
 {
 public:
-  PlanStage(const planning_scene::PlanningSceneConstPtr& scene,
-            const planning_pipeline::PlanningPipelinePtr& planning_pipeline);
+  PlanStage(const planning_scene::PlanningSceneConstPtr scene,
+            const planning_pipeline::PlanningPipelinePtr planning_pipeline);
 
   void signalStop() override;
 
-  bool evaluate(const ManipulationPlanPtr& plan) const override;
+  bool evaluate(const ManipulationPlanPtr plan) const override;
 
 private:
   planning_scene::PlanningSceneConstPtr planning_scene_;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/reachable_valid_pose_filter.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/reachable_valid_pose_filter.h
@@ -45,14 +45,14 @@ namespace pick_place
 class ReachableAndValidPoseFilter : public ManipulationStage
 {
 public:
-  ReachableAndValidPoseFilter(const planning_scene::PlanningSceneConstPtr& scene,
-                              const collision_detection::AllowedCollisionMatrixConstPtr& collision_matrix,
-                              const constraint_samplers::ConstraintSamplerManagerPtr& constraints_sampler_manager);
+  ReachableAndValidPoseFilter(const planning_scene::PlanningSceneConstPtr scene,
+                              const collision_detection::AllowedCollisionMatrixConstPtr collision_matrix,
+                              const constraint_samplers::ConstraintSamplerManagerPtr constraints_sampler_manager);
 
-  bool evaluate(const ManipulationPlanPtr& plan) const override;
+  bool evaluate(const ManipulationPlanPtr plan) const override;
 
 private:
-  bool isEndEffectorFree(const ManipulationPlanPtr& plan, robot_state::RobotState& token_state) const;
+  bool isEndEffectorFree(const ManipulationPlanPtr plan, robot_state::RobotState& token_state) const;
 
   planning_scene::PlanningSceneConstPtr planning_scene_;
   collision_detection::AllowedCollisionMatrixConstPtr collision_matrix_;

--- a/moveit_ros/move_group/include/moveit/move_group/move_group_capability.h
+++ b/moveit_ros/move_group/include/moveit/move_group/move_group_capability.h
@@ -65,7 +65,7 @@ public:
   {
   }
 
-  void setContext(const MoveGroupContextPtr& context);
+  void setContext(const MoveGroupContextPtr context);
 
   virtual void initialize() = 0;
 
@@ -82,7 +82,7 @@ protected:
   void convertToMsg(const std::vector<plan_execution::ExecutableTrajectory>& trajectory,
                     moveit_msgs::RobotState& first_state_msg,
                     std::vector<moveit_msgs::RobotTrajectory>& trajectory_msg) const;
-  void convertToMsg(const robot_trajectory::RobotTrajectoryPtr& trajectory, moveit_msgs::RobotState& first_state_msg,
+  void convertToMsg(const robot_trajectory::RobotTrajectoryPtr trajectory, moveit_msgs::RobotState& first_state_msg,
                     moveit_msgs::RobotTrajectory& trajectory_msg) const;
   void convertToMsg(const std::vector<plan_execution::ExecutableTrajectory>& trajectory,
                     moveit_msgs::RobotState& first_state_msg, moveit_msgs::RobotTrajectory& trajectory_msg) const;

--- a/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
+++ b/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
@@ -65,7 +65,7 @@ MOVEIT_STRUCT_FORWARD(MoveGroupContext);
 
 struct MoveGroupContext
 {
-  MoveGroupContext(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
+  MoveGroupContext(const planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor,
                    bool allow_trajectory_execution = false, bool debug = false);
   ~MoveGroupContext();
 

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -55,8 +55,8 @@ public:
   void initialize() override;
 
 private:
-  void executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal);
-  void executePath(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
+  void executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr goal);
+  void executePath(const moveit_msgs::ExecuteTrajectoryGoalConstPtr goal,
                    moveit_msgs::ExecuteTrajectoryResult& action_res);
   void preemptExecuteTrajectoryCallback();
   void setExecuteTrajectoryState(MoveGroupState state);

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -51,10 +51,10 @@ public:
   void initialize() override;
 
 private:
-  void executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal);
-  void executeMoveCallbackPlanAndExecute(const moveit_msgs::MoveGroupGoalConstPtr& goal,
+  void executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr goal);
+  void executeMoveCallbackPlanAndExecute(const moveit_msgs::MoveGroupGoalConstPtr goal,
                                          moveit_msgs::MoveGroupResult& action_res);
-  void executeMoveCallbackPlanOnly(const moveit_msgs::MoveGroupGoalConstPtr& goal,
+  void executeMoveCallbackPlanOnly(const moveit_msgs::MoveGroupGoalConstPtr goal,
                                    moveit_msgs::MoveGroupResult& action_res);
   void startMoveExecutionCallback();
   void startMoveLookCallback();

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -71,14 +71,14 @@ public:
 
   /** @brief Get a pointer to the underlying octree for this monitor. Lock the tree before reading or writing using this
    *  pointer. The value of this pointer stays the same throughout the existance of the monitor instance. */
-  const OccMapTreePtr& getOcTreePtr()
+  const OccMapTreePtr getOcTreePtr()
   {
     return tree_;
   }
 
   /** @brief Get a const pointer to the underlying octree for this monitor. Lock the
    *  tree before reading this pointer */
-  const OccMapTreeConstPtr& getOcTreePtr() const
+  const OccMapTreeConstPtr getOcTreePtr() const
   {
     return tree_const_;
   }
@@ -100,10 +100,10 @@ public:
     return tf_buffer_;
   }
 
-  void addUpdater(const OccupancyMapUpdaterPtr& updater);
+  void addUpdater(const OccupancyMapUpdaterPtr updater);
 
   /** \brief Add this shape to the set of shapes to be filtered out from the octomap */
-  ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape);
+  ShapeHandle excludeShape(const shapes::ShapeConstPtr shape);
 
   /** \brief Forget about this shape handle and the shapes it corresponds to */
   void forgetShape(ShapeHandle handle);

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -78,7 +78,7 @@ public:
 
   virtual void stop() = 0;
 
-  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape) = 0;
+  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr shape) = 0;
 
   virtual void forgetShape(ShapeHandle handle) = 0;
 

--- a/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -57,11 +57,11 @@ public:
   bool initialize() override;
   void start() override;
   void stop() override;
-  ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape) override;
+  ShapeHandle excludeShape(const shapes::ShapeConstPtr shape) override;
   void forgetShape(ShapeHandle handle) override;
 
 private:
-  void depthImageCallback(const sensor_msgs::ImageConstPtr& depth_msg, const sensor_msgs::CameraInfoConstPtr& info_msg);
+  void depthImageCallback(const sensor_msgs::ImageConstPtr depth_msg, const sensor_msgs::CameraInfoConstPtr info_msg);
   bool getShapeTransform(mesh_filter::MeshHandle h, Eigen::Isometry3d& transform) const;
   void stopHelper();
 

--- a/moveit_ros/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
+++ b/moveit_ros/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
@@ -46,7 +46,7 @@ namespace occupancy_map_monitor
 class LazyFreeSpaceUpdater
 {
 public:
-  LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned int max_batch_size = 10);
+  LazyFreeSpaceUpdater(const OccMapTreePtr tree, unsigned int max_batch_size = 10);
   ~LazyFreeSpaceUpdater();
 
   void pushLazyUpdate(octomap::KeySet* occupied_cells, octomap::KeySet* model_cells,

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
@@ -73,7 +73,7 @@ private:
    * \brief main filtering routine
    * \author Suat Gedikli (gedikli@willowgarage.com)
    */
-  void filter(const sensor_msgs::ImageConstPtr& depth_msg, const sensor_msgs::CameraInfoConstPtr& info_msg);
+  void filter(const sensor_msgs::ImageConstPtr depth_msg, const sensor_msgs::CameraInfoConstPtr info_msg);
 
   /**
    * \brief Callback for connection/deconnection of listener
@@ -87,7 +87,7 @@ private:
    * @param depth_msg depth image
    * @param info_msg camera information containing parameters frame, etc.
    */
-  void depthCb(const sensor_msgs::ImageConstPtr& depth_msg, const sensor_msgs::CameraInfoConstPtr& info_msg);
+  void depthCb(const sensor_msgs::ImageConstPtr depth_msg, const sensor_msgs::CameraInfoConstPtr info_msg);
 
 private:
   // member variables to handle ros messages

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.h
@@ -221,7 +221,7 @@ protected:
    * \brief add a Job for the main thread that needs to be executed there
    * \param[in] job the job object that has the function o be executed
    */
-  void addJob(const JobPtr& job) const;
+  void addJob(const JobPtr job) const;
 
   /**
    * \brief sets the size of the fram buffers

--- a/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -70,7 +70,7 @@ public:
   /** \brief Destructor to clean up */
   ~ShapeMask();
 
-  ShapeHandle addShape(const shapes::ShapeConstPtr& shape, double scale = 1.0, double padding = 0.0);
+  ShapeHandle addShape(const shapes::ShapeConstPtr shape, double scale = 1.0, double padding = 0.0);
   void removeShape(ShapeHandle handle);
 
   void setTransformCallback(const TransformCallback& transform_callback);

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -59,7 +59,7 @@ public:
   bool initialize() override;
   void start() override;
   void stop() override;
-  ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape) override;
+  ShapeHandle excludeShape(const shapes::ShapeConstPtr shape) override;
   void forgetShape(ShapeHandle handle) override;
 
 protected:
@@ -68,7 +68,7 @@ protected:
 
 private:
   bool getShapeTransform(ShapeHandle h, Eigen::Isometry3d& transform) const;
-  void cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
+  void cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr cloud_msg);
   void stopHelper();
 
   ros::NodeHandle root_nh_;

--- a/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
+++ b/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
@@ -68,7 +68,7 @@ public:
    * @brief A (simple) semantic world representation for pick and place and other tasks.
    * Currently this is used only to represent tables.
    */
-  SemanticWorld(const planning_scene::PlanningSceneConstPtr& planning_scene);
+  SemanticWorld(const planning_scene::PlanningSceneConstPtr planning_scene);
 
   /**
    * @brief Get all the tables within a region of interest
@@ -88,7 +88,7 @@ public:
    * The assumption is that the object is represented by a mesh.
    */
   std::vector<geometry_msgs::PoseStamped> generatePlacePoses(const std::string& table_name,
-                                                             const shapes::ShapeConstPtr& object_shape,
+                                                             const shapes::ShapeConstPtr object_shape,
                                                              const geometry_msgs::Quaternion& object_orientation,
                                                              double resolution, double delta_height = 0.01,
                                                              unsigned int num_heights = 2) const;
@@ -99,7 +99,7 @@ public:
    * The assumption is that the object is represented by a mesh.
    */
   std::vector<geometry_msgs::PoseStamped> generatePlacePoses(const object_recognition_msgs::Table& table,
-                                                             const shapes::ShapeConstPtr& object_shape,
+                                                             const shapes::ShapeConstPtr object_shape,
                                                              const geometry_msgs::Quaternion& object_orientation,
                                                              double resolution, double delta_height = 0.01,
                                                              unsigned int num_heights = 2) const;
@@ -137,7 +137,7 @@ private:
 
   shapes::Mesh* orientPlanarPolygon(const shapes::Mesh& polygon) const;
 
-  void tableCallback(const object_recognition_msgs::TableArrayPtr& msg);
+  void tableCallback(const object_recognition_msgs::TableArrayPtr msg);
 
   void transformTableArray(object_recognition_msgs::TableArray& table_array) const;
 

--- a/moveit_ros/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
+++ b/moveit_ros/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
@@ -50,7 +50,7 @@ public:
   ~CollisionPluginLoader();
 
   /** @brief This can be called on a new planning scene to setup the collision detector. */
-  void setupScene(ros::NodeHandle& nh, const planning_scene::PlanningScenePtr& scene);
+  void setupScene(ros::NodeHandle& nh, const planning_scene::PlanningScenePtr scene);
 
   /**
    * @brief Load a collision detection robot/world into a planning scene instance.
@@ -59,7 +59,7 @@ public:
    * @param exclusive If true, sets the new detection robot/world to be the only one.
    * @return True if collision robot/world were added to scene.
    */
-  bool activate(const std::string& name, const planning_scene::PlanningScenePtr& scene, bool exclusive);
+  bool activate(const std::string& name, const planning_scene::PlanningScenePtr scene, bool exclusive);
 
 private:
   MOVEIT_CLASS_FORWARD(CollisionPluginLoaderImpl);

--- a/moveit_ros/planning/constraint_sampler_manager_loader/include/moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/include/moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h
@@ -47,9 +47,9 @@ class ConstraintSamplerManagerLoader
 {
 public:
   ConstraintSamplerManagerLoader(
-      const constraint_samplers::ConstraintSamplerManagerPtr& csm = constraint_samplers::ConstraintSamplerManagerPtr());
+      const constraint_samplers::ConstraintSamplerManagerPtr csm = constraint_samplers::ConstraintSamplerManagerPtr());
 
-  const constraint_samplers::ConstraintSamplerManagerPtr& getConstraintSamplerManager() const
+  const constraint_samplers::ConstraintSamplerManagerPtr getConstraintSamplerManager() const
   {
     return constraint_sampler_manager_;
   }

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -83,7 +83,7 @@ public:
 
   /** \brief Get a function pointer that allocates and initializes a kinematics solver. If not previously called, this
    * function reads ROS parameters for the groups defined in the SRDF. */
-  robot_model::SolverAllocatorFn getLoaderFunction(const srdf::ModelSharedPtr& srdf_model);
+  robot_model::SolverAllocatorFn getLoaderFunction(const srdf::ModelSharedPtr srdf_model);
 
   /** \brief Get the groups for which the function pointer returned by getLoaderFunction() can allocate a solver */
   const std::vector<std::string>& getKnownGroups() const

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -88,16 +88,16 @@ public:
     boost::function<void()> done_callback_;
   };
 
-  PlanExecution(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-                const trajectory_execution_manager::TrajectoryExecutionManagerPtr& trajectory_execution);
+  PlanExecution(const planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor,
+                const trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution);
   ~PlanExecution();
 
-  const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor() const
+  const planning_scene_monitor::PlanningSceneMonitorPtr getPlanningSceneMonitor() const
   {
     return planning_scene_monitor_;
   }
 
-  const trajectory_execution_manager::TrajectoryExecutionManagerPtr& getTrajectoryExecutionManager() const
+  const trajectory_execution_manager::TrajectoryExecutionManagerPtr getTrajectoryExecutionManager() const
   {
     return trajectory_execution_manager_;
   }

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
@@ -52,7 +52,7 @@ struct ExecutableTrajectory
   {
   }
 
-  ExecutableTrajectory(const robot_trajectory::RobotTrajectoryPtr& trajectory, const std::string& description)
+  ExecutableTrajectory(const robot_trajectory::RobotTrajectoryPtr trajectory, const std::string& description)
     : trajectory_(trajectory), description_(description), trajectory_monitoring_(true)
   {
   }

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
@@ -53,10 +53,10 @@ MOVEIT_CLASS_FORWARD(PlanWithSensing);
 class PlanWithSensing
 {
 public:
-  PlanWithSensing(const trajectory_execution_manager::TrajectoryExecutionManagerPtr& trajectory_execution);
+  PlanWithSensing(const trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution);
   ~PlanWithSensing();
 
-  const trajectory_execution_manager::TrajectoryExecutionManagerPtr& getTrajectoryExecutionManager() const
+  const trajectory_execution_manager::TrajectoryExecutionManagerPtr getTrajectoryExecutionManager() const
   {
     return trajectory_execution_manager_;
   }

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -75,7 +75,7 @@ public:
       \param adapter_plugins_param_name The name of the ROS parameter under which the names of the request adapter
      plugins are specified (plugin names separated by space; order matters)
   */
-  PlanningPipeline(const robot_model::RobotModelConstPtr& model, const ros::NodeHandle& nh = ros::NodeHandle("~"),
+  PlanningPipeline(const robot_model::RobotModelConstPtr model, const ros::NodeHandle& nh = ros::NodeHandle("~"),
                    const std::string& planning_plugin_param_name = "planning_plugin",
                    const std::string& adapter_plugins_param_name = "request_adapters");
 
@@ -85,7 +85,7 @@ public:
       \param planning_plugin_name The name of the planning plugin to load
       \param adapter_plugins_names The names of the planning request adapter plugins to load
   */
-  PlanningPipeline(const robot_model::RobotModelConstPtr& model, const ros::NodeHandle& nh,
+  PlanningPipeline(const robot_model::RobotModelConstPtr model, const ros::NodeHandle& nh,
                    const std::string& planning_plugin_name, const std::vector<std::string>& adapter_plugin_names);
 
   /** \brief Pass a flag telling the pipeline whether or not to publish the computed motion plans on DISPLAY_PATH_TOPIC.
@@ -122,7 +122,7 @@ public:
       \param planning_scene The planning scene where motion planning is to be done
       \param req The request for motion planning
       \param res The motion planning response */
-  bool generatePlan(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool generatePlan(const planning_scene::PlanningSceneConstPtr planning_scene,
                     const planning_interface::MotionPlanRequest& req,
                     planning_interface::MotionPlanResponse& res) const;
 
@@ -134,7 +134,7 @@ public:
      add the current state of the robot as prefix, when the robot started to plan only from near that state, as the
      current state itself appears to touch obstacles). This is helpful because the added states should not be considered
      invalid in all situations. */
-  bool generatePlan(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  bool generatePlan(const planning_scene::PlanningSceneConstPtr planning_scene,
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& adapter_added_state_index) const;
 
@@ -154,13 +154,13 @@ public:
   }
 
   /** \brief Get the planner manager for the loaded planning plugin */
-  const planning_interface::PlannerManagerPtr& getPlannerManager()
+  const planning_interface::PlannerManagerPtr getPlannerManager()
   {
     return planner_instance_;
   }
 
   /** \brief Get the robot model that this pipeline is using */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -46,7 +46,7 @@
 
 namespace planning_scene_monitor
 {
-typedef boost::function<void(const sensor_msgs::JointStateConstPtr& joint_state)> JointStateUpdateCallback;
+typedef boost::function<void(const sensor_msgs::JointStateConstPtr joint_state)> JointStateUpdateCallback;
 
 /** @class CurrentStateMonitor
     @brief Monitors the joint_states topic and tf to maintain the current state of the robot. */
@@ -60,7 +60,7 @@ public:
    * @param robot_model The current kinematic model to build on
    * @param tf_buffer A pointer to the tf2_ros Buffer to use
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr robot_model,
                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
   /** @brief Constructor.
@@ -68,7 +68,7 @@ public:
    *  @param tf_buffer A pointer to the tf2_ros Buffer to use
    *  @param nh A ros::NodeHandle to pass node specific options
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr robot_model,
                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::NodeHandle& nh);
 
   ~CurrentStateMonitor();
@@ -86,7 +86,7 @@ public:
   bool isActive() const;
 
   /** @brief Get the RobotModel for which we are monitoring state */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -188,7 +188,7 @@ public:
   }
 
 private:
-  void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
+  void jointStateCallback(const sensor_msgs::JointStateConstPtr joint_state);
   void tfCallback();
 
   ros::NodeHandle nh_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -136,8 +136,7 @@ public:
    *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
-  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene,
-                       const robot_model_loader::RobotModelLoaderPtr rml,
+  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene, const robot_model_loader::RobotModelLoaderPtr rml,
                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
@@ -150,8 +149,8 @@ public:
    *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
-  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene,
-                       const robot_model_loader::RobotModelLoaderPtr rml, const ros::NodeHandle& nh,
+  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene, const robot_model_loader::RobotModelLoaderPtr rml,
+                       const ros::NodeHandle& nh,
                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -116,7 +116,7 @@ public:
    *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
-  PlanningSceneMonitor(const robot_model_loader::RobotModelLoaderPtr& rml,
+  PlanningSceneMonitor(const robot_model_loader::RobotModelLoaderPtr rml,
                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
@@ -126,7 +126,7 @@ public:
    *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
-  PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene, const std::string& robot_description,
+  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene, const std::string& robot_description,
                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
@@ -136,8 +136,8 @@ public:
    *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
-  PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
-                       const robot_model_loader::RobotModelLoaderPtr& rml,
+  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene,
+                       const robot_model_loader::RobotModelLoaderPtr rml,
                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
@@ -150,8 +150,8 @@ public:
    *  @param tf_buffer A pointer to a tf2_ros::Buffer
    *  @param name A name identifying this planning scene monitor
    */
-  PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
-                       const robot_model_loader::RobotModelLoaderPtr& rml, const ros::NodeHandle& nh,
+  PlanningSceneMonitor(const planning_scene::PlanningScenePtr scene,
+                       const robot_model_loader::RobotModelLoaderPtr rml, const ros::NodeHandle& nh,
                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
                        const std::string& name = "");
 
@@ -164,12 +164,12 @@ public:
   }
 
   /** \brief Get the user kinematic model loader */
-  const robot_model_loader::RobotModelLoaderPtr& getRobotModelLoader() const
+  const robot_model_loader::RobotModelLoaderPtr getRobotModelLoader() const
   {
     return rm_loader_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -188,7 +188,7 @@ public:
    * @see LockedPlanningSceneRO
    * @see LockedPlanningSceneRW.
    * @return A pointer to the current planning scene.*/
-  const planning_scene::PlanningScenePtr& getPlanningScene()
+  const planning_scene::PlanningScenePtr getPlanningScene()
   {
     return scene_;
   }
@@ -196,7 +196,7 @@ public:
   /*! @brief <b>Avoid this function!</b>  Returns an @b
    *         unsafe pointer to the current planning scene.
    * @copydetails PlanningSceneMonitor::getPlanningScene() */
-  const planning_scene::PlanningSceneConstPtr& getPlanningScene() const
+  const planning_scene::PlanningSceneConstPtr getPlanningScene() const
   {
     return scene_const_;
   }
@@ -205,13 +205,13 @@ public:
       or indirectly by this monitor. This function will return true if
       the pointer of the scene is the same as the one maintained,
       or if a parent of the scene is the one maintained. */
-  bool updatesScene(const planning_scene::PlanningSceneConstPtr& scene) const;
+  bool updatesScene(const planning_scene::PlanningSceneConstPtr scene) const;
 
   /** @brief Return true if the scene \e scene can be updated directly
       or indirectly by this monitor. This function will return true if
       the pointer of the scene is the same as the one maintained,
       or if a parent of the scene is the one maintained. */
-  bool updatesScene(const planning_scene::PlanningScenePtr& scene) const;
+  bool updatesScene(const planning_scene::PlanningScenePtr scene) const;
 
   /** @brief Get the stored robot description
    *  @return An instance of the stored robot description*/
@@ -277,12 +277,12 @@ public:
 
   /** @brief Get the stored instance of the stored current state monitor
    *  @return An instance of the stored current state monitor*/
-  const CurrentStateMonitorPtr& getStateMonitor() const
+  const CurrentStateMonitorPtr getStateMonitor() const
   {
     return current_state_monitor_;
   }
 
-  CurrentStateMonitorPtr& getStateMonitorNonConst()
+  CurrentStateMonitorPtr getStateMonitorNonConst()
   {
     return current_state_monitor_;
   }
@@ -405,31 +405,31 @@ protected:
   /** @brief Initialize the planning scene monitor
    *  @param scene The scene instance to fill with data (an instance is allocated if the one passed in is not allocated)
    */
-  void initialize(const planning_scene::PlanningScenePtr& scene);
+  void initialize(const planning_scene::PlanningScenePtr scene);
 
   /** @brief Configure the collision matrix for a particular scene */
-  void configureCollisionMatrix(const planning_scene::PlanningScenePtr& scene);
+  void configureCollisionMatrix(const planning_scene::PlanningScenePtr scene);
 
   /** @brief Configure the default padding*/
   void configureDefaultPadding();
 
   /** @brief Callback for a new collision object msg*/
-  void collisionObjectCallback(const moveit_msgs::CollisionObjectConstPtr& obj);
+  void collisionObjectCallback(const moveit_msgs::CollisionObjectConstPtr obj);
 
   /** @brief Callback for a new planning scene world*/
-  void newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr& world);
+  void newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr world);
 
   /** @brief Callback for octomap updates */
   void octomapUpdateCallback();
 
   /** @brief Callback for a new attached object msg*/
-  void attachObjectCallback(const moveit_msgs::AttachedCollisionObjectConstPtr& obj);
+  void attachObjectCallback(const moveit_msgs::AttachedCollisionObjectConstPtr obj);
 
   /** @brief Callback for a change for an attached object of the current state of the planning scene */
   void currentStateAttachedBodyUpdateCallback(robot_state::AttachedBody* attached_body, bool just_attached);
 
   /** @brief Callback for a change in the world maintained by the planning scene */
-  void currentWorldObjectUpdateCallback(const collision_detection::World::ObjectConstPtr& object,
+  void currentWorldObjectUpdateCallback(const collision_detection::World::ObjectConstPtr object,
                                         collision_detection::World::Action action);
 
   void includeRobotLinksInOctree();
@@ -437,8 +437,8 @@ protected:
 
   void excludeWorldObjectsFromOctree();
   void includeWorldObjectsInOctree();
-  void excludeWorldObjectFromOctree(const collision_detection::World::ObjectConstPtr& obj);
-  void includeWorldObjectInOctree(const collision_detection::World::ObjectConstPtr& obj);
+  void excludeWorldObjectFromOctree(const collision_detection::World::ObjectConstPtr obj);
+  void includeWorldObjectInOctree(const collision_detection::World::ObjectConstPtr obj);
 
   void excludeAttachedBodiesFromOctree();
   void includeAttachedBodiesInOctree();
@@ -527,13 +527,13 @@ private:
   void scenePublishingThread();
 
   // called by current_state_monitor_ when robot state (as monitored on joint state topic) changes
-  void onStateUpdate(const sensor_msgs::JointStateConstPtr& joint_state);
+  void onStateUpdate(const sensor_msgs::JointStateConstPtr joint_state);
 
   // called by state_update_timer_ when a state update it pending
   void stateUpdateTimerCallback(const ros::WallTimerEvent& event);
 
   // Callback for a new planning scene msg
-  void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr& scene);
+  void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr scene);
 
   // Lock for state_update_pending_ and dt_state_update_
   boost::mutex state_pending_mutex_;
@@ -593,13 +593,13 @@ private:
 class LockedPlanningSceneRO
 {
 public:
-  LockedPlanningSceneRO(const PlanningSceneMonitorPtr& planning_scene_monitor)
+  LockedPlanningSceneRO(const PlanningSceneMonitorPtr planning_scene_monitor)
     : planning_scene_monitor_(planning_scene_monitor)
   {
     initialize(true);
   }
 
-  const PlanningSceneMonitorPtr& getPlanningSceneMonitor()
+  const PlanningSceneMonitorPtr getPlanningSceneMonitor()
   {
     return planning_scene_monitor_;
   }
@@ -609,18 +609,18 @@ public:
     return planning_scene_monitor_ && planning_scene_monitor_->getPlanningScene();
   }
 
-  operator const planning_scene::PlanningSceneConstPtr&() const
+  operator const planning_scene::PlanningSceneConstPtr() const
   {
     return static_cast<const PlanningSceneMonitor*>(planning_scene_monitor_.get())->getPlanningScene();
   }
 
-  const planning_scene::PlanningSceneConstPtr& operator->() const
+  const planning_scene::PlanningSceneConstPtr operator->() const
   {
     return static_cast<const PlanningSceneMonitor*>(planning_scene_monitor_.get())->getPlanningScene();
   }
 
 protected:
-  LockedPlanningSceneRO(const PlanningSceneMonitorPtr& planning_scene_monitor, bool read_only)
+  LockedPlanningSceneRO(const PlanningSceneMonitorPtr planning_scene_monitor, bool read_only)
     : planning_scene_monitor_(planning_scene_monitor)
   {
     initialize(read_only);
@@ -685,17 +685,17 @@ protected:
 class LockedPlanningSceneRW : public LockedPlanningSceneRO
 {
 public:
-  LockedPlanningSceneRW(const PlanningSceneMonitorPtr& planning_scene_monitor)
+  LockedPlanningSceneRW(const PlanningSceneMonitorPtr planning_scene_monitor)
     : LockedPlanningSceneRO(planning_scene_monitor, false)
   {
   }
 
-  operator const planning_scene::PlanningScenePtr&()
+  operator const planning_scene::PlanningScenePtr()
   {
     return planning_scene_monitor_->getPlanningScene();
   }
 
-  const planning_scene::PlanningScenePtr& operator->()
+  const planning_scene::PlanningScenePtr operator->()
   {
     return planning_scene_monitor_->getPlanningScene();
   }

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -44,7 +44,7 @@
 
 namespace planning_scene_monitor
 {
-typedef boost::function<void(const robot_state::RobotStateConstPtr& state, const ros::Time& stamp)>
+typedef boost::function<void(const robot_state::RobotStateConstPtr state, const ros::Time& stamp)>
     TrajectoryStateAddedCallback;
 
 MOVEIT_CLASS_FORWARD(TrajectoryMonitor);
@@ -56,7 +56,7 @@ class TrajectoryMonitor
 public:
   /** @brief Constructor.
    */
-  TrajectoryMonitor(const CurrentStateMonitorConstPtr& state_monitor, double sampling_frequency = 0.0);
+  TrajectoryMonitor(const CurrentStateMonitorConstPtr state_monitor, double sampling_frequency = 0.0);
 
   ~TrajectoryMonitor();
 

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -65,13 +65,13 @@ public:
   }
 
   /** @brief Get the parsed URDF model*/
-  const urdf::ModelInterfaceSharedPtr& getURDF() const
+  const urdf::ModelInterfaceSharedPtr getURDF() const
   {
     return urdf_;
   }
 
   /** @brief Get the parsed SRDF model*/
-  const srdf::ModelSharedPtr& getSRDF() const
+  const srdf::ModelSharedPtr getSRDF() const
   {
     return srdf_;
   }

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -84,7 +84,7 @@ public:
   ~RobotModelLoader();
 
   /** @brief Get the constructed planning_models::RobotModel */
-  const robot_model::RobotModelPtr& getModel() const
+  const robot_model::RobotModelPtr getModel() const
   {
     return model_;
   }
@@ -96,33 +96,33 @@ public:
   }
 
   /** @brief Get the parsed URDF model*/
-  const urdf::ModelInterfaceSharedPtr& getURDF() const
+  const urdf::ModelInterfaceSharedPtr getURDF() const
   {
     return rdf_loader_->getURDF();
   }
 
   /** @brief Get the parsed SRDF model*/
-  const srdf::ModelSharedPtr& getSRDF() const
+  const srdf::ModelSharedPtr getSRDF() const
   {
     return rdf_loader_->getSRDF();
   }
 
   /** @brief Get the instance of rdf_loader::RDFLoader that was used to load the robot description */
-  const rdf_loader::RDFLoaderPtr& getRDFLoader() const
+  const rdf_loader::RDFLoaderPtr getRDFLoader() const
   {
     return rdf_loader_;
   }
 
   /** \brief Get the kinematics solvers plugin loader.
       \note This instance needs to be kept in scope, otherwise kinematics solver plugins may get unloaded. */
-  const kinematics_plugin_loader::KinematicsPluginLoaderPtr& getKinematicsPluginLoader() const
+  const kinematics_plugin_loader::KinematicsPluginLoaderPtr getKinematicsPluginLoader() const
   {
     return kinematics_loader_;
   }
 
   /** @brief Load the kinematics solvers into the kinematic model. This is done by default, unless disabled explicitly
    * by the options passed to the constructor */
-  void loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr& kloader =
+  void loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr kloader =
                                  kinematics_plugin_loader::KinematicsPluginLoaderPtr());
 
 private:

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -81,12 +81,12 @@ public:
   };
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm);
+  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr robot_model,
+                             const planning_scene_monitor::CurrentStateMonitorPtr csm);
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
+  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr robot_model,
+                             const planning_scene_monitor::CurrentStateMonitorPtr csm, bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)
   ~TrajectoryExecutionManager();
@@ -95,7 +95,7 @@ public:
   bool isManagingControllers() const;
 
   /// Get the instance of the controller manager used (this is the plugin instance loaded)
-  const moveit_controller_manager::MoveItControllerManagerPtr& getControllerManager() const;
+  const moveit_controller_manager::MoveItControllerManagerPtr getControllerManager() const;
 
   /** \brief Execute a named event (e.g., 'stop') */
   void processEvent(const std::string& event);
@@ -296,7 +296,7 @@ private:
 
   void stopExecutionInternal();
 
-  void receiveEvent(const std_msgs::StringConstPtr& event);
+  void receiveEvent(const std_msgs::StringConstPtr event);
 
   void loadControllerParams();
 

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -55,7 +55,7 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
   @param tf_buffer
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
 /**
@@ -66,7 +66,7 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot
   @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                      const ros::NodeHandle& nh);
 

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -99,7 +99,7 @@ typedef boost::function<bool(const robot_state::RobotState& state, visualization
 ///           is somehow invalid or erronious (e.g. in collision).  true if
 ///           everything worked well.
 typedef boost::function<bool(robot_state::RobotState& state,
-                             const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback)>
+                             const visualization_msgs::InteractiveMarkerFeedbackConstPtr feedback)>
     ProcessFeedbackFn;
 
 /// Type of function for updating marker pose for new state.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -76,19 +76,19 @@ class InteractionHandler : public LockedRobotState
 {
 public:
   // Use this constructor if you have an initial RobotState already.
-  InteractionHandler(const RobotInteractionPtr& robot_interaction, const std::string& name,
+  InteractionHandler(const RobotInteractionPtr robot_interaction, const std::string& name,
                      const robot_state::RobotState& initial_robot_state,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   // Use this constructor to start with a default state.
-  InteractionHandler(const RobotInteractionPtr& robot_interaction, const std::string& name,
+  InteractionHandler(const RobotInteractionPtr robot_interaction, const std::string& name,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   // DEPRECATED.
   InteractionHandler(const std::string& name, const robot_state::RobotState& initial_robot_state,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
   // DEPRECATED.
-  InteractionHandler(const std::string& name, const robot_model::RobotModelConstPtr& model,
+  InteractionHandler(const std::string& name, const robot_model::RobotModelConstPtr model,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   ~InteractionHandler() override
@@ -190,17 +190,17 @@ public:
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
   virtual void handleEndEffector(const EndEffectorInteraction& eef,
-                                 const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
+                                 const visualization_msgs::InteractiveMarkerFeedbackConstPtr feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
   virtual void handleJoint(const JointInteraction& vj,
-                           const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
+                           const visualization_msgs::InteractiveMarkerFeedbackConstPtr feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
   virtual void handleGeneric(const GenericInteraction& g,
-                             const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
+                             const visualization_msgs::InteractiveMarkerFeedbackConstPtr feedback);
 
   /** \brief Check if the marker corresponding to this end-effector leads to an
    * invalid state */
@@ -218,7 +218,7 @@ public:
   void clearError(void);
 
 protected:
-  bool transformFeedbackPose(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback,
+  bool transformFeedbackPose(const visualization_msgs::InteractiveMarkerFeedbackConstPtr feedback,
                              const geometry_msgs::Pose& offset, geometry_msgs::PoseStamped& tpose);
 
   const std::string name_;

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -61,7 +61,7 @@ class LockedRobotState
 {
 public:
   LockedRobotState(const robot_state::RobotState& state);
-  LockedRobotState(const robot_model::RobotModelPtr& model);
+  LockedRobotState(const robot_model::RobotModelPtr model);
 
   virtual ~LockedRobotState();
 

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -76,7 +76,7 @@ public:
   /// The topic name on which the internal Interactive Marker Server operates
   static const std::string INTERACTIVE_MARKER_TOPIC;
 
-  RobotInteraction(const robot_model::RobotModelConstPtr& robot_model, const std::string& ns = "");
+  RobotInteraction(const robot_model::RobotModelConstPtr robot_model, const std::string& ns = "");
   virtual ~RobotInteraction();
 
   const std::string& getServerTopic(void) const
@@ -119,14 +119,14 @@ public:
   /// call this for each handler for which you want markers.
   /// The markers are not actually added until you call
   /// publishInteractiveMarkers().
-  void addInteractiveMarkers(const InteractionHandlerPtr& handler, const double marker_scale = 0.0);
+  void addInteractiveMarkers(const InteractionHandlerPtr handler, const double marker_scale = 0.0);
 
   // Update pose of all interactive markers to match the handler's RobotState.
   // Call this when the handler's RobotState changes.
-  void updateInteractiveMarkers(const InteractionHandlerPtr& handler);
+  void updateInteractiveMarkers(const InteractionHandlerPtr handler);
 
   // True if markers are being shown for this handler.
-  bool showingMarkers(const InteractionHandlerPtr& handler);
+  bool showingMarkers(const InteractionHandlerPtr handler);
 
   // Display all markers that have been added.
   // This is needed after calls to addInteractiveMarkers() to publish the
@@ -140,7 +140,7 @@ public:
   // is needed to actually remove the markers from the display.
   void clearInteractiveMarkers();
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -172,23 +172,23 @@ private:
   // called by decideActiveComponents(); add markers for planar and floating joints
   void decideActiveJoints(const std::string& group);
 
-  void moveInteractiveMarker(const std::string& name, const geometry_msgs::PoseStampedConstPtr& msg);
+  void moveInteractiveMarker(const std::string& name, const geometry_msgs::PoseStampedConstPtr msg);
   // register the name of the topic and marker name to move interactive marker from other ROS nodes
   void registerMoveInteractiveMarkerTopic(const std::string& marker_name, const std::string& name);
   // return the diameter of the sphere that certainly can enclose the AABB of the link
   double computeLinkMarkerSize(const std::string& link);
   // return the diameter of the sphere that certainly can enclose the AABB of the links in this group
   double computeGroupMarkerSize(const std::string& group);
-  void computeMarkerPose(const InteractionHandlerPtr& handler, const EndEffectorInteraction& eef,
+  void computeMarkerPose(const InteractionHandlerPtr handler, const EndEffectorInteraction& eef,
                          const robot_state::RobotState& robot_state, geometry_msgs::Pose& pose,
                          geometry_msgs::Pose& control_to_eef_tf) const;
 
-  void addEndEffectorMarkers(const InteractionHandlerPtr& handler, const EndEffectorInteraction& eef,
+  void addEndEffectorMarkers(const InteractionHandlerPtr handler, const EndEffectorInteraction& eef,
                              visualization_msgs::InteractiveMarker& im, bool position = true, bool orientation = true);
-  void addEndEffectorMarkers(const InteractionHandlerPtr& handler, const EndEffectorInteraction& eef,
+  void addEndEffectorMarkers(const InteractionHandlerPtr handler, const EndEffectorInteraction& eef,
                              const geometry_msgs::Pose& offset, visualization_msgs::InteractiveMarker& im,
                              bool position = true, bool orientation = true);
-  void processInteractiveMarkerFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
+  void processInteractiveMarkerFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr feedback);
   void subscribeMoveInteractiveMarker(const std::string marker_name, const std::string& name);
   void processingThread();
   void clearInteractiveMarkersUnsafe();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -107,17 +107,17 @@ public:
     return query_goal_state_->getState();
   }
 
-  const robot_interaction::RobotInteractionPtr& getRobotInteraction() const
+  const robot_interaction::RobotInteractionPtr getRobotInteraction() const
   {
     return robot_interaction_;
   }
 
-  const robot_interaction::InteractionHandlerPtr& getQueryStartStateHandler() const
+  const robot_interaction::InteractionHandlerPtr getQueryStartStateHandler() const
   {
     return query_start_state_;
   }
 
-  const robot_interaction::InteractionHandlerPtr& getQueryGoalStateHandler() const
+  const robot_interaction::InteractionHandlerPtr getQueryGoalStateHandler() const
   {
     return query_goal_state_;
   }
@@ -220,7 +220,7 @@ protected:
   void setQueryStateHelper(bool use_start_state, const std::string& v);
   void populateMenuHandler(std::shared_ptr<interactive_markers::MenuHandler>& mh);
 
-  void selectPlanningGroupCallback(const std_msgs::StringConstPtr& msg);
+  void selectPlanningGroupCallback(const std_msgs::StringConstPtr msg);
 
   // overrides from Display
   void onInitialize() override;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -236,7 +236,7 @@ private:
   void goalStateTextChangedExec(const std::string& goal_state);
 
   // Scene objects tab
-  void addObject(const collision_detection::WorldPtr& world, const std::string& id, const shapes::ShapeConstPtr& shape,
+  void addObject(const collision_detection::WorldPtr world, const std::string& id, const shapes::ShapeConstPtr shape,
                  const Eigen::Isometry3d& pose);
   void updateCollisionObjectPose(bool update_marker_position);
   void createSceneInteractiveMarker();
@@ -284,7 +284,7 @@ private:
   template <typename T>
   void waitForAction(const T& action, const ros::NodeHandle& node_handle, const ros::Duration& wait_for_server,
                      const std::string& name);
-  void listenDetectedObjects(const object_recognition_msgs::RecognizedObjectArrayPtr& msg);
+  void listenDetectedObjects(const object_recognition_msgs::RecognizedObjectArrayPtr msg);
   ros::Subscriber object_recognition_subscriber_;
 
   ros::Subscriber plan_subscriber_;
@@ -299,13 +299,13 @@ private:
   void importResource(const std::string& path);
   void loadStoredStates(const std::string& pattern);
 
-  void remotePlanCallback(const std_msgs::EmptyConstPtr& msg);
-  void remoteExecuteCallback(const std_msgs::EmptyConstPtr& msg);
-  void remoteStopCallback(const std_msgs::EmptyConstPtr& msg);
-  void remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr& msg);
-  void remoteUpdateGoalStateCallback(const std_msgs::EmptyConstPtr& msg);
-  void remoteUpdateCustomStartStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
-  void remoteUpdateCustomGoalStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
+  void remotePlanCallback(const std_msgs::EmptyConstPtr msg);
+  void remoteExecuteCallback(const std_msgs::EmptyConstPtr msg);
+  void remoteStopCallback(const std_msgs::EmptyConstPtr msg);
+  void remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr msg);
+  void remoteUpdateGoalStateCallback(const std_msgs::EmptyConstPtr msg);
+  void remoteUpdateCustomStartStateCallback(const moveit_msgs::RobotStateConstPtr msg);
+  void remoteUpdateCustomGoalStateCallback(const moveit_msgs::RobotStateConstPtr msg);
 
   /* Selects or unselects a item in a list by the item name */
   void setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
@@ -56,7 +56,7 @@ public:
   MotionPlanningParamWidget(QWidget* parent = 0);
   ~MotionPlanningParamWidget() override;
 
-  void setMoveGroup(const moveit::planning_interface::MoveGroupInterfacePtr& mg);
+  void setMoveGroup(const moveit::planning_interface::MoveGroupInterfacePtr mg);
   void setGroupName(const std::string& group_name);
 
 public Q_SLOTS:

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -102,7 +102,7 @@ public:
   void clearJobs();
 
   const std::string getMoveGroupNS() const;
-  const robot_model::RobotModelConstPtr& getRobotModel() const;
+  const robot_model::RobotModelConstPtr getRobotModel() const;
 
   /// wait for robot state more recent than t
   bool waitForCurrentRobotState(const ros::Time& t = ros::Time::now());
@@ -110,7 +110,7 @@ public:
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
   /// get write access to planning scene
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
-  const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
+  const planning_scene_monitor::PlanningSceneMonitorPtr getPlanningSceneMonitor();
 
 private Q_SLOTS:
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -75,7 +75,7 @@ public:
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const robot_model::RobotModelConstPtr getRobotModel() const
   {
     return robot_model_;
   }
@@ -109,7 +109,7 @@ protected:
   void setLinkColor(rviz::Robot* robot, const std::string& link_name, const QColor& color);
   void unsetLinkColor(rviz::Robot* robot, const std::string& link_name);
 
-  void newRobotStateCallback(const moveit_msgs::DisplayRobotState::ConstPtr& state);
+  void newRobotStateCallback(const moveit_msgs::DisplayRobotState::ConstPtr state);
 
   void setRobotHighlights(const moveit_msgs::DisplayRobotState::_highlight_links_type& highlight_links);
   void setHighlight(const std::string& link_name, const std_msgs::ColorRGBA& color);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_link_updater.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_link_updater.h
@@ -45,7 +45,7 @@ namespace moveit_rviz_plugin
 class PlanningLinkUpdater : public rviz::LinkUpdater
 {
 public:
-  PlanningLinkUpdater(const robot_state::RobotStateConstPtr& state) : kinematic_state_(state)
+  PlanningLinkUpdater(const robot_state::RobotStateConstPtr state) : kinematic_state_(state)
   {
   }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
@@ -62,7 +62,7 @@ class PlanningSceneRender
 {
 public:
   PlanningSceneRender(Ogre::SceneNode* root_node, rviz::DisplayContext* context,
-                      const RobotStateVisualizationPtr& robot);
+                      const RobotStateVisualizationPtr robot);
   ~PlanningSceneRender();
 
   Ogre::SceneNode* getGeometryNode()
@@ -70,12 +70,12 @@ public:
     return planning_scene_geometry_node_;
   }
 
-  const RobotStateVisualizationPtr& getRobotVisualization()
+  const RobotStateVisualizationPtr getRobotVisualization()
   {
     return scene_robot_;
   }
 
-  void renderPlanningScene(const planning_scene::PlanningSceneConstPtr& scene, const rviz::Color& default_scene_color,
+  void renderPlanningScene(const planning_scene::PlanningSceneConstPtr scene, const rviz::Color& default_scene_color,
                            const rviz::Color& default_attached_color, OctreeVoxelRenderMode voxel_render_mode,
                            OctreeVoxelColorMode voxel_color_mode, float default_scene_alpha);
   void clear();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -61,10 +61,10 @@ public:
   void load(const urdf::ModelInterface& descr, bool visual = true, bool collision = true);
   void clear();
 
-  void update(const robot_state::RobotStateConstPtr& kinematic_state);
-  void update(const robot_state::RobotStateConstPtr& kinematic_state,
+  void update(const robot_state::RobotStateConstPtr kinematic_state);
+  void update(const robot_state::RobotStateConstPtr kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color);
-  void update(const robot_state::RobotStateConstPtr& kinematic_state,
+  void update(const robot_state::RobotStateConstPtr kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color,
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
@@ -95,7 +95,7 @@ public:
   void setAlpha(float alpha);
 
 private:
-  void updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
+  void updateHelper(const robot_state::RobotStateConstPtr kinematic_state,
                     const std_msgs::ColorRGBA& default_attached_object_color,
                     const std::map<std::string, std_msgs::ColorRGBA>* color_map);
   rviz::Robot robot_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -89,7 +89,7 @@ public:
   virtual void reset();
 
   void onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context, const ros::NodeHandle& update_nh);
-  void onRobotModelLoaded(const robot_model::RobotModelConstPtr& robot_model);
+  void onRobotModelLoaded(const robot_model::RobotModelConstPtr robot_model);
   void onEnable();
   void onDisable();
   void setName(const QString& name);
@@ -121,7 +121,7 @@ protected:
   /**
    * \brief ROS callback for an incoming path message
    */
-  void incomingDisplayTrajectory(const moveit_msgs::DisplayTrajectory::ConstPtr& msg);
+  void incomingDisplayTrajectory(const moveit_msgs::DisplayTrajectory::ConstPtr msg);
   float getStateDisplayTime();
   void clearTrajectoryTrail();
 

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/compute_default_collisions.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/compute_default_collisions.h
@@ -84,7 +84,7 @@ typedef std::map<std::pair<std::string, std::string>, LinkPairData> LinkPairMap;
  * "always" in collision
  * \return Adj List of unique set of pairs of links in string-based form
  */
-LinkPairMap computeDefaultCollisions(const planning_scene::PlanningSceneConstPtr& parent_scene, unsigned int* progress,
+LinkPairMap computeDefaultCollisions(const planning_scene::PlanningSceneConstPtr parent_scene, unsigned int* progress,
                                      const bool include_never_colliding, const unsigned int trials,
                                      const double min_collision_faction, const bool verbose);
 

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -277,7 +277,7 @@ public:
   // ******************************************************************************************
 
   /// Load a robot model
-  void setRobotModel(const moveit::core::RobotModelPtr& robot_model);
+  void setRobotModel(const moveit::core::RobotModelPtr robot_model);
 
   /// Provide a shared kinematic model loader
   robot_model::RobotModelConstPtr getRobotModel();

--- a/moveit_setup_assistant/src/widgets/author_information_widget.h
+++ b/moveit_setup_assistant/src/widgets/author_information_widget.h
@@ -58,7 +58,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  AuthorInformationWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  AuthorInformationWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.h
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.h
@@ -81,7 +81,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  ConfigurationFilesWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  ConfigurationFilesWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.h
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.h
@@ -57,7 +57,7 @@ public:
   // ******************************************************************************************
 
   /// Constructor
-  ControllerEditWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  ControllerEditWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Set the previous data
   void setSelected(const std::string& controller_name);

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -84,7 +84,7 @@ public:
    * \brief User interface for editing the default collision matrix list in an SRDF
    * \param urdf_file String srdf file location. It will create a new file or will edit an existing one
    */
-  DefaultCollisionsWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  DefaultCollisionsWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
   ~DefaultCollisionsWidget() override;
 
   /**

--- a/moveit_setup_assistant/src/widgets/double_list_widget.h
+++ b/moveit_setup_assistant/src/widgets/double_list_widget.h
@@ -59,7 +59,7 @@ public:
   // ******************************************************************************************
 
   /// Constructor
-  DoubleListWidget(QWidget* parent, const MoveItConfigDataPtr& config_data, const QString& long_name,
+  DoubleListWidget(QWidget* parent, const MoveItConfigDataPtr config_data, const QString& long_name,
                    const QString& short_name, bool add_ok_cancel = true);
 
   /// Loads the availble data list

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.h
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.h
@@ -68,7 +68,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  EndEffectorsWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  EndEffectorsWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.h
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.h
@@ -58,7 +58,7 @@ public:
   // ******************************************************************************************
 
   /// Constructor
-  GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Set the previous data
   void setSelected(const std::string& group_name);

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
@@ -60,7 +60,7 @@ public:
   // ******************************************************************************************
 
   /// Constructor
-  KinematicChainWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  KinematicChainWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Loads the availble data list
   void setAvailable();

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.h
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.h
@@ -67,7 +67,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  PassiveJointsWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  PassiveJointsWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;

--- a/moveit_setup_assistant/src/widgets/perception_widget.h
+++ b/moveit_setup_assistant/src/widgets/perception_widget.h
@@ -64,7 +64,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  PerceptionWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  PerceptionWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.h
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.h
@@ -82,7 +82,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  PlanningGroupsWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  PlanningGroupsWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   void changeScreen(int index);
 

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.h
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.h
@@ -70,7 +70,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  RobotPosesWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  RobotPosesWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.h
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.h
@@ -66,7 +66,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  ROSControllersWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  ROSControllersWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   void changeScreen(int index);
 

--- a/moveit_setup_assistant/src/widgets/simulation_widget.h
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.h
@@ -64,7 +64,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  SimulationWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  SimulationWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
 private Q_SLOTS:
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -72,7 +72,7 @@ public:
   /**
    * \brief Start screen user interface for MoveIt Configuration Assistant
    */
-  StartScreenWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  StartScreenWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   ~StartScreenWidget() override;
 

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.h
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.h
@@ -66,7 +66,7 @@ public:
   // Public Functions
   // ******************************************************************************************
 
-  VirtualJointsWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
+  VirtualJointsWidget(QWidget* parent, const MoveItConfigDataPtr config_data);
 
   /// Received when this widget is chosen from the navigation menu
   void focusGiven() override;


### PR DESCRIPTION
A reference to a shared_ptr in a function call presents an opportunity for use after free bugs.  If we are ok with the overhead cost of shared_ptr for memory safety we should never make a reference to one as it does not increase the reference count and therefore presents opportunity for memory bugs and security issues.

This also applies to functions that return a reference to the object pointed to by a shared pointer.  I did not address those in this PR.  If the goal of using shared_ptr is to get memory safety we should avoid ever having a reference to the object it points to, let alone making that part of the API.

For an example of why this is a bad practice:
```
#include <memory>
#include <thread>
#include <iostream>
#include <functional>

// moveit API function
void foo(std::shared_ptr<int>& data) {
    while( true ) {
        std::cout << data.use_count() << std::endl;
        std::this_thread::sleep_for (std::chrono::milliseconds(100));
    }
}

// async user code
std::shared_ptr<std::thread> my_thread_;
void bar() {
    std::shared_ptr<int> data = std::make_shared<int>(42);
    my_thread_.reset( new std::thread(std::bind(foo, std::ref(data))));
}

int main() {
    bar();
    while(true);
    return 0;
}
```

This will brake any interface that expects the api function to reset the shared_ptr it previously had a reference to.