### PR TITLE
Fixup #1625: in MSA explicitly call setVisible(true)

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -83,6 +83,9 @@ public:
   void setLinkColor(const std::string& link_name, const QColor& color);
   void unsetLinkColor(const std::string& link_name);
 
+public Q_SLOTS:
+  void setVisible(bool visible);
+
 private Q_SLOTS:
 
   // ******************************************************************************************

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -341,6 +341,11 @@ void RobotStateDisplay::unsetLinkColor(const std::string& link_name)
   unsetLinkColor(&robot_->getRobot(), link_name);
 }
 
+void RobotStateDisplay::setVisible(bool visible)
+{
+  robot_->setVisible(visible);
+}
+
 void RobotStateDisplay::setLinkColor(rviz::Robot* robot, const std::string& link_name, const QColor& color)
 {
   rviz::RobotLink* link = robot->getLink(link_name);
@@ -416,7 +421,10 @@ void RobotStateDisplay::update(float wall_dt, float ros_dt)
   if (load_robot_model_)
   {
     loadRobotModel();
+    // The following call to changedRobotStateTopic() should not change visibility
+    bool visible = robot_->isVisible();
     changedRobotStateTopic();
+    robot_->setVisible(visible);
   }
 
   calculateOffsetPosition();

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -397,6 +397,7 @@ void SetupAssistantWidget::loadRviz()
 
   // Set robot description
   robot_state_display_->subProp("Robot Description")->setValue(QString::fromStdString(ROBOT_DESCRIPTION));
+  robot_state_display_->setVisible(true);
 
   // Zoom into robot
   rviz::ViewController* view = rviz_manager_->getViewManager()->getCurrent();


### PR DESCRIPTION
... to actually show the robot of the RobotStateDisplay (which is hidden initially since #1625).
Fixes b0f01b2dc79f99f5650933834c8e50905bdbe168.
Addresses https://github.com/ros-planning/moveit/issues/1736#issuecomment-554953490.
