### PR TITLE
Wait for done-callback

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -128,7 +128,7 @@ public:
     if (controller_action_client_ && !done_)
     {
       bool result = controller_action_client_->waitForResult(timeout);
-      while(ros::ok() && !done_ && (timeout.isZero() || ros::Time::now() < end_time))
+      while (ros::ok() && !done_ && (timeout.isZero() || ros::Time::now() < end_time))
         ros::Duration(0.0001).sleep();  // wait for done callback (race-condition)
       return result && (timeout.isZero() || ros::Time::now() < end_time);
     }

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -128,9 +128,13 @@ public:
     if (controller_action_client_ && !done_)
     {
       bool result = controller_action_client_->waitForResult(timeout);
+#if 1  // TODO: remove when https://github.com/ros/actionlib/issues/155 is fixed
+      // workaround for actionlib issue: waitForResult() might return before our doneCB finished
       while (ros::ok() && !done_ && (timeout.isZero() || ros::Time::now() < end_time))
-        ros::Duration(0.0001).sleep();  // wait for done callback (race-condition)
-      return result && (timeout.isZero() || ros::Time::now() < end_time);
+        ros::Duration(0.0001).sleep();  // thus check the done_ flag explicitly
+      result = result && (timeout.isZero() || ros::Time::now() < end_time);
+#endif
+      return result;
     }
     return true;
   }

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -124,8 +124,14 @@ public:
 
   bool waitForExecution(const ros::Duration& timeout = ros::Duration(0)) override
   {
+    ros::Time end_time = ros::Time::now() + timeout;
     if (controller_action_client_ && !done_)
-      return controller_action_client_->waitForResult(timeout);
+    {
+      bool result = controller_action_client_->waitForResult(timeout);
+      while(ros::ok() && !done_ && (timeout.isZero() || ros::Time::now() < end_time))
+        ros::Duration(0.0001).sleep();// wait for done callback (race-condition)
+      return result && (timeout.isZero() || ros::Time::now() < end_time);
+    }
     return true;
   }
 

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -129,7 +129,7 @@ public:
     {
       bool result = controller_action_client_->waitForResult(timeout);
       while(ros::ok() && !done_ && (timeout.isZero() || ros::Time::now() < end_time))
-        ros::Duration(0.0001).sleep();// wait for done callback (race-condition)
+        ros::Duration(0.0001).sleep();  // wait for done callback (race-condition)
       return result && (timeout.isZero() || ros::Time::now() < end_time);
     }
     return true;


### PR DESCRIPTION
Fixes #1493

### Description

After `waitForResult` returned, we cannot assume that the done callback has been called already. This PR still uses the `waitForResult` function, that has sophisticated boost-wait-conditions inside, but adds a while-loop afterwards waiting for the done-flag to be set within our callback routine.

Please cherry-pick to melodic.
