### PR TITLE
Add "<previous>" support robot state to RViz motion display #14.

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -108,6 +108,11 @@ public:
     return query_goal_state_->getState();
   }
 
+  const robot_state::RobotState& getPreviousState() const
+  {
+    return *previous_state_;
+  }
+
   const robot_interaction::RobotInteractionPtr& getRobotInteraction() const
   {
     return robot_interaction_;
@@ -133,6 +138,7 @@ public:
 
   void updateQueryStartState();
   void updateQueryGoalState();
+  void updatePreviousState();
 
   void useApproximateIK(bool flag);
 
@@ -254,6 +260,7 @@ protected:
   std::shared_ptr<interactive_markers::MenuHandler> menu_handler_goal_;
   std::map<std::string, LinkDisplayStatus> status_links_start_;
   std::map<std::string, LinkDisplayStatus> status_links_goal_;
+  robot_state::RobotStatePtr previous_state_;
 
   /// Hold the names of the groups for which the query states have been updated (and should not be altered when new info
   /// is received from the planning scene)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -260,6 +260,7 @@ protected:
   std::shared_ptr<interactive_markers::MenuHandler> menu_handler_goal_;
   std::map<std::string, LinkDisplayStatus> status_links_start_;
   std::map<std::string, LinkDisplayStatus> status_links_goal_;
+  /// remember previous start state (updated before starting execution)
   robot_state::RobotStatePtr previous_state_;
 
   /// Hold the names of the groups for which the query states have been updated (and should not be altered when new info

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -138,7 +138,7 @@ public:
 
   void updateQueryStartState();
   void updateQueryGoalState();
-  void updatePreviousState();
+  void rememberPreviousStartState();
 
   void useApproximateIK(bool flag);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -936,6 +936,11 @@ void MotionPlanningDisplay::updateQueryGoalState()
   context_->queueRender();
 }
 
+void MotionPlanningDisplay::updatePreviousState()
+{
+  *previous_state_ = *query_start_state_->getState();
+}
+
 void MotionPlanningDisplay::setQueryStartState(const robot_state::RobotState& start)
 {
   query_start_state_->setState(start);
@@ -1142,6 +1147,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
                                                                     planning_scene_monitor_->getTFClient()));
   query_start_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryStartState, this, _1, _2));
   query_goal_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryGoalState, this, _1, _2));
+  previous_state_ = ks;
 
   // Interactive marker menus
   populateMenuHandler(menu_handler_start_);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -936,7 +936,7 @@ void MotionPlanningDisplay::updateQueryGoalState()
   context_->queueRender();
 }
 
-void MotionPlanningDisplay::updatePreviousState()
+void MotionPlanningDisplay::rememberPreviousStartState()
 {
   *previous_state_ = *query_start_state_->getState();
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1140,14 +1140,14 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   query_robot_start_->load(*getRobotModel()->getURDF());
   query_robot_goal_->load(*getRobotModel()->getURDF());
 
-  robot_state::RobotStatePtr ks(new robot_state::RobotState(getPlanningSceneRO()->getCurrentState()));
-  query_start_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "start", *ks,
+  robot_state::RobotStatePtr robot_state(new robot_state::RobotState(getPlanningSceneRO()->getCurrentState()));
+  query_start_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "start", *robot_state,
                                                                      planning_scene_monitor_->getTFClient()));
-  query_goal_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "goal", *ks,
+  query_goal_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "goal", *robot_state,
                                                                     planning_scene_monitor_->getTFClient()));
   query_start_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryStartState, this, _1, _2));
   query_goal_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryGoalState, this, _1, _2));
-  previous_state_ = ks;
+  previous_state_ = robot_state;
 
   // Interactive marker menus
   populateMenuHandler(menu_handler_start_);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1140,14 +1140,14 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   query_robot_start_->load(*getRobotModel()->getURDF());
   query_robot_goal_->load(*getRobotModel()->getURDF());
 
-  robot_state::RobotStatePtr robot_state(new robot_state::RobotState(getPlanningSceneRO()->getCurrentState()));
-  query_start_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "start", *robot_state,
+  // initialize previous state to current state
+  previous_state_ = std::make_shared<robot_state::RobotState>(getPlanningSceneRO()->getCurrentState());
+  query_start_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "start", *previous_state_,
                                                                      planning_scene_monitor_->getTFClient()));
-  query_goal_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "goal", *robot_state,
+  query_goal_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "goal", *previous_state_,
                                                                     planning_scene_monitor_->getTFClient()));
   query_start_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryStartState, this, _1, _2));
   query_goal_state_->setUpdateCallback(boost::bind(&MotionPlanningDisplay::scheduleDrawQueryGoalState, this, _1, _2));
-  previous_state_ = robot_state;
 
   // Interactive marker menus
   populateMenuHandler(menu_handler_start_);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -281,11 +281,13 @@ void MotionPlanningFrame::fillStateSelectionOptions()
     ui_->start_state_combo_box->addItem(QString("<random>"));
     ui_->start_state_combo_box->addItem(QString("<current>"));
     ui_->start_state_combo_box->addItem(QString("<same as goal>"));
+    ui_->start_state_combo_box->addItem(QString("<previous>"));
 
     ui_->goal_state_combo_box->addItem(QString("<random valid>"));
     ui_->goal_state_combo_box->addItem(QString("<random>"));
     ui_->goal_state_combo_box->addItem(QString("<current>"));
     ui_->goal_state_combo_box->addItem(QString("<same as start>"));
+    ui_->goal_state_combo_box->addItem(QString("<previous>"));
 
     const std::vector<std::string>& known_states = jmg->getDefaultStateNames();
     if (!known_states.empty())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -281,7 +281,6 @@ void MotionPlanningFrame::fillStateSelectionOptions()
     ui_->start_state_combo_box->addItem(QString("<random>"));
     ui_->start_state_combo_box->addItem(QString("<current>"));
     ui_->start_state_combo_box->addItem(QString("<same as goal>"));
-    ui_->start_state_combo_box->addItem(QString("<previous>"));
 
     ui_->goal_state_combo_box->addItem(QString("<random valid>"));
     ui_->goal_state_combo_box->addItem(QString("<random>"));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -242,6 +242,16 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
   // update query start state to current if neccessary
   if (ui_->start_state_combo_box->currentText() == "<current>")
     startStateTextChanged(ui_->start_state_combo_box->currentText());
+
+  // update previous state if plan is successfully executed
+  if (success)
+  {
+    planning_display_->updatePreviousState();
+    if (ui_->goal_state_combo_box->currentText() == "<previous>")
+    {
+      goalStateTextChanged(ui_->goal_state_combo_box->currentText());
+    }
+  }
 }
 
 void MotionPlanningFrame::startStateTextChanged(const QString& start_state)
@@ -341,6 +351,12 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState& state,
   if (v == "<same as start>")
   {
     state = *planning_display_->getQueryStartState();
+    return;
+  }
+
+  if (v == "<previous>")
+  {
+    state = planning_display_->getPreviousState();
     return;
   }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -246,7 +246,7 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
   // update previous state if plan is successfully executed
   if (success)
   {
-    planning_display_->updatePreviousState();
+    planning_display_->rememberPreviousStartState();
     if (ui_->goal_state_combo_box->currentText() == "<previous>")
     {
       goalStateTextChanged(ui_->goal_state_combo_box->currentText());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -172,6 +172,7 @@ void MotionPlanningFrame::computePlanButtonClicked()
   ui_->result_label->setText("Planning...");
 
   configureForPlanning();
+  planning_display_->rememberPreviousStartState();
   bool success = (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState()) ?
                      computeCartesianPlan() :
                      computeJointSpacePlan();
@@ -206,6 +207,7 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   if (!move_group_)
     return;
   configureForPlanning();
+  planning_display_->rememberPreviousStartState();
   // move_group::move() on the server side, will always start from the current state
   // to suppress a warning, we pass an empty state (which encodes "start from current state")
   move_group_->setStartStateToCurrentState();
@@ -243,15 +245,10 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
   if (ui_->start_state_combo_box->currentText() == "<current>")
     startStateTextChanged(ui_->start_state_combo_box->currentText());
 
-  // update previous state if plan is successfully executed
-  if (success)
-  {
-    planning_display_->rememberPreviousStartState();
-    if (ui_->goal_state_combo_box->currentText() == "<previous>")
-    {
-      goalStateTextChanged(ui_->goal_state_combo_box->currentText());
-    }
-  }
+  // auto-update goal to stored previous state (but only on success)
+  // on failure, the user must update the goal to the previous state himself
+  if (ui_->goal_state_combo_box->currentText() == "<previous>")
+    goalStateTextChanged(ui_->goal_state_combo_box->currentText());
 }
 
 void MotionPlanningFrame::startStateTextChanged(const QString& start_state)


### PR DESCRIPTION
### Description

Add an entry "<previous"> in the Update Start/Goal State drop-down list for referencing a previous pose. 

Fixes #14 

![add_previous_robot_state_to_rviz](https://user-images.githubusercontent.com/2109183/69224737-6d15e800-0bc0-11ea-82d5-0ece8d3c88d3.gif)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Include a screenshot if changing a GUI
