### PR TITLE
Adapt cmake for Bullet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - TEST="clang-format catkin_lint"
     - TEST=code-coverage
     - ROS_DISTRO=melodic
+    - ROS_DISTRO=kinetic
 
 matrix: # Add a separate config to the matrix, using clang as compiler
   include:

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -22,16 +22,14 @@ endif()
 find_package(Boost REQUIRED system filesystem date_time thread iostreams)
 find_package(Eigen3 REQUIRED)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+
 # TODO: Move collision detection into separate packages
-find_package(Bullet CONFIG)
+find_package(Bullet)
 
 # TODO(j-petit): Version check can be dropped when Xenial reaches end-of-life
 if(BULLET_FOUND AND BULLET_VERSION_STRING VERSION_GREATER "2.86")
   set(BULLET_ENABLE "BULLET")
-  set(BULLET_INCLUDE_DIRS "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
-  set(BULLET_INCLUDE_DIR "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIR}")
-  set(BULLET_LIBRARY_DIRS "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS}")
-  set(BULLET_LIBRARIES "libBulletDynamics.so;libBulletCollision.so;libLinearMath.so;libBulletSoftBody.so")
   message(STATUS "Compiling with Bullet")
 else()
   message(STATUS "Version of Bullet too old or not available: disabling Bullet collision detection plugin. Try using Ubuntu 18.04 or later.")

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -25,10 +25,10 @@ find_package(Eigen3 REQUIRED)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 # TODO: Move collision detection into separate packages
-find_package(Bullet)
+find_package(Bullet 2.87)
 
 # TODO(j-petit): Version check can be dropped when Xenial reaches end-of-life
-if(BULLET_FOUND AND BULLET_VERSION_STRING VERSION_GREATER "2.86")
+if(BULLET_FOUND)
   set(BULLET_ENABLE "BULLET")
   message(STATUS "Compiling with Bullet")
 else()
@@ -40,6 +40,7 @@ pkg_check_modules(LIBFCL_PC REQUIRED fcl)
 # find *absolute* paths to LIBFCL_INCLUDE_DIRS and LIBFCL_LIBRARIES
 find_path(LIBFCL_INCLUDE_DIRS fcl/config.h HINTS ${LIBFCL_PC_INCLUDE_DIR} ${LIBFCL_PC_INCLUDE_DIRS})
 find_library(LIBFCL_LIBRARIES fcl HINTS ${LIBFCL_PC_LIBRARY_DIRS})
+
 
 find_package(octomap REQUIRED)
 find_package(urdfdom REQUIRED)

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -22,7 +22,13 @@ endif()
 find_package(Boost REQUIRED system filesystem date_time thread iostreams)
 find_package(Eigen3 REQUIRED)
  # TODO: Move collision detection into separate packages
-find_package(Bullet REQUIRED)
+
+find_package(Bullet CONFIG)
+if (BULLET_VERSION_STRING VERSION_GREATER "2.86")
+  set(MOVEIT_HAVE_BULLET 1)
+  # TODO: Add here all cmake code which is bullet specific
+  add_subdirectory(collision_detection_bullet)
+endif()
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBFCL_PC REQUIRED fcl)

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -30,6 +30,8 @@ find_package(Bullet 2.87)
 # TODO(j-petit): Version check can be dropped when Xenial reaches end-of-life
 if(BULLET_FOUND)
   set(BULLET_ENABLE "BULLET")
+  set(BULLET_LIB "moveit_collision_detection_bullet")
+  set(BULLET_INC "collision_detection_bullet/include")
   message(STATUS "Compiling with Bullet")
 else()
   message(STATUS "Version of Bullet too old or not available: disabling Bullet collision detection plugin. Try using Ubuntu 18.04 or later.")
@@ -83,7 +85,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     backtrace/include
     collision_detection/include
     collision_detection_fcl/include
-    collision_detection_bullet/include
+    ${BULLET_INC}
     constraint_samplers/include
     controller_manager/include
     distance_field/include
@@ -120,7 +122,7 @@ catkin_package(
     moveit_planning_interface
     moveit_collision_detection
     moveit_collision_detection_fcl
-    moveit_collision_detection_bullet
+    ${BULLET_LIB}
     moveit_kinematic_constraints
     moveit_planning_scene
     moveit_constraint_samplers

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -21,13 +21,18 @@ endif()
 
 find_package(Boost REQUIRED system filesystem date_time thread iostreams)
 find_package(Eigen3 REQUIRED)
- # TODO: Move collision detection into separate packages
 
+# TODO: Move collision detection into separate packages
 find_package(Bullet CONFIG)
-if (BULLET_VERSION_STRING VERSION_GREATER "2.86")
-  set(MOVEIT_HAVE_BULLET 1)
-  # TODO: Add here all cmake code which is bullet specific
-  add_subdirectory(collision_detection_bullet)
+if(BULLET_FOUND AND BULLET_VERSION_STRING VERSION_GREATER "2.86")
+  set(BULLET_ENABLE "BULLET")
+  set(BULLET_INCLUDE_DIRS "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+  set(BULLET_INCLUDE_DIR "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIR}")
+  set(BULLET_LIBRARY_DIRS "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS}")
+  set(BULLET_LIBRARIES "libBulletDynamics.so;libBulletCollision.so;libLinearMath.so;libBulletSoftBody.so")
+  message(STATUS "Compiling with Bullet")
+else()
+  message(STATUS "Version of Bullet too old or not available: disabling Bullet collision detection plugin")
 endif()
 
 find_package(PkgConfig REQUIRED)
@@ -151,7 +156,7 @@ catkin_package(
     OCTOMAP
     urdfdom
     urdfdom_headers
-    BULLET
+    ${BULLET_ENABLE}
     )
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
@@ -196,7 +201,6 @@ add_subdirectory(robot_state)
 add_subdirectory(robot_trajectory)
 add_subdirectory(collision_detection)
 add_subdirectory(collision_detection_fcl)
-add_subdirectory(collision_detection_bullet)
 add_subdirectory(kinematic_constraints)
 add_subdirectory(planning_scene)
 add_subdirectory(constraint_samplers)
@@ -207,3 +211,7 @@ add_subdirectory(distance_field)
 add_subdirectory(collision_distance_field)
 add_subdirectory(kinematics_metrics)
 add_subdirectory(dynamics_solver)
+
+if(BULLET_ENABLE)
+  add_subdirectory(collision_detection_bullet)
+endif()

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(Eigen3 REQUIRED)
 
 # TODO: Move collision detection into separate packages
 find_package(Bullet CONFIG)
+
+# TODO(j-petit): Version check can be dropped when Xenial reaches end-of-life
 if(BULLET_FOUND AND BULLET_VERSION_STRING VERSION_GREATER "2.86")
   set(BULLET_ENABLE "BULLET")
   set(BULLET_INCLUDE_DIRS "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
@@ -32,7 +34,7 @@ if(BULLET_FOUND AND BULLET_VERSION_STRING VERSION_GREATER "2.86")
   set(BULLET_LIBRARIES "libBulletDynamics.so;libBulletCollision.so;libLinearMath.so;libBulletSoftBody.so")
   message(STATUS "Compiling with Bullet")
 else()
-  message(STATUS "Version of Bullet too old or not available: disabling Bullet collision detection plugin")
+  message(STATUS "Version of Bullet too old or not available: disabling Bullet collision detection plugin. Try using Ubuntu 18.04 or later.")
 endif()
 
 find_package(PkgConfig REQUIRED)

--- a/moveit_core/CMakeModules/FindBullet.cmake
+++ b/moveit_core/CMakeModules/FindBullet.cmake
@@ -1,96 +1,10 @@
-# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
+include(FindPackageHandleStandardArgs)
+find_package(PkgConfig)
 
-#.rst:
-# FindBullet
-# ----------
-#
-# Try to find the Bullet physics engine
-#
-#
-#
-# ::
-#
-#   This module defines the following variables
-#
-#
-#
-# ::
-#
-#   BULLET_FOUND - Was bullet found
-#   BULLET_INCLUDE_DIRS - the Bullet include directories
-#   BULLET_LIBRARIES - Link to this, by default it includes
-#                      all bullet components (Dynamics,
-#                      Collision, LinearMath, & SoftBody)
-#
-#
-#
-# ::
-#
-#   This module accepts the following variables
-#
-#
-#
-# ::
-#
-#   BULLET_ROOT - Can be set to bullet install path or Windows build path
-
-if(EXISTS "/usr/lib/x86_64-linux-gnu/cmake/bullet/BulletConfig.cmake")
-  include("/usr/lib/x86_64-linux-gnu/cmake/bullet/BulletConfig.cmake")
+if(PKGCONFIG_FOUND)
+  pkg_check_modules(BULLET bullet)
 endif()
 
-macro(_FIND_BULLET_LIBRARY _var)
-  find_library(${_var}
-     NAMES
-        ${ARGN}
-     HINTS
-        ${BULLET_ROOT}
-        ${BULLET_ROOT}/lib/Release
-        ${BULLET_ROOT}/lib/Debug
-        ${BULLET_ROOT}/out/release8/libs
-        ${BULLET_ROOT}/out/debug8/libs
-     PATH_SUFFIXES lib
-  )
-  mark_as_advanced(${_var})
-endmacro()
-
-macro(_BULLET_APPEND_LIBRARIES _list _release)
-   set(_debug ${_release}_DEBUG)
-   if(${_debug})
-      set(${_list} ${${_list}} optimized ${${_release}} debug ${${_debug}})
-   else()
-      set(${_list} ${${_list}} ${${_release}})
-   endif()
-endmacro()
-
-find_path(BULLET_INCLUDE_DIR NAMES btBulletCollisionCommon.h
-  HINTS
-    ${BULLET_ROOT}/include
-    ${BULLET_ROOT}/src
-  PATH_SUFFIXES bullet
-)
-
-# Find the libraries
-
-_FIND_BULLET_LIBRARY(BULLET_DYNAMICS_LIBRARY        BulletDynamics)
-_FIND_BULLET_LIBRARY(BULLET_DYNAMICS_LIBRARY_DEBUG  BulletDynamics_Debug BulletDynamics_d)
-_FIND_BULLET_LIBRARY(BULLET_COLLISION_LIBRARY       BulletCollision)
-_FIND_BULLET_LIBRARY(BULLET_COLLISION_LIBRARY_DEBUG BulletCollision_Debug BulletCollision_d)
-_FIND_BULLET_LIBRARY(BULLET_MATH_LIBRARY            BulletMath LinearMath)
-_FIND_BULLET_LIBRARY(BULLET_MATH_LIBRARY_DEBUG      BulletMath_Debug BulletMath_d LinearMath_Debug LinearMath_d)
-_FIND_BULLET_LIBRARY(BULLET_SOFTBODY_LIBRARY        BulletSoftBody)
-_FIND_BULLET_LIBRARY(BULLET_SOFTBODY_LIBRARY_DEBUG  BulletSoftBody_Debug BulletSoftBody_d)
-
-
-find_package(PackageHandleStandardArgs REQUIRED)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Bullet DEFAULT_MSG
-    BULLET_DYNAMICS_LIBRARY BULLET_COLLISION_LIBRARY BULLET_MATH_LIBRARY
-    BULLET_SOFTBODY_LIBRARY BULLET_INCLUDE_DIR)
-
-set(BULLET_INCLUDE_DIRS ${BULLET_INCLUDE_DIR})
-if(BULLET_FOUND)
-   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_DYNAMICS_LIBRARY)
-   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_COLLISION_LIBRARY)
-   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_MATH_LIBRARY)
-   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_SOFTBODY_LIBRARY)
-endif()
+find_package_handle_standard_args(Bullet
+                                  REQUIRED_VARS BULLET_LIBRARIES BULLET_INCLUDE_DIRS
+                                  VERSION_VAR BULLET_VERSION)

--- a/moveit_core/CMakeModules/FindBullet.cmake
+++ b/moveit_core/CMakeModules/FindBullet.cmake
@@ -1,0 +1,96 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindBullet
+# ----------
+#
+# Try to find the Bullet physics engine
+#
+#
+#
+# ::
+#
+#   This module defines the following variables
+#
+#
+#
+# ::
+#
+#   BULLET_FOUND - Was bullet found
+#   BULLET_INCLUDE_DIRS - the Bullet include directories
+#   BULLET_LIBRARIES - Link to this, by default it includes
+#                      all bullet components (Dynamics,
+#                      Collision, LinearMath, & SoftBody)
+#
+#
+#
+# ::
+#
+#   This module accepts the following variables
+#
+#
+#
+# ::
+#
+#   BULLET_ROOT - Can be set to bullet install path or Windows build path
+
+if(EXISTS "/usr/lib/x86_64-linux-gnu/cmake/bullet/BulletConfig.cmake")
+  include("/usr/lib/x86_64-linux-gnu/cmake/bullet/BulletConfig.cmake")
+endif()
+
+macro(_FIND_BULLET_LIBRARY _var)
+  find_library(${_var}
+     NAMES
+        ${ARGN}
+     HINTS
+        ${BULLET_ROOT}
+        ${BULLET_ROOT}/lib/Release
+        ${BULLET_ROOT}/lib/Debug
+        ${BULLET_ROOT}/out/release8/libs
+        ${BULLET_ROOT}/out/debug8/libs
+     PATH_SUFFIXES lib
+  )
+  mark_as_advanced(${_var})
+endmacro()
+
+macro(_BULLET_APPEND_LIBRARIES _list _release)
+   set(_debug ${_release}_DEBUG)
+   if(${_debug})
+      set(${_list} ${${_list}} optimized ${${_release}} debug ${${_debug}})
+   else()
+      set(${_list} ${${_list}} ${${_release}})
+   endif()
+endmacro()
+
+find_path(BULLET_INCLUDE_DIR NAMES btBulletCollisionCommon.h
+  HINTS
+    ${BULLET_ROOT}/include
+    ${BULLET_ROOT}/src
+  PATH_SUFFIXES bullet
+)
+
+# Find the libraries
+
+_FIND_BULLET_LIBRARY(BULLET_DYNAMICS_LIBRARY        BulletDynamics)
+_FIND_BULLET_LIBRARY(BULLET_DYNAMICS_LIBRARY_DEBUG  BulletDynamics_Debug BulletDynamics_d)
+_FIND_BULLET_LIBRARY(BULLET_COLLISION_LIBRARY       BulletCollision)
+_FIND_BULLET_LIBRARY(BULLET_COLLISION_LIBRARY_DEBUG BulletCollision_Debug BulletCollision_d)
+_FIND_BULLET_LIBRARY(BULLET_MATH_LIBRARY            BulletMath LinearMath)
+_FIND_BULLET_LIBRARY(BULLET_MATH_LIBRARY_DEBUG      BulletMath_Debug BulletMath_d LinearMath_Debug LinearMath_d)
+_FIND_BULLET_LIBRARY(BULLET_SOFTBODY_LIBRARY        BulletSoftBody)
+_FIND_BULLET_LIBRARY(BULLET_SOFTBODY_LIBRARY_DEBUG  BulletSoftBody_Debug BulletSoftBody_d)
+
+
+find_package(PackageHandleStandardArgs REQUIRED)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Bullet DEFAULT_MSG
+    BULLET_DYNAMICS_LIBRARY BULLET_COLLISION_LIBRARY BULLET_MATH_LIBRARY
+    BULLET_SOFTBODY_LIBRARY BULLET_INCLUDE_DIR)
+
+set(BULLET_INCLUDE_DIRS ${BULLET_INCLUDE_DIR})
+if(BULLET_FOUND)
+   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_DYNAMICS_LIBRARY)
+   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_COLLISION_LIBRARY)
+   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_MATH_LIBRARY)
+   _BULLET_APPEND_LIBRARIES(BULLET_LIBRARIES BULLET_SOFTBODY_LIBRARY)
+endif()

--- a/moveit_ros/planning/planning_components_tools/CMakeLists.txt
+++ b/moveit_ros/planning/planning_components_tools/CMakeLists.txt
@@ -14,8 +14,10 @@ target_link_libraries(moveit_visualize_robot_collision_volume moveit_planning_sc
 add_executable(moveit_evaluate_collision_checking_speed src/evaluate_collision_checking_speed.cpp)
 target_link_libraries(moveit_evaluate_collision_checking_speed moveit_planning_scene_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_executable(moveit_compare_collision_checking_speed_fcl_bullet src/compare_collision_speed_checking_fcl_bullet.cpp)
-target_link_libraries(moveit_compare_collision_checking_speed_fcl_bullet moveit_planning_scene_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+if("${catkin_LIBRARIES}" MATCHES "moveit_collision_detection_bullet")
+  add_executable(moveit_compare_collision_checking_speed_fcl_bullet src/compare_collision_speed_checking_fcl_bullet.cpp)
+  target_link_libraries(moveit_compare_collision_checking_speed_fcl_bullet moveit_planning_scene_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+endif()
 
 add_executable(moveit_kinematics_speed_and_validity_evaluator src/kinematics_speed_and_validity_evaluator.cpp)
 target_link_libraries(moveit_kinematics_speed_and_validity_evaluator moveit_robot_model_loader ${catkin_LIBRARIES} ${Boost_LIBRARIES})


### PR DESCRIPTION
### Description
This PR adapts the build process in order to add the Bullet dependent code only if the available version is greater than Bullet version 2.86 (2.87 is the one available through apt on Ubuntu 18.04).