### PR TITLE
Fixing MSA: incorrect 3D sensor configuration if no sensor option selected

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1007,31 +1007,27 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
 bool MoveItConfigData::output3DSensorPluginYAML(const std::string& file_path)
 {
   YAML::Emitter emitter;
-  emitter << YAML::BeginMap;
+  emitter << YAML::Comment("The name of this file shouldn't be changed, else the Setup Assistant won't detect it");
 
-  emitter << YAML::Comment("The name of this file shouldn't be changed, or else the Setup Assistant won't detect it");
+  emitter << YAML::BeginMap;
   emitter << YAML::Key << "sensors";
   emitter << YAML::Value << YAML::BeginSeq;
 
-  // Can we have more than one plugin config?
-  emitter << YAML::BeginMap;
-
-  // Make sure sensors_plugin_config_parameter_list_ is not empty
-  if (!sensors_plugin_config_parameter_list_.empty())
+  // Make sure sensors_plugin_config_parameter_list_ parameters map is not empty
+  if (!sensors_plugin_config_parameter_list_[0].empty())
   {
+    // Can we have more than one plugin config?
+    emitter << YAML::BeginMap;
     for (auto& parameter : sensors_plugin_config_parameter_list_[0])
     {
       emitter << YAML::Key << parameter.first;
       emitter << YAML::Value << parameter.second.getValue();
     }
+    emitter << YAML::EndMap;
   }
 
-  emitter << YAML::EndMap;
-
   emitter << YAML::EndSeq;
-
   emitter << YAML::EndMap;
-
   std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
   if (!output_stream.good())
   {


### PR DESCRIPTION
### Description

Fixing issue #1680  

Thanks @gavanderhoorn for the detailed issue, this PR should fix and it would be a sequence in case of empty config.

```
sensors: []
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
