### PR TITLE
delete IKCache copy constructor

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -90,7 +90,7 @@ public:
 
   IKCache();
   ~IKCache();
-  IKCache(const IKCache&) = default;
+  IKCache(const IKCache&) = delete;
 
   /** get the entry from the IK cache that best matches a given pose */
   const IKEntry& getBestApproximateIKSolution(const Pose& pose) const;


### PR DESCRIPTION
It never existed, because the class contains a mutex object (not copyable).
clang complained about this discrepancy.