### PR TITLE
Update issue template to non-legacy workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
 ### Description
 
 Overview of your issue here.
 
 ### Your environment
-* ROS Distro: [Indigo|Jade|Kinetic]
-* OS Version: e.g. Ubuntu 16.04
+* ROS Distro: [Kinetic|Melodic]
+* OS Version: e.g. Ubuntu 18.04
 * Source or Binary build?
 * If binary, which release version?
-* If source, which git commit or tag?
+* If source, which branch?
 
 ### Steps to reproduce
 Tell us how to reproduce this issue. Attempt to provide a working demo, perhaps using Docker.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Currently we're using the old single-template issue approach:
https://help.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository

Switching to dual approach: bug vs feature request