### PR TITLE
Create a feature for scaling the distance metrics for the manipulators

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -350,18 +350,12 @@ public:
 
   /** \brief Get the factor that should be applied to the value returned by distance() when that value is used in
    * compound distances */
-  double getDistanceFactor() const
-  {
-    return distance_factor_;
-  }
-
+  double getDistanceFactor() const = 0;
+ 
   /** \brief Set the factor that should be applied to the value returned by distance() when that value is used in
    * compound distances */
-  void setDistanceFactor(double factor)
-  {
-    distance_factor_ = factor;
-  }
-
+  void setDistanceFactor(double factor);
+  
   /** \brief Get the dimension of the state space that corresponds to this joint */
   virtual unsigned int getStateSpaceDimension() const = 0;
 

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -96,14 +96,14 @@ bool JointModel::harmonizePosition(double* values, const Bounds& other_bounds) c
 }
 
 double JointModel::getDistanceFactor() const
-  {
-    return distance_factor_;
-  }
+{
+  return distance_factor_;
+}
 
 void JointModel::setDistanceFactor(double factor)
-  {
-    distance_factor_ = factor;
-  }
+{
+  distance_factor_ = factor;
+}
 
 bool JointModel::enforceVelocityBounds(double* values, const Bounds& other_bounds) const
 {

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -95,6 +95,16 @@ bool JointModel::harmonizePosition(double* values, const Bounds& other_bounds) c
   return false;
 }
 
+double JointModel::getDistanceFactor() const
+  {
+    return distance_factor_;
+  }
+
+void JointModel::setDistanceFactor(double factor)
+  {
+    distance_factor_ = factor;
+  }
+
 bool JointModel::enforceVelocityBounds(double* values, const Bounds& other_bounds) const
 {
   bool change = false;

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -110,9 +110,20 @@ void RobotModelLoader::configure(const Options& opt)
     for (moveit::core::JointModel* jmodel : model_->getJointModels())
     {
       std::vector<moveit_msgs::JointLimits> jlim = jmodel->getVariableBoundsMsg();
+			std::vector<double> jw = jmodel->getDistanceFactor();			
+
       for (std::size_t j = 0; j < jlim.size(); ++j)
       {
         std::string prefix = rdf_loader_->getRobotDescription() + "_planning/joint_limits/" + jlim[j].joint_name + "/";
+
+				double weight;
+        if (nh.getParam(prefix + "weight", weight))
+        {
+          if (canSpecifyPosition(jmodel, j))
+          {
+            jw[j].distance_factor_ = weight;
+          }
+        }
 
         double max_position;
         if (nh.getParam(prefix + "max_position", max_position))
@@ -153,6 +164,7 @@ void RobotModelLoader::configure(const Options& opt)
           jlim[j].has_acceleration_limits = has_acc_limits;
       }
       jmodel->setVariableBounds(jlim);
+			jmodel->setDistanceFactor(jw);
     }
   }
 

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -107,64 +107,64 @@ void RobotModelLoader::configure(const Options& opt)
     // if there are additional joint limits specified in some .yaml file, read those in
     ros::NodeHandle nh("~");
 
-    for (moveit::core::JointModel* jmodel : model_->getJointModels())
+    for (moveit::core::JointModel* joint_model : model_->getJointModels())
     {
-      std::vector<moveit_msgs::JointLimits> jlim = jmodel->getVariableBoundsMsg();
-      std::vector<double> jweight = jmodel->getDistanceFactor();			
+      std::vector<moveit_msgs::JointLimits> joint_limit = joint_model->getVariableBoundsMsg();
+      std::vector<double> joint_weight = joint_model->getDistanceFactor();			
 
-      for (std::size_t j = 0; j < jlim.size(); ++j)
+      for (std::size_t joint_id = 0; joint_id < joint_limit.size(); ++j)
       {
-        std::string prefix = rdf_loader_->getRobotDescription() + "_planning/joint_limits/" + jlim[j].joint_name + "/";
+        std::string prefix = rdf_loader_->getRobotDescription() + "_planning/joint_limits/" + joint_limit[joint_id].joint_name + "/";
 
 	double weight;
         if (nh.getParam(prefix + "weight", weight))
         {
-          if (canSpecifyPosition(jmodel, j))
+          if (canSpecifyPosition(joint_model, joint_id))
           {
-            jweight[j].distance_factor_ = weight;
+            joint_weight[joint_id].distance_factor_ = weight;
           }
         }
 
         double max_position;
         if (nh.getParam(prefix + "max_position", max_position))
         {
-          if (canSpecifyPosition(jmodel, j))
+          if (canSpecifyPosition(joint_model, joint_id))
           {
-            jlim[j].has_position_limits = true;
-            jlim[j].max_position = max_position;
+            joint_limit[joint_id].has_position_limits = true;
+            joint_limit[joint_id].max_position = max_position;
           }
         }
         double min_position;
         if (nh.getParam(prefix + "min_position", min_position))
         {
-          if (canSpecifyPosition(jmodel, j))
+          if (canSpecifyPosition(joint_model, joint_id))
           {
-            jlim[j].has_position_limits = true;
-            jlim[j].min_position = min_position;
+            joint_limit[joint_id].has_position_limits = true;
+            joint_limit[joint_id].min_position = min_position;
           }
         }
         double max_velocity;
         if (nh.getParam(prefix + "max_velocity", max_velocity))
         {
-          jlim[j].has_velocity_limits = true;
-          jlim[j].max_velocity = max_velocity;
+          joint_limit[joint_id].has_velocity_limits = true;
+          joint_limit[joint_id].max_velocity = max_velocity;
         }
         bool has_vel_limits;
         if (nh.getParam(prefix + "has_velocity_limits", has_vel_limits))
-          jlim[j].has_velocity_limits = has_vel_limits;
+          joint_limit[joint_id].has_velocity_limits = has_vel_limits;
 
         double max_acc;
         if (nh.getParam(prefix + "max_acceleration", max_acc))
         {
-          jlim[j].has_acceleration_limits = true;
-          jlim[j].max_acceleration = max_acc;
+          joint_limit[joint_id].has_acceleration_limits = true;
+          joint_limit[joint_id].max_acceleration = max_acc;
         }
         bool has_acc_limits;
         if (nh.getParam(prefix + "has_acceleration_limits", has_acc_limits))
-          jlim[j].has_acceleration_limits = has_acc_limits;
+          joint_limit[joint_id].has_acceleration_limits = has_acc_limits;
       }
-      jmodel->setVariableBounds(jlim);
-      jmodel->setDistanceFactor(jweight);
+      joint_model->setVariableBounds(joint_limit);
+      joint_model->setDistanceFactor(joint_weight);
     }
   }
 

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -110,13 +110,13 @@ void RobotModelLoader::configure(const Options& opt)
     for (moveit::core::JointModel* jmodel : model_->getJointModels())
     {
       std::vector<moveit_msgs::JointLimits> jlim = jmodel->getVariableBoundsMsg();
-			std::vector<double> jw = jmodel->getDistanceFactor();			
+      std::vector<double> jw = jmodel->getDistanceFactor();			
 
       for (std::size_t j = 0; j < jlim.size(); ++j)
       {
         std::string prefix = rdf_loader_->getRobotDescription() + "_planning/joint_limits/" + jlim[j].joint_name + "/";
 
-				double weight;
+	double weight;
         if (nh.getParam(prefix + "weight", weight))
         {
           if (canSpecifyPosition(jmodel, j))
@@ -164,7 +164,7 @@ void RobotModelLoader::configure(const Options& opt)
           jlim[j].has_acceleration_limits = has_acc_limits;
       }
       jmodel->setVariableBounds(jlim);
-			jmodel->setDistanceFactor(jw);
+      jmodel->setDistanceFactor(jw);
     }
   }
 

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -110,7 +110,7 @@ void RobotModelLoader::configure(const Options& opt)
     for (moveit::core::JointModel* jmodel : model_->getJointModels())
     {
       std::vector<moveit_msgs::JointLimits> jlim = jmodel->getVariableBoundsMsg();
-      std::vector<double> jw = jmodel->getDistanceFactor();			
+      std::vector<double> jweight = jmodel->getDistanceFactor();			
 
       for (std::size_t j = 0; j < jlim.size(); ++j)
       {
@@ -121,7 +121,7 @@ void RobotModelLoader::configure(const Options& opt)
         {
           if (canSpecifyPosition(jmodel, j))
           {
-            jw[j].distance_factor_ = weight;
+            jweight[j].distance_factor_ = weight;
           }
         }
 
@@ -164,7 +164,7 @@ void RobotModelLoader::configure(const Options& opt)
           jlim[j].has_acceleration_limits = has_acc_limits;
       }
       jmodel->setVariableBounds(jlim);
-      jmodel->setDistanceFactor(jw);
+      jmodel->setDistanceFactor(jweight);
     }
   }
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_context.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_context.launch
@@ -14,8 +14,10 @@
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/joint_limits.yaml"/>
+		<!-- Load updated joint weights -->
+		<rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/joint_weights.yaml"/>
   </group>
-
+ 
   <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
   <group ns="$(arg robot_description)_kinematics">
     <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/kinematics.yaml"/>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_context.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_context.launch
@@ -13,9 +13,9 @@
 
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
-    <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/joint_limits.yaml"/>
-		<!-- Load updated joint weights -->
-		<rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/joint_weights.yaml"/>
+  <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/joint_limits.yaml"/>
+  <!-- Load updated joint weights -->
+  <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/joint_weights.yaml"/>
   </group>
  
   <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->


### PR DESCRIPTION
### Description

- Create a yaml file for joint weights which is included in the panda_moveit_config/config
- Load the yaml param file in the planning_context.launch along with the joint_limits
- Modify the declaration & definition for setDistanceFactor() and getDistanceFactor() functions in the joint_model.h and joint_model.cpp respectively
- Get the distance_factor_ in the robot_model_loader.cpp and set it to the values of the weights from the joint_weights.yaml file 
- This pull request depends on a pull request in panda_moveit_config repo to add joint_weights.yaml file 
- Thus, the user can create a joint_weights.yaml file for their robot and set the values according to their desired scaling factor
 