### PR TITLE
move_group capability for publishing planning scene frames to the tf system

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/get_planning_scene_service_capability.cpp
   src/default_capabilities/apply_planning_scene_service_capability.cpp
   src/default_capabilities/clear_octomap_service_capability.cpp
+  src/default_capabilities/tf_publisher_capability.cpp
   )
 set_target_properties(moveit_move_group_default_capabilities PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 add_dependencies(moveit_move_group_default_capabilities ${catkin_EXPORTED_TARGETS})

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -66,7 +66,7 @@
     </description>
   </class>
   
-  <class name="move_group/TfPublisher" type="move_group::MoveGroupTfPublisher" base_class_type="move_group::MoveGroupCapability">
+  <class name="move_group/TfPublisher" type="move_group::TfPublisher" base_class_type="move_group::MoveGroupCapability">
     <description>
       Provide a capability that publishes PlanningScene frames to the tf system
     </description>

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -65,5 +65,11 @@
       Provide a ROS service that allows for clearing the octomap
     </description>
   </class>
+  
+  <class name="move_group/MoveGroupTfPublisher" type="move_group::MoveGroupTfPublisher" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      Provide a capability that publishes PlanningScene frames to the tf system
+    </description>
+  </class>
 
 </library>

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -66,7 +66,7 @@
     </description>
   </class>
   
-  <class name="move_group/MoveGroupTfPublisher" type="move_group::MoveGroupTfPublisher" base_class_type="move_group::MoveGroupCapability">
+  <class name="move_group/TfPublisher" type="move_group::MoveGroupTfPublisher" base_class_type="move_group::MoveGroupCapability">
     <description>
       Provide a capability that publishes PlanningScene frames to the tf system
     </description>

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -84,8 +84,9 @@ void MoveGroupTfPublisher::initialize()
 {
   ros::NodeHandle nh = ros::NodeHandle("~");
 
-  prefix_ = nh.getNamespace() + "/";
+  std::string prefix = nh.getNamespace() + "/";
   nh.param("planning_scene_frame_publishing_rate", rate_, 10);
+  nh.param("planning_scene_tf_prefix", prefix_, prefix);
 
   ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
   std::thread publisher_thread(&MoveGroupTfPublisher::publishPlanningSceneFrames, this);

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -1,0 +1,83 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jonas Tietz */
+
+#include "tf_publisher_capability.h"
+#include <moveit/utils/message_checks.h>
+#include <moveit/move_group/capability_names.h>
+#include <thread>
+#include <tf/transform_broadcaster.h>
+#include <tf_conversions/tf_eigen.h>
+
+namespace move_group
+{
+MoveGroupTfPublisher::MoveGroupTfPublisher() : MoveGroupCapability("TfPublisher")
+{
+}
+
+void MoveGroupTfPublisher::publishPlanningSceneFrames()
+{
+  tf::TransformBroadcaster broadcaster;
+  tf::Transform transform;
+  ros::Rate rate(10);
+  std::string prefix = "move_group/";
+
+  while (ros::ok())
+  {
+    planning_scene_monitor::LockedPlanningSceneRO locked_planning_scene(context_->planning_scene_monitor_);
+    collision_detection::WorldConstPtr world = locked_planning_scene->getWorld();
+    std::string planning_frame = locked_planning_scene->getPlanningFrame();
+
+    for (auto obj = world->begin(); obj != world->end(); ++obj)
+    {
+      tf::poseEigenToTF(obj->second->shape_poses_[0], transform);
+      broadcaster.sendTransform(
+          tf::StampedTransform(transform, ros::Time::now(), planning_frame, prefix + obj->second->id_));
+    }
+
+    rate.sleep();
+  }
+}
+
+void MoveGroupTfPublisher::initialize()
+{
+  ROS_INFO("Initializing MoveGroupTfPublisher");
+  std::thread publisher_thread(&MoveGroupTfPublisher::publishPlanningSceneFrames, this);
+  publisher_thread.detach();
+}
+}
+
+#include <class_loader/class_loader.hpp>
+CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupTfPublisher, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -51,7 +51,7 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
 {
   tf::TransformBroadcaster broadcaster;
   tf::Transform transform;
-  ros::Rate rate(10);
+  ros::Rate rate(rate_);
   std::string prefix = "move_group/";
 
   while (ros::ok())
@@ -75,7 +75,9 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
 
 void MoveGroupTfPublisher::initialize()
 {
-  ROS_INFO("Initializing MoveGroupTfPublisher");
+  ros::NodeHandle nh = ros::NodeHandle("~");
+  nh.param("planning_scene_frame_publishing_rate",rate_,10);
+  ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
   std::thread publisher_thread(&MoveGroupTfPublisher::publishPlanningSceneFrames, this);
   publisher_thread.detach();
 }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -52,8 +52,7 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
   tf::TransformBroadcaster broadcaster;
   tf::Transform transform;
   ros::Rate rate(rate_);
-  std::string prefix = "move_group/";
-
+  
   while (ros::ok())
   {
     {
@@ -65,7 +64,7 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
       {
         tf::poseEigenToTF(obj->second->shape_poses_[0], transform);
         broadcaster.sendTransform(
-            tf::StampedTransform(transform, ros::Time::now(), planning_frame, prefix + obj->second->id_));
+            tf::StampedTransform(transform, ros::Time::now(), planning_frame, prefix_ + obj->second->id_));
       }
     }
 
@@ -76,7 +75,10 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
 void MoveGroupTfPublisher::initialize()
 {
   ros::NodeHandle nh = ros::NodeHandle("~");
+
+  prefix_ = nh.getNamespace() + "/";
   nh.param("planning_scene_frame_publishing_rate",rate_,10);
+
   ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
   std::thread publisher_thread(&MoveGroupTfPublisher::publishPlanningSceneFrames, this);
   publisher_thread.detach();

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -65,19 +65,19 @@ void TfPublisher::publishPlanningSceneFrames()
       collision_detection::WorldConstPtr world = locked_planning_scene->getWorld();
       std::string planning_frame = locked_planning_scene->getPlanningFrame();
 
-      for (auto obj = world->begin(); obj != world->end(); ++obj)
+      for (const auto& obj : *world)
       {
-        std::string parent_frame = prefix_ + obj->second->id_;
-        transform = tf2::eigenToTransform(obj->second->shape_poses_[0]);
+        std::string parent_frame = prefix_ + obj.second->id_;
+        transform = tf2::eigenToTransform(obj.second->shape_poses_[0]);
         transform.child_frame_id = parent_frame;
         transform.header.frame_id = planning_frame;
         broadcaster.sendTransform(transform);
 
-        moveit::core::FixedTransformsMap subframes = obj->second->subframe_poses_;
-        for (auto frame = subframes.begin(); frame != subframes.end(); ++frame)
+        moveit::core::FixedTransformsMap subframes = obj.second->subframe_poses_;
+        for (auto& subframe : subframes)
         {
-          transform = tf2::eigenToTransform(frame->second);
-          transform.child_frame_id = parent_frame + "/" + frame->first;
+          transform = tf2::eigenToTransform(subframe.second);
+          transform.child_frame_id = parent_frame + "/" + subframe.first;
           transform.header.frame_id = parent_frame;
           broadcaster.sendTransform(transform);
         }
@@ -100,7 +100,7 @@ void TfPublisher::initialize()
   ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
   thread_ = std::thread(&TfPublisher::publishPlanningSceneFrames, this);
 }
-}
+}  // namespace move_group
 
 #include <class_loader/class_loader.hpp>
 CLASS_LOADER_REGISTER_CLASS(move_group::TfPublisher, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -48,6 +48,7 @@ TfPublisher::TfPublisher() : MoveGroupCapability("TfPublisher")
 
 TfPublisher::~TfPublisher()
 {
+  keep_running_ = false;
   thread_.join();
 }
 
@@ -57,7 +58,7 @@ void TfPublisher::publishPlanningSceneFrames()
   geometry_msgs::TransformStamped transform;
   ros::Rate rate(rate_);
 
-  while (ros::ok())
+  while (keep_running_)
   {
     {
       planning_scene_monitor::LockedPlanningSceneRO locked_planning_scene(context_->planning_scene_monitor_);
@@ -94,6 +95,7 @@ void TfPublisher::initialize()
   std::string prefix = nh.getNamespace() + "/";
   nh.param("planning_scene_frame_publishing_rate", rate_, 10);
   nh.param("planning_scene_tf_prefix", prefix_, prefix);
+  keep_running_ = true;
 
   ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
   thread_ = std::thread(&TfPublisher::publishPlanningSceneFrames, this);

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -43,11 +43,11 @@
 
 namespace move_group
 {
-MoveGroupTfPublisher::MoveGroupTfPublisher() : MoveGroupCapability("TfPublisher")
+TfPublisher::TfPublisher() : MoveGroupCapability("TfPublisher")
 {
 }
 
-void MoveGroupTfPublisher::publishPlanningSceneFrames()
+void TfPublisher::publishPlanningSceneFrames()
 {
   tf::TransformBroadcaster broadcaster;
   tf::Transform transform;
@@ -80,7 +80,7 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
   }
 }
 
-void MoveGroupTfPublisher::initialize()
+void TfPublisher::initialize()
 {
   ros::NodeHandle nh = ros::NodeHandle("~");
 
@@ -89,10 +89,10 @@ void MoveGroupTfPublisher::initialize()
   nh.param("planning_scene_tf_prefix", prefix_, prefix);
 
   ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
-  std::thread publisher_thread(&MoveGroupTfPublisher::publishPlanningSceneFrames, this);
+  std::thread publisher_thread(&TfPublisher::publishPlanningSceneFrames, this);
   publisher_thread.detach();
 }
 }
 
 #include <class_loader/class_loader.hpp>
-CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupTfPublisher, move_group::MoveGroupCapability)
+CLASS_LOADER_REGISTER_CLASS(move_group::TfPublisher, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2019, Hamburg University
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of Hamburg University nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -56,15 +56,17 @@ void MoveGroupTfPublisher::publishPlanningSceneFrames()
 
   while (ros::ok())
   {
-    planning_scene_monitor::LockedPlanningSceneRO locked_planning_scene(context_->planning_scene_monitor_);
-    collision_detection::WorldConstPtr world = locked_planning_scene->getWorld();
-    std::string planning_frame = locked_planning_scene->getPlanningFrame();
-
-    for (auto obj = world->begin(); obj != world->end(); ++obj)
     {
-      tf::poseEigenToTF(obj->second->shape_poses_[0], transform);
-      broadcaster.sendTransform(
-          tf::StampedTransform(transform, ros::Time::now(), planning_frame, prefix + obj->second->id_));
+      planning_scene_monitor::LockedPlanningSceneRO locked_planning_scene(context_->planning_scene_monitor_);
+      collision_detection::WorldConstPtr world = locked_planning_scene->getWorld();
+      std::string planning_frame = locked_planning_scene->getPlanningFrame();
+
+      for (auto obj = world->begin(); obj != world->end(); ++obj)
+      {
+        tf::poseEigenToTF(obj->second->shape_poses_[0], transform);
+        broadcaster.sendTransform(
+            tf::StampedTransform(transform, ros::Time::now(), planning_frame, prefix + obj->second->id_));
+      }
     }
 
     rate.sleep();

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -37,7 +37,6 @@
 #include "tf_publisher_capability.h"
 #include <moveit/utils/message_checks.h>
 #include <moveit/move_group/capability_names.h>
-#include <thread>
 #include <tf/transform_broadcaster.h>
 #include <tf_conversions/tf_eigen.h>
 
@@ -45,6 +44,11 @@ namespace move_group
 {
 TfPublisher::TfPublisher() : MoveGroupCapability("TfPublisher")
 {
+}
+
+TfPublisher::~TfPublisher()
+{
+  thread_.join();
 }
 
 void TfPublisher::publishPlanningSceneFrames()
@@ -89,8 +93,7 @@ void TfPublisher::initialize()
   nh.param("planning_scene_tf_prefix", prefix_, prefix);
 
   ROS_INFO("Initializing MoveGroupTfPublisher with a frame publishing rate of %d", rate_);
-  std::thread publisher_thread(&TfPublisher::publishPlanningSceneFrames, this);
-  publisher_thread.detach();
+  thread_ = std::thread(&TfPublisher::publishPlanningSceneFrames, this);
 }
 }
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -50,5 +50,6 @@ public:
 private:
   void publishPlanningSceneFrames();
   int rate_;
+  std::string prefix_;
 };
 }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -49,5 +49,6 @@ public:
 
 private:
   void publishPlanningSceneFrames();
+  int rate_;
 };
 }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
+#include <thread>
 
 namespace move_group
 {
@@ -44,6 +45,7 @@ class TfPublisher : public MoveGroupCapability
 {
 public:
   TfPublisher();
+  ~TfPublisher();
 
   void initialize() override;
 
@@ -51,5 +53,6 @@ private:
   void publishPlanningSceneFrames();
   int rate_;
   std::string prefix_;
+  std::thread thread_;
 };
 }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -40,10 +40,10 @@
 
 namespace move_group
 {
-class MoveGroupTfPublisher : public MoveGroupCapability
+class TfPublisher : public MoveGroupCapability
 {
 public:
-  MoveGroupTfPublisher();
+  TfPublisher();
 
   void initialize() override;
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -1,0 +1,53 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jonas Tietz */
+
+#pragma once
+
+#include <moveit/move_group/move_group_capability.h>
+
+namespace move_group
+{
+class MoveGroupTfPublisher : public MoveGroupCapability
+{
+public:
+  MoveGroupTfPublisher();
+
+  void initialize() override;
+
+private:
+  void publishPlanningSceneFrames();
+};
+}

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -54,5 +54,6 @@ private:
   int rate_;
   std::string prefix_;
   std::thread thread_;
+  bool keep_running_;
 };
 }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2019, Hamburg University
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of Hamburg University nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *


### PR DESCRIPTION
### Description

This PR points to issue #1735 . I have implemented a move_group capability, which publishes frames of planning scene objects to the tf system.

