### PR TITLE
Unify jog_arm package to be C++14

### DIFF
--- a/moveit_experimental/moveit_jog_arm/CMakeLists.txt
+++ b/moveit_experimental/moveit_jog_arm/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_jog_arm)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
We're [officially C++14](https://moveit.ros.org/documentation/contributing/code/), which was already reflected in all packages except this one