### PR TITLE
Show attached bodies trail in RViz

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
@@ -70,6 +70,7 @@ public:
   void renderShape(Ogre::SceneNode* node, const shapes::Shape* s, const Eigen::Isometry3d& p,
                    OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
                    const rviz::Color& color, float alpha);
+  void updateShapeColors(float r, float g, float b, float a);
   void clear();
 
 private:

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -69,6 +69,8 @@ public:
               const std_msgs::ColorRGBA& default_attached_object_color,
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
+  /// update color of all attached object shapes
+  void updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color);
 
   /**
    * \brief Set the robot as a whole to be visible or not

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -135,7 +135,7 @@ protected:
 
   robot_trajectory::RobotTrajectoryPtr displaying_trajectory_message_;
   robot_trajectory::RobotTrajectoryPtr trajectory_message_to_display_;
-  std::vector<rviz::Robot*> trajectory_trail_;
+  std::vector<RobotStateVisualizationPtr> trajectory_trail_;
   ros::Subscriber trajectory_topic_sub_;
   bool animating_path_;
   bool drop_displaying_trajectory_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -135,7 +135,7 @@ protected:
 
   robot_trajectory::RobotTrajectoryPtr displaying_trajectory_message_;
   robot_trajectory::RobotTrajectoryPtr trajectory_message_to_display_;
-  std::vector<RobotStateVisualizationPtr> trajectory_trail_;
+  std::vector<RobotStateVisualization*> trajectory_trail_;
   ros::Subscriber trajectory_topic_sub_;
   bool animating_path_;
   bool drop_displaying_trajectory_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -128,6 +128,7 @@ protected:
 
   // Handles actually drawing the robot along motion plans
   RobotStateVisualizationPtr display_path_robot_;
+  std_msgs::ColorRGBA default_attached_object_color_;
 
   // Handle colouring of robot
   void setRobotColor(rviz::Robot* robot, const QColor& color);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -186,4 +186,11 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
     scene_shapes_.emplace_back(ogre_shape);
   }
 }
+
+void RenderShapes::updateShapeColors(float r, float g, float b, float a)
+{
+  for (auto it = scene_shapes_.begin(), end = scene_shapes_.end(); it != end; ++it)
+    (**it).setColor(r, g, b, a);
+}
+
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -107,13 +107,13 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
 
   std::vector<const robot_state::AttachedBody*> attached_bodies;
   kinematic_state->getAttachedBodies(attached_bodies);
-  for (std::size_t i = 0; i < attached_bodies.size(); ++i)
+  for (const robot_state::AttachedBody* attached_body : attached_bodies)
   {
     std_msgs::ColorRGBA color = default_attached_object_color;
     float alpha = robot_.getAlpha();
     if (color_map)
     {
-      std::map<std::string, std_msgs::ColorRGBA>::const_iterator it = color_map->find(attached_bodies[i]->getName());
+      std::map<std::string, std_msgs::ColorRGBA>::const_iterator it = color_map->find(attached_body->getName());
       if (it != color_map->end())
       {  // render attached bodies with a color that is a bit different
         color.r = std::max(1.0f, it->second.r * 1.05f);
@@ -123,8 +123,8 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
       }
     }
     rviz::Color rcolor(color.r, color.g, color.b);
-    const EigenSTL::vector_Isometry3d& ab_t = attached_bodies[i]->getGlobalCollisionBodyTransforms();
-    const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_bodies[i]->getShapes();
+    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getGlobalCollisionBodyTransforms();
+    const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)
     {
       render_shapes_->renderShape(robot_.getVisualNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -80,6 +80,12 @@ void RobotStateVisualization::setDefaultAttachedObjectColor(const std_msgs::Colo
   default_attached_object_color_ = default_attached_object_color;
 }
 
+void RobotStateVisualization::updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color)
+{
+  render_shapes_->updateShapeColors(attached_object_color.r, attached_object_color.g, attached_object_color.b,
+                                    robot_.getAlpha());
+}
+
 void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state)
 {
   updateHelper(kinematic_state, default_attached_object_color_, nullptr);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -202,7 +202,7 @@ void TrajectoryVisualization::reset()
 void TrajectoryVisualization::clearTrajectoryTrail()
 {
   for (std::size_t i = 0; i < trajectory_trail_.size(); ++i)
-    trajectory_trail_[i].reset();
+    delete trajectory_trail_[i];
   trajectory_trail_.clear();
 }
 
@@ -231,16 +231,17 @@ void TrajectoryVisualization::changedShowTrail()
   for (std::size_t i = 0; i < trajectory_trail_.size(); i++)
   {
     int waypoint_i = std::min(i * stepsize, t->getWayPointCount() - 1);  // limit to last trajectory point
-    trajectory_trail_[i].reset(new RobotStateVisualization(
-        scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i), nullptr));
-    trajectory_trail_[i]->load(*robot_model_->getURDF());
-    trajectory_trail_[i]->setVisualVisible(display_path_visual_enabled_property_->getBool());
-    trajectory_trail_[i]->setCollisionVisible(display_path_collision_enabled_property_->getBool());
-    trajectory_trail_[i]->setAlpha(robot_path_alpha_property_->getFloat());
-    trajectory_trail_[i]->update(t->getWayPointPtr(waypoint_i));
+    auto r = new RobotStateVisualization(scene_node_, context_, "Trail Robot " + boost::lexical_cast<std::string>(i),
+                                         nullptr);
+    r->load(*robot_model_->getURDF());
+    r->setVisualVisible(display_path_visual_enabled_property_->getBool());
+    r->setCollisionVisible(display_path_collision_enabled_property_->getBool());
+    r->setAlpha(robot_path_alpha_property_->getFloat());
+    r->update(t->getWayPointPtr(waypoint_i));
     if (enable_robot_color_property_->getBool())
-      setRobotColor(&(trajectory_trail_[i]->getRobot()), robot_color_property_->getColor());
-    trajectory_trail_[i]->setVisible(display_->isEnabled() && (!animating_path_ || waypoint_i <= current_state_));
+      setRobotColor(&(r->getRobot()), robot_color_property_->getColor());
+    r->setVisible(display_->isEnabled() && (!animating_path_ || waypoint_i <= current_state_));
+    trajectory_trail_[i] = r;
   }
 }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -537,7 +537,12 @@ void TrajectoryVisualization::setDefaultAttachedObjectColor(const QColor& color)
   default_attached_object_color_.a = color.alphaF();
 
   if (display_path_robot_)
+  {
     display_path_robot_->setDefaultAttachedObjectColor(default_attached_object_color_);
+    display_path_robot_->updateAttachedObjectColors(default_attached_object_color_);
+  }
+  for (RobotStateVisualization* r : trajectory_trail_)
+    r->updateAttachedObjectColors(default_attached_object_color_);
 }
 
 void TrajectoryVisualization::setRobotColor(rviz::Robot* robot, const QColor& color)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -237,7 +237,7 @@ void TrajectoryVisualization::changedShowTrail()
     r->setVisualVisible(display_path_visual_enabled_property_->getBool());
     r->setCollisionVisible(display_path_collision_enabled_property_->getBool());
     r->setAlpha(robot_path_alpha_property_->getFloat());
-    r->update(t->getWayPointPtr(waypoint_i));
+    r->update(t->getWayPointPtr(waypoint_i), default_attached_object_color_);
     if (enable_robot_color_property_->getBool())
       setRobotColor(&(r->getRobot()), robot_color_property_->getColor());
     r->setVisible(display_->isEnabled() && (!animating_path_ || waypoint_i <= current_state_));
@@ -531,15 +531,13 @@ void TrajectoryVisualization::unsetRobotColor(rviz::Robot* robot)
 
 void TrajectoryVisualization::setDefaultAttachedObjectColor(const QColor& color)
 {
-  if (!display_path_robot_)
-    return;
+  default_attached_object_color_.r = color.redF();
+  default_attached_object_color_.g = color.greenF();
+  default_attached_object_color_.b = color.blueF();
+  default_attached_object_color_.a = color.alphaF();
 
-  std_msgs::ColorRGBA color_msg;
-  color_msg.r = color.redF();
-  color_msg.g = color.greenF();
-  color_msg.b = color.blueF();
-  color_msg.a = color.alphaF();
-  display_path_robot_->setDefaultAttachedObjectColor(color_msg);
+  if (display_path_robot_)
+    display_path_robot_->setDefaultAttachedObjectColor(default_attached_object_color_);
 }
 
 void TrajectoryVisualization::setRobotColor(rviz::Robot* robot, const QColor& color)


### PR DESCRIPTION
### Description
Attached bodies were not included in the trail visualization of a trajectory, changing the type from rviz::Robot to RobotStateVisualization solves this issue (#190).

Anyway, the bodies color is always green, I didn't find a proper way to get the color of the attached object and set it in the update method.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
