### PR TITLE
fixing CADB loading bug

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -834,7 +834,6 @@ bool ompl_interface::ModelBasedPlanningContext::loadConstraintApproximations(con
   std::string constraint_path;
   if (nh.getParam("constraint_approximations_path", constraint_path))
   {
-    loadConstraintApproximations(constraint_path);
     constraints_library_->loadConstraintApproximations(constraint_path);
     std::stringstream ss;
     constraints_library_->printConstraintApproximations(ss);


### PR DESCRIPTION

This fixes a small bug introduced in https://github.com/ros-planning/moveit/pull/1428 where loadConstraintDatabase would load the parameter from rosparam and then try to recursively call itself.

