### PR TITLE
support unique_ptr.

### DIFF
--- a/moveit_core/macros/include/moveit/macros/class_forward.h
+++ b/moveit_core/macros/include/moveit/macros/class_forward.h
@@ -40,9 +40,7 @@
 
 /**
  * \def MOVEIT_CLASS_FORWARD
- * Macro that forward declares a class and defines two shared ptrs types:
- *  - ${Class}Ptr      = shared_ptr<${Class}>
- *  - ${Class}ConstPtr = shared_ptr<const ${Class}>
+ * Macro that forward declares a class and defines the respective smartpointers through MOVEIT_DECLARE_PTR.
  */
 
 #define MOVEIT_CLASS_FORWARD(C)                                                                                        \

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -51,21 +51,22 @@
   typedef std::shared_ptr<Type> Name##Ptr;                                                                             \
   typedef std::shared_ptr<const Type> Name##ConstPtr;                                                                  \
   typedef std::weak_ptr<Type> Name##WeakPtr;                                                                           \
-  typedef std::weak_ptr<const Type> Name##ConstWeakPtr;
+  typedef std::weak_ptr<const Type> Name##ConstWeakPtr;                                                                \
+  typedef std::unique_ptr<Type> Name##UniquePtr;                                                                       \
+  typedef std::unique_ptr<const Type> Name##ConstUniquePtr;
 
 /**
  * \def MOVEIT_DELCARE_PTR_MEMBER
- * Macro that given a Type declares the following types:
- * - Ptr      = shared_ptr<${Type}>
- * - ConstPtr = shared_ptr<const ${Type}>
+ * The macro defines the same typedefs as MOVEIT_DECLARE_PTR, but shortens the new names to their suffix.
  *
- * This macro is intended for declaring the pointer typedefs as members of a
- * class template. In other situations, MOVEIT_CLASS_FORWARD and
- * MOVEIT_DECLARE_PTR should be preferred.
+ * This can be used to create `Classname::Ptr` style names, but in most situations in MoveIt's codebase,
+ * MOVEIT_CLASS_FORWARD and MOVEIT_DECLARE_PTR should be preferred.
  */
 
 #define MOVEIT_DECLARE_PTR_MEMBER(Type)                                                                                \
   typedef std::shared_ptr<Type> Ptr;                                                                                   \
   typedef std::shared_ptr<const Type> ConstPtr;                                                                        \
   typedef std::weak_ptr<Type> WeakPtr;                                                                                 \
-  typedef std::weak_ptr<const Type> ConstWeakPtr;
+  typedef std::weak_ptr<const Type> ConstWeakPtr;                                                                      \
+  typedef std::unique_ptr<Type> UniquePtr;                                                                             \
+  typedef std::unique_ptr<const Type> ConstUniquePtr;

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -39,8 +39,12 @@
 /**
  * \def MOVEIT_DELCARE_PTR
  * Macro that given a Name and a Type declares the following types:
- * - ${Name}Ptr      = shared_ptr<${Type}>
- * - ${Name}ConstPtr = shared_ptr<const ${Type}>
+ * - ${Name}Ptr            = shared_ptr<${Type}>
+ * - ${Name}ConstPtr       = shared_ptr<const ${Type}>
+ * - ${Name}WeakPtr        = weak_ptr<${Type}>
+ * - ${Name}ConstWeakPtr   = weak_ptr<const ${Type}>
+ * - ${Name}UniquePtr      = unique_ptr<${Type}>
+ * - ${Name}ConstUniquePtr = unique_ptr<const ${Type}>
  *
  * For best portability the exact type of shared_ptr declared by the macro
  * should be considered to be an implementation detail, liable to change in


### PR DESCRIPTION
Lately, we encountered a number of interfaces, where unique_ptr
would be the preferred smart pointer to use.

This adds them to the class forward macros.

Fixes  #1770 .