### PR TITLE
rviz panel: pass <current> start state as empty to move_group

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -172,6 +172,9 @@ void MotionPlanningFrame::computePlanButtonClicked()
   ui_->result_label->setText("Planning...");
 
   configureForPlanning();
+  // move_group node uses an empty start state to refer to the most recent current state
+  if (ui_->start_state_combo_box->currentText() == "<current>")
+    move_group_->setStartStateToCurrentState();
   planning_display_->rememberPreviousStartState();
   bool success = (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState()) ?
                      computeCartesianPlan() :


### PR DESCRIPTION
... to ensure that the most recent current state is actually used for planning

When testing #1766 I observed several times that planning, triggered from, rviz wasn't using the most recent RobotState (where I just added an attached object).
The reason was the following:
- The rviz plugin queried the current state on startup.
- Then I added an attached object, which was correctly reflected by the PlanningSceneDisplay.
However, the start state was still referring to the original state at startup.
- Planning didn't use the current robot state, but the one saved at some point in the past.
- I was wondering, why the attached object wasn't considered during planning.