### PR TITLE
Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - WARNINGS_OK=false
   matrix:
     - TEST="clang-format catkin_lint"
+    - TEST=code-coverage
     - ROS_DISTRO=melodic
     - ROS_DISTRO=kinetic
 

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -145,16 +145,6 @@ catkin_package(
     urdfdom_headers
     )
 
-
-# to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
-if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
-  find_package(code_coverage REQUIRED)   # catkin package ros-*-code-coverage
-  include(CodeCoverage)
-  APPEND_COVERAGE_COMPILER_FLAGS()
-  set(COVERAGE_EXCLUDES "*/test/*")
-  add_code_coverage(NAME ${PROJECT_NAME}_coverage)
-endif()
-
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
                            ${LIBFCL_INCLUDE_DIRS}
                            )

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -53,7 +53,6 @@
   <test_depend>tf2_kdl</test_depend>
   <test_depend>orocos_kdl</test_depend>
   <test_depend>rosunit</test_depend>
-  <test_depend>code_coverage</test_depend>
 
   <export>
     <moveit_core plugin="${prefix}/collision_detector_fcl_description.xml"/>


### PR DESCRIPTION
Reopening #1765. This is an alternative to #1719, not requiring to touch cmake files.