### PR TITLE
Move ASSERT() into test setup function

### DIFF
--- a/moveit_core/planning_scene/test/test_multi_threaded.cpp
+++ b/moveit_core/planning_scene/test/test_multi_threaded.cpp
@@ -73,8 +73,7 @@ protected:
   void SetUp() override
   {
     robot_model_ = moveit::core::loadTestingRobotModel("panda");
-
-    ASSERT_TRUE(robot_model_);
+    ASSERT_TRUE(static_cast<bool>(robot_model_));
 
     robot_state_.reset(new robot_state::RobotState(robot_model_));
     planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));

--- a/moveit_core/planning_scene/test/test_multi_threaded.cpp
+++ b/moveit_core/planning_scene/test/test_multi_threaded.cpp
@@ -73,7 +73,9 @@ protected:
   void SetUp() override
   {
     robot_model_ = moveit::core::loadTestingRobotModel("panda");
-    robot_model_ok_ = static_cast<bool>(robot_model_);
+
+    ASSERT_TRUE(robot_model_);
+
     robot_state_.reset(new robot_state::RobotState(robot_model_));
     planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
   }
@@ -94,11 +96,6 @@ protected:
 
   planning_scene::PlanningScenePtr planning_scene_;
 };
-
-TEST_F(CollisionDetectorThreadedTest, InitOk)
-{
-  ASSERT_TRUE(robot_model_ok_);
-}
 
 /** \brief Tests the FCL collision detector in multiple threads. */
 TEST_F(CollisionDetectorThreadedTest, FCLThreaded)


### PR DESCRIPTION
### Description
As discussed in [this PR review](https://github.com/ros-planning/moveit/pull/1657#discussion_r348925925), instead of an extra test case the robot setup should be tested in each run.