### PR TITLE
Fix moveitcpp unit test bug

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -133,7 +133,7 @@ public:
     if (!node_handle_.getParam("initial", initial))
     {
       ROS_INFO_NAMED("loadInitialJointValues",
-                     "No initial pose specifid for any joint model group, using the default values for the joints");
+                     "No initial pose specified for any joint model group, using the default values for the joints");
     }
     else
     {

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -125,7 +125,6 @@ public:
     XmlRpc::XmlRpcValue initial;
     robot_model_loader::RobotModelLoader robot_model_loader(ROBOT_DESCRIPTION);
     const robot_model::RobotModelPtr& robot_model = robot_model_loader.getModel();
-
     typedef std::map<std::string, double> JointPoseMap;
     JointPoseMap joints;
 

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -124,7 +124,7 @@ public:
   MoveItCpp& operator=(MoveItCpp&& other);
 
   /** \brief Destructor */
-  ~MoveItCpp();
+  ~MoveItCpp() = default;
 
   /** \brief Get the RobotModel object. */
   robot_model::RobotModelConstPtr getRobotModel() const;

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -130,7 +130,7 @@ public:
   PlanningComponent& operator=(PlanningComponent&& other);
 
   /** \brief Destructor */
-  ~PlanningComponent();
+  ~PlanningComponent() = default;
 
   /** \brief Get the name of the planning group */
   const std::string& getPlanningGroupName() const;

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -101,12 +101,6 @@ MoveItCpp::MoveItCpp(MoveItCpp&& other)
   other.clearContents();
 }
 
-MoveItCpp::~MoveItCpp()
-{
-  ROS_INFO_NAMED(LOGNAME, "Deleting MoveItCpp");
-  clearContents();
-}
-
 MoveItCpp& MoveItCpp::operator=(MoveItCpp&& other)
 {
   if (this != &other)

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -154,7 +154,6 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   moveit::core::RobotStatePtr start_state = considered_start_state_;
   if (!start_state)
     start_state = moveit_cpp_->getCurrentState();
-  start_state->update();
   moveit::core::robotStateToRobotStateMsg(*start_state, req.start_state);
   planning_scene->setCurrentState(*start_state);
 

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -88,12 +88,6 @@ PlanningComponent::PlanningComponent(const std::string& group_name, const ros::N
 {
 }
 
-PlanningComponent::~PlanningComponent()
-{
-  ROS_INFO_NAMED(LOGNAME, "Deleting PlanningComponent '%s'", group_name_.c_str());
-  clearContents();
-}
-
 PlanningComponent& PlanningComponent::operator=(PlanningComponent&& other)
 {
   if (this != &other)
@@ -160,6 +154,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   moveit::core::RobotStatePtr start_state = considered_start_state_;
   if (!start_state)
     start_state = moveit_cpp_->getCurrentState();
+  start_state->update();
   moveit::core::robotStateToRobotStateMsg(*start_state, req.start_state);
   planning_scene->setCurrentState(*start_state);
 

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
@@ -131,8 +131,6 @@ TEST_F(MoveItCppTest, TestSetStartStateToCurrentState)
 TEST_F(MoveItCppTest, TestSetGoalFromPoseStamped)
 {
   planning_component_ptr->setStartStateToCurrentState();
-
-  geometry_msgs::PoseStamped target_pose1;
   planning_component_ptr->setGoal(target_pose1, "panda_link8");
 
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -19,7 +19,7 @@
     </include>
 
     <!-- If needed, broadcast static tf for robot root -->
-    <!--node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" /-->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
 
     <!-- Send fake joint values -->
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -30,5 +30,5 @@
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
     <!-- Unit Test /-->
-    <test test-name="moveit_cpp_test" pkg="moveit_ros_planning_interface" type="moveit_cpp_test" />
+    <test test-name="moveit_cpp_test" pkg="moveit_ros_planning_interface" type="moveit_cpp_test" args="--gtest_repeat=350 --gtest_break_on_failure" time-limit="2500"/>
 </launch>


### PR DESCRIPTION
### Description

This PR fix ~~3~~ 2 bugs

1- As @henningkayser explained in his [comment](https://github.com/ros-planning/moveit/pull/1656#issuecomment-558271580) 

2- Seem like there's a race condition happen sometime which is fixed by defaulting both destructors
```bash
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```
~~3- When I get a warning about dirty transform the tests segfaults~~

This will always publish an initial joint state msg even if no initial pose specified for any joint model group, by calling `robot_model->getVariableDefaultPositions(joints);`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
