### PR TITLE
Fix group states

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -136,9 +136,11 @@ public:
 
     robot_model_loader::RobotModelLoader robot_model_loader(ROBOT_DESCRIPTION);
     const robot_model::RobotModelPtr& robot_model = robot_model_loader.getModel();
+    moveit::core::RobotState robot_state(robot_model);
     typedef std::map<std::string, double> JointPoseMap;
     JointPoseMap joints;
 
+    robot_state.setToDefaultValues();  // initialize all joint values (just in case...)
     for (int i = 0, end = param.size(); i != end; ++i)
     {
       try
@@ -151,7 +153,6 @@ public:
           continue;
         }
         moveit::core::JointModelGroup* jmg = robot_model->getJointModelGroup(group_name);
-        moveit::core::RobotState robot_state(robot_model);
         const std::vector<std::string>& joint_names = jmg->getActiveJointModelNames();
 
         if (!robot_state.setToDefaultValues(jmg, pose_name))

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -319,6 +319,7 @@ const std::shared_ptr<tf2_ros::Buffer>& MoveItCpp::getTFBuffer() const
 
 void MoveItCpp::clearContents()
 {
+  tf_listener_.reset();
   tf_buffer_.reset();
   planning_scene_monitor_.reset();
   robot_model_.reset();

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -160,6 +160,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   moveit::core::RobotStatePtr start_state = considered_start_state_;
   if (!start_state)
     start_state = moveit_cpp_->getCurrentState();
+  start_state->update();
   moveit::core::robotStateToRobotStateMsg(*start_state, req.start_state);
   planning_scene->setCurrentState(*start_state);
 

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -5,9 +5,8 @@ if (CATKIN_ENABLE_TESTING)
   add_executable(test_cleanup test_cleanup.cpp)
   target_link_libraries(test_cleanup moveit_move_group_interface)
 
-  # TODO: Fix flaky test
-  #add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
-  #target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
+  add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
+  target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
 
   add_rostest(python_move_group.test)
   add_rostest(python_move_group_ns.test)

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
@@ -130,9 +130,6 @@ TEST_F(MoveItCppTest, TestSetStartStateToCurrentState)
 // Test setting the goal using geometry_msgs::PoseStamped and a robot's link name
 TEST_F(MoveItCppTest, TestSetGoalFromPoseStamped)
 {
-  planning_component_ptr->setStartStateToCurrentState();
-
-  geometry_msgs::PoseStamped target_pose1;
   planning_component_ptr->setGoal(target_pose1, "panda_link8");
 
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -19,7 +19,7 @@
     </include>
 
     <!-- If needed, broadcast static tf for robot root -->
-    <!--node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" /-->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
 
     <!-- Send fake joint values -->
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">


### PR DESCRIPTION
As pointed out in https://github.com/ros-planning/moveit/pull/1780#issuecomment-558587911,

1. The robot model loader doesn't complain about malformed group states (having missing joints).
2. FakeControllers used those uninitialized joint values for publishing.

Both issues are fixed with this PR. This should fix the flaky moveit-cpp unit test.