### PR TITLE
disable flaky moveit_cpp_test

### DIFF
--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -5,8 +5,10 @@ if (CATKIN_ENABLE_TESTING)
   add_executable(test_cleanup test_cleanup.cpp)
   target_link_libraries(test_cleanup moveit_move_group_interface)
 
-  add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
-  target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
+  # TODO: Fix flaky test
+  #add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
+  #target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
+
   add_rostest(python_move_group.test)
   add_rostest(python_move_group_ns.test)
   add_rostest(robot_state_update.test)


### PR DESCRIPTION
As we don't yet have a solution for the flaky test (#1780 and #1781 still fail), I suggest to disable the unit test for now. @JafarAbdi, please test #1781 locally and provide a stack trace if possible.