### PR TITLE
ControllerManager: wait for done-callback

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -126,6 +126,11 @@ public:
   {
     if (controller_action_client_ && !done_)
       return controller_action_client_->waitForResult(timeout);
+#if 1  // TODO: remove when https://github.com/ros/actionlib/issues/155 is fixed
+    // workaround for actionlib issue: waitForResult() might return before our doneCB finished
+    while (!done_ && ros::ok())       // Thus, check the done_ flag explicitly,
+      ros::Duration(0.0001).sleep();  // which is eventually set in finishControllerExecution
+#endif
     return true;
   }
 

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -128,8 +128,9 @@ public:
       return controller_action_client_->waitForResult(timeout);
 #if 1  // TODO: remove when https://github.com/ros/actionlib/issues/155 is fixed
     // workaround for actionlib issue: waitForResult() might return before our doneCB finished
-    while (!done_ && ros::ok())       // Thus, check the done_ flag explicitly,
-      ros::Duration(0.0001).sleep();  // which is eventually set in finishControllerExecution
+    ros::Time deadline = ros::Time::now() + ros::Duration(0.1);  // limit waiting to 0.1s
+    while (!done_ && ros::ok() && ros::Time::now() < deadline)   // Check the done_ flag explicitly,
+      ros::Duration(0.0001).sleep();                             // which is eventually set in finishControllerExecution
 #endif
     return true;
   }


### PR DESCRIPTION
This is an alternative for #1741. Thanks to the very detailed analysis of @jschleicher, the race condition reported in #1493 was tracked down to an issue in actionlib: https://github.com/ros/actionlib/issues/155.
"As the done callback is really short" (https://github.com/ros-planning/moveit/pull/1741#issuecomment-557279556), the busy-waiting solution offered in #1741 is temporarily acceptable. Due to the same fact, I suggest to drop the remaining boilerplate (considering the timeout) of #1741 as well and keep the quick fix as simple as possible.