### PR TITLE
[moveit_commander] python3 import fixes

### DIFF
--- a/moveit_commander/src/moveit_commander/conversions.py
+++ b/moveit_commander/src/moveit_commander/conversions.py
@@ -33,8 +33,10 @@
 # Author: Ioan Sucan
 
 try:
+    # Try Python 2.7 behaviour first
     from StringIO import StringIO
 except ImportError:
+    # Use Python 3.x behaviour as fallback
     from io import StringIO
 
 from moveit_commander import MoveItCommanderException

--- a/moveit_commander/src/moveit_commander/conversions.py
+++ b/moveit_commander/src/moveit_commander/conversions.py
@@ -32,14 +32,18 @@
 #
 # Author: Ioan Sucan
 
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from moveit_commander import MoveItCommanderException
 from geometry_msgs.msg import Pose, PoseStamped, Transform
 import rospy
 import tf
 
 def msg_to_string(msg):
-    buf = StringIO.StringIO()
+    buf = StringIO()
     msg.serialize(buf)
     return buf.getvalue()
 

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -33,13 +33,13 @@
 # Author: Ioan Sucan, Felix Messmer
 
 import rospy
-import conversions
+from . import conversions
 
 from moveit_msgs.msg import PlanningScene, CollisionObject, AttachedCollisionObject
 from moveit_ros_planning_interface import _moveit_planning_scene_interface
 from geometry_msgs.msg import Pose, Point
 from shape_msgs.msg import SolidPrimitive, Plane, Mesh, MeshTriangle
-from exception import MoveItCommanderException
+from .exception import MoveItCommanderException
 from moveit_msgs.srv import ApplyPlanningScene, ApplyPlanningSceneRequest
 
 try:


### PR DESCRIPTION
### Description

Python3 related import fixes for moveit_commander package.

- force relative import in conversions.py and planning_scene_interface.py
- try to import StringIO from StringIO module first, then from io module

Related to #1722

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
