### PR TITLE
[moveit_commander] python3 import fixes

### DIFF
--- a/moveit_commander/src/moveit_commander/conversions.py
+++ b/moveit_commander/src/moveit_commander/conversions.py
@@ -32,14 +32,20 @@
 #
 # Author: Ioan Sucan
 
-import StringIO
+try:
+    # Try Python 2.7 behaviour first
+    from StringIO import StringIO
+except ImportError:
+    # Use Python 3.x behaviour as fallback
+    from io import StringIO
+
 from moveit_commander import MoveItCommanderException
 from geometry_msgs.msg import Pose, PoseStamped, Transform
 import rospy
 import tf
 
 def msg_to_string(msg):
-    buf = StringIO.StringIO()
+    buf = StringIO()
     msg.serialize(buf)
     return buf.getvalue()
 

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -33,13 +33,13 @@
 # Author: Ioan Sucan, Felix Messmer
 
 import rospy
-import conversions
+from . import conversions
 
 from moveit_msgs.msg import PlanningScene, CollisionObject, AttachedCollisionObject
 from moveit_ros_planning_interface import _moveit_planning_scene_interface
 from geometry_msgs.msg import Pose, Point
 from shape_msgs.msg import SolidPrimitive, Plane, Mesh, MeshTriangle
-from exception import MoveItCommanderException
+from .exception import MoveItCommanderException
 from moveit_msgs.srv import ApplyPlanningScene, ApplyPlanningSceneRequest
 
 try:


### PR DESCRIPTION
* [moveit_commander] python3 import fixes

- force relative import in conversions.py and planning_scene_interface.py
- try to import StringIO from StringIO module first, then from io module

CP of #1786 