### PR TITLE
codecov yml setting master as default branch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: master


### PR DESCRIPTION
### Description

This change sets the default branch for code coverage to be `master`.  This is the branch that new PRs will be compared against for relative changes in code coverage.