### PR TITLE
Publish attached collsion objects with the move_group TfPublisher capability

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -87,15 +87,15 @@ void TfPublisher::publishPlanningSceneFrames()
 
       for (const auto& obj : *world)
       {
-        std::string parent_frame = prefix_ + obj.second->id_;
+        std::string object_frame = prefix_ + obj.second->id_;
         transform = tf2::eigenToTransform(obj.second->shape_poses_[0]);
-        transform.child_frame_id = parent_frame;
+        transform.child_frame_id = object_frame;
         transform.header.stamp = stamp;
         transform.header.frame_id = planning_frame;
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = obj.second->subframe_poses_;
-        publishSubframes(broadcaster, subframes, parent_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
 
       const robot_state::RobotState& rs = locked_planning_scene->getCurrentState();
@@ -103,15 +103,15 @@ void TfPublisher::publishPlanningSceneFrames()
       rs.getAttachedBodies(attached_collision_objects);
       for (const robot_state::AttachedBody* attached_body : attached_collision_objects)
       {
-        std::string parent_frame = prefix_ + attached_body->getName();
+        std::string object_frame = prefix_ + attached_body->getName();
         transform = tf2::eigenToTransform(attached_body->getFixedTransforms()[0]);
-        transform.child_frame_id = parent_frame;
+        transform.child_frame_id = object_frame;
         transform.header.stamp = stamp;
         transform.header.frame_id = attached_body->getAttachedLinkName();
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframeTransforms();
-        publishSubframes(broadcaster, subframes, parent_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
     }
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -70,6 +70,7 @@ void TfPublisher::publishPlanningSceneFrames()
         std::string parent_frame = prefix_ + obj.second->id_;
         transform = tf2::eigenToTransform(obj.second->shape_poses_[0]);
         transform.child_frame_id = parent_frame;
+        transform.header.stamp = ros::Time::now();
         transform.header.frame_id = planning_frame;
         broadcaster.sendTransform(transform);
 
@@ -78,6 +79,7 @@ void TfPublisher::publishPlanningSceneFrames()
         {
           transform = tf2::eigenToTransform(subframe.second);
           transform.child_frame_id = parent_frame + "/" + subframe.first;
+          transform.header.stamp = ros::Time::now();
           transform.header.frame_id = parent_frame;
           broadcaster.sendTransform(transform);
         }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -68,7 +68,7 @@ void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::
     broadcaster.sendTransform(transform);
   }
 }
-}
+}  // namespace
 
 void TfPublisher::publishPlanningSceneFrames()
 {

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -37,6 +37,7 @@
 #include "tf_publisher_capability.h"
 #include <moveit/utils/message_checks.h>
 #include <moveit/move_group/capability_names.h>
+#include <tf2_ros/transform_broadcaster.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/attached_body.h>
@@ -56,7 +57,7 @@ TfPublisher::~TfPublisher()
 namespace
 {
 void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::core::FixedTransformsMap& subframes,
-                      std::string& parent_frame, ros::Time stamp)
+                      const std::string& parent_frame, const ros::Time& stamp)
 {
   geometry_msgs::TransformStamped transform;
   for (auto& subframe : subframes)
@@ -93,14 +94,14 @@ void TfPublisher::publishPlanningSceneFrames()
         transform.header.frame_id = planning_frame;
         broadcaster.sendTransform(transform);
 
-        moveit::core::FixedTransformsMap subframes = obj.second->subframe_poses_;
+        const moveit::core::FixedTransformsMap& subframes = obj.second->subframe_poses_;
         publishSubframes(broadcaster, subframes, parent_frame, stamp);
       }
 
       const robot_state::RobotState& rs = locked_planning_scene->getCurrentState();
       std::vector<const robot_state::AttachedBody*> attached_collision_objects;
       rs.getAttachedBodies(attached_collision_objects);
-      for (auto& attached_body : attached_collision_objects)
+      for (const robot_state::AttachedBody* attached_body : attached_collision_objects)
       {
         std::string parent_frame = prefix_ + attached_body->getName();
         transform = tf2::eigenToTransform(attached_body->getFixedTransforms()[0]);

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -52,8 +52,6 @@ public:
 
 private:
   void publishPlanningSceneFrames();
-  void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, moveit::core::FixedTransformsMap& subframes,
-                        std::string parent_frame);
   int rate_;
   std::string prefix_;
   std::thread thread_;

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
+#include <tf2_ros/transform_broadcaster.h>
 #include <thread>
 
 namespace move_group
@@ -51,6 +52,8 @@ public:
 
 private:
   void publishPlanningSceneFrames();
+  void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, moveit::core::FixedTransformsMap& subframes,
+                        std::string parent_frame);
   int rate_;
   std::string prefix_;
   std::thread thread_;

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.h
@@ -37,7 +37,6 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
-#include <tf2_ros/transform_broadcaster.h>
 #include <thread>
 
 namespace move_group


### PR DESCRIPTION
### Description

This PR adds functionality of publishing attached collision objects and their subframes to the TfPublisher capability.
It also fixes the timestamps for the transform msgs.