### PR TITLE
Add interactive marker resizing

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -138,6 +138,7 @@ protected:
   moveit_warehouse::RobotStateStoragePtr robot_state_storage_;
 
   std::shared_ptr<rviz::InteractiveMarker> scene_marker_;
+  std::shared_ptr<visualization_msgs::InteractiveMarker> viz_scene_marker_;
 
   typedef std::map<std::string, moveit_msgs::RobotState> RobotStateMap;
   typedef std::pair<std::string, moveit_msgs::RobotState> RobotStatePair;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -516,8 +516,10 @@ void MotionPlanningFrame::disable()
 
 void MotionPlanningFrame::tabChanged(int index)
 {
-  if (scene_marker_ && ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS)
+  if (scene_marker_ && viz_scene_marker_ &&ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS){
     scene_marker_.reset();
+    viz_scene_marker_.reset();
+  }
   else if (ui_->tabWidget->tabText(index).toStdString() == TAB_OBJECTS)
     selectedCollisionObjectChanged();
 }


### PR DESCRIPTION
### Description
As mentioned at #1115 , the scene objects marker was broken at scaling.
This PR fix that problem.

### The change on GUI
With this PR, the marker on the scene objects will be able to change their scales as showing on following.
This PR also fix the default marker size to fit the size of the objects.
![scale1](https://user-images.githubusercontent.com/8377208/69918159-e6abb100-14b1-11ea-98ae-1408eaaedd95.gif)
![scale2](https://user-images.githubusercontent.com/8377208/69918161-ea3f3800-14b1-11ea-8e6b-482f858f039d.gif)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
