### PR TITLE
Resize scene marker with collision object

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -133,6 +133,7 @@ protected:
   moveit_warehouse::RobotStateStoragePtr robot_state_storage_;
 
   std::shared_ptr<rviz::InteractiveMarker> scene_marker_;
+  std::shared_ptr<visualization_msgs::InteractiveMarker> viz_scene_marker_;
 
   typedef std::map<std::string, moveit_msgs::RobotState> RobotStateMap;
   typedef std::pair<std::string, moveit_msgs::RobotState> RobotStatePair;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -182,6 +182,7 @@ private Q_SLOTS:
   void copySelectedCollisionObject();
   void exportAsTextButtonClicked();
   void importFromTextButtonClicked();
+  void resizeInteractiveMarker(const shapes::Shape* shape);
 
   // Stored scenes tab
   void saveSceneButtonClicked();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -133,7 +133,6 @@ protected:
   moveit_warehouse::RobotStateStoragePtr robot_state_storage_;
 
   std::shared_ptr<rviz::InteractiveMarker> scene_marker_;
-  std::shared_ptr<visualization_msgs::InteractiveMarker> viz_scene_marker_;
 
   typedef std::map<std::string, moveit_msgs::RobotState> RobotStateMap;
   typedef std::pair<std::string, moveit_msgs::RobotState> RobotStatePair;
@@ -182,7 +181,6 @@ private Q_SLOTS:
   void copySelectedCollisionObject();
   void exportAsTextButtonClicked();
   void importFromTextButtonClicked();
-  void resizeInteractiveMarker(const shapes::Shape* shape);
 
   // Stored scenes tab
   void saveSceneButtonClicked();
@@ -248,6 +246,7 @@ private:
   void populateCollisionObjectsList();
   void computeImportFromText(const std::string& path);
   void computeExportAsText(const std::string& path);
+  visualization_msgs::InteractiveMarker createObjectMarkerMsg(const collision_detection::CollisionEnv::ObjectConstPtr& obj);
 
   // Stored scenes tab
   void computeSaveSceneButtonClicked();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -505,11 +505,8 @@ void MotionPlanningFrame::disable()
 
 void MotionPlanningFrame::tabChanged(int index)
 {
-  if (scene_marker_ && viz_scene_marker_ && ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS)
-  {
+  if (scene_marker_ && ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS)
     scene_marker_.reset();
-    viz_scene_marker_.reset();
-  }
   else if (ui_->tabWidget->tabText(index).toStdString() == TAB_OBJECTS)
     selectedCollisionObjectChanged();
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -505,8 +505,10 @@ void MotionPlanningFrame::disable()
 
 void MotionPlanningFrame::tabChanged(int index)
 {
-  if (scene_marker_ && ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS)
+  if (scene_marker_ && viz_scene_marker_ &&ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS){
     scene_marker_.reset();
+    viz_scene_marker_.reset();
+  }
   else if (ui_->tabWidget->tabText(index).toStdString() == TAB_OBJECTS)
     selectedCollisionObjectChanged();
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -505,7 +505,8 @@ void MotionPlanningFrame::disable()
 
 void MotionPlanningFrame::tabChanged(int index)
 {
-  if (scene_marker_ && viz_scene_marker_ &&ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS){
+  if (scene_marker_ && viz_scene_marker_ && ui_->tabWidget->tabText(index).toStdString() != TAB_OBJECTS)
+  {
     scene_marker_.reset();
     viz_scene_marker_.reset();
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -105,6 +105,70 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
           s->scale((double)value / 100.0);
           ps->getWorldNonConst()->addToObject(scaled_object_->id_, shapes::ShapeConstPtr(s),
                                               scaled_object_->shape_poses_[i]);
+
+          // get shape bound size
+          double half_bound = -std::numeric_limits<double>::max();
+          switch(s->type){
+            case shapes::ShapeType::SPHERE:{
+              shapes::Sphere* sphere = static_cast<shapes::Sphere*>(s);
+              half_bound = sphere->radius;
+              break;
+            }
+            case shapes::ShapeType::CYLINDER:{
+              shapes::Cylinder* cylinder = static_cast<shapes::Cylinder*>(s);
+              half_bound = (cylinder->radius > cylinder->length/2.0) ? cylinder->radius : cylinder->length/2.0;
+              break;
+            }
+            case shapes::ShapeType::CONE:{
+              shapes::Cone* cone = static_cast<shapes::Cone*>(s);
+              half_bound = (cone->radius > cone->length/2.0) ? cone->radius : cone->length/2.0;
+              break;
+            }
+            case shapes::ShapeType::BOX:{
+              shapes::Box* box = static_cast<shapes::Box*>(s);
+              for(std::size_t i = 0; i < 3; i++)
+                half_bound = (half_bound < box->size[i]/2.0) ? box->size[i]/2.0 : half_bound;
+              break;
+            }
+            case shapes::ShapeType::MESH:{
+              shapes::Mesh* mesh = static_cast<shapes::Mesh*>(s);
+              for(std::size_t i = 0; i < mesh->vertex_count*3+3; i++)
+                half_bound = (half_bound < abs(mesh->vertices[i])) ? abs(mesh->vertices[i]) : half_bound;
+              break;
+            }
+            default:
+              break;
+          }
+          // Change marker size
+          for(std::size_t i = 0; i < viz_scene_marker_->controls.size(); i++)
+          {
+            for(std::size_t j = 0; j < viz_scene_marker_->controls[i].markers.size(); j++)
+            {
+              switch(viz_scene_marker_->controls[i].markers[j].type){
+                case visualization_msgs::Marker::ARROW:{
+                  // // bound + padding (40%) size
+                  double bound_size = half_bound*2.0*1.4;
+                  viz_scene_marker_->controls[i].markers[j].points[0].x = pow(-1.0,j%2)*(bound_size*0.5);
+                  viz_scene_marker_->controls[i].markers[j].points[1].x = pow(-1.0,j%2)*(bound_size*0.9);
+                  viz_scene_marker_->controls[i].markers[j].scale.x = bound_size*0.15;
+                  viz_scene_marker_->controls[i].markers[j].scale.y = bound_size*0.25;
+                  viz_scene_marker_->controls[i].markers[j].scale.z = bound_size*0.2;                  
+                  break;
+                }
+                case visualization_msgs::Marker::TRIANGLE_LIST:{
+                  // bound + padding (40%) size
+                  double bound_size = half_bound*2.0*1.4;
+                  viz_scene_marker_->controls[i].markers[j].scale.x = bound_size;
+                  viz_scene_marker_->controls[i].markers[j].scale.y = bound_size;
+                  viz_scene_marker_->controls[i].markers[j].scale.z = bound_size;
+                  break;
+                }
+                default:
+                  break;
+              }
+            }
+          }
+          scene_marker_->processMessage(*viz_scene_marker_);
         }
         planning_display_->queueRenderSceneGeometry();
       }
@@ -151,6 +215,7 @@ void MotionPlanningFrame::removeObjectButtonClicked()
       else
         ps->getCurrentStateNonConst().clearAttachedBody(sel[i]->text().toStdString());
     scene_marker_.reset();
+    viz_scene_marker_.reset();
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
     planning_display_->queueRenderSceneGeometry();
   }
@@ -216,6 +281,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
 
     ui_->object_status->setText("");
     scene_marker_.reset();
+    viz_scene_marker_.reset();
     ui_->scene_scale->setEnabled(false);
   }
   else if (planning_display_->getPlanningSceneMonitor())
@@ -318,6 +384,17 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
       ps->getWorldNonConst()->moveShapeInObject(obj->id_, obj->shapes_[0], p);
       planning_display_->queueRenderSceneGeometry();
 
+      // Update visualization_msgs interactive marker pose update
+      if(viz_scene_marker_){
+        Eigen::Quaterniond eq(p.rotation());
+        viz_scene_marker_->pose.position.x = ui_->object_x->value();
+        viz_scene_marker_->pose.position.y = ui_->object_y->value();
+        viz_scene_marker_->pose.position.z = ui_->object_z->value();
+        viz_scene_marker_->pose.orientation.w = eq.w();
+        viz_scene_marker_->pose.orientation.x = eq.x();
+        viz_scene_marker_->pose.orientation.y = eq.y();
+        viz_scene_marker_->pose.orientation.z = eq.z();
+      }
       // Update the interactive marker pose to match the manually introduced one
       if (update_marker_position && scene_marker_)
       {
@@ -709,12 +786,78 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
         robot_interaction::make6DOFMarker(std::string("marker_") + sel[0]->text().toStdString(), shape_pose, 1.0);
     int_marker.header.frame_id = planning_display_->getRobotModel()->getModelFrame();
     int_marker.description = sel[0]->text().toStdString();
-
+    
     rviz::InteractiveMarker* imarker = new rviz::InteractiveMarker(planning_display_->getSceneNode(), context_);
     interactive_markers::autoComplete(int_marker);
+
+    // Resize the marker scale
+    // 1. get obj shape bound size
+    double half_bound = -std::numeric_limits<double>::max();
+    switch(obj->shapes_[0]->type){
+      case shapes::ShapeType::SPHERE:{
+        shapes::Sphere* sphere = static_cast<shapes::Sphere*>(obj->shapes_[0]->clone());
+        half_bound = sphere->radius;
+        break;
+      }
+      case shapes::ShapeType::CYLINDER:{
+        shapes::Cylinder* cylinder = static_cast<shapes::Cylinder*>(obj->shapes_[0]->clone());
+        half_bound = (cylinder->radius > cylinder->length/2.0) ? cylinder->radius : cylinder->length/2.0;
+        break;
+      }
+      case shapes::ShapeType::CONE:{
+        shapes::Cone* cone = static_cast<shapes::Cone*>(obj->shapes_[0]->clone());
+        half_bound = (cone->radius > cone->length/2.0) ? cone->radius : cone->length/2.0;
+        break;
+      }
+      case shapes::ShapeType::BOX:{
+        shapes::Box* box = static_cast<shapes::Box*>(obj->shapes_[0]->clone());
+        for(std::size_t i = 0; i < 3; i++)
+          half_bound = (half_bound < box->size[i]/2.0) ? box->size[i]/2.0 : half_bound;
+        break;
+      }
+      case shapes::ShapeType::MESH:{
+        shapes::Mesh* mesh = static_cast<shapes::Mesh*>(obj->shapes_[0]->clone());
+        for(std::size_t i = 0; i < mesh->vertex_count*3+3; i++)
+          half_bound = (half_bound < abs(mesh->vertices[i])) ? abs(mesh->vertices[i]) : half_bound;
+        break;
+      }
+      default:
+        break;
+    }
+    // 2. Change marker size
+    for(std::size_t i = 0; i < int_marker.controls.size(); i++)
+    {
+      for(std::size_t j = 0; j < int_marker.controls[i].markers.size(); j++)
+      {
+        switch(int_marker.controls[i].markers[j].type){
+          case visualization_msgs::Marker::ARROW:{
+            // // bound + padding (40%) size
+            double bound_size = half_bound*2.0*1.4;
+            int_marker.controls[i].markers[j].points[0].x = pow(-1.0,j%2)*(bound_size*0.5);
+            int_marker.controls[i].markers[j].points[1].x = pow(-1.0,j%2)*(bound_size*0.9);
+            int_marker.controls[i].markers[j].scale.x = bound_size*0.15;
+            int_marker.controls[i].markers[j].scale.y = bound_size*0.25;
+            int_marker.controls[i].markers[j].scale.z = bound_size*0.2;                  
+            break;
+          }
+          case visualization_msgs::Marker::TRIANGLE_LIST:{
+            // bound + padding (40%) size
+            double bound_size = half_bound*2.0*1.4;
+            int_marker.controls[i].markers[j].scale.x = bound_size;
+            int_marker.controls[i].markers[j].scale.y = bound_size;
+            int_marker.controls[i].markers[j].scale.z = bound_size;
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
     imarker->processMessage(int_marker);
     imarker->setShowAxes(false);
     scene_marker_.reset(imarker);
+    viz_scene_marker_.reset(new visualization_msgs::InteractiveMarker);
+    *viz_scene_marker_ = int_marker;
 
     // Connect signals
     connect(imarker, SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
@@ -723,6 +866,7 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
   else
   {
     scene_marker_.reset();
+    viz_scene_marker_.reset();
   }
 }
 
@@ -768,6 +912,10 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       {
         scene_marker_.reset();
         planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::createSceneInteractiveMarker, this));
+      }
+      if (viz_scene_marker_)
+      {
+        viz_scene_marker_.reset();
       }
     }
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -105,8 +105,8 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
           s->scale((double)value / 100.0);
           ps->getWorldNonConst()->addToObject(scaled_object_->id_, shapes::ShapeConstPtr(s),
                                               scaled_object_->shape_poses_[i]);
-          resizeInteractiveMarker(s);
         }
+        scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));
         planning_display_->queueRenderSceneGeometry();
       }
       else
@@ -152,7 +152,6 @@ void MotionPlanningFrame::removeObjectButtonClicked()
       else
         ps->getCurrentStateNonConst().clearAttachedBody(sel[i]->text().toStdString());
     scene_marker_.reset();
-    viz_scene_marker_.reset();
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
     planning_display_->queueRenderSceneGeometry();
   }
@@ -218,7 +217,6 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
 
     ui_->object_status->setText("");
     scene_marker_.reset();
-    viz_scene_marker_.reset();
     ui_->scene_scale->setEnabled(false);
   }
   else if (planning_display_->getPlanningSceneMonitor())
@@ -321,18 +319,6 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
       ps->getWorldNonConst()->moveShapeInObject(obj->id_, obj->shapes_[0], p);
       planning_display_->queueRenderSceneGeometry();
 
-      // Update visualization_msgs interactive marker pose update
-      if (viz_scene_marker_)
-      {
-        Eigen::Quaterniond eq(p.rotation());
-        viz_scene_marker_->pose.position.x = ui_->object_x->value();
-        viz_scene_marker_->pose.position.y = ui_->object_y->value();
-        viz_scene_marker_->pose.position.z = ui_->object_z->value();
-        viz_scene_marker_->pose.orientation.w = eq.w();
-        viz_scene_marker_->pose.orientation.x = eq.x();
-        viz_scene_marker_->pose.orientation.y = eq.y();
-        viz_scene_marker_->pose.orientation.z = eq.z();
-      }
       // Update the interactive marker pose to match the manually introduced one
       if (update_marker_position && scene_marker_)
       {
@@ -695,6 +681,24 @@ void MotionPlanningFrame::addObject(const collision_detection::WorldPtr& world, 
   planning_display_->queueRenderSceneGeometry();
 }
 
+visualization_msgs::InteractiveMarker
+MotionPlanningFrame::createObjectMarkerMsg(const collision_detection::CollisionEnv::ObjectConstPtr& obj)
+{
+  Eigen::Vector3d center;
+  double scale;
+  shapes::computeShapeBoundingSphere(obj->shapes_[0].get(), center, scale);
+  geometry_msgs::PoseStamped shape_pose = tf2::toMsg(tf2::Stamped<Eigen::Isometry3d>(
+      obj->shape_poses_[0], ros::Time(), planning_display_->getRobotModel()->getModelFrame()));
+  scale = (scale + center.cwiseAbs().maxCoeff()) * 2.0 * 1.2;  // add padding of 20% size
+
+  // create an interactive marker msg for the given shape
+  visualization_msgs::InteractiveMarker imarker =
+      robot_interaction::make6DOFMarker("marker_scene_object", shape_pose, scale);
+  imarker.description = obj->id_;
+  interactive_markers::autoComplete(imarker);
+  return imarker;
+}
+
 void MotionPlanningFrame::createSceneInteractiveMarker()
 {
   QList<QListWidgetItem*> sel = ui_->collision_objects_list->selectedItems();
@@ -709,38 +713,17 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
       ps->getWorld()->getObject(sel[0]->text().toStdString());
   if (obj && obj->shapes_.size() == 1)
   {
-    Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
-    geometry_msgs::PoseStamped shape_pose;
-    shape_pose.pose.position.x = obj->shape_poses_[0].translation()[0];
-    shape_pose.pose.position.y = obj->shape_poses_[0].translation()[1];
-    shape_pose.pose.position.z = obj->shape_poses_[0].translation()[2];
-    shape_pose.pose.orientation.x = eq.x();
-    shape_pose.pose.orientation.y = eq.y();
-    shape_pose.pose.orientation.z = eq.z();
-    shape_pose.pose.orientation.w = eq.w();
-
-    // create an interactive marker for moving the shape in the world
-    visualization_msgs::InteractiveMarker int_marker =
-        robot_interaction::make6DOFMarker(std::string("marker_") + sel[0]->text().toStdString(), shape_pose, 1.0);
-    int_marker.header.frame_id = planning_display_->getRobotModel()->getModelFrame();
-    int_marker.description = sel[0]->text().toStdString();
-
-    rviz::InteractiveMarker* imarker = new rviz::InteractiveMarker(planning_display_->getSceneNode(), context_);
-    interactive_markers::autoComplete(int_marker);
-    imarker->setShowAxes(false);
-    scene_marker_.reset(imarker);
-    viz_scene_marker_.reset(new visualization_msgs::InteractiveMarker);
-    *viz_scene_marker_ = int_marker;
-    resizeInteractiveMarker(obj->shapes_[0]->clone());
+    scene_marker_ = std::make_shared<rviz::InteractiveMarker>(planning_display_->getSceneNode(), context_);
+    scene_marker_->processMessage(createObjectMarkerMsg(obj));
+    scene_marker_->setShowAxes(false);
 
     // Connect signals
-    connect(imarker, SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
+    connect(scene_marker_.get(), SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
             SLOT(imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback&)));
   }
   else
   {
     scene_marker_.reset();
-    viz_scene_marker_.reset();
   }
 }
 
@@ -786,10 +769,6 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       {
         scene_marker_.reset();
         planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::createSceneInteractiveMarker, this));
-      }
-      if (viz_scene_marker_)
-      {
-        viz_scene_marker_.reset();
       }
     }
   }
@@ -976,46 +955,5 @@ void MotionPlanningFrame::importFromTextButtonClicked()
   if (!path.isEmpty())
     planning_display_->addBackgroundJob(
         boost::bind(&MotionPlanningFrame::computeImportFromText, this, path.toStdString()), "import from text");
-}
-
-void MotionPlanningFrame::resizeInteractiveMarker(const shapes::Shape* shape)
-{
-  // Resize the marker scale
-  // 1. Get obj shape bound size
-  Eigen::Vector3d center;
-  double radius;
-  shapes::computeShapeBoundingSphere(shape, center, radius);
-  double bound = (center.cwiseAbs().maxCoeff() + radius) * 2.0;
-  // bound + padding (20%) size
-  bound *= 1.2;
-  // 2. Change marker size
-  for (std::size_t i = 0; i < viz_scene_marker_->controls.size(); i++)
-  {
-    for (std::size_t j = 0; j < viz_scene_marker_->controls[i].markers.size(); j++)
-    {
-      switch (viz_scene_marker_->controls[i].markers[j].type)
-      {
-        case visualization_msgs::Marker::ARROW:
-        {
-          viz_scene_marker_->controls[i].markers[j].points[0].x = pow(-1.0, j % 2) * (bound * 0.5);
-          viz_scene_marker_->controls[i].markers[j].points[1].x = pow(-1.0, j % 2) * (bound * 0.9);
-          viz_scene_marker_->controls[i].markers[j].scale.x = bound * 0.15;
-          viz_scene_marker_->controls[i].markers[j].scale.y = bound * 0.25;
-          viz_scene_marker_->controls[i].markers[j].scale.z = bound * 0.2;
-          break;
-        }
-        case visualization_msgs::Marker::TRIANGLE_LIST:
-        {
-          viz_scene_marker_->controls[i].markers[j].scale.x = bound;
-          viz_scene_marker_->controls[i].markers[j].scale.y = bound;
-          viz_scene_marker_->controls[i].markers[j].scale.z = bound;
-          break;
-        }
-        default:
-          break;
-      }
-    }
-  }
-  scene_marker_->processMessage(*viz_scene_marker_);
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -110,25 +110,28 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
           // 1. Get obj shape bound size
           Eigen::Vector3d center;
           double radius;
-          shapes::computeShapeBoundingSphere(s,center,radius);
-          double bound = (center.cwiseAbs().maxCoeff() + radius)*2.0;
+          shapes::computeShapeBoundingSphere(s, center, radius);
+          double bound = (center.cwiseAbs().maxCoeff() + radius) * 2.0;
           // bound + padding (20%) size
           bound *= 1.2;
           // 2. Change marker size
-          for(std::size_t i = 0; i < viz_scene_marker_->controls.size(); i++)
+          for (std::size_t i = 0; i < viz_scene_marker_->controls.size(); i++)
           {
-            for(std::size_t j = 0; j < viz_scene_marker_->controls[i].markers.size(); j++)
+            for (std::size_t j = 0; j < viz_scene_marker_->controls[i].markers.size(); j++)
             {
-              switch(viz_scene_marker_->controls[i].markers[j].type){
-                case visualization_msgs::Marker::ARROW:{
-                  viz_scene_marker_->controls[i].markers[j].points[0].x = pow(-1.0,j%2)*(bound*0.5);
-                  viz_scene_marker_->controls[i].markers[j].points[1].x = pow(-1.0,j%2)*(bound*0.9);
-                  viz_scene_marker_->controls[i].markers[j].scale.x = bound*0.15;
-                  viz_scene_marker_->controls[i].markers[j].scale.y = bound*0.25;
-                  viz_scene_marker_->controls[i].markers[j].scale.z = bound*0.2;                  
+              switch (viz_scene_marker_->controls[i].markers[j].type)
+              {
+                case visualization_msgs::Marker::ARROW:
+                {
+                  viz_scene_marker_->controls[i].markers[j].points[0].x = pow(-1.0, j % 2) * (bound * 0.5);
+                  viz_scene_marker_->controls[i].markers[j].points[1].x = pow(-1.0, j % 2) * (bound * 0.9);
+                  viz_scene_marker_->controls[i].markers[j].scale.x = bound * 0.15;
+                  viz_scene_marker_->controls[i].markers[j].scale.y = bound * 0.25;
+                  viz_scene_marker_->controls[i].markers[j].scale.z = bound * 0.2;
                   break;
                 }
-                case visualization_msgs::Marker::TRIANGLE_LIST:{
+                case visualization_msgs::Marker::TRIANGLE_LIST:
+                {
                   viz_scene_marker_->controls[i].markers[j].scale.x = bound;
                   viz_scene_marker_->controls[i].markers[j].scale.y = bound;
                   viz_scene_marker_->controls[i].markers[j].scale.z = bound;
@@ -356,7 +359,8 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
       planning_display_->queueRenderSceneGeometry();
 
       // Update visualization_msgs interactive marker pose update
-      if(viz_scene_marker_){
+      if (viz_scene_marker_)
+      {
         Eigen::Quaterniond eq(p.rotation());
         viz_scene_marker_->pose.position.x = ui_->object_x->value();
         viz_scene_marker_->pose.position.y = ui_->object_y->value();
@@ -757,7 +761,7 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
         robot_interaction::make6DOFMarker(std::string("marker_") + sel[0]->text().toStdString(), shape_pose, 1.0);
     int_marker.header.frame_id = planning_display_->getRobotModel()->getModelFrame();
     int_marker.description = sel[0]->text().toStdString();
-    
+
     rviz::InteractiveMarker* imarker = new rviz::InteractiveMarker(planning_display_->getSceneNode(), context_);
     interactive_markers::autoComplete(int_marker);
 
@@ -765,25 +769,28 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
     // 1. Get obj shape bound size
     Eigen::Vector3d center;
     double radius;
-    shapes::computeShapeBoundingSphere(obj->shapes_[0]->clone(),center,radius);
-    double bound = (center.cwiseAbs().maxCoeff() + radius)*2.0;
+    shapes::computeShapeBoundingSphere(obj->shapes_[0]->clone(), center, radius);
+    double bound = (center.cwiseAbs().maxCoeff() + radius) * 2.0;
     // bound + padding (20%) size
     bound *= 1.2;
     // 2. Change marker size
-    for(std::size_t i = 0; i < int_marker.controls.size(); i++)
+    for (std::size_t i = 0; i < int_marker.controls.size(); i++)
     {
-      for(std::size_t j = 0; j < int_marker.controls[i].markers.size(); j++)
+      for (std::size_t j = 0; j < int_marker.controls[i].markers.size(); j++)
       {
-        switch(int_marker.controls[i].markers[j].type){
-          case visualization_msgs::Marker::ARROW:{
-            int_marker.controls[i].markers[j].points[0].x = pow(-1.0,j%2)*(bound*0.5);
-            int_marker.controls[i].markers[j].points[1].x = pow(-1.0,j%2)*(bound*0.9);
-            int_marker.controls[i].markers[j].scale.x = bound*0.15;
-            int_marker.controls[i].markers[j].scale.y = bound*0.25;
-            int_marker.controls[i].markers[j].scale.z = bound*0.2;
+        switch (int_marker.controls[i].markers[j].type)
+        {
+          case visualization_msgs::Marker::ARROW:
+          {
+            int_marker.controls[i].markers[j].points[0].x = pow(-1.0, j % 2) * (bound * 0.5);
+            int_marker.controls[i].markers[j].points[1].x = pow(-1.0, j % 2) * (bound * 0.9);
+            int_marker.controls[i].markers[j].scale.x = bound * 0.15;
+            int_marker.controls[i].markers[j].scale.y = bound * 0.25;
+            int_marker.controls[i].markers[j].scale.z = bound * 0.2;
             break;
           }
-          case visualization_msgs::Marker::TRIANGLE_LIST:{
+          case visualization_msgs::Marker::TRIANGLE_LIST:
+          {
             int_marker.controls[i].markers[j].scale.x = bound;
             int_marker.controls[i].markers[j].scale.y = bound;
             int_marker.controls[i].markers[j].scale.z = bound;


### PR DESCRIPTION
### Description
As mentioned at #1115 , the scene objects marker was broken at scaling.
This PR fix that problem.
And the same PR for master branch on #1795 .
This PR is for melodic-devel branch.

### The change on GUI
With this PR, the marker on the scene objects will be able to change their scales as showing on following.
This PR also fix the default marker size to fit the size of the objects.
![scale1](https://user-images.githubusercontent.com/8377208/69918159-e6abb100-14b1-11ea-98ae-1408eaaedd95.gif)
![scale2](https://user-images.githubusercontent.com/8377208/69918161-ea3f3800-14b1-11ea-8e6b-482f858f039d.gif)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

