### PR TITLE
Add support for pos_vel_controllers and pos_vel_acc_controllers

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
+++ b/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
@@ -9,5 +9,11 @@
     <class name="effort_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
         <description></description>
     </class>
+    <class name="pos_vel_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+    <class name="pos_vel_acc_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
   </library>
 </class_libraries>

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
@@ -195,11 +195,12 @@ void ControllerEditWidget::loadControllersTypesComboBox()
     return;
   has_loaded_ = true;
 
-  const std::array<std::string, 8> default_types = {
+  const std::array<std::string, 10> default_types = {
     "effort_controllers/JointTrajectoryController",   "effort_controllers/JointPositionController",
     "effort_controllers/JointVelocityController",     "effort_controllers/JointEffortController",
     "position_controllers/JointPositionController",   "position_controllers/JointTrajectoryController",
-    "velocity_controllers/JointTrajectoryController", "velocity_controllers/JointVelocityController"
+    "velocity_controllers/JointTrajectoryController", "velocity_controllers/JointVelocityController",
+    "pos_vel_controllers/JointTrajectoryController", "pos_vel_acc_controllers/JointTrajectoryController"
   };
 
   // Remove all old items

--- a/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controller_edit_widget.cpp
@@ -200,7 +200,7 @@ void ControllerEditWidget::loadControllersTypesComboBox()
     "effort_controllers/JointVelocityController",     "effort_controllers/JointEffortController",
     "position_controllers/JointPositionController",   "position_controllers/JointTrajectoryController",
     "velocity_controllers/JointTrajectoryController", "velocity_controllers/JointVelocityController",
-    "pos_vel_controllers/JointTrajectoryController", "pos_vel_acc_controllers/JointTrajectoryController"
+    "pos_vel_controllers/JointTrajectoryController",  "pos_vel_acc_controllers/JointTrajectoryController"
   };
 
   // Remove all old items


### PR DESCRIPTION
Added support for ros_control controllers:
- pos_vel_controllers/JointTrajectoryController
- pos_vel_acc_controllers/JointTrajectoryController

### Description

Adds the pos_vel_controllers/JointTrajectoryController and the pos_vel_acc_controllers/JointTrajectoryController to the moveit_ros_control_plugin_interface.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
