### PR TITLE
fix scene object marker in rviz plugin

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -251,6 +251,8 @@ private:
   void populateCollisionObjectsList();
   void computeImportFromText(const std::string& path);
   void computeExportAsText(const std::string& path);
+  visualization_msgs::InteractiveMarker
+  createObjectMarkerMsg(const collision_detection::CollisionEnv::ObjectConstPtr& obj);
 
   // Stored scenes tab
   void computeSaveSceneButtonClicked();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1249,8 +1249,7 @@ void MotionPlanningDisplay::onEnable()
   int_marker_display_->setEnabled(true);
   int_marker_display_->setFixedFrame(fixed_frame_);
 
-  if (frame_ && frame_->parentWidget())
-    frame_->parentWidget()->show();
+  frame_->enable();
 }
 
 // ******************************************************************************************
@@ -1271,8 +1270,7 @@ void MotionPlanningDisplay::onDisable()
   // Planned Path Display
   trajectory_visual_->onDisable();
 
-  if (frame_ && frame_->parentWidget())
-    frame_->parentWidget()->hide();
+  frame_->disable();
 }
 
 // ******************************************************************************************

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1213,14 +1213,14 @@ void MotionPlanningDisplay::onSceneMonitorReceivedUpdate(
   robot_state::RobotState current_state = getPlanningSceneRO()->getCurrentState();
   std::string group = planning_group_property_->getStdString();
 
-  if (query_start_state_property_->getBool() && !group.empty())
+  if (query_start_state_ && query_start_state_property_->getBool() && !group.empty())
   {
     robot_state::RobotState start = *getQueryStartState();
     updateStateExceptModified(start, current_state);
     setQueryStartState(start);
   }
 
-  if (query_goal_state_property_->getBool() && !group.empty())
+  if (query_goal_state_ && query_goal_state_property_->getBool() && !group.empty())
   {
     robot_state::RobotState goal = *getQueryGoalState();
     updateStateExceptModified(goal, current_state);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -511,6 +511,7 @@ void MotionPlanningFrame::enable()
 void MotionPlanningFrame::disable()
 {
   move_group_.reset();
+  scene_marker_.reset();
   parentWidget()->hide();
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -217,14 +217,14 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
 
     ui_->object_status->setText("");
     scene_marker_.reset();
-    ui_->scene_scale->setEnabled(false);
+    ui_->pose_scale_group_box->setEnabled(false);
   }
   else if (planning_display_->getPlanningSceneMonitor())
   {
     // if this is a CollisionWorld element
     if (sel[0]->checkState() == Qt::Unchecked)
     {
-      ui_->scene_scale->setEnabled(true);
+      ui_->pose_scale_group_box->setEnabled(true);
       bool update_scene_marker = false;
       Eigen::Isometry3d obj_pose;
       {
@@ -276,7 +276,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
     }
     else
     {
-      ui_->scene_scale->setEnabled(false);
+      ui_->pose_scale_group_box->setEnabled(false);
       // if it is an attached object
       scene_marker_.reset();
       const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -106,6 +106,7 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
           ps->getWorldNonConst()->addToObject(scaled_object_->id_, shapes::ShapeConstPtr(s),
                                               scaled_object_->shape_poses_[i]);
         }
+        scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));
         planning_display_->queueRenderSceneGeometry();
       }
       else
@@ -679,6 +680,24 @@ void MotionPlanningFrame::addObject(const collision_detection::WorldPtr& world, 
   planning_display_->queueRenderSceneGeometry();
 }
 
+visualization_msgs::InteractiveMarker
+MotionPlanningFrame::createObjectMarkerMsg(const collision_detection::CollisionEnv::ObjectConstPtr& obj)
+{
+  Eigen::Vector3d center;
+  double scale;
+  shapes::computeShapeBoundingSphere(obj->shapes_[0].get(), center, scale);
+  geometry_msgs::PoseStamped shape_pose = tf2::toMsg(tf2::Stamped<Eigen::Isometry3d>(
+      obj->shape_poses_[0], ros::Time(), planning_display_->getRobotModel()->getModelFrame()));
+  scale = (scale + center.cwiseAbs().maxCoeff()) * 2.0 * 1.2;  // add padding of 20% size
+
+  // create an interactive marker msg for the given shape
+  visualization_msgs::InteractiveMarker imarker =
+      robot_interaction::make6DOFMarker("marker_scene_object", shape_pose, scale);
+  imarker.description = obj->id_;
+  interactive_markers::autoComplete(imarker);
+  return imarker;
+}
+
 void MotionPlanningFrame::createSceneInteractiveMarker()
 {
   QList<QListWidgetItem*> sel = ui_->collision_objects_list->selectedItems();
@@ -693,30 +712,12 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
       ps->getWorld()->getObject(sel[0]->text().toStdString());
   if (obj && obj->shapes_.size() == 1)
   {
-    Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
-    geometry_msgs::PoseStamped shape_pose;
-    shape_pose.pose.position.x = obj->shape_poses_[0].translation()[0];
-    shape_pose.pose.position.y = obj->shape_poses_[0].translation()[1];
-    shape_pose.pose.position.z = obj->shape_poses_[0].translation()[2];
-    shape_pose.pose.orientation.x = eq.x();
-    shape_pose.pose.orientation.y = eq.y();
-    shape_pose.pose.orientation.z = eq.z();
-    shape_pose.pose.orientation.w = eq.w();
-
-    // create an interactive marker for moving the shape in the world
-    visualization_msgs::InteractiveMarker int_marker =
-        robot_interaction::make6DOFMarker(std::string("marker_") + sel[0]->text().toStdString(), shape_pose, 1.0);
-    int_marker.header.frame_id = planning_display_->getRobotModel()->getModelFrame();
-    int_marker.description = sel[0]->text().toStdString();
-
-    rviz::InteractiveMarker* imarker = new rviz::InteractiveMarker(planning_display_->getSceneNode(), context_);
-    interactive_markers::autoComplete(int_marker);
-    imarker->processMessage(int_marker);
-    imarker->setShowAxes(false);
-    scene_marker_.reset(imarker);
+    scene_marker_ = std::make_shared<rviz::InteractiveMarker>(planning_display_->getSceneNode(), context_);
+    scene_marker_->processMessage(createObjectMarkerMsg(obj));
+    scene_marker_->setShowAxes(false);
 
     // Connect signals
-    connect(imarker, SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
+    connect(scene_marker_.get(), SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
             SLOT(imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback&)));
   }
   else

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -966,7 +966,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QGroupBox" name="groupBox_4">
+        <widget class="QGroupBox" name="pose_scale_group_box">
          <property name="title">
           <string>Manage Pose and Scale</string>
          </property>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -988,6 +988,9 @@
               <property name="maximum">
                <double>1000.000000000000000</double>
               </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
              </widget>
             </item>
             <item>
@@ -998,6 +1001,9 @@
               <property name="maximum">
                <double>1000.000000000000000</double>
               </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
              </widget>
             </item>
             <item>
@@ -1007,6 +1013,9 @@
               </property>
               <property name="maximum">
                <double>1000.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
               </property>
              </widget>
             </item>
@@ -1030,7 +1039,7 @@
                <double>3.140000000000000</double>
               </property>
               <property name="singleStep">
-               <double>0.200000000000000</double>
+               <double>0.100000000000000</double>
               </property>
              </widget>
             </item>
@@ -1043,7 +1052,7 @@
                <double>3.140000000000000</double>
               </property>
               <property name="singleStep">
-               <double>0.200000000000000</double>
+               <double>0.100000000000000</double>
               </property>
              </widget>
             </item>
@@ -1056,7 +1065,7 @@
                <double>3.140000000000000</double>
               </property>
               <property name="singleStep">
-               <double>0.200000000000000</double>
+               <double>0.100000000000000</double>
               </property>
              </widget>
             </item>

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -518,6 +518,8 @@ void PlanningSceneDisplay::loadRobotModel()
   if (psm->getPlanningScene())
   {
     planning_scene_monitor_.swap(psm);
+    planning_scene_monitor_->addUpdateCallback(
+        boost::bind(&PlanningSceneDisplay::sceneMonitorReceivedUpdate, this, _1));
     addMainLoopJob(boost::bind(&PlanningSceneDisplay::onRobotModelLoaded, this));
     setStatus(rviz::StatusProperty::Ok, "PlanningScene", "Planning Scene Loaded Successfully");
     waitForAllMainLoopJobs();
@@ -526,10 +528,6 @@ void PlanningSceneDisplay::loadRobotModel()
   {
     setStatus(rviz::StatusProperty::Error, "PlanningScene", "No Planning Scene Loaded");
   }
-
-  if (planning_scene_monitor_)
-    planning_scene_monitor_->addUpdateCallback(
-        boost::bind(&PlanningSceneDisplay::sceneMonitorReceivedUpdate, this, _1));
 
   model_is_loading_ = false;
 }


### PR DESCRIPTION
This fixes all issues outlined in #1115 (and some more) regarding the interactive marker for the selected planning scene object in the `Scene Objects` tab of the motion planning panel:
- Resize the interactive marker with the object shape
- Remove visual artifacts (showing a coordinate frame and black lines) when re-enabling the display
This was caused by the marker being re-enabled (with all its children nodes) before axes got disabled again. I fixed this by calling `MotionPlanningFrame::disable()` in `MotionPlanningDisplay::onDisable()` - instead of just hiding the panel (as introduced in #760) - and resetting the interactive marker there.
- This also resolved the third issue mentioned in #1115: The interactive marker showed up in the rendering panel even though the motion planning display was disabled. This issue was unrelated to an additional PlanningSceneDisplay as originally speculated there.
- When starting rviz (much) later than the `move_group` node, the scene objects were displayed in the render panel, but the corresponding list in the `Scene Objects` tab wasn't populated. The reason was that the corresponding `updateCallback` was only defined after it would have been triggered in `onRobotModelLoaded()`.
- The widgets to modify the pose and size of the selected object are only enabled if an object is actually selected.
- The step size for those spinbox widgets is reduced to `0.1`.

This PR includes and thus replaces #1796. Each commit handles one of the mentioned issues. Thus this PR should **not** be squashed into a single commit.