### PR TITLE
[AIST-QA]Fix possibile division-by-zero issues.

### DIFF
--- a/moveit_kinematics/test/benchmark_ik.cpp
+++ b/moveit_kinematics/test/benchmark_ik.cpp
@@ -148,9 +148,16 @@ int main(int argc, char* argv[])
                        ik_time.count() / (double)i, i, 100. * num_failed_calls / i,
                        100. * num_self_collisions / (num_self_collisions + i));
     }
-    ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
+    if (i != 0)
+    {
+      ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
                    ik_time.count() / (double)i, 100. * num_failed_calls / i,
                    100. * num_self_collisions / (num_self_collisions + i));
+    }
+    else
+    {
+      ROS_WARN_NAMED("cached_ik.measure_ik_call_cost", "fail.");
+    }
   }
 
   ros::shutdown();

--- a/moveit_kinematics/test/benchmark_ik.cpp
+++ b/moveit_kinematics/test/benchmark_ik.cpp
@@ -151,12 +151,12 @@ int main(int argc, char* argv[])
     if (i != 0)
     {
       ROS_INFO_NAMED("cached_ik.measure_ik_call_cost", "Summary for group %s: %g %g %g", group->getName().c_str(),
-                   ik_time.count() / (double)i, 100. * num_failed_calls / i,
-                   100. * num_self_collisions / (num_self_collisions + i));
+                     ik_time.count() / (double)i, 100. * num_failed_calls / i,
+                     100. * num_self_collisions / (num_self_collisions + i));
     }
     else
     {
-      ROS_WARN_NAMED("cached_ik.measure_ik_call_cost", "fail.");
+      ROS_WARN_NAMED("cached_ik.measure_ik_call_cost", "Failure: No valid start positions found.");
     }
   }
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -95,6 +95,9 @@ double ChompCost::getMaxQuadCostInvValue() const
 
 void ChompCost::scale(double scale)
 {
+  if (scale == 0.0)
+    return;
+
   double inv_scale = 1.0 / scale;
   quad_cost_inv_ *= inv_scale;
   quad_cost_ *= scale;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -97,7 +97,7 @@ void ChompCost::scale(double scale)
 {
   if (scale == 0.0)
   {
-    ROS_WARN("ChompCost::scale recieved factor 0. Not changing cost.");
+    ROS_WARN_NAMED("chomp_cost", "Scale received factor 0. Not changing cost.");
     return;
   }
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -96,7 +96,10 @@ double ChompCost::getMaxQuadCostInvValue() const
 void ChompCost::scale(double scale)
 {
   if (scale == 0.0)
+  {
+    ROS_WARN("ChompCost::scale recieved factor 0. Not changing cost.");
     return;
+  }
 
   double inv_scale = 1.0 / scale;
   quad_cost_inv_ *= inv_scale;


### PR DESCRIPTION
### Description

Local variables are used as denominator in `measure_ik_call_cost.cpp` and `chomp_optimizer.cpp`.
These variables are initialized with zero and there are cases when they are used without changing value.
This fix adds checking the local variable against zero. (In `chomp_optimizer`, the fix is applied to the function `ChompCost::scale`)

This contribution is made by AIST ( https://www.aist.go.jp ) based on static code analysis with klocwork (Perforce Software).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
