### PR TITLE
Fix compatibility issues with Ogre 1.10..1.12

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -31,7 +31,7 @@ set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NA
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
-  ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+  ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${MOVEIT_LIB_NAME}_core
   src/planning_scene_display.cpp
   include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -162,7 +162,7 @@ PlanningSceneDisplay::~PlanningSceneDisplay()
 
   planning_scene_render_.reset();
   if (context_ && context_->getSceneManager() && planning_scene_node_)
-    context_->getSceneManager()->destroySceneNode(planning_scene_node_->getName());
+    context_->getSceneManager()->destroySceneNode(planning_scene_node_);
   if (planning_scene_robot_)
     planning_scene_robot_.reset();
   planning_scene_monitor_.reset();

--- a/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(${MOVEIT_LIB_NAME}_core
   include/moveit/robot_state_rviz_plugin/robot_state_display.h)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools
-  ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+  ${catkin_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
@@ -17,4 +17,3 @@ install(TARGETS ${MOVEIT_LIB_NAME}_core ${MOVEIT_LIB_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -26,7 +26,6 @@ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_V
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   ${catkin_LIBRARIES}
-  ${OGRE_LIBRARIES}
   ${QT_LIBRARIES}
   ${Boost_LIBRARIES}
 )

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -44,19 +44,11 @@ SILENT_UNUSED_PARAM
 #include <rviz/ogre_helpers/point_cloud.h>
 DIAGNOSTIC_POP
 #include <moveit/rviz_plugin_render_tools/octomap_render.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace octomap
 {
 class OcTree;
-}
-
-namespace Ogre
-{
-class SceneManager;
-class SceneNode;
-class AxisAlignedBox;
-class Vector3;
-class Quaternion;
 }
 
 namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -53,7 +53,7 @@ PlanningSceneRender::PlanningSceneRender(Ogre::SceneNode* node, rviz::DisplayCon
 
 PlanningSceneRender::~PlanningSceneRender()
 {
-  context_->getSceneManager()->destroySceneNode(planning_scene_geometry_node_->getName());
+  context_->getSceneManager()->destroySceneNode(planning_scene_geometry_node_);
 }
 
 void PlanningSceneRender::clear()

--- a/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NA
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
-  ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES}
 )
 
 # Plugin Initializer


### PR DESCRIPTION
Switching to a newer Ogre version (as supported by rviz' noetic version) requires some changes in MoveIt as well...