### PR TITLE
[AIST-QA]Fix potential null-pointer dereferencing issues in moveit_setup_assistant.

### DIFF
--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -132,8 +132,8 @@ DisabledReason CollisionLinearModel::reason(int row) const
   CollisionMatrixModel* m = qobject_cast<CollisionMatrixModel*>(sourceModel());
   if (!m)
   {
-    Q_ASSERT(m);
-    return moveit_setup_assistant::NOT_DISABLED;
+    ROS_FATAL_NAMED("collision_linear_model", "sourceModel() is null");
+    ROS_BREAK();
   }
   QModelIndex srcIndex = this->mapToSource(index(row, 0));
 
@@ -247,7 +247,10 @@ bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& s
 {
   CollisionLinearModel* m = qobject_cast<CollisionLinearModel*>(sourceModel());
   if (!m)
-    return false;
+  {
+    ROS_FATAL_NAMED("collision_linear_model", "sourceModel() is null");
+    ROS_BREAK();
+  }
 
   if (!(show_all_ || m->reason(source_row) <= moveit_setup_assistant::ALWAYS ||
         m->data(m->index(source_row, 2), Qt::CheckStateRole) == Qt::Checked))

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -129,8 +129,15 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
 
 DisabledReason CollisionLinearModel::reason(int row) const
 {
+  CollisionMatrixModel* m = qobject_cast<CollisionMatrixModel*>(sourceModel());
+  if (!m)
+  {
+    Q_ASSERT(m);
+    return moveit_setup_assistant::NOT_DISABLED;
+  }
   QModelIndex srcIndex = this->mapToSource(index(row, 0));
-  return qobject_cast<CollisionMatrixModel*>(sourceModel())->reason(srcIndex);
+
+  return m->reason(srcIndex);
 }
 
 bool CollisionLinearModel::setData(const QModelIndex& index, const QVariant& value, int role)
@@ -239,6 +246,9 @@ void SortFilterProxyModel::setShowAll(bool show_all)
 bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
 {
   CollisionLinearModel* m = qobject_cast<CollisionLinearModel*>(sourceModel());
+  if (!m)
+    return false;
+
   if (!(show_all_ || m->reason(source_row) <= moveit_setup_assistant::ALWAYS ||
         m->data(m->index(source_row, 2), Qt::CheckStateRole) == Qt::Checked))
     return false;  // not accepted due to check state

--- a/moveit_setup_assistant/src/tools/rotated_header_view.cpp
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.cpp
@@ -80,8 +80,8 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
   QAbstractItemModel* m = model();
   if (m == nullptr)
   {
-    Q_ASSERT(m);
-    return QSize();
+    ROS_FATAL_NAMED("rotated_header_view", "model() is null");
+    ROS_BREAK();
   }
 
   // use SizeHintRole
@@ -127,7 +127,10 @@ int RotatedHeaderView::sectionSizeHint(int logicalIndex) const
   QSize size;
   QAbstractItemModel* m = model();
   if (m == nullptr)
-    return -1;
+  {
+    ROS_FATAL_NAMED("rotated_header_view", "QAbstractItemModel is null");
+    ROS_BREAK();
+  }
   QVariant value = m->headerData(logicalIndex, orientation(), Qt::SizeHintRole);
   if (value.isValid())
     size = qvariant_cast<QSize>(value);

--- a/moveit_setup_assistant/src/tools/rotated_header_view.cpp
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.cpp
@@ -83,7 +83,7 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
     Q_ASSERT(m);
     return QSize();
   }
-  
+
   // use SizeHintRole
   QVariant variant = m->headerData(logicalIndex, Qt::Vertical, Qt::SizeHintRole);
   if (variant.isValid())

--- a/moveit_setup_assistant/src/tools/rotated_header_view.cpp
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.cpp
@@ -77,8 +77,15 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
 
   ensurePolished();
 
+  QAbstractItemModel* m = model();
+  if (m == nullptr)
+  {
+    Q_ASSERT(m);
+    return QSize();
+  }
+  
   // use SizeHintRole
-  QVariant variant = model()->headerData(logicalIndex, Qt::Vertical, Qt::SizeHintRole);
+  QVariant variant = m->headerData(logicalIndex, Qt::Vertical, Qt::SizeHintRole);
   if (variant.isValid())
     return qvariant_cast<QSize>(variant);
 
@@ -86,7 +93,7 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
   QStyleOptionHeader opt;
   initStyleOption(&opt);
   opt.section = logicalIndex;
-  QVariant var = model()->headerData(logicalIndex, orientation(), Qt::FontRole);
+  QVariant var = m->headerData(logicalIndex, orientation(), Qt::FontRole);
   QFont fnt;
   if (var.isValid() && var.canConvert<QFont>())
     fnt = qvariant_cast<QFont>(var);
@@ -94,8 +101,8 @@ QSize RotatedHeaderView::sectionSizeFromContents(int logicalIndex) const
     fnt = font();
   fnt.setBold(true);
   opt.fontMetrics = QFontMetrics(fnt);
-  opt.text = model()->headerData(logicalIndex, orientation(), Qt::DisplayRole).toString();
-  variant = model()->headerData(logicalIndex, orientation(), Qt::DecorationRole);
+  opt.text = m->headerData(logicalIndex, orientation(), Qt::DisplayRole).toString();
+  variant = m->headerData(logicalIndex, orientation(), Qt::DecorationRole);
   opt.icon = qvariant_cast<QIcon>(variant);
   if (opt.icon.isNull())
     opt.icon = qvariant_cast<QPixmap>(variant);
@@ -118,7 +125,10 @@ int RotatedHeaderView::sectionSizeHint(int logicalIndex) const
   if (logicalIndex < 0 || logicalIndex >= count())
     return -1;
   QSize size;
-  QVariant value = model()->headerData(logicalIndex, orientation(), Qt::SizeHintRole);
+  QAbstractItemModel* m = model();
+  if (m == nullptr)
+    return -1;
+  QVariant value = m->headerData(logicalIndex, orientation(), Qt::SizeHintRole);
   if (value.isValid())
     size = qvariant_cast<QSize>(value);
   else

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -448,8 +448,11 @@ void DefaultCollisionsWidget::hideSections()
     list << clicked_section_;
   }
 
-  for (auto index : list)
-    header->setSectionHidden(index, true);
+  if (header != nullptr)
+  {
+    for (auto index : list)
+      header->setSectionHidden(index, true);
+  }
 }
 
 void DefaultCollisionsWidget::hideOtherSections()
@@ -478,13 +481,16 @@ void DefaultCollisionsWidget::hideOtherSections()
     list << clicked_section_;
   }
 
-  // first hide all sections
-  for (std::size_t index = 0, end = header->count(); index != end; ++index)
-    header->setSectionHidden(index, true);
+  if (header != nullptr)
+  {
+    // first hide all sections
+    for (std::size_t index = 0, end = header->count(); index != end; ++index)
+      header->setSectionHidden(index, true);
 
-  // and subsequently show selected ones
-  for (auto index : list)
-    header->setSectionHidden(index, false);
+    // and subsequently show selected ones
+    for (auto index : list)
+      header->setSectionHidden(index, false);
+  }
 }
 
 void DefaultCollisionsWidget::showSections()
@@ -529,7 +535,11 @@ void DefaultCollisionsWidget::showSections()
     list.clear();
     list << clicked_section_;
   }
-  showSections(header, list);
+
+  if (header != nullptr)
+  {
+    showSections(header, list);
+  }
 }
 void DefaultCollisionsWidget::showSections(QHeaderView* header, const QList<int>& logicalIndexes)
 {
@@ -659,7 +669,8 @@ void DefaultCollisionsWidget::disableControls(bool disable)
 void DefaultCollisionsWidget::checkedFilterChanged()
 {
   SortFilterProxyModel* m = qobject_cast<SortFilterProxyModel*>(model_);
-  m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
+  if (m)
+    m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
 }
 
 // Output Link Pairs to SRDF Format and update the collision matrix

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -448,11 +448,13 @@ void DefaultCollisionsWidget::hideSections()
     list << clicked_section_;
   }
 
-  if (header != nullptr)
+  if (header == nullptr)
   {
-    for (auto index : list)
-      header->setSectionHidden(index, true);
+    ROS_FATAL_NAMED("default_collisions_widget", "QHeaderView is null");
+    ROS_BREAK();
   }
+  for (auto index : list)
+    header->setSectionHidden(index, true);
 }
 
 void DefaultCollisionsWidget::hideOtherSections()
@@ -481,16 +483,18 @@ void DefaultCollisionsWidget::hideOtherSections()
     list << clicked_section_;
   }
 
-  if (header != nullptr)
+  if (header == nullptr)
   {
-    // first hide all sections
-    for (std::size_t index = 0, end = header->count(); index != end; ++index)
-      header->setSectionHidden(index, true);
-
-    // and subsequently show selected ones
-    for (auto index : list)
-      header->setSectionHidden(index, false);
+    ROS_FATAL_NAMED("default_collisions_widget", "QHeaderView is null");
+    ROS_BREAK();
   }
+  // first hide all sections
+  for (std::size_t index = 0, end = header->count(); index != end; ++index)
+    header->setSectionHidden(index, true);
+
+  // and subsequently show selected ones
+  for (auto index : list)
+    header->setSectionHidden(index, false);
 }
 
 void DefaultCollisionsWidget::showSections()
@@ -536,10 +540,12 @@ void DefaultCollisionsWidget::showSections()
     list << clicked_section_;
   }
 
-  if (header != nullptr)
+  if (header == nullptr)
   {
-    showSections(header, list);
+    ROS_FATAL_NAMED("default_collisions_widget", "header is null");
+    ROS_BREAK();
   }
+  showSections(header, list);
 }
 void DefaultCollisionsWidget::showSections(QHeaderView* header, const QList<int>& logicalIndexes)
 {
@@ -669,8 +675,12 @@ void DefaultCollisionsWidget::disableControls(bool disable)
 void DefaultCollisionsWidget::checkedFilterChanged()
 {
   SortFilterProxyModel* m = qobject_cast<SortFilterProxyModel*>(model_);
-  if (m)
-    m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
+  if (!m)
+  {
+    ROS_FATAL_NAMED("default_collisions_widget", "SortFilterProxyModel is null");
+    ROS_BREAK();
+  }
+  m->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
 }
 
 // Output Link Pairs to SRDF Format and update the collision matrix

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -317,7 +317,10 @@ void EndEffectorsWidget::edit(const std::string& name)
   // Find the selected in datastruture
   srdf::Model::EndEffector* effector = findEffectorByName(name);
   if (effector == NULL)
-    return;
+  {
+    ROS_FATAL_NAMED("end_effectors_widget", "findEffectorByName() returned null");
+    ROS_BREAK();
+  }
 
   // Set effector name
   effector_name_field_->setText(effector->name_.c_str());

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -316,6 +316,8 @@ void EndEffectorsWidget::edit(const std::string& name)
 
   // Find the selected in datastruture
   srdf::Model::EndEffector* effector = findEffectorByName(name);
+  if (effector == NULL)
+    return;
 
   // Set effector name
   effector_name_field_->setText(effector->name_.c_str());

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -206,9 +206,13 @@ bool KinematicChainWidget::addLinkChildRecursive(QTreeWidgetItem* parent, const 
   {
     for (int i = 0; i < parent->childCount(); i++)
     {
-      if (addLinkChildRecursive(parent->child(i), link, parent_name))
+      QTreeWidgetItem* item = parent->child(i);
+      if (item != NULL)
       {
-        return true;
+        if (addLinkChildRecursive(item, link, parent_name))
+        {
+          return true;
+        }
       }
     }
   }

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -207,12 +207,14 @@ bool KinematicChainWidget::addLinkChildRecursive(QTreeWidgetItem* parent, const 
     for (int i = 0; i < parent->childCount(); i++)
     {
       QTreeWidgetItem* item = parent->child(i);
-      if (item != NULL)
+      if (item == NULL)
       {
-        if (addLinkChildRecursive(item, link, parent_name))
-        {
+        ROS_FATAL_NAMED("kinematic_chain_widget", "QTreeWidgetItem is null");
+        ROS_BREAK();
+      }
+      if (addLinkChildRecursive(item, link, parent_name))
+      {
           return true;
-        }
       }
     }
   }

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -87,11 +87,15 @@ void NavigationWidget::setNavs(const QList<QString>& navs)
 
 void NavigationWidget::setEnabled(const int& index, bool enabled)
 {
+  QStandardItem* item = model_->item(index);
+  if (item == nullptr)
+    return;
+
   if (enabled)
-    model_->item(index)->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled |
-                                  Qt::ItemIsDropEnabled | Qt::ItemIsEnabled);
+	  item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled |
+                     Qt::ItemIsDropEnabled | Qt::ItemIsEnabled);
   else
-    model_->item(index)->setFlags(Qt::NoItemFlags);
+	  item->setFlags(Qt::NoItemFlags);
 }
 
 void NavigationWidget::setSelected(const int& index)

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -89,7 +89,10 @@ void NavigationWidget::setEnabled(const int& index, bool enabled)
 {
   QStandardItem* item = model_->item(index);
   if (item == nullptr)
-    return;
+  {
+    ROS_FATAL_NAMED("navigation_widget", "QStandardItem is null");
+    ROS_BREAK();
+  }
 
   if (enabled)
     item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled |

--- a/moveit_setup_assistant/src/widgets/navigation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.cpp
@@ -92,10 +92,10 @@ void NavigationWidget::setEnabled(const int& index, bool enabled)
     return;
 
   if (enabled)
-	  item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled |
-                     Qt::ItemIsDropEnabled | Qt::ItemIsEnabled);
+    item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled |
+                   Qt::ItemIsEnabled);
   else
-	  item->setFlags(Qt::NoItemFlags);
+    item->setFlags(Qt::NoItemFlags);
 }
 
 void NavigationWidget::setSelected(const int& index)

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -422,7 +422,10 @@ void RobotPosesWidget::edit(int row)
   // Find the selected in datastruture
   srdf::Model::GroupState* pose = findPoseByName(name, group);
   if (pose == NULL)
-    return;
+  {
+    ROS_FATAL_NAMED("robot_poses_widget", "findPoseByName() returned null");
+    ROS_BREAK();
+  }
   current_edit_pose_ = pose;
 
   // Set pose name

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -421,6 +421,8 @@ void RobotPosesWidget::edit(int row)
 
   // Find the selected in datastruture
   srdf::Model::GroupState* pose = findPoseByName(name, group);
+  if (pose == NULL)
+    return;
   current_edit_pose_ = pose;
 
   // Set pose name

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -212,10 +212,13 @@ void SetupAssistantWidget::moveToScreen(const int index)
   {
     // Send the focus lost command to the screen widget
     SetupScreenWidget* ssw = qobject_cast<SetupScreenWidget*>(main_content_->widget(current_index_));
-    if (!ssw->focusLost())
+    if (ssw != NULL)
     {
-      navs_view_->setSelected(current_index_);
-      return;  // switching not accepted
+      if (!ssw->focusLost())
+      {
+        navs_view_->setSelected(current_index_);
+        return;  // switching not accepted
+      }
     }
 
     current_index_ = index;
@@ -228,7 +231,8 @@ void SetupAssistantWidget::moveToScreen(const int index)
 
     // Send the focus given command to the screen widget
     ssw = qobject_cast<SetupScreenWidget*>(main_content_->widget(index));
-    ssw->focusGiven();
+    if (ssw != NULL)
+      ssw->focusGiven();
 
     // Change navigation selected option
     navs_view_->setSelected(index);  // Select first item in list

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -212,13 +212,15 @@ void SetupAssistantWidget::moveToScreen(const int index)
   {
     // Send the focus lost command to the screen widget
     SetupScreenWidget* ssw = qobject_cast<SetupScreenWidget*>(main_content_->widget(current_index_));
-    if (ssw != NULL)
+    if (ssw == NULL)
     {
-      if (!ssw->focusLost())
-      {
-        navs_view_->setSelected(current_index_);
-        return;  // switching not accepted
-      }
+      ROS_FATAL_NAMED("setup_assistant_widget", "SetupScreenWidget is null");
+      ROS_BREAK();
+    }
+    if (!ssw->focusLost())
+    {
+      navs_view_->setSelected(current_index_);
+      return;  // switching not accepted
     }
 
     current_index_ = index;
@@ -231,8 +233,12 @@ void SetupAssistantWidget::moveToScreen(const int index)
 
     // Send the focus given command to the screen widget
     ssw = qobject_cast<SetupScreenWidget*>(main_content_->widget(index));
-    if (ssw != NULL)
-      ssw->focusGiven();
+    if (ssw == NULL)
+    {
+      ROS_FATAL_NAMED("setup_assistant_widget", "SetupScreenWidget is null");
+      ROS_BREAK();
+    }
+    ssw->focusGiven();
 
     // Change navigation selected option
     navs_view_->setSelected(index);  // Select first item in list

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -306,6 +306,8 @@ void VirtualJointsWidget::edit(const std::string& name)
 
   // Find the selected in datastruture
   srdf::Model::VirtualJoint* vjoint = findVJointByName(name);
+  if (vjoint == NULL)
+    return;
 
   // Set vjoint name
   vjoint_name_field_->setText(vjoint->name_.c_str());

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -307,7 +307,10 @@ void VirtualJointsWidget::edit(const std::string& name)
   // Find the selected in datastruture
   srdf::Model::VirtualJoint* vjoint = findVJointByName(name);
   if (vjoint == NULL)
-    return;
+  {
+    ROS_FATAL_NAMED("virtual_joints_widget", "findVJointByName() returned null");
+    ROS_BREAK();
+  }
 
   // Set vjoint name
   vjoint_name_field_->setText(vjoint->name_.c_str());


### PR DESCRIPTION
### Description

`model()` may return `nullptr` and `qobject_cast<>`, `findPoseByName()` and `findVJointByName` may return zero on failure.
Furthermore, in `default_collisions_widget.cpp`, the `header` variable is not initialized. 
These variables are used without checking, potentially causing null pointer de-referencing.
This fix adds safeguards to mitigate this risk.

This contribution is made by AIST ( https://www.aist.go.jp ) based on static code analysis with klocwork (Perforce Software).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
