### PR TITLE
Improve JogArm thread handling

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <atomic>
 #include "jog_arm_data.h"
 #include "low_pass_filter.h"
 #include <moveit/robot_model_loader/robot_model_loader.h>
@@ -48,8 +49,19 @@ namespace moveit_jog_arm
 class CollisionCheckThread
 {
 public:
-  CollisionCheckThread(const moveit_jog_arm::JogArmParameters parameters,
-                       moveit_jog_arm::JogArmShared& shared_variables, std::mutex& mutex,
+  CollisionCheckThread(const moveit_jog_arm::JogArmParameters& parameters,
                        const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+
+  void startMainLoop(moveit_jog_arm::JogArmShared& shared_variables, std::mutex& mutex);
+
+  void stopMainLoop();
+
+private:
+  // Loop termination flag
+  std::atomic<bool> stop_requested_;
+
+  const moveit_jog_arm::JogArmParameters parameters_;
+
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 };
 }

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <atomic>
 #include "jog_arm_data.h"
 #include "low_pass_filter.h"
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
@@ -49,11 +50,17 @@ namespace moveit_jog_arm
 class JogCalcs
 {
 public:
-  JogCalcs(const JogArmParameters& parameters, JogArmShared& shared_variables, std::mutex& mutex,
-           const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+  JogCalcs(const JogArmParameters& parameters, const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+
+  void startMainLoop(JogArmShared& shared_variables, std::mutex& mutex);
+
+  void stopMainLoop();
 
 protected:
   ros::NodeHandle nh_;
+
+  // Loop termination flag
+  std::atomic<bool> stop_requested_;
 
   sensor_msgs::JointState incoming_joints_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <atomic>
 #include "jog_interface_base.h"
 
 namespace moveit_jog_arm
@@ -51,7 +52,11 @@ class JogCppApi : JogInterfaceBase
 public:
   JogCppApi();
 
-  void mainLoop();
+  ~JogCppApi();
+
+  void startMainLoop();
+
+  void stopMainLoop();
 
   // Provide a Cartesian velocity command to the jogger.
   // The units are determined by settings in the yaml file.
@@ -70,5 +75,7 @@ public:
 
 private:
   ros::NodeHandle nh_;
+
+  std::atomic<bool> stop_requested_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
@@ -59,9 +59,11 @@ public:
 
   // Jogging calculation thread
   bool startJogCalcThread();
+  bool stopJogCalcThread();
 
   // Collision checking thread
   bool startCollisionCheckThread();
+  bool stopCollisionCheckThread();
 
 protected:
   bool readParameters(ros::NodeHandle& n);
@@ -74,5 +76,13 @@ protected:
   // Share data between threads
   JogArmShared shared_variables_;
   std::mutex shared_variables_mutex_;
+
+  // Jog calcs
+  std::unique_ptr<JogCalcs> jog_calcs_;
+  std::unique_ptr<std::thread> jog_calc_thread_;
+
+  // Collision checks
+  std::unique_ptr<CollisionCheckThread> collision_checker_;
+  std::unique_ptr<std::thread> collision_check_thread_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -41,96 +41,93 @@
 namespace moveit_jog_arm
 {
 // Constructor for the class that handles collision checking
-CollisionCheckThread::CollisionCheckThread(const moveit_jog_arm::JogArmParameters parameters,
-                                           JogArmShared& shared_variables, std::mutex& mutex,
+CollisionCheckThread::CollisionCheckThread(const moveit_jog_arm::JogArmParameters& parameters,
                                            const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr)
+  : parameters_(parameters)
 {
-  // If user specified true in yaml file
-  if (parameters.check_collisions)
+  // MoveIt Setup
+  while (ros::ok() && !model_loader_ptr)
   {
-    // MoveIt Setup
-    while (ros::ok() && !model_loader_ptr)
-    {
-      ROS_WARN_THROTTLE_NAMED(5, LOGNAME, "Waiting for a non-null robot_model_loader pointer");
-      ros::Duration(WHILE_LOOP_WAIT).sleep();
-    }
-    const robot_model::RobotModelPtr& kinematic_model = model_loader_ptr->getModel();
-    planning_scene::PlanningScene planning_scene(kinematic_model);
-    collision_detection::CollisionRequest collision_request;
-    collision_request.group_name = parameters.move_group_name;
-    collision_request.distance = true;
-    collision_detection::CollisionResult collision_result;
-    robot_state::RobotState& current_state = planning_scene.getCurrentStateNonConst();
-
-    planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor;
-    planning_scene_monitor.reset(new planning_scene_monitor::PlanningSceneMonitor(model_loader_ptr));
-    planning_scene_monitor->startSceneMonitor();
-    planning_scene_monitor->startStateMonitor();
-
-    if (planning_scene_monitor->getPlanningScene())
-    {
-      planning_scene_monitor->startSceneMonitor("/planning_scene");
-      planning_scene_monitor->startWorldGeometryMonitor();
-      planning_scene_monitor->startStateMonitor();
-    }
-    else
-    {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "Error in setting up the PlanningSceneMonitor.");
-      exit(EXIT_FAILURE);
-    }
-
-    double velocity_scale_coefficient = -log(0.001) / parameters.collision_proximity_threshold;
-
-    // Wait for initial messages
-    ROS_INFO_NAMED(LOGNAME, "collision_check_thread: Waiting for first joint msg.");
-    ros::topic::waitForMessage<sensor_msgs::JointState>(parameters.joint_topic);
-    ROS_INFO_NAMED(LOGNAME, "collision_check_thread: Received first joint msg.");
-
-    ROS_INFO_NAMED(LOGNAME, "Waiting for first command msg.");
-    ros::topic::waitForMessage<geometry_msgs::TwistStamped>(parameters.cartesian_command_in_topic);
-    ROS_INFO_NAMED(LOGNAME, "Received first command msg.");
-
-    ros::Rate collision_rate(parameters.collision_check_rate);
-
-    /////////////////////////////////////////////////
-    // Spin while checking collisions
-    /////////////////////////////////////////////////
-    while (ros::ok())
-    {
-      mutex.lock();
-      sensor_msgs::JointState jts = shared_variables.joints;
-      mutex.unlock();
-
-      for (std::size_t i = 0; i < jts.position.size(); ++i)
-        current_state.setJointPositions(jts.name[i], &jts.position[i]);
-
-      collision_result.clear();
-      planning_scene_monitor->getPlanningScene()->checkCollision(collision_request, collision_result, current_state);
-
-      // Scale robot velocity according to collision proximity and user-defined thresholds.
-      // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.
-      // Proximity decreasing --> decelerate
-      double velocity_scale = 1;
-
-      // If we are far from a collision, velocity_scale should be 1.
-      // If we are very close to a collision, velocity_scale should be ~zero.
-      // When collision_proximity_threshold is breached, start decelerating exponentially.
-      if (collision_result.distance < parameters.collision_proximity_threshold)
-      {
-        // velocity_scale = e ^ k * (collision_distance - threshold)
-        // k = - ln(0.001) / collision_proximity_threshold
-        // velocity_scale should equal one when collision_distance is at collision_proximity_threshold.
-        // velocity_scale should equal 0.001 when collision_distance is at zero.
-        velocity_scale =
-            exp(velocity_scale_coefficient * (collision_result.distance - parameters.collision_proximity_threshold));
-      }
-
-      mutex.lock();
-      shared_variables.collision_velocity_scale = velocity_scale;
-      mutex.unlock();
-
-      collision_rate.sleep();
-    }
+    ROS_WARN_THROTTLE_NAMED(5, LOGNAME, "Waiting for a non-null robot_model_loader pointer");
+    ros::Duration(WHILE_LOOP_WAIT).sleep();
   }
+
+  planning_scene_monitor_.reset(new planning_scene_monitor::PlanningSceneMonitor(model_loader_ptr));
+  planning_scene_monitor_->startSceneMonitor();
+  planning_scene_monitor_->startStateMonitor();
+
+  if (planning_scene_monitor_->getPlanningScene())
+  {
+    planning_scene_monitor_->startSceneMonitor("/planning_scene");
+    planning_scene_monitor_->startWorldGeometryMonitor();
+    planning_scene_monitor_->startStateMonitor();
+  }
+  else
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Error in setting up the PlanningSceneMonitor.");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables, std::mutex& mutex)
+{
+  // Reset loop termination flag
+  stop_requested_ = false;
+
+  // Init collision request and current state
+  collision_detection::CollisionRequest collision_request;
+  collision_request.group_name = parameters_.move_group_name;
+  collision_request.distance = true;
+  collision_detection::CollisionResult collision_result;
+  robot_state::RobotState& current_state = planning_scene_monitor_->getPlanningScene()->getCurrentStateNonConst();
+
+  double velocity_scale_coefficient = -log(0.001) / parameters_.collision_proximity_threshold;
+
+  ros::Rate collision_rate(parameters_.collision_check_rate);
+
+  /////////////////////////////////////////////////
+  // Spin while checking collisions
+  /////////////////////////////////////////////////
+  while (ros::ok() && !stop_requested_)
+  {
+    mutex.lock();
+    sensor_msgs::JointState jts = shared_variables.joints;
+    mutex.unlock();
+
+    for (std::size_t i = 0; i < jts.position.size(); ++i)
+      current_state.setJointPositions(jts.name[i], &jts.position[i]);
+
+    collision_result.clear();
+    planning_scene_monitor_->getPlanningScene()->checkCollision(collision_request, collision_result, current_state);
+
+    // Scale robot velocity according to collision proximity and user-defined thresholds.
+    // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.
+    // Proximity decreasing --> decelerate
+    double velocity_scale = 1;
+
+    // If we are far from a collision, velocity_scale should be 1.
+    // If we are very close to a collision, velocity_scale should be ~zero.
+    // When collision_proximity_threshold is breached, start decelerating exponentially.
+    if (collision_result.distance < parameters_.collision_proximity_threshold)
+    {
+      // velocity_scale = e ^ k * (collision_distance - threshold)
+      // k = - ln(0.001) / collision_proximity_threshold
+      // velocity_scale should equal one when collision_distance is at collision_proximity_threshold.
+      // velocity_scale should equal 0.001 when collision_distance is at zero.
+      velocity_scale =
+          exp(velocity_scale_coefficient * (collision_result.distance - parameters_.collision_proximity_threshold));
+    }
+
+    mutex.lock();
+    shared_variables.collision_velocity_scale = velocity_scale;
+    mutex.unlock();
+
+    collision_rate.sleep();
+  }
+}
+
+void CollisionCheckThread::stopMainLoop()
+{
+  stop_requested_ = true;
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 
   // Run the jogging C++ interface in a new thread to ensure a constant outgoing message rate.
   moveit_jog_arm::JogCppApi jog_interface;
-  std::thread jogging_thread(&moveit_jog_arm::JogCppApi::mainLoop, &jog_interface);
+  std::thread jogging_thread([&]() { jog_interface.startMainLoop(); });
 
   // Make a Cartesian velocity message
   geometry_msgs::TwistStamped velocity_msg;
@@ -93,6 +93,7 @@ int main(int argc, char** argv)
   sensor_msgs::JointState current_joint_state = jog_interface.getJointState();
   ROS_INFO_STREAM(current_joint_state);
 
+  jog_interface.stopMainLoop();
   jogging_thread.join();
   return 0;
 }

--- a/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
@@ -61,10 +61,11 @@ JogROSInterface::JogROSInterface()
   model_loader_ptr_ = std::shared_ptr<robot_model_loader::RobotModelLoader>(new robot_model_loader::RobotModelLoader);
 
   // Crunch the numbers in this thread
-  std::thread jogging_thread(&JogInterfaceBase::startJogCalcThread, dynamic_cast<JogInterfaceBase*>(this));
+  startJogCalcThread();
 
   // Check collisions in this thread
-  std::thread collision_thread(&JogInterfaceBase::startCollisionCheckThread, dynamic_cast<JogInterfaceBase*>(this));
+  if (ros_parameters_.check_collisions)
+    startCollisionCheckThread();
 
   // ROS subscriptions. Share the data with the worker threads
   ros::Subscriber cmd_sub =
@@ -146,8 +147,8 @@ JogROSInterface::JogROSInterface()
     main_rate.sleep();
   }
 
-  jogging_thread.join();
-  collision_thread.join();
+  stopJogCalcThread();
+  stopCollisionCheckThread();
 }
 
 // Listen to cartesian delta commands. Store them in a shared variable.


### PR DESCRIPTION
This moves thread handling to the JogBaseInterface class and adds atomic bool flags for stopping all main loops from outside their threads.

Also, this fixes an issue where the `CollisionCheckThread` would indefinitely wait for command messages and won't get to run any collision checks using the C++ API.