### PR TITLE
[AIST-QA] Initialized scene_manager_ member varianle in OcTreeRender constructor

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -53,7 +53,7 @@ OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
                            OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
                            std::size_t max_octree_depth, Ogre::SceneManager* scene_manager,
                            Ogre::SceneNode* parent_node = nullptr)
-  : octree_(octree), colorFactor_(0.8)
+  : octree_(octree), scene_manager_(scene_manager), colorFactor_(0.8)
 {
   if (!parent_node)
   {


### PR DESCRIPTION
### Description

The member variable `scene_manager_` is not initialized in the constructor of `OcTreeRender`. Since a parameter called `scene_manager` exists in the constructor arguments, it appears to have been forgotten to initialize `sacene_manager_`.
This fix adds initialization of  `scene_manager_` to the `OcTreeRender` constructor.

This contribution is made by AIST ( https://www.aist.go.jp ) based on static code analysis with klocwork (Perforce Software).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
