### PR TITLE
[AIST-QA] Fix potential use of uninitialized variable in moveit_ros.

### DIFF
--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -73,8 +73,10 @@ void parseStart(std::istream& in, planning_scene_monitor::PlanningSceneMonitor* 
           if (marker != "=")
             joint = ".";
           else
+          {
             in >> value;
-          v[joint] = value;
+            v[joint] = value;
+          }
           if (joint != ".")
             in >> joint;
         }


### PR DESCRIPTION
### Description

The local variable `value` is not initialized and stored in `std::map <std::string, double> v[joint]` regardless of whether `maker` equals `"="` or not. For that reason, it may cause undefined behavior if `marker` is `"="` and `value` is not set via input stream.
This fix extends the scope of the conditional branch of `marker`: `value` is stored `v[joint]` only when `marker` equals `"="`.

This contribution is made by AIST ( https://www.aist.go.jp ) based on static code analysis with klocwork (Perforce Software).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
