### PR TITLE
delete attached body before adding a new one with the same id

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -880,7 +880,7 @@ const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 
 void RobotState::attachBody(AttachedBody* attached_body)
 {
-  // Remove the old attached body if it still exists
+  // If an attached body with the same id exists, remove it
   clearAttachedBody(attached_body->getName());
 
   attached_body_map_[attached_body->getName()] = attached_body;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -880,14 +880,8 @@ const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 
 void RobotState::attachBody(AttachedBody* attached_body)
 {
-  // Does the old attached body hang around?
-  std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(attached_body->getName());
-  if (it != attached_body_map_.end())
-  {
-    if (attached_body_update_callback_)
-      attached_body_update_callback_(it->second, false);
-    delete it->second;
-  }
+  // Remove the old attached body if it still exists
+  clearAttachedBody(attached_body->getName());
 
   attached_body_map_[attached_body->getName()] = attached_body;
   attached_body->computeTransform(getGlobalLinkTransform(attached_body->getAttachedLink()));

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -880,6 +880,15 @@ const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 
 void RobotState::attachBody(AttachedBody* attached_body)
 {
+  // Does the old attached body hang around?
+  std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(attached_body->getName());
+  if (it != attached_body_map_.end())
+  {
+    if (attached_body_update_callback_)
+      attached_body_update_callback_(it->second, false);
+    delete it->second;
+  }
+
   attached_body_map_[attached_body->getName()] = attached_body;
   attached_body->computeTransform(getGlobalLinkTransform(attached_body->getAttachedLink()));
   if (attached_body_update_callback_)


### PR DESCRIPTION
### Description

Fixes a memory leak described here: https://github.com/ros-planning/moveit/issues/1820