### PR TITLE
Cleanup OcTreeRender's constructor interface

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -77,8 +77,7 @@ class OcTreeRender
 {
 public:
   OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree, OctreeVoxelRenderMode octree_voxel_rendering,
-               OctreeVoxelColorMode octree_color_mode, std::size_t max_octree_depth, Ogre::SceneManager* scene_manager,
-               Ogre::SceneNode* parent_node);
+               OctreeVoxelColorMode octree_color_mode, std::size_t max_octree_depth, Ogre::SceneNode* parent_node);
   virtual ~OcTreeRender();
 
   void setPosition(const Ogre::Vector3& position);
@@ -96,7 +95,6 @@ private:
   std::shared_ptr<const octomap::OcTree> octree_;
 
   Ogre::SceneNode* scene_node_;
-  Ogre::SceneManager* scene_manager_;
 
   double colorFactor_;
   std::size_t octree_depth_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -54,15 +54,9 @@ typedef std::vector<VPoint> VVPoint;
 
 OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
                            OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
-                           std::size_t max_octree_depth, Ogre::SceneManager* /*scene_manager*/,
-                           Ogre::SceneNode* parent_node = nullptr)
+                           std::size_t max_octree_depth, Ogre::SceneNode* parent_node)
   : octree_(octree), colorFactor_(0.8)
 {
-  if (!parent_node)
-  {
-    parent_node = scene_manager_->getRootSceneNode();
-  }
-
   if (!max_octree_depth)
   {
     octree_depth_ = octree->getTreeDepth();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -161,7 +161,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
     case shapes::OCTREE:
     {
       OcTreeRenderPtr octree(new OcTreeRender(static_cast<const shapes::OcTree*>(s)->octree, octree_voxel_rendering,
-                                              octree_color_mode, 0u, context_->getSceneManager(), node));
+                                              octree_color_mode, 0u, node));
       octree->setPosition(position);
       octree->setOrientation(orientation);
       octree_voxel_grids_.push_back(octree);


### PR DESCRIPTION
Require a valid `parent_node` to be passed (and drop `scene_manager` argument that was just used to retrieve the scene's root node in case parent_node was `NULL`).
Modified cherry-pick of #1817.