### PR TITLE
ikfast: implement Translation*AxisAngle4D IK type

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -570,15 +570,6 @@ size_t IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<d
       ComputeIk(trans, direction.data, vfree.size() > 0 ? &vfree[0] : nullptr, solutions);
       return solutions.GetNumSolutions();
 
-    case IKP_TranslationXAxisAngle4D:
-    case IKP_TranslationYAxisAngle4D:
-    case IKP_TranslationZAxisAngle4D:
-      // For *TranslationXAxisAngle4D*, *TranslationYAxisAngle4D*, *TranslationZAxisAngle4D* - end effector origin
-      // reaches desired 3D translation, manipulator direction makes a specific angle with x/y/z-axis (defined in the
-      // manipulator base link’s coordinate system)
-      ROS_ERROR_NAMED(name_, "IK for this IkParameterizationType not implemented yet.");
-      return 0;
-
     case IKP_TranslationLocalGlobal6D:
       // For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end
       // effector coordinate system.
@@ -592,6 +583,10 @@ size_t IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<d
       ROS_ERROR_NAMED(name_, "IK for this IkParameterizationType not implemented yet.");
       return 0;
 
+    case IKP_TranslationXAxisAngle4D:
+    // For *TranslationXAxisAngle4D*, *TranslationYAxisAngle4D*, *TranslationZAxisAngle4D* - end effector origin
+    // reaches desired 3D translation, manipulator direction makes a specific angle with x/y/z-axis (defined in the
+    // manipulator base link's coordinate system)
     case IKP_TranslationXAxisAngleZNorm4D:
       double roll, pitch, yaw;
       // For **TranslationXAxisAngleZNorm4D** - end effector origin reaches desired 3D translation, manipulator
@@ -601,6 +596,7 @@ size_t IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<d
       ComputeIk(trans, &yaw, vfree.size() > 0 ? &vfree[0] : nullptr, solutions);
       return solutions.GetNumSolutions();
 
+    case IKP_TranslationYAxisAngle4D:
     case IKP_TranslationYAxisAngleXNorm4D:
       // For **TranslationYAxisAngleXNorm4D** - end effector origin reaches desired 3D translation, manipulator
       // direction needs to be orthogonal to x axis and be rotated at a certain angle starting from the y axis (defined
@@ -609,6 +605,7 @@ size_t IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<d
       ComputeIk(trans, &roll, vfree.size() > 0 ? &vfree[0] : nullptr, solutions);
       return solutions.GetNumSolutions();
 
+    case IKP_TranslationZAxisAngle4D:
     case IKP_TranslationZAxisAngleYNorm4D:
       // For **TranslationZAxisAngleYNorm4D** - end effector origin reaches desired 3D translation, manipulator
       // direction needs to be orthogonal to y axis and be rotated at a certain angle starting from the z axis (defined


### PR DESCRIPTION
Added an implementation for TranslationXAxisAngle4D TranslationYAxisAngle4D and
TranslationZAxisAngle4D. @nxdefiant tested this with his robot arm for the
TranslationZAxisAngle4D IK type (see #548); the rest should be analogous.

Can be cherry-picked onto kinetic.

Fixes #548 .


- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"