### PR TITLE
update link transforms before calling checkCollision on robot state in jog_arm

### DIFF
--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -98,6 +98,7 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables, std::mu
       current_state.setJointPositions(jts.name[i], &jts.position[i]);
 
     collision_result.clear();
+    current_state.updateCollisionBodyTransforms();
     planning_scene_monitor_->getPlanningScene()->checkCollision(collision_request, collision_result, current_state);
 
     // Scale robot velocity according to collision proximity and user-defined thresholds.


### PR DESCRIPTION
### Description

Fix issue in collision_check_thread in jog_arm where link transforms aren't being updated before call to checkCollision.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
