### PR TITLE
[AIST-QA]  Fix memory leak issue in rdf_loader

### DIFF
--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -69,6 +69,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
   if (!umodel->initString(content))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse URDF from parameter '%s'", robot_description_.c_str());
+    delete umodel;
     return;
   }
   urdf_.reset(umodel);

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -65,7 +65,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
     return;
   }
 
-  urdf::ModelPtr urdf(new urdf::Model());
+  urdf::ModelInterfaceSharedPtr urdf(new urdf::Model());
   if (!urdf->initString(content))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse URDF from parameter '%s'", robot_description_.c_str());
@@ -82,7 +82,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
     return;
   }
 
-  srdf::ModelPtr srdf(new srdf::Model());
+  srdf::ModelSharedPtr srdf(new srdf::Model());
   if (!srdf->initString(*urdf_, scontent))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse SRDF from parameter '%s'", srdf_description.c_str());

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -65,14 +65,13 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
     return;
   }
 
-  urdf::Model* umodel = new urdf::Model();
-  if (!umodel->initString(content))
+  urdf::ModelPtr urdf(new urdf::Model());
+  if (!urdf->initString(content))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse URDF from parameter '%s'", robot_description_.c_str());
-    delete umodel;
     return;
   }
-  urdf_.reset(umodel);
+  urdf_ = std::move(urdf);
 
   const std::string srdf_description(robot_description_ + "_semantic");
   std::string scontent;
@@ -83,13 +82,13 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
     return;
   }
 
-  srdf_.reset(new srdf::Model());
-  if (!srdf_->initString(*urdf_, scontent))
+  srdf::ModelPtr srdf(new srdf::Model());
+  if (!srdf->initString(*urdf_, scontent))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse SRDF from parameter '%s'", srdf_description.c_str());
-    srdf_.reset();
     return;
   }
+  srdf_ = std::move(srdf);
 
   ROS_DEBUG_STREAM_NAMED("rdf", "Loaded robot model in " << (ros::WallTime::now() - start).toSec() << " seconds");
 }

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -65,7 +65,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
     return;
   }
 
-  urdf::ModelInterfaceSharedPtr urdf(new urdf::Model());
+  std::unique_ptr<urdf::Model> urdf(new urdf::Model());
   if (!urdf->initString(content))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse URDF from parameter '%s'", robot_description_.c_str());

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -488,13 +488,12 @@ void EndEffectorsWidget::doneEditing()
   }
 
   // Check that the effector name is unique
-  for (std::vector<srdf::Model::EndEffector>::const_iterator data_it = config_data_->srdf_->end_effectors_.begin();
-       data_it != config_data_->srdf_->end_effectors_.end(); ++data_it)
+  for (const auto& eef : config_data_->srdf_->end_effectors_)
   {
-    if (data_it->name_.compare(effector_name) == 0)  // the names are the same
+    if (eef.name_ == effector_name)
     {
       // is this our existing effector? check if effector pointers are same
-      if (&(*data_it) != searched_data)
+      if (&eef != searched_data)
       {
         QMessageBox::warning(
             this, "Error Saving",

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -488,12 +488,13 @@ void EndEffectorsWidget::doneEditing()
   }
 
   // Check that the effector name is unique
-  for (const auto& eef : config_data_->srdf_->end_effectors_)
+  for (std::vector<srdf::Model::EndEffector>::const_iterator data_it = config_data_->srdf_->end_effectors_.begin();
+       data_it != config_data_->srdf_->end_effectors_.end(); ++data_it)
   {
-    if (eef.name_ == effector_name)
+    if (data_it->name_.compare(effector_name) == 0)  // the names are the same
     {
       // is this our existing effector? check if effector pointers are same
-      if (&eef != searched_data)
+      if (&(*data_it) != searched_data)
       {
         QMessageBox::warning(
             this, "Error Saving",


### PR DESCRIPTION
### Description

In the constructor of `RDFLoader` class, when `umodel` can not initialized, an error is shown and the constructor returns after showing an error message. In this case however, the `umodel` variable is not deleted which causes a memory leak.
This fix adds `delete umodel;` to the scope when constructor terminate prematurely.

This contribution is made by AIST ( https://www.aist.go.jp ) based on static code analysis with klocwork (Perforce Software).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
