### PR TITLE
[AIST-QA] Fix memory leak issue in end_effectors_widget.

### DIFF
--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -566,6 +566,7 @@ void EndEffectorsWidget::doneEditing()
   if (isNew)
   {
     config_data_->srdf_->end_effectors_.push_back(*searched_data);
+    delete searched_data;
   }
 
   // Finish up ------------------------------------------------------


### PR DESCRIPTION
### Description

In `end_effectors_widget.cpp`, `searched_data` variable is not deleted which causes a memory leak.
This issue may have been overlooked because the similar bugs were fixed in other source files (`virtual_joints_widget.cpp` and `robot_poses_widget.cpp`).
This fix adds `delete searched_data;` to the function `doneEditing()`.

This contribution is made by AIST ( https://www.aist.go.jp ) based on static code analysis with klocwork (Perforce Software).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
