### PR TITLE
Follow up on #1828 and #1829

### DIFF
--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -488,13 +488,12 @@ void EndEffectorsWidget::doneEditing()
   }
 
   // Check that the effector name is unique
-  for (std::vector<srdf::Model::EndEffector>::const_iterator data_it = config_data_->srdf_->end_effectors_.begin();
-       data_it != config_data_->srdf_->end_effectors_.end(); ++data_it)
+  for (const auto& eef : config_data_->srdf_->end_effectors_)
   {
-    if (data_it->name_.compare(effector_name) == 0)  // the names are the same
+    if (eef.name_ == effector_name)
     {
       // is this our existing effector? check if effector pointers are same
-      if (&(*data_it) != searched_data)
+      if (&eef != searched_data)
       {
         QMessageBox::warning(
             this, "Error Saving",


### PR DESCRIPTION
Better fix for #1828: Avoid explicit use of new/delete when we use shared pointers anyway.
Cleanup #1829: Use range-based for-loop