### PR TITLE
Allow specification of controller names for trajectories

### DIFF
--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -115,6 +115,12 @@ public:
           controllers_[name].reset(new InterpolatingController(name, joints, pub_));
         else
           ROS_ERROR_STREAM("Unknown fake controller type: " << type);
+
+        moveit_controller_manager::MoveItControllerManager::ControllerState state;
+        state.default_ = controller_list[i].hasMember("default") ? (bool)controller_list[i]["default"] : false;
+        state.active_ = true;
+
+        controller_states_[name] = state;
       }
       catch (...)
       {
@@ -258,16 +264,10 @@ public:
     }
   }
 
-  /*
-   * Controllers are all active and default.
-   */
   moveit_controller_manager::MoveItControllerManager::ControllerState
-  getControllerState(const std::string& /*name*/) override
+  getControllerState(const std::string& name) override
   {
-    moveit_controller_manager::MoveItControllerManager::ControllerState state;
-    state.active_ = true;
-    state.default_ = true;
-    return state;
+    return controller_states_[name];
   }
 
   /* Cannot switch our controllers */
@@ -281,6 +281,7 @@ protected:
   ros::NodeHandle node_handle_;
   ros::Publisher pub_;
   std::map<std::string, BaseFakeControllerPtr> controllers_;
+  std::map<std::string, moveit_controller_manager::MoveItControllerManager::ControllerState> controller_states_;
 };
 
 }  // end namespace moveit_fake_controller_manager

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -145,6 +145,12 @@ public:
           continue;
         }
 
+        moveit_controller_manager::MoveItControllerManager::ControllerState state;
+        state.default_ = controller_list[i].hasMember("default") ? (bool)controller_list[i]["default"] : false;
+        state.active_ = true;
+
+        controller_states_[name] = state;
+
         /* add list of joints, used by controller manager and MoveIt */
         for (int j = 0; j < controller_list[i]["joints"].size(); ++j)
           new_handle->addJoint(std::string(controller_list[i]["joints"][j]));
@@ -220,16 +226,10 @@ public:
     }
   }
 
-  /*
-   * Controllers are all active and default -- that's what makes this thing simple.
-   */
   moveit_controller_manager::MoveItControllerManager::ControllerState
-  getControllerState(const std::string& /* name */) override
+  getControllerState(const std::string& name) override
   {
-    moveit_controller_manager::MoveItControllerManager::ControllerState state;
-    state.active_ = true;
-    state.default_ = true;
-    return state;
+    return controller_states_[name];
   }
 
   /* Cannot switch our controllers */
@@ -242,6 +242,7 @@ public:
 protected:
   ros::NodeHandle node_handle_;
   std::map<std::string, ActionBasedControllerHandleBasePtr> controllers_;
+  std::map<std::string, moveit_controller_manager::MoveItControllerManager::ControllerState> controller_states_;
 };
 
 }  // end namespace moveit_simple_controller_manager

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
@@ -52,8 +52,12 @@ struct ExecutableTrajectory
   {
   }
 
-  ExecutableTrajectory(const robot_trajectory::RobotTrajectoryPtr& trajectory, const std::string& description)
-    : trajectory_(trajectory), description_(description), trajectory_monitoring_(true)
+  ExecutableTrajectory(const robot_trajectory::RobotTrajectoryPtr& trajectory, const std::string& description,
+                       std::vector<std::string> controller_names = {})
+    : trajectory_(trajectory)
+    , description_(description)
+    , trajectory_monitoring_(true)
+    , controller_names_(std::move(controller_names))
   {
   }
 
@@ -62,6 +66,7 @@ struct ExecutableTrajectory
   bool trajectory_monitoring_;
   collision_detection::AllowedCollisionMatrixConstPtr allowed_collision_matrix_;
   boost::function<bool(const ExecutableMotionPlan*)> effect_on_success_;
+  std::vector<std::string> controller_names_;
 };
 
 /// A generic representation on what a computed motion plan looks like

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -370,7 +370,7 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
     // convert to message, pass along
     moveit_msgs::RobotTrajectory msg;
     plan.plan_components_[i].trajectory_->getRobotTrajectoryMsg(msg);
-    if (!trajectory_execution_manager_->push(msg))
+    if (!trajectory_execution_manager_->push(msg, plan.plan_components_[i].controller_names_))
     {
       trajectory_execution_manager_->clear();
       ROS_ERROR_STREAM_NAMED("plan_execution", "Apparently trajectory initialization failed");


### PR DESCRIPTION
### Description

This PR adds a list of controller names to `ExecutableTrajectory` which is passed to the `TrajectoryExecutionManager` (TEM) in `PlanExecution::executeAndMonitor()`. This allows users to specify which controllers should execute a certain trajectory (or only a part of it). The TEM already had the ability to manage different controllers for different trajectory parts, it just was not used before.

Additonally, the `FakeControllerManager` now reads the `default` parameter from the `controller_list` on the param server and initializes the `ControllerState`  accordingly. Before, each `ControllerState` had `default_` and `active_` set to `true` which lead the TEM's controller selection mechanism to choose any controller when no explicit controller name was given.
[The documentation](https://ros-planning.github.io/moveit_tutorials/doc/controller_configuration/controller_configuration_tutorial.html) mentions this parameter, but neither [SimpleControllerManager](https://github.com/ros-planning/moveit/blob/master/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp#L227) nor [FakeControllerManager](https://github.com/ros-planning/moveit/blob/master/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp#L265) use it.

When I did these changes, I stumbled upon comments hinting that controller switching was possible or discontinued. Someone with a better overview of MoveIt should probably decide whether it okay to allow it again. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
