### PR TITLE
[jog_arm] Remove scale/joint parameter

### DIFF
--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -7,9 +7,11 @@ use_gazebo: true # Whether the robot is started in a Gazebo simulation environme
 robot_link_command_frame:  world  # commands must be given in the frame of a robot link. Usually either the base or end effector
 command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
-  linear:  0.6  # Max linear velocity. Meters per publish_period. Units is [m/s]. Only used if command_in_type=="unitless"
-  rotational:  0.3 # Max angular velocity. Rads per publish_period. Units is [rad/s]. Only used if command_in_type=="unitless"
-  joint: 0.3  # Max joint angular/linear velocity. Rads or Meters per publish period. Units is [rad/s] or [m/s].
+  # Scale parameters are only used if command_in_type=="unitless"
+  linear:  0.6  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.3 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  joint: 0.01
 low_pass_filter_coeff: 2.  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## Properties of outgoing commands

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -87,12 +87,32 @@ struct JogArmShared
 // ROS params to be read. See the yaml file in /config for a description of each.
 struct JogArmParameters
 {
-  std::string move_group_name, joint_topic, cartesian_command_in_topic, robot_link_command_frame, command_out_topic,
-      planning_frame, warning_topic, joint_command_in_topic, command_in_type, command_out_type;
-  double linear_scale, rotational_scale, joint_scale, lower_singularity_threshold, hard_stop_singularity_threshold,
-      collision_proximity_threshold, low_pass_filter_coeff, publish_period, incoming_command_timeout,
-      joint_limit_margin, collision_check_rate;
+  std::string move_group_name;
+  std::string joint_topic;
+  std::string cartesian_command_in_topic;
+  std::string robot_link_command_frame;
+  std::string command_out_topic;
+  std::string planning_frame;
+  std::string warning_topic;
+  std::string joint_command_in_topic;
+  std::string command_in_type;
+  std::string command_out_type;
+  double linear_scale;
+  double rotational_scale;
+  double joint_scale;
+  double lower_singularity_threshold;
+  double hard_stop_singularity_threshold;
+  double collision_proximity_threshold;
+  double low_pass_filter_coeff;
+  double publish_period;
+  double incoming_command_timeout;
+  double joint_limit_margin;
+  double collision_check_rate;
   int num_outgoing_halt_msgs_to_publish;
-  bool use_gazebo, check_collisions, publish_joint_positions, publish_joint_velocities, publish_joint_accelerations;
+  bool use_gazebo;
+  bool check_collisions;
+  bool publish_joint_positions;
+  bool publish_joint_velocities;
+  bool publish_joint_accelerations;
 };
 }

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -77,9 +77,6 @@ protected:
 
   bool addJointIncrements(sensor_msgs::JointState& output, const Eigen::VectorXd& increments) const;
 
-  // Scale the delta theta to match joint velocity limits. Uniform scaling
-  void enforceJointVelocityLimits(Eigen::VectorXd& calculated_joint_velocity);
-
   // Reset the data stored in low-pass filters so the trajectory won't jump when jogging is resumed.
   void resetVelocityFilters();
 
@@ -89,7 +86,8 @@ protected:
 
   void publishWarning(bool active) const;
 
-  bool checkIfJointsWithinURDFBounds(trajectory_msgs::JointTrajectory_<std::allocator<void>>& new_joint_traj);
+  // Scale the delta theta to match joint velocity limits
+  bool checkIfJointsWithinSRDFBounds(trajectory_msgs::JointTrajectory& new_joint_traj);
 
   // Possibly calculate a velocity scaling factor, due to proximity of
   // singularity and direction of motion
@@ -127,7 +125,8 @@ protected:
   // For jacobian calculations
   Eigen::MatrixXd jacobian_, pseudo_inverse_, matrix_s_;
   Eigen::JacobiSVD<Eigen::MatrixXd> svd_;
-  Eigen::VectorXd delta_theta_;
+  // Use ArrayXd type to enable more coefficient-wise operations
+  Eigen::ArrayXd delta_theta_;
 
   Eigen::Isometry3d tf_moveit_to_cmd_frame_;
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -312,7 +312,6 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   else
     publishWarning(false);
 
-
   // If using Gazebo simulator, insert redundant points
   if (parameters_.use_gazebo)
   {
@@ -363,7 +362,6 @@ bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& /*
   {
     publishWarning(false);
   }
-
 
   // done with calculations
   if (parameters_.use_gazebo)

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -101,6 +101,12 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
   rosparam_shortcuts::shutdownIfError(parameter_ns, error);
 
   // Input checking
+  if (ros_parameters_.publish_period <= 0.)
+  {
+    ROS_WARN_NAMED(LOGNAME, "Parameter 'publish_period' should be "
+                            "greater than zero. Check yaml file.");
+    return false;
+  }
   if (ros_parameters_.num_outgoing_halt_msgs_to_publish < 0)
   {
     ROS_WARN_NAMED(LOGNAME,

--- a/moveit_experimental/moveit_jog_arm/test/arm_setup/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/arm_setup/config/jog_settings.yaml
@@ -7,9 +7,11 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 robot_link_command_frame:  panda_link0  # commands must be given in the frame of a robot link. Usually either the base or end effector
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
-  linear:  0.003  # Max linear velocity. Meters per publish_period. Units is [m/s]. Only used if command_in_type=="unitless"
-  rotational:  0.006 # Max angular velocity. Rads per publish_period. Units is [rad/s]. Only used if command_in_type=="unitless"
-  joint: 0.01  # Max joint angular/linear velocity. Rads or Meters per publish period. Units is [rad/s] or [m/s].
+  # Scale parameters are only used if command_in_type=="unitless"
+  linear:  0.003  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.006 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  joint: 0.01
 low_pass_filter_coeff: 2.  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## Properties of outgoing commands


### PR DESCRIPTION
Previously, the `scale/joint parameter` was also being used to check velocity limits. This was confusing (even to me!). It's also redundant with the SRDF velocity limits.

So that velocity check is removed.

This PR also adds:

-  a unit test for direct joint jogging commands.

- a check that publish_period is >0