### PR TITLE
Reduce console output warnings

### DIFF
--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -37,6 +37,7 @@
 *******************************************************************************/
 
 #include <moveit_jog_arm/collision_check_thread.h>
+#include <tf2_ros/buffer.h>
 
 namespace moveit_jog_arm
 {
@@ -52,7 +53,7 @@ CollisionCheckThread::CollisionCheckThread(const moveit_jog_arm::JogArmParameter
     ros::Duration(WHILE_LOOP_WAIT).sleep();
   }
 
-  planning_scene_monitor_.reset(new planning_scene_monitor::PlanningSceneMonitor(model_loader_ptr));
+  planning_scene_monitor_ = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(model_loader_ptr, std::make_shared<tf2_ros::Buffer>());
   planning_scene_monitor_->startSceneMonitor();
   planning_scene_monitor_->startStateMonitor();
 

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -53,7 +53,7 @@ CollisionCheckThread::CollisionCheckThread(const moveit_jog_arm::JogArmParameter
   }
 
   planning_scene_monitor_.reset(new planning_scene_monitor::PlanningSceneMonitor(model_loader_ptr));
-  if (planning_scene_monitor_->getPlanningScene())
+  if (!planning_scene_monitor_->getPlanningScene())
   {
     ROS_ERROR_STREAM_NAMED(LOGNAME, "Error in setting up the PlanningSceneMonitor.");
     exit(EXIT_FAILURE);

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -51,7 +51,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
 {
-  ROS_INFO("Initializing OMPL interface using ROS parameters");
+  ROS_DEBUG("Initializing OMPL interface using ROS parameters");
   loadPlannerConfigurations();
   loadConstraintSamplers();
 }
@@ -66,7 +66,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
 {
-  ROS_INFO("Initializing OMPL interface using specified configuration");
+  ROS_DEBUG("Initializing OMPL interface using specified configuration");
   setPlannerConfigurations(pconfig);
   loadConstraintSamplers();
 }

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -90,7 +90,7 @@ void OccupancyMapMonitor::initialize()
         ROS_WARN("No target frame specified for Octomap. No transforms will be applied to received data.");
 
   if (!tf_buffer_ && !map_frame_.empty())
-    ROS_WARN("Target frame specified but no TF instance specified. No transforms will be applied to received data.");
+    ROS_WARN_STREAM("Target frame \"" << map_frame_ << "\" specified but no TF instance (buffer) specified. No transforms will be applied to received data.");
 
   tree_.reset(new OccMapTree(map_resolution_));
   tree_const_ = tree_;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -90,7 +90,8 @@ void OccupancyMapMonitor::initialize()
         ROS_WARN("No target frame specified for Octomap. No transforms will be applied to received data.");
 
   if (!tf_buffer_ && !map_frame_.empty())
-    ROS_WARN_STREAM("Target frame \"" << map_frame_ << "\" specified but no TF instance (buffer) specified. No transforms will be applied to received data.");
+    ROS_WARN_STREAM("Target frame \"" << map_frame_ << "\" specified but no TF instance (buffer) specified. "
+                                                       "No transforms will be applied to received data.");
 
   tree_.reset(new OccMapTree(map_resolution_));
   tree_const_ = tree_;

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -94,7 +94,7 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& /*unused*/,
   trajectory_execution_manager_.reset(new trajectory_execution_manager::TrajectoryExecutionManager(
       robot_model_, planning_scene_monitor_->getStateMonitor()));
 
-  ROS_INFO_NAMED(LOGNAME, "MoveItCpp running");
+  ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }
 
 MoveItCpp::MoveItCpp(MoveItCpp&& other)


### PR DESCRIPTION
- jog_arm loads a PSM which always had a warning because no tf_buffer was loaded.
- A number of ROS_INFOs I thought were unnecessary, so I moved to DEBUG
- Made one warning more useful