### PR TITLE
[jog_arm] Pass planning scene monitor into cpp interface

### DIFF
--- a/moveit_experimental/moveit_jog_arm/CMakeLists.txt
+++ b/moveit_experimental/moveit_jog_arm/CMakeLists.txt
@@ -7,8 +7,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(LIBRARY_NAME jog_arm_cpp_api)
 
-set(LIBRARY_NAME jog_arm_cpp_api)
-
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -66,10 +64,7 @@ target_link_libraries(${LIBRARY_NAME}
 
 # An example of using the C++ library
 add_executable(cpp_interface_example
-  src/collision_check_thread.cpp
   src/cpp_interface_example/cpp_interface_example.cpp
-  src/jog_calcs.cpp
-  src/low_pass_filter.cpp
 )
 add_dependencies(cpp_interface_example ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cpp_interface_example
@@ -125,12 +120,21 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## TESTING ##
 #############
 
-#############
-## TESTING ##
-#############
-
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   find_package(ros_pytest REQUIRED)
+
+  # jog_server
   add_rostest(test/launch/jog_arm_integration_test.test)
+
+  # jog_cpp_interface
+  add_rostest_gtest(jog_cpp_interface_test
+    test/jog_cpp_interface_test.test
+    test/jog_cpp_interface_test.cpp
+  )
+  target_link_libraries(jog_cpp_interface_test
+    ${LIBRARY_NAME}
+    ${catkin_LIBRARIES}
+    ${Boost_LIBRARIES}
+  )
 endif()

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -50,7 +50,7 @@ class CollisionCheckThread
 {
 public:
   /** \brief Constructor
-   *  \param parameters: common settings of jog_rm
+   *  \param parameters: common settings of jog_arm
    *  \param planning_scene_monitor: PSM should already have scene monitor and state monitor started when passed into
    * this class
    */

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -49,8 +49,16 @@ namespace moveit_jog_arm
 class CollisionCheckThread
 {
 public:
+  /** \brief Constructor
+   *  \param parameters: common settings of jog_rm
+   *  \param planning_scene_monitor: PSM should already have scene monitor and state monitor started when passed into
+   * this class
+   */
   CollisionCheckThread(const moveit_jog_arm::JogArmParameters& parameters,
-                       const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+                       const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
+
+  // Get thread-safe read only lock of planning scene
+  planning_scene_monitor::LockedPlanningSceneRO getLockedPlanningSceneRO() const;
 
   void startMainLoop(moveit_jog_arm::JogArmShared& shared_variables, std::mutex& mutex);
 
@@ -62,6 +70,7 @@ private:
 
   const moveit_jog_arm::JogArmParameters parameters_;
 
+  // Pointer to the collision environment
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 };
 }

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -48,7 +48,6 @@
 
 namespace moveit_jog_arm
 {
-static const std::string LOGNAME = "jog_server";
 static const double WHILE_LOOP_WAIT = 0.001;
 
 // Variables to share between threads, and their mutexes

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -47,10 +47,10 @@ namespace moveit_jog_arm
 * Class JogCppApi - This class should be instantiated in a new thread
 * See cpp_interface_example.cpp
 */
-class JogCppApi : JogInterfaceBase
+class JogCppApi : protected JogInterfaceBase
 {
 public:
-  JogCppApi();
+  JogCppApi(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   ~JogCppApi();
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
@@ -55,6 +55,8 @@ namespace moveit_jog_arm
 class JogInterfaceBase
 {
 public:
+  JogInterfaceBase();
+
   void jointsCB(const sensor_msgs::JointStateConstPtr& msg);
 
   // Jogging calculation thread
@@ -68,7 +70,8 @@ public:
 protected:
   bool readParameters(ros::NodeHandle& n);
 
-  robot_model_loader::RobotModelLoaderPtr model_loader_ptr_;
+  // Pointer to the collision environment
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
   // Store the parameters that were read from ROS server
   JogArmParameters ros_parameters_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_ros_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_ros_interface.h
@@ -47,7 +47,7 @@ namespace moveit_jog_arm
 /**
  * Class JogROSInterface - Instantiated in main(). Handles ROS subs & pubs and creates the worker threads.
  */
-class JogROSInterface : JogInterfaceBase
+class JogROSInterface : protected JogInterfaceBase
 {
 public:
   JogROSInterface();

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -38,6 +38,8 @@
 
 #include <moveit_jog_arm/jog_calcs.h>
 
+static const std::string LOGNAME = "jog_calcs";
+
 namespace moveit_jog_arm
 {
 // Constructor for the class that handles jogging calculations

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -38,16 +38,19 @@
 
 #include "moveit_jog_arm/jog_cpp_interface.h"
 
+// TODO(davetcoleman): rename JogCppApi to JogCppInterface to match file name
+
+static const std::string LOGNAME = "jog_cpp_interface";
+
 namespace moveit_jog_arm
 {
-JogCppApi::JogCppApi()
+JogCppApi::JogCppApi(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
 {
+  planning_scene_monitor_ = planning_scene_monitor;
+
   // Read ROS parameters, typically from YAML file
   if (!readParameters(nh_))
     exit(EXIT_FAILURE);
-
-  // Load the robot model. This is used by the worker threads.
-  model_loader_ptr_ = std::shared_ptr<robot_model_loader::RobotModelLoader>(new robot_model_loader::RobotModelLoader);
 }
 
 JogCppApi::~JogCppApi()

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -38,8 +38,14 @@
 
 #include "moveit_jog_arm/jog_interface_base.h"
 
+static const std::string LOGNAME = "jog_interface_base";
+
 namespace moveit_jog_arm
 {
+JogInterfaceBase::JogInterfaceBase()
+{
+}
+
 // Read ROS parameters, typically from YAML file
 bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
 {
@@ -191,7 +197,7 @@ void JogInterfaceBase::jointsCB(const sensor_msgs::JointStateConstPtr& msg)
 bool JogInterfaceBase::startJogCalcThread()
 {
   if (!jog_calcs_)
-    jog_calcs_.reset(new JogCalcs(ros_parameters_, model_loader_ptr_));
+    jog_calcs_.reset(new JogCalcs(ros_parameters_, planning_scene_monitor_->getRobotModelLoader()));
 
   jog_calc_thread_.reset(
       new std::thread([&]() { jog_calcs_->startMainLoop(shared_variables_, shared_variables_mutex_); }));
@@ -219,7 +225,7 @@ bool JogInterfaceBase::stopJogCalcThread()
 bool JogInterfaceBase::startCollisionCheckThread()
 {
   if (!collision_checker_)
-    collision_checker_.reset(new CollisionCheckThread(ros_parameters_, model_loader_ptr_));
+    collision_checker_.reset(new CollisionCheckThread(ros_parameters_, planning_scene_monitor_));
 
   collision_check_thread_.reset(
       new std::thread([&]() { collision_checker_->startMainLoop(shared_variables_, shared_variables_mutex_); }));

--- a/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
@@ -40,6 +40,8 @@
 
 #include <moveit_jog_arm/jog_ros_interface.h>
 
+static const std::string LOGNAME = "jog_ros_interface";
+
 namespace moveit_jog_arm
 {
 /////////////////////////////////////////////////////////////////////////////////
@@ -57,8 +59,20 @@ JogROSInterface::JogROSInterface()
   if (!readParameters(nh))
     exit(EXIT_FAILURE);
 
-  // Load the robot model. This is used by the worker threads.
-  model_loader_ptr_ = std::shared_ptr<robot_model_loader::RobotModelLoader>(new robot_model_loader::RobotModelLoader);
+  // Load the planning scene monitor
+  planning_scene_monitor_ = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
+  if (!planning_scene_monitor_->getPlanningScene())
+  {
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Error in setting up the PlanningSceneMonitor.");
+    exit(EXIT_FAILURE);
+  }
+
+  planning_scene_monitor_->startSceneMonitor();
+  planning_scene_monitor_->startWorldGeometryMonitor(
+      planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC,
+      planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
+      false /* skip octomap monitor */);
+  planning_scene_monitor_->startStateMonitor();
 
   // Crunch the numbers in this thread
   startJogCalcThread();

--- a/moveit_experimental/moveit_jog_arm/src/jog_server.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_server.cpp
@@ -38,9 +38,11 @@
 
 #include <moveit_jog_arm/jog_ros_interface.h>
 
+static const std::string LOGNAME = "jog_server";
+
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, moveit_jog_arm::LOGNAME);
+  ros::init(argc, argv, LOGNAME);
 
   moveit_jog_arm::JogROSInterface ros_interface;
 

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -37,6 +37,9 @@
 *******************************************************************************/
 
 #include <moveit_jog_arm/low_pass_filter.h>
+#include <string>
+
+static const std::string LOGNAME = "low_pass_filter";
 
 namespace moveit_jog_arm
 {

--- a/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.cpp
+++ b/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.cpp
@@ -1,0 +1,105 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman
+   Desc:   Stub test for the C++ interface to JogArm
+*/
+
+// C++
+#include <string>
+
+// ROS
+#include <ros/ros.h>
+
+// Testing
+#include <gtest/gtest.h>
+
+// Main class
+#include <moveit_jog_arm/jog_cpp_interface.h>
+
+static const std::string LOGNAME = "jog_cpp_interface_test";
+
+namespace moveit_jog_arm
+{
+class TestJogCppInterface : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    nh_.reset(new ros::NodeHandle("~"));
+
+    // Load the planning scene monitor
+    planning_scene_monitor_ = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
+    planning_scene_monitor_->startSceneMonitor();
+    planning_scene_monitor_->startStateMonitor();
+  }
+  void TearDown() override
+  {
+  }
+
+protected:
+  std::unique_ptr<ros::NodeHandle> nh_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+};  // class TestJogCppInterface
+
+TEST_F(TestJogCppInterface, PlanningSceneTest)
+{
+  EXPECT_TRUE(planning_scene_monitor_->getPlanningScene());
+}
+
+TEST_F(TestJogCppInterface, InitTest)
+{
+  moveit_jog_arm::JogCppApi jog_cpp_interface(planning_scene_monitor_);
+}
+
+// TODO(davetcoleman): due to many blocking checks for ROS messages, and
+// an abundance of threads, unit tests are not currently feasible for the
+// cpp interface. This should be addressed in future re-factors
+
+}  // namespace moveit_jog_arm
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "jog_cpp_interface_test_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+
+  spinner.stop();
+  ros::shutdown();
+  return result;
+}

--- a/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.cpp
+++ b/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.cpp
@@ -73,14 +73,10 @@ protected:
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 };  // class TestJogCppInterface
 
-TEST_F(TestJogCppInterface, PlanningSceneTest)
-{
-  EXPECT_TRUE(planning_scene_monitor_->getPlanningScene());
-}
-
 TEST_F(TestJogCppInterface, InitTest)
 {
   moveit_jog_arm::JogCppApi jog_cpp_interface(planning_scene_monitor_);
+  ros::Duration(2).sleep();
 }
 
 // TODO(davetcoleman): due to many blocking checks for ROS messages, and

--- a/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.test
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Note, we're using fake, simulated trajectory controllers.  -->
+
+  <!-- Load URDF, SRDF -->
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch" >
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <test pkg="moveit_jog_arm" type="jog_cpp_interface_test" test-name="jog_cpp_interface_test" time-limit="10" args="">
+    <param name="parameter_ns" type="string" value="jog_cpp_interface_test" />
+    <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/jog_settings.yaml"/>
+  </test>
+</launch>

--- a/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.test
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <!-- Note, we're using fake, simulated trajectory controllers.  -->
-
   <!-- Load URDF, SRDF -->
   <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true"/>

--- a/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_integration_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_integration_test.test
@@ -2,12 +2,13 @@
 <launch>
   <arg name="debug" value="false" />
 
-  <!-- send urdf to param server -->
-  <param name="robot_description"
-  command="$(find xacro)/xacro --inorder '$(find moveit_resources)/panda_description/urdf/panda.urdf'"/>
+  <!-- Load URDF, SRDF -->
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch" >
+    <arg name="load_robot_description" value="true"/>
+  </include>
 
   <!-- Note, we're using fake, simulated trajectory controllers.
-       These aren't suitable for actually jogging a robot in RViz, but they are good enough to 
+       These aren't suitable for actually jogging a robot in RViz, but they are good enough to
        test jog node output.
   -->
   <include file="$(find moveit_jog_arm)/test/arm_setup/launch/panda_move_group.launch">


### PR DESCRIPTION
- Separate LOGNAME into each file
- Add unit test

I need to pass in the PSM from a larger application. Previously it required creating a new PSM even in the same process