### PR TITLE
Reenable ros-shadow-fixed on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ matrix: # Add a separate config to the matrix, using clang as compiler
   include:
     # add a config to the matrix using clang as compiler and also test ikfast plugin creation
     - compiler: clang
-      env: TEST=clang-tidy-fix
+      env: ROS_REPO=ros-shadow-fixed
+           TEST=clang-tidy-fix
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
 


### PR DESCRIPTION
This reverts commit 384c231b143b73ada9a8ee0eb11cf22435309ef3 as the offending tf2 release commit was reverted: https://github.com/ros/rosdistro/pull/23469#issuecomment-576669925.
