### PR TITLE
Move get_planning_scene service into PSM for reusability

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.cpp
@@ -45,23 +45,9 @@ MoveGroupGetPlanningSceneService::MoveGroupGetPlanningSceneService() : MoveGroup
 
 void MoveGroupGetPlanningSceneService::initialize()
 {
-  get_scene_service_ = root_node_handle_.advertiseService(
-      GET_PLANNING_SCENE_SERVICE_NAME, &MoveGroupGetPlanningSceneService::getPlanningSceneService, this);
+  context_->planning_scene_monitor_->providePlanningSceneService(GET_PLANNING_SCENE_SERVICE_NAME);
 }
 
-bool MoveGroupGetPlanningSceneService::getPlanningSceneService(moveit_msgs::GetPlanningScene::Request& req,
-                                                               moveit_msgs::GetPlanningScene::Response& res)
-{
-  if (req.components.components & moveit_msgs::PlanningSceneComponents::TRANSFORMS)
-    context_->planning_scene_monitor_->updateFrameTransforms();
-  planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);
-
-  moveit_msgs::PlanningSceneComponents all_components;
-  all_components.components = UINT_MAX;  // Return all scene components if nothing is specified.
-  ps->getPlanningSceneMsg(res.scene, req.components.components ? req.components : all_components);
-
-  return true;
-}
 }  // namespace move_group
 
 #include <class_loader/class_loader.hpp>

--- a/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/get_planning_scene_service_capability.h
@@ -37,7 +37,6 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
-#include <moveit_msgs/GetPlanningScene.h>
 
 namespace move_group
 {
@@ -47,11 +46,5 @@ public:
   MoveGroupGetPlanningSceneService();
 
   void initialize() override;
-
-private:
-  bool getPlanningSceneService(moveit_msgs::GetPlanningScene::Request& req,
-                               moveit_msgs::GetPlanningScene::Response& res);
-
-  ros::ServiceServer get_scene_service_;
 };
 }

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -325,14 +325,14 @@ public:
       return 0.0;
   }
 
-  /** @brief Start the scene monitor (ROS message-based, not service-based)
+  /** @brief Start the scene monitor (ROS topic-based)
    *  @param scene_topic The name of the planning scene topic
    */
   void startSceneMonitor(const std::string& scene_topic = DEFAULT_PLANNING_SCENE_TOPIC);
 
   /** @brief Request a full planning scene state using a service call
-   *         Becareful not to use this in conjunction with providePlanningSceneService(),
-   *         as it will create a pointless feedback loop
+   *         Be careful not to use this in conjunction with providePlanningSceneService(),
+   *         as it will create a pointless feedback loop.
    *  @param service_name The name of the service to use for requesting the planning scene.
    *         This must be a service of type moveit_msgs::GetPlanningScene and is usually called
    *         "/get_planning_scene".
@@ -341,9 +341,9 @@ public:
 
   /** @brief Create an optional service for getting the complete planning scene
    *         This is useful for satisfying the Rviz PlanningScene display's need for a service
-   *         without having to use MoveGroup
-   *         Becareful not to use this in conjunction with requestPlanningSceneState(),
-   *         as it will create a pointless feedback loop
+   *         without having to use a move_group node.
+   *         Be careful not to use this in conjunction with requestPlanningSceneState(),
+   *         as it will create a pointless feedback loop.
    *  @param service_name The topic to provide the service
    */
   void providePlanningSceneService(const std::string& service_name = DEFAULT_PLANNING_SCENE_SERVICE);

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -325,22 +325,25 @@ public:
       return 0.0;
   }
 
-  /** @brief Start the scene monitor
+  /** @brief Start the scene monitor (ROS message-based, not service-based)
    *  @param scene_topic The name of the planning scene topic
    */
   void startSceneMonitor(const std::string& scene_topic = DEFAULT_PLANNING_SCENE_TOPIC);
 
-  /** @brief Request planning scene state using a service call
-   *  @param service_name The name of the service to use for requesting the
-   *     planning scene.  This must be a service of type
-   *     moveit_msgs::GetPlanningScene and is usually called
-   *     "/get_planning_scene".
+  /** @brief Request a full planning scene state using a service call
+   *         Becareful not to use this in conjunction with providePlanningSceneService(),
+   *         as it will create a pointless feedback loop
+   *  @param service_name The name of the service to use for requesting the planning scene.
+   *         This must be a service of type moveit_msgs::GetPlanningScene and is usually called
+   *         "/get_planning_scene".
    */
   bool requestPlanningSceneState(const std::string& service_name = DEFAULT_PLANNING_SCENE_SERVICE);
 
   /** @brief Create an optional service for getting the complete planning scene
    *         This is useful for satisfying the Rviz PlanningScene display's need for a service
    *         without having to use MoveGroup
+   *         Becareful not to use this in conjunction with requestPlanningSceneState(),
+   *         as it will create a pointless feedback loop
    *  @param service_name The topic to provide the service
    */
   void providePlanningSceneService(const std::string& service_name = DEFAULT_PLANNING_SCENE_SERVICE);

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -45,6 +45,7 @@
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit/collision_plugin_loader/collision_plugin_loader.h>
+#include <moveit_msgs/GetPlanningScene.h>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
@@ -337,6 +338,13 @@ public:
    */
   bool requestPlanningSceneState(const std::string& service_name = DEFAULT_PLANNING_SCENE_SERVICE);
 
+  /** @brief Create an optional service for getting the complete planning scene
+   *         This is useful for satisfying the Rviz PlanningScene display's need for a service
+   *         without having to use MoveGroup
+   *  @param service_name The topic to provide the service
+   */
+  void providePlanningSceneService(const std::string& service_name = DEFAULT_PLANNING_SCENE_SERVICE);
+
   /** @brief Stop the scene monitor*/
   void stopSceneMonitor();
 
@@ -495,6 +503,10 @@ protected:
   ros::Subscriber attached_collision_object_subscriber_;
   ros::Subscriber collision_object_subscriber_;
 
+  // provide an optional service to get the full planning scene state
+  // this is used by MoveGroup and related application nodes
+  ros::ServiceServer get_scene_service_;
+
   // include a octomap monitor
   std::unique_ptr<occupancy_map_monitor::OccupancyMapMonitor> octomap_monitor_;
 
@@ -534,6 +546,10 @@ private:
 
   // Callback for a new planning scene msg
   void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr& scene);
+
+  // Callback for requesting the full planning scene via service
+  bool getPlanningSceneServiceCallback(moveit_msgs::GetPlanningScene::Request& req,
+                                       moveit_msgs::GetPlanningScene::Response& res);
 
   // Lock for state_update_pending_ and dt_state_update_
   boost::mutex state_pending_mutex_;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -467,6 +467,11 @@ void PlanningSceneMonitor::triggerSceneUpdateEvent(SceneUpdateType update_type)
 
 bool PlanningSceneMonitor::requestPlanningSceneState(const std::string& service_name)
 {
+  if (get_scene_service_.getService() == service_name)
+  {
+    ROS_FATAL_STREAM_NAMED(LOGNAME, "requestPlanningSceneState() to self-provided service '" << service_name << "'");
+    throw std::runtime_error("requestPlanningSceneState() to self-provided service: " + service_name);
+  }
   // use global namespace for service
   ros::ServiceClient client = ros::NodeHandle().serviceClient<moveit_msgs::GetPlanningScene>(service_name);
   // all scene components are returned if none are specified

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -485,8 +485,10 @@ bool PlanningSceneMonitor::requestPlanningSceneState(const std::string& service_
   }
   else
   {
-    ROS_INFO_NAMED(LOGNAME, "Failed to call service %s, have you launched move_group? at %s:%d", service_name.c_str(),
-                   __FILE__, __LINE__);
+    ROS_INFO_NAMED(
+        LOGNAME,
+        "Failed to call service %s, have you launched move_group or called psm.providePlanningSceneService()? at %s:%d",
+        service_name.c_str(), __FILE__, __LINE__);
     return false;
   }
   return true;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -486,9 +486,8 @@ bool PlanningSceneMonitor::requestPlanningSceneState(const std::string& service_
   else
   {
     ROS_INFO_NAMED(
-        LOGNAME,
-        "Failed to call service %s, have you launched move_group or called psm.providePlanningSceneService()? at %s:%d",
-        service_name.c_str(), __FILE__, __LINE__);
+        LOGNAME, "Failed to call service %s, have you launched move_group or called psm.providePlanningSceneService()?",
+        service_name.c_str());
     return false;
   }
   return true;


### PR DESCRIPTION
This is a relaunch of #1852, which was prematurely merged and subsequently reverted.
To avoid calling its own service to initialize the PlanningScene, I added a protection in `requestPlanningSceneState()`.