### PR TITLE
[jog_arm] a ROS service to enable task redundancy

### DIFF
--- a/moveit_experimental/moveit_jog_arm/CMakeLists.txt
+++ b/moveit_experimental/moveit_jog_arm/CMakeLists.txt
@@ -132,6 +132,9 @@ if(CATKIN_ENABLE_TESTING)
   # Python integration test that a halt message is published at a singularity
   add_rostest(test/launch/jog_arm_halt_msg_test.test)
 
+  # Python integration test of a service to enable drift in some dimensions
+  add_rostest(test/launch/jog_arm_drift_dimensions_service_test.test)
+
   # jog_cpp_interface
   add_rostest_gtest(jog_cpp_interface_test
     test/jog_cpp_interface_test.test

--- a/moveit_experimental/moveit_jog_arm/CMakeLists.txt
+++ b/moveit_experimental/moveit_jog_arm/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 find_package(catkin REQUIRED COMPONENTS
   control_msgs
   geometry_msgs
+  moveit_msgs
   moveit_ros_planning_interface
   rosparam_shortcuts
   sensor_msgs
@@ -30,6 +31,7 @@ catkin_package(
   CATKIN_DEPENDS
     control_msgs
     geometry_msgs
+    moveit_msgs
     moveit_ros_planning_interface
     rosparam_shortcuts
     sensor_msgs

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -79,6 +79,9 @@ struct JogArmShared
 
   // The transform from the MoveIt planning frame to robot_link_command_frame
   Eigen::Isometry3d tf_moveit_to_cmd_frame;
+
+  // Allow these dimensions to drift. In the command frame. [x, y, z, roll, pitch, yaw]
+  std::vector<bool> drift_dimensions{ false, false, false, true, true, true };
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -80,8 +80,8 @@ struct JogArmShared
   // The transform from the MoveIt planning frame to robot_link_command_frame
   Eigen::Isometry3d tf_moveit_to_cmd_frame;
 
-  // Allow these dimensions to drift. In the command frame. [x, y, z, roll, pitch, yaw]
-  std::vector<bool> drift_dimensions{ false, true, false, true, true, true };
+  // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
+  std::vector<bool> drift_dimensions{ false, false, false, false, false, false };
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -81,7 +81,8 @@ struct JogArmShared
   Eigen::Isometry3d tf_moveit_to_cmd_frame;
 
   // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
-  std::vector<bool> drift_dimensions{ false, false, false, false, false, false };
+  std::atomic_bool drift_dimensions [6] =
+    {ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false)};
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -81,7 +81,7 @@ struct JogArmShared
   Eigen::Isometry3d tf_moveit_to_cmd_frame;
 
   // Allow these dimensions to drift. In the command frame. [x, y, z, roll, pitch, yaw]
-  std::vector<bool> drift_dimensions{ false, false, false, true, true, true };
+  std::vector<bool> drift_dimensions{ false, true, false, true, true, true };
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -81,8 +81,8 @@ struct JogArmShared
   Eigen::Isometry3d tf_moveit_to_cmd_frame;
 
   // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
-  std::atomic_bool drift_dimensions [6] =
-    {ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false)};
+  std::atomic_bool drift_dimensions[6] = { ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false),
+                                           ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false) };
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -132,7 +132,7 @@ protected:
    * Remove the Jacobian row and the delta-x element of one Cartesian dimension, to take advantage of task redundancy
    *
    * @param matrix The Jacobian matrix.
-   * @param delta_x Vector of Cartesian delta commands, should be 6-long.
+   * @param delta_x Vector of Cartesian delta commands, should be the same size as matrix.rows()
    * @param row_to_remove Dimension that will be allowed to drift, e.g. row_to_remove = 2 allows z-translation drift.
    */
   void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, unsigned int row_to_remove);

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -128,20 +128,8 @@ protected:
 
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& trajectory, int count) const;
 
-  inline Eigen::MatrixXd removeMatrixRow(const Eigen::MatrixXd original_matrix, const int row_to_remove)
-  {
-    Eigen::MatrixXd new_matrix(original_matrix.rows()-1, original_matrix.cols());
-    int row_to_fill = 0;
-    for (int orig_matrix_row = 0; orig_matrix_row < original_matrix.rows(); ++orig_matrix_row)
-    {
-      if (orig_matrix_row != row_to_remove)
-      {
-        new_matrix.row(row_to_fill) = original_matrix.row(orig_matrix_row);
-        ++row_to_fill;
-      }
-    }
-    return new_matrix;
-  }
+  // Remove the Jacobian row and the delta-x element of one Cartesian dimension, to take advantage of task redundancy
+  inline void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, const int row_to_remove);
 
   const robot_state::JointModelGroup* joint_model_group_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -135,7 +135,7 @@ protected:
    * @param delta_x Vector of Cartesian delta commands, should be 6-long.
    * @param row_to_remove Dimension that will be allowed to drift, e.g. row_to_remove = 2 allows z-translation drift.
    */
-  void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, const int row_to_remove);
+  void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, unsigned int row_to_remove);
 
   const robot_state::JointModelGroup* joint_model_group_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -128,12 +128,19 @@ protected:
 
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& trajectory, int count) const;
 
-  template<typename T>
-  inline constexpr auto removeMatrixRow(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& matrix, const int& rowNum)
+  inline Eigen::MatrixXd removeMatrixRow(const Eigen::MatrixXd original_matrix, const int row_to_remove)
   {
-      return (Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(matrix.rows() - 1, matrix.cols())
-          << static_cast<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(matrix.topRows(rowNum - 1)),
-          static_cast<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(matrix.bottomRows(matrix.rows() - rowNum))).finished();
+    Eigen::MatrixXd new_matrix(original_matrix.rows()-1, original_matrix.cols());
+    int row_to_fill = 0;
+    for (int orig_matrix_row = 0; orig_matrix_row < original_matrix.rows(); ++orig_matrix_row)
+    {
+      if (orig_matrix_row != row_to_remove)
+      {
+        new_matrix.row(row_to_fill) = original_matrix.row(orig_matrix_row);
+        ++row_to_fill;
+      }
+    }
+    return new_matrix;
   }
 
   const robot_state::JointModelGroup* joint_model_group_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -128,6 +128,14 @@ protected:
 
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& trajectory, int count) const;
 
+  template<typename T>
+  inline constexpr auto removeMatrixRow(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& matrix, const int& rowNum)
+  {
+      return (Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(matrix.rows() - 1, matrix.cols())
+          << static_cast<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(matrix.topRows(rowNum - 1)),
+          static_cast<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(matrix.bottomRows(matrix.rows() - rowNum))).finished();
+  }
+
   const robot_state::JointModelGroup* joint_model_group_;
 
   robot_state::RobotStatePtr kinematic_state_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -128,8 +128,14 @@ protected:
 
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& trajectory, int count) const;
 
-  // Remove the Jacobian row and the delta-x element of one Cartesian dimension, to take advantage of task redundancy
-  inline void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, const int row_to_remove);
+  /**
+   * Remove the Jacobian row and the delta-x element of one Cartesian dimension, to take advantage of task redundancy
+   *
+   * @param matrix The Jacobian matrix.
+   * @param delta_x Vector of Cartesian delta commands, should be 6-long.
+   * @param row_to_remove Dimension that will be allowed to drift, e.g. row_to_remove = 2 allows z-translation drift.
+   */
+  void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, const int row_to_remove);
 
   const robot_state::JointModelGroup* joint_model_group_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
@@ -42,6 +42,7 @@
 #include "jog_calcs.h"
 #include "low_pass_filter.h"
 #include <moveit/robot_state/robot_state.h>
+#include <moveit_msgs/ChangeDriftDimensions.h>
 #include <rosparam_shortcuts/rosparam_shortcuts.h>
 #include <sensor_msgs/Joy.h>
 #include <std_msgs/Float64MultiArray.h>
@@ -58,6 +59,10 @@ public:
   JogInterfaceBase();
 
   void jointsCB(const sensor_msgs::JointStateConstPtr& msg);
+
+  // Service callback for changing drift dimensions,
+  // e.g. to allow the wrist joint to rotate
+  bool changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req, moveit_msgs::ChangeDriftDimensions::Response& res);
 
   // Jogging calculation thread
   bool startJogCalcThread();

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
@@ -62,7 +62,8 @@ public:
 
   // Service callback for changing drift dimensions,
   // e.g. to allow the wrist joint to rotate
-  bool changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req, moveit_msgs::ChangeDriftDimensions::Response& res);
+  bool changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req,
+                             moveit_msgs::ChangeDriftDimensions::Response& res);
 
   // Jogging calculation thread
   bool startJogCalcThread();

--- a/moveit_experimental/moveit_jog_arm/package.xml
+++ b/moveit_experimental/moveit_jog_arm/package.xml
@@ -24,6 +24,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>trajectory_msgs</depend>
+  <depend>moveit_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>rosparam_shortcuts</depend>
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -327,7 +327,6 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   // i.e. take advantage of task redundancy.
   // Remove the Jacobian rows corresponding to True in the vector shared_variables.drift_dimensions
   // Work backwards through the 6-vector so indices don't get out of order
-  mutex.lock();
   for (auto dimension = jacobian_.rows(); dimension >= 0; --dimension)
   {
     if (shared_variables.drift_dimensions[dimension] == true && jacobian_.rows() > 1)
@@ -335,7 +334,6 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
       removeDimension(jacobian_, delta_x, dimension);
     }
   }
-  mutex.unlock();
 
   svd_ = Eigen::JacobiSVD<Eigen::MatrixXd>(jacobian_, Eigen::ComputeThinU | Eigen::ComputeThinV);
   matrix_s_ = svd_.singularValues().asDiagonal();

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -749,23 +749,19 @@ bool JogCalcs::addJointIncrements(sensor_msgs::JointState& output, const Eigen::
   return true;
 }
 
-void JogCalcs::removeDimension(Eigen::MatrixXd& jacobian, Eigen::VectorXd& delta_x, const int row_to_remove)
+void JogCalcs::removeDimension(Eigen::MatrixXd& jacobian, Eigen::VectorXd& delta_x, unsigned int row_to_remove)
 {
-  Eigen::MatrixXd new_matrix(jacobian.rows() - 1, jacobian.cols());
-  Eigen::VectorXd new_vector(jacobian.rows() - 1);
-  int row_to_fill = 0;
-  for (int orig_matrix_row = 0; orig_matrix_row < jacobian.rows(); ++orig_matrix_row)
-  {
-    // Keep elements we want
-    if (orig_matrix_row != row_to_remove)
-    {
-      new_matrix.row(row_to_fill) = jacobian.row(orig_matrix_row);
-      new_vector(row_to_fill) = delta_x(orig_matrix_row);
-      ++row_to_fill;
-    }
-  }
+  unsigned int num_rows = jacobian.rows() - 1;
+  unsigned int num_cols = jacobian.cols();
 
-  jacobian = new_matrix;
-  delta_x = new_vector;
+  if (row_to_remove < num_rows)
+  {
+    jacobian.block(row_to_remove, 0, num_rows - row_to_remove, num_cols) =
+        jacobian.block(row_to_remove + 1, 0, num_rows - row_to_remove, num_cols);
+    delta_x.segment(row_to_remove, num_rows - row_to_remove) =
+        delta_x.segment(row_to_remove + 1, num_rows - row_to_remove);
+  }
+  jacobian.conservativeResize(num_rows, num_cols);
+  delta_x.conservativeResize(num_rows);
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -328,9 +328,9 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   // Remove the Jacobian rows corresponding to True in the vector shared_variables.drift_dimensions
   // Work backwards through the 6-vector so indices don't get out of order
   mutex.lock();
-  for (size_t dimension = 5; dimension > 0; --dimension)
+  for (auto dimension = jacobian_.rows(); dimension >= 0; --dimension)
   {
-    if (shared_variables.drift_dimensions[dimension] == true && jacobian_.cols() > 1)
+    if (shared_variables.drift_dimensions[dimension] == true && jacobian_.rows() > 1)
     {
       jacobian_ = removeMatrixRow(jacobian_, dimension);
     }

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -751,8 +751,8 @@ bool JogCalcs::addJointIncrements(sensor_msgs::JointState& output, const Eigen::
 
 void JogCalcs::removeDimension(Eigen::MatrixXd& jacobian, Eigen::VectorXd& delta_x, const int row_to_remove)
 {
-  Eigen::MatrixXd new_matrix(jacobian.rows()-1, jacobian.cols());
-  Eigen::VectorXd new_vector(jacobian.rows()-1);
+  Eigen::MatrixXd new_matrix(jacobian.rows() - 1, jacobian.cols());
+  Eigen::VectorXd new_vector(jacobian.rows() - 1);
   int row_to_fill = 0;
   for (int orig_matrix_row = 0; orig_matrix_row < jacobian.rows(); ++orig_matrix_row)
   {

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -330,7 +330,7 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   mutex.lock();
   for (size_t dimension = 5; dimension > 0; --dimension)
   {
-    if (shared_variables.drift_dimensions[dimension] == true)
+    if (shared_variables.drift_dimensions[dimension] == true && jacobian_.cols() > 1)
     {
       jacobian_ = removeMatrixRow(jacobian_, dimension);
     }

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -329,7 +329,7 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   // Work backwards through the 6-vector so indices don't get out of order
   for (auto dimension = jacobian_.rows(); dimension >= 0; --dimension)
   {
-    if (shared_variables.drift_dimensions[dimension] == true && jacobian_.rows() > 1)
+    if (shared_variables.drift_dimensions[dimension] && jacobian_.rows() > 1)
     {
       removeDimension(jacobian_, delta_x, dimension);
     }

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -195,22 +195,20 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
 // Listen to joint angles. Store them in a shared variable.
 void JogInterfaceBase::jointsCB(const sensor_msgs::JointStateConstPtr& msg)
 {
-  shared_variables_mutex_.lock();
+  const std::lock_guard<std::mutex> lock(shared_variables_mutex_);
   shared_variables_.joints = *msg;
-  shared_variables_mutex_.unlock();
 }
 
 bool JogInterfaceBase::changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req,
                                              moveit_msgs::ChangeDriftDimensions::Response& res)
 {
-  shared_variables_mutex_.lock();
+  // These are std::atomic's, they are threadsafe without a mutex lock
   shared_variables_.drift_dimensions[0] = req.drift_x_translation;
   shared_variables_.drift_dimensions[1] = req.drift_y_translation;
   shared_variables_.drift_dimensions[2] = req.drift_z_translation;
   shared_variables_.drift_dimensions[3] = req.drift_x_rotation;
   shared_variables_.drift_dimensions[4] = req.drift_y_rotation;
   shared_variables_.drift_dimensions[5] = req.drift_z_rotation;
-  shared_variables_mutex_.unlock();
 
   res.success = true;
   return true;

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -200,6 +200,22 @@ void JogInterfaceBase::jointsCB(const sensor_msgs::JointStateConstPtr& msg)
   shared_variables_mutex_.unlock();
 }
 
+bool JogInterfaceBase::changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req,
+                                              moveit_msgs::ChangeDriftDimensions::Response& res)
+{
+  shared_variables_mutex_.lock();
+  shared_variables_.drift_dimensions[0] = req.drift_x_translation;
+  shared_variables_.drift_dimensions[1] = req.drift_y_translation;
+  shared_variables_.drift_dimensions[2] = req.drift_z_translation;
+  shared_variables_.drift_dimensions[3] = req.drift_x_rotation;
+  shared_variables_.drift_dimensions[4] = req.drift_y_rotation;
+  shared_variables_.drift_dimensions[5] = req.drift_z_rotation;
+  shared_variables_mutex_.unlock();
+
+  res.success = true;
+  return true;
+}
+
 // A separate thread for the heavy jogging calculations.
 bool JogInterfaceBase::startJogCalcThread()
 {

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -201,7 +201,7 @@ void JogInterfaceBase::jointsCB(const sensor_msgs::JointStateConstPtr& msg)
 }
 
 bool JogInterfaceBase::changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req,
-                                              moveit_msgs::ChangeDriftDimensions::Response& res)
+                                             moveit_msgs::ChangeDriftDimensions::Response& res)
 {
   shared_variables_mutex_.lock();
   shared_variables_.drift_dimensions[0] = req.drift_x_translation;

--- a/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
@@ -90,6 +90,11 @@ JogROSInterface::JogROSInterface()
   ros::Subscriber joints_sub =
       nh.subscribe(ros_parameters_.joint_topic, 1, &JogInterfaceBase::jointsCB, dynamic_cast<JogInterfaceBase*>(this));
 
+  // ROS Server for allowing drift in some dimensions
+  ros::ServiceServer drift_dimensions_server =
+      nh.advertiseService(nh.getNamespace() + "/" + ros::this_node::getName() + "/change_drift_dimensions",
+                          &JogInterfaceBase::changeDriftDimensions, dynamic_cast<JogInterfaceBase*>(this));
+
   // Publish freshly-calculated joints to the robot.
   // Put the outgoing msg in the right format (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
   ros::Publisher outgoing_cmd_pub;

--- a/moveit_experimental/moveit_jog_arm/test/arm_setup/config/initial_position.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/arm_setup/config/initial_position.yaml
@@ -1,3 +1,4 @@
+# This is a good initial position, not near joint limits or singularity
 zeros:
   panda_joint1: 0
   panda_joint2: -0.785

--- a/moveit_experimental/moveit_jog_arm/test/arm_setup/config/singular_position.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/arm_setup/config/singular_position.yaml
@@ -1,3 +1,4 @@
+# This position is at a singularity
 zeros:
   panda_joint1: 0
   panda_joint2: 0

--- a/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_drift_dimensions_service_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_drift_dimensions_service_test.test
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="debug" value="false" />
+
+  <!-- Load URDF, SRDF -->
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch" >
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Note, we're using fake, simulated trajectory controllers.
+       These aren't suitable for actually jogging a robot in RViz, but they are good enough to
+       test jog node output.
+  -->
+  <include file="$(find moveit_jog_arm)/test/arm_setup/launch/panda_move_group.launch">
+    <arg name="fake_execution" value="true"/>
+  </include>
+
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="tool_state_publisher">
+    <param name="publish_frequency" type="double" value="50.0"/>
+  </node>
+
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+	  <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/singular_position.yaml" />
+  </node>
+
+  <group ns="jog_server" if="$(arg debug)">
+    <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/jog_settings.yaml"/>
+  </group>
+
+  <group unless="$(arg debug)">
+    <node name="jog_server" pkg="moveit_jog_arm" type="jog_server" output="screen">
+      <param name="parameter_ns" type="string" value="jog_server"/>
+      <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/jog_settings.yaml"/>
+    </node>
+  </group>
+
+  <param name="test_module" value="$(find moveit_jog_arm)/test/test_drift_dimensions_service" />
+  <test test-name="jog_arm_drift_dimensions_service_test" pkg="ros_pytest" type="ros_pytest_runner" />
+</launch>

--- a/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_drift_dimensions_service_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_drift_dimensions_service_test.test
@@ -20,7 +20,7 @@
   </node>
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-	  <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/singular_position.yaml" />
+	  <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/initial_position.yaml" />
   </node>
 
   <group ns="jog_server" if="$(arg debug)">

--- a/moveit_experimental/moveit_jog_arm/test/test_drift_dimensions_service/test_drift_dimensions_service.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_drift_dimensions_service/test_drift_dimensions_service.py
@@ -27,44 +27,13 @@ def node():
     return rospy.init_node('pytest', anonymous=True)
 
 
-class CartesianJogCmd(object):
-    def __init__(self):
-        self._pub = rospy.Publisher(
-            CARTESIAN_JOG_COMMAND_TOPIC, TwistStamped, queue_size=1
-        )
-
-    def send_cmd(self, linear, angular):
-        ts = TwistStamped()
-        ts.header.stamp = rospy.Time.now()
-        ts.twist.linear.x, ts.twist.linear.y, ts.twist.linear.z = linear
-        ts.twist.angular.x, ts.twist.angular.y, ts.twist.angular.z = angular
-        self._pub.publish(ts)
-
-
 def test_drift_dimensions_service(node):
-    sub = rospy.Subscriber(
-        COMMAND_OUT_TOPIC, JointTrajectory, lambda msg: received.append(msg)
-    )
-    cartesian_cmd = CartesianJogCmd()
-    time.sleep(ROS_SETTLE_TIME_S)  # wait for pub/subs to settle
-    time.sleep(JOG_ARM_SETTLE_TIME_S)  # wait for jog_arm server to init
-
     # Make the service call to allow drift in all dimensions except y-translation
     drift_service = rospy.ServiceProxy('jog_server/change_drift_dimensions', ChangeDriftDimensions)
     # the transform is an identity matrix, not used for now
     drift_response = drift_service(True, False, True, True, True, True, Transform())
     # Check for successful response
     assert drift_response.success == True
-
-    # This nonzero command should produce jogging output
-    # A subscriber in a different thread fills `received`
-    TEST_DURATION = 1
-    cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
-    received = []
-    rospy.sleep(TEST_DURATION)
-
-    # Ensure some messages have been received
-    assert len(received) > 10
 
 
 if __name__ == '__main__':

--- a/moveit_experimental/moveit_jog_arm/test/test_drift_dimensions_service/test_drift_dimensions_service.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_drift_dimensions_service/test_drift_dimensions_service.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+import time
+
+import pytest
+import rospy
+
+from moveit_msgs.srv import ChangeDriftDimensions
+from geometry_msgs.msg import Transform
+from geometry_msgs.msg import TwistStamped
+from std_msgs.msg import Bool
+from trajectory_msgs.msg import JointTrajectory
+
+# Send a service call to allow drift in all but the y-dimension.
+# In other words, only the y-dimension will be controlled exactly.
+# Check that the service returns and the jog node continues to publish commands to the robot.
+
+JOG_ARM_SETTLE_TIME_S = 10
+ROS_SETTLE_TIME_S = 10
+
+CARTESIAN_JOG_COMMAND_TOPIC = 'jog_server/delta_jog_cmds'
+
+COMMAND_OUT_TOPIC = 'jog_server/command'
+
+
+@pytest.fixture
+def node():
+    return rospy.init_node('pytest', anonymous=True)
+
+
+class CartesianJogCmd(object):
+    def __init__(self):
+        self._pub = rospy.Publisher(
+            CARTESIAN_JOG_COMMAND_TOPIC, TwistStamped, queue_size=1
+        )
+
+    def send_cmd(self, linear, angular):
+        ts = TwistStamped()
+        ts.header.stamp = rospy.Time.now()
+        ts.twist.linear.x, ts.twist.linear.y, ts.twist.linear.z = linear
+        ts.twist.angular.x, ts.twist.angular.y, ts.twist.angular.z = angular
+        self._pub.publish(ts)
+
+
+def test_drift_dimensions_service(node):
+    sub = rospy.Subscriber(
+        COMMAND_OUT_TOPIC, JointTrajectory, lambda msg: received.append(msg)
+    )
+    cartesian_cmd = CartesianJogCmd()
+    time.sleep(ROS_SETTLE_TIME_S)  # wait for pub/subs to settle
+    time.sleep(JOG_ARM_SETTLE_TIME_S)  # wait for jog_arm server to init
+
+    # Make the service call to allow drift in all dimensions except y-translation
+    drift_service = rospy.ServiceProxy('jog_server/change_drift_dimensions', ChangeDriftDimensions)
+    # the transform is an identity matrix, not used for now
+    drift_response = drift_service(True, False, True, True, True, True, Transform())
+    # Check for successful response
+    assert drift_response.success == True
+
+    # This nonzero command should produce jogging output
+    # A subscriber in a different thread fills `received`
+    TEST_DURATION = 1
+    cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
+    received = []
+    rospy.sleep(TEST_DURATION)
+
+    # Ensure some messages have been received
+    assert len(received) > 10
+
+
+if __name__ == '__main__':
+   node = node()
+   test_drift_dimensions_service(node)

--- a/moveit_experimental/moveit_jog_arm/test/test_halt_msg/test_jog_arm_halt_msg.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_halt_msg/test_jog_arm_halt_msg.py
@@ -52,9 +52,11 @@ def test_jog_arm_halt_msg(node):
     # This nonzero command should produce jogging output
     # A subscriber in a different thread fills `received`
     TEST_DURATION = 1
-    cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
     received = []
-    rospy.sleep(TEST_DURATION)
+    start_time = rospy.get_rostime()
+    while (rospy.get_rostime() - start_time).to_sec() < TEST_DURATION:
+        cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
+        time.sleep(0.1)
 
     # Check the received messages
     assert len(received) > 1

--- a/moveit_experimental/moveit_jog_arm/test/test_msg_reception/test_jog_arm_msg_reception.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_msg_reception/test_jog_arm_msg_reception.py
@@ -73,10 +73,13 @@ def test_jog_arm_cartesian_command(node):
     # This nonzero command should produce jogging output
     # A subscriber in a different thread fills `received`
     TEST_DURATION = 1
-    PUBLISH_PERIOD = 0.01 # 'PUBLISH_PERIOD' from config file
-    cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
+    PUBLISH_PERIOD = 0.01 # 'PUBLISH_PERIOD' from jog_arm config file
     received = []
-    rospy.sleep(TEST_DURATION)
+
+    start_time = rospy.get_rostime()
+    while (rospy.get_rostime() - start_time).to_sec() < TEST_DURATION:
+        cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
+        time.sleep(0.1)
     # TEST_DURATION/PUBLISH_PERIOD is the expected number of messages in this duration.
     # Allow a small +/- window due to rounding/timing errors
     assert len(received) >= TEST_DURATION/PUBLISH_PERIOD - 5
@@ -96,11 +99,13 @@ def test_jog_arm_joint_command(node):
 
     received = []
     TEST_DURATION = 1
-    PUBLISH_PERIOD = 0.01 # 'PUBLISH_PERIOD' from config file
-    JOINT_VELOCITY_LIMIT = 1
+    PUBLISH_PERIOD = 0.01 # 'PUBLISH_PERIOD' from jog_arm config file
     velocities = [0.1]
-    joint_cmd.send_joint_velocity_cmd(velocities)
-    rospy.sleep(TEST_DURATION)
+
+    start_time = rospy.get_rostime()
+    while (rospy.get_rostime() - start_time).to_sec() < TEST_DURATION:
+        joint_cmd.send_joint_velocity_cmd(velocities)
+        time.sleep(0.1)
     # TEST_DURATION/PUBLISH_PERIOD is the expected number of messages in this duration.
     # Allow a small +/- window due to rounding/timing errors
     assert len(received) >= TEST_DURATION/PUBLISH_PERIOD - 20


### PR DESCRIPTION
Add a ROS service to turn redundancy on/off in specific dimensions. For example, maybe you could allow wrist rotation by `drift_x_rotation == true`. For now, the reference frame is the jogging command frame.

This depends on this moveit_msgs [PR](https://github.com/ros-planning/moveit_msgs/pull/63)

Here are 2 gif's starting from a singular position, without and with allowing drift respectively. It's trying to move in the world Y-direction. The first gif shows it stuck. The second gif moves past the singularity, no problem.
![no_drift_allowed](https://user-images.githubusercontent.com/11284393/72939956-8c053780-3d33-11ea-8974-c556aa8550d3.gif)

![with_drift_allowed](https://user-images.githubusercontent.com/11284393/72939991-9cb5ad80-3d33-11ea-8764-064fe5c23e04.gif)
