### PR TITLE
Fix the logic on empty trajectory check

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -87,7 +87,7 @@ protected:
   void publishWarning(bool active) const;
 
   // Scale the delta theta to match joint velocity limits
-  bool checkIfJointsWithinSRDFBounds(trajectory_msgs::JointTrajectory& new_joint_traj);
+  bool enforceSRDFJointBounds(trajectory_msgs::JointTrajectory& new_joint_traj);
 
   // Possibly calculate a velocity scaling factor, due to proximity of
   // singularity and direction of motion

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -320,7 +320,7 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   applyVelocityScaling(shared_variables, mutex, outgoing_command_, delta_theta_,
                        decelerateForSingularity(delta_x, svd_));
 
-  if (!checkIfJointsWithinSRDFBounds(outgoing_command_))
+  if (!enforceSRDFJointBounds(outgoing_command_))
   {
     suddenHalt(outgoing_command_);
     publishWarning(true);
@@ -369,7 +369,7 @@ bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& /*
 
   outgoing_command_ = composeOutgoingMessage(joint_state_);
 
-  if (!checkIfJointsWithinSRDFBounds(outgoing_command_))
+  if (!enforceSRDFJointBounds(outgoing_command_))
   {
     suddenHalt(outgoing_command_);
     publishWarning(true);
@@ -554,11 +554,11 @@ double JogCalcs::decelerateForSingularity(const Eigen::VectorXd& commanded_veloc
   return velocity_scale;
 }
 
-bool JogCalcs::checkIfJointsWithinSRDFBounds(trajectory_msgs::JointTrajectory& new_joint_traj)
+bool JogCalcs::enforceSRDFJointBounds(trajectory_msgs::JointTrajectory& new_joint_traj)
 {
   bool halting = false;
 
-  if (!new_joint_traj.points.empty())
+  if (new_joint_traj.points.empty())
   {
     ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, "Empty trajectory passed into checkIfJointsWithinURDFBounds().");
     return true;  // technically an empty trajectory is still within bounds

--- a/moveit_experimental/moveit_jog_arm/test/integration/test_jog_arm_integration.py
+++ b/moveit_experimental/moveit_jog_arm/test/integration/test_jog_arm_integration.py
@@ -11,8 +11,8 @@ from trajectory_msgs.msg import JointTrajectory
 # This can be run as part of a pytest, or like a normal ROS executable:
 # rosrun moveit_jog_arm test_jog_arm_integration.py
 
-JOG_ARM_SETTLE_TIME_S = 3
-ROS_SETTLE_TIME_S = 3
+JOG_ARM_SETTLE_TIME_S = 10
+ROS_SETTLE_TIME_S = 10
 
 JOINT_JOG_COMMAND_TOPIC = 'jog_server/joint_delta_jog_cmds'
 CARTESIAN_JOG_COMMAND_TOPIC = 'jog_server/delta_jog_cmds'


### PR DESCRIPTION
Fix the logic on empty trajectory check

Restore the integration test settle time.

Rename checkIfJointsWithingSRDFBounds -> enforceSRDFJointBounds

Credit to Henning for catching the logic error.

Hopefully fixes #1858 