### PR TITLE
Fix segfault in totg

### DIFF
--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -110,7 +110,6 @@ public:
     const Eigen::VectorXd start_direction = (intersection - start).normalized();
     const Eigen::VectorXd end_direction = (end - intersection).normalized();
 
-    // check if directions are divergent
     if ((start_direction - end_direction).norm() < 0.000001)
     {
       length_ = 0.0;

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -121,7 +121,7 @@ public:
     }
 
     // directions must be different at this point so angle is always non-zero
-    const double angle = acos(start_direction.dot(end_direction));
+    const double angle = acos(std::max(-1.0, start_direction.dot(end_direction)));
     const double start_distance = (start - intersection).norm();
     const double end_distance = (end - intersection).norm();
 


### PR DESCRIPTION
### Description

(At least partially) fixes  #1805.  Calls to `acos` can result in nan values if not careful due to numerical floating point errors.  If there is a possibility of calling `acos` on values that are approximately `-1`, then it will result in nan, which leads to a segfault later in totg. Also removes an incorrect comment that implies a section would avoid this error, but it actually handles a different case.
