### PR TITLE
Fix subframes disappearing when object is detached/scaled/renamed

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1607,14 +1607,14 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       const moveit::core::AttachedBody* body = robot_state_->getAttachedBody(object.object.id);
       if (body)
       {
-        attached_bodies.push_back(body);
-        if ((body->getAttachedLinkName() != object.link_name) && (!object.link_name.empty()))
+        if (!object.link_name.empty() && (body->getAttachedLinkName() != object.link_name))
         {
-          ROS_ERROR_NAMED(LOGNAME, "The AttachedCollisionObject message stated that the object is attached to ",
-                          object.link_name, ", but it was actually attached to ", body->getAttachedLinkName(),
-                          ". Did something go wrong? Aborting and leaving the body attached.");
+          ROS_ERROR_NAMED(LOGNAME, "The AttachedCollisionObject message states the object is attached to ",
+                          object.link_name, ", but it is actually attached to ", body->getAttachedLinkName(),
+                          ". Leave the link_name empty or specify the correct link.");
           return false;
         }
+        attached_bodies.push_back(body);
       }
     }
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1608,10 +1608,13 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       if (body)
       {
         attached_bodies.push_back(body);
-        if (body->getAttachedLinkName() != object.link_name)
-          ROS_WARN_NAMED(LOGNAME, "The AttachedCollisionObject message stated that the object is attached to ",
-                         object.link_name, ", but it was actually attached to ", body->getAttachedLinkName(),
-                         ". Did something go wrong?");
+        if ((body->getAttachedLinkName() != object.link_name) && (!object.link_name.empty()))
+        {
+          ROS_ERROR_NAMED(LOGNAME, "The AttachedCollisionObject message stated that the object is attached to ",
+                          object.link_name, ", but it was actually attached to ", body->getAttachedLinkName(),
+                          ". Did something go wrong? Aborting and leaving the body attached.");
+          return false;
+        }
       }
     }
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1609,9 +1609,10 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       {
         if (!object.link_name.empty() && (body->getAttachedLinkName() != object.link_name))
         {
-          ROS_ERROR_NAMED(LOGNAME, "The AttachedCollisionObject message states the object is attached to ",
-                          object.link_name, ", but it is actually attached to ", body->getAttachedLinkName(),
-                          ". Leave the link_name empty or specify the correct link.");
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "The AttachedCollisionObject message states the object is attached to "
+                                              << object.link_name << ", but it is actually attached to "
+                                              << body->getAttachedLinkName()
+                                              << ". Leave the link_name empty or specify the correct link.");
           return false;
         }
         attached_bodies.push_back(body);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1606,7 +1606,13 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
     {
       const moveit::core::AttachedBody* body = robot_state_->getAttachedBody(object.object.id);
       if (body)
+      {
         attached_bodies.push_back(body);
+        if (body->getAttachedLinkName() != object.link_name)
+          ROS_WARN_NAMED(LOGNAME, "The AttachedCollisionObject message stated that the object is attached to ",
+                         object.link_name, ", but it was actually attached to ", body->getAttachedLinkName(),
+                         ". Did something go wrong?");
+      }
     }
 
     // STEP 2+3: Remove the attached object(s) from the RobotState and put them in the world
@@ -1756,7 +1762,7 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
   if (!object.type.key.empty() || !object.type.db.empty())
     setObjectType(object.id, object.type);
 
-  // Add subframes
+  // Add subframes to the newly created (or possibly modified) object
   moveit::core::FixedTransformsMap subframes = world_->getObject(object.id)->subframe_poses_;
   Eigen::Isometry3d frame_pose;
   for (std::size_t i = 0; i < object.subframe_poses.size(); ++i)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1814,7 +1814,7 @@ bool PlanningScene::processCollisionObjectMove(const moveit_msgs::CollisionObjec
     }
 
     collision_detection::World::ObjectConstPtr obj = world_->getObject(object.id);
-    
+
     if (obj->shapes_.size() == new_poses.size())
     {
       std::vector<shapes::ShapeConstPtr> shapes = obj->shapes_;

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -120,6 +120,12 @@ public:
     return subframe_poses_;
   }
 
+  /** \brief Get subframes of this object (relative to the link) */
+  const moveit::core::FixedTransformsMap& getGlobalSubframeTransforms() const
+  {
+    return global_subframe_poses_;
+  }
+
   /** \brief Set all subframes of this object.
    *
    * Use these to define points of interest on the object to plan with

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -120,7 +120,7 @@ public:
     return subframe_poses_;
   }
 
-  /** \brief Get subframes of this object (relative to the link) */
+  /** \brief Get subframes of this object (in the world frame) */
   const moveit::core::FixedTransformsMap& getGlobalSubframeTransforms() const
   {
     return global_subframe_poses_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -168,6 +168,7 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
           ps->getWorldNonConst()->addToObject(scaled_object_->id_, shapes::ShapeConstPtr(s),
                                               scaled_object_->shape_poses_[i]);
         }
+        // TODO(felixvd): Scale subframes too
         ps->getWorldNonConst()->setSubframesOfObject(scaled_object_->id_, subframes);
         setLocalSceneEdited();
         scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -159,6 +159,7 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
     {
       if (ps->getWorld()->hasObject(scaled_object_->id_))
       {
+        const moveit::core::FixedTransformsMap subframes = scaled_object_->subframe_poses_;  // Keep subframes
         ps->getWorldNonConst()->removeObject(scaled_object_->id_);
         for (std::size_t i = 0; i < scaled_object_->shapes_.size(); ++i)
         {
@@ -167,6 +168,7 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
           ps->getWorldNonConst()->addToObject(scaled_object_->id_, shapes::ShapeConstPtr(s),
                                               scaled_object_->shape_poses_[i]);
         }
+        ps->getWorldNonConst()->setSubframesOfObject(scaled_object_->id_, subframes);
         setLocalSceneEdited();
         scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));
         planning_display_->queueRenderSceneGeometry();
@@ -823,9 +825,11 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
     if (obj)
     {
       known_collision_objects_[item->type()].first = item_text;
+      const moveit::core::FixedTransformsMap subframes = obj->subframe_poses_;  // Keep subframes
       ps->getWorldNonConst()->removeObject(obj->id_);
       ps->getWorldNonConst()->addToObject(known_collision_objects_[item->type()].first, obj->shapes_,
                                           obj->shape_poses_);
+      ps->getWorldNonConst()->setSubframesOfObject(obj->id_, subframes);
       if (scene_marker_)
       {
         scene_marker_.reset();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -827,6 +827,7 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
     {
       known_collision_objects_[item->type()].first = item_text;
       const moveit::core::FixedTransformsMap subframes = obj->subframe_poses_;  // Keep subframes
+      // TODO(felixvd): Scale the subframes with the object
       ps->getWorldNonConst()->removeObject(obj->id_);
       ps->getWorldNonConst()->addToObject(known_collision_objects_[item->type()].first, obj->shapes_,
                                           obj->shape_poses_);


### PR DESCRIPTION
### Description

Subframes were being forgotten when objects were detached/removed from the robot, and when they were moved. They also would have overwritten the old subframes during an APPEND call. This PR should fix all of that, and adds a line to the Rviz plugin that says "The object has subframes X, Y, Z."

Subframes are not updated if the object is moved from the Rviz plugin. I am filing another PR about this in a minute.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [X] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
