### PR TITLE
[jog_arm] Rework the halt msg functionality

### DIFF
--- a/moveit_experimental/moveit_jog_arm/CMakeLists.txt
+++ b/moveit_experimental/moveit_jog_arm/CMakeLists.txt
@@ -124,8 +124,11 @@ if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   find_package(ros_pytest REQUIRED)
 
-  # jog_server
-  add_rostest(test/launch/jog_arm_integration_test.test)
+  # Python integration test of basic message reception/publication
+  add_rostest(test/launch/jog_arm_msg_reception_test.test)
+
+  # Python integration test that a halt message is published at a singularity
+  add_rostest(test/launch/jog_arm_halt_msg_test.test)
 
   # jog_cpp_interface
   add_rostest_gtest(jog_cpp_interface_test

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -94,7 +94,15 @@ protected:
   double decelerateForSingularity(const Eigen::VectorXd& commanded_velocity,
                                   const Eigen::JacobiSVD<Eigen::MatrixXd>& svd);
 
-  // Apply velocity scaling for proximity of collisions and singularities
+  /**
+   * Slow motion down if close to singularity or collision.
+   * @param shared_variables data shared between threads, tells how close we are to collision
+   * @param mutex locks shared data
+   * @param new_joint_traj store the motion in the first waypoint of this trajectory
+   * @param delta_theta motion command, used in calculating new_joint_tray
+   * @param singularity_scale tells how close we are to a singularity
+   * @return false if very close to collision or singularity
+   */
   bool applyVelocityScaling(JogArmShared& shared_variables, std::mutex& mutex,
                             trajectory_msgs::JointTrajectory& new_joint_traj, const Eigen::VectorXd& delta_theta,
                             double singularity_scale);

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -317,7 +317,8 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   outgoing_command_ = composeOutgoingMessage(joint_state_);
 
   // If close to a collision or a singularity, decelerate and publish a warning
-  if (!applyVelocityScaling(shared_variables, mutex, outgoing_command_, delta_theta_, decelerateForSingularity(delta_x, svd_)))
+  if (!applyVelocityScaling(shared_variables, mutex, outgoing_command_, delta_theta_,
+                            decelerateForSingularity(delta_x, svd_)))
   {
     suddenHalt(outgoing_command_);
     publishWarning(true);
@@ -487,10 +488,7 @@ bool JogCalcs::applyVelocityScaling(JogArmShared& shared_variables, std::mutex& 
   }
 
   // Heuristic: flag that we are stuck if velocity scaling is < X%
-  if (collision_scale * singularity_scale < 0.1)
-    return false;
-
-  return true;
+  return collision_scale * singularity_scale >= 0.1;
 }
 
 // Possibly calculate a velocity scaling factor, due to proximity of singularity and direction of motion

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -316,11 +316,14 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
 
   outgoing_command_ = composeOutgoingMessage(joint_state_);
 
-  // If close to a collision or a singularity, decelerate
-  applyVelocityScaling(shared_variables, mutex, outgoing_command_, delta_theta_,
-                       decelerateForSingularity(delta_x, svd_));
-
-  if (!enforceSRDFJointBounds(outgoing_command_))
+  // If close to a collision or a singularity, decelerate and publish a warning
+  if (!applyVelocityScaling(shared_variables, mutex, outgoing_command_, delta_theta_, decelerateForSingularity(delta_x, svd_)))
+  {
+    suddenHalt(outgoing_command_);
+    publishWarning(true);
+  }
+  // If a joint limit would be exceeded, halt and publish a warning
+  else if (!enforceSRDFJointBounds(outgoing_command_))
   {
     suddenHalt(outgoing_command_);
     publishWarning(true);
@@ -482,6 +485,10 @@ bool JogCalcs::applyVelocityScaling(JogArmShared& shared_variables, std::mutex& 
     if (parameters_.publish_joint_velocities)
       new_joint_traj.points[0].velocities[i] *= singularity_scale * collision_scale;
   }
+
+  // Heuristic: flag that we are stuck if velocity scaling is < X%
+  if (collision_scale * singularity_scale < 0.1)
+    return false;
 
   return true;
 }

--- a/moveit_experimental/moveit_jog_arm/test/arm_setup/config/singular_position.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/arm_setup/config/singular_position.yaml
@@ -1,0 +1,10 @@
+zeros:
+  panda_joint1: 0
+  panda_joint2: 0
+  panda_joint3: 0
+  panda_joint4: 0
+  panda_joint5: 0
+  panda_joint6: 1.57
+  panda_joint7: 1.57
+publish_default_positions: True
+

--- a/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_halt_msg_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_halt_msg_test.test
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="debug" value="false" />
+
+  <!-- Load URDF, SRDF -->
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch" >
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Note, we're using fake, simulated trajectory controllers.
+       These aren't suitable for actually jogging a robot in RViz, but they are good enough to
+       test jog node output.
+  -->
+  <include file="$(find moveit_jog_arm)/test/arm_setup/launch/panda_move_group.launch">
+    <arg name="fake_execution" value="true"/>
+  </include>
+
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="tool_state_publisher">
+    <param name="publish_frequency" type="double" value="50.0"/>
+  </node>
+
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+	  <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/singular_position.yaml" />
+  </node>
+
+  <group ns="jog_server" if="$(arg debug)">
+    <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/jog_settings.yaml"/>
+  </group>
+
+  <group unless="$(arg debug)">
+    <node name="jog_server" pkg="moveit_jog_arm" type="jog_server" output="screen">
+      <param name="parameter_ns" type="string" value="jog_server"/>
+      <rosparam command="load" file="$(find moveit_jog_arm)/test/arm_setup/config/jog_settings.yaml"/>
+    </node>
+  </group>
+
+  <param name="test_module" value="$(find moveit_jog_arm)/test/test_halt_msg" />
+  <test test-name="jog_arm_halt_msg_test" pkg="ros_pytest" type="ros_pytest_runner" />
+</launch>

--- a/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_msg_reception_test.test
+++ b/moveit_experimental/moveit_jog_arm/test/launch/jog_arm_msg_reception_test.test
@@ -34,6 +34,6 @@
     </node>
   </group>
 
-  <param name="test_module" value="$(find moveit_jog_arm)/test/integration" />
-  <test test-name="jog_arm_integration_test" pkg="ros_pytest" type="ros_pytest_runner" />
+  <param name="test_module" value="$(find moveit_jog_arm)/test/test_msg_reception" />
+  <test test-name="jog_arm_msg_reception_test" pkg="ros_pytest" type="ros_pytest_runner" />
 </launch>

--- a/moveit_experimental/moveit_jog_arm/test/test_halt_msg/test_jog_arm_halt_msg.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_halt_msg/test_jog_arm_halt_msg.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+import time
+
+import pytest
+import rospy
+from geometry_msgs.msg import TwistStamped
+
+from control_msgs.msg import JointJog
+from std_msgs.msg import Bool
+
+# The robot starts at a singular position (see config file).
+# Listen for a halt message from the jogger.
+# This can be run as part of a pytest, or like a normal ROS executable:
+# rosrun moveit_jog_arm test_jog_arm_integration.py
+
+JOG_ARM_SETTLE_TIME_S = 10
+ROS_SETTLE_TIME_S = 10
+
+CARTESIAN_JOG_COMMAND_TOPIC = 'jog_server/delta_jog_cmds'
+
+# jog_arm should publish 'true' here if it halts
+HALT_TOPIC = 'jog_server/halted'
+
+
+@pytest.fixture
+def node():
+    return rospy.init_node('pytest', anonymous=True)
+
+
+class CartesianJogCmd(object):
+    def __init__(self):
+        self._pub = rospy.Publisher(
+            CARTESIAN_JOG_COMMAND_TOPIC, TwistStamped, queue_size=1
+        )
+
+    def send_cmd(self, linear, angular):
+        ts = TwistStamped()
+        ts.header.stamp = rospy.Time.now()
+        ts.twist.linear.x, ts.twist.linear.y, ts.twist.linear.z = linear
+        ts.twist.angular.x, ts.twist.angular.y, ts.twist.angular.z = angular
+        self._pub.publish(ts)
+
+
+def test_jog_arm_halt_msg(node):
+    sub = rospy.Subscriber(
+        HALT_TOPIC, Bool, lambda msg: received.append(msg)
+    )
+    cartesian_cmd = CartesianJogCmd()
+    time.sleep(ROS_SETTLE_TIME_S)  # wait for pub/subs to settle
+    time.sleep(JOG_ARM_SETTLE_TIME_S)  # wait for jog_arm server to init
+
+    # This nonzero command should produce jogging output
+    # A subscriber in a different thread fills `received`
+    TEST_DURATION = 1
+    cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 1])
+    received = []
+    rospy.sleep(TEST_DURATION)
+
+    # Check the received messages
+    assert len(received) > 1
+    assert received[-1].data == True
+
+
+if __name__ == '__main__':
+   node = node()
+   test_jog_arm_halt_msg(node)

--- a/moveit_experimental/moveit_jog_arm/test/test_msg_reception/test_jog_arm_msg_reception.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_msg_reception/test_jog_arm_msg_reception.py
@@ -8,6 +8,7 @@ from geometry_msgs.msg import TwistStamped
 from control_msgs.msg import JointJog
 from trajectory_msgs.msg import JointTrajectory
 
+# Test that the jogger publishes controller commands when it receives Cartesian or joint commands.
 # This can be run as part of a pytest, or like a normal ROS executable:
 # rosrun moveit_jog_arm test_jog_arm_integration.py
 
@@ -51,7 +52,7 @@ class CartesianJogCmd(object):
         self._pub.publish(ts)
 
 
-def test_jog_arm_trajectory_generated_when_jog_command_is_received(node):
+def test_jog_arm_cartesian_command(node):
     sub = rospy.Subscriber(
         COMMAND_OUT_TOPIC, JointTrajectory, lambda msg: received.append(msg)
     )
@@ -108,5 +109,5 @@ def test_jog_arm_joint_command(node):
 
 if __name__ == '__main__':
    node = node()
-   test_jog_arm_trajectory_generated_when_jog_command_is_received(node)
+   test_jog_arm_cartesian_command(node)
    test_jog_arm_joint_command(node)


### PR DESCRIPTION
- Document the applyVelocityScaling() function better

- Rework the halt message so it includes singularities and collision proximity, as well as joint limits

- Add a test for this

The gif shows True being published when close to collision (you have to look fast though, true only flashes for a second).

![halt_msg](https://user-images.githubusercontent.com/11284393/73297511-521faf80-41d1-11ea-8a5d-3e2727990056.gif)
