### PR TITLE
Python 3 friendly message serialization

### DIFF
--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -42,7 +42,7 @@ class SimpleCompleter(object):
         prefix = ""
         if len(cmds) > 0:
             prefix = cmds[0]
-            if not self.options.has_key(prefix):
+            if not prefix in self.options:
                 prefix = ""
 
         if state == 0:

--- a/moveit_commander/src/moveit_commander/conversions.py
+++ b/moveit_commander/src/moveit_commander/conversions.py
@@ -36,8 +36,8 @@ try:
     # Try Python 2.7 behaviour first
     from StringIO import StringIO
 except ImportError:
-    # Use Python 3.x behaviour as fallback
-    from io import StringIO
+    # Use Python 3.x behaviour as fallback and choose the non-unicode version
+    from io import BytesIO as StringIO
 
 from moveit_commander import MoveItCommanderException
 from geometry_msgs.msg import Pose, PoseStamped, Transform

--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -103,7 +103,7 @@ class MoveGroupCommandInterpreter(object):
                         clist[1] = self._prev_group_name
                         if len(clist[1]) == 0:
                             return (MoveGroupInfoLevel.DEBUG, "OK")
-                    if self._gdict.has_key(clist[1]):
+                    if clist[1] in self._gdict:
                         self._prev_group_name = self._group_name
                         self._group_name = clist[1]
                         return (MoveGroupInfoLevel.DEBUG, "OK")
@@ -267,7 +267,7 @@ class MoveGroupCommandInterpreter(object):
         assign_match = re.match(r"^(\w+)\s*=\s*(\w+)$", cmd)
         if assign_match:
             known = g.get_remembered_joint_values()
-            if known.has_key(assign_match.group(2)):
+            if assign_match.group(2) in known:
                 g.remember_joint_values(assign_match.group(1), known[assign_match.group(2)])
                 return (MoveGroupInfoLevel.SUCCESS, assign_match.group(1) + " is now the same as " + assign_match.group(2))
             else:
@@ -286,7 +286,7 @@ class MoveGroupCommandInterpreter(object):
         component_match = re.match(r"^(\w+)\s*\[\s*(\d+)\s*\]\s*=\s*([\d\.e\-\+]+)$", cmd)
         if component_match:
             known = g.get_remembered_joint_values()
-            if known.has_key(component_match.group(1)):
+            if component_match.group(1) in known:
                 try:
                     val = known[component_match.group(1)]
                     val[int(component_match.group(2))] = float(component_match.group(3))
@@ -303,7 +303,7 @@ class MoveGroupCommandInterpreter(object):
         # if this is an unknown one-word command, it is probably a variable
         if len(clist) == 1:
             known = g.get_remembered_joint_values()
-            if known.has_key(cmd):
+            if cmd in known:
                 return (MoveGroupInfoLevel.INFO, "[" + " ".join([str(x) for x in known[cmd]]) + "]")
             else:
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
@@ -381,7 +381,7 @@ class MoveGroupCommandInterpreter(object):
                 return (MoveGroupInfoLevel.SUCCESS, "Forgot joint values under the name " + clist[1])
             elif clist[0] == "show":
                 known = g.get_remembered_joint_values()
-                if known.has_key(clist[1]):
+                if clist[1] in known:
                     return (MoveGroupInfoLevel.INFO, "[" + " ".join([str(x) for x in known[clist[1]]]) + "]")
                 else:
                     return (MoveGroupInfoLevel.WARN, "Joint values for " + clist[1] + " are not known")
@@ -423,7 +423,7 @@ class MoveGroupCommandInterpreter(object):
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
         if len(clist) == 3:
-            if clist[0] == "go" and self.GO_DIRS.has_key(clist[1]):
+            if clist[0] == "go" and clist[1] in self.GO_DIRS:
                 self._last_plan = None
                 try:
                     offset = float(clist[2])

--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -261,7 +261,7 @@ class RobotCommander(object):
         @param name str: Name of movegroup
         @rtype: moveit_commander.MoveGroupCommander
         """
-        if not self._groups.has_key(name):
+        if not name in self._groups:
             if not self.has_group(name):
                 raise MoveItCommanderException("There is no group named %s" % name)
             self._groups[name] = MoveGroupCommander(name, self._robot_description, self._ns)
@@ -279,7 +279,7 @@ class RobotCommander(object):
         Get the name of the smallest group (fewest joints) that includes
         the joint name specified as argument.
         """
-        if not self._joint_owner_groups.has_key(joint_name):
+        if not joint_name in self._joint_owner_groups:
             group = None
             for g in self.get_group_names():
                 if joint_name in self.get_joint_names(g):

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -94,28 +94,30 @@ public:
     return setJointValueTarget(v);
   }
 
-  bool setJointValueTargetFromPosePython(const std::string& pose_str, const std::string& eef, bool approx)
+  bool setJointValueTargetFromPosePython(const py_bindings_tools::ByteString& pose_str, const std::string& eef,
+                                         bool approx)
   {
     geometry_msgs::Pose pose_msg;
     py_bindings_tools::deserializeMsg(pose_str, pose_msg);
     return approx ? setApproximateJointValueTarget(pose_msg, eef) : setJointValueTarget(pose_msg, eef);
   }
 
-  bool setJointValueTargetFromPoseStampedPython(const std::string& pose_str, const std::string& eef, bool approx)
+  bool setJointValueTargetFromPoseStampedPython(const py_bindings_tools::ByteString& pose_str, const std::string& eef,
+                                                bool approx)
   {
     geometry_msgs::PoseStamped pose_msg;
     py_bindings_tools::deserializeMsg(pose_str, pose_msg);
     return approx ? setApproximateJointValueTarget(pose_msg, eef) : setJointValueTarget(pose_msg, eef);
   }
 
-  bool setJointValueTargetFromJointStatePython(const std::string& js_str)
+  bool setJointValueTargetFromJointStatePython(const py_bindings_tools::ByteString& js_str)
   {
     sensor_msgs::JointState js_msg;
     py_bindings_tools::deserializeMsg(js_str, js_msg);
     return setJointValueTarget(js_msg);
   }
 
-  bool setStateValueTarget(const std::string& state_str)
+  bool setStateValueTarget(const py_bindings_tools::ByteString& state_str)
   {
     moveit_msgs::RobotState msg;
     py_bindings_tools::deserializeMsg(state_str, msg);
@@ -133,12 +135,12 @@ public:
     return l;
   }
 
-  std::string getJointValueTarget()
+  py_bindings_tools::ByteString getJointValueTarget()
   {
     moveit_msgs::RobotState msg;
     const robot_state::RobotState state = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
     moveit::core::robotStateToRobotStateMsg(state, msg);
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
   void rememberJointValuesFromPythonList(const std::string& string, bp::list& values)
@@ -151,11 +153,11 @@ public:
     return getPlanningFrame().c_str();
   }
 
-  std::string getInterfaceDescriptionPython()
+  py_bindings_tools::ByteString getInterfaceDescriptionPython()
   {
     moveit_msgs::PlannerInterfaceDescription msg;
     getInterfaceDescription(msg);
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
   bp::list getActiveJointsList() const
@@ -268,7 +270,8 @@ public:
     return place(object_name, msg, plan_only) == MoveItErrorCode::SUCCESS;
   }
 
-  bool placeLocation(const std::string& object_name, const std::string& location_str, bool plan_only = false)
+  bool placeLocation(const std::string& object_name, const py_bindings_tools::ByteString& location_str,
+                     bool plan_only = false)
   {
     std::vector<moveit_msgs::PlaceLocation> locations(1);
     py_bindings_tools::deserializeMsg(location_str, locations[0]);
@@ -321,7 +324,7 @@ public:
     return output;
   }
 
-  void setStartStatePython(const std::string& msg_str)
+  void setStartStatePython(const py_bindings_tools::ByteString& msg_str)
   {
     moveit_msgs::RobotState msg;
     py_bindings_tools::deserializeMsg(msg_str, msg);
@@ -334,10 +337,10 @@ public:
     convertListToArrayOfPoses(poses, msg);
     return setPoseTargets(msg, end_effector_link);
   }
-  std::string getPoseTargetPython(const std::string& end_effector_link)
+  py_bindings_tools::ByteString getPoseTargetPython(const std::string& end_effector_link)
   {
     geometry_msgs::PoseStamped pose = moveit::planning_interface::MoveGroupInterface::getPoseTarget(end_effector_link);
-    return py_bindings_tools::serializeMsg(pose);
+    return py_bindings_tools::serializeMsgByteString(pose);
   }
 
   bool setPoseTargetPython(bp::list& pose, const std::string& end_effector_link = "")
@@ -414,25 +417,25 @@ public:
     return attachObject(object_name, link_name, py_bindings_tools::stringFromList(touch_links));
   }
 
-  bool executePython(const std::string& plan_str)
+  bool executePython(const py_bindings_tools::ByteString& plan_str)
   {
     MoveGroupInterface::Plan plan;
     py_bindings_tools::deserializeMsg(plan_str, plan.trajectory_);
     return execute(plan) == MoveItErrorCode::SUCCESS;
   }
 
-  bool asyncExecutePython(const std::string& plan_str)
+  bool asyncExecutePython(const py_bindings_tools::ByteString& plan_str)
   {
     MoveGroupInterface::Plan plan;
     py_bindings_tools::deserializeMsg(plan_str, plan.trajectory_);
     return asyncExecute(plan) == MoveItErrorCode::SUCCESS;
   }
 
-  std::string getPlanPython()
+  py_bindings_tools::ByteString getPlanPython()
   {
     MoveGroupInterface::Plan plan;
     MoveGroupInterface::plan(plan);
-    return py_bindings_tools::serializeMsg(plan.trajectory_);
+    return py_bindings_tools::serializeMsgByteString(plan.trajectory_);
   }
 
   bp::tuple computeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
@@ -443,7 +446,8 @@ public:
   }
 
   bp::tuple computeCartesianPathConstrainedPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                                  bool avoid_collisions, const std::string& path_constraints_str)
+                                                  bool avoid_collisions,
+                                                  const py_bindings_tools::ByteString& path_constraints_str)
   {
     moveit_msgs::Constraints path_constraints;
     py_bindings_tools::deserializeMsg(path_constraints_str, path_constraints);
@@ -458,10 +462,10 @@ public:
     moveit_msgs::RobotTrajectory trajectory;
     double fraction =
         computeCartesianPath(poses, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
-    return bp::make_tuple(py_bindings_tools::serializeMsg(trajectory), fraction);
+    return bp::make_tuple(py_bindings_tools::serializeMsgByteString(trajectory), fraction);
   }
 
-  int pickGrasp(const std::string& object, const std::string& grasp_str, bool plan_only = false)
+  int pickGrasp(const std::string& object, const py_bindings_tools::ByteString& grasp_str, bool plan_only = false)
   {
     moveit_msgs::Grasp grasp;
     py_bindings_tools::deserializeMsg(grasp_str, grasp);
@@ -477,23 +481,23 @@ public:
     return pick(object, grasps, plan_only).val;
   }
 
-  void setPathConstraintsFromMsg(const std::string& constraints_str)
+  void setPathConstraintsFromMsg(const py_bindings_tools::ByteString& constraints_str)
   {
     moveit_msgs::Constraints constraints_msg;
     py_bindings_tools::deserializeMsg(constraints_str, constraints_msg);
     setPathConstraints(constraints_msg);
   }
 
-  std::string getPathConstraintsPython()
+  py_bindings_tools::ByteString getPathConstraintsPython()
   {
     moveit_msgs::Constraints constraints_msg(getPathConstraints());
-    std::string constraints_str = py_bindings_tools::serializeMsg(constraints_msg);
-    return constraints_str;
+    return py_bindings_tools::serializeMsgByteString(constraints_msg);
   }
 
-  std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
-                               double velocity_scaling_factor, double acceleration_scaling_factor,
-                               std::string algorithm)
+  py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
+                                                 const py_bindings_tools::ByteString& traj_str,
+                                                 double velocity_scaling_factor, double acceleration_scaling_factor,
+                                                 std::string algorithm)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -526,20 +530,17 @@ public:
       else
       {
         ROS_ERROR_STREAM_NAMED("move_group_py", "Unknown time parameterization algorithm: " << algorithm);
-        return py_bindings_tools::serializeMsg(moveit_msgs::RobotTrajectory());
+        return py_bindings_tools::serializeMsgByteString(moveit_msgs::RobotTrajectory());
       }
 
       // Convert the retimed trajectory back into a message
       traj_obj.getRobotTrajectoryMsg(traj_msg);
-      std::string traj_str = py_bindings_tools::serializeMsg(traj_msg);
-
-      // Return it.
-      return traj_str;
+      return py_bindings_tools::serializeMsgByteString(traj_msg);
     }
     else
     {
       ROS_ERROR("Unable to convert RobotState message to RobotState instance.");
-      return "";
+      return py_bindings_tools::ByteString("");
     }
   }
 

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -74,9 +74,9 @@ public:
   bp::dict getObjectPosesPython(const bp::list& object_ids)
   {
     std::map<std::string, geometry_msgs::Pose> ops = getObjectPoses(py_bindings_tools::stringFromList(object_ids));
-    std::map<std::string, std::string> ser_ops;
+    std::map<std::string, py_bindings_tools::ByteString> ser_ops;
     for (std::map<std::string, geometry_msgs::Pose>::const_iterator it = ops.begin(); it != ops.end(); ++it)
-      ser_ops[it->first] = py_bindings_tools::serializeMsg(it->second);
+      ser_ops[it->first] = py_bindings_tools::serializeMsgByteString(it->second);
 
     return py_bindings_tools::dictFromType(ser_ops);
   }
@@ -85,9 +85,9 @@ public:
   {
     std::map<std::string, moveit_msgs::CollisionObject> objs =
         getObjects(py_bindings_tools::stringFromList(object_ids));
-    std::map<std::string, std::string> ser_objs;
+    std::map<std::string, py_bindings_tools::ByteString> ser_objs;
     for (std::map<std::string, moveit_msgs::CollisionObject>::const_iterator it = objs.begin(); it != objs.end(); ++it)
-      ser_objs[it->first] = py_bindings_tools::serializeMsg(it->second);
+      ser_objs[it->first] = py_bindings_tools::serializeMsgByteString(it->second);
 
     return py_bindings_tools::dictFromType(ser_objs);
   }
@@ -96,15 +96,15 @@ public:
   {
     std::map<std::string, moveit_msgs::AttachedCollisionObject> aobjs =
         getAttachedObjects(py_bindings_tools::stringFromList(object_ids));
-    std::map<std::string, std::string> ser_aobjs;
+    std::map<std::string, py_bindings_tools::ByteString> ser_aobjs;
     for (std::map<std::string, moveit_msgs::AttachedCollisionObject>::const_iterator it = aobjs.begin();
          it != aobjs.end(); ++it)
-      ser_aobjs[it->first] = py_bindings_tools::serializeMsg(it->second);
+      ser_aobjs[it->first] = py_bindings_tools::serializeMsgByteString(it->second);
 
     return py_bindings_tools::dictFromType(ser_aobjs);
   }
 
-  bool applyPlanningScenePython(const std::string& ps_str)
+  bool applyPlanningScenePython(const py_bindings_tools::ByteString& ps_str)
   {
     moveit_msgs::PlanningScene ps_msg;
     py_bindings_tools::deserializeMsg(ps_str, ps_msg);

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -223,14 +223,14 @@ public:
     return true;
   }
 
-  std::string getCurrentState()
+  py_bindings_tools::ByteString getCurrentState()
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString("");
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     moveit_msgs::RobotState msg;
     robot_state::robotStateToRobotStateMsg(*s, msg);
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
   bp::tuple getEndEffectorParentGroup(const std::string& group)
@@ -244,7 +244,7 @@ public:
     return boost::python::make_tuple(parent_group.first, parent_group.second);
   }
 
-  std::string getRobotMarkersPythonDictList(bp::dict& values, bp::list& links)
+  py_bindings_tools::ByteString getRobotMarkersPythonDictList(bp::dict& values, bp::list& links)
   {
     robot_state::RobotStatePtr state;
     if (ensureCurrentState())
@@ -270,16 +270,16 @@ public:
     visualization_msgs::MarkerArray msg;
     state->getRobotMarkers(msg, py_bindings_tools::stringFromList(links));
 
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
-  std::string getRobotMarkersPythonDict(bp::dict& values)
+  py_bindings_tools::ByteString getRobotMarkersPythonDict(bp::dict& values)
   {
     bp::list links = py_bindings_tools::listFromString(robot_model_->getLinkModelNames());
     return getRobotMarkersPythonDictList(values, links);
   }
 
-  std::string getRobotMarkersFromMsg(const std::string& state_str)
+  py_bindings_tools::ByteString getRobotMarkersFromMsg(const py_bindings_tools::ByteString& state_str)
   {
     moveit_msgs::RobotState state_msg;
     robot_state::RobotState state(robot_model_);
@@ -289,35 +289,35 @@ public:
     visualization_msgs::MarkerArray msg;
     state.getRobotMarkers(msg, state.getRobotModel()->getLinkModelNames());
 
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
-  std::string getRobotMarkers()
+  py_bindings_tools::ByteString getRobotMarkers()
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString();
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     visualization_msgs::MarkerArray msg;
     s->getRobotMarkers(msg, s->getRobotModel()->getLinkModelNames());
 
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
-  std::string getRobotMarkersPythonList(const bp::list& links)
+  py_bindings_tools::ByteString getRobotMarkersPythonList(const bp::list& links)
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString("");
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     visualization_msgs::MarkerArray msg;
     s->getRobotMarkers(msg, py_bindings_tools::stringFromList(links));
 
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
-  std::string getRobotMarkersGroup(const std::string& group)
+  py_bindings_tools::ByteString getRobotMarkersGroup(const std::string& group)
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString("");
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     visualization_msgs::MarkerArray msg;
@@ -326,14 +326,14 @@ public:
       s->getRobotMarkers(msg, jmg->getLinkModelNames());
     }
 
-    return py_bindings_tools::serializeMsg(msg);
+    return py_bindings_tools::serializeMsgByteString(msg);
   }
 
-  std::string getRobotMarkersGroupPythonDict(const std::string& group, bp::dict& values)
+  py_bindings_tools::ByteString getRobotMarkersGroupPythonDict(const std::string& group, bp::dict& values)
   {
     const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (!jmg)
-      return "";
+      return py_bindings_tools::ByteString("");
     bp::list links = py_bindings_tools::listFromString(jmg->getLinkModelNames());
     return getRobotMarkersPythonDictList(values, links);
   }

--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -453,7 +453,7 @@ class MoveitJoy:
                 self.marker_lock.acquire()
                 self.initialize_poses = True
                 topic_suffix = next_topic.split("/")[-1]
-                if self.initial_poses.has_key(topic_suffix):
+                if topic_suffix in self.initial_poses:
                     self.pre_pose = PoseStamped(pose=self.initial_poses[topic_suffix])
                     self.initialize_poses = False
                     return True


### PR DESCRIPTION
### Description

Messages are passed between C++ and Python via wrapper classes written in C++ and boost::python. These messages are (de-) serialized on both sides. With Python 3, `std::string` are implicitly converted to `Unicode` objects by boost which does not work with arbitrary binary data.
When compiled with Python 3, a new C++ class (`moveit::py_bindings_tools::ByteString`) builds a bridge between `std::string` and Python 3 `Bytes` objects. Nothing is changed under Python 2.

Related: #1722 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
