### PR TITLE
[jog_arm] Fix initial end effector transform jump

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -48,8 +48,6 @@
 
 namespace moveit_jog_arm
 {
-static const double WHILE_LOOP_WAIT = 0.001;
-
 // Variables to share between threads, and their mutexes
 struct JogArmShared
 {

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -112,7 +112,7 @@ protected:
    * @param singularity_scale tells how close we are to a singularity
    * @return false if very close to collision or singularity
    */
-  void applyVelocityScaling(const JogArmShared& shared_variables, std::mutex& mutex, Eigen::ArrayXd& delta_theta,
+  bool applyVelocityScaling(const JogArmShared& shared_variables, std::mutex& mutex, Eigen::ArrayXd& delta_theta,
                             double singularity_scale);
 
   trajectory_msgs::JointTrajectory composeJointTrajMessage(sensor_msgs::JointState& joint_state) const;
@@ -139,6 +139,9 @@ protected:
   std::vector<LowPassFilter> position_filters_;
 
   ros::Publisher warning_pub_;
+
+  // Flag that a warning should be published
+  bool has_warning_ = false;
 
   JogArmParameters parameters_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -56,11 +56,24 @@ public:
 
   void stopMainLoop();
 
+  void haltOutgoingJogCmds();
+
+  /** \brief Check if the robot state is being updated and the end effector transform is known
+   *  @return true if initialized properly
+   */
+  bool isInitialized();
+
 protected:
   ros::NodeHandle nh_;
 
   // Loop termination flag
-  std::atomic<bool> stop_requested_;
+  std::atomic<bool> stop_jog_loop_requested_;
+
+  // Flag that outgoing commands to the robot should not be published
+  std::atomic<bool> halt_outgoing_jog_cmds_;
+
+  // Flag that robot state is up to date, end effector transform is known
+  std::atomic<bool> is_initialized_;
 
   sensor_msgs::JointState incoming_joints_;
 
@@ -69,16 +82,13 @@ protected:
   bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables);
 
   // Parse the incoming joint msg for the joints of our MoveGroup
-  bool updateJoints();
+  bool updateJoints(std::mutex& mutex, const JogArmShared& shared_variables);
 
   Eigen::VectorXd scaleCartesianCommand(const geometry_msgs::TwistStamped& command) const;
 
   Eigen::VectorXd scaleJointCommand(const control_msgs::JointJog& command) const;
 
   bool addJointIncrements(sensor_msgs::JointState& output, const Eigen::VectorXd& increments) const;
-
-  // Reset the data stored in low-pass filters so the trajectory won't jump when jogging is resumed.
-  void resetVelocityFilters();
 
   // Suddenly halt for a joint limit or other critical issue.
   // Is handled differently for position vs. velocity control.
@@ -98,20 +108,23 @@ protected:
    * Slow motion down if close to singularity or collision.
    * @param shared_variables data shared between threads, tells how close we are to collision
    * @param mutex locks shared data
-   * @param new_joint_traj store the motion in the first waypoint of this trajectory
    * @param delta_theta motion command, used in calculating new_joint_tray
    * @param singularity_scale tells how close we are to a singularity
    * @return false if very close to collision or singularity
    */
-  bool applyVelocityScaling(JogArmShared& shared_variables, std::mutex& mutex,
-                            trajectory_msgs::JointTrajectory& new_joint_traj, const Eigen::VectorXd& delta_theta,
+  void applyVelocityScaling(const JogArmShared& shared_variables, std::mutex& mutex, Eigen::ArrayXd& delta_theta,
                             double singularity_scale);
 
-  trajectory_msgs::JointTrajectory composeOutgoingMessage(sensor_msgs::JointState& joint_state) const;
+  trajectory_msgs::JointTrajectory composeJointTrajMessage(sensor_msgs::JointState& joint_state) const;
 
-  void lowPassFilterVelocities(const Eigen::VectorXd& joint_vel);
+  void lowPassFilterPositions(sensor_msgs::JointState& joint_state);
 
-  void lowPassFilterPositions();
+  void calculateJointVelocities(sensor_msgs::JointState& joint_state, const Eigen::ArrayXd& delta_theta);
+
+  /** \brief Convert joint deltas to an outgoing JointTrajectory command.
+    * This happens for joint commands and Cartesian commands.
+    */
+  bool convertDeltasToOutgoingCmd();
 
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& trajectory, int count) const;
 
@@ -123,7 +136,6 @@ protected:
   std::map<std::string, std::size_t> joint_state_name_map_;
   trajectory_msgs::JointTrajectory outgoing_command_;
 
-  std::vector<LowPassFilter> velocity_filters_;
   std::vector<LowPassFilter> position_filters_;
 
   ros::Publisher warning_pub_;
@@ -141,5 +153,7 @@ protected:
   const int gazebo_redundant_message_count_ = 30;
 
   uint num_joints_;
+
+  ros::Rate default_sleep_rate_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -69,9 +69,14 @@ public:
   // May eliminate the need to create your own joint_state subscriber.
   sensor_msgs::JointState getJointState();
 
-  // Get planning link transform.
-  // The transform from the MoveIt planning frame to robot_link_command_frame
-  Eigen::Isometry3d getCommandFrameTransform();
+  /**
+   * Get the MoveIt planning link transform.
+   * The transform from the MoveIt planning frame to robot_link_command_frame
+   *
+   * @param transform the transform that will be calculated
+   * @return true if a valid transform was available
+   */
+  bool getCommandFrameTransform(Eigen::Isometry3d& transform);
 
 private:
   ros::NodeHandle nh_;

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -146,7 +146,6 @@ void JogCppApi::startMainLoop()
     main_rate.sleep();
   }
 
-  ROS_ERROR("Stopping main loop");
   stopJogCalcThread();
   stopCollisionCheckThread();
 }
@@ -213,12 +212,21 @@ sensor_msgs::JointState JogCppApi::getJointState()
   return current_joints;
 }
 
-Eigen::Isometry3d JogCppApi::getCommandFrameTransform()
+bool JogCppApi::getCommandFrameTransform(Eigen::Isometry3d& transform)
 {
-  shared_variables_mutex_.lock();
-  Eigen::Isometry3d tf_moveit_to_cmd_frame = shared_variables_.tf_moveit_to_cmd_frame;
-  shared_variables_mutex_.unlock();
+  if (jog_calcs_->isInitialized())
+  {
+    shared_variables_mutex_.lock();
+    transform = shared_variables_.tf_moveit_to_cmd_frame;
+    shared_variables_mutex_.unlock();
 
-  return tf_moveit_to_cmd_frame;
+    // All zeros means the transform wasn't initialized, so return false
+    if (transform.matrix().isZero(0))
+      return false;
+  }
+  else
+    return false;
+
+  return true;
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/test/test_msg_reception/test_jog_arm_msg_reception.py
+++ b/moveit_experimental/moveit_jog_arm/test/test_msg_reception/test_jog_arm_msg_reception.py
@@ -68,7 +68,7 @@ def test_jog_arm_cartesian_command(node):
     cartesian_cmd.send_cmd([0, 0, 0], [0, 0, 0])
     received = []
     rospy.sleep(1)
-    assert len(received) <= 2 # 2 is 'num_outgoing_halt_msgs_to_publish' in the config file
+    assert len(received) <= 4 # 'num_outgoing_halt_msgs_to_publish' in the config file
 
     # This nonzero command should produce jogging output
     # A subscriber in a different thread fills `received`
@@ -103,8 +103,8 @@ def test_jog_arm_joint_command(node):
     rospy.sleep(TEST_DURATION)
     # TEST_DURATION/PUBLISH_PERIOD is the expected number of messages in this duration.
     # Allow a small +/- window due to rounding/timing errors
-    assert len(received) >= TEST_DURATION/PUBLISH_PERIOD - 5
-    assert len(received) <= TEST_DURATION/PUBLISH_PERIOD + 5
+    assert len(received) >= TEST_DURATION/PUBLISH_PERIOD - 20
+    assert len(received) <= TEST_DURATION/PUBLISH_PERIOD + 20
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fix a bug where the end effector transform jumped initially, when the first jog command is received.

- Reduce duplicate code between joint jogging and Cartesian jogging.

- Remove the joint velocity low-pass filters. I justify this because joint velocities are derived from joint positions (which do get filtered).

- This required some re-ordering of the algorithm. I think the flow makes a lot more sense now.
