### PR TITLE
add warnings to jog_arm low_pass filter

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
@@ -51,6 +51,9 @@ namespace moveit_jog_arm
 class LowPassFilter
 {
 public:
+  // Larger filter_coeff-> more smoothing of jog commands, but more lag.
+  // Rough plot, with cutoff frequency on the y-axis:
+  // https://www.wolframalpha.com/input/?i=plot+arccot(c)
   explicit LowPassFilter(double low_pass_filter_coeff);
   double filter(double new_measurement);
   void reset(double data);
@@ -59,10 +62,6 @@ private:
   static constexpr std::size_t FILTER_LENGTH = 2;
   double previous_measurements_[FILTER_LENGTH];
   double previous_filtered_measurement_;
-  // Larger filter_coeff-> more smoothing of jog commands, but more lag.
-  // Rough plot, with cutoff frequency on the y-axis:
-  // https://www.wolframalpha.com/input/?i=plot+arccot(c)
-  const double filter_coeff_;
   // Scale and feedback term are calculated from supplied filter coefficient
   const double scale_term_;
   const double feedback_term_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace moveit_jog_arm
 {
 /**
@@ -54,8 +56,9 @@ public:
   void reset(double data);
 
 private:
-  double previous_measurements_[2] = { 0., 0. };
-  double previous_filtered_measurement_ = 0.;
+  static constexpr std::size_t FILTER_LENGTH = 2;
+  double previous_measurements_[FILTER_LENGTH];
+  double previous_filtered_measurement_;
   // Larger filter_coeff-> more smoothing of jog commands, but more lag.
   // Rough plot, with cutoff frequency on the y-axis:
   // https://www.wolframalpha.com/input/?i=plot+arccot(c)

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
@@ -59,6 +59,9 @@ private:
   // Larger filter_coeff-> more smoothing of jog commands, but more lag.
   // Rough plot, with cutoff frequency on the y-axis:
   // https://www.wolframalpha.com/input/?i=plot+arccot(c)
-  double filter_coeff_ = 10.;
+  const double filter_coeff_;
+  // Scale and feedback term are calculated from supplied filter coefficient
+  const double scale_term_;
+  const double feedback_term_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -39,6 +39,7 @@
 
 #include <moveit_jog_arm/low_pass_filter.h>
 #include <string>
+#include <ros/ros.h>
 
 static const std::string LOGNAME = "low_pass_filter";
 
@@ -47,6 +48,18 @@ namespace moveit_jog_arm
 LowPassFilter::LowPassFilter(double low_pass_filter_coeff)
 {
   filter_coeff_ = low_pass_filter_coeff;
+  if (low_pass_filter_coeff == 1.0)
+  {
+    ROS_WARN_NAMED(LOGNAME, "LowPassFilter constructed as a 2 tap boxcar FIR");
+  }
+  else if (low_pass_filter_coeff == -1.0)
+  {
+    ROS_FATAL_NAMED(LOGNAME, "LowPassFilter coeff value of -1.0 will result in divide by zero error");
+  }
+  else if (low_pass_filter_coeff < 1.0)
+  {
+    ROS_ERROR_NAMED(LOGNAME, "LowPassFilter constructed as an unstable IIR");
+  }
 }
 
 void LowPassFilter::reset(double data)

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -55,7 +55,7 @@ LowPassFilter::LowPassFilter(double low_pass_filter_coeff)
   , feedback_term_(1. - low_pass_filter_coeff)
 {
   // guarantee this doesn't change because the logic depends on this length implicity
-  static_assert(LowPassFilter::FILTER_LENGTH == 2);
+  static_assert(LowPassFilter::FILTER_LENGTH == 2, "moveit_jog_arm::LowPassFilter::FILTER_LENGTH should be 2");
 
   if (std::abs(feedback_term_) < EPSILON)
   {

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -76,7 +76,7 @@ LowPassFilter::LowPassFilter(double low_pass_filter_coeff)
   {
     ROS_ERROR_STREAM_NAMED(
         LOGNAME,
-        "Filter coefficient < 1. makes single order Butterworth an unstable Infinite Impulse Response (IIR) filter, ");
+        "Filter coefficient < 1. makes single order Butterworth an unstable Infinite Impulse Response (IIR) filter");
   }
 }
 
@@ -94,12 +94,12 @@ double LowPassFilter::filter(double new_measurement)
   previous_measurements_[1] = previous_measurements_[0];
   previous_measurements_[0] = new_measurement;
 
-  double new_filtered_msrmt = scale_term_ * (previous_measurements_[1] + previous_measurements_[0] -
-                                             feedback_term_ * previous_filtered_measurement_);
+  double new_filtered_measurement = scale_term_ * (previous_measurements_[1] + previous_measurements_[0] -
+                                                   feedback_term_ * previous_filtered_measurement_);
 
   // Store the new filtered measurement
-  previous_filtered_measurement_ = new_filtered_msrmt;
+  previous_filtered_measurement_ = new_filtered_measurement;
 
-  return new_filtered_msrmt;
+  return new_filtered_measurement;
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -42,39 +42,37 @@
 #include <string>
 #include <ros/ros.h>
 
-const std::string LOGNAME = "low_pass_filter";
-constexpr double EPSILON = 1e-9;
-
 namespace moveit_jog_arm
 {
+namespace
+{
+constexpr char LOGNAME[] = "low_pass_filter";
+constexpr double EPSILON = 1e-9;
+}
+
 LowPassFilter::LowPassFilter(double low_pass_filter_coeff)
   : previous_measurements_{ 0., 0. }
   , previous_filtered_measurement_(0.)
-  , filter_coeff_(low_pass_filter_coeff)
   , scale_term_(1. / (1. + low_pass_filter_coeff))
   , feedback_term_(1. - low_pass_filter_coeff)
 {
-  // guarantee this doesn't change because the logic depends on this length implicity
+  // guarantee this doesn't change because the logic below depends on this length implicity
   static_assert(LowPassFilter::FILTER_LENGTH == 2, "moveit_jog_arm::LowPassFilter::FILTER_LENGTH should be 2");
+
+  ROS_ASSERT_MSG(!std::isinf(feedback_term_), "%s: outputs from filter will be inf because feedback term is inf",
+                 LOGNAME);
+  ROS_ASSERT_MSG(!std::isinf(scale_term_), "%s: outputs from filter will be inf because denominator of scale is 0",
+                 LOGNAME);
+  ROS_ASSERT_MSG(low_pass_filter_coeff >= 1., "%s: Filter coefficient < 1. makes the lowpass filter unstable", LOGNAME);
 
   if (std::abs(feedback_term_) < EPSILON)
   {
     ROS_WARN_STREAM_NAMED(
         LOGNAME, "Filter coefficient value of "
-                     << filter_coeff_
+                     << low_pass_filter_coeff
                      << " resulted in feedback term of 0. "
                         " This results in a window averaging Finite Impulse Response (FIR) filter with a gain of "
                      << scale_term_ * LowPassFilter::FILTER_LENGTH);
-  }
-  if (std::isinf(scale_term_))
-  {
-    ROS_FATAL_STREAM_NAMED(LOGNAME, "Filter coefficient value of "
-                                        << filter_coeff_
-                                        << ", outputs from filter will be inf because denominator of scale is 0");
-  }
-  if (filter_coeff_ < 1.)
-  {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "Filter coefficient < 1. makes the lowpass filter unstable");
   }
 }
 

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -74,9 +74,7 @@ LowPassFilter::LowPassFilter(double low_pass_filter_coeff)
   }
   if (filter_coeff_ < 1.)
   {
-    ROS_ERROR_STREAM_NAMED(
-        LOGNAME,
-        "Filter coefficient < 1. makes single order Butterworth an unstable Infinite Impulse Response (IIR) filter");
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Filter coefficient < 1. makes the lowpass filter unstable");
   }
 }
 

--- a/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/low_pass_filter.cpp
@@ -52,9 +52,9 @@ LowPassFilter::LowPassFilter(double low_pass_filter_coeff)
   , previous_filtered_measurement_(0.)
   , filter_coeff_(low_pass_filter_coeff)
   , scale_term_(1. / (1. + low_pass_filter_coeff))
-  , feedback_term_(-low_pass_filter_coeff + 1.)
+  , feedback_term_(1. - low_pass_filter_coeff)
 {
-  // guarentee this doesn't change because the logic depends on this length implicity
+  // guarantee this doesn't change because the logic depends on this length implicity
   static_assert(LowPassFilter::FILTER_LENGTH == 2);
 
   if (std::abs(feedback_term_) < EPSILON)


### PR DESCRIPTION
### Description

These warnings and errors handle warning the user of bad input parameter values for the low pass filter in jog arm.  Here is the function of the feedback magnitude with respect to the `low_pass_filter_coeff` value: https://www.wolframalpha.com/input/?i=y+%3D+%281%2F%281%2Bx%29%29+*+%281-x%29

Here is a small python script that shows why these values are problematic:

```python
def run_filter(mu, length):
  x0 = x1 = y1 = 0

  y = x = [0 for i in range(length)]
  x[0] = 1

  for i in range(length):
    x1 = x0
    x0 = x[i]

    y[i] = (1.0 / (1.0 + mu)) * (x1 + x0 + (1.0 - mu)*y1)
    y1 = y[i]

  print(mu, sum(y))

run_filter(2.0, 1000)
run_filter(1.0, 1000)
run_filter(0.5, 1000)
run_filter(0, 1000)
run_filter(-0.5, 1000)
run_filter(-0.999, 1000)
run_filter(-2, 1000)

```

output:
```
(2.0, 0.5000000000000002)
(1.0, 1.0)
(0.5, 1.9999999999999991)
(0, 1999.0)
(-0.5, inf)
(-0.999, inf)
(-2, nan)
```

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
