### PR TITLE
Fix spurious warning message (# IK attempts)

### DIFF
--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -346,7 +346,8 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const s
 
           // TODO: Remove in future release (deprecated in PR #1288, Jan-2019, Melodic)
           std::string ksolver_attempts_param_name;
-          if (nh.searchParam(base_param_name + "/kinematics_solver_attempts", ksolver_attempts_param_name))
+          if (nh.searchParam(base_param_name + "/kinematics_solver_attempts", ksolver_attempts_param_name) &&
+              nh.hasParam(ksolver_attempts_param_name))
           {
             ROS_WARN_ONCE_NAMED(LOGNAME, "Kinematics solver doesn't support #attempts anymore, but only a timeout.\n"
                                          "Please remove the parameter '%s' from your configuration.",


### PR DESCRIPTION
Workaround for #1875. Looks like `NodeHandle::searchParam` is buggy and returns true even if it hasn't found the parameter. Similar code proceeds in the same fashion, i.e. using an addition `hasParam()` test:
https://github.com/ros-planning/moveit/blob/1ec63725e998a377edb743bd33819fc9e304dab7/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp#L302-L303