### PR TITLE
Cherry-pick #1685 to melodic-devel

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -157,17 +157,17 @@ void OcTreeRender::setColor(double z_pos, double min_z, double max_z, double col
 void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& octree,
                                   OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode)
 {
-  VVPoint pointBuf_;
-  pointBuf_.resize(octree_depth_);
+  VVPoint point_buf;
+  point_buf.resize(octree_depth_);
 
   // get dimensions of octree
-  double minX, minY, minZ, maxX, maxY, maxZ;
-  octree->getMetricMin(minX, minY, minZ);
-  octree->getMetricMax(maxX, maxY, maxZ);
+  double min_x, min_y, min_z, max_x, max_y, max_z;
+  octree->getMetricMin(min_x, min_y, min_z);
+  octree->getMetricMax(max_x, max_y, max_z);
 
   unsigned int render_mode_mask = static_cast<unsigned int>(octree_voxel_rendering);
 
-  size_t pointCount = 0;
+  size_t point_count = 0;
   {
     // traverse all leafs in the tree:
     for (octomap::OcTree::iterator it = octree->begin(octree_depth_), end = octree->end(); it != end; ++it)
@@ -178,18 +178,18 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
       if (((int)octree->isNodeOccupied(*it) + 1) & render_mode_mask)
       {
         // check if current voxel has neighbors on all sides -> no need to be displayed
-        bool allNeighborsFound = true;
+        bool all_neighbors_found = true;
 
         octomap::OcTreeKey key;
-        octomap::OcTreeKey nKey = it.getKey();
+        octomap::OcTreeKey n_key = it.getKey();
 
-        for (key[2] = nKey[2] - 1; allNeighborsFound && key[2] <= nKey[2] + 1; ++key[2])
+        for (key[2] = n_key[2] - 1; all_neighbors_found && key[2] <= n_key[2] + 1; ++key[2])
         {
-          for (key[1] = nKey[1] - 1; allNeighborsFound && key[1] <= nKey[1] + 1; ++key[1])
+          for (key[1] = n_key[1] - 1; all_neighbors_found && key[1] <= n_key[1] + 1; ++key[1])
           {
-            for (key[0] = nKey[0] - 1; allNeighborsFound && key[0] <= nKey[0] + 1; ++key[0])
+            for (key[0] = n_key[0] - 1; all_neighbors_found && key[0] <= n_key[0] + 1; ++key[0])
             {
-              if (key != nKey)
+              if (key != n_key)
               {
                 octomap::OcTreeNode* node = octree->search(key);
 
@@ -197,34 +197,34 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
                 if (!(node && (((int)octree->isNodeOccupied(node)) + 1) & render_mode_mask))
                 {
                   // we do not have a neighbor => break!
-                  allNeighborsFound = false;
+                  all_neighbors_found = false;
                 }
               }
             }
           }
         }
 
-        display_voxel |= !allNeighborsFound;
+        display_voxel |= !all_neighbors_found;
       }
 
       if (display_voxel)
       {
-        rviz::PointCloud::Point newPoint;
+        rviz::PointCloud::Point new_point;
 
-        newPoint.position.x = it.getX();
-        newPoint.position.y = it.getY();
-        newPoint.position.z = it.getZ();
+        new_point.position.x = it.getX();
+        new_point.position.y = it.getY();
+        new_point.position.z = it.getZ();
 
         float cell_probability;
 
         switch (octree_color_mode)
         {
           case OCTOMAP_Z_AXIS_COLOR:
-            setColor(newPoint.position.z, minZ, maxZ, colorFactor_, &newPoint);
+            setColor(new_point.position.z, min_z, max_z, colorFactor_, &new_point);
             break;
           case OCTOMAP_PROBABLILTY_COLOR:
             cell_probability = it->getOccupancy();
-            newPoint.setColor((1.0f - cell_probability), cell_probability, 0.0);
+            new_point.setColor((1.0f - cell_probability), cell_probability, 0.0);
             break;
           default:
             break;
@@ -232,9 +232,9 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
 
         // push to point vectors
         unsigned int depth = it.getDepth();
-        pointBuf_[depth - 1].push_back(newPoint);
+        point_buf[depth - 1].push_back(new_point);
 
-        ++pointCount;
+        ++point_count;
       }
     }
   }
@@ -246,8 +246,8 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
     cloud_[i]->clear();
     cloud_[i]->setDimensions(size, size, size);
 
-    cloud_[i]->addPoints(&pointBuf_[i].front(), pointBuf_[i].size());
-    pointBuf_[i].clear();
+    cloud_[i]->addPoints(&point_buf[i].front(), point_buf[i].size());
+    point_buf[i].clear();
   }
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -169,6 +169,8 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
 
   size_t point_count = 0;
   {
+    int step_size = 1 << (octree->getTreeDepth() - octree_depth_);  // for pruning of occluded voxels
+
     // traverse all leafs in the tree:
     for (octomap::OcTree::iterator it = octree->begin(octree_depth_), end = octree->end(); it != end; ++it)
     {
@@ -181,20 +183,35 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
         bool all_neighbors_found = true;
 
         octomap::OcTreeKey key;
-        octomap::OcTreeKey n_key = it.getKey();
+        octomap::OcTreeKey n_key = it.getIndexKey();  // key of the maximum-depth voxel at the current voxel corner
 
-        for (key[2] = n_key[2] - 1; all_neighbors_found && key[2] <= n_key[2] + 1; ++key[2])
+        // determine indices of potentially neighboring voxels for depths < maximum tree depth
+        // +/-1 at maximum depth, -1 and +depth_difference on other depths
+        int diff_base = 1 << (octree->getTreeDepth() - it.getDepth());
+        int diff[2] = { -1, diff_base };
+
+        // cells with adjacent faces can occlude a voxel, iterate over the cases x,y,z (idxCase) and +/- (diff)
+        for (unsigned int idx_case = 0; idx_case < 3; ++idx_case)
         {
-          for (key[1] = n_key[1] - 1; all_neighbors_found && key[1] <= n_key[1] + 1; ++key[1])
+          int idx_0 = idx_case % 3;
+          int idx_1 = (idx_case + 1) % 3;
+          int idx_2 = (idx_case + 2) % 3;
+
+          for (int i = 0; all_neighbors_found && i < 2; ++i)
           {
-            for (key[0] = n_key[0] - 1; all_neighbors_found && key[0] <= n_key[0] + 1; ++key[0])
+            key[idx_0] = n_key[idx_0] + diff[i];
+            // if rendering is restricted to treeDepth < maximum tree depth inner nodes with distance step_size can
+            // already occlude a voxel
+            for (key[idx_1] = n_key[idx_1] + diff[0] + 1; all_neighbors_found && key[idx_1] < n_key[idx_1] + diff[1];
+                 key[idx_1] += step_size)
             {
-              if (key != n_key)
+              for (key[idx_2] = n_key[idx_2] + diff[0] + 1; all_neighbors_found && key[idx_2] < n_key[idx_2] + diff[1];
+                   key[idx_2] += step_size)
               {
-                octomap::OcTreeNode* node = octree->search(key);
+                octomap::OcTreeNode* node = octree->search(key, octree_depth_);
 
                 // the left part evaluates to 1 for free voxels and 2 for occupied voxels
-                if (!(node && (((int)octree->isNodeOccupied(node)) + 1) & render_mode_mask))
+                if (!(node && ((((int)octree->isNodeOccupied(node)) + 1) & render_mode_mask)))
                 {
                   // we do not have a neighbor => break!
                   all_neighbors_found = false;


### PR DESCRIPTION
This cherry-picks the bugfix from #1685 to melodic-devel, previously applying the variable name changes originally introduced by clang-tidy on master branch.