### PR TITLE
[Windows][master] Fix various build breaks found in Windows build

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 if(WIN32)
   find_package(Boost REQUIRED system filesystem date_time thread iostreams zlib)
 else()
+  #catkin_lint: ignore_once shadowed_find
   find_package(Boost REQUIRED system filesystem date_time thread iostreams)
 endif()
 find_package(Eigen3 REQUIRED)

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -22,7 +22,12 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time thread iostreams zlib)
+# boost::iostreams on Windows depends on boost::zlib
+if(WIN32)
+  find_package(Boost REQUIRED system filesystem date_time thread iostreams zlib)
+else()
+  find_package(Boost REQUIRED system filesystem date_time thread iostreams)
+endif()
 find_package(Eigen3 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -5,10 +5,12 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Warnings
-add_compile_options(-Wall -Wextra
-  -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
-  -Wno-unused-parameter -Wno-unused-function)
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Warnings
+  add_compile_options(-Wall -Wextra
+    -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
+    -Wno-unused-parameter -Wno-unused-function)
+endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # This too often has false-positives
   add_compile_options(-Wno-maybe-uninitialized)
@@ -20,7 +22,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time thread iostreams)
+find_package(Boost REQUIRED system filesystem date_time thread iostreams zlib)
 find_package(Eigen3 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # Warnings
+  # Enable warnings
   add_compile_options(-Wall -Wextra
     -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
     -Wno-unused-parameter -Wno-unused-function)
@@ -24,11 +24,9 @@ endif()
 
 # boost::iostreams on Windows depends on boost::zlib
 if(WIN32)
-  find_package(Boost REQUIRED system filesystem date_time thread iostreams zlib)
-else()
-  #catkin_lint: ignore_once shadowed_find
-  find_package(Boost REQUIRED system filesystem date_time thread iostreams)
+  set(EXTRA_BOOST_COMPONENTS zlib)
 endif()
+find_package(Boost REQUIRED system filesystem date_time thread iostreams ${EXTRA_BOOST_COMPONENTS})
 find_package(Eigen3 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -2,9 +2,12 @@ set(MOVEIT_LIB_NAME moveit_kinematics_base)
 
 add_library(${MOVEIT_LIB_NAME} src/kinematics_base.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-# Avoid warnings about deprecated members of KinematicsBase when building KinematicsBase itself.
-# TODO: remove when deperecated variables (tip_frame_, search_discretization_) are finally removed.
-target_compile_options(${MOVEIT_LIB_NAME} PRIVATE -Wno-deprecated-declarations)
+
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Avoid warnings about deprecated members of KinematicsBase when building KinematicsBase itself.
+  # TODO: remove when deperecated variables (tip_frame_, search_discretization_) are finally removed.
+  target_compile_options(${MOVEIT_LIB_NAME} PRIVATE -Wno-deprecated-declarations)
+endif()
 
 # This line is needed to ensure that messages are done being built before this is built
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_kinematics/test/CMakeLists.txt
+++ b/moveit_kinematics/test/CMakeLists.txt
@@ -8,7 +8,9 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_executable_with_gtest(test_kinematics_plugin test_kinematics_plugin.cpp)
   target_link_libraries(test_kinematics_plugin ${catkin_LIBRARIES} ${moveit_ros_planning_LIBRARIES} ${xmlrpcpp_LIBRARIES})
-  target_compile_options(test_kinematics_plugin PRIVATE -Wno-deprecated-declarations)
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(test_kinematics_plugin PRIVATE -Wno-deprecated-declarations)
+  endif()
 
   set(DEPS DEPENDENCIES test_kinematics_plugin)
   set(ARGS ARGS ik_plugin:=kdl_kinematics_plugin/KDLKinematicsPlugin)

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${MOVEIT_LIB_NAME}
   )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} glut GLEW)
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} ${GLUT_LIBRARIES} ${GLEW_LIBRARIES})
 
 if (CATKIN_ENABLE_TESTING)
   #catkin_lint: ignore_once env_var

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${MOVEIT_LIB_NAME}
   )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} ${GLUT_LIBRARIES} ${GLEW_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} GLUT::GLUT ${GLEW_LIBRARIES})
 
 if (CATKIN_ENABLE_TESTING)
   #catkin_lint: ignore_once env_var


### PR DESCRIPTION
### Description

Fix various build breaks found in Windows build:
* Conditionally guard some add_compile_options doesn't apply to `MSVC`.
* Add `zlib` as a dependency to look for in `Boost`. (On Windows, `boost::iostreams` depends on `boost::zlib` at linkage time.)
* Replace `glut` and `GLEW` with the CMake variables.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
