### PR TITLE
Initialize zero dynamics in CurrentStateMonitor

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -144,9 +144,9 @@ void RobotState::copyFrom(const RobotState& other)
   if (dirty_link_transforms_ == robot_model_->getRootJoint())
   {
     // everything is dirty; no point in copying transforms; copy positions, potentially velocity & acceleration
-    memcpy(position_, other.position_, robot_model_->getVariableCount() * sizeof(double) *
-                                           (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
-                                            ((has_acceleration_ || has_effort_) ? 1 : 0)));
+    memcpy(position_, other.position_,
+           robot_model_->getVariableCount() * sizeof(double) *
+               (1 + (has_velocity_ ? 1 : 0) + ((has_acceleration_ || has_effort_) ? 1 : 0)));
     // and just initialize transforms
     initTransforms();
   }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -385,7 +385,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
       {
         // update joint velocities
         if (joint_state->name.size() == joint_state->velocity.size() &&
-            robot_state_.getJointVelocities(jm)[0] != joint_state->velocity[i])
+            (!robot_state_.hasVelocities() || robot_state_.getJointVelocities(jm)[0] != joint_state->velocity[i]))
         {
           update = true;
           robot_state_.setJointVelocities(jm, &(joint_state->velocity[i]));
@@ -393,7 +393,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
 
         // update joint efforts
         if (joint_state->name.size() == joint_state->effort.size() &&
-            robot_state_.getJointEffort(jm)[0] != joint_state->effort[i])
+            (!robot_state_.hasEffort() || robot_state_.getJointEffort(jm)[0] != joint_state->effort[i]))
         {
           update = true;
           robot_state_.setJointEfforts(jm, &(joint_state->effort[i]));


### PR DESCRIPTION
Currently, when setting `copy_dynamics_` to `true`, the current state would not have any velocity or effort values (i.e. `RobotSate::hasVelocities()` is *false*) if the joint state message only contains zero values for dynamics. IMO the values should be written to the robot state initially so that a caller can check if dynamics have been updated or not even though the values are 0. With this PR, the robot state dynamics will always be updated if `hasVelocities()`/`hasEffort()` are false.