### PR TITLE
[melodic][cherry-pick] remove GCC extension and alternative operator usage. (#1583)

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1200,7 +1200,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     const JointModel* pjm = link->getParentJointModel();
     if (pjm->getVariableCount() > 0)
     {
-      if (not group->hasJointModel(pjm->getName()))
+      if (!group->hasJointModel(pjm->getName()))
       {
         link = pjm->getParentLinkModel();
         continue;

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -120,14 +120,14 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
     return;
   }
   // First link should already be added.
-  if (not urdf_model_->getLink(link_names[0]))
+  if (!urdf_model_->getLink(link_names[0]))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_names[0].c_str());
     is_valid_ = false;
     return;
   }
 
-  if (not joint_origins.empty() && link_names.size() - 1 != joint_origins.size())
+  if (!joint_origins.empty() && link_names.size() - 1 != joint_origins.size())
   {
     ROS_ERROR_NAMED(LOGNAME, "There should be one more link (%zu) than there are joint origins (%zu)",
                     link_names.size(), joint_origins.size());
@@ -152,7 +152,7 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
     joint->name = link_names[i - 1] + "-" + link_names[i] + "-joint";
     // Default to Identity transform for origins.
     joint->parent_to_joint_origin_transform.clear();
-    if (not joint_origins.empty())
+    if (!joint_origins.empty())
     {
       geometry_msgs::Pose o = joint_origins[i - 1];
       joint->parent_to_joint_origin_transform.position = urdf::Vector3(o.position.x, o.position.y, o.position.z);
@@ -197,7 +197,7 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
 void RobotModelBuilder::addInertial(const std::string& link_name, double mass, geometry_msgs::Pose origin, double ixx,
                                     double ixy, double ixz, double iyy, double iyz, double izz)
 {
-  if (not urdf_model_->getLink(link_name))
+  if (!urdf_model_->getLink(link_name))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_name.c_str());
     is_valid_ = false;
@@ -260,7 +260,7 @@ void RobotModelBuilder::addCollisionMesh(const std::string& link_name, const std
 void RobotModelBuilder::addLinkCollision(const std::string& link_name, const urdf::CollisionSharedPtr& collision,
                                          geometry_msgs::Pose origin)
 {
-  if (not urdf_model_->getLink(link_name))
+  if (!urdf_model_->getLink(link_name))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_name.c_str());
     is_valid_ = false;
@@ -278,7 +278,7 @@ void RobotModelBuilder::addLinkCollision(const std::string& link_name, const urd
 void RobotModelBuilder::addLinkVisual(const std::string& link_name, const urdf::VisualSharedPtr& vis,
                                       geometry_msgs::Pose origin)
 {
-  if (not urdf_model_->getLink(link_name))
+  if (!urdf_model_->getLink(link_name))
   {
     ROS_ERROR_NAMED(LOGNAME, "Link %s not present in builder yet!", link_name.c_str());
     is_valid_ = false;
@@ -290,7 +290,7 @@ void RobotModelBuilder::addLinkVisual(const std::string& link_name, const urdf::
 
   urdf::LinkSharedPtr link;
   urdf_model_->getLink(link_name, link);
-  if (not link->visual_array.empty())
+  if (!link->visual_array.empty())
   {
     link->visual_array.push_back(vis);
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -218,7 +218,7 @@ void ChompTrajectory::fillInMinJerk()
   // calculate the spline coefficients for each joint:
   // (these are for the special case of zero start and end vel and acc)
   std::vector<double[6]> coeff(num_joints_);
-  for (size_t i = 0; i < num_joints_; i++)
+  for (int i = 0; i < num_joints_; i++)
   {
     double x0 = (*this)(start_index, i);
     double x1 = (*this)(end_index, i);

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -217,8 +217,8 @@ void ChompTrajectory::fillInMinJerk()
 
   // calculate the spline coefficients for each joint:
   // (these are for the special case of zero start and end vel and acc)
-  double coeff[num_joints_][6];
-  for (int i = 0; i < num_joints_; i++)
+  std::vector<double[6]> coeff(num_joints_);
+  for (size_t i = 0; i < num_joints_; i++)
   {
     double x0 = (*this)(start_index, i);
     double x1 = (*this)(end_index, i);

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -444,20 +444,20 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
         continue;
       joint_time_[joint] = latest_common_time;
 
-      double new_values[joint->getStateSpaceDimension()];
+      std::vector<double> new_values(joint->getStateSpaceDimension());
       const robot_model::LinkModel* link = joint->getChildLinkModel();
       if (link->jointOriginTransformIsIdentity())
-        joint->computeVariablePositions(tf2::transformToEigen(transf), new_values);
+        joint->computeVariablePositions(tf2::transformToEigen(transf), new_values.data());
       else
         joint->computeVariablePositions(link->getJointOriginTransform().inverse() * tf2::transformToEigen(transf),
-                                        new_values);
+                                        new_values.data());
 
-      if (joint->distance(new_values, robot_state_.getJointPositions(joint)) > 1e-5)
+      if (joint->distance(new_values.data(), robot_state_.getJointPositions(joint)) > 1e-5)
       {
         changes = true;
       }
 
-      robot_state_.setJointPositions(joint, new_values);
+      robot_state_.setJointPositions(joint, new_values.data());
       update = true;
     }
   }


### PR DESCRIPTION
### Description

[melodic][cherry-pick] remove GCC extension and alternative operator usage. (#1583)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
