### PR TITLE
WIP: Reduce default velocity and acceleration scaling to 0.2

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -124,8 +124,8 @@ public:
     goal_orientation_tolerance_ = 1e-3;  // ~0.1 deg
     allowed_planning_time_ = 5.0;
     num_planning_attempts_ = 1;
-    max_velocity_scaling_factor_ = 1.0;
-    max_acceleration_scaling_factor_ = 1.0;
+    max_velocity_scaling_factor_ = 0.2;
+    max_acceleration_scaling_factor_ = 0.2;
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -641,7 +641,7 @@
                <double>0.010000000000000</double>
               </property>
               <property name="value">
-               <double>1.000000000000000</double>
+               <double>0.200000000000000</double>
               </property>
              </widget>
             </item>
@@ -668,7 +668,7 @@
                <double>0.010000000000000</double>
               </property>
               <property name="value">
-               <double>1.000000000000000</double>
+               <double>0.200000000000000</double>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
First part of implementing #1888. According to https://github.com/ros-planning/moveit/issues/1888#issuecomment-584166598 there are two major locations to modify the default scaling factors:
- the MoveGroupInterface and
- the rviz GUI

This PR just hard-codes these factors to a value of 0.2. According to @v4hn original suggestion, the hard-coded values should be replaced by ROS parameters. It remains to decide their name and a location to set them in some config files. What about augmenting [`joint_limits.yaml`](https://github.com/ros-planning/panda_moveit_config/blob/melodic-devel/config/joint_limits.yaml) with parameters `max_velocity_scaling_factor` and `max_acceleration_scaling_factor` at the root level?