### PR TITLE
Add initial poses to fake_controllers.yaml

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -529,6 +529,34 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     emitter << YAML::EndSeq;
     emitter << YAML::EndMap;
   }
+
+  emitter << YAML::EndSeq;
+
+  // Add an initial pose for each group
+  emitter << YAML::Key << "initial" << YAML::Comment("Default robot poses can be defined here");
+  emitter << YAML::Value << YAML::BeginSeq;
+
+  bool found = false;
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    const robot_model::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+
+    for (srdf::Model::GroupState& group_state : srdf_->group_states_)
+    {
+      if (group.name_ == group_state.group_)
+      {
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "group";
+        emitter << YAML::Value << group.name_;
+        emitter << YAML::Key << "pose";
+        emitter << YAML::Value << group_state.name_;
+        emitter << YAML::EndMap;
+        found = true;
+        break;
+      }
+    }
+  }
+
   emitter << YAML::EndSeq;
   emitter << YAML::EndMap;
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -533,10 +533,9 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
   emitter << YAML::EndSeq;
 
   // Add an initial pose for each group
-  emitter << YAML::Key << "initial" << YAML::Comment("Default robot poses can be defined here");
-  emitter << YAML::Value << YAML::BeginSeq;
+  emitter << YAML::Key << "initial" << YAML::Comment("Define initial robot poses.");
 
-  bool found = false;
+  bool pose_found = false;
   for (srdf::Model::Group& group : srdf_->groups_)
   {
     const robot_model::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
@@ -545,19 +544,27 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     {
       if (group.name_ == group_state.group_)
       {
+        if (!pose_found)
+        {
+          pose_found = true;
+          emitter << YAML::Value << YAML::BeginSeq;
+        }
         emitter << YAML::BeginMap;
         emitter << YAML::Key << "group";
         emitter << YAML::Value << group.name_;
         emitter << YAML::Key << "pose";
         emitter << YAML::Value << group_state.name_;
         emitter << YAML::EndMap;
-        found = true;
         break;
       }
     }
   }
+  if (pose_found)
+    emitter << YAML::EndSeq;
+  else
+    // Add commented lines to show how the feature can be used
+    emitter << YAML::Comment(" - group: panda_arm \n   pose: ready");
 
-  emitter << YAML::EndSeq;
   emitter << YAML::EndMap;
 
   std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -64,7 +64,8 @@ RobotPosesWidget::RobotPosesWidget(QWidget* parent, const MoveItConfigDataPtr& c
 
   HeaderWidget* header = new HeaderWidget(
       "Define Robot Poses", "Create poses for the robot. Poses are defined as sets of joint values for "
-                            "particular planning groups. This is useful for things like <i>home position</i>.",
+                            "particular planning groups. This is useful for things like <i>home position</i>."
+                            "The first pose for each robot will be its initial pose in simulation.",
       this);
   layout->addWidget(header);
 


### PR DESCRIPTION
### Description

It looks ugly when robots start up in nonsensical poses when running `demo.launch`, and I don't think it should be the default behavior. Setting the robots' initial pose is perfectly possible, but it requires [a manual addition to `kinematics.yaml`](http://docs.ros.org/api/moveit_tutorials/html/doc/fake_controller_manager/fake_controller_manager_tutorial.html#yaml-file-examples) that users have to look up. This PR changes the behavior of the setup assistant so that if group states (robot poses) are defined in the setup assistant/SRDF, the first one is automatically exported to `kinematics.yaml` as the initial pose of that group.

I believe this will increase discoverability of the feature and be a better default setting.

When no pose is set, the default name "home" is exported. I confirmed that setting the parameter this way does not cause problems and tested it with multiple groups.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers