### PR TITLE
added options to start and end state dropdowns

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -283,12 +283,14 @@ void MotionPlanningFrame::fillStateSelectionOptions()
   const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
+    ui_->start_state_combo_box->addItem(QString("Query Start State"));
     ui_->start_state_combo_box->addItem(QString("<random valid>"));
     ui_->start_state_combo_box->addItem(QString("<random>"));
     ui_->start_state_combo_box->addItem(QString("<current>"));
     ui_->start_state_combo_box->addItem(QString("<same as goal>"));
     ui_->start_state_combo_box->addItem(QString("<previous>"));
 
+    ui_->goal_state_combo_box->addItem(QString("Query Goal State"));
     ui_->goal_state_combo_box->addItem(QString("<random valid>"));
     ui_->goal_state_combo_box->addItem(QString("<random>"));
     ui_->goal_state_combo_box->addItem(QString("<current>"));
@@ -307,8 +309,8 @@ void MotionPlanningFrame::fillStateSelectionOptions()
       }
     }
 
-    ui_->start_state_combo_box->setCurrentIndex(2);  // default to 'current'
-    ui_->goal_state_combo_box->setCurrentIndex(2);   // default to 'current'
+    ui_->start_state_combo_box->setCurrentIndex(0);  // default to 'Query Start State'
+    ui_->goal_state_combo_box->setCurrentIndex(0);   // default to 'Query Goal State'
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -342,13 +342,13 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState& state,
     return;
   }
 
-  if (v == "<same as goal>")
+  if (v == "<same as goal>" || "Query Goal State")
   {
     state = *planning_display_->getQueryGoalState();
     return;
   }
 
-  if (v == "<same as start>")
+  if (v == "<same as start>" || "Query Start State")
   {
     state = *planning_display_->getQueryStartState();
     return;


### PR DESCRIPTION
The current default behavior is unintuitive, and may be wrong. Changing
the start state in the graphical interface does not impact the plan
generated--it just starts from the robot's current state. The sematics
of `<current>` are unclear, and apparently different for the start state
and the end state.

I added the "Query Start State" option to the Start State dropdown menu,
and similarly "Query Goal State" for the Goal State menu. These options
intuitively correspond to the states defined in the graphical interface.
I also made them the default options.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
