### PR TITLE
changes made to ModelBasedStateSpacePtr() calls

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
@@ -52,5 +52,5 @@ int ompl_interface::JointModelStateSpaceFactory::canRepresentProblem(
 ompl_interface::ModelBasedStateSpacePtr
 ompl_interface::JointModelStateSpaceFactory::allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const
 {
-  return ModelBasedStateSpacePtr(new JointModelStateSpace(space_spec));
+  return std::make_shared<JointModelStateSpace(space_spec);
 }

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
@@ -52,5 +52,5 @@ int ompl_interface::JointModelStateSpaceFactory::canRepresentProblem(
 ompl_interface::ModelBasedStateSpacePtr
 ompl_interface::JointModelStateSpaceFactory::allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const
 {
-  return std::make_shared<JointModelStateSpace(space_spec);
+  return std::make_shared<JointModelStateSpace>(space_spec);
 }

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
@@ -86,5 +86,5 @@ int ompl_interface::PoseModelStateSpaceFactory::canRepresentProblem(
 ompl_interface::ModelBasedStateSpacePtr
 ompl_interface::PoseModelStateSpaceFactory::allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const
 {
-  return ModelBasedStateSpacePtr(new PoseModelStateSpace(space_spec));
+  return std::make_shared<PoseModelStateSpace>(space_spec);
 }


### PR DESCRIPTION
### Description

Fixes issue #1411 
So found two occurrences of ModelBasedSpacePtr() allocations and changed it to `std::make_shared` type allocations.
Any other places this performance fix may apply ? 
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
