### PR TITLE
Installs an empty plugin description xml file if bullet is not found

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -224,4 +224,6 @@ add_subdirectory(dynamics_solver)
 
 if(BULLET_ENABLE)
   add_subdirectory(collision_detection_bullet)
+else()
+  install(FILES collision_detection_bullet/empty_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} RENAME collision_detector_bullet_description.xml)
 endif()

--- a/moveit_core/collision_detection_bullet/empty_description.xml
+++ b/moveit_core/collision_detection_bullet/empty_description.xml
@@ -1,0 +1,1 @@
+<class_libraries/>

--- a/moveit_core/collision_detection_bullet/empty_description.xml
+++ b/moveit_core/collision_detection_bullet/empty_description.xml
@@ -1,1 +1,2 @@
+<!-- This file is empty because Bullet 2.87 was not found at compile time -->
 <class_libraries/>


### PR DESCRIPTION
Fair warning: This only fixes the install workspace, in the devel workspace if bullet was not found at compile you will still get errors from pluginlib.

### Description

Added an "empty" pluginlib xml file to be installed in place of `collision_detector_bullet_description.xml` if bullet is not found at compile time.
Related PR: #1839 

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
