### PR TITLE
"object" collides with "object": unconditionally allocate unpadded collision environments

### DIFF
--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -125,6 +125,13 @@ TEST(PlanningScene, LoadRestoreDiff)
   EXPECT_EQ(next->getWorld()->size(), 2u);
   EXPECT_EQ(ps->getWorld()->size(), 1u);
 
+  /* the worlds used for collision detection contain one and two objects, respectively */
+  EXPECT_EQ(ps->getCollisionEnv()->getWorld()->size(), 1u);
+  EXPECT_EQ(ps->getCollisionEnvUnpadded()->getWorld()->size(), 1u);
+
+  EXPECT_EQ(next->getCollisionEnv()->getWorld()->size(), 2u);
+  EXPECT_EQ(next->getCollisionEnvUnpadded()->getWorld()->size(), 2u);
+
   /* maintained diff contains only overlay object */
   next->getPlanningSceneDiffMsg(ps_msg);
   EXPECT_EQ(ps_msg.world.collision_objects.size(), 1u);
@@ -142,6 +149,8 @@ TEST(PlanningScene, LoadRestoreDiff)
   EXPECT_EQ(ps_msg.world.collision_objects.size(), 2u);
   ps->setPlanningSceneMsg(ps_msg);
   EXPECT_EQ(ps->getWorld()->size(), 2u);
+  EXPECT_EQ(ps->getCollisionEnv()->getWorld()->size(), 2u);
+  EXPECT_EQ(ps->getCollisionEnvUnpadded()->getWorld()->size(), 2u);
 }
 
 TEST(PlanningScene, MakeAttachedDiff)

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -100,28 +100,44 @@ TEST(PlanningScene, LoadRestoreDiff)
   planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
 
   collision_detection::World& world = *ps->getWorldNonConst();
+
+  /* add one object to ps's world */
   Eigen::Isometry3d id = Eigen::Isometry3d::Identity();
   world.addToObject("sphere", shapes::ShapeConstPtr(new shapes::Sphere(0.4)), id);
 
+  /* ps can be written to and set from message */
   moveit_msgs::PlanningScene ps_msg;
   ps_msg.robot_state.is_diff = true;
   EXPECT_TRUE(moveit::core::isEmpty(ps_msg));
   ps->getPlanningSceneMsg(ps_msg);
   ps->setPlanningSceneMsg(ps_msg);
-  EXPECT_FALSE(moveit::core::isEmpty(ps_msg));
+  EXPECT_EQ(ps_msg.world.collision_objects.size(), 1u);
+  EXPECT_EQ(ps_msg.world.collision_objects[0].id, "sphere");
   EXPECT_TRUE(world.hasObject("sphere"));
 
+  /* test diff scene on top of ps */
   planning_scene::PlanningScenePtr next = ps->diff();
+  /* world is inherited from ps */
   EXPECT_TRUE(next->getWorld()->hasObject("sphere"));
-  next->getWorldNonConst()->addToObject("sphere2", shapes::ShapeConstPtr(new shapes::Sphere(0.5)), id);
+
+  /* object in overlay is only added in overlay */
+  next->getWorldNonConst()->addToObject("sphere_in_next_only", shapes::ShapeConstPtr(new shapes::Sphere(0.5)), id);
   EXPECT_EQ(next->getWorld()->size(), 2u);
   EXPECT_EQ(ps->getWorld()->size(), 1u);
+
+  /* maintained diff contains only overlay object */
   next->getPlanningSceneDiffMsg(ps_msg);
   EXPECT_EQ(ps_msg.world.collision_objects.size(), 1u);
+
+  /* copy ps to next and apply diff */
   next->decoupleParent();
   moveit_msgs::PlanningScene ps_msg2;
+
+  /* diff is empty now */
   next->getPlanningSceneDiffMsg(ps_msg2);
   EXPECT_EQ(ps_msg2.world.collision_objects.size(), 0u);
+
+  /* next's world contains both objects */
   next->getPlanningSceneMsg(ps_msg);
   EXPECT_EQ(ps_msg.world.collision_objects.size(), 2u);
   ps->setPlanningSceneMsg(ps_msg);
@@ -136,21 +152,27 @@ TEST(PlanningScene, MakeAttachedDiff)
 
   planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
 
+  /* add a single object to ps's world */
   collision_detection::World& world = *ps->getWorldNonConst();
   Eigen::Isometry3d id = Eigen::Isometry3d::Identity();
   world.addToObject("sphere", shapes::ShapeConstPtr(new shapes::Sphere(0.4)), id);
 
+  /* attach object in diff */
   planning_scene::PlanningScenePtr attached_object_diff_scene = ps->diff();
 
   moveit_msgs::AttachedCollisionObject att_obj;
   att_obj.link_name = "r_wrist_roll_link";
   att_obj.object.operation = moveit_msgs::CollisionObject::ADD;
   att_obj.object.id = "sphere";
+  attached_object_diff_scene->processAttachedCollisionObjectMsg(att_obj);
+
+  /* object is not in world anymore */
+  EXPECT_EQ(attached_object_diff_scene->getWorld()->size(), 0u);
+  /* it became part of the robot state though */
+  EXPECT_TRUE(attached_object_diff_scene->getCurrentState().hasAttachedBody("sphere"));
 
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
-
-  attached_object_diff_scene->processAttachedCollisionObjectMsg(att_obj);
   attached_object_diff_scene->checkCollision(req, res);
   ps->checkCollision(req, res);
 }


### PR DESCRIPTION
I just read through https://github.com/ros-planning/moveit/issues/1835 and https://github.com/ros-planning/moveit_task_constructor/issues/122 which describe a problem with collision checking of attached objects ending up in self-collision.

I am sorry. I debugged this problem in a hurry already back in October for a demo,
but did not get around to investigate further or create a thread for it. :frowning_face: 

This patch resolved the problem for me, although it is likely not the best solution.
Without digging deeper into this again, here's what I recall:

- Collision detectors maintain separate collision structures for padded and unpadded collision checking
- Apparently the unpadded collision checking is thought to be less popular and is only allocated when it is requested through API that allows to write to it
- As long as it is not allocated, a standard pattern in the PlanningScene structures is applied and **the parents** unpadded collision structure is used if required
- @j-petit 's global unification of `CollisionRobot` and `CollisionWorld` into `CollisionEnv` seems to have exposed the issue to trigger with MTC's execution capability, although I'm not convinced the logic was perfectly sane before
- Currently, things go wrong the moment an object becomes attached in a diff planning scene
  - it is removed from the collision world
  - it is added to the collision robot structure
  - during *unpadded* collision checking, the parent's (unpadded) collision world is returned which still contains the object
  - Thus the object suddenly collides with itself

The patch addresses this logic bug simply by always allocating the unpadded collision environment.
I am not convinced it is worth the effort to try to fix the lazy allocation scheme here, but I did not benchmark anything and this only becomes relevant when the benchmarks include attach/detach operations...

On top of that, I am not convinced this double-accounting for padded and unpadded checking makes sense anymore(?), but I did not look into the underlying structures deep enough to understand this.