### PR TITLE
delete world object only once

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1453,8 +1453,6 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
           // Extract the shapes from the world
           shapes = obj_in_world->shapes_;
           poses = obj_in_world->shape_poses_;
-          // Remove the object from the collision world
-          world_->removeObject(object.object.id);
 
           // Transform shape poses to the link frame
           const Eigen::Isometry3d& inv_transform = robot_state_->getGlobalLinkTransform(link_model).inverse();


### PR DESCRIPTION
This is another older patch I did not get around to pull-request before...

The world object already gets removed from the world [later on](https://github.com/ros-planning/moveit/compare/master...v4hn:pr-master-delete-once?expand=1#diff-8aac12a54166575f8df07630635ac4ffR1554), so it does not make a lot of sense to remove it here?