### PR TITLE
[occupancy_map_monitor] add dependencies

### DIFF
--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -19,7 +19,9 @@ endif(APPLE)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_msgs
+  geometric_shapes
   pluginlib
+  tf2_ros
 )
 
 find_package(Eigen3 REQUIRED)
@@ -33,6 +35,8 @@ catkin_package(
   CATKIN_DEPENDS
     moveit_core
     moveit_msgs
+    geometric_shapes
+    tf2_ros
   DEPENDS
     EIGEN3
     OCTOMAP

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -23,6 +23,8 @@
   <depend>moveit_msgs</depend>
   <depend>octomap</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
+  <depend>tf2_ros</depend>
+  <depend>geometric_shapes</depend>
 
   <build_depend>eigen</build_depend>
 


### PR DESCRIPTION
### Description

explicit dependencies to tf2_ros, geometric_shapes and boost are added.
I noticed some linking errors while compiling from source. Applies to master as well

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
