### PR TITLE
Fix usages of panda_moveit_config

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -24,3 +24,7 @@
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
     version: master
+- git:
+    local-name: panda_moveit_config
+    uri: https://github.com/ros-planning/panda_moveit_config.git
+    version: melodic-devel

--- a/moveit_planners/trajopt/test/trajectory_test.test
+++ b/moveit_planners/trajopt/test/trajectory_test.test
@@ -3,7 +3,7 @@
 
   <test pkg="moveit_planners_trajopt" type="trajectory_test" test-name="trajectory_test" time-limit="300" args="">
 
-    <rosparam command="load" file="$(find panda_moveit_config)/config/trajopt_planning.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/trajopt_planning.yaml"/>
 
   </test>
 

--- a/moveit_ros/benchmarks/examples/demo_panda.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda.launch
@@ -3,17 +3,17 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo1.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark/ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
 
   <!-- Launch benchmark node -->
   <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
@@ -3,24 +3,24 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_panda_all_planners.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
 
   <!-- Load all planning pipelines that will be benchmarked -->
   <group ns="moveit_run_benchmark">
-    <include ns="ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="stomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="stomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="stomp" />
     </include>
   </group>

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
@@ -3,24 +3,24 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_obstacles.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
 
   <!-- Load all planning pipelines that will be benchmarked -->
   <group ns="moveit_run_benchmark">
-    <include ns="ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="stomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="stomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="stomp" />
     </include>
   </group>

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch
@@ -3,24 +3,24 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_panda_predefined_poses.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find panda_moveit_config)/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
 
   <!-- Load all planning pipelines that will be benchmarked -->
   <group ns="moveit_run_benchmark">
-    <include ns="ompl" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="stomp" file="$(find panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="stomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="stomp" />
     </include>
   </group>

--- a/moveit_ros/planning/launch/collision_checker_compare.launch
+++ b/moveit_ros/planning/launch/collision_checker_compare.launch
@@ -4,13 +4,13 @@
   <!-- send Panda urdf to parameter server -->
   <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'" />
 
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch"/>
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch"/>
 
   <node name="compare_collision_checking_speed" pkg="moveit_ros_planning" type="moveit_compare_collision_checking_speed_fcl_bullet" respawn="false" output="screen">
-    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/kinematics.yaml"/>
     <param name="visualization" value="$(arg visualization)" type="bool"/>
   </node>
 
-  <include if="$(arg visualization)" file="$(find panda_moveit_config)/launch/demo.launch"/>
+  <include if="$(arg visualization)" file="$(find moveit_resources)/panda_moveit_config/launch/demo.launch"/>
 
 </launch>

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -3,18 +3,18 @@
     <rosparam ns="moveit_cpp_test" command="load" file="$(find moveit_ros_planning_interface)/test/moveit_cpp.yaml" />
 
     <!-- Planning Pipeline -->
-    <include ns="/moveit_cpp_test/ompl" file="$(find panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml"/>
+    <include ns="/moveit_cpp_test/ompl" file="$(find moveit_resources)/panda_moveit_config/launch/ompl_planning_pipeline.launch.xml"/>
 
     <!-- Trajectory execution  -->
-    <!--include ns="moveit_cpp_test" file="$(find panda_moveit_config)/launch/trajectory_execution.launch.xml">
+    <!--include ns="moveit_cpp_test" file="$(find moveit_resources)/panda_moveit_config/launch/trajectory_execution.launch.xml">
       <arg name="moveit_controller_manager" value="fake"/>
     </include-->
 
     <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
-    <include ns="moveit_cpp_test" file="$(find panda_moveit_config)/launch/fake_moveit_controller_manager.launch.xml" />
+    <include ns="moveit_cpp_test" file="$(find moveit_resources)/panda_moveit_config/launch/fake_moveit_controller_manager.launch.xml" />
 
     <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-    <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
       <arg name="load_robot_description" value="true"/>
     </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_trajopt.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_trajopt.launch
@@ -4,19 +4,19 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find panda_moveit_config)/launch/warehouse.launch">
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_trajopt_benchmark_warehouse"/>
   </include>
 
   <!-- Start Benchmark Executable -->
   <node name="$(anon moveit_benchmark)" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" args="$(arg cfg) --benchmark-planners" respawn="false" output="screen">
-    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
-    <rosparam command="load" file="$(find panda_moveit_config)/config/trajopt_planning.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/trajopt_planning.yaml"/>
   </node>
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
@@ -17,6 +17,6 @@
   <param name="request_adapters" value="$(arg planning_adapters)" />
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
-  <rosparam command="load" file="$(find panda_moveit_config)/config/trajopt_planning.yaml"/>
+  <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/trajopt_planning.yaml"/>
 
 </launch>


### PR DESCRIPTION
As pointed out in https://github.com/ros-planning/moveit/issues/1903#issuecomment-586569789, following our [install-from-source procedure](https://moveit.ros.org/install/source/), will install `panda_move_config` and, as their dependencies, several other MoveIt packages from debians.
This is usually not desired.
Interestingly, none of the MoveIt packages actually package-depend on panda_moveit_config.
However, `moveit_tutorials` does. As this, but not `panda_moveit_config` is listed in `moveit.rosinstall`, all these binary packages get installed.
Searching for panda_moveit_config in the source base, I found several uses of the package, which will get replaced by the corresponding `moveit_resources` package now.

Please merge as a merge-commit to keep all three, independent commits.
Fixes #1903.
Relies on https://github.com/ros-planning/moveit_resources/pull/28