### PR TITLE
Jog cpp api fixes

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -102,8 +102,7 @@ protected:
   // Possibly calculate a velocity scaling factor, due to proximity of
   // singularity and direction of motion
   double decelerateForSingularity(const Eigen::VectorXd& commanded_velocity,
-                                  const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
-                                  const Eigen::MatrixXd& jacobian);
+                                  const Eigen::JacobiSVD<Eigen::MatrixXd>& svd, const Eigen::MatrixXd& jacobian);
 
   /**
    * Slow motion down if close to singularity or collision.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -101,8 +101,9 @@ protected:
 
   // Possibly calculate a velocity scaling factor, due to proximity of
   // singularity and direction of motion
-  double decelerateForSingularity(const Eigen::VectorXd& commanded_velocity,
-                                  const Eigen::JacobiSVD<Eigen::MatrixXd>& svd, const Eigen::MatrixXd& jacobian);
+  double velocityScalingFactorForSingularity(const Eigen::VectorXd& commanded_velocity,
+                                             const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
+                                             const Eigen::MatrixXd& jacobian, const Eigen::MatrixXd& pseudo_inverse);
 
   /**
    * Slow motion down if close to singularity or collision.
@@ -154,9 +155,6 @@ protected:
 
   JogArmParameters parameters_;
 
-  // Preallocate for jacobian calculations
-  Eigen::MatrixXd pseudo_inverse_, matrix_s_;
-  Eigen::JacobiSVD<Eigen::MatrixXd> svd_;
   // Use ArrayXd type to enable more coefficient-wise operations
   Eigen::ArrayXd delta_theta_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -102,7 +102,8 @@ protected:
   // Possibly calculate a velocity scaling factor, due to proximity of
   // singularity and direction of motion
   double decelerateForSingularity(const Eigen::VectorXd& commanded_velocity,
-                                  const Eigen::JacobiSVD<Eigen::MatrixXd>& svd);
+                                  const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
+                                  const Eigen::MatrixXd& jacobian);
 
   /**
    * Slow motion down if close to singularity or collision.
@@ -154,8 +155,8 @@ protected:
 
   JogArmParameters parameters_;
 
-  // For jacobian calculations
-  Eigen::MatrixXd jacobian_, pseudo_inverse_, matrix_s_;
+  // Preallocate for jacobian calculations
+  Eigen::MatrixXd pseudo_inverse_, matrix_s_;
   Eigen::JacobiSVD<Eigen::MatrixXd> svd_;
   // Use ArrayXd type to enable more coefficient-wise operations
   Eigen::ArrayXd delta_theta_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -44,15 +44,15 @@
 namespace moveit_jog_arm
 {
 /**
-* Class JogCppApi - This class should be instantiated in a new thread
+* Class JogCppInterface - This class should be instantiated in a new thread
 * See cpp_interface_example.cpp
 */
-class JogCppApi : protected JogInterfaceBase
+class JogCppInterface : public JogInterfaceBase
 {
 public:
-  JogCppApi(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
+  JogCppInterface(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
-  ~JogCppApi();
+  ~JogCppInterface();
 
   void startMainLoop();
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
@@ -58,19 +58,30 @@ class JogInterfaceBase
 public:
   JogInterfaceBase();
 
+  /** \brief Update the joints of the robot */
   void jointsCB(const sensor_msgs::JointStateConstPtr& msg);
 
-  // Service callback for changing drift dimensions,
-  // e.g. to allow the wrist joint to rotate
+  /**
+   * Allow drift in certain dimensions. For example, may allow the wrist to rotate freely.
+   * This can help avoid singularities.
+   *
+   * @param request the service request
+   * @param response the service response
+   * @return true if the adjustment was made
+   */
   bool changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req,
                              moveit_msgs::ChangeDriftDimensions::Response& res);
 
-  // Jogging calculation thread
+  /** \brief Start the main calculation thread */
   bool startJogCalcThread();
+
+  /** \brief Stop the main calculation thread */
   bool stopJogCalcThread();
 
-  // Collision checking thread
+  /** \brief Start collision checking */
   bool startCollisionCheckThread();
+
+  /** \brief Stop collision checking */
   bool stopCollisionCheckThread();
 
 protected:

--- a/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
   planning_scene_monitor->startStateMonitor();
 
   // Run the jogging C++ interface in a new thread to ensure a constant outgoing message rate.
-  moveit_jog_arm::JogCppApi jog_interface(planning_scene_monitor);
+  moveit_jog_arm::JogCppInterface jog_interface(planning_scene_monitor);
   std::thread jogging_thread([&]() { jog_interface.startMainLoop(); });
 
   // Make a Cartesian velocity message

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -474,8 +474,7 @@ bool JogCalcs::applyVelocityScaling(const JogArmShared& shared_variables, std::m
 
 // Possibly calculate a velocity scaling factor, due to proximity of singularity and direction of motion
 double JogCalcs::decelerateForSingularity(const Eigen::VectorXd& commanded_velocity,
-                                          const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
-                                          const Eigen::MatrixXd& jacobian)
+                                          const Eigen::JacobiSVD<Eigen::MatrixXd>& svd, const Eigen::MatrixXd& jacobian)
 {
   double velocity_scale = 1;
 
@@ -751,19 +750,19 @@ bool JogCalcs::addJointIncrements(sensor_msgs::JointState& output, const Eigen::
 
 void JogCalcs::removeDimension(Eigen::MatrixXd& jacobian, Eigen::VectorXd& delta_x, unsigned int row_to_remove)
 {
-/*
-  unsigned int num_rows = jacobian.rows() - 1;
-  unsigned int num_cols = jacobian.cols();
+  /*
+    unsigned int num_rows = jacobian.rows() - 1;
+    unsigned int num_cols = jacobian.cols();
 
-  if (row_to_remove < num_rows)
-  {
-    jacobian.block(row_to_remove, 0, num_rows - row_to_remove, num_cols) =
-        jacobian.block(row_to_remove + 1, 0, num_rows - row_to_remove, num_cols);
-    delta_x.segment(row_to_remove, num_rows - row_to_remove) =
-        delta_x.segment(row_to_remove + 1, num_rows - row_to_remove);
-  }
-  jacobian.conservativeResize(num_rows, num_cols);
-  delta_x.conservativeResize(num_rows);
-*/
+    if (row_to_remove < num_rows)
+    {
+      jacobian.block(row_to_remove, 0, num_rows - row_to_remove, num_cols) =
+          jacobian.block(row_to_remove + 1, 0, num_rows - row_to_remove, num_cols);
+      delta_x.segment(row_to_remove, num_rows - row_to_remove) =
+          delta_x.segment(row_to_remove + 1, num_rows - row_to_remove);
+    }
+    jacobian.conservativeResize(num_rows, num_cols);
+    delta_x.conservativeResize(num_rows);
+  */
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -335,10 +335,10 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
     }
   }
 
-  static Eigen::JacobiSVD<Eigen::MatrixXd> svd =
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd =
       Eigen::JacobiSVD<Eigen::MatrixXd>(jacobian, Eigen::ComputeThinU | Eigen::ComputeThinV);
-  static Eigen::MatrixXd matrix_s = svd.singularValues().asDiagonal();
-  static Eigen::MatrixXd pseudo_inverse = svd.matrixV() * matrix_s.inverse() * svd.matrixU().transpose();
+  Eigen::MatrixXd matrix_s = svd.singularValues().asDiagonal();
+  Eigen::MatrixXd pseudo_inverse = svd.matrixV() * matrix_s.inverse() * svd.matrixU().transpose();
 
   delta_theta_ = pseudo_inverse * delta_x;
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -39,8 +39,6 @@
 
 #include "moveit_jog_arm/jog_cpp_interface.h"
 
-// TODO(davetcoleman): rename JogCppInterface to JogCppInterface to match file name
-
 static const std::string LOGNAME = "jog_cpp_interface";
 
 namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -39,13 +39,13 @@
 
 #include "moveit_jog_arm/jog_cpp_interface.h"
 
-// TODO(davetcoleman): rename JogCppApi to JogCppInterface to match file name
+// TODO(davetcoleman): rename JogCppInterface to JogCppInterface to match file name
 
 static const std::string LOGNAME = "jog_cpp_interface";
 
 namespace moveit_jog_arm
 {
-JogCppApi::JogCppApi(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+JogCppInterface::JogCppInterface(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
 {
   planning_scene_monitor_ = planning_scene_monitor;
 
@@ -54,12 +54,12 @@ JogCppApi::JogCppApi(const planning_scene_monitor::PlanningSceneMonitorPtr& plan
     exit(EXIT_FAILURE);
 }
 
-JogCppApi::~JogCppApi()
+JogCppInterface::~JogCppInterface()
 {
   stopMainLoop();
 }
 
-void JogCppApi::startMainLoop()
+void JogCppInterface::startMainLoop()
 {
   // Reset loop termination flag
   stop_requested_ = false;
@@ -150,12 +150,12 @@ void JogCppApi::startMainLoop()
   stopCollisionCheckThread();
 }
 
-void JogCppApi::stopMainLoop()
+void JogCppInterface::stopMainLoop()
 {
   stop_requested_ = true;
 }
 
-void JogCppApi::provideTwistStampedCommand(const geometry_msgs::TwistStamped& velocity_command)
+void JogCppInterface::provideTwistStampedCommand(const geometry_msgs::TwistStamped& velocity_command)
 {
   shared_variables_mutex_.lock();
 
@@ -183,7 +183,7 @@ void JogCppApi::provideTwistStampedCommand(const geometry_msgs::TwistStamped& ve
   shared_variables_mutex_.unlock();
 };
 
-void JogCppApi::provideJointCommand(const control_msgs::JointJog& joint_command)
+void JogCppInterface::provideJointCommand(const control_msgs::JointJog& joint_command)
 {
   shared_variables_mutex_.lock();
   shared_variables_.joint_command_deltas = joint_command;
@@ -203,7 +203,7 @@ void JogCppApi::provideJointCommand(const control_msgs::JointJog& joint_command)
   shared_variables_mutex_.unlock();
 }
 
-sensor_msgs::JointState JogCppApi::getJointState()
+sensor_msgs::JointState JogCppInterface::getJointState()
 {
   shared_variables_mutex_.lock();
   sensor_msgs::JointState current_joints = shared_variables_.joints;
@@ -212,7 +212,7 @@ sensor_msgs::JointState JogCppApi::getJointState()
   return current_joints;
 }
 
-bool JogCppApi::getCommandFrameTransform(Eigen::Isometry3d& transform)
+bool JogCppInterface::getCommandFrameTransform(Eigen::Isometry3d& transform)
 {
   if (!jog_calcs_ || !jog_calcs_->isInitialized())
     return false;

--- a/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.cpp
+++ b/moveit_experimental/moveit_jog_arm/test/jog_cpp_interface_test.cpp
@@ -75,7 +75,7 @@ protected:
 
 TEST_F(TestJogCppInterface, InitTest)
 {
-  moveit_jog_arm::JogCppApi jog_cpp_interface(planning_scene_monitor_);
+  moveit_jog_arm::JogCppInterface jog_cpp_interface(planning_scene_monitor_);
   ros::Duration(1).sleep();  // Give the started thread some time to run
 }
 


### PR DESCRIPTION
This cleans up a few things in jog_arm:

- Renames JogCppApi class to JogCppInterface to match the filename

- Fix a crash when the dimensions of the Jacobian changed

- Doxygenize some comments

- Make the inheritance of JogInterfaceBase public. I wanted this so I could call the functions from external C++ code, like this:  `jog_interface_ptr_->changeDriftDimensions(...)`