### PR TITLE
Adding panda_moveit_config as test_depend

### DIFF
--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -39,4 +39,5 @@
 
   <test_depend>moveit_resources</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>panda_moveit_config</test_depend>
 </package>


### PR DESCRIPTION
### Description
I had problems because this test https://github.com/ros-planning/moveit/blob/master/moveit_ros/planning_interface/test/moveit_cpp_test.test uses `panda_moveit_config` which was no test dependency.