### PR TITLE
[jog_arm] Publish more detailed warnings

### DIFF
--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -47,7 +47,7 @@ joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving
 cartesian_command_in_topic: jog_server/delta_jog_cmds  # Topic for incoming Cartesian twist commands
 joint_command_in_topic: jog_server/joint_delta_jog_cmds # Topic for incoming joint angle commands
 joint_topic:  joint_states
-warning_topic: jog_server/halted # Publish boolean warnings to this topic
+status_topic: jog_server/status # Publish status to this topic
 command_out_topic: joint_group_position_controller/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -60,7 +60,7 @@ public:
   // Get thread-safe read-only lock of planning scene
   planning_scene_monitor::LockedPlanningSceneRO getLockedPlanningSceneRO() const;
 
-  void startMainLoop(moveit_jog_arm::JogArmShared& shared_variables, std::mutex& mutex);
+  void startMainLoop(moveit_jog_arm::JogArmShared& shared_variables);
 
   void stopMainLoop();
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -38,13 +38,21 @@
 
 #pragma once
 
-#include <control_msgs/JointJog.h>
-#include <Eigen/Geometry>
-#include <geometry_msgs/TwistStamped.h>
+// System
 #include <mutex>
-#include <sensor_msgs/JointState.h>
 #include <thread>
+
+// Eigen
+#include <Eigen/Geometry>
+
+// ROS
+#include <control_msgs/JointJog.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <sensor_msgs/JointState.h>
 #include <trajectory_msgs/JointTrajectory.h>
+
+// moveit_jog_arm
+#include "status_codes.h"
 
 namespace moveit_jog_arm
 {
@@ -83,6 +91,9 @@ struct JogArmShared
   // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
   std::atomic_bool drift_dimensions[6] = { ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false),
                                            ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false) };
+
+  // Current status of the jogger. In collision, etc.
+  StatusCode status;
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -57,7 +57,8 @@
 namespace moveit_jog_arm
 {
 // Variables to share between threads, and their mutexes
-struct JogArmShared
+// Inherit from a mutex so the struct can be locked/unlocked easily
+struct JogArmShared : public std::mutex
 {
   geometry_msgs::TwistStamped command_deltas;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -92,8 +92,8 @@ struct JogArmShared
   std::atomic_bool drift_dimensions[6] = { ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false),
                                            ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false) };
 
-  // Current status of the jogger. In collision, etc.
-  StatusCode status;
+  // Status of the jogger. 0 for no warning. The meaning of nonzero values can be seen in status_codes.h
+  std::atomic<StatusCode> status;
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -94,7 +94,7 @@ struct JogArmParameters
   std::string robot_link_command_frame;
   std::string command_out_topic;
   std::string planning_frame;
-  std::string warning_topic;
+  std::string status_topic;
   std::string joint_command_in_topic;
   std::string command_in_type;
   std::string command_out_type;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -181,7 +181,7 @@ protected:
 
   ros::Publisher status_pub_;
 
-  StatusCode status_ = kNoWarning;
+  StatusCode status_ = NO_WARNING;
 
   JogArmParameters parameters_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -58,7 +58,7 @@ class JogCalcs
 public:
   JogCalcs(const JogArmParameters& parameters, const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
 
-  void startMainLoop(JogArmShared& shared_variables, std::mutex& mutex);
+  void startMainLoop(JogArmShared& shared_variables);
 
   void stopMainLoop();
 
@@ -82,7 +82,7 @@ protected:
   std::atomic<bool> is_initialized_;
 
   /** \brief Do jogging calculations for Cartesian twist commands. */
-  bool cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared& shared_variables, std::mutex& mutex);
+  bool cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared& shared_variables);
 
   /** \brief Do jogging calculations for direct commands to a joint. */
   bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables);
@@ -91,7 +91,7 @@ protected:
   void updateCachedStatus(JogArmShared& shared_variables);
 
   /** \brief Parse the incoming joint msg for the joints of our MoveGroup */
-  bool updateJoints(std::mutex& mutex, const JogArmShared& shared_variables);
+  bool updateJoints(JogArmShared& shared_variables);
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
@@ -130,13 +130,11 @@ protected:
   /**
    * Slow motion down if close to singularity or collision.
    * @param shared_variables data shared between threads, tells how close we are to collision
-   * @param mutex locks shared data
    * @param delta_theta motion command, used in calculating new_joint_tray
    * @param singularity_scale tells how close we are to a singularity
    * @return false if very close to collision or singularity
    */
-  bool applyVelocityScaling(const JogArmShared& shared_variables, std::mutex& mutex, Eigen::ArrayXd& delta_theta,
-                            double singularity_scale);
+  bool applyVelocityScaling(JogArmShared& shared_variables, Eigen::ArrayXd& delta_theta, double singularity_scale);
 
   /** \brief Compose the outgoing JointTrajectory message */
   trajectory_msgs::JointTrajectory composeJointTrajMessage(sensor_msgs::JointState& joint_state) const;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -152,9 +152,9 @@ protected:
     */
   bool convertDeltasToOutgoingCmd();
 
-    /** \brief Gazebo simulations have very strict message timestamp requirements.
-     * Satisfy Gazebo by stuffing multiple messages into one.
-     */
+  /** \brief Gazebo simulations have very strict message timestamp requirements.
+   * Satisfy Gazebo by stuffing multiple messages into one.
+   */
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& trajectory, int count) const;
 
   /**

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -112,7 +112,7 @@ protected:
   void suddenHalt(Eigen::ArrayXd& delta_theta);
 
   /** \brief Publish the status of the jogger to a ROS topic */
-  void publishStatus(StatusCode status) const;
+  void publishStatus() const;
 
   /** \brief  Scale the delta theta to match joint velocity/acceleration limits */
   void enforceSRDFAccelVelLimits(Eigen::ArrayXd& delta_theta);

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -85,10 +85,10 @@ protected:
   bool cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared& shared_variables, std::mutex& mutex);
 
   /** \brief Do jogging calculations for direct commands to a joint. */
-  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables);
+  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables, std::mutex& mutex);
 
   /** \brief Update the stashed status so it can be retrieved asynchronously */
-  void updateCachedStatus();
+  void updateCachedStatus(JogArmShared& shared_variables, std::mutex& mutex);
 
   /** \brief Parse the incoming joint msg for the joints of our MoveGroup */
   bool updateJoints(std::mutex& mutex, const JogArmShared& shared_variables);
@@ -182,8 +182,6 @@ protected:
   ros::Publisher status_pub_;
 
   StatusCode status_ = kNoWarning;
-  // Cache the previous status, for retrieval at any time
-  StatusCode prev_status_ = kNoWarning;
 
   JogArmParameters parameters_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -85,10 +85,10 @@ protected:
   bool cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared& shared_variables, std::mutex& mutex);
 
   /** \brief Do jogging calculations for direct commands to a joint. */
-  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables, std::mutex& mutex);
+  bool jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables);
 
   /** \brief Update the stashed status so it can be retrieved asynchronously */
-  void updateCachedStatus(JogArmShared& shared_variables, std::mutex& mutex);
+  void updateCachedStatus(JogArmShared& shared_variables);
 
   /** \brief Parse the incoming joint msg for the joints of our MoveGroup */
   bool updateJoints(std::mutex& mutex, const JogArmShared& shared_variables);

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -40,6 +40,7 @@
 
 #include <atomic>
 #include "jog_interface_base.h"
+#include <std_msgs/Int8.h>
 
 namespace moveit_jog_arm
 {
@@ -82,6 +83,13 @@ public:
    * @return true if a valid transform was available
    */
   bool getCommandFrameTransform(Eigen::Isometry3d& transform);
+
+  /**
+   * Get the status of the jogger.
+   *
+   * @return 0 for no warning. The meaning of nonzero values can be seen in status_codes.h
+   */
+  StatusCode getJoggerStatus();
 
 private:
   ros::NodeHandle nh_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -58,15 +58,20 @@ public:
 
   void stopMainLoop();
 
-  // Provide a Cartesian velocity command to the jogger.
-  // The units are determined by settings in the yaml file.
+  /** \brief Provide a Cartesian velocity command to the jogger.
+   * The units are determined by settings in the yaml file.
+   */
   void provideTwistStampedCommand(const geometry_msgs::TwistStamped& velocity_command);
 
-  // Send joint position(s) commands
+  /** \brief Send joint position(s) commands */
   void provideJointCommand(const control_msgs::JointJog& joint_command);
 
-  // Returns the most recent JointState that the jogger has received.
-  // May eliminate the need to create your own joint_state subscriber.
+  /**
+   * Returns the most recent JointState that the jogger has received.
+   * May eliminate the need to create your own joint_state subscriber.
+   *
+   * @return the most recent joints known to the jogger
+   */
   sensor_msgs::JointState getJointState();
 
   /**

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_interface_base.h
@@ -95,7 +95,6 @@ protected:
 
   // Share data between threads
   JogArmShared shared_variables_;
-  std::mutex shared_variables_mutex_;
 
   // Jog calcs
   std::unique_ptr<JogCalcs> jog_calcs_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *      Title     : status_codes.h
+ *      Project   : moveit_jog_arm
+ *      Created   : 2/25/2019
+ *      Author    : Andy Zelenak
+ *
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2019, Los Alamos National Security, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace moveit_jog_arm
+{
+enum StatusCode: int8_t
+{
+  kNoWarning = 0,
+  kSingularity = 1,
+  kCollision = 2,
+  kJointBound = 3
+};
+
+const std::unordered_map<uint, std::string>
+    kStatusCodeMap({ {kNoWarning, "No warnings" },
+					 { kSingularity, "Close to a singularity, decelerating" },
+                     { kCollision, "Close to a collision, decelerating" },
+                     { kJointBound, "Close to a joint bound (position or velocity), decelerating" } });
+}  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -46,14 +46,16 @@ namespace moveit_jog_arm
 enum StatusCode: int8_t
 {
   kNoWarning = 0,
-  kSingularity = 1,
-  kCollision = 2,
-  kJointBound = 3
+  kSingularityDecelerate = 1,
+  kSingularityHalt = 2,
+  kCollision = 3,
+  kJointBound = 4
 };
 
 const std::unordered_map<uint, std::string>
     kStatusCodeMap({ {kNoWarning, "No warnings" },
-					 { kSingularity, "Close to a singularity, decelerating" },
-                     { kCollision, "Close to a collision, decelerating" },
-                     { kJointBound, "Close to a joint bound (position or velocity), decelerating" } });
+					 { kSingularityDecelerate, "Close to a singularity, decelerating" },
+					 { kSingularityHalt, "Very close to a singularity, halting" },
+                     { kCollision, "Close to a collision, halting." },
+                     { kJointBound, "Close to a joint bound (position or velocity), halting" } });
 }  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -45,17 +45,17 @@ namespace moveit_jog_arm
 {
 enum StatusCode : int8_t
 {
-  kNoWarning = 0,
-  kSingularityDecelerate = 1,
-  kSingularityHalt = 2,
-  kCollision = 3,
-  kJointBound = 4
+  NO_WARNING = 0,
+  DECELERATE_FOR_SINGULARITY = 1,
+  HALT_FOR_SINGULARITY = 2,
+  COLLISION = 3,
+  JOINT_BOUND = 4
 };
 
 const std::unordered_map<uint, std::string>
-    kStatusCodeMap({ { kNoWarning, "No warnings" },
-                     { kSingularityDecelerate, "Close to a singularity, decelerating" },
-                     { kSingularityHalt, "Very close to a singularity, halting" },
-                     { kCollision, "Close to a collision, halting." },
-                     { kJointBound, "Close to a joint bound (position or velocity), halting" } });
+    JOG_ARM_STATUS_CODE_MAP({ { NO_WARNING, "No warnings" },
+                     { DECELERATE_FOR_SINGULARITY, "Close to a singularity, decelerating" },
+                     { HALT_FOR_SINGULARITY, "Very close to a singularity, halting" },
+                     { COLLISION, "Close to a collision, halting." },
+                     { JOINT_BOUND, "Close to a joint bound (position or velocity), halting" } });
 }  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -54,8 +54,8 @@ enum StatusCode : int8_t
 
 const std::unordered_map<uint, std::string>
     JOG_ARM_STATUS_CODE_MAP({ { NO_WARNING, "No warnings" },
-                     { DECELERATE_FOR_SINGULARITY, "Close to a singularity, decelerating" },
-                     { HALT_FOR_SINGULARITY, "Very close to a singularity, halting" },
-                     { COLLISION, "Close to a collision, halting." },
-                     { JOINT_BOUND, "Close to a joint bound (position or velocity), halting" } });
+                              { DECELERATE_FOR_SINGULARITY, "Close to a singularity, decelerating" },
+                              { HALT_FOR_SINGULARITY, "Very close to a singularity, halting" },
+                              { COLLISION, "Close to a collision, halting." },
+                              { JOINT_BOUND, "Close to a joint bound (position or velocity), halting" } });
 }  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -43,7 +43,7 @@
 
 namespace moveit_jog_arm
 {
-enum StatusCode: int8_t
+enum StatusCode : int8_t
 {
   kNoWarning = 0,
   kSingularityDecelerate = 1,
@@ -53,9 +53,9 @@ enum StatusCode: int8_t
 };
 
 const std::unordered_map<uint, std::string>
-    kStatusCodeMap({ {kNoWarning, "No warnings" },
-					 { kSingularityDecelerate, "Close to a singularity, decelerating" },
-					 { kSingularityHalt, "Very close to a singularity, halting" },
+    kStatusCodeMap({ { kNoWarning, "No warnings" },
+                     { kSingularityDecelerate, "Close to a singularity, decelerating" },
+                     { kSingularityHalt, "Very close to a singularity, halting" },
                      { kCollision, "Close to a collision, halting." },
                      { kJointBound, "Close to a joint bound (position or velocity), halting" } });
 }  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -56,7 +56,7 @@ planning_scene_monitor::LockedPlanningSceneRO CollisionCheckThread::getLockedPla
   return planning_scene_monitor::LockedPlanningSceneRO(planning_scene_monitor_);
 }
 
-void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables, std::mutex& mutex)
+void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
 {
   // Reset loop termination flag
   stop_requested_ = false;
@@ -78,9 +78,9 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables, std::mu
   /////////////////////////////////////////////////
   while (ros::ok() && !stop_requested_)
   {
-    mutex.lock();
+    shared_variables.lock();
     sensor_msgs::JointState jts = shared_variables.joints;
-    mutex.unlock();
+    shared_variables.unlock();
 
     for (std::size_t i = 0; i < jts.position.size(); ++i)
       current_state.setJointPositions(jts.name[i], &jts.position[i]);
@@ -108,9 +108,9 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables, std::mu
           exp(velocity_scale_coefficient * (collision_result.distance - parameters_.collision_proximity_threshold));
     }
 
-    mutex.lock();
+    shared_variables.lock();
     shared_variables.collision_velocity_scale = velocity_scale;
-    mutex.unlock();
+    shared_variables.unlock();
 
     collision_rate.sleep();
   }

--- a/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
@@ -115,8 +115,7 @@ int main(int argc, char** argv)
 
   // Retrieve the current status of the jogger
   moveit_jog_arm::StatusCode status = jog_interface.getJoggerStatus();
-  ROS_INFO_STREAM_NAMED(LOGNAME, "Jogger status:");
-  ROS_INFO_STREAM_NAMED(LOGNAME, status);
+  ROS_INFO_STREAM_NAMED(LOGNAME, "Jogger status:\n" << status);
 
   jog_interface.stopMainLoop();
   jogging_thread.join();

--- a/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
@@ -110,13 +110,13 @@ int main(int argc, char** argv)
 
   // Retrieve the current joint state from the jogger
   sensor_msgs::JointState current_joint_state = jog_interface.getJointState();
-  ROS_INFO_STREAM("Current joint state:");
-  ROS_INFO_STREAM(current_joint_state);
+  ROS_INFO_STREAM_NAMED(LOGNAME, "Current joint state:");
+  ROS_INFO_STREAM_NAMED(LOGNAME, current_joint_state);
 
   // Retrieve the current status of the jogger
   moveit_jog_arm::StatusCode status = jog_interface.getJoggerStatus();
-  ROS_INFO_STREAM("Jogger status:");
-  ROS_INFO_STREAM(status);
+  ROS_INFO_STREAM_NAMED(LOGNAME, "Jogger status:");
+  ROS_INFO_STREAM_NAMED(LOGNAME, status);
 
   jog_interface.stopMainLoop();
   jogging_thread.join();

--- a/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/cpp_interface_example/cpp_interface_example.cpp
@@ -36,7 +36,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#include <moveit_jog_arm/jog_cpp_interface.h>
+#include "moveit_jog_arm/jog_cpp_interface.h"
+#include "moveit_jog_arm/status_codes.h"
 
 static const std::string LOGNAME = "cpp_interface_example";
 
@@ -109,7 +110,13 @@ int main(int argc, char** argv)
 
   // Retrieve the current joint state from the jogger
   sensor_msgs::JointState current_joint_state = jog_interface.getJointState();
+  ROS_INFO_STREAM("Current joint state:");
   ROS_INFO_STREAM(current_joint_state);
+
+  // Retrieve the current status of the jogger
+  moveit_jog_arm::StatusCode status = jog_interface.getJoggerStatus();
+  ROS_INFO_STREAM("Jogger status:");
+  ROS_INFO_STREAM(status);
 
   jog_interface.stopMainLoop();
   jogging_thread.join();

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -397,7 +397,7 @@ void JogCalcs::updateCachedStatus(JogArmShared& shared_variables, std::mutex& mu
   mutex.lock();
   shared_variables.status = status_;
   mutex.unlock();
-  status_ = kNoWarning;
+  status_ = NO_WARNING;
 }
 
 bool JogCalcs::convertDeltasToOutgoingCmd()
@@ -415,7 +415,7 @@ bool JogCalcs::convertDeltasToOutgoingCmd()
   if (!enforceSRDFPositionLimits(outgoing_command_))
   {
     suddenHalt(outgoing_command_);
-    status_ = kJointBound;
+    status_ = JOINT_BOUND;
   }
 
   // done with calculations
@@ -494,8 +494,8 @@ bool JogCalcs::applyVelocityScaling(const JogArmShared& shared_variables, std::m
 
   if (collision_scale < 1)
   {
-    status_ = kCollision;
-    ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, kStatusCodeMap.at(status_));
+    status_ = COLLISION;
+    ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, JOG_ARM_STATUS_CODE_MAP.at(status_));
   }
 
   delta_theta = collision_scale * singularity_scale * delta_theta;
@@ -556,16 +556,16 @@ double JogCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& comm
       velocity_scale = 1. -
                        (ini_condition - parameters_.lower_singularity_threshold) /
                            (parameters_.hard_stop_singularity_threshold - parameters_.lower_singularity_threshold);
-      status_ = kSingularityDecelerate;
-      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, kStatusCodeMap.at(status_));
+      status_ = DECELERATE_FOR_SINGULARITY;
+      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, JOG_ARM_STATUS_CODE_MAP.at(status_));
     }
 
     // Very close to singularity, so halt.
     else if (ini_condition > parameters_.hard_stop_singularity_threshold)
     {
       velocity_scale = 0;
-      status_ = kSingularityHalt;
-      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, kStatusCodeMap.at(status_));
+      status_ = HALT_FOR_SINGULARITY;
+      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, JOG_ARM_STATUS_CODE_MAP.at(status_));
     }
   }
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -493,7 +493,7 @@ bool JogCalcs::applyVelocityScaling(const JogArmShared& shared_variables, std::m
   if (collision_scale < 1)
   {
     status_ = kCollision;
-    ROS_WARN_THROTTLE_NAMED(2, LOGNAME, "Close to a collision. Halting.");
+    ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, kStatusCodeMap.at(status_));
   }
 
   delta_theta = collision_scale * singularity_scale * delta_theta;
@@ -554,14 +554,16 @@ double JogCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& comm
       velocity_scale = 1. -
                        (ini_condition - parameters_.lower_singularity_threshold) /
                            (parameters_.hard_stop_singularity_threshold - parameters_.lower_singularity_threshold);
+      status_ = kSingularityDecelerate;
+      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, kStatusCodeMap.at(status_));
     }
 
     // Very close to singularity, so halt.
     else if (ini_condition > parameters_.hard_stop_singularity_threshold)
     {
       velocity_scale = 0;
-      status_ = kSingularity;
-      ROS_WARN_THROTTLE_NAMED(2, LOGNAME, "Close to a singularity. Halting.");
+      status_ = kSingularityHalt;
+      ROS_WARN_STREAM_THROTTLE_NAMED(2, LOGNAME, kStatusCodeMap.at(status_));
     }
   }
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -202,7 +202,7 @@ void JogCalcs::startMainLoop(JogArmShared& shared_variables, std::mutex& mutex)
         joint_deltas = shared_variables.joint_command_deltas;
         mutex.unlock();
 
-        if (!jointJogCalcs(joint_deltas, shared_variables, mutex))
+        if (!jointJogCalcs(joint_deltas, shared_variables))
           continue;
       }
       else
@@ -359,12 +359,12 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
 
   publishStatus();
   // Cache the status so it can be retrieved asynchronously
-  updateCachedStatus(shared_variables, mutex);
+  updateCachedStatus(shared_variables);
 
   return convertDeltasToOutgoingCmd();
 }
 
-bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables, std::mutex& mutex)
+bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& shared_variables)
 {
   // Check for nan's or |delta|>1 in the incoming command
   for (double velocity : cmd.velocities)
@@ -387,12 +387,12 @@ bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& sh
 
   publishStatus();
   // Cache the status so it can be retrieved asynchronously
-  updateCachedStatus(shared_variables, mutex);
+  updateCachedStatus(shared_variables);
 
   return convertDeltasToOutgoingCmd();
 }
 
-void JogCalcs::updateCachedStatus(JogArmShared& shared_variables, std::mutex& mutex)
+void JogCalcs::updateCachedStatus(JogArmShared& shared_variables)
 {
   shared_variables.status = status_;
   status_ = NO_WARNING;

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -352,7 +352,7 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
   if (!applyVelocityScaling(shared_variables, delta_theta_,
                             velocityScalingFactorForSingularity(delta_x, svd, jacobian, pseudo_inverse)))
   {
-    suddenHalt(outgoing_command_);
+    suddenHalt(delta_theta_);
   }
 
   prev_joint_velocity_ = delta_theta_ / parameters_.publish_period;

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -357,7 +357,7 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
 
   prev_joint_velocity_ = delta_theta_ / parameters_.publish_period;
 
-  publishStatus(status_);
+  publishStatus();
   // Cache the status so it can be retrieved asynchronously
   updateCachedStatus(shared_variables, mutex);
 
@@ -385,7 +385,7 @@ bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& sh
 
   prev_joint_velocity_ = delta_theta_ / parameters_.publish_period;
 
-  publishStatus(status_);
+  publishStatus();
   // Cache the status so it can be retrieved asynchronously
   updateCachedStatus(shared_variables, mutex);
 
@@ -394,9 +394,7 @@ bool JogCalcs::jointJogCalcs(const control_msgs::JointJog& cmd, JogArmShared& sh
 
 void JogCalcs::updateCachedStatus(JogArmShared& shared_variables, std::mutex& mutex)
 {
-  mutex.lock();
   shared_variables.status = status_;
-  mutex.unlock();
   status_ = NO_WARNING;
 }
 
@@ -676,10 +674,10 @@ bool JogCalcs::enforceSRDFPositionLimits(trajectory_msgs::JointTrajectory& new_j
   return !halting;
 }
 
-void JogCalcs::publishStatus(StatusCode status) const
+void JogCalcs::publishStatus() const
 {
   std_msgs::Int8 status_msg;
-  status_msg.data = status;
+  status_msg.data = status_;
   status_pub_.publish(status_msg);
 }
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -224,10 +224,6 @@ bool JogCppInterface::getCommandFrameTransform(Eigen::Isometry3d& transform)
 
 StatusCode JogCppInterface::getJoggerStatus()
 {
-  shared_variables_mutex_.lock();
-  StatusCode status = shared_variables_.status;
-  shared_variables_mutex_.unlock();
-
-  return status;
+  return shared_variables_.status;
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -95,7 +95,7 @@ void JogCppInterface::startMainLoop()
   {
     ros::spinOnce();
 
-    shared_variables_mutex_.lock();
+    shared_variables_.lock();
     trajectory_msgs::JointTrajectory outgoing_command = shared_variables_.outgoing_command;
 
     // Check if incoming commands are stale
@@ -139,7 +139,7 @@ void JogCppInterface::startMainLoop()
       ROS_DEBUG_STREAM_THROTTLE_NAMED(10, LOGNAME, "All-zero command. Doing nothing.");
     }
 
-    shared_variables_mutex_.unlock();
+    shared_variables_.unlock();
 
     main_rate.sleep();
   }
@@ -155,7 +155,7 @@ void JogCppInterface::stopMainLoop()
 
 void JogCppInterface::provideTwistStampedCommand(const geometry_msgs::TwistStamped& velocity_command)
 {
-  shared_variables_mutex_.lock();
+  shared_variables_.lock();
 
   shared_variables_.command_deltas.twist = velocity_command.twist;
   shared_variables_.command_deltas.header = velocity_command.header;
@@ -178,12 +178,12 @@ void JogCppInterface::provideTwistStampedCommand(const geometry_msgs::TwistStamp
   {
     shared_variables_.latest_nonzero_cmd_stamp = velocity_command.header.stamp;
   }
-  shared_variables_mutex_.unlock();
+  shared_variables_.unlock();
 };
 
 void JogCppInterface::provideJointCommand(const control_msgs::JointJog& joint_command)
 {
-  shared_variables_mutex_.lock();
+  shared_variables_.lock();
   shared_variables_.joint_command_deltas = joint_command;
 
   // Check if joint inputs is all zeros. Flag it if so to skip calculations/publication
@@ -198,14 +198,14 @@ void JogCppInterface::provideJointCommand(const control_msgs::JointJog& joint_co
   {
     shared_variables_.latest_nonzero_cmd_stamp = joint_command.header.stamp;
   }
-  shared_variables_mutex_.unlock();
+  shared_variables_.unlock();
 }
 
 sensor_msgs::JointState JogCppInterface::getJointState()
 {
-  shared_variables_mutex_.lock();
+  shared_variables_.lock();
   sensor_msgs::JointState current_joints = shared_variables_.joints;
-  shared_variables_mutex_.unlock();
+  shared_variables_.unlock();
 
   return current_joints;
 }
@@ -215,8 +215,9 @@ bool JogCppInterface::getCommandFrameTransform(Eigen::Isometry3d& transform)
   if (!jog_calcs_ || !jog_calcs_->isInitialized())
     return false;
 
-  const std::lock_guard<std::mutex> lock(shared_variables_mutex_);
+  shared_variables_.lock();
   transform = shared_variables_.tf_moveit_to_cmd_frame;
+  shared_variables_.unlock();
 
   // All zeros means the transform wasn't initialized, so return false
   return !transform.matrix().isZero(0);

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -221,4 +221,13 @@ bool JogCppInterface::getCommandFrameTransform(Eigen::Isometry3d& transform)
   // All zeros means the transform wasn't initialized, so return false
   return !transform.matrix().isZero(0);
 }
+
+StatusCode JogCppInterface::getJoggerStatus()
+{
+  shared_variables_mutex_.lock();
+  StatusCode status = shared_variables_.status;
+  shared_variables_mutex_.unlock();
+
+  return status;
+}
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -104,21 +104,13 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/publish_joint_accelerations",
                                     ros_parameters_.publish_joint_accelerations);
 
-  // This parameter name was changed recently. Give a deprecation warning.
-  if (n.hasParam(parameter_ns + "/status_topic"))
+  // This parameter name was changed recently.
+  // Try retrieving from the correct name. If it fails, then try the deprecated name.
+  if (!rosparam_shortcuts::get("", n, parameter_ns + "/status_topic", ros_parameters_.status_topic))
   {
-    error += !rosparam_shortcuts::get("", n, parameter_ns + "/status_topic", ros_parameters_.status_topic);
-  }
-  else if (n.hasParam(parameter_ns + "/warning_topic"))
-  {
+    ROS_WARN_NAMED(LOGNAME, "'status_topic' parameter is missing. Recently renamed from 'warning_topic'. Please update "
+                            "the jogging yaml file.");
     error += !rosparam_shortcuts::get("", n, parameter_ns + "/warning_topic", ros_parameters_.status_topic);
-    ROS_WARN_NAMED(LOGNAME,
-                   "Topic 'warning_topic' was renamed to 'status_topic'. Please update the jogging yaml file.");
-  }
-  else
-  {
-    ROS_WARN_NAMED(LOGNAME,
-                   "Topic 'warning_topic' was renamed to 'status_topic'. Please update the jogging yaml file.");
   }
 
   rosparam_shortcuts::shutdownIfError(parameter_ns, error);

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -94,7 +94,7 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/planning_frame", ros_parameters_.planning_frame);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/use_gazebo", ros_parameters_.use_gazebo);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/check_collisions", ros_parameters_.check_collisions);
-  error += !rosparam_shortcuts::get("", n, parameter_ns + "/warning_topic", ros_parameters_.warning_topic);
+  error += !rosparam_shortcuts::get("", n, parameter_ns + "/status_topic", ros_parameters_.status_topic);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/joint_limit_margin", ros_parameters_.joint_limit_margin);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/command_out_topic", ros_parameters_.command_out_topic);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/command_out_type", ros_parameters_.command_out_type);

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -106,6 +106,7 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
 
   // This parameter name was changed recently.
   // Try retrieving from the correct name. If it fails, then try the deprecated name.
+  // TODO(andyz): remove this deprecation warning in ROS Noetic
   if (!rosparam_shortcuts::get("", n, parameter_ns + "/status_topic", ros_parameters_.status_topic))
   {
     ROS_WARN_NAMED(LOGNAME, "'status_topic' parameter is missing. Recently renamed from 'warning_topic'. Please update "

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -94,7 +94,6 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/planning_frame", ros_parameters_.planning_frame);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/use_gazebo", ros_parameters_.use_gazebo);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/check_collisions", ros_parameters_.check_collisions);
-  error += !rosparam_shortcuts::get("", n, parameter_ns + "/status_topic", ros_parameters_.status_topic);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/joint_limit_margin", ros_parameters_.joint_limit_margin);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/command_out_topic", ros_parameters_.command_out_topic);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/command_out_type", ros_parameters_.command_out_type);
@@ -104,6 +103,23 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
                                     ros_parameters_.publish_joint_velocities);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/publish_joint_accelerations",
                                     ros_parameters_.publish_joint_accelerations);
+
+  // This parameter name was changed recently. Give a deprecation warning.
+  if (n.hasParam(parameter_ns + "/status_topic"))
+  {
+    error += !rosparam_shortcuts::get("", n, parameter_ns + "/status_topic", ros_parameters_.status_topic);
+  }
+  else if (n.hasParam(parameter_ns + "/warning_topic"))
+  {
+    error += !rosparam_shortcuts::get("", n, parameter_ns + "/warning_topic", ros_parameters_.status_topic);
+    ROS_WARN_NAMED(LOGNAME,
+                   "Topic 'warning_topic' was renamed to 'status_topic'. Please update the jogging yaml file.");
+  }
+  else
+  {
+    ROS_WARN_NAMED(LOGNAME,
+                   "Topic 'warning_topic' was renamed to 'status_topic'. Please update the jogging yaml file.");
+  }
 
   rosparam_shortcuts::shutdownIfError(parameter_ns, error);
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
@@ -117,7 +117,7 @@ JogROSInterface::JogROSInterface()
   {
     ros::spinOnce();
 
-    shared_variables_mutex_.lock();
+    shared_variables_.lock();
     trajectory_msgs::JointTrajectory outgoing_command = shared_variables_.outgoing_command;
 
     // Check for stale cmds
@@ -162,7 +162,7 @@ JogROSInterface::JogROSInterface()
       ROS_DEBUG_STREAM_THROTTLE_NAMED(10, LOGNAME, "All-zero command. Doing nothing.");
     }
 
-    shared_variables_mutex_.unlock();
+    shared_variables_.unlock();
 
     main_rate.sleep();
   }
@@ -174,7 +174,7 @@ JogROSInterface::JogROSInterface()
 // Listen to cartesian delta commands. Store them in a shared variable.
 void JogROSInterface::deltaCartesianCmdCB(const geometry_msgs::TwistStampedConstPtr& msg)
 {
-  shared_variables_mutex_.lock();
+  shared_variables_.lock();
 
   // Copy everything but the frame name. The frame name is set by yaml file at startup.
   // (so it isn't copied over and over)
@@ -199,13 +199,13 @@ void JogROSInterface::deltaCartesianCmdCB(const geometry_msgs::TwistStampedConst
   {
     shared_variables_.latest_nonzero_cmd_stamp = msg->header.stamp;
   }
-  shared_variables_mutex_.unlock();
+  shared_variables_.unlock();
 }
 
 // Listen to joint delta commands. Store them in a shared variable.
 void JogROSInterface::deltaJointCmdCB(const control_msgs::JointJogConstPtr& msg)
 {
-  shared_variables_mutex_.lock();
+  shared_variables_.lock();
   shared_variables_.joint_command_deltas = *msg;
 
   // Check if joint inputs is all zeros. Flag it if so to skip calculations/publication
@@ -220,6 +220,6 @@ void JogROSInterface::deltaJointCmdCB(const control_msgs::JointJogConstPtr& msg)
   {
     shared_variables_.latest_nonzero_cmd_stamp = msg->header.stamp;
   }
-  shared_variables_mutex_.unlock();
+  shared_variables_.unlock();
 }
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
@@ -47,7 +47,7 @@ joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving
 cartesian_command_in_topic: jog_server/delta_jog_cmds  # Topic for incoming Cartesian twist commands
 joint_command_in_topic: jog_server/joint_delta_jog_cmds # Topic for incoming joint angle commands
 joint_topic:  joint_states
-warning_topic: jog_server/halted # Publish boolean warnings to this topic
+status_topic: jog_server/status # Publish status to this topic
 command_out_topic: jog_server/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body

--- a/moveit_experimental/moveit_jog_arm/test/python_tests/halt_msg/test_jog_arm_halt_msg.py
+++ b/moveit_experimental/moveit_jog_arm/test/python_tests/halt_msg/test_jog_arm_halt_msg.py
@@ -6,7 +6,7 @@ import rospy
 from geometry_msgs.msg import TwistStamped
 
 from control_msgs.msg import JointJog
-from std_msgs.msg import Bool
+from std_msgs.msg import Int8
 
 # Import common Python test utilities
 from os import sys, path
@@ -14,14 +14,15 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 import util
 
 # The robot starts at a singular position (see config file).
-# Listen for a halt message from the jogger.
+# The jogger should halt and publish a warning.
+# Listen for a warning message from the jogger.
 # This can be run as part of a pytest, or like a normal ROS executable:
-# rosrun moveit_jog_arm test_jog_arm_integration.py
+# rosrun moveit_jog_arm test_jog_arm_halt_msg.py
 
 CARTESIAN_JOG_COMMAND_TOPIC = 'jog_server/delta_jog_cmds'
 
-# jog_arm should publish 'true' here if it halts
-HALT_TOPIC = 'jog_server/halted'
+# jog_arm should publish a nonzero warning code here
+HALT_TOPIC = 'jog_server/status'
 
 # Check if jogger is initialized with this service
 SERVICE_NAME = 'jog_server/change_drift_dimensions'
@@ -51,7 +52,7 @@ def test_jog_arm_halt_msg(node):
 
     received = []
     sub = rospy.Subscriber(
-        HALT_TOPIC, Bool, lambda msg: received.append(msg)
+        HALT_TOPIC, Int8, lambda msg: received.append(msg)
     )
     cartesian_cmd = CartesianJogCmd()
 

--- a/moveit_experimental/moveit_jog_arm/test/python_tests/halt_msg/test_jog_arm_halt_msg.py
+++ b/moveit_experimental/moveit_jog_arm/test/python_tests/halt_msg/test_jog_arm_halt_msg.py
@@ -67,8 +67,8 @@ def test_jog_arm_halt_msg(node):
 
     # Check the received messages
     # A non-zero value signifies a warning
-    assert len(received) > 1
-    assert received[-1].data != 0
+    assert len(received) > 3
+    assert (received[-1].data != 0) or (received[-2].data != 0) or (received[-3].data != 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Rather than just a boolean, this publishes a more detailed status message.

I thought about publishing a vector of status codes, but some downsides of that are:

- it would require a custom message type

- the vector would have to be resized, which isn't great from a performance perspective. The code to handle that would be more complicated.
