### PR TITLE
Fix for ompl 1.5.0 in g++5 (Xenial)

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -192,34 +192,35 @@ ompl_interface::MultiQueryPlannerAllocator::allocatePersistentPlanner(const ob::
   return nullptr;
 };
 // TODO: remove when ROS Melodic and older are no longer supported
+// namespace is scoped instead of global because of GCC bug 56480
 #if OMPL_VERSION_VALUE >= 1005000
+namespace ompl_interface
+{
 template <>
 inline ompl::base::Planner*
-ompl_interface::MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::PRM>(const ob::PlannerData& data)
+MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::PRM>(const ob::PlannerData& data)
 {
   return new og::PRM(data);
 };
 template <>
 inline ompl::base::Planner*
-ompl_interface::MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::PRMstar>(
-    const ob::PlannerData& data)
+MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::PRMstar>(const ob::PlannerData& data)
 {
   return new og::PRMstar(data);
 };
 template <>
 inline ompl::base::Planner*
-ompl_interface::MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::LazyPRM>(
-    const ob::PlannerData& data)
+MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::LazyPRM>(const ob::PlannerData& data)
 {
   return new og::LazyPRM(data);
 };
 template <>
 inline ompl::base::Planner*
-ompl_interface::MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::LazyPRMstar>(
-    const ob::PlannerData& data)
+MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::LazyPRMstar>(const ob::PlannerData& data)
 {
   return new og::LazyPRMstar(data);
 };
+}
 #endif
 
 ompl_interface::PlanningContextManager::PlanningContextManager(robot_model::RobotModelConstPtr robot_model,


### PR DESCRIPTION
### Description

GCC 5 suffers from [this](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480) bug, which means that you cannot have template specializations defined outside a scope (in the global namespace).

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
