### PR TITLE
Improves documentation for setJointPositions()

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -487,24 +487,29 @@ public:
 
   /** @} */
 
-  /** \name Getting and setting joint positions, velocities, accelerations and effort
+  /** \name Getting and setting group positions
    *  @{
    */
+
+  /** \brief Sets position for 1 joint only. Check setVariablePositions() to set position values to multiple joints. */
   void setJointPositions(const std::string& joint_name, const double* position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), position);
   }
 
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints. */
   void setJointPositions(const std::string& joint_name, const std::vector<double>& position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), &position[0]);
   }
 
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints. */
   void setJointPositions(const JointModel* joint, const std::vector<double>& position)
   {
     setJointPositions(joint, &position[0]);
   }
 
+  /** \brief Set positions for 1 joint only. Check setVariablePositions() to set position values to multiple joints. */
   void setJointPositions(const JointModel* joint, const double* position)
   {
     memcpy(position_ + joint->getFirstVariableIndex(), position, joint->getVariableCount() * sizeof(double));
@@ -512,11 +517,13 @@ public:
     updateMimicJoint(joint);
   }
 
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints.*/
   void setJointPositions(const std::string& joint_name, const Eigen::Isometry3d& transform)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), transform);
   }
 
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints. */
   void setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
   {
     joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -487,7 +487,7 @@ public:
 
   /** @} */
 
-  /** \name Getting and setting group positions
+  /** \name Getting and setting joint positions, velocities, accelerations and effort
    *  @{
    */
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -487,11 +487,11 @@ public:
 
   /** @} */
 
-  /** \name Getting and setting joint positions, velocities, accelerations and effort for a single, potentially multiple-dof, joint
-   * \brief See setVariablePositions(), setVariableVelocities(), setVariableEffort() to handle multiple joints.
+  /** \name Getting and setting joint positions, velocities, accelerations and effort for a single joint
+   *  The joint might be multi-dof, i.e. have more than one variables involved.
+   *  See setVariablePositions(), setVariableVelocities(), setVariableEffort() to handle multiple joints.
    *  @{
    */
-
   void setJointPositions(const std::string& joint_name, const double* position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), position);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -487,33 +487,26 @@ public:
 
   /** @} */
 
-  /** \name Getting and setting joint positions, velocities, accelerations and effort
+  /** \name Getting and setting joint positions, velocities, accelerations and effort for a single, potentially multiple-dof, joint
+   * \brief See setVariablePositions(), setVariableVelocities(), setVariableEffort() to handle multiple joints.
    *  @{
    */
 
-  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
-   * joints. */
   void setJointPositions(const std::string& joint_name, const double* position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), position);
   }
 
-  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
-   * joints. */
   void setJointPositions(const std::string& joint_name, const std::vector<double>& position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), &position[0]);
   }
 
-  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
-   * joints. */
   void setJointPositions(const JointModel* joint, const std::vector<double>& position)
   {
     setJointPositions(joint, &position[0]);
   }
 
-  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
-   * joints. */
   void setJointPositions(const JointModel* joint, const double* position)
   {
     memcpy(position_ + joint->getFirstVariableIndex(), position, joint->getVariableCount() * sizeof(double));
@@ -521,15 +514,11 @@ public:
     updateMimicJoint(joint);
   }
 
-  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
-   * joints.*/
   void setJointPositions(const std::string& joint_name, const Eigen::Isometry3d& transform)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), transform);
   }
 
-  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
-   * joints. */
   void setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
   {
     joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -491,27 +491,29 @@ public:
    *  @{
    */
 
-  /** \brief Sets position for 1 joint only. Check setVariablePositions() to set position values to multiple joints. */
+  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
+   * joints. */
   void setJointPositions(const std::string& joint_name, const double* position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), position);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
-   * values to multiple joints. */
+  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
+   * joints. */
   void setJointPositions(const std::string& joint_name, const std::vector<double>& position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), &position[0]);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
-   * values to multiple joints. */
+  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
+   * joints. */
   void setJointPositions(const JointModel* joint, const std::vector<double>& position)
   {
     setJointPositions(joint, &position[0]);
   }
 
-  /** \brief Set positions for 1 joint only. Check setVariablePositions() to set position values to multiple joints. */
+  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
+   * joints. */
   void setJointPositions(const JointModel* joint, const double* position)
   {
     memcpy(position_ + joint->getFirstVariableIndex(), position, joint->getVariableCount() * sizeof(double));
@@ -519,15 +521,15 @@ public:
     updateMimicJoint(joint);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
-   * values to multiple joints.*/
+  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
+   * joints.*/
   void setJointPositions(const std::string& joint_name, const Eigen::Isometry3d& transform)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), transform);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
-   * values to multiple joints. */
+  /** \brief Set position(s) for a single, potentially multi-dof joint. See setVariablePositions() to handle multiple
+   * joints. */
   void setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
   {
     joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -488,7 +488,7 @@ public:
   /** @} */
 
   /** \name Getting and setting joint positions, velocities, accelerations and effort for a single joint
-   *  The joint might be multi-dof, i.e. have more than one variables involved.
+   *  The joint might be multi-DOF, i.e. require more than one variable to set.
    *  See setVariablePositions(), setVariableVelocities(), setVariableEffort() to handle multiple joints.
    *  @{
    */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -497,13 +497,15 @@ public:
     setJointPositions(robot_model_->getJointModel(joint_name), position);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints. */
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
+   * values to multiple joints. */
   void setJointPositions(const std::string& joint_name, const std::vector<double>& position)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), &position[0]);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints. */
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
+   * values to multiple joints. */
   void setJointPositions(const JointModel* joint, const std::vector<double>& position)
   {
     setJointPositions(joint, &position[0]);
@@ -517,13 +519,15 @@ public:
     updateMimicJoint(joint);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints.*/
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
+   * values to multiple joints.*/
   void setJointPositions(const std::string& joint_name, const Eigen::Isometry3d& transform)
   {
     setJointPositions(robot_model_->getJointModel(joint_name), transform);
   }
 
-  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position values to multiple joints. */
+  /** \brief Sets positions for 1 joint only (joint with more than 1 DOF). Check setVariablePositions() to set position
+   * values to multiple joints. */
   void setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
   {
     joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());


### PR DESCRIPTION
### Description

Fixes issue #1908.
`setJointPositions` method is misleading for some users to believe that they can set positions for multiple joints. `setVariablePositions` is for that purpose. I have added documentation explaining the same.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
