### PR TITLE
Replace namespaces robot_state and robot_model with moveit::core

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_env_allvalid.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_env_allvalid.h
@@ -46,31 +46,31 @@ namespace collision_detection
 class CollisionEnvAllValid : public CollisionEnv
 {
 public:
-  CollisionEnvAllValid(const robot_model::RobotModelConstPtr& robot_model, double padding = 0.0, double scale = 1.0);
-  CollisionEnvAllValid(const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world, double padding = 0.0,
                        double scale = 1.0);
   CollisionEnvAllValid(const CollisionEnv& other, const WorldPtr& world);
 
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                           const robot_state::RobotState& state) const override;
-  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+                           const moveit::core::RobotState& state) const override;
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                            const AllowedCollisionMatrix& acm) const override;
-  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state1,
-                           const robot_state::RobotState& state2) const override;
-  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state1,
-                           const robot_state::RobotState& state2, const AllowedCollisionMatrix& acm) const override;
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state1,
+                           const moveit::core::RobotState& state2) const override;
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state1,
+                           const moveit::core::RobotState& state2, const AllowedCollisionMatrix& acm) const override;
 
-  virtual double distanceRobot(const robot_state::RobotState& state) const;
-  virtual double distanceRobot(const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const;
+  virtual double distanceRobot(const moveit::core::RobotState& state) const;
+  virtual double distanceRobot(const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const;
   void distanceRobot(const DistanceRequest& req, DistanceResult& res,
-                     const robot_state::RobotState& state) const override;
+                     const moveit::core::RobotState& state) const override;
 
   void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                          const robot_state::RobotState& state) const override;
-  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+                          const moveit::core::RobotState& state) const override;
+  void checkSelfCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                           const AllowedCollisionMatrix& acm) const override;
 
   void distanceSelf(const DistanceRequest& req, DistanceResult& res,
-                    const robot_state::RobotState& state) const override;
+                    const moveit::core::RobotState& state) const override;
 };
 }

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -256,7 +256,7 @@ struct DistanceRequest
   }
 
   /// Compute \e active_components_only_ based on \e req_
-  void enableGroup(const robot_model::RobotModelConstPtr& robot_model)
+  void enableGroup(const moveit::core::RobotModelConstPtr& robot_model)
   {
     if (robot_model->hasJointModelGroup(group_name))
       active_components_only = &robot_model->getJointModelGroup(group_name)->getUpdatedLinkModelsSet();
@@ -282,7 +282,7 @@ struct DistanceRequest
   std::string group_name;
 
   /// The set of active components to check
-  const std::set<const robot_model::LinkModel*>* active_components_only;
+  const std::set<const moveit::core::LinkModel*>* active_components_only;
 
   /// The allowed collision matrix used to filter checks
   const AllowedCollisionMatrix* acm;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -56,7 +56,7 @@ public:
 
   /** create a new CollisionWorld for checking collisions with the supplied world. */
   virtual CollisionEnvPtr allocateEnv(const WorldPtr& world,
-                                      const robot_model::RobotModelConstPtr& robot_model) const = 0;
+                                      const moveit::core::RobotModelConstPtr& robot_model) const = 0;
 
   /** create a new CollisionWorld by copying an existing CollisionWorld of the same type.s
    * The world must be either the same world as used by \orig or a copy of that world which has not yet been modified.
@@ -64,7 +64,7 @@ public:
   virtual CollisionEnvPtr allocateEnv(const CollisionEnvConstPtr& orig, const WorldPtr& world) const = 0;
 
   /** create a new CollisionEnv given a robot_model with a new empty world */
-  virtual CollisionEnvPtr allocateEnv(const robot_model::RobotModelConstPtr& robot_model) const = 0;
+  virtual CollisionEnvPtr allocateEnv(const moveit::core::RobotModelConstPtr& robot_model) const = 0;
 };
 
 /** \brief Template class to make it easy to create an allocator for a specific CollisionWorld/CollisionRobot pair. */
@@ -77,7 +77,7 @@ public:
     return CollisionDetectorAllocatorType::NAME;
   }
 
-  CollisionEnvPtr allocateEnv(const WorldPtr& world, const robot_model::RobotModelConstPtr& robot_model) const override
+  CollisionEnvPtr allocateEnv(const WorldPtr& world, const moveit::core::RobotModelConstPtr& robot_model) const override
   {
     return CollisionEnvPtr(new CollisionEnvType(robot_model, world));
   }
@@ -87,7 +87,7 @@ public:
     return CollisionEnvPtr(new CollisionEnvType(dynamic_cast<const CollisionEnvType&>(*orig), world));
   }
 
-  CollisionEnvPtr allocateEnv(const robot_model::RobotModelConstPtr& robot_model) const override
+  CollisionEnvPtr allocateEnv(const moveit::core::RobotModelConstPtr& robot_model) const override
   {
     return CollisionEnvPtr(new CollisionEnvType(robot_model));
   }

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -58,14 +58,14 @@ public:
    *  @param padding The padding to use for all objects/links on the robot
    *  @scale scale A common scaling to use for all objects/links on the robot
    */
-  CollisionEnv(const robot_model::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnv(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
 
   /** @brief Constructor
    *  @param model A robot model to construct the collision robot from
    *  @param padding The padding to use for all objects/links on the robot
    *  @scale scale A common scaling to use for all objects/links on the robot
    */
-  CollisionEnv(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnv(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
                double scale = 1.0);
 
   /** \brief Copy constructor */
@@ -82,7 +82,7 @@ public:
    *  @param res A CollisionResult object that encapsulates the collision result
    *  @param state The kinematic state for which checks are being made */
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state) const = 0;
+                                  const moveit::core::RobotState& state) const = 0;
 
   /** \brief Check for self collision. Allowed collisions specified by the allowed collision matrix are
    *   taken into account.
@@ -91,7 +91,7 @@ public:
    *  @param state The kinematic state for which checks are being made
    *  @param acm The allowed collision matrix. */
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const = 0;
+                                  const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const = 0;
 
   /** \brief Check whether the robot model is in collision with itself or the world at a particular state.
    *  Any collision between any pair of links is checked for, NO collisions are ignored.
@@ -99,7 +99,7 @@ public:
    *  @param res A CollisionResult object that encapsulates the collision result
    *  @param state The kinematic state for which checks are being made         */
   virtual void checkCollision(const CollisionRequest& req, CollisionResult& res,
-                              const robot_state::RobotState& state) const;
+                              const moveit::core::RobotState& state) const;
 
   /** \brief Check whether the robot model is in collision with itself or the world at a particular state.
    *  Allowed collisions specified by the allowed collision matrix are taken into account.
@@ -107,7 +107,7 @@ public:
    *  @param res A CollisionResult object that encapsulates the collision result
    *  @param state The kinematic state for which checks are being made
    *  @param acm The allowed collision matrix. */
-  virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                               const AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the robot model is in collision with the world. Any collisions between a robot link
@@ -118,7 +118,7 @@ public:
    *  @param state The kinematic state for which checks are being made
    */
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state) const = 0;
+                                   const moveit::core::RobotState& state) const = 0;
 
   /** \brief Check whether the robot model is in collision with the world.
    *  Allowed collisions are ignored. Self collisions are not checked.
@@ -128,7 +128,7 @@ public:
    *  @param state The kinematic state for which checks are being made
    *  @param acm The allowed collision matrix.*/
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const = 0;
+                                   const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const = 0;
 
   /** \brief Check whether the robot model is in collision with the world in a continuous manner (between two robot
    * states).
@@ -140,7 +140,7 @@ public:
    *  @param state2 The kinematic state at the end of the segment for which checks are being made
    *  @param acm The allowed collision matrix.*/
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                   const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
                                    const AllowedCollisionMatrix& acm) const = 0;
 
   /** \brief Check whether the robot model is in collision with the world in a continuous manner (between two robot
@@ -153,18 +153,18 @@ public:
    *  @param state2 The kinematic state at the end of the segment for which checks are being made
    *  @param acm The allowed collision matrix.*/
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1,
-                                   const robot_state::RobotState& state2) const = 0;
+                                   const moveit::core::RobotState& state1,
+                                   const moveit::core::RobotState& state2) const = 0;
 
   /** \brief The distance to self-collision given the robot is at state \e state.
       @param req A DistanceRequest object that encapsulates the distance request
       @param res A DistanceResult object that encapsulates the distance result
       @param state The state of this robot to consider */
   virtual void distanceSelf(const DistanceRequest& req, DistanceResult& res,
-                            const robot_state::RobotState& state) const = 0;
+                            const moveit::core::RobotState& state) const = 0;
 
   /** \brief The distance to self-collision given the robot is at state \e state. */
-  inline double distanceSelf(const robot_state::RobotState& state) const
+  inline double distanceSelf(const moveit::core::RobotState& state) const
   {
     DistanceRequest req;
     DistanceResult res;
@@ -176,7 +176,7 @@ public:
 
   /** \brief The distance to self-collision given the robot is at state \e state, ignoring
       the distances between links that are allowed to always collide (as specified by \e acm) */
-  inline double distanceSelf(const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const
+  inline double distanceSelf(const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
   {
     DistanceRequest req;
     DistanceResult res;
@@ -193,13 +193,13 @@ public:
    *  @param robot The robot to check distance for
    *  @param state The state for the robot to check distances from */
   virtual void distanceRobot(const DistanceRequest& req, DistanceResult& res,
-                             const robot_state::RobotState& state) const = 0;
+                             const moveit::core::RobotState& state) const = 0;
 
   /** \brief Compute the shortest distance between a robot and the world
    *  @param robot The robot to check distance for
    *  @param state The state for the robot to check distances from
    *  @param verbose Output debug information about distance checks */
-  inline double distanceRobot(const robot_state::RobotState& state, bool verbose = false) const
+  inline double distanceRobot(const moveit::core::RobotState& state, bool verbose = false) const
   {
     DistanceRequest req;
     DistanceResult res;
@@ -217,7 +217,7 @@ public:
    *  @param acm Using an allowed collision matrix has the effect of ignoring distances from links that are always
    * allowed to be in collision.
    *  @param verbose Output debug information about distance checks */
-  inline double distanceRobot(const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
+  inline double distanceRobot(const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm,
                               bool verbose = false) const
   {
     DistanceRequest req;
@@ -252,7 +252,7 @@ public:
   typedef World::ObjectConstPtr ObjectConstPtr;
 
   /** @brief The kinematic model corresponding to this collision model*/
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -312,7 +312,7 @@ protected:
   virtual void updatedPaddingOrScaling(const std::vector<std::string>& links);
 
   /** @brief The kinematic model corresponding to this collision model*/
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
   /** @brief The internally maintained map (from link names to padding)*/
   std::map<std::string, double> link_padding_;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -51,7 +51,7 @@
 #include <fstream>
 
 /** \brief Brings the panda robot in user defined home position */
-inline void setToHome(robot_state::RobotState& panda_state)
+inline void setToHome(moveit::core::RobotState& panda_state)
 {
   panda_state.setToDefaultValues();
   double joint2 = -0.785;
@@ -90,7 +90,7 @@ protected:
 
     cenv_ = value_->allocateEnv(robot_model_);
 
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
+    robot_state_.reset(new moveit::core::RobotState(robot_model_));
     setToHome(*robot_state_);
   }
 
@@ -100,13 +100,13 @@ protected:
 
   bool robot_model_ok_;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
   collision_detection::CollisionEnvPtr cenv_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;
 
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
 };
 
 TYPED_TEST_CASE_P(CollisionDetectorPandaTest);

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
@@ -78,7 +78,7 @@ protected:
 
   bool robot_model_ok_;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
   collision_detection::CollisionEnvPtr cenv_;
 
@@ -96,7 +96,7 @@ TYPED_TEST_P(CollisionDetectorTest, InitOK)
 
 TYPED_TEST_P(CollisionDetectorTest, DefaultNotInCollision)
 {
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -115,7 +115,7 @@ TYPED_TEST_P(CollisionDetectorTest, LinksInCollision)
   // req.contacts = true;
   // req.max_contacts = 100;
 
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -154,7 +154,7 @@ TYPED_TEST_P(CollisionDetectorTest, ContactReporting)
   req.contacts = true;
   req.max_contacts = 1;
 
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -208,7 +208,7 @@ TYPED_TEST_P(CollisionDetectorTest, ContactPositions)
   req.contacts = true;
   req.max_contacts = 1;
 
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -278,7 +278,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
 
   this->acm_.reset(new collision_detection::AllowedCollisionMatrix(this->robot_model_->getLinkModelNames(), true));
 
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -341,7 +341,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
 
 TYPED_TEST_P(CollisionDetectorTest, DiffSceneTester)
 {
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -403,7 +403,7 @@ TYPED_TEST_P(CollisionDetectorTest, ConvertObjectToAttached)
 
   this->cenv_->getWorld()->addToObject("kinect", shape, pos1);
 
-  robot_state::RobotState robot_state(this->robot_model_);
+  moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -419,8 +419,8 @@ TYPED_TEST_P(CollisionDetectorTest, ConvertObjectToAttached)
   collision_detection::CollisionEnv::ObjectConstPtr object = this->cenv_->getWorld()->getObject("kinect");
   this->cenv_->getWorld()->removeObject("kinect");
 
-  robot_state::RobotState robot_state1(this->robot_model_);
-  robot_state::RobotState robot_state2(this->robot_model_);
+  moveit::core::RobotState robot_state1(this->robot_model_);
+  moveit::core::RobotState robot_state2(this->robot_model_);
   robot_state1.setToDefaultValues();
   robot_state2.setToDefaultValues();
   robot_state1.update();
@@ -475,7 +475,7 @@ TYPED_TEST_P(CollisionDetectorTest, TestCollisionMapAdditionSpeed)
 
 TYPED_TEST_P(CollisionDetectorTest, MoveMesh)
 {
-  robot_state::RobotState robot_state1(this->robot_model_);
+  moveit::core::RobotState robot_state1(this->robot_model_);
   robot_state1.setToDefaultValues();
   robot_state1.update();
 
@@ -499,7 +499,7 @@ TYPED_TEST_P(CollisionDetectorTest, MoveMesh)
 
 TYPED_TEST_P(CollisionDetectorTest, TestChangingShapeSize)
 {
-  robot_state::RobotState robot_state1(this->robot_model_);
+  moveit::core::RobotState robot_state1(this->robot_model_);
   robot_state1.setToDefaultValues();
   robot_state1.update();
 

--- a/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
@@ -39,13 +39,13 @@
 
 const std::string collision_detection::CollisionDetectorAllocatorAllValid::NAME("ALL_VALID");
 
-collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const robot_model::RobotModelConstPtr& robot_model,
+collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model,
                                                                 double padding, double scale)
   : CollisionEnv(robot_model, padding, scale)
 {
 }
 
-collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const robot_model::RobotModelConstPtr& robot_model,
+collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const moveit::core::RobotModelConstPtr& robot_model,
                                                                 const WorldPtr& world, double padding, double scale)
   : CollisionEnv(robot_model, world, padding, scale)
 {
@@ -57,7 +57,7 @@ collision_detection::CollisionEnvAllValid::CollisionEnvAllValid(const CollisionE
 }
 
 void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const robot_state::RobotState& state) const
+                                                                    const moveit::core::RobotState& state) const
 {
   res.collision = false;
   if (req.verbose)
@@ -65,7 +65,7 @@ void collision_detection::CollisionEnvAllValid::checkRobotCollision(const Collis
 }
 
 void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const robot_state::RobotState& state,
+                                                                    const moveit::core::RobotState& state,
                                                                     const AllowedCollisionMatrix& acm) const
 {
   res.collision = false;
@@ -74,8 +74,8 @@ void collision_detection::CollisionEnvAllValid::checkRobotCollision(const Collis
 }
 
 void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const robot_state::RobotState& state1,
-                                                                    const robot_state::RobotState& state2) const
+                                                                    const moveit::core::RobotState& state1,
+                                                                    const moveit::core::RobotState& state2) const
 {
   res.collision = false;
   if (req.verbose)
@@ -83,8 +83,8 @@ void collision_detection::CollisionEnvAllValid::checkRobotCollision(const Collis
 }
 
 void collision_detection::CollisionEnvAllValid::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                    const robot_state::RobotState& state1,
-                                                                    const robot_state::RobotState& state2,
+                                                                    const moveit::core::RobotState& state1,
+                                                                    const moveit::core::RobotState& state2,
                                                                     const AllowedCollisionMatrix& acm) const
 {
   res.collision = false;
@@ -99,19 +99,19 @@ void collision_detection::CollisionEnvAllValid::distanceRobot(const collision_de
   res.collision = false;
 }
 
-double collision_detection::CollisionEnvAllValid::distanceRobot(const robot_state::RobotState& state) const
+double collision_detection::CollisionEnvAllValid::distanceRobot(const moveit::core::RobotState& state) const
 {
   return 0.0;
 }
 
-double collision_detection::CollisionEnvAllValid::distanceRobot(const robot_state::RobotState& state,
+double collision_detection::CollisionEnvAllValid::distanceRobot(const moveit::core::RobotState& state,
                                                                 const AllowedCollisionMatrix& acm) const
 {
   return 0.0;
 }
 
 void collision_detection::CollisionEnvAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                   const robot_state::RobotState& state) const
+                                                                   const moveit::core::RobotState& state) const
 {
   res.collision = false;
   if (req.verbose)
@@ -119,7 +119,7 @@ void collision_detection::CollisionEnvAllValid::checkSelfCollision(const Collisi
 }
 
 void collision_detection::CollisionEnvAllValid::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                                                   const robot_state::RobotState& state,
+                                                                   const moveit::core::RobotState& state,
                                                                    const AllowedCollisionMatrix& acm) const
 {
   res.collision = false;

--- a/moveit_core/collision_detection/src/collision_env.cpp
+++ b/moveit_core/collision_detection/src/collision_env.cpp
@@ -69,7 +69,7 @@ static inline bool validatePadding(double padding)
 
 namespace collision_detection
 {
-CollisionEnv::CollisionEnv(const robot_model::RobotModelConstPtr& model, double padding, double scale)
+CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
   : robot_model_(model), world_(new World()), world_const_(world_)
 {
   if (!validateScale(scale))
@@ -77,7 +77,7 @@ CollisionEnv::CollisionEnv(const robot_model::RobotModelConstPtr& model, double 
   if (!validatePadding(padding))
     padding = 0.0;
 
-  const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (auto link : links)
   {
     link_padding_[link->getName()] = padding;
@@ -85,7 +85,7 @@ CollisionEnv::CollisionEnv(const robot_model::RobotModelConstPtr& model, double 
   }
 }
 
-CollisionEnv::CollisionEnv(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding,
+CollisionEnv::CollisionEnv(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding,
                            double scale)
   : robot_model_(model), world_(world), world_const_(world_)
 {
@@ -94,7 +94,7 @@ CollisionEnv::CollisionEnv(const robot_model::RobotModelConstPtr& model, const W
   if (!validatePadding(padding))
     padding = 0.0;
 
-  const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (auto link : links)
   {
     link_padding_[link->getName()] = padding;
@@ -113,7 +113,7 @@ void CollisionEnv::setPadding(double padding)
   if (!validatePadding(padding))
     return;
   std::vector<std::string> u;
-  const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (auto link : links)
   {
     if (getLinkPadding(link->getName()) != padding)
@@ -129,7 +129,7 @@ void CollisionEnv::setScale(double scale)
   if (!validateScale(scale))
     return;
   std::vector<std::string> u;
-  const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
   for (auto link : links)
   {
     if (getLinkScale(link->getName()) != scale)
@@ -289,7 +289,7 @@ void CollisionEnv::setWorld(const WorldPtr& world)
 }
 
 void CollisionEnv::checkCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state) const
+                                  const moveit::core::RobotState& state) const
 {
   checkSelfCollision(req, res, state);
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
@@ -297,7 +297,7 @@ void CollisionEnv::checkCollision(const CollisionRequest& req, CollisionResult& 
 }
 
 void CollisionEnv::checkCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const
+                                  const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
 {
   checkSelfCollision(req, res, state, acm);
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))

--- a/moveit_core/collision_detection/test/test_all_valid.cpp
+++ b/moveit_core/collision_detection/test/test_all_valid.cpp
@@ -47,8 +47,8 @@ TEST(AllValid, Instantiate)
   urdf_model.reset(new urdf::ModelInterface());
   srdf::ModelConstSharedPtr srdf_model;
   srdf_model.reset(new srdf::Model());
-  robot_model::RobotModelConstPtr robot_model;
-  robot_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
+  moveit::core::RobotModelConstPtr robot_model;
+  robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   CollisionEnvAllValid env(robot_model);
 }
 

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
@@ -103,8 +103,8 @@ protected:
                          std::vector<collision_detection_bullet::CollisionObjectWrapperPtr>& cows) const;
 
   /** \brief Bundles the different checkSelfCollision functions into a single function */
-  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
-                                const AllowedCollisionMatrix* acm) const;
+  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
 
   void checkRobotCollisionHelperCCD(const CollisionRequest& req, CollisionResult& res,
                                     const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
@@ -48,9 +48,9 @@ class CollisionEnvBullet : public CollisionEnv
 public:
   CollisionEnvBullet() = delete;
 
-  CollisionEnvBullet(const robot_model::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
 
-  CollisionEnvBullet(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
                      double scale = 1.0);
 
   CollisionEnvBullet(const CollisionEnvBullet& other, const WorldPtr& world);
@@ -60,38 +60,38 @@ public:
   CollisionEnvBullet(CollisionEnvBullet&) = delete;
 
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state) const override;
+                                  const moveit::core::RobotState& state) const override;
 
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state,
+                                  const moveit::core::RobotState& state,
                                   const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state) const override;
+                                   const moveit::core::RobotState& state) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state,
+                                   const moveit::core::RobotState& state,
                                    const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1,
-                                   const robot_state::RobotState& state2) const override;
+                                   const moveit::core::RobotState& state1,
+                                   const moveit::core::RobotState& state2) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                   const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
                                    const AllowedCollisionMatrix& acm) const override;
 
   virtual void distanceSelf(const DistanceRequest& req, DistanceResult& res,
-                            const robot_state::RobotState& state) const override;
+                            const moveit::core::RobotState& state) const override;
 
   virtual void distanceRobot(const DistanceRequest& req, DistanceResult& res,
-                             const robot_state::RobotState& state) const override;
+                             const moveit::core::RobotState& state) const override;
 
   void setWorld(const WorldPtr& world) override;
 
 protected:
   /** \brief Updates the poses of the objects in the manager according to given robot state */
-  void updateTransformsFromState(const robot_state::RobotState& state,
+  void updateTransformsFromState(const moveit::core::RobotState& state,
                                  const collision_detection_bullet::BulletDiscreteBVHManagerPtr& manager) const;
 
   /** \brief Updates the collision objects saved in the manager to reflect a new padding or scaling of the robot links
@@ -99,19 +99,19 @@ protected:
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
 
   /** \brief All of the attached objects in the robot state are wrapped into bullet collision objects */
-  void addAttachedOjects(const robot_state::RobotState& state,
+  void addAttachedOjects(const moveit::core::RobotState& state,
                          std::vector<collision_detection_bullet::CollisionObjectWrapperPtr>& cows) const;
 
   /** \brief Bundles the different checkSelfCollision functions into a single function */
-  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                                 const AllowedCollisionMatrix* acm) const;
 
   void checkRobotCollisionHelperCCD(const CollisionRequest& req, CollisionResult& res,
-                                    const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                    const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
                                     const AllowedCollisionMatrix* acm) const;
 
   void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
-                                 const robot_state::RobotState& state, const AllowedCollisionMatrix* acm) const;
+                                 const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
 
   /** \brief Construts a bullet collision object out of a robot link */
   void addLinkAsCollisionObject(const urdf::LinkSharedPtr& link);

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -46,7 +46,7 @@ namespace collision_detection
 const std::string CollisionDetectorAllocatorBullet::NAME("Bullet");
 const double MAX_DISTANCE_MARGIN = 99;
 
-CollisionEnvBullet::CollisionEnvBullet(const robot_model::RobotModelConstPtr& model, double padding, double scale)
+CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
   : CollisionEnv(model, padding, scale)
 {
   // request notifications about changes to new world
@@ -58,7 +58,7 @@ CollisionEnvBullet::CollisionEnvBullet(const robot_model::RobotModelConstPtr& mo
   }
 }
 
-CollisionEnvBullet::CollisionEnvBullet(const robot_model::RobotModelConstPtr& model, const WorldPtr& world,
+CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world,
                                        double padding, double scale)
   : CollisionEnv(model, world, padding, scale)
 {
@@ -93,20 +93,20 @@ CollisionEnvBullet::~CollisionEnvBullet()
 }
 
 void CollisionEnvBullet::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                            const robot_state::RobotState& state) const
+                                            const moveit::core::RobotState& state) const
 {
   checkSelfCollisionHelper(req, res, state, nullptr);
 }
 
 void CollisionEnvBullet::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                            const robot_state::RobotState& state,
+                                            const moveit::core::RobotState& state,
                                             const AllowedCollisionMatrix& acm) const
 {
   checkSelfCollisionHelper(req, res, state, &acm);
 }
 
 void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
-                                                  const robot_state::RobotState& state,
+                                                  const moveit::core::RobotState& state,
                                                   const AllowedCollisionMatrix* acm) const
 {
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> cows;
@@ -139,35 +139,35 @@ void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, C
 }
 
 void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                             const robot_state::RobotState& state) const
+                                             const moveit::core::RobotState& state) const
 {
   checkRobotCollisionHelper(req, res, state, nullptr);
 }
 
 void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                             const robot_state::RobotState& state,
+                                             const moveit::core::RobotState& state,
                                              const AllowedCollisionMatrix& acm) const
 {
   checkRobotCollisionHelper(req, res, state, &acm);
 }
 
 void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                             const robot_state::RobotState& state1,
-                                             const robot_state::RobotState& state2) const
+                                             const moveit::core::RobotState& state1,
+                                             const moveit::core::RobotState& state2) const
 {
   checkRobotCollisionHelperCCD(req, res, state1, state2, nullptr);
 }
 
 void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                             const robot_state::RobotState& state1,
-                                             const robot_state::RobotState& state2,
+                                             const moveit::core::RobotState& state1,
+                                             const moveit::core::RobotState& state2,
                                              const AllowedCollisionMatrix& acm) const
 {
   checkRobotCollisionHelperCCD(req, res, state1, state2, &acm);
 }
 
 void CollisionEnvBullet::checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
-                                                   const robot_state::RobotState& state,
+                                                   const moveit::core::RobotState& state,
                                                    const AllowedCollisionMatrix* acm) const
 {
   if (req.distance)
@@ -195,8 +195,8 @@ void CollisionEnvBullet::checkRobotCollisionHelper(const CollisionRequest& req, 
 }
 
 void CollisionEnvBullet::checkRobotCollisionHelperCCD(const CollisionRequest& req, CollisionResult& res,
-                                                      const robot_state::RobotState& state1,
-                                                      const robot_state::RobotState& state2,
+                                                      const moveit::core::RobotState& state1,
+                                                      const moveit::core::RobotState& state2,
                                                       const AllowedCollisionMatrix* acm) const
 {
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
@@ -225,13 +225,13 @@ void CollisionEnvBullet::checkRobotCollisionHelperCCD(const CollisionRequest& re
 }
 
 void CollisionEnvBullet::distanceSelf(const DistanceRequest& req, DistanceResult& res,
-                                      const robot_state::RobotState& state) const
+                                      const moveit::core::RobotState& state) const
 {
   ROS_INFO_NAMED("collision_detection.bullet", "Distance to self not implemented yet.");
 }
 
 void CollisionEnvBullet::distanceRobot(const DistanceRequest& req, DistanceResult& res,
-                                       const robot_state::RobotState& state) const
+                                       const moveit::core::RobotState& state) const
 {
   ROS_INFO_NAMED("collision_detection.bullet", "Distance to self not implemented yet.");
 }
@@ -313,13 +313,13 @@ void CollisionEnvBullet::notifyObjectChange(const ObjectConstPtr& obj, World::Ac
 }
 
 void CollisionEnvBullet::addAttachedOjects(
-    const robot_state::RobotState& state,
+    const moveit::core::RobotState& state,
     std::vector<collision_detection_bullet::CollisionObjectWrapperPtr>& cows) const
 {
-  std::vector<const robot_state::AttachedBody*> attached_bodies;
+  std::vector<const moveit::core::AttachedBody*> attached_bodies;
   state.getAttachedBodies(attached_bodies);
 
-  for (const robot_state::AttachedBody*& body : attached_bodies)
+  for (const moveit::core::AttachedBody*& body : attached_bodies)
   {
     const EigenSTL::vector_Isometry3d& attached_body_transform = body->getGlobalCollisionBodyTransforms();
 
@@ -357,7 +357,7 @@ void CollisionEnvBullet::updatedPaddingOrScaling(const std::vector<std::string>&
 }
 
 void CollisionEnvBullet::updateTransformsFromState(
-    const robot_state::RobotState& state, const collision_detection_bullet::BulletDiscreteBVHManagerPtr& manager) const
+    const moveit::core::RobotState& state, const collision_detection_bullet::BulletDiscreteBVHManagerPtr& manager) const
 {
   // updating link positions with the current robot state
   for (const std::string& link : active_)

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -54,7 +54,7 @@
 namespace cb = collision_detection_bullet;
 
 /** \brief Brings the panda robot in user defined home position */
-inline void setToHome(robot_state::RobotState& panda_state)
+inline void setToHome(moveit::core::RobotState& panda_state)
 {
   panda_state.setToDefaultValues();
   double joint2 = -0.785;
@@ -88,7 +88,7 @@ protected:
 
     cenv_.reset(new collision_detection::CollisionEnvBullet(robot_model_));
 
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
+    robot_state_.reset(new moveit::core::RobotState(robot_model_));
 
     setToHome(*robot_state_);
   }
@@ -100,13 +100,13 @@ protected:
 protected:
   bool robot_model_ok_;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
   collision_detection::CollisionEnvPtr cenv_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;
 
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
 };
 
 void addCollisionObjects(cb::BulletCastBVHManager& checker)
@@ -231,8 +231,8 @@ TEST_F(BulletCollisionDetectionTester, DISABLED_ContinuousCollisionSelf)
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
 
-  robot_state::RobotState state1(robot_model_);
-  robot_state::RobotState state2(robot_model_);
+  moveit::core::RobotState state1(robot_model_);
+  moveit::core::RobotState state2(robot_model_);
 
   setToHome(state1);
   double joint2 = 0.15;
@@ -274,8 +274,8 @@ TEST_F(BulletCollisionDetectionTester, ContinuousCollisionWorld)
   req.max_contacts = 10;
   collision_detection::CollisionResult res;
 
-  robot_state::RobotState state1(robot_model_);
-  robot_state::RobotState state2(robot_model_);
+  moveit::core::RobotState state1(robot_model_);
+  moveit::core::RobotState state2(robot_model_);
 
   setToHome(state1);
   state1.update();

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -62,7 +62,8 @@ MOVEIT_STRUCT_FORWARD(CollisionGeometryData);
 struct CollisionGeometryData
 {
   /** \brief Constructor for a robot link collision geometry object. */
-  CollisionGeometryData(const moveit::core::LinkModel* link, int index) : type(BodyTypes::ROBOT_LINK), shape_index(index)
+  CollisionGeometryData(const moveit::core::LinkModel* link, int index)
+    : type(BodyTypes::ROBOT_LINK), shape_index(index)
   {
     ptr.link = link;
   }

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -62,13 +62,13 @@ MOVEIT_STRUCT_FORWARD(CollisionGeometryData);
 struct CollisionGeometryData
 {
   /** \brief Constructor for a robot link collision geometry object. */
-  CollisionGeometryData(const robot_model::LinkModel* link, int index) : type(BodyTypes::ROBOT_LINK), shape_index(index)
+  CollisionGeometryData(const moveit::core::LinkModel* link, int index) : type(BodyTypes::ROBOT_LINK), shape_index(index)
   {
     ptr.link = link;
   }
 
   /** \brief Constructor for a new collision geometry object which is attached to the robot. */
-  CollisionGeometryData(const robot_state::AttachedBody* ab, int index)
+  CollisionGeometryData(const moveit::core::AttachedBody* ab, int index)
     : type(BodyTypes::ROBOT_ATTACHED), shape_index(index)
   {
     ptr.ab = ab;
@@ -128,8 +128,8 @@ struct CollisionGeometryData
   /** \brief Points to the type of body which contains the geometry. */
   union
   {
-    const robot_model::LinkModel* link;
-    const robot_state::AttachedBody* ab;
+    const moveit::core::LinkModel* link;
+    const moveit::core::AttachedBody* ab;
     const World::Object* obj;
     const void* raw;
   } ptr;
@@ -152,7 +152,7 @@ struct CollisionData
   }
 
   /** \brief Compute \e active_components_only_ based on the joint group specified in \e req_ */
-  void enableGroup(const robot_model::RobotModelConstPtr& robot_model);
+  void enableGroup(const moveit::core::RobotModelConstPtr& robot_model);
 
   /** \brief The collision request passed by the user */
   const CollisionRequest* req_;
@@ -161,7 +161,7 @@ struct CollisionData
    *  are considered for collision.
    *
    *  If the pointer is NULL, all collisions are considered. */
-  const std::set<const robot_model::LinkModel*>* active_components_only_;
+  const std::set<const moveit::core::LinkModel*>* active_components_only_;
 
   /** \brief The user-specified response location. */
   CollisionResult* res_;
@@ -203,14 +203,14 @@ struct FCLGeometry
   }
 
   /** \brief Constructor for a robot link. */
-  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const robot_model::LinkModel* link, int shape_index)
+  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const moveit::core::LinkModel* link, int shape_index)
     : collision_geometry_(collision_geometry), collision_geometry_data_(new CollisionGeometryData(link, shape_index))
   {
     collision_geometry_->setUserData(collision_geometry_data_.get());
   }
 
   /** \brief Constructor for an attached body. */
-  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const robot_state::AttachedBody* ab, int shape_index)
+  FCLGeometry(fcl::CollisionGeometryd* collision_geometry, const moveit::core::AttachedBody* ab, int shape_index)
     : collision_geometry_(collision_geometry), collision_geometry_data_(new CollisionGeometryData(ab, shape_index))
   {
     collision_geometry_->setUserData(collision_geometry_data_.get());
@@ -285,11 +285,11 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist);
 
 /** \brief Create new FCLGeometry object out of robot link model. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_model::LinkModel* link,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const moveit::core::LinkModel* link,
                                             int shape_index);
 
 /** \brief Create new FCLGeometry object out of attached body. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_state::AttachedBody* ab,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const moveit::core::AttachedBody* ab,
                                             int shape_index);
 
 /** \brief Create new FCLGeometry object out of a world object.
@@ -299,11 +299,11 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of robot link model. */
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
-                                            const robot_model::LinkModel* link, int shape_index);
+                                            const moveit::core::LinkModel* link, int shape_index);
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of an attached body. */
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
-                                            const robot_state::AttachedBody* ab, int shape_index);
+                                            const moveit::core::AttachedBody* ab, int shape_index);
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of an world object. */
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -105,8 +105,8 @@ protected:
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
 
   /** \brief Bundles the different checkSelfCollision functions into a single function */
-  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
-                                const AllowedCollisionMatrix* acm) const;
+  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
 
   /** \brief Bundles the different checkRobotCollision functions into a single function */
   void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -55,9 +55,9 @@ class CollisionEnvFCL : public CollisionEnv
 public:
   CollisionEnvFCL() = delete;
 
-  CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
 
-  CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
+  CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
                   double scale = 1.0);
 
   CollisionEnvFCL(const CollisionEnvFCL& other, const WorldPtr& world);
@@ -65,32 +65,32 @@ public:
   ~CollisionEnvFCL() override;
 
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state) const override;
+                                  const moveit::core::RobotState& state) const override;
 
   virtual void checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                  const robot_state::RobotState& state,
+                                  const moveit::core::RobotState& state,
                                   const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state) const override;
+                                   const moveit::core::RobotState& state) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state,
+                                   const moveit::core::RobotState& state,
                                    const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                   const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
                                    const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1,
-                                   const robot_state::RobotState& state2) const override;
+                                   const moveit::core::RobotState& state1,
+                                   const moveit::core::RobotState& state2) const override;
 
   virtual void distanceSelf(const DistanceRequest& req, DistanceResult& res,
-                            const robot_state::RobotState& state) const override;
+                            const moveit::core::RobotState& state) const override;
 
   virtual void distanceRobot(const DistanceRequest& req, DistanceResult& res,
-                             const robot_state::RobotState& state) const override;
+                             const moveit::core::RobotState& state) const override;
 
   void setWorld(const WorldPtr& world) override;
 
@@ -105,12 +105,12 @@ protected:
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
 
   /** \brief Bundles the different checkSelfCollision functions into a single function */
-  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                                 const AllowedCollisionMatrix* acm) const;
 
   /** \brief Bundles the different checkRobotCollision functions into a single function */
   void checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
-                                 const robot_state::RobotState& state, const AllowedCollisionMatrix* acm) const;
+                                 const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm) const;
 
   /** \brief Construct an FCL collision object from MoveIt's World::Object. */
   void constructFCLObjectWorld(const World::Object* obj, FCLObject& fcl_obj) const;
@@ -128,11 +128,11 @@ protected:
   *
   *   \param state The current robot state
   *   \param fcl_obj The newly filled object */
-  void constructFCLObjectRobot(const robot_state::RobotState& state, FCLObject& fcl_obj) const;
+  void constructFCLObjectRobot(const moveit::core::RobotState& state, FCLObject& fcl_obj) const;
 
   /** \brief Prepares for the collision check through constructing an FCL collision object out of the current robot
   *   state and specifying a broadphase collision manager of FCL where the constructed object is registered to. */
-  void allocSelfCollisionBroadPhase(const robot_state::RobotState& state, FCLManager& manager) const;
+  void allocSelfCollisionBroadPhase(const moveit::core::RobotState& state, FCLManager& manager) const;
 
   /** \brief Converts all shapes which make up an atttached body into a vector of FCLGeometryConstPtr.
   *
@@ -141,7 +141,7 @@ protected:
   *   \param ab Pointer to the attached body
   *   \param geoms Output vector of geometries
   */
-  void getAttachedBodyObjects(const robot_state::AttachedBody* ab, std::vector<FCLGeometryConstPtr>& geoms) const;
+  void getAttachedBodyObjects(const moveit::core::AttachedBody* ab, std::vector<FCLGeometryConstPtr>& geoms) const;
 
   /** \brief Vector of shared pointers to the FCL geometry for the objects in fcl_objs_. */
   std::vector<FCLGeometryConstPtr> robot_geoms_;

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -67,11 +67,11 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
   // If active components are specified
   if (cdata->active_components_only_)
   {
-    const robot_model::LinkModel* l1 =
+    const moveit::core::LinkModel* l1 =
         cd1->type == BodyTypes::ROBOT_LINK ?
             cd1->ptr.link :
             (cd1->type == BodyTypes::ROBOT_ATTACHED ? cd1->ptr.ab->getAttachedLink() : nullptr);
-    const robot_model::LinkModel* l2 =
+    const moveit::core::LinkModel* l2 =
         cd2->type == BodyTypes::ROBOT_LINK ?
             cd2->ptr.link :
             (cd2->type == BodyTypes::ROBOT_ATTACHED ? cd2->ptr.ab->getAttachedLink() : nullptr);
@@ -414,11 +414,11 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   // If active components are specified
   if (cdata->req->active_components_only)
   {
-    const robot_model::LinkModel* l1 =
+    const moveit::core::LinkModel* l1 =
         cd1->type == BodyTypes::ROBOT_LINK ?
             cd1->ptr.link :
             (cd1->type == BodyTypes::ROBOT_ATTACHED ? cd1->ptr.ab->getAttachedLink() : nullptr);
-    const robot_model::LinkModel* l2 =
+    const moveit::core::LinkModel* l2 =
         cd2->type == BodyTypes::ROBOT_LINK ?
             cd2->ptr.link :
             (cd2->type == BodyTypes::ROBOT_ATTACHED ? cd2->ptr.ab->getAttachedLink() : nullptr);
@@ -707,7 +707,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
   // attached objects could have previously been World::Object; we try to move them
   // from their old cache to the new one, if possible. the code is not pretty, but should help
   // when we attach/detach objects that are in the world
-  if (IfSameType<T, robot_state::AttachedBody>::value == 1)
+  if (IfSameType<T, moveit::core::AttachedBody>::value == 1)
   {
     // get the cache that corresponds to objects; maybe this attached object used to be a world object
     FCLShapeCache& othercache = GetShapeCache<BV, World::Object>();
@@ -743,7 +743,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       if (IfSameType<T, World::Object>::value == 1)
   {
     // get the cache that corresponds to objects; maybe this attached object used to be a world object
-    FCLShapeCache& othercache = GetShapeCache<BV, robot_state::AttachedBody>();
+    FCLShapeCache& othercache = GetShapeCache<BV, moveit::core::AttachedBody>();
 
     // attached bodies could be just moved from the environment.
     auto cache_it = othercache.map_.find(wptr);
@@ -852,16 +852,16 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
   return FCLGeometryConstPtr();
 }
 
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_model::LinkModel* link,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const moveit::core::LinkModel* link,
                                             int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSSd, robot_model::LinkModel>(shape, link, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, moveit::core::LinkModel>(shape, link, shape_index);
 }
 
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const robot_state::AttachedBody* ab,
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const moveit::core::AttachedBody* ab,
                                             int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSSd, robot_state::AttachedBody>(shape, ab, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, moveit::core::AttachedBody>(shape, ab, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const World::Object* obj)
@@ -887,15 +887,15 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
-                                            const robot_model::LinkModel* link, int shape_index)
+                                            const moveit::core::LinkModel* link, int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSSd, robot_model::LinkModel>(shape, scale, padding, link, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, moveit::core::LinkModel>(shape, scale, padding, link, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
-                                            const robot_state::AttachedBody* ab, int shape_index)
+                                            const moveit::core::AttachedBody* ab, int shape_index)
 {
-  return createCollisionGeometry<fcl::OBBRSSd, robot_state::AttachedBody>(shape, scale, padding, ab, shape_index);
+  return createCollisionGeometry<fcl::OBBRSSd, moveit::core::AttachedBody>(shape, scale, padding, ab, shape_index);
 }
 
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
@@ -910,13 +910,13 @@ void cleanCollisionGeometryCache()
   {
     cache1.bumpUseCount(true);
   }
-  FCLShapeCache& cache2 = GetShapeCache<fcl::OBBRSSd, robot_state::AttachedBody>();
+  FCLShapeCache& cache2 = GetShapeCache<fcl::OBBRSSd, moveit::core::AttachedBody>();
   {
     cache2.bumpUseCount(true);
   }
 }
 
-void CollisionData::enableGroup(const robot_model::RobotModelConstPtr& robot_model)
+void CollisionData::enableGroup(const moveit::core::RobotModelConstPtr& robot_model)
 {
   if (robot_model->hasJointModelGroup(req_->group_name))
     active_components_only_ = &robot_model->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsSet();

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -263,7 +263,8 @@ void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, Collision
 }
 
 void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                          const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
+                                          const moveit::core::RobotState& state,
+                                          const AllowedCollisionMatrix& acm) const
 {
   checkRobotCollisionHelper(req, res, state, &acm);
 }
@@ -276,7 +277,8 @@ void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, Collision
 }
 
 void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                          const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
+                                          const moveit::core::RobotState& state1,
+                                          const moveit::core::RobotState& state2,
                                           const AllowedCollisionMatrix& acm) const
 {
   ROS_ERROR_NAMED("collision_detection.fcl", "Not implemented");

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -48,10 +48,10 @@ namespace collision_detection
 {
 const std::string CollisionDetectorAllocatorFCL::NAME("FCL");
 
-CollisionEnvFCL::CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, double padding, double scale)
+CollisionEnvFCL::CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
   : CollisionEnv(model, padding, scale)
 {
-  const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
   std::size_t index;
   robot_geoms_.resize(robot_model_->getLinkGeometryCount());
   robot_fcl_objs_.resize(robot_model_->getLinkGeometryCount());
@@ -86,11 +86,11 @@ CollisionEnvFCL::CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, d
   observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvFCL::notifyObjectChange, this, _1, _2));
 }
 
-CollisionEnvFCL::CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, const WorldPtr& world, double padding,
+CollisionEnvFCL::CollisionEnvFCL(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding,
                                  double scale)
   : CollisionEnv(model, world, padding, scale)
 {
-  const std::vector<const robot_model::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
+  const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModelsWithCollisionGeometry();
   std::size_t index;
   robot_geoms_.resize(robot_model_->getLinkGeometryCount());
   robot_fcl_objs_.resize(robot_model_->getLinkGeometryCount());
@@ -148,7 +148,7 @@ CollisionEnvFCL::CollisionEnvFCL(const CollisionEnvFCL& other, const WorldPtr& w
   observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvFCL::notifyObjectChange, this, _1, _2));
 }
 
-void CollisionEnvFCL::getAttachedBodyObjects(const robot_state::AttachedBody* ab,
+void CollisionEnvFCL::getAttachedBodyObjects(const moveit::core::AttachedBody* ab,
                                              std::vector<FCLGeometryConstPtr>& geoms) const
 {
   const std::vector<shapes::ShapeConstPtr>& shapes = ab->getShapes();
@@ -174,7 +174,7 @@ void CollisionEnvFCL::constructFCLObjectWorld(const World::Object* obj, FCLObjec
   }
 }
 
-void CollisionEnvFCL::constructFCLObjectRobot(const robot_state::RobotState& state, FCLObject& fcl_obj) const
+void CollisionEnvFCL::constructFCLObjectRobot(const moveit::core::RobotState& state, FCLObject& fcl_obj) const
 {
   fcl_obj.collision_objects_.reserve(robot_geoms_.size());
   fcl::Transform3d fcl_tf;
@@ -191,8 +191,8 @@ void CollisionEnvFCL::constructFCLObjectRobot(const robot_state::RobotState& sta
       fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(coll_obj));
     }
 
-  // TODO: Implement a method for caching fcl::CollisionObject's for robot_state::AttachedBody's
-  std::vector<const robot_state::AttachedBody*> ab;
+  // TODO: Implement a method for caching fcl::CollisionObject's for moveit::core::AttachedBody's
+  std::vector<const moveit::core::AttachedBody*> ab;
   state.getAttachedBodies(ab);
   for (auto& body : ab)
   {
@@ -212,7 +212,7 @@ void CollisionEnvFCL::constructFCLObjectRobot(const robot_state::RobotState& sta
   }
 }
 
-void CollisionEnvFCL::allocSelfCollisionBroadPhase(const robot_state::RobotState& state, FCLManager& manager) const
+void CollisionEnvFCL::allocSelfCollisionBroadPhase(const moveit::core::RobotState& state, FCLManager& manager) const
 {
   auto m = new fcl::DynamicAABBTreeCollisionManagerd();
   // m->tree_init_level = 2;
@@ -223,19 +223,19 @@ void CollisionEnvFCL::allocSelfCollisionBroadPhase(const robot_state::RobotState
 }
 
 void CollisionEnvFCL::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                         const robot_state::RobotState& state) const
+                                         const moveit::core::RobotState& state) const
 {
   checkSelfCollisionHelper(req, res, state, nullptr);
 }
 
 void CollisionEnvFCL::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
-                                         const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const
+                                         const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
 {
   checkSelfCollisionHelper(req, res, state, &acm);
 }
 
 void CollisionEnvFCL::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
-                                               const robot_state::RobotState& state,
+                                               const moveit::core::RobotState& state,
                                                const AllowedCollisionMatrix* acm) const
 {
   FCLManager manager;
@@ -257,33 +257,33 @@ void CollisionEnvFCL::checkSelfCollisionHelper(const CollisionRequest& req, Coll
 }
 
 void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                          const robot_state::RobotState& state) const
+                                          const moveit::core::RobotState& state) const
 {
   checkRobotCollisionHelper(req, res, state, nullptr);
 }
 
 void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                          const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const
+                                          const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
 {
   checkRobotCollisionHelper(req, res, state, &acm);
 }
 
 void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                          const robot_state::RobotState& state1,
-                                          const robot_state::RobotState& state2) const
+                                          const moveit::core::RobotState& state1,
+                                          const moveit::core::RobotState& state2) const
 {
   ROS_ERROR_NAMED("collision_detection.bullet", "Continuous collision not implemented");
 }
 
 void CollisionEnvFCL::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                          const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                          const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
                                           const AllowedCollisionMatrix& acm) const
 {
   ROS_ERROR_NAMED("collision_detection.fcl", "Not implemented");
 }
 
 void CollisionEnvFCL::checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
-                                                const robot_state::RobotState& state,
+                                                const moveit::core::RobotState& state,
                                                 const AllowedCollisionMatrix* acm) const
 {
   FCLObject fcl_obj;
@@ -308,7 +308,7 @@ void CollisionEnvFCL::checkRobotCollisionHelper(const CollisionRequest& req, Col
 }
 
 void CollisionEnvFCL::distanceSelf(const DistanceRequest& req, DistanceResult& res,
-                                   const robot_state::RobotState& state) const
+                                   const moveit::core::RobotState& state) const
 {
   FCLManager manager;
   allocSelfCollisionBroadPhase(state, manager);
@@ -318,7 +318,7 @@ void CollisionEnvFCL::distanceSelf(const DistanceRequest& req, DistanceResult& r
 }
 
 void CollisionEnvFCL::distanceRobot(const DistanceRequest& req, DistanceResult& res,
-                                    const robot_state::RobotState& state) const
+                                    const moveit::core::RobotState& state) const
 {
   FCLObject fcl_obj;
   constructFCLObjectRobot(state, fcl_obj);
@@ -411,7 +411,7 @@ void CollisionEnvFCL::updatedPaddingOrScaling(const std::vector<std::string>& li
   std::size_t index;
   for (const auto& link : links)
   {
-    const robot_model::LinkModel* lmodel = robot_model_->getLinkModel(link);
+    const moveit::core::LinkModel* lmodel = robot_model_->getLinkModel(link);
     if (lmodel)
     {
       for (std::size_t j = 0; j < lmodel->getShapes().size(); ++j)

--- a/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
@@ -50,7 +50,7 @@
 #include <geometric_shapes/shape_operations.h>
 
 /** \brief Brings the panda robot in user defined home position */
-inline void setToHome(robot_state::RobotState& panda_state)
+inline void setToHome(moveit::core::RobotState& panda_state)
 {
   panda_state.setToDefaultValues();
   double joint2 = -0.785;
@@ -90,7 +90,7 @@ protected:
 
     c_env_.reset(new collision_detection::CollisionEnvFCL(robot_model_));
 
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
+    robot_state_.reset(new moveit::core::RobotState(robot_model_));
 
     setToHome(*robot_state_);
   }
@@ -102,13 +102,13 @@ protected:
 protected:
   bool robot_model_ok_;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
   collision_detection::CollisionEnvPtr c_env_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;
 
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
 };
 
 /** \brief Correct setup testing. */
@@ -230,8 +230,8 @@ TEST_F(CollisionDetectionEnvTest, DISABLED_ContinuousCollisionSelf)
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
 
-  robot_state::RobotState state1(robot_model_);
-  robot_state::RobotState state2(robot_model_);
+  moveit::core::RobotState state1(robot_model_);
+  moveit::core::RobotState state2(robot_model_);
 
   setToHome(state1);
   double joint2 = 0.15;
@@ -276,8 +276,8 @@ TEST_F(CollisionDetectionEnvTest, DISABLED_ContinuousCollisionWorld)
   req.max_contacts = 10;
   collision_detection::CollisionResult res;
 
-  robot_state::RobotState state1(robot_model_);
-  robot_state::RobotState state2(robot_model_);
+  moveit::core::RobotState state1(robot_model_);
+  moveit::core::RobotState state2(robot_model_);
 
   setToHome(state1);
   state1.update();

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -114,7 +114,7 @@ struct DistanceFieldCacheEntry
   /** for checking collisions between this group and other objects */
   std::string group_name_;
   /** RobotState that this cache entry represents */
-  robot_state::RobotStatePtr state_;
+  moveit::core::RobotStatePtr state_;
   /** list of indices into the state_values_ vector.  One index for each joint
    * variable which is NOT in the group or a child of the group.  In other
    * words, variables which should not change if only joints in the group move.
@@ -170,10 +170,10 @@ BodyDecompositionConstPtr getBodyDecompositionCacheEntry(const shapes::ShapeCons
 PosedBodyPointDecompositionVectorPtr getCollisionObjectPointDecomposition(const collision_detection::World::Object& obj,
                                                                           double resolution);
 
-PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const robot_state::AttachedBody* att,
+PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const moveit::core::AttachedBody* att,
                                                                          double resolution);
 
-PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const robot_state::AttachedBody* att,
+PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const moveit::core::AttachedBody* att,
                                                                        double resolution);
 
 void getBodySphereVisualizationMarkers(const GroupStateRepresentationPtr& gsr, const std::string& reference_frame,

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -60,7 +60,7 @@ class CollisionEnvDistanceField : public CollisionEnv
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CollisionEnvDistanceField(const robot_model::RobotModelConstPtr& robot_model,
+  CollisionEnvDistanceField(const moveit::core::RobotModelConstPtr& robot_model,
                             const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                                 std::map<std::string, std::vector<CollisionSphere>>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
@@ -71,7 +71,7 @@ public:
                             double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                             double scale = 1.0);
 
-  CollisionEnvDistanceField(const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
+  CollisionEnvDistanceField(const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
                             const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                                 std::map<std::string, std::vector<CollisionSphere>>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
@@ -117,7 +117,7 @@ public:
   }
 
   void distanceSelf(const DistanceRequest& /* req */, DistanceResult& /* res */,
-                    const robot_state::RobotState& /* state */) const override
+                    const moveit::core::RobotState& /* state */) const override
   {
     ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
@@ -145,46 +145,46 @@ public:
   ~CollisionEnvDistanceField() override;
 
   void checkCollision(const CollisionRequest& req, CollisionResult& res,
-                      const robot_state::RobotState& state) const override;
+                      const moveit::core::RobotState& state) const override;
 
-  virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                               GroupStateRepresentationPtr& gsr) const;
 
-  void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void checkCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                       const AllowedCollisionMatrix& acm) const override;
 
-  virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  virtual void checkCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                               const AllowedCollisionMatrix& acm, GroupStateRepresentationPtr& gsr) const;
 
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                           const robot_state::RobotState& state) const override;
+                           const moveit::core::RobotState& state) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                                   const moveit::core::RobotState& state, GroupStateRepresentationPtr& gsr) const;
 
-  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                            const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
+                                   const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm,
                                    GroupStateRepresentationPtr& gsr) const;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1, const robot_state::RobotState& state2,
+                                   const moveit::core::RobotState& state1, const moveit::core::RobotState& state2,
                                    const AllowedCollisionMatrix& acm) const override;
 
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state1,
-                                   const robot_state::RobotState& state2) const override;
+                                   const moveit::core::RobotState& state1,
+                                   const moveit::core::RobotState& state2) const override;
 
-  virtual double distanceRobot(const robot_state::RobotState& state, bool verbose = false) const
+  virtual double distanceRobot(const moveit::core::RobotState& state, bool verbose = false) const
   {
     (void)state;
     (void)verbose;
     return 0.0;
   }
 
-  virtual double distanceRobot(const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
+  virtual double distanceRobot(const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm,
                                bool verbose = false) const
   {
     (void)state;
@@ -194,7 +194,7 @@ public:
   }
 
   void distanceRobot(const DistanceRequest& /* req */, DistanceResult& /* res */,
-                     const robot_state::RobotState& /* state */) const override
+                     const moveit::core::RobotState& /* state */) const override
   {
     ROS_ERROR_NAMED("collision_distance_field", "Not implemented");
   }
@@ -211,10 +211,10 @@ public:
     return last_gsr_;
   }
 
-  void getCollisionGradients(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void getCollisionGradients(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                              const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
 
-  void getAllCollisions(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void getAllCollisions(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                         const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
 
 protected:

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
@@ -52,7 +52,7 @@ class CollisionEnvHybrid : public collision_detection::CollisionEnvFCL
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CollisionEnvHybrid(const robot_model::RobotModelConstPtr& robot_model,
+  CollisionEnvHybrid(const moveit::core::RobotModelConstPtr& robot_model,
                      const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                          std::map<std::string, std::vector<CollisionSphere>>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
@@ -62,7 +62,7 @@ public:
                      double max_propogation_distance = DEFAULT_MAX_PROPOGATION_DISTANCE, double padding = 0.0,
                      double scale = 1.0);
 
-  CollisionEnvHybrid(const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
+  CollisionEnvHybrid(const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
                      const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
                          std::map<std::string, std::vector<CollisionSphere>>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
@@ -89,18 +89,18 @@ public:
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                        collision_detection::CollisionResult& res,
-                                       const robot_state::RobotState& state) const;
+                                       const moveit::core::RobotState& state) const;
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
-                                       collision_detection::CollisionResult& res, const robot_state::RobotState& state,
+                                       collision_detection::CollisionResult& res, const moveit::core::RobotState& state,
                                        GroupStateRepresentationPtr& gsr) const;
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
-                                       collision_detection::CollisionResult& res, const robot_state::RobotState& state,
+                                       collision_detection::CollisionResult& res, const moveit::core::RobotState& state,
                                        const collision_detection::AllowedCollisionMatrix& acm) const;
 
   void checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
-                                       collision_detection::CollisionResult& res, const robot_state::RobotState& state,
+                                       collision_detection::CollisionResult& res, const moveit::core::RobotState& state,
                                        const collision_detection::AllowedCollisionMatrix& acm,
                                        GroupStateRepresentationPtr& gsr) const;
   const CollisionEnvDistanceFieldConstPtr getCollisionRobotDistanceField() const
@@ -109,37 +109,37 @@ public:
   }
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state) const;
+                                   const moveit::core::RobotState& state) const;
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                                   const moveit::core::RobotState& state, GroupStateRepresentationPtr& gsr) const;
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const;
+                                   const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const;
 
   void checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                   const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
+                                   const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm,
                                    GroupStateRepresentationPtr& gsr) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                        const robot_state::RobotState& state) const;
+                                        const moveit::core::RobotState& state) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                        const robot_state::RobotState& state, GroupStateRepresentationPtr& gsr) const;
+                                        const moveit::core::RobotState& state, GroupStateRepresentationPtr& gsr) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                        const robot_state::RobotState& state, const AllowedCollisionMatrix& acm) const;
+                                        const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const;
 
   void checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                        const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
+                                        const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm,
                                         GroupStateRepresentationPtr& gsr) const;
 
   void setWorld(const WorldPtr& world) override;
 
-  void getCollisionGradients(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void getCollisionGradients(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                              const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
 
-  void getAllCollisions(const CollisionRequest& req, CollisionResult& res, const robot_state::RobotState& state,
+  void getAllCollisions(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state,
                         const AllowedCollisionMatrix* acm, GroupStateRepresentationPtr& gsr) const;
 
   const CollisionEnvDistanceFieldConstPtr getCollisionWorldDistanceField() const

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -100,7 +100,7 @@ PosedBodyPointDecompositionVectorPtr getCollisionObjectPointDecomposition(const 
   return ret;
 }
 
-PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const robot_state::AttachedBody* att,
+PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const moveit::core::AttachedBody* att,
                                                                          double resolution)
 {
   PosedBodySphereDecompositionVectorPtr ret(new PosedBodySphereDecompositionVector());
@@ -114,7 +114,7 @@ PosedBodySphereDecompositionVectorPtr getAttachedBodySphereDecomposition(const r
   return ret;
 }
 
-PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const robot_state::AttachedBody* att,
+PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const moveit::core::AttachedBody* att,
                                                                        double resolution)
 {
   PosedBodyPointDecompositionVectorPtr ret(new PosedBodyPointDecompositionVector());

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -53,7 +53,7 @@ const double EPSILON = 0.001f;
 const std::string collision_detection::CollisionDetectorAllocatorDistanceField::NAME("DISTANCE_FIELD");
 
 CollisionEnvDistanceField::CollisionEnvDistanceField(
-    const robot_model::RobotModelConstPtr& robot_model,
+    const moveit::core::RobotModelConstPtr& robot_model,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
     double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
@@ -71,7 +71,7 @@ CollisionEnvDistanceField::CollisionEnvDistanceField(
 }
 
 CollisionEnvDistanceField::CollisionEnvDistanceField(
-    const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
+    const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
     double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
@@ -1388,14 +1388,14 @@ bool CollisionEnvDistanceField::compareCacheEntryToAllowedCollisionMatrix(
 // }
 
 void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, CollisionResult& res,
-                                               const robot_state::RobotState& state) const
+                                               const moveit::core::RobotState& state) const
 {
   GroupStateRepresentationPtr gsr;
   checkCollision(req, res, state, gsr);
 }
 
 void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, CollisionResult& res,
-                                               const robot_state::RobotState& state,
+                                               const moveit::core::RobotState& state,
                                                GroupStateRepresentationPtr& gsr) const
 {
   if (!gsr)
@@ -1420,7 +1420,7 @@ void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, Coll
 }
 
 void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, CollisionResult& res,
-                                               const robot_state::RobotState& state,
+                                               const moveit::core::RobotState& state,
                                                const AllowedCollisionMatrix& acm) const
 {
   GroupStateRepresentationPtr gsr;
@@ -1428,7 +1428,7 @@ void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, Coll
 }
 
 void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, CollisionResult& res,
-                                               const robot_state::RobotState& state, const AllowedCollisionMatrix& acm,
+                                               const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm,
                                                GroupStateRepresentationPtr& gsr) const
 {
   if (!gsr)
@@ -1453,14 +1453,14 @@ void CollisionEnvDistanceField::checkCollision(const CollisionRequest& req, Coll
 }
 
 void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                    const robot_state::RobotState& state) const
+                                                    const moveit::core::RobotState& state) const
 {
   GroupStateRepresentationPtr gsr;
   checkRobotCollision(req, res, state, gsr);
 }
 
 void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                    const robot_state::RobotState& state,
+                                                    const moveit::core::RobotState& state,
                                                     GroupStateRepresentationPtr& gsr) const
 {
   distance_field::DistanceFieldConstPtr env_distance_field = distance_field_cache_entry_world_->distance_field_;
@@ -1479,7 +1479,7 @@ void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req,
 }
 
 void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                    const robot_state::RobotState& state,
+                                                    const moveit::core::RobotState& state,
                                                     const AllowedCollisionMatrix& acm) const
 {
   GroupStateRepresentationPtr gsr;
@@ -1487,7 +1487,7 @@ void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req,
 }
 
 void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                    const robot_state::RobotState& state,
+                                                    const moveit::core::RobotState& state,
                                                     const AllowedCollisionMatrix& acm,
                                                     GroupStateRepresentationPtr& gsr) const
 {
@@ -1508,22 +1508,22 @@ void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req,
 }
 
 void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                    const robot_state::RobotState& state1,
-                                                    const robot_state::RobotState& state2,
+                                                    const moveit::core::RobotState& state1,
+                                                    const moveit::core::RobotState& state2,
                                                     const AllowedCollisionMatrix& acm) const
 {
   ROS_ERROR_NAMED("collision_detection.distance", "Continuous collision checking not implemented");
 }
 
 void CollisionEnvDistanceField::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
-                                                    const robot_state::RobotState& state1,
-                                                    const robot_state::RobotState& state2) const
+                                                    const moveit::core::RobotState& state1,
+                                                    const moveit::core::RobotState& state2) const
 {
   ROS_ERROR_NAMED("collision_detection.distance", "Continuous collision checking not implemented");
 }
 
 void CollisionEnvDistanceField::getCollisionGradients(const CollisionRequest& req, CollisionResult& res,
-                                                      const robot_state::RobotState& state,
+                                                      const moveit::core::RobotState& state,
                                                       const AllowedCollisionMatrix* acm,
                                                       GroupStateRepresentationPtr& gsr) const
 {
@@ -1546,7 +1546,7 @@ void CollisionEnvDistanceField::getCollisionGradients(const CollisionRequest& re
 }
 
 void CollisionEnvDistanceField::getAllCollisions(const CollisionRequest& req, CollisionResult& res,
-                                                 const robot_state::RobotState& state,
+                                                 const moveit::core::RobotState& state,
                                                  const AllowedCollisionMatrix* acm,
                                                  GroupStateRepresentationPtr& gsr) const
 {

--- a/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
@@ -43,7 +43,7 @@ namespace collision_detection
 const std::string collision_detection::CollisionDetectorAllocatorHybrid::NAME("HYBRID");
 
 CollisionEnvHybrid::CollisionEnvHybrid(
-    const robot_model::RobotModelConstPtr& robot_model,
+    const moveit::core::RobotModelConstPtr& robot_model,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
     double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
@@ -55,7 +55,7 @@ CollisionEnvHybrid::CollisionEnvHybrid(
 }
 
 CollisionEnvHybrid::CollisionEnvHybrid(
-    const robot_model::RobotModelConstPtr& robot_model, const WorldPtr& world,
+    const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
     double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
@@ -74,14 +74,14 @@ CollisionEnvHybrid::CollisionEnvHybrid(const CollisionEnvHybrid& other, const Wo
 
 void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                                          collision_detection::CollisionResult& res,
-                                                         const robot_state::RobotState& state) const
+                                                         const moveit::core::RobotState& state) const
 {
   cenv_distance_->checkSelfCollision(req, res, state);
 }
 
 void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                                          collision_detection::CollisionResult& res,
-                                                         const robot_state::RobotState& state,
+                                                         const moveit::core::RobotState& state,
                                                          GroupStateRepresentationPtr& gsr) const
 {
   cenv_distance_->checkSelfCollision(req, res, state, gsr);
@@ -89,7 +89,7 @@ void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detecti
 
 void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                                          collision_detection::CollisionResult& res,
-                                                         const robot_state::RobotState& state,
+                                                         const moveit::core::RobotState& state,
                                                          const collision_detection::AllowedCollisionMatrix& acm) const
 {
   cenv_distance_->checkSelfCollision(req, res, state, acm);
@@ -97,7 +97,7 @@ void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detecti
 
 void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detection::CollisionRequest& req,
                                                          collision_detection::CollisionResult& res,
-                                                         const robot_state::RobotState& state,
+                                                         const moveit::core::RobotState& state,
                                                          const collision_detection::AllowedCollisionMatrix& acm,
                                                          GroupStateRepresentationPtr& gsr) const
 {
@@ -105,27 +105,27 @@ void CollisionEnvHybrid::checkSelfCollisionDistanceField(const collision_detecti
 }
 
 void CollisionEnvHybrid::checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                     const robot_state::RobotState& state) const
+                                                     const moveit::core::RobotState& state) const
 {
   cenv_distance_->checkCollision(req, res, state);
 }
 
 void CollisionEnvHybrid::checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                     const robot_state::RobotState& state,
+                                                     const moveit::core::RobotState& state,
                                                      GroupStateRepresentationPtr& gsr) const
 {
   cenv_distance_->checkCollision(req, res, state, gsr);
 }
 
 void CollisionEnvHybrid::checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                     const robot_state::RobotState& state,
+                                                     const moveit::core::RobotState& state,
                                                      const AllowedCollisionMatrix& acm) const
 {
   cenv_distance_->checkCollision(req, res, state, acm);
 }
 
 void CollisionEnvHybrid::checkCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                     const robot_state::RobotState& state,
+                                                     const moveit::core::RobotState& state,
                                                      const AllowedCollisionMatrix& acm,
                                                      GroupStateRepresentationPtr& gsr) const
 {
@@ -133,27 +133,27 @@ void CollisionEnvHybrid::checkCollisionDistanceField(const CollisionRequest& req
 }
 
 void CollisionEnvHybrid::checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                          const robot_state::RobotState& state) const
+                                                          const moveit::core::RobotState& state) const
 {
   cenv_distance_->checkRobotCollision(req, res, state);
 }
 
 void CollisionEnvHybrid::checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                          const robot_state::RobotState& state,
+                                                          const moveit::core::RobotState& state,
                                                           GroupStateRepresentationPtr& gsr) const
 {
   cenv_distance_->checkRobotCollision(req, res, state, gsr);
 }
 
 void CollisionEnvHybrid::checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                          const robot_state::RobotState& state,
+                                                          const moveit::core::RobotState& state,
                                                           const AllowedCollisionMatrix& acm) const
 {
   cenv_distance_->checkRobotCollision(req, res, state, acm);
 }
 
 void CollisionEnvHybrid::checkRobotCollisionDistanceField(const CollisionRequest& req, CollisionResult& res,
-                                                          const robot_state::RobotState& state,
+                                                          const moveit::core::RobotState& state,
                                                           const AllowedCollisionMatrix& acm,
                                                           GroupStateRepresentationPtr& gsr) const
 {
@@ -170,14 +170,14 @@ void CollisionEnvHybrid::setWorld(const WorldPtr& world)
 }
 
 void CollisionEnvHybrid::getCollisionGradients(const CollisionRequest& req, CollisionResult& res,
-                                               const robot_state::RobotState& state, const AllowedCollisionMatrix* acm,
+                                               const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm,
                                                GroupStateRepresentationPtr& gsr) const
 {
   cenv_distance_->getCollisionGradients(req, res, state, acm, gsr);
 }
 
 void CollisionEnvHybrid::getAllCollisions(const CollisionRequest& req, CollisionResult& res,
-                                          const robot_state::RobotState& state, const AllowedCollisionMatrix* acm,
+                                          const moveit::core::RobotState& state, const AllowedCollisionMatrix* acm,
                                           GroupStateRepresentationPtr& gsr) const
 {
   cenv_distance_->getAllCollisions(req, res, state, acm, gsr);

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -80,7 +80,7 @@ protected:
     srdf_ok_ = srdf_model_->initFile(*urdf_model_,
                                      ros::package::getPath("moveit_resources") + "/pr2_description/srdf/robot.xml");
 
-    robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_model_));
+    robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_model_));
 
     acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
@@ -99,10 +99,10 @@ protected:
   urdf::ModelInterfaceSharedPtr urdf_model_;
   srdf::ModelSharedPtr srdf_model_;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
-  robot_state::TransformsPtr ftf_;
-  robot_state::TransformsConstPtr ftf_const_;
+  moveit::core::TransformsPtr ftf_;
+  moveit::core::TransformsConstPtr ftf_const_;
 
   collision_detection::CollisionEnvPtr cenv_;
 
@@ -111,7 +111,7 @@ protected:
 
 TEST_F(DistanceFieldCollisionDetectionTester, DefaultNotInCollision)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -126,7 +126,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, DefaultNotInCollision)
 
 TEST_F(DistanceFieldCollisionDetectionTester, ChangeTorsoPosition)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -154,7 +154,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, LinksInCollision)
   // req.max_contacts = 100;
   req.group_name = "whole_body";
 
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
@@ -186,7 +186,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactReporting)
   req.max_contacts = 1;
   req.group_name = "whole_body";
 
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
@@ -235,7 +235,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, ContactPositions)
   req.max_contacts = 1;
   req.group_name = "whole_body";
 
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   Eigen::Isometry3d pos1 = Eigen::Isometry3d::Identity();
@@ -299,7 +299,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
 
   acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
 
@@ -326,7 +326,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   poses.push_back(Eigen::Isometry3d::Identity());
   std::set<std::string> touch_links;
   trajectory_msgs::JointTrajectory empty_state;
-  robot_state::AttachedBody* attached_body = new robot_state::AttachedBody(
+  moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
       robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
 
   robot_state.attachBody(attached_body);
@@ -341,7 +341,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   touch_links.insert("r_gripper_palm_link");
   shapes[0].reset(new shapes::Box(.1, .1, .1));
 
-  robot_state::AttachedBody* attached_body_1 = new robot_state::AttachedBody(
+  moveit::core::AttachedBody* attached_body_1 = new moveit::core::AttachedBody(
       robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
   robot_state.attachBody(attached_body_1);
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -104,7 +104,7 @@ public:
    *
    * @return The joint model group
    */
-  const robot_model::JointModelGroup* getJointModelGroup() const
+  const moveit::core::JointModelGroup* getJointModelGroup() const
   {
     return jmg_;
   }
@@ -140,7 +140,7 @@ public:
    * \brief Gets the callback used to determine state validity during sampling. The sampler will attempt
    *        to satisfy this constraint if possible, but there is no guarantee.
    */
-  const robot_state::GroupStateValidityCallbackFn& getGroupStateValidityCallback() const
+  const moveit::core::GroupStateValidityCallbackFn& getGroupStateValidityCallback() const
   {
     return group_state_validity_callback_;
   }
@@ -151,7 +151,7 @@ public:
    *
    * @param callback The callback to set
    */
-  void setGroupStateValidityCallback(const robot_state::GroupStateValidityCallbackFn& callback)
+  void setGroupStateValidityCallback(const moveit::core::GroupStateValidityCallbackFn& callback)
   {
     group_state_validity_callback_ = callback;
   }
@@ -166,7 +166,7 @@ public:
    *
    * @return True if a sample was successfully taken, false otherwise
    */
-  bool sample(robot_state::RobotState& state)
+  bool sample(moveit::core::RobotState& state)
   {
     return sample(state, state, DEFAULT_MAX_SAMPLING_ATTEMPTS);
   }
@@ -182,7 +182,7 @@ public:
    *
    * @return True if a sample was successfully taken, false otherwise
    */
-  bool sample(robot_state::RobotState& state, unsigned int max_attempts)
+  bool sample(moveit::core::RobotState& state, unsigned int max_attempts)
   {
     return sample(state, state, max_attempts);
   }
@@ -197,7 +197,7 @@ public:
    *
    * @return True if a sample was successfully taken, false otherwise
    */
-  bool sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state)
+  bool sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state)
   {
     return sample(state, reference_state, DEFAULT_MAX_SAMPLING_ATTEMPTS);
   }
@@ -212,7 +212,7 @@ public:
    *
    * @return True if a sample was successfully projected, false otherwise
    */
-  bool project(robot_state::RobotState& state)
+  bool project(moveit::core::RobotState& state)
   {
     return project(state, DEFAULT_MAX_SAMPLING_ATTEMPTS);
   }
@@ -228,7 +228,7 @@ public:
    *
    * @return True if a sample was successfully taken, false otherwise
    */
-  virtual bool sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+  virtual bool sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
                       unsigned int max_attempts) = 0;
 
   /**
@@ -242,7 +242,7 @@ public:
    *
    * @return True if a sample was successfully projected, false otherwise
    */
-  virtual bool project(robot_state::RobotState& state, unsigned int max_attempts) = 0;
+  virtual bool project(moveit::core::RobotState& state, unsigned int max_attempts) = 0;
 
   /**
    * \brief Returns whether or not the constraint sampler is valid or not.
@@ -287,11 +287,11 @@ protected:
   /// Holds the planning scene
   planning_scene::PlanningSceneConstPtr scene_;
   /// Holds the joint model group associated with this constraint
-  const robot_model::JointModelGroup* const jmg_;
+  const moveit::core::JointModelGroup* const jmg_;
   /// Holds the set of frames that must exist in the reference state to allow samples to be drawn
   std::vector<std::string> frame_depends_;
   /// Holds the callback for state validity
-  robot_state::GroupStateValidityCallbackFn group_state_validity_callback_;
+  moveit::core::GroupStateValidityCallbackFn group_state_validity_callback_;
   bool verbose_;  ///< True if verbosity is on
 };
 }

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
@@ -41,7 +41,7 @@
 
 namespace constraint_samplers
 {
-void visualizeDistribution(const ConstraintSamplerPtr& sampler, const robot_state::RobotState& reference_state,
+void visualizeDistribution(const ConstraintSamplerPtr& sampler, const moveit::core::RobotState& reference_state,
                            const std::string& link_name, unsigned int sample_count,
                            visualization_msgs::MarkerArray& markers);
 
@@ -49,7 +49,7 @@ void visualizeDistribution(const moveit_msgs::Constraints& constr, const plannin
                            const std::string& group, const std::string& link_name, unsigned int sample_count,
                            visualization_msgs::MarkerArray& markers);
 
-double countSamplesPerSecond(const ConstraintSamplerPtr& sampler, const robot_state::RobotState& reference_state);
+double countSamplesPerSecond(const ConstraintSamplerPtr& sampler, const moveit::core::RobotState& reference_state);
 
 double countSamplesPerSecond(const moveit_msgs::Constraints& constr, const planning_scene::PlanningSceneConstPtr& scene,
                              const std::string& group);

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -116,9 +116,9 @@ public:
    */
   bool configure(const std::vector<kinematic_constraints::JointConstraint>& jc);
 
-  bool sample(robot_state::RobotState& state, const robot_state::RobotState& ks, unsigned int max_attempts) override;
+  bool sample(moveit::core::RobotState& state, const moveit::core::RobotState& ks, unsigned int max_attempts) override;
 
-  bool project(robot_state::RobotState& state, unsigned int max_attempts) override;
+  bool project(moveit::core::RobotState& state, unsigned int max_attempts) override;
 
   /**
    * \brief Gets the number of constrained joints - joints that have an
@@ -195,7 +195,7 @@ protected:
   std::vector<JointInfo> bounds_; /**< \brief The bounds for any joint with bounds that are more restrictive than the
                                      joint limits */
 
-  std::vector<const robot_model::JointModel*> unbounded_; /**< \brief The joints that are not bounded except by joint
+  std::vector<const moveit::core::JointModel*> unbounded_; /**< \brief The joints that are not bounded except by joint
                                                              limits */
   std::vector<unsigned int> uindex_; /**< \brief The index of the unbounded joints in the joint state vector */
   std::vector<double> values_;       /**< \brief Values associated with this group to avoid continuously reallocating */
@@ -445,10 +445,10 @@ public:
    *
    * @return True if a valid sample pose was produced and valid IK found for that pose.  Otherwise false.
    */
-  bool sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+  bool sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
               unsigned int max_attempts) override;
 
-  bool project(robot_state::RobotState& state, unsigned int max_attempts) override;
+  bool project(moveit::core::RobotState& state, unsigned int max_attempts) override;
   /**
    * \brief Returns a pose that falls within the constraint regions.
    *
@@ -471,7 +471,7 @@ public:
    *
    * @return True if a sample was successfully produced, otherwise false
    */
-  bool samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& quat, const robot_state::RobotState& ks,
+  bool samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& quat, const moveit::core::RobotState& ks,
                   unsigned int max_attempts);
 
   /**
@@ -508,10 +508,10 @@ protected:
    */
   bool callIK(const geometry_msgs::Pose& ik_query,
               const kinematics::KinematicsBase::IKCallbackFn& adapted_ik_validity_callback, double timeout,
-              robot_state::RobotState& state, bool use_as_seed);
-  bool sampleHelper(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+              moveit::core::RobotState& state, bool use_as_seed);
+  bool sampleHelper(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
                     unsigned int max_attempts, bool project);
-  bool validate(robot_state::RobotState& state) const;
+  bool validate(moveit::core::RobotState& state) const;
 
   random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random generator used by the sampler */
   IKSamplingPose sampling_pose_;                                  /**< \brief Holder for the pose used for sampling */

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -148,10 +148,10 @@ public:
    *
    * @return True if all invidual samplers return true
    */
-  bool sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+  bool sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
               unsigned int max_attempts) override;
 
-  bool project(robot_state::RobotState& state, unsigned int max_attempts) override;
+  bool project(moveit::core::RobotState& state, unsigned int max_attempts) override;
 
   /**
    * \brief Get the name of the constraint sampler, for debugging purposes

--- a/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
@@ -57,7 +57,7 @@ constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(const planni
                                                                     const std::string& group_name,
                                                                     const moveit_msgs::Constraints& constr)
 {
-  const robot_model::JointModelGroup* jmg = scene->getRobotModel()->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* jmg = scene->getRobotModel()->getJointModelGroup(group_name);
   if (!jmg)
     return constraint_samplers::ConstraintSamplerPtr();
   std::stringstream ss;
@@ -135,8 +135,8 @@ constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(const planni
     samplers.push_back(joint_sampler);
 
   // read the ik allocators, if any
-  const robot_model::JointModelGroup::KinematicsSolver& ik_alloc = jmg->getGroupKinematics().first;
-  const robot_model::JointModelGroup::KinematicsSolverMap& ik_subgroup_alloc = jmg->getGroupKinematics().second;
+  const moveit::core::JointModelGroup::KinematicsSolver& ik_alloc = jmg->getGroupKinematics().first;
+  const moveit::core::JointModelGroup::KinematicsSolverMap& ik_subgroup_alloc = jmg->getGroupKinematics().second;
 
   // if we have a means of computing complete states for the group using IK, then we try to see if any IK constraints
   // should be used
@@ -297,7 +297,7 @@ constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(const planni
     bool some_sampler_valid = false;
 
     std::set<std::size_t> used_p, used_o;
-    for (robot_model::JointModelGroup::KinematicsSolverMap::const_iterator it = ik_subgroup_alloc.begin();
+    for (moveit::core::JointModelGroup::KinematicsSolverMap::const_iterator it = ik_subgroup_alloc.begin();
          it != ik_subgroup_alloc.end(); ++it)
     {
       // construct a sub-set of constraints that operate on the sub-group for which we have an IK allocator

--- a/moveit_core/constraint_samplers/src/constraint_sampler_tools.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_tools.cpp
@@ -55,14 +55,14 @@ double constraint_samplers::countSamplesPerSecond(const moveit_msgs::Constraints
 }
 
 double constraint_samplers::countSamplesPerSecond(const ConstraintSamplerPtr& sampler,
-                                                  const robot_state::RobotState& reference_state)
+                                                  const moveit::core::RobotState& reference_state)
 {
   if (!sampler)
   {
     ROS_ERROR_NAMED("constraint_samplers", "No sampler specified for counting samples per second");
     return 0.0;
   }
-  robot_state::RobotState ks(reference_state);
+  moveit::core::RobotState ks(reference_state);
   unsigned long int valid = 0;
   unsigned long int total = 0;
   ros::WallTime end = ros::WallTime::now() + ros::WallDuration(1.0);
@@ -80,7 +80,7 @@ double constraint_samplers::countSamplesPerSecond(const ConstraintSamplerPtr& sa
 }
 
 void constraint_samplers::visualizeDistribution(const ConstraintSamplerPtr& sampler,
-                                                const robot_state::RobotState& reference_state,
+                                                const moveit::core::RobotState& reference_state,
                                                 const std::string& link_name, unsigned int sample_count,
                                                 visualization_msgs::MarkerArray& markers)
 {
@@ -89,10 +89,10 @@ void constraint_samplers::visualizeDistribution(const ConstraintSamplerPtr& samp
     ROS_ERROR_NAMED("constraint_samplers", "No sampler specified for visualizing distribution of samples");
     return;
   }
-  const robot_state::LinkModel* lm = reference_state.getLinkModel(link_name);
+  const moveit::core::LinkModel* lm = reference_state.getLinkModel(link_name);
   if (!lm)
     return;
-  robot_state::RobotState ks(reference_state);
+  moveit::core::RobotState ks(reference_state);
   std_msgs::ColorRGBA color;
   color.r = 1.0f;
   color.g = 0.0f;

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -74,13 +74,13 @@ bool JointConstraintSampler::configure(const std::vector<kinematic_constraints::
     if (!joint_constraint.enabled())
       continue;
 
-    const robot_model::JointModel* jm = joint_constraint.getJointModel();
+    const moveit::core::JointModel* jm = joint_constraint.getJointModel();
     if (!jmg_->hasJointModel(jm->getName()))
       continue;
 
     some_valid_constraint = true;
 
-    const robot_model::VariableBounds& joint_bounds = jm->getVariableBounds(joint_constraint.getJointVariableName());
+    const moveit::core::VariableBounds& joint_bounds = jm->getVariableBounds(joint_constraint.getJointVariableName());
     JointInfo ji;
     std::map<std::string, JointInfo>::iterator it = bound_data.find(joint_constraint.getJointVariableName());
     if (it != bound_data.end())
@@ -120,8 +120,8 @@ bool JointConstraintSampler::configure(const std::vector<kinematic_constraints::
     bounds_.push_back(it.second);
 
   // get a separate list of joints that are not bounded; we will sample these randomly
-  const std::vector<const robot_model::JointModel*>& joints = jmg_->getJointModels();
-  for (const robot_model::JointModel* joint : joints)
+  const std::vector<const moveit::core::JointModel*>& joints = jmg_->getJointModels();
+  for (const moveit::core::JointModel* joint : joints)
     if (bound_data.find(joint->getName()) == bound_data.end() && joint->getVariableCount() > 0 &&
         joint->getMimic() == nullptr)
     {
@@ -148,8 +148,8 @@ bool JointConstraintSampler::configure(const std::vector<kinematic_constraints::
   return true;
 }
 
-bool JointConstraintSampler::sample(robot_state::RobotState& state,
-                                    const robot_state::RobotState& /* reference_state */,
+bool JointConstraintSampler::sample(moveit::core::RobotState& state,
+                                    const moveit::core::RobotState& /* reference_state */,
                                     unsigned int /* max_attempts */)
 {
   if (!is_valid_)
@@ -178,7 +178,7 @@ bool JointConstraintSampler::sample(robot_state::RobotState& state,
   return true;
 }
 
-bool JointConstraintSampler::project(robot_state::RobotState& state, unsigned int max_attempts)
+bool JointConstraintSampler::project(moveit::core::RobotState& state, unsigned int max_attempts)
 {
   return sample(state, state, max_attempts);
 }
@@ -349,7 +349,7 @@ bool IKConstraintSampler::loadIKSolver()
 
   // check if we need to transform the request into the coordinate frame expected by IK
   ik_frame_ = kb_->getBaseFrame();
-  transform_ik_ = !robot_state::Transforms::sameFrame(ik_frame_, jmg_->getParentModel().getModelFrame());
+  transform_ik_ = !moveit::core::Transforms::sameFrame(ik_frame_, jmg_->getParentModel().getModelFrame());
   if (!ik_frame_.empty() && ik_frame_[0] == '/')
     ik_frame_.erase(ik_frame_.begin());
   if (transform_ik_)
@@ -385,7 +385,7 @@ bool IKConstraintSampler::loadIKSolver()
   if (!wrong_link && sampling_pose_.orientation_constraint_)
   {
     const moveit::core::LinkModel* lm = sampling_pose_.orientation_constraint_->getLinkModel();
-    if (!robot_state::Transforms::sameFrame(kb_->getTipFrame(), lm->getName()))
+    if (!moveit::core::Transforms::sameFrame(kb_->getTipFrame(), lm->getName()))
     {
       wrong_link = true;
       const moveit::core::LinkTransformMap& fixed_links = lm->getAssociatedFixedTransforms();
@@ -413,7 +413,7 @@ bool IKConstraintSampler::loadIKSolver()
   return true;
 }
 
-bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& quat, const robot_state::RobotState& ks,
+bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& quat, const moveit::core::RobotState& ks,
                                      unsigned int max_attempts)
 {
   if (ks.dirtyLinkTransforms())
@@ -459,7 +459,7 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
   else
   {
     // do FK for rand state
-    robot_state::RobotState temp_state(ks);
+    moveit::core::RobotState temp_state(ks);
     temp_state.setToRandomPositions(jmg_);
     pos = temp_state.getGlobalLinkTransform(sampling_pose_.orientation_constraint_->getLinkModel()).translation();
   }
@@ -509,8 +509,8 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
 
 namespace
 {
-void samplingIkCallbackFnAdapter(robot_state::RobotState* state, const robot_model::JointModelGroup* jmg,
-                                 const robot_state::GroupStateValidityCallbackFn& constraint,
+void samplingIkCallbackFnAdapter(moveit::core::RobotState* state, const moveit::core::JointModelGroup* jmg,
+                                 const moveit::core::GroupStateValidityCallbackFn& constraint,
                                  const geometry_msgs::Pose& /*unused*/, const std::vector<double>& ik_sol,
                                  moveit_msgs::MoveItErrorCodes& error_code)
 {
@@ -525,13 +525,13 @@ void samplingIkCallbackFnAdapter(robot_state::RobotState* state, const robot_mod
 }
 }  // namespace
 
-bool IKConstraintSampler::sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+bool IKConstraintSampler::sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
                                  unsigned int max_attempts)
 {
   return sampleHelper(state, reference_state, max_attempts, false);
 }
 
-bool IKConstraintSampler::sampleHelper(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+bool IKConstraintSampler::sampleHelper(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
                                        unsigned int max_attempts, bool project)
 {
   if (!is_valid_)
@@ -592,12 +592,12 @@ bool IKConstraintSampler::sampleHelper(robot_state::RobotState& state, const rob
   return false;
 }
 
-bool IKConstraintSampler::project(robot_state::RobotState& state, unsigned int max_attempts)
+bool IKConstraintSampler::project(moveit::core::RobotState& state, unsigned int max_attempts)
 {
   return sampleHelper(state, state, max_attempts, true);
 }
 
-bool IKConstraintSampler::validate(robot_state::RobotState& state) const
+bool IKConstraintSampler::validate(moveit::core::RobotState& state) const
 {
   state.update();
   return (!sampling_pose_.orientation_constraint_ ||
@@ -608,7 +608,7 @@ bool IKConstraintSampler::validate(robot_state::RobotState& state) const
 
 bool IKConstraintSampler::callIK(const geometry_msgs::Pose& ik_query,
                                  const kinematics::KinematicsBase::IKCallbackFn& adapted_ik_validity_callback,
-                                 double timeout, robot_state::RobotState& state, bool use_as_seed)
+                                 double timeout, moveit::core::RobotState& state, bool use_as_seed)
 {
   const std::vector<unsigned int>& ik_joint_bijection = jmg_->getKinematicsSolverJointBijection();
   std::vector<double> seed(ik_joint_bijection.size(), 0.0);

--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -123,7 +123,7 @@ UnionConstraintSampler::UnionConstraintSampler(const planning_scene::PlanningSce
   }
 }
 
-bool UnionConstraintSampler::sample(robot_state::RobotState& state, const robot_state::RobotState& reference_state,
+bool UnionConstraintSampler::sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
                                     unsigned int max_attempts)
 {
   state = reference_state;
@@ -147,7 +147,7 @@ bool UnionConstraintSampler::sample(robot_state::RobotState& state, const robot_
   return true;
 }
 
-bool UnionConstraintSampler::project(robot_state::RobotState& state, unsigned int max_attempts)
+bool UnionConstraintSampler::project(moveit::core::RobotState& state, unsigned int max_attempts)
 {
   for (ConstraintSamplerPtr& sampler : samplers_)
   {

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -56,14 +56,14 @@
 class LoadPlanningModelsPr2 : public testing::Test
 {
 protected:
-  kinematics::KinematicsBasePtr getKinematicsSolverRightArm(const robot_model::JointModelGroup* jmg)
+  kinematics::KinematicsBasePtr getKinematicsSolverRightArm(const moveit::core::JointModelGroup* jmg)
   {
     {
       return pr2_kinematics_plugin_right_arm_;
     }
   }
 
-  kinematics::KinematicsBasePtr getKinematicsSolverLeftArm(const robot_model::JointModelGroup* jmg)
+  kinematics::KinematicsBasePtr getKinematicsSolverLeftArm(const moveit::core::JointModelGroup* jmg)
   {
     {
       return pr2_kinematics_plugin_left_arm_;
@@ -85,7 +85,7 @@ protected:
     func_right_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverRightArm, this, _1);
     func_left_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverLeftArm, this, _1);
 
-    std::map<std::string, robot_model::SolverAllocatorFn> allocators;
+    std::map<std::string, moveit::core::SolverAllocatorFn> allocators;
     allocators["right_arm"] = func_right_arm_;
     allocators["left_arm"] = func_left_arm_;
     allocators["whole_body"] = func_right_arm_;
@@ -101,20 +101,20 @@ protected:
   }
 
 protected:
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
   planning_scene::PlanningScenePtr ps_;
   pr2_arm_kinematics::PR2ArmKinematicsPluginPtr pr2_kinematics_plugin_right_arm_;
   pr2_arm_kinematics::PR2ArmKinematicsPluginPtr pr2_kinematics_plugin_left_arm_;
-  robot_model::SolverAllocatorFn func_right_arm_;
-  robot_model::SolverAllocatorFn func_left_arm_;
+  moveit::core::SolverAllocatorFn func_right_arm_;
+  moveit::core::SolverAllocatorFn func_left_arm_;
 };
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsSamplerSimple)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
 
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
 
   kinematic_constraints::JointConstraint jc1(robot_model_);
@@ -253,7 +253,7 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsSamplerSimple)
 
 TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerSimple)
 {
-  robot_state::Transforms& tf = ps_->getTransformsNonConst();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
 
   kinematic_constraints::PositionConstraint pc(robot_model_);
   moveit_msgs::PositionConstraint pcm;
@@ -316,14 +316,14 @@ TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerSimple)
 
 TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSampler)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 
-  robot_state::Transforms& tf = ps_->getTransformsNonConst();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
 
   kinematic_constraints::OrientationConstraint oc(robot_model_);
   moveit_msgs::OrientationConstraint ocm;
@@ -359,14 +359,14 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSampler)
 
 TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerValid)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 
-  robot_state::Transforms& tf = ps_->getTransformsNonConst();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
 
   kinematic_constraints::PositionConstraint pc(robot_model_);
   moveit_msgs::PositionConstraint pcm;
@@ -438,15 +438,15 @@ TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerValid)
 
 TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
 
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 
-  robot_state::Transforms& tf = ps_->getTransformsNonConst();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
 
   kinematic_constraints::JointConstraint jc1(robot_model_);
 
@@ -606,10 +606,10 @@ TEST_F(LoadPlanningModelsPr2, UnionConstraintSampler)
 
 TEST_F(LoadPlanningModelsPr2, PoseConstraintSamplerManager)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 
@@ -692,7 +692,7 @@ TEST_F(LoadPlanningModelsPr2, PoseConstraintSamplerManager)
 
 TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
 
@@ -861,10 +861,10 @@ TEST_F(LoadPlanningModelsPr2, JointVersusPoseConstraintSamplerManager)
 
 TEST_F(LoadPlanningModelsPr2, MixedJointAndIkSamplerManager)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 
@@ -937,10 +937,10 @@ TEST_F(LoadPlanningModelsPr2, MixedJointAndIkSamplerManager)
 
 TEST_F(LoadPlanningModelsPr2, SubgroupJointConstraintsSamplerManager)
 {
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 
@@ -1078,7 +1078,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
   ocm.weight = 1.0;
   c.orientation_constraints.push_back(ocm);
 
-  robot_state::Transforms& tf = ps_->getTransformsNonConst();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
   constraint_samplers::ConstraintSamplerPtr s =
       constraint_samplers::ConstraintSamplerManager::selectDefaultSampler(ps_, "arms", c);
   EXPECT_TRUE(static_cast<bool>(s));
@@ -1089,10 +1089,10 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
   kinematic_constraints::KinematicConstraintSet kset(robot_model_);
   kset.add(c, tf);
 
-  robot_state::RobotState ks(robot_model_);
+  moveit::core::RobotState ks(robot_model_);
   ks.setToDefaultValues();
   ks.update();
-  robot_state::RobotState ks_const(robot_model_);
+  moveit::core::RobotState ks_const(robot_model_);
   ks_const.setToDefaultValues();
   ks_const.update();
 

--- a/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
+++ b/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
@@ -66,7 +66,7 @@ public:
    * @param group_name The name of the group to compute stuff for
    * @return False if initialization failed
    */
-  DynamicsSolver(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
+  DynamicsSolver(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
                  const geometry_msgs::Vector3& gravity_vector);
 
   /**
@@ -124,12 +124,12 @@ public:
    * @brief Get the kinematic model
    * @return kinematic model
    */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
 
-  const robot_model::JointModelGroup* getGroup() const
+  const moveit::core::JointModelGroup* getGroup() const
   {
     return joint_model_group_;
   }
@@ -138,10 +138,10 @@ private:
   std::shared_ptr<KDL::ChainIdSolver_RNE> chain_id_solver_;  // KDL chain inverse dynamics
   KDL::Chain kdl_chain_;                                     // KDL chain
 
-  robot_model::RobotModelConstPtr robot_model_;
-  const robot_model::JointModelGroup* joint_model_group_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  const moveit::core::JointModelGroup* joint_model_group_;
 
-  robot_state::RobotStatePtr state_;  // robot state
+  moveit::core::RobotStatePtr state_;  // robot state
 
   std::string base_name_, tip_name_;        // base name, tip name
   unsigned int num_joints_, num_segments_;  // number of joints in group, number of segments in group

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -64,7 +64,7 @@ inline geometry_msgs::Vector3 transformVector(const Eigen::Isometry3d& transform
 }
 }  // namespace
 
-DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
+DynamicsSolver::DynamicsSolver(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
                                const geometry_msgs::Vector3& gravity_vector)
 {
   robot_model_ = robot_model;
@@ -88,7 +88,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
     return;
   }
 
-  const robot_model::JointModel* joint = joint_model_group_->getJointRoots()[0];
+  const moveit::core::JointModel* joint = joint_model_group_->getJointRoots()[0];
   if (!joint->getParentLinkModel())
   {
     ROS_ERROR_NAMED("dynamics_solver", "Group '%s' does not have a parent link", group_name.c_str());
@@ -120,7 +120,7 @@ DynamicsSolver::DynamicsSolver(const robot_model::RobotModelConstPtr& robot_mode
   num_joints_ = kdl_chain_.getNrOfJoints();
   num_segments_ = kdl_chain_.getNrOfSegments();
 
-  state_.reset(new robot_state::RobotState(robot_model_));
+  state_.reset(new moveit::core::RobotState(robot_model_));
   state_->setToDefaultValues();
 
   const std::vector<std::string>& joint_model_names = joint_model_group_->getJointModelNames();

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -92,7 +92,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  KinematicConstraint(const robot_model::RobotModelConstPtr& model);
+  KinematicConstraint(const moveit::core::RobotModelConstPtr& model);
   virtual ~KinematicConstraint();
 
   /** \brief Clear the stored constraint */
@@ -106,7 +106,7 @@ public:
    *
    * @return
    */
-  virtual ConstraintEvaluationResult decide(const robot_state::RobotState& state, bool verbose = false) const = 0;
+  virtual ConstraintEvaluationResult decide(const moveit::core::RobotState& state, bool verbose = false) const = 0;
 
   /** \brief This function returns true if this constraint is
       configured and able to decide whether states do meet the
@@ -166,14 +166,14 @@ public:
    *
    * @return The kinematic model associated with this constraint
    */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
 
 protected:
   ConstraintType type_;                         /**< \brief The type of the constraint */
-  robot_model::RobotModelConstPtr robot_model_; /**< \brief The kinematic model associated with this constraint */
+  moveit::core::RobotModelConstPtr robot_model_; /**< \brief The kinematic model associated with this constraint */
   double constraint_weight_; /**< \brief The weight of a constraint is a multiplicative factor associated to the
                                 distance computed by the decide() function  */
 };
@@ -207,7 +207,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  JointConstraint(const robot_model::RobotModelConstPtr& model)
+  JointConstraint(const moveit::core::RobotModelConstPtr& model)
     : KinematicConstraint(model), joint_model_(NULL), joint_variable_index_(-1)
   {
     type_ = JOINT_CONSTRAINT;
@@ -245,7 +245,7 @@ public:
    */
   bool equal(const KinematicConstraint& other, double margin) const override;
 
-  ConstraintEvaluationResult decide(const robot_state::RobotState& state, bool verbose = false) const override;
+  ConstraintEvaluationResult decide(const moveit::core::RobotState& state, bool verbose = false) const override;
   bool enabled() const override;
   void clear() override;
   void print(std::ostream& out = std::cout) const override;
@@ -255,7 +255,7 @@ public:
    *
    * @return The relevant joint model if enabled, and otherwise NULL
    */
-  const robot_model::JointModel* getJointModel() const
+  const moveit::core::JointModel* getJointModel() const
   {
     return joint_model_;
   }
@@ -273,7 +273,7 @@ public:
   }
 
   /**
-   *  \brief Gets the joint variable name, as known to the robot_model::RobotModel
+   *  \brief Gets the joint variable name, as known to the moveit::core::RobotModel
    *
    * This will include the local variable name if a variable of a multi-DOF joint is constrained.
    *
@@ -323,7 +323,7 @@ public:
   }
 
 protected:
-  const robot_model::JointModel* joint_model_; /**< \brief The joint from the kinematic model for this constraint */
+  const moveit::core::JointModel* joint_model_; /**< \brief The joint from the kinematic model for this constraint */
   bool joint_is_continuous_;                   /**< \brief Whether or not the joint is continuous */
   std::string local_variable_name_;            /**< \brief The local variable name for a multi DOF joint, if any */
   std::string joint_variable_name_;            /**< \brief The joint variable name */
@@ -355,7 +355,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  OrientationConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  OrientationConstraint(const moveit::core::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
   {
     type_ = ORIENTATION_CONSTRAINT;
   }
@@ -373,7 +373,7 @@ public:
    *
    * @return True if constraint can be configured from oc
    */
-  bool configure(const moveit_msgs::OrientationConstraint& oc, const robot_state::Transforms& tf);
+  bool configure(const moveit_msgs::OrientationConstraint& oc, const moveit::core::Transforms& tf);
 
   /**
    * \brief Check if two orientation constraints are the same.
@@ -394,7 +394,7 @@ public:
   bool equal(const KinematicConstraint& other, double margin) const override;
 
   void clear() override;
-  ConstraintEvaluationResult decide(const robot_state::RobotState& state, bool verbose = false) const override;
+  ConstraintEvaluationResult decide(const moveit::core::RobotState& state, bool verbose = false) const override;
   bool enabled() const override;
   void print(std::ostream& out = std::cout) const override;
 
@@ -404,7 +404,7 @@ public:
    *
    * @return Returns the current link model
    */
-  const robot_model::LinkModel* getLinkModel() const
+  const moveit::core::LinkModel* getLinkModel() const
   {
     return link_model_;
   }
@@ -475,7 +475,7 @@ public:
   }
 
 protected:
-  const robot_model::LinkModel* link_model_;    /**< \brief The target link model */
+  const moveit::core::LinkModel* link_model_;    /**< \brief The target link model */
   Eigen::Matrix3d desired_rotation_matrix_;     /**< \brief The desired rotation matrix in the tf frame */
   Eigen::Matrix3d desired_rotation_matrix_inv_; /**< \brief The inverse of the desired rotation matrix, precomputed for
                                                  * efficiency
@@ -512,7 +512,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  PositionConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  PositionConstraint(const moveit::core::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
   {
     type_ = POSITION_CONSTRAINT;
   }
@@ -533,7 +533,7 @@ public:
    *
    * @return True if constraint can be configured from pc
    */
-  bool configure(const moveit_msgs::PositionConstraint& pc, const robot_state::Transforms& tf);
+  bool configure(const moveit_msgs::PositionConstraint& pc, const moveit::core::Transforms& tf);
 
   /**
    * \brief Check if two constraints are the same.  For position
@@ -561,7 +561,7 @@ public:
   bool equal(const KinematicConstraint& other, double margin) const override;
 
   void clear() override;
-  ConstraintEvaluationResult decide(const robot_state::RobotState& state, bool verbose = false) const override;
+  ConstraintEvaluationResult decide(const moveit::core::RobotState& state, bool verbose = false) const override;
   bool enabled() const override;
   void print(std::ostream& out = std::cout) const override;
 
@@ -571,7 +571,7 @@ public:
    *
    * @return The link model
    */
-  const robot_model::LinkModel* getLinkModel() const
+  const moveit::core::LinkModel* getLinkModel() const
   {
     return link_model_;
   }
@@ -644,7 +644,7 @@ protected:
   EigenSTL::vector_Isometry3d constraint_region_pose_; /**< \brief The constraint region pose vector */
   bool mobile_frame_;                                  /**< \brief Whether or not a mobile frame is employed*/
   std::string constraint_frame_id_;                    /**< \brief The constraint frame id */
-  const robot_model::LinkModel* link_model_;           /**< \brief The link model constraint subject */
+  const moveit::core::LinkModel* link_model_;           /**< \brief The link model constraint subject */
 };
 
 MOVEIT_CLASS_FORWARD(VisibilityConstraint);
@@ -757,7 +757,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  VisibilityConstraint(const robot_model::RobotModelConstPtr& model);
+  VisibilityConstraint(const moveit::core::RobotModelConstPtr& model);
 
   /**
    * \brief Configure the constraint based on a
@@ -771,7 +771,7 @@ public:
    *
    * @return True if constraint can be configured from vc
    */
-  bool configure(const moveit_msgs::VisibilityConstraint& vc, const robot_state::Transforms& tf);
+  bool configure(const moveit_msgs::VisibilityConstraint& vc, const moveit::core::Transforms& tf);
 
   /**
    * \brief Check if two constraints are the same.
@@ -800,7 +800,7 @@ public:
    *
    * @return The shape associated with the cone
    */
-  shapes::Mesh* getVisibilityCone(const robot_state::RobotState& state) const;
+  shapes::Mesh* getVisibilityCone(const moveit::core::RobotState& state) const;
 
   /**
    * \brief Adds markers associated with the visibility cone, sensor
@@ -813,10 +813,10 @@ public:
    * @param [in] state The state from which to produce the markers
    * @param [out] markers The marker array to which the markers will be added
    */
-  void getMarkers(const robot_state::RobotState& state, visualization_msgs::MarkerArray& markers) const;
+  void getMarkers(const moveit::core::RobotState& state, visualization_msgs::MarkerArray& markers) const;
 
   bool enabled() const override;
-  ConstraintEvaluationResult decide(const robot_state::RobotState& state, bool verbose = false) const override;
+  ConstraintEvaluationResult decide(const moveit::core::RobotState& state, bool verbose = false) const override;
   void print(std::ostream& out = std::cout) const override;
 
 protected:
@@ -868,7 +868,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  KinematicConstraintSet(const robot_model::RobotModelConstPtr& model) : robot_model_(model)
+  KinematicConstraintSet(const moveit::core::RobotModelConstPtr& model) : robot_model_(model)
   {
   }
 
@@ -890,7 +890,7 @@ public:
    * KinematicConstraintSet can still be used even if the addition
    * returns false.
    */
-  bool add(const moveit_msgs::Constraints& c, const robot_state::Transforms& tf);
+  bool add(const moveit_msgs::Constraints& c, const moveit::core::Transforms& tf);
 
   /**
    * \brief Add a vector of joint constraints
@@ -908,7 +908,7 @@ public:
    *
    * @return Will return true only if all constraints are valid, and false otherwise
    */
-  bool add(const std::vector<moveit_msgs::PositionConstraint>& pc, const robot_state::Transforms& tf);
+  bool add(const std::vector<moveit_msgs::PositionConstraint>& pc, const moveit::core::Transforms& tf);
 
   /**
    * \brief Add a vector of orientation constraints
@@ -917,7 +917,7 @@ public:
    *
    * @return Will return true only if all constraints are valid, and false otherwise
    */
-  bool add(const std::vector<moveit_msgs::OrientationConstraint>& oc, const robot_state::Transforms& tf);
+  bool add(const std::vector<moveit_msgs::OrientationConstraint>& oc, const moveit::core::Transforms& tf);
 
   /**
    * \brief Add a vector of visibility constraints
@@ -926,7 +926,7 @@ public:
    *
    * @return Will return true only if all constraints are valid, and false otherwise
    */
-  bool add(const std::vector<moveit_msgs::VisibilityConstraint>& vc, const robot_state::Transforms& tf);
+  bool add(const std::vector<moveit_msgs::VisibilityConstraint>& vc, const moveit::core::Transforms& tf);
 
   /**
    * \brief Determines whether all constraints are satisfied by state,
@@ -939,7 +939,7 @@ public:
    * report satisfied only if all constraints are satisfied, and with
    * a distance that is the sum of all individual distances.
    */
-  ConstraintEvaluationResult decide(const robot_state::RobotState& state, bool verbose = false) const;
+  ConstraintEvaluationResult decide(const moveit::core::RobotState& state, bool verbose = false) const;
 
   /**
    *
@@ -959,7 +959,7 @@ public:
    * report satisfied only if all constraints are satisfied, and with
    * a distance that is the sum of all individual distances.
    */
-  ConstraintEvaluationResult decide(const robot_state::RobotState& state,
+  ConstraintEvaluationResult decide(const moveit::core::RobotState& state,
                                     std::vector<ConstraintEvaluationResult>& results, bool verbose = false) const;
 
   /**
@@ -1053,7 +1053,7 @@ public:
   }
 
 protected:
-  robot_model::RobotModelConstPtr robot_model_; /**< \brief The kinematic model used for by the Set */
+  moveit::core::RobotModelConstPtr robot_model_; /**< \brief The kinematic model used for by the Set */
   std::vector<KinematicConstraintPtr>
       kinematic_constraints_; /**<  \brief Shared pointers to all the member constraints */
 

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -172,7 +172,7 @@ public:
   }
 
 protected:
-  ConstraintType type_;                         /**< \brief The type of the constraint */
+  ConstraintType type_;                          /**< \brief The type of the constraint */
   moveit::core::RobotModelConstPtr robot_model_; /**< \brief The kinematic model associated with this constraint */
   double constraint_weight_; /**< \brief The weight of a constraint is a multiplicative factor associated to the
                                 distance computed by the decide() function  */
@@ -324,9 +324,9 @@ public:
 
 protected:
   const moveit::core::JointModel* joint_model_; /**< \brief The joint from the kinematic model for this constraint */
-  bool joint_is_continuous_;                   /**< \brief Whether or not the joint is continuous */
-  std::string local_variable_name_;            /**< \brief The local variable name for a multi DOF joint, if any */
-  std::string joint_variable_name_;            /**< \brief The joint variable name */
+  bool joint_is_continuous_;                    /**< \brief Whether or not the joint is continuous */
+  std::string local_variable_name_;             /**< \brief The local variable name for a multi DOF joint, if any */
+  std::string joint_variable_name_;             /**< \brief The joint variable name */
   int joint_variable_index_; /**< \brief The index of the joint variable name in the full robot state */
   double joint_position_, joint_tolerance_above_, joint_tolerance_below_; /**< \brief Position and tolerance values*/
 };
@@ -475,7 +475,7 @@ public:
   }
 
 protected:
-  const moveit::core::LinkModel* link_model_;    /**< \brief The target link model */
+  const moveit::core::LinkModel* link_model_;   /**< \brief The target link model */
   Eigen::Matrix3d desired_rotation_matrix_;     /**< \brief The desired rotation matrix in the tf frame */
   Eigen::Matrix3d desired_rotation_matrix_inv_; /**< \brief The inverse of the desired rotation matrix, precomputed for
                                                  * efficiency
@@ -644,7 +644,7 @@ protected:
   EigenSTL::vector_Isometry3d constraint_region_pose_; /**< \brief The constraint region pose vector */
   bool mobile_frame_;                                  /**< \brief Whether or not a mobile frame is employed*/
   std::string constraint_frame_id_;                    /**< \brief The constraint frame id */
-  const moveit::core::LinkModel* link_model_;           /**< \brief The link model constraint subject */
+  const moveit::core::LinkModel* link_model_;          /**< \brief The link model constraint subject */
 };
 
 MOVEIT_CLASS_FORWARD(VisibilityConstraint);

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/utils.h
@@ -83,8 +83,8 @@ std::size_t countIndividualConstraints(const moveit_msgs::Constraints& constr);
  *
  * @return A full constraint message containing all the joint constraints
  */
-moveit_msgs::Constraints constructGoalConstraints(const robot_state::RobotState& state,
-                                                  const robot_model::JointModelGroup* jmg, double tolerance_below,
+moveit_msgs::Constraints constructGoalConstraints(const moveit::core::RobotState& state,
+                                                  const moveit::core::JointModelGroup* jmg, double tolerance_below,
                                                   double tolerance_above);
 
 /**
@@ -98,8 +98,8 @@ moveit_msgs::Constraints constructGoalConstraints(const robot_state::RobotState&
  *
  * @return A full constraint message containing all the joint constraints
  */
-moveit_msgs::Constraints constructGoalConstraints(const robot_state::RobotState& state,
-                                                  const robot_model::JointModelGroup* jmg,
+moveit_msgs::Constraints constructGoalConstraints(const moveit::core::RobotState& state,
+                                                  const moveit::core::JointModelGroup* jmg,
                                                   double tolerance = std::numeric_limits<double>::epsilon());
 
 /**
@@ -213,5 +213,5 @@ bool constructConstraints(XmlRpc::XmlRpcValue& params, moveit_msgs::Constraints&
  * @param [in] state The RobotState used to resolve frames.
  * @param [in] constraints The constraint to resolve.
  */
-bool resolveConstraintFrames(const robot_state::RobotState& state, moveit_msgs::Constraints& constraints);
+bool resolveConstraintFrames(const moveit::core::RobotState& state, moveit_msgs::Constraints& constraints);
 }

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -142,7 +142,8 @@ bool JointConstraint::configure(const moveit_msgs::JointConstraint& jc)
     joint_is_continuous_ = false;
     if (joint_model_->getType() == moveit::core::JointModel::REVOLUTE)
     {
-      const moveit::core::RevoluteJointModel* rjoint = static_cast<const moveit::core::RevoluteJointModel*>(joint_model_);
+      const moveit::core::RevoluteJointModel* rjoint =
+          static_cast<const moveit::core::RevoluteJointModel*>(joint_model_);
       if (rjoint->isContinuous())
         joint_is_continuous_ = true;
     }

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -57,7 +57,7 @@ static double normalizeAngle(double angle)
   return v;
 }
 
-KinematicConstraint::KinematicConstraint(const robot_model::RobotModelConstPtr& model)
+KinematicConstraint::KinematicConstraint(const moveit::core::RobotModelConstPtr& model)
   : type_(UNKNOWN_CONSTRAINT), robot_model_(model), constraint_weight_(std::numeric_limits<double>::epsilon())
 {
 }
@@ -140,13 +140,13 @@ bool JointConstraint::configure(const moveit_msgs::JointConstraint& jc)
 
     // check if we have to wrap angles when computing distances
     joint_is_continuous_ = false;
-    if (joint_model_->getType() == robot_model::JointModel::REVOLUTE)
+    if (joint_model_->getType() == moveit::core::JointModel::REVOLUTE)
     {
-      const robot_model::RevoluteJointModel* rjoint = static_cast<const robot_model::RevoluteJointModel*>(joint_model_);
+      const moveit::core::RevoluteJointModel* rjoint = static_cast<const moveit::core::RevoluteJointModel*>(joint_model_);
       if (rjoint->isContinuous())
         joint_is_continuous_ = true;
     }
-    else if (joint_model_->getType() == robot_model::JointModel::PLANAR)
+    else if (joint_model_->getType() == moveit::core::JointModel::PLANAR)
     {
       if (local_variable_name_ == "theta")
         joint_is_continuous_ = true;
@@ -159,7 +159,7 @@ bool JointConstraint::configure(const moveit_msgs::JointConstraint& jc)
     else
     {
       joint_position_ = jc.position;
-      const robot_model::VariableBounds& bounds = joint_model_->getVariableBounds(joint_variable_name_);
+      const moveit::core::VariableBounds& bounds = joint_model_->getVariableBounds(joint_variable_name_);
 
       if (bounds.min_position_ > joint_position_ + joint_tolerance_above_)
       {
@@ -204,7 +204,7 @@ bool JointConstraint::equal(const KinematicConstraint& other, double margin) con
   return false;
 }
 
-ConstraintEvaluationResult JointConstraint::decide(const robot_state::RobotState& state, bool verbose) const
+ConstraintEvaluationResult JointConstraint::decide(const moveit::core::RobotState& state, bool verbose) const
 {
   if (!joint_model_)
     return ConstraintEvaluationResult(true, 0.0);
@@ -268,7 +268,7 @@ void JointConstraint::print(std::ostream& out) const
     out << "No constraint" << std::endl;
 }
 
-bool PositionConstraint::configure(const moveit_msgs::PositionConstraint& pc, const robot_state::Transforms& tf)
+bool PositionConstraint::configure(const moveit_msgs::PositionConstraint& pc, const moveit::core::Transforms& tf)
 {
   // clearing before we configure to get rid of any old data
   clear();
@@ -378,7 +378,7 @@ bool PositionConstraint::equal(const KinematicConstraint& other, double margin) 
     return false;
   const PositionConstraint& o = static_cast<const PositionConstraint&>(other);
 
-  if (link_model_ == o.link_model_ && robot_state::Transforms::sameFrame(constraint_frame_id_, o.constraint_frame_id_))
+  if (link_model_ == o.link_model_ && moveit::core::Transforms::sameFrame(constraint_frame_id_, o.constraint_frame_id_))
   {
     if ((offset_ - o.offset_).norm() > margin)
       return false;
@@ -429,7 +429,7 @@ static inline ConstraintEvaluationResult finishPositionConstraintDecision(const 
   return ConstraintEvaluationResult(result, weight * sqrt(dx * dx + dy * dy + dz * dz));
 }
 
-ConstraintEvaluationResult PositionConstraint::decide(const robot_state::RobotState& state, bool verbose) const
+ConstraintEvaluationResult PositionConstraint::decide(const moveit::core::RobotState& state, bool verbose) const
 {
   if (!link_model_ || constraint_region_.empty())
     return ConstraintEvaluationResult(true, 0.0);
@@ -489,7 +489,7 @@ bool PositionConstraint::enabled() const
   return link_model_ && !constraint_region_.empty();
 }
 
-bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& oc, const robot_state::Transforms& tf)
+bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& oc, const moveit::core::Transforms& tf)
 {
   // clearing out any old data
   clear();
@@ -562,7 +562,7 @@ bool OrientationConstraint::equal(const KinematicConstraint& other, double margi
   const OrientationConstraint& o = static_cast<const OrientationConstraint&>(other);
 
   if (o.link_model_ == link_model_ &&
-      robot_state::Transforms::sameFrame(desired_rotation_frame_id_, o.desired_rotation_frame_id_))
+      moveit::core::Transforms::sameFrame(desired_rotation_frame_id_, o.desired_rotation_frame_id_))
   {
     if (!desired_rotation_matrix_.isApprox(o.desired_rotation_matrix_))
       return false;
@@ -588,7 +588,7 @@ bool OrientationConstraint::enabled() const
   return link_model_;
 }
 
-ConstraintEvaluationResult OrientationConstraint::decide(const robot_state::RobotState& state, bool verbose) const
+ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::RobotState& state, bool verbose) const
 {
   if (!link_model_)
     return ConstraintEvaluationResult(true, 0.0);
@@ -642,7 +642,7 @@ void OrientationConstraint::print(std::ostream& out) const
     out << "No constraint" << std::endl;
 }
 
-VisibilityConstraint::VisibilityConstraint(const robot_model::RobotModelConstPtr& model)
+VisibilityConstraint::VisibilityConstraint(const moveit::core::RobotModelConstPtr& model)
   : KinematicConstraint(model), collision_env_(new collision_detection::CollisionEnvFCL(model))
 {
   type_ = VISIBILITY_CONSTRAINT;
@@ -664,7 +664,7 @@ void VisibilityConstraint::clear()
   max_range_angle_ = 0.0;
 }
 
-bool VisibilityConstraint::configure(const moveit_msgs::VisibilityConstraint& vc, const robot_state::Transforms& tf)
+bool VisibilityConstraint::configure(const moveit_msgs::VisibilityConstraint& vc, const moveit::core::Transforms& tf)
 {
   clear();
   target_radius_ = fabs(vc.target_radius);
@@ -746,8 +746,8 @@ bool VisibilityConstraint::equal(const KinematicConstraint& other, double margin
     return false;
   const VisibilityConstraint& o = static_cast<const VisibilityConstraint&>(other);
 
-  if (robot_state::Transforms::sameFrame(target_frame_id_, o.target_frame_id_) &&
-      robot_state::Transforms::sameFrame(sensor_frame_id_, o.sensor_frame_id_) && cone_sides_ == o.cone_sides_ &&
+  if (moveit::core::Transforms::sameFrame(target_frame_id_, o.target_frame_id_) &&
+      moveit::core::Transforms::sameFrame(sensor_frame_id_, o.sensor_frame_id_) && cone_sides_ == o.cone_sides_ &&
       sensor_view_direction_ == o.sensor_view_direction_)
   {
     if (fabs(max_view_angle_ - o.max_view_angle_) > margin || fabs(target_radius_ - o.target_radius_) > margin)
@@ -772,7 +772,7 @@ bool VisibilityConstraint::enabled() const
   return target_radius_ > std::numeric_limits<double>::epsilon();
 }
 
-shapes::Mesh* VisibilityConstraint::getVisibilityCone(const robot_state::RobotState& state) const
+shapes::Mesh* VisibilityConstraint::getVisibilityCone(const moveit::core::RobotState& state) const
 {
   // the current pose of the sensor
 
@@ -846,7 +846,7 @@ shapes::Mesh* VisibilityConstraint::getVisibilityCone(const robot_state::RobotSt
   return m;
 }
 
-void VisibilityConstraint::getMarkers(const robot_state::RobotState& state,
+void VisibilityConstraint::getMarkers(const moveit::core::RobotState& state,
                                       visualization_msgs::MarkerArray& markers) const
 {
   shapes::Mesh* m = getVisibilityCone(state);
@@ -918,7 +918,7 @@ void VisibilityConstraint::getMarkers(const robot_state::RobotState& state,
   markers.markers.push_back(mka);
 }
 
-ConstraintEvaluationResult VisibilityConstraint::decide(const robot_state::RobotState& state, bool verbose) const
+ConstraintEvaluationResult VisibilityConstraint::decide(const moveit::core::RobotState& state, bool verbose) const
 {
   if (target_radius_ <= std::numeric_limits<double>::epsilon())
     return ConstraintEvaluationResult(true, 0.0);
@@ -1015,16 +1015,16 @@ bool VisibilityConstraint::decideContact(const collision_detection::Contact& con
     return true;
   if (contact.body_type_1 == collision_detection::BodyTypes::ROBOT_LINK &&
       contact.body_type_2 == collision_detection::BodyTypes::WORLD_OBJECT &&
-      (robot_state::Transforms::sameFrame(contact.body_name_1, sensor_frame_id_) ||
-       robot_state::Transforms::sameFrame(contact.body_name_1, target_frame_id_)))
+      (moveit::core::Transforms::sameFrame(contact.body_name_1, sensor_frame_id_) ||
+       moveit::core::Transforms::sameFrame(contact.body_name_1, target_frame_id_)))
   {
     ROS_DEBUG_NAMED("kinematic_constraints", "Accepted collision with either sensor or target");
     return true;
   }
   if (contact.body_type_2 == collision_detection::BodyTypes::ROBOT_LINK &&
       contact.body_type_1 == collision_detection::BodyTypes::WORLD_OBJECT &&
-      (robot_state::Transforms::sameFrame(contact.body_name_2, sensor_frame_id_) ||
-       robot_state::Transforms::sameFrame(contact.body_name_2, target_frame_id_)))
+      (moveit::core::Transforms::sameFrame(contact.body_name_2, sensor_frame_id_) ||
+       moveit::core::Transforms::sameFrame(contact.body_name_2, target_frame_id_)))
   {
     ROS_DEBUG_NAMED("kinematic_constraints", "Accepted collision with either sensor or target");
     return true;
@@ -1070,7 +1070,7 @@ bool KinematicConstraintSet::add(const std::vector<moveit_msgs::JointConstraint>
 }
 
 bool KinematicConstraintSet::add(const std::vector<moveit_msgs::PositionConstraint>& pc,
-                                 const robot_state::Transforms& tf)
+                                 const moveit::core::Transforms& tf)
 {
   bool result = true;
   for (const moveit_msgs::PositionConstraint& position_constraint : pc)
@@ -1086,7 +1086,7 @@ bool KinematicConstraintSet::add(const std::vector<moveit_msgs::PositionConstrai
 }
 
 bool KinematicConstraintSet::add(const std::vector<moveit_msgs::OrientationConstraint>& oc,
-                                 const robot_state::Transforms& tf)
+                                 const moveit::core::Transforms& tf)
 {
   bool result = true;
   for (const moveit_msgs::OrientationConstraint& orientation_constraint : oc)
@@ -1102,7 +1102,7 @@ bool KinematicConstraintSet::add(const std::vector<moveit_msgs::OrientationConst
 }
 
 bool KinematicConstraintSet::add(const std::vector<moveit_msgs::VisibilityConstraint>& vc,
-                                 const robot_state::Transforms& tf)
+                                 const moveit::core::Transforms& tf)
 {
   bool result = true;
   for (const moveit_msgs::VisibilityConstraint& visibility_constraint : vc)
@@ -1117,7 +1117,7 @@ bool KinematicConstraintSet::add(const std::vector<moveit_msgs::VisibilityConstr
   return result;
 }
 
-bool KinematicConstraintSet::add(const moveit_msgs::Constraints& c, const robot_state::Transforms& tf)
+bool KinematicConstraintSet::add(const moveit_msgs::Constraints& c, const moveit::core::Transforms& tf)
 {
   bool j = add(c.joint_constraints);
   bool p = add(c.position_constraints, tf);
@@ -1126,7 +1126,7 @@ bool KinematicConstraintSet::add(const moveit_msgs::Constraints& c, const robot_
   return j && p && o && v;
 }
 
-ConstraintEvaluationResult KinematicConstraintSet::decide(const robot_state::RobotState& state, bool verbose) const
+ConstraintEvaluationResult KinematicConstraintSet::decide(const moveit::core::RobotState& state, bool verbose) const
 {
   ConstraintEvaluationResult res(true, 0.0);
   for (const KinematicConstraintPtr& kinematic_constraint : kinematic_constraints_)
@@ -1139,7 +1139,7 @@ ConstraintEvaluationResult KinematicConstraintSet::decide(const robot_state::Rob
   return res;
 }
 
-ConstraintEvaluationResult KinematicConstraintSet::decide(const robot_state::RobotState& state,
+ConstraintEvaluationResult KinematicConstraintSet::decide(const moveit::core::RobotState& state,
                                                           std::vector<ConstraintEvaluationResult>& results,
                                                           bool verbose) const
 {

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -126,14 +126,14 @@ std::size_t countIndividualConstraints(const moveit_msgs::Constraints& constr)
          constr.visibility_constraints.size() + constr.joint_constraints.size();
 }
 
-moveit_msgs::Constraints constructGoalConstraints(const robot_state::RobotState& state,
-                                                  const robot_model::JointModelGroup* jmg, double tolerance)
+moveit_msgs::Constraints constructGoalConstraints(const moveit::core::RobotState& state,
+                                                  const moveit::core::JointModelGroup* jmg, double tolerance)
 {
   return constructGoalConstraints(state, jmg, tolerance, tolerance);
 }
 
-moveit_msgs::Constraints constructGoalConstraints(const robot_state::RobotState& state,
-                                                  const robot_model::JointModelGroup* jmg, double tolerance_below,
+moveit_msgs::Constraints constructGoalConstraints(const moveit::core::RobotState& state,
+                                                  const moveit::core::JointModelGroup* jmg, double tolerance_below,
                                                   double tolerance_above)
 {
   moveit_msgs::Constraints goal;
@@ -529,7 +529,7 @@ bool constructConstraints(XmlRpc::XmlRpcValue& params, moveit_msgs::Constraints&
 }
 }  // namespace kinematic_constraints
 
-bool kinematic_constraints::resolveConstraintFrames(const robot_state::RobotState& state,
+bool kinematic_constraints::resolveConstraintFrames(const moveit::core::RobotState& state,
                                                     moveit_msgs::Constraints& constraints)
 {
   for (auto& c : constraints.position_constraints)

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -54,14 +54,14 @@ protected:
   }
 
 protected:
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 };
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsSimple)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::JointConstraint jc(robot_model_);
   moveit_msgs::JointConstraint jcm;
@@ -174,10 +174,10 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsSimple)
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsCont)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::JointConstraint jc(robot_model_);
   moveit_msgs::JointConstraint jcm;
@@ -305,7 +305,7 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsCont)
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsMultiDOF)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   kinematic_constraints::JointConstraint jc(robot_model_);
@@ -356,10 +356,10 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsMultiDOF)
 
 TEST_F(LoadPlanningModelsPr2, PositionConstraintsFixed)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update(true);
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
   kinematic_constraints::PositionConstraint pc(robot_model_);
   moveit_msgs::PositionConstraint pcm;
 
@@ -432,9 +432,9 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsFixed)
 
 TEST_F(LoadPlanningModelsPr2, PositionConstraintsMobile)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
   robot_state.update();
 
   kinematic_constraints::PositionConstraint pc(robot_model_);
@@ -509,9 +509,9 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsMobile)
 
 TEST_F(LoadPlanningModelsPr2, PositionConstraintsEquality)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::PositionConstraint pc(robot_model_);
   kinematic_constraints::PositionConstraint pc2(robot_model_);
@@ -595,10 +595,10 @@ TEST_F(LoadPlanningModelsPr2, PositionConstraintsEquality)
 
 TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::OrientationConstraint oc(robot_model_);
 
@@ -656,10 +656,10 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
 
 TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsSimple)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::VisibilityConstraint vc(robot_model_);
   moveit_msgs::VisibilityConstraint vcm;
@@ -707,10 +707,10 @@ TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsSimple)
 
 TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsPR2)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::VisibilityConstraint vc(robot_model_);
   moveit_msgs::VisibilityConstraint vcm;
@@ -781,9 +781,9 @@ TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsPR2)
 
 TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSet)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::KinematicConstraintSet kcs(robot_model_);
   EXPECT_TRUE(kcs.empty());
@@ -847,9 +847,9 @@ TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSet)
 
 TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSetEquality)
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
-  robot_state::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
   kinematic_constraints::KinematicConstraintSet kcs(robot_model_);
   kinematic_constraints::KinematicConstraintSet kcs2(robot_model_);

--- a/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
+++ b/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
@@ -98,8 +98,8 @@ public:
    * @return False if the group was not found
    */
   bool getManipulabilityEllipsoid(const moveit::core::RobotState& state,
-                                  const moveit::core::JointModelGroup* joint_model_group, Eigen::MatrixXcd& eigen_values,
-                                  Eigen::MatrixXcd& eigen_vectors) const;
+                                  const moveit::core::JointModelGroup* joint_model_group,
+                                  Eigen::MatrixXcd& eigen_values, Eigen::MatrixXcd& eigen_vectors) const;
 
   /**
    * @brief Get the manipulability = sigma_min/sigma_max

--- a/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
+++ b/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
@@ -52,7 +52,7 @@ class KinematicsMetrics
 {
 public:
   /** \brief Construct a KinematicsMetricss from a RobotModel */
-  KinematicsMetrics(const robot_model::RobotModelConstPtr& robot_model)
+  KinematicsMetrics(const moveit::core::RobotModelConstPtr& robot_model)
     : robot_model_(robot_model), penalty_multiplier_(0.0)
   {
   }
@@ -64,7 +64,7 @@ public:
    * @param manipulability_index The computed manipulability = sqrt(det(JJ^T))
    * @return False if the group was not found
    */
-  bool getManipulabilityIndex(const robot_state::RobotState& state, const std::string& group_name,
+  bool getManipulabilityIndex(const moveit::core::RobotState& state, const std::string& group_name,
                               double& manipulability_index, bool translation = false) const;
 
   /**
@@ -74,8 +74,8 @@ public:
    * @param manipulability_index The computed manipulability = sqrt(det(JJ^T))
    * @return False if the group was not found
    */
-  bool getManipulabilityIndex(const robot_state::RobotState& state,
-                              const robot_model::JointModelGroup* joint_model_group, double& manipulability_index,
+  bool getManipulabilityIndex(const moveit::core::RobotState& state,
+                              const moveit::core::JointModelGroup* joint_model_group, double& manipulability_index,
                               bool translation = false) const;
 
   /**
@@ -86,7 +86,7 @@ public:
    * @param eigen_vectors The eigen vectors for the translation part of JJ^T
    * @return False if the group was not found
    */
-  bool getManipulabilityEllipsoid(const robot_state::RobotState& state, const std::string& group_name,
+  bool getManipulabilityEllipsoid(const moveit::core::RobotState& state, const std::string& group_name,
                                   Eigen::MatrixXcd& eigen_values, Eigen::MatrixXcd& eigen_vectors) const;
 
   /**
@@ -97,8 +97,8 @@ public:
    * @param eigen_vectors The eigen vectors for the translation part of JJ^T
    * @return False if the group was not found
    */
-  bool getManipulabilityEllipsoid(const robot_state::RobotState& state,
-                                  const robot_model::JointModelGroup* joint_model_group, Eigen::MatrixXcd& eigen_values,
+  bool getManipulabilityEllipsoid(const moveit::core::RobotState& state,
+                                  const moveit::core::JointModelGroup* joint_model_group, Eigen::MatrixXcd& eigen_values,
                                   Eigen::MatrixXcd& eigen_vectors) const;
 
   /**
@@ -110,7 +110,7 @@ public:
    * @param condition_number Condition number for JJ^T
    * @return False if the group was not found
    */
-  bool getManipulability(const robot_state::RobotState& state, const std::string& group_name, double& condition_number,
+  bool getManipulability(const moveit::core::RobotState& state, const std::string& group_name, double& condition_number,
                          bool translation = false) const;
 
   /**
@@ -122,7 +122,7 @@ public:
    * @param condition_number Condition number for JJ^T
    * @return False if the group was not found
    */
-  bool getManipulability(const robot_state::RobotState& state, const robot_model::JointModelGroup* joint_model_group,
+  bool getManipulability(const moveit::core::RobotState& state, const moveit::core::JointModelGroup* joint_model_group,
                          double& condition_number, bool translation = false) const;
 
   void setPenaltyMultiplier(double multiplier)
@@ -136,7 +136,7 @@ public:
   }
 
 protected:
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
 private:
   /**
@@ -151,8 +151,8 @@ private:
  * Ohio State University, 1986, for more details.
  * @return multiplier that is multiplied with every manipulability measure computed here
  */
-  double getJointLimitsPenalty(const robot_state::RobotState& state,
-                               const robot_model::JointModelGroup* joint_model_group) const;
+  double getJointLimitsPenalty(const moveit::core::RobotState& state,
+                               const moveit::core::JointModelGroup* joint_model_group) const;
 
   double penalty_multiplier_;
 };

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -41,25 +41,25 @@
 
 namespace kinematics_metrics
 {
-double KinematicsMetrics::getJointLimitsPenalty(const robot_state::RobotState& state,
-                                                const robot_model::JointModelGroup* joint_model_group) const
+double KinematicsMetrics::getJointLimitsPenalty(const moveit::core::RobotState& state,
+                                                const moveit::core::JointModelGroup* joint_model_group) const
 {
   if (fabs(penalty_multiplier_) <= boost::math::tools::epsilon<double>())
     return 1.0;
   double joint_limits_multiplier(1.0);
-  const std::vector<const robot_model::JointModel*>& joint_model_vector = joint_model_group->getJointModels();
-  for (const robot_model::JointModel* joint_model : joint_model_vector)
+  const std::vector<const moveit::core::JointModel*>& joint_model_vector = joint_model_group->getJointModels();
+  for (const moveit::core::JointModel* joint_model : joint_model_vector)
   {
-    if (joint_model->getType() == robot_model::JointModel::REVOLUTE)
+    if (joint_model->getType() == moveit::core::JointModel::REVOLUTE)
     {
-      const robot_model::RevoluteJointModel* revolute_model =
-          static_cast<const robot_model::RevoluteJointModel*>(joint_model);
+      const moveit::core::RevoluteJointModel* revolute_model =
+          static_cast<const moveit::core::RevoluteJointModel*>(joint_model);
       if (revolute_model->isContinuous())
         continue;
     }
-    if (joint_model->getType() == robot_model::JointModel::PLANAR)
+    if (joint_model->getType() == moveit::core::JointModel::PLANAR)
     {
-      const robot_model::JointModel::Bounds& bounds = joint_model->getVariableBounds();
+      const moveit::core::JointModel::Bounds& bounds = joint_model->getVariableBounds();
       if (bounds[0].min_position_ == -std::numeric_limits<double>::max() ||
           bounds[0].max_position_ == std::numeric_limits<double>::max() ||
           bounds[1].min_position_ == -std::numeric_limits<double>::max() ||
@@ -68,13 +68,13 @@ double KinematicsMetrics::getJointLimitsPenalty(const robot_state::RobotState& s
           bounds[2].max_position_ == boost::math::constants::pi<double>())
         continue;
     }
-    if (joint_model->getType() == robot_model::JointModel::FLOATING)
+    if (joint_model->getType() == moveit::core::JointModel::FLOATING)
     {
       // Joint limits are not well-defined for floating joints
       continue;
     }
     const double* joint_values = state.getJointPositions(joint_model);
-    const robot_model::JointModel::Bounds& bounds = joint_model->getVariableBounds();
+    const moveit::core::JointModel::Bounds& bounds = joint_model->getVariableBounds();
     std::vector<double> lower_bounds, upper_bounds;
     for (const moveit::core::VariableBounds& bound : bounds)
     {
@@ -91,18 +91,18 @@ double KinematicsMetrics::getJointLimitsPenalty(const robot_state::RobotState& s
   return (1.0 - exp(-penalty_multiplier_ * joint_limits_multiplier));
 }
 
-bool KinematicsMetrics::getManipulabilityIndex(const robot_state::RobotState& state, const std::string& group_name,
+bool KinematicsMetrics::getManipulabilityIndex(const moveit::core::RobotState& state, const std::string& group_name,
                                                double& manipulability_index, bool translation) const
 {
-  const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
   if (joint_model_group)
     return getManipulabilityIndex(state, joint_model_group, manipulability_index, translation);
   else
     return false;
 }
 
-bool KinematicsMetrics::getManipulabilityIndex(const robot_state::RobotState& state,
-                                               const robot_model::JointModelGroup* joint_model_group,
+bool KinematicsMetrics::getManipulabilityIndex(const moveit::core::RobotState& state,
+                                               const moveit::core::JointModelGroup* joint_model_group,
                                                double& manipulability_index, bool translation) const
 {
   // state.getJacobian() only works for chain groups.
@@ -162,19 +162,19 @@ bool KinematicsMetrics::getManipulabilityIndex(const robot_state::RobotState& st
   return true;
 }
 
-bool KinematicsMetrics::getManipulabilityEllipsoid(const robot_state::RobotState& state, const std::string& group_name,
+bool KinematicsMetrics::getManipulabilityEllipsoid(const moveit::core::RobotState& state, const std::string& group_name,
                                                    Eigen::MatrixXcd& eigen_values,
                                                    Eigen::MatrixXcd& eigen_vectors) const
 {
-  const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
   if (joint_model_group)
     return getManipulabilityEllipsoid(state, joint_model_group, eigen_values, eigen_vectors);
   else
     return false;
 }
 
-bool KinematicsMetrics::getManipulabilityEllipsoid(const robot_state::RobotState& state,
-                                                   const robot_model::JointModelGroup* joint_model_group,
+bool KinematicsMetrics::getManipulabilityEllipsoid(const moveit::core::RobotState& state,
+                                                   const moveit::core::JointModelGroup* joint_model_group,
                                                    Eigen::MatrixXcd& eigen_values,
                                                    Eigen::MatrixXcd& eigen_vectors) const
 {
@@ -192,18 +192,18 @@ bool KinematicsMetrics::getManipulabilityEllipsoid(const robot_state::RobotState
   return true;
 }
 
-bool KinematicsMetrics::getManipulability(const robot_state::RobotState& state, const std::string& group_name,
+bool KinematicsMetrics::getManipulability(const moveit::core::RobotState& state, const std::string& group_name,
                                           double& manipulability, bool translation) const
 {
-  const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
   if (joint_model_group)
     return getManipulability(state, joint_model_group, manipulability, translation);
   else
     return false;
 }
 
-bool KinematicsMetrics::getManipulability(const robot_state::RobotState& state,
-                                          const robot_model::JointModelGroup* joint_model_group, double& manipulability,
+bool KinematicsMetrics::getManipulability(const moveit::core::RobotState& state,
+                                          const moveit::core::JointModelGroup* joint_model_group, double& manipulability,
                                           bool translation) const
 {
   // state.getJacobian() only works for chain groups.

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -203,8 +203,8 @@ bool KinematicsMetrics::getManipulability(const moveit::core::RobotState& state,
 }
 
 bool KinematicsMetrics::getManipulability(const moveit::core::RobotState& state,
-                                          const moveit::core::JointModelGroup* joint_model_group, double& manipulability,
-                                          bool translation) const
+                                          const moveit::core::JointModelGroup* joint_model_group,
+                                          double& manipulability, bool translation) const
 {
   // state.getJacobian() only works for chain groups.
   if (!joint_model_group->isChain())

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -163,7 +163,7 @@ public:
   /// It is assumed that motion plans will be computed for the robot described by \e model and that any exposed ROS
   /// functionality
   /// or required ROS parameters are namespaced by \e ns
-  virtual bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& ns);
+  virtual bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns);
 
   /// Get \brief a short string that identifies the planning interface
   virtual std::string getDescription() const;

--- a/moveit_core/planning_interface/src/planning_interface.cpp
+++ b/moveit_core/planning_interface/src/planning_interface.cpp
@@ -91,7 +91,7 @@ void PlanningContext::setMotionPlanRequest(const MotionPlanRequest& request)
   request_.num_planning_attempts = std::max(1, request_.num_planning_attempts);
 }
 
-bool PlannerManager::initialize(const robot_model::RobotModelConstPtr& /*unused*/, const std::string& /*unused*/)
+bool PlannerManager::initialize(const moveit::core::RobotModelConstPtr& /*unused*/, const std::string& /*unused*/)
 {
   return true;
 }

--- a/moveit_core/planning_interface/src/planning_response.cpp
+++ b/moveit_core/planning_interface/src/planning_response.cpp
@@ -43,7 +43,7 @@ void planning_interface::MotionPlanResponse::getMessage(moveit_msgs::MotionPlanR
   msg.planning_time = planning_time_;
   if (trajectory_ && !trajectory_->empty())
   {
-    robot_state::robotStateToRobotStateMsg(trajectory_->getFirstWayPoint(), msg.trajectory_start);
+    moveit::core::robotStateToRobotStateMsg(trajectory_->getFirstWayPoint(), msg.trajectory_start);
     trajectory_->getRobotTrajectoryMsg(msg.trajectory);
     msg.group_name = trajectory_->getGroupName();
   }
@@ -66,7 +66,7 @@ void planning_interface::MotionPlanDetailedResponse::getMessage(moveit_msgs::Mot
     if (first)
     {
       first = false;
-      robot_state::robotStateToRobotStateMsg(trajectory_[i]->getFirstWayPoint(), msg.trajectory_start);
+      moveit::core::robotStateToRobotStateMsg(trajectory_[i]->getFirstWayPoint(), msg.trajectory_start);
       msg.group_name = trajectory_[i]->getGroupName();
     }
     msg.trajectory.resize(msg.trajectory.size() + 1);

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -72,7 +72,8 @@ typedef boost::function<bool(const moveit::core::RobotState&, bool)> StateFeasib
     The order of the arguments matters: the notion of feasibility is to be checked for motion segments that start at the
    first state and end at the second state. The third argument indicates
     whether the check should be verbose or not. */
-typedef boost::function<bool(const moveit::core::RobotState&, const moveit::core::RobotState&, bool)> MotionFeasibilityFn;
+typedef boost::function<bool(const moveit::core::RobotState&, const moveit::core::RobotState&, bool)>
+    MotionFeasibilityFn;
 
 /** \brief A map from object names (e.g., attached bodies, collision objects) to their colors */
 typedef std::map<std::string, std_msgs::ColorRGBA> ObjectColorMap;
@@ -481,7 +482,8 @@ public:
                           moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), getAllowedCollisionMatrix());
+    checkSelfCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state),
+                       getAllowedCollisionMatrix());
   }
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision */
@@ -965,7 +967,7 @@ private:
 
   /* helper function to create a RobotModel from a urdf/srdf. */
   static moveit::core::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
-                                                     const srdf::ModelConstSharedPtr& srdf_model);
+                                                      const srdf::ModelConstSharedPtr& srdf_model);
 
   /* Helper functions for processing collision objects */
   bool processCollisionObjectAdd(const moveit_msgs::CollisionObject& object);

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -65,14 +65,14 @@ MOVEIT_CLASS_FORWARD(PlanningScene);
    respecting constraints and collision avoidance).
     The first argument is the state to check the feasibility for, the second one is whether the check should be verbose
    or not. */
-typedef boost::function<bool(const robot_state::RobotState&, bool)> StateFeasibilityFn;
+typedef boost::function<bool(const moveit::core::RobotState&, bool)> StateFeasibilityFn;
 
 /** \brief This is the function signature for additional feasibility checks to be imposed on motions segments between
    states (in addition to respecting constraints and collision avoidance).
     The order of the arguments matters: the notion of feasibility is to be checked for motion segments that start at the
    first state and end at the second state. The third argument indicates
     whether the check should be verbose or not. */
-typedef boost::function<bool(const robot_state::RobotState&, const robot_state::RobotState&, bool)> MotionFeasibilityFn;
+typedef boost::function<bool(const moveit::core::RobotState&, const moveit::core::RobotState&, bool)> MotionFeasibilityFn;
 
 /** \brief A map from object names (e.g., attached bodies, collision objects) to their colors */
 typedef std::map<std::string, std_msgs::ColorRGBA> ObjectColorMap;
@@ -88,7 +88,7 @@ class PlanningScene : private boost::noncopyable, public std::enable_shared_from
 public:
   /** \brief construct using an existing RobotModel */
   PlanningScene(
-      const robot_model::RobotModelConstPtr& robot_model,
+      const moveit::core::RobotModelConstPtr& robot_model,
       const collision_detection::WorldPtr& world = collision_detection::WorldPtr(new collision_detection::World()));
 
   /** \brief construct using a urdf and srdf.
@@ -137,23 +137,23 @@ public:
   }
 
   /** \brief Get the kinematic model for which the planning scene is maintained */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     // the kinematic model does not change
     return robot_model_;
   }
 
   /** \brief Get the state at which the robot is assumed to be. */
-  const robot_state::RobotState& getCurrentState() const
+  const moveit::core::RobotState& getCurrentState() const
   {
     // if we have an updated state, return it; otherwise, return the parent one
     return robot_state_ ? *robot_state_ : parent_->getCurrentState();
   }
   /** \brief Get the state at which the robot is assumed to be. */
-  robot_state::RobotState& getCurrentStateNonConst();
+  moveit::core::RobotState& getCurrentStateNonConst();
 
   /** \brief Get a copy of the current state with components overwritten by the state message \e update */
-  robot_state::RobotStatePtr getCurrentStateUpdated(const moveit_msgs::RobotState& update) const;
+  moveit::core::RobotStatePtr getCurrentStateUpdated(const moveit_msgs::RobotState& update) const;
 
   /**
    * \name Reasoning about frames
@@ -168,7 +168,7 @@ public:
   }
 
   /** \brief Get the set of fixed transforms from known frames to the planning frame */
-  const robot_state::Transforms& getTransforms() const
+  const moveit::core::Transforms& getTransforms() const
   {
     if (scene_transforms_ || !parent_)
     {
@@ -181,10 +181,10 @@ public:
 
   /** \brief Get the set of fixed transforms from known frames to the planning frame. This variant is non-const and also
    * updates the current state */
-  const robot_state::Transforms& getTransforms();
+  const moveit::core::Transforms& getTransforms();
 
   /** \brief Get the set of fixed transforms from known frames to the planning frame */
-  robot_state::Transforms& getTransformsNonConst();
+  moveit::core::Transforms& getTransformsNonConst();
 
   /** \brief Get the transform corresponding to the frame \e id. This will be known if \e id is a link name, an attached
      body id or a collision object.
@@ -204,17 +204,17 @@ public:
       Return identity when no transform is available. Use knowsFrameTransform() to test if this function will be
      successful or not. This function also
       updates the link transforms of \e state. */
-  const Eigen::Isometry3d& getFrameTransform(robot_state::RobotState& state, const std::string& id) const
+  const Eigen::Isometry3d& getFrameTransform(moveit::core::RobotState& state, const std::string& id) const
   {
     state.updateLinkTransforms();
-    return getFrameTransform(static_cast<const robot_state::RobotState&>(state), id);
+    return getFrameTransform(static_cast<const moveit::core::RobotState&>(state), id);
   }
 
   /** \brief Get the transform corresponding to the frame \e id. This will be known if \e id is a link name, an attached
      body id or a collision object.
       Return identity when no transform is available. Use knowsFrameTransform() to test if this function will be
      successful or not. */
-  const Eigen::Isometry3d& getFrameTransform(const robot_state::RobotState& state, const std::string& id) const;
+  const Eigen::Isometry3d& getFrameTransform(const moveit::core::RobotState& state, const std::string& id) const;
 
   /** \brief Check if a transform to the frame \e id is known. This will be known if \e id is a link name, an attached
    * body id or a collision object */
@@ -222,7 +222,7 @@ public:
 
   /** \brief Check if a transform to the frame \e id is known. This will be known if \e id is a link name, an attached
    * body id or a collision object */
-  bool knowsFrameTransform(const robot_state::RobotState& state, const std::string& id) const;
+  bool knowsFrameTransform(const moveit::core::RobotState& state, const std::string& id) const;
 
   /**@}*/
 
@@ -356,16 +356,16 @@ public:
      specified,
       collision checking is done for that group only. The link transforms for \e state are updated before the collision
      check. */
-  bool isStateColliding(robot_state::RobotState& state, const std::string& group = "", bool verbose = false) const
+  bool isStateColliding(moveit::core::RobotState& state, const std::string& group = "", bool verbose = false) const
   {
     state.updateCollisionBodyTransforms();
-    return isStateColliding(static_cast<const robot_state::RobotState&>(state), group, verbose);
+    return isStateColliding(static_cast<const moveit::core::RobotState&>(state), group, verbose);
   }
 
   /** \brief Check if a given state is in collision (with the environment or self collision)
       If a group name is specified, collision checking is done for that group only. It is expected that the link
       transforms of \e state are up to date. */
-  bool isStateColliding(const robot_state::RobotState& state, const std::string& group = "",
+  bool isStateColliding(const moveit::core::RobotState& state, const std::string& group = "",
                         bool verbose = false) const;
 
   /** \brief Check if a given state is in collision (with the environment or self collision)
@@ -386,33 +386,33 @@ public:
   /** \brief Check whether a specified state (\e robot_state) is in collision. This variant of the function takes
       a non-const \e robot_state and calls updateCollisionBodyTransforms() on it. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      robot_state::RobotState& robot_state) const
+                      moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state));
+    checkCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state));
   }
 
   /** \brief Check whether a specified state (\e robot_state) is in collision. The collision transforms of \e
    * robot_state are
    * expected to be up to date. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      const robot_state::RobotState& robot_state) const;
+                      const moveit::core::RobotState& robot_state) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm). This variant of the function takes
       a non-const \e robot_state and updates its link transforms if needed. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      robot_state::RobotState& robot_state,
+                      moveit::core::RobotState& robot_state,
                       const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state), acm);
+    checkCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm). */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      const robot_state::RobotState& robot_state,
+                      const moveit::core::RobotState& robot_state,
                       const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the current state is in collision,
@@ -433,7 +433,7 @@ public:
       but use a collision_detection::CollisionRobot instance that has no padding.  */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
                               collision_detection::CollisionResult& res,
-                              const robot_state::RobotState& robot_state) const
+                              const moveit::core::RobotState& robot_state) const
   {
     checkCollisionUnpadded(req, res, robot_state, getAllowedCollisionMatrix());
   }
@@ -442,10 +442,10 @@ public:
       but use a collision_detection::CollisionRobot instance that has no padding.
       Update the link transforms of \e robot_state if needed. */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, robot_state::RobotState& robot_state) const
+                              collision_detection::CollisionResult& res, moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(robot_state),
+    checkCollisionUnpadded(req, res, static_cast<const moveit::core::RobotState&>(robot_state),
                            getAllowedCollisionMatrix());
   }
 
@@ -453,17 +453,17 @@ public:
       allowed collision matrix (\e acm), but use a collision_detection::CollisionRobot instance that has no padding.
       This variant of the function takes a non-const \e robot_state and calls updates the link transforms if needed. */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, robot_state::RobotState& robot_state,
+                              collision_detection::CollisionResult& res, moveit::core::RobotState& robot_state,
                               const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, static_cast<const robot_state::RobotState&>(robot_state), acm);
+    checkCollisionUnpadded(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm), but use a collision_detection::CollisionRobot instance that has no padding.  */
   void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, const robot_state::RobotState& robot_state,
+                              collision_detection::CollisionResult& res, const moveit::core::RobotState& robot_state,
                               const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the current state is in self collision */
@@ -478,15 +478,15 @@ public:
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          robot_state::RobotState& robot_state) const
+                          moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state), getAllowedCollisionMatrix());
+    checkSelfCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), getAllowedCollisionMatrix());
   }
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          const robot_state::RobotState& robot_state) const
+                          const moveit::core::RobotState& robot_state) const
   {
     // do self-collision checking with the unpadded version of the robot
     getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, getAllowedCollisionMatrix());
@@ -495,17 +495,17 @@ public:
   /** \brief Check whether a specified state (\e robot_state) is in self collision, with respect to a given
       allowed collision matrix (\e acm). The link transforms of \e robot_state are updated if needed. */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          robot_state::RobotState& robot_state,
+                          moveit::core::RobotState& robot_state,
                           const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const robot_state::RobotState&>(robot_state), acm);
+    checkSelfCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision, with respect to a given
       allowed collision matrix (\e acm) */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          const robot_state::RobotState& robot_state,
+                          const moveit::core::RobotState& robot_state,
                           const collision_detection::AllowedCollisionMatrix& acm) const
   {
     // do self-collision checking with the unpadded version of the robot
@@ -523,30 +523,30 @@ public:
 
   /** \brief Get the names of the links that are involved in collisions for the state \e robot_state.
       Update the link transforms for \e robot_state if needed. */
-  void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& robot_state) const
+  void getCollidingLinks(std::vector<std::string>& links, moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(robot_state), getAllowedCollisionMatrix());
+    getCollidingLinks(links, static_cast<const moveit::core::RobotState&>(robot_state), getAllowedCollisionMatrix());
   }
 
   /** \brief Get the names of the links that are involved in collisions for the state \e robot_state */
-  void getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& robot_state) const
+  void getCollidingLinks(std::vector<std::string>& links, const moveit::core::RobotState& robot_state) const
   {
     getCollidingLinks(links, robot_state, getAllowedCollisionMatrix());
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm) */
-  void getCollidingLinks(std::vector<std::string>& links, robot_state::RobotState& robot_state,
+  void getCollidingLinks(std::vector<std::string>& links, moveit::core::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    getCollidingLinks(links, static_cast<const robot_state::RobotState&>(robot_state), acm);
+    getCollidingLinks(links, static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm) */
-  void getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& robot_state,
+  void getCollidingLinks(std::vector<std::string>& links, const moveit::core::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Get the names of the links that are involved in collisions for the current state.
@@ -561,7 +561,7 @@ public:
 
   /** \brief Get the names of the links that are involved in collisions for the state \e robot_state */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         const robot_state::RobotState& robot_state) const
+                         const moveit::core::RobotState& robot_state) const
   {
     getCollidingPairs(contacts, robot_state, getAllowedCollisionMatrix());
   }
@@ -569,26 +569,26 @@ public:
   /** \brief Get the names of the links that are involved in collisions for the state \e robot_state.
       Update the link transforms for \e robot_state if needed. */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         robot_state::RobotState& robot_state) const
+                         moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(robot_state), getAllowedCollisionMatrix());
+    getCollidingPairs(contacts, static_cast<const moveit::core::RobotState&>(robot_state), getAllowedCollisionMatrix());
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm). Update the link transforms for \e robot_state if needed. */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         robot_state::RobotState& robot_state,
+                         moveit::core::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    getCollidingPairs(contacts, static_cast<const robot_state::RobotState&>(robot_state), acm);
+    getCollidingPairs(contacts, static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief  Get the names of the links that are involved in collisions for the state \e robot_state given the
       allowed collision matrix (\e acm) */
   void getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                         const robot_state::RobotState& robot_state,
+                         const moveit::core::RobotState& robot_state,
                          const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /**@}*/
@@ -601,31 +601,31 @@ public:
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
    * self-collisions)
    */
-  double distanceToCollision(robot_state::RobotState& robot_state) const
+  double distanceToCollision(moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    return distanceToCollision(static_cast<const robot_state::RobotState&>(robot_state));
+    return distanceToCollision(static_cast<const moveit::core::RobotState&>(robot_state));
   }
 
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
    * self-collisions)
    */
-  double distanceToCollision(const robot_state::RobotState& robot_state) const
+  double distanceToCollision(const moveit::core::RobotState& robot_state) const
   {
     return getCollisionEnv()->distanceRobot(robot_state, getAllowedCollisionMatrix());
   }
 
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
    * self-collisions), if the robot has no padding */
-  double distanceToCollisionUnpadded(robot_state::RobotState& robot_state) const
+  double distanceToCollisionUnpadded(moveit::core::RobotState& robot_state) const
   {
     robot_state.updateCollisionBodyTransforms();
-    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(robot_state));
+    return distanceToCollisionUnpadded(static_cast<const moveit::core::RobotState&>(robot_state));
   }
 
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision (ignoring
    * self-collisions), if the robot has no padding */
-  double distanceToCollisionUnpadded(const robot_state::RobotState& robot_state) const
+  double distanceToCollisionUnpadded(const moveit::core::RobotState& robot_state) const
   {
     return getCollisionEnvUnpadded()->distanceRobot(robot_state, getAllowedCollisionMatrix());
   }
@@ -633,17 +633,17 @@ public:
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
    * self-collisions
    * and elements that are allowed to collide. */
-  double distanceToCollision(robot_state::RobotState& robot_state,
+  double distanceToCollision(moveit::core::RobotState& robot_state,
                              const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    return distanceToCollision(static_cast<const robot_state::RobotState&>(robot_state), acm);
+    return distanceToCollision(static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
    * self-collisions
    * and elements that are allowed to collide. */
-  double distanceToCollision(const robot_state::RobotState& robot_state,
+  double distanceToCollision(const moveit::core::RobotState& robot_state,
                              const collision_detection::AllowedCollisionMatrix& acm) const
   {
     return getCollisionEnv()->distanceRobot(robot_state, acm);
@@ -652,17 +652,17 @@ public:
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
    * self-collisions
    * and elements that are allowed to collide, if the robot has no padding. */
-  double distanceToCollisionUnpadded(robot_state::RobotState& robot_state,
+  double distanceToCollisionUnpadded(moveit::core::RobotState& robot_state,
                                      const collision_detection::AllowedCollisionMatrix& acm) const
   {
     robot_state.updateCollisionBodyTransforms();
-    return distanceToCollisionUnpadded(static_cast<const robot_state::RobotState&>(robot_state), acm);
+    return distanceToCollisionUnpadded(static_cast<const moveit::core::RobotState&>(robot_state), acm);
   }
 
   /** \brief The distance between the robot model at state \e robot_state to the nearest collision, ignoring
    * self-collisions
    * and elements that always allowed to collide, if the robot has no padding. */
-  double distanceToCollisionUnpadded(const robot_state::RobotState& robot_state,
+  double distanceToCollisionUnpadded(const moveit::core::RobotState& robot_state,
                                      const collision_detection::AllowedCollisionMatrix& acm) const
   {
     return getCollisionEnvUnpadded()->distanceRobot(robot_state, acm);
@@ -752,10 +752,10 @@ public:
   void setCurrentState(const moveit_msgs::RobotState& state);
 
   /** \brief Set the current robot state */
-  void setCurrentState(const robot_state::RobotState& state);
+  void setCurrentState(const moveit::core::RobotState& state);
 
   /** \brief Set the callback to be triggered when changes are made to the current scene state */
-  void setAttachedBodyUpdateCallback(const robot_state::AttachedBodyCallback& callback);
+  void setAttachedBodyUpdateCallback(const moveit::core::AttachedBodyCallback& callback);
 
   /** \brief Set the callback to be triggered when changes are made to the current scene world */
   void setCollisionObjectUpdateCallback(const collision_detection::World::ObserverCallbackFn& callback);
@@ -823,14 +823,14 @@ public:
 
   /** \brief Check if a given state is feasible, in accordance to the feasibility predicate specified by
    * setStateFeasibilityPredicate(). Returns true if no feasibility predicate was specified. */
-  bool isStateFeasible(const robot_state::RobotState& state, bool verbose = false) const;
+  bool isStateFeasible(const moveit::core::RobotState& state, bool verbose = false) const;
 
   /** \brief Check if a given state satisfies a set of constraints */
   bool isStateConstrained(const moveit_msgs::RobotState& state, const moveit_msgs::Constraints& constr,
                           bool verbose = false) const;
 
   /** \brief Check if a given state satisfies a set of constraints */
-  bool isStateConstrained(const robot_state::RobotState& state, const moveit_msgs::Constraints& constr,
+  bool isStateConstrained(const moveit::core::RobotState& state, const moveit_msgs::Constraints& constr,
                           bool verbose = false) const;
 
   /** \brief Check if a given state satisfies a set of constraints */
@@ -838,14 +838,14 @@ public:
                           const kinematic_constraints::KinematicConstraintSet& constr, bool verbose = false) const;
 
   /** \brief Check if a given state satisfies a set of constraints */
-  bool isStateConstrained(const robot_state::RobotState& state,
+  bool isStateConstrained(const moveit::core::RobotState& state,
                           const kinematic_constraints::KinematicConstraintSet& constr, bool verbose = false) const;
 
   /** \brief Check if a given state is valid. This means checking for collisions and feasibility */
   bool isStateValid(const moveit_msgs::RobotState& state, const std::string& group = "", bool verbose = false) const;
 
   /** \brief Check if a given state is valid. This means checking for collisions and feasibility */
-  bool isStateValid(const robot_state::RobotState& state, const std::string& group = "", bool verbose = false) const;
+  bool isStateValid(const moveit::core::RobotState& state, const std::string& group = "", bool verbose = false) const;
 
   /** \brief Check if a given state is valid. This means checking for collisions, feasibility  and whether the user
    * specified validity conditions hold as well */
@@ -854,12 +854,12 @@ public:
 
   /** \brief Check if a given state is valid. This means checking for collisions, feasibility  and whether the user
    * specified validity conditions hold as well */
-  bool isStateValid(const robot_state::RobotState& state, const moveit_msgs::Constraints& constr,
+  bool isStateValid(const moveit::core::RobotState& state, const moveit_msgs::Constraints& constr,
                     const std::string& group = "", bool verbose = false) const;
 
   /** \brief Check if a given state is valid. This means checking for collisions, feasibility  and whether the user
    * specified validity conditions hold as well */
-  bool isStateValid(const robot_state::RobotState& state, const kinematic_constraints::KinematicConstraintSet& constr,
+  bool isStateValid(const moveit::core::RobotState& state, const kinematic_constraints::KinematicConstraintSet& constr,
                     const std::string& group = "", bool verbose = false) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance and feasibility) */
@@ -928,12 +928,12 @@ public:
                       double overlap_fraction = 0.9) const;
 
   /** \brief Get the top \e max_costs cost sources for a specified state. The resulting costs are stored in \e costs */
-  void getCostSources(const robot_state::RobotState& state, std::size_t max_costs,
+  void getCostSources(const moveit::core::RobotState& state, std::size_t max_costs,
                       std::set<collision_detection::CostSource>& costs) const;
 
   /** \brief Get the top \e max_costs cost sources for a specified state, but only for group \e group_name. The
    * resulting costs are stored in \e costs */
-  void getCostSources(const robot_state::RobotState& state, std::size_t max_costs, const std::string& group_name,
+  void getCostSources(const moveit::core::RobotState& state, std::size_t max_costs, const std::string& group_name,
                       std::set<collision_detection::CostSource>& costs) const;
 
   /** \brief Outputs debug information about the planning scene contents */
@@ -964,7 +964,7 @@ private:
   void initialize();
 
   /* helper function to create a RobotModel from a urdf/srdf. */
-  static robot_model::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
+  static moveit::core::RobotModelPtr createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
                                                      const srdf::ModelConstSharedPtr& srdf_model);
 
   /* Helper functions for processing collision objects */
@@ -1012,16 +1012,16 @@ private:
 
   PlanningSceneConstPtr parent_;  // Null unless this is a diff scene
 
-  robot_model::RobotModelConstPtr robot_model_;  // Never null (may point to same model as parent)
+  moveit::core::RobotModelConstPtr robot_model_;  // Never null (may point to same model as parent)
 
-  robot_state::RobotStatePtr robot_state_;  // if NULL use parent's
+  moveit::core::RobotStatePtr robot_state_;  // if NULL use parent's
 
   // Called when changes are made to attached bodies
-  robot_state::AttachedBodyCallback current_state_attached_body_callback_;
+  moveit::core::AttachedBodyCallback current_state_attached_body_callback_;
 
   // This variable is not necessarily used by child planning scenes
   // This Transforms class is actually a SceneTransform class
-  robot_state::TransformsPtr scene_transforms_;  // if NULL use parent's
+  moveit::core::TransformsPtr scene_transforms_;  // if NULL use parent's
 
   collision_detection::WorldPtr world_;             // never NULL, never shared with parent/child
   collision_detection::WorldConstPtr world_const_;  // copy of world_

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -56,7 +56,7 @@ const std::string PlanningScene::DEFAULT_SCENE_NAME = "(noname)";
 
 const std::string LOGNAME = "planning_scene";
 
-class SceneTransforms : public robot_state::Transforms
+class SceneTransforms : public moveit::core::Transforms
 {
 public:
   SceneTransforms(const PlanningScene* scene) : Transforms(scene->getRobotModel()->getModelFrame()), scene_(scene)
@@ -110,7 +110,7 @@ bool PlanningScene::isEmpty(const moveit_msgs::PlanningSceneWorld& msg)
   return moveit::core::isEmpty(msg);
 }
 
-PlanningScene::PlanningScene(const robot_model::RobotModelConstPtr& robot_model,
+PlanningScene::PlanningScene(const moveit::core::RobotModelConstPtr& robot_model,
                              const collision_detection::WorldPtr& world)
   : robot_model_(robot_model), world_(world), world_const_(world)
 {
@@ -146,7 +146,7 @@ void PlanningScene::initialize()
 
   scene_transforms_.reset(new SceneTransforms(this));
 
-  robot_state_.reset(new robot_state::RobotState(robot_model_));
+  robot_state_.reset(new moveit::core::RobotState(robot_model_));
   robot_state_->setToDefaultValues();
   robot_state_->update();
 
@@ -164,12 +164,12 @@ void PlanningScene::initialize()
 }
 
 /* return NULL on failure */
-robot_model::RobotModelPtr PlanningScene::createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
+moveit::core::RobotModelPtr PlanningScene::createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
                                                            const srdf::ModelConstSharedPtr& srdf_model)
 {
-  robot_model::RobotModelPtr robot_model(new robot_model::RobotModel(urdf_model, srdf_model));
+  moveit::core::RobotModelPtr robot_model(new moveit::core::RobotModel(urdf_model, srdf_model));
   if (!robot_model || !robot_model->getRootJoint())
-    return robot_model::RobotModelPtr();
+    return moveit::core::RobotModelPtr();
 
   return robot_model;
 }
@@ -484,7 +484,7 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
 
 void PlanningScene::checkCollision(const collision_detection::CollisionRequest& req,
                                    collision_detection::CollisionResult& res,
-                                   const robot_state::RobotState& robot_state) const
+                                   const moveit::core::RobotState& robot_state) const
 {
   // check collision with the world using the padded version
   getCollisionEnv()->checkRobotCollision(req, res, robot_state, getAllowedCollisionMatrix());
@@ -507,7 +507,7 @@ void PlanningScene::checkSelfCollision(const collision_detection::CollisionReque
 
 void PlanningScene::checkCollision(const collision_detection::CollisionRequest& req,
                                    collision_detection::CollisionResult& res,
-                                   const robot_state::RobotState& robot_state,
+                                   const moveit::core::RobotState& robot_state,
                                    const collision_detection::AllowedCollisionMatrix& acm) const
 {
   // check collision with the world using the padded version
@@ -529,7 +529,7 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
 
 void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
                                            collision_detection::CollisionResult& res,
-                                           const robot_state::RobotState& robot_state,
+                                           const moveit::core::RobotState& robot_state,
                                            const collision_detection::AllowedCollisionMatrix& acm) const
 {
   // check collision with the world using the unpadded version
@@ -551,7 +551,7 @@ void PlanningScene::getCollidingPairs(collision_detection::CollisionResult::Cont
 }
 
 void PlanningScene::getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts,
-                                      const robot_state::RobotState& robot_state,
+                                      const moveit::core::RobotState& robot_state,
                                       const collision_detection::AllowedCollisionMatrix& acm) const
 {
   collision_detection::CollisionRequest req;
@@ -571,7 +571,7 @@ void PlanningScene::getCollidingLinks(std::vector<std::string>& links)
     getCollidingLinks(links, getCurrentState(), getAllowedCollisionMatrix());
 }
 
-void PlanningScene::getCollidingLinks(std::vector<std::string>& links, const robot_state::RobotState& robot_state,
+void PlanningScene::getCollidingLinks(std::vector<std::string>& links, const moveit::core::RobotState& robot_state,
                                       const collision_detection::AllowedCollisionMatrix& acm) const
 {
   collision_detection::CollisionResult::ContactMap contacts;
@@ -593,25 +593,25 @@ const collision_detection::CollisionEnvPtr& PlanningScene::getCollisionEnvNonCon
   return active_collision_->cenv_;
 }
 
-robot_state::RobotState& PlanningScene::getCurrentStateNonConst()
+moveit::core::RobotState& PlanningScene::getCurrentStateNonConst()
 {
   if (!robot_state_)
   {
-    robot_state_.reset(new robot_state::RobotState(parent_->getCurrentState()));
+    robot_state_.reset(new moveit::core::RobotState(parent_->getCurrentState()));
     robot_state_->setAttachedBodyUpdateCallback(current_state_attached_body_callback_);
   }
   robot_state_->update();
   return *robot_state_;
 }
 
-robot_state::RobotStatePtr PlanningScene::getCurrentStateUpdated(const moveit_msgs::RobotState& update) const
+moveit::core::RobotStatePtr PlanningScene::getCurrentStateUpdated(const moveit_msgs::RobotState& update) const
 {
-  robot_state::RobotStatePtr state(new robot_state::RobotState(getCurrentState()));
-  robot_state::robotStateMsgToRobotState(getTransforms(), update, *state);
+  moveit::core::RobotStatePtr state(new moveit::core::RobotState(getCurrentState()));
+  moveit::core::robotStateMsgToRobotState(getTransforms(), update, *state);
   return state;
 }
 
-void PlanningScene::setAttachedBodyUpdateCallback(const robot_state::AttachedBodyCallback& callback)
+void PlanningScene::setAttachedBodyUpdateCallback(const moveit::core::AttachedBodyCallback& callback)
 {
   current_state_attached_body_callback_ = callback;
   if (robot_state_)
@@ -634,14 +634,14 @@ collision_detection::AllowedCollisionMatrix& PlanningScene::getAllowedCollisionM
   return *acm_;
 }
 
-const robot_state::Transforms& PlanningScene::getTransforms()
+const moveit::core::Transforms& PlanningScene::getTransforms()
 {
   // Trigger an update of the robot transforms
   getCurrentStateNonConst().update();
   return static_cast<const PlanningScene*>(this)->getTransforms();
 }
 
-robot_state::Transforms& PlanningScene::getTransformsNonConst()
+moveit::core::Transforms& PlanningScene::getTransformsNonConst()
 {
   // Trigger an update of the robot transforms
   getCurrentStateNonConst().update();
@@ -667,7 +667,7 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
     scene_msg.fixed_frame_transforms.clear();
 
   if (robot_state_)
-    robot_state::robotStateToRobotStateMsg(*robot_state_, scene_msg.robot_state);
+    moveit::core::robotStateToRobotStateMsg(*robot_state_, scene_msg.robot_state);
   else
   {
     scene_msg.robot_state = moveit_msgs::RobotState();
@@ -876,7 +876,7 @@ void PlanningScene::getPlanningSceneMsg(moveit_msgs::PlanningScene& scene_msg) c
   scene_msg.robot_model_name = getRobotModel()->getName();
   getTransforms().copyTransforms(scene_msg.fixed_frame_transforms);
 
-  robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state);
+  moveit::core::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state);
   getAllowedCollisionMatrix().getMessage(scene_msg.allowed_collision_matrix);
   getCollisionEnv()->getPadding(scene_msg.link_padding);
   getCollisionEnv()->getScale(scene_msg.link_scale);
@@ -905,7 +905,7 @@ void PlanningScene::getPlanningSceneMsg(moveit_msgs::PlanningScene& scene_msg,
 
   if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE_ATTACHED_OBJECTS)
   {
-    robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, true);
+    moveit::core::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, true);
     for (moveit_msgs::AttachedCollisionObject& attached_collision_object :
          scene_msg.robot_state.attached_collision_objects)
     {
@@ -917,7 +917,7 @@ void PlanningScene::getPlanningSceneMsg(moveit_msgs::PlanningScene& scene_msg,
   }
   else if (comp.components & moveit_msgs::PlanningSceneComponents::ROBOT_STATE)
   {
-    robot_state::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, false);
+    moveit::core::robotStateToRobotStateMsg(getCurrentState(), scene_msg.robot_state, false);
   }
 
   if (comp.components & moveit_msgs::PlanningSceneComponents::ALLOWED_COLLISION_MATRIX)
@@ -1089,13 +1089,13 @@ void PlanningScene::setCurrentState(const moveit_msgs::RobotState& state)
   {
     if (!robot_state_)
     {
-      robot_state_.reset(new robot_state::RobotState(parent_->getCurrentState()));
+      robot_state_.reset(new moveit::core::RobotState(parent_->getCurrentState()));
       robot_state_->setAttachedBodyUpdateCallback(current_state_attached_body_callback_);
     }
-    robot_state::robotStateMsgToRobotState(getTransforms(), state_no_attached, *robot_state_);
+    moveit::core::robotStateMsgToRobotState(getTransforms(), state_no_attached, *robot_state_);
   }
   else
-    robot_state::robotStateMsgToRobotState(*scene_transforms_, state_no_attached, *robot_state_);
+    moveit::core::robotStateMsgToRobotState(*scene_transforms_, state_no_attached, *robot_state_);
 
   for (std::size_t i = 0; i < state.attached_collision_objects.size(); ++i)
   {
@@ -1110,7 +1110,7 @@ void PlanningScene::setCurrentState(const moveit_msgs::RobotState& state)
   }
 }
 
-void PlanningScene::setCurrentState(const robot_state::RobotState& state)
+void PlanningScene::setCurrentState(const moveit::core::RobotState& state)
 {
   getCurrentStateNonConst() = state;
 }
@@ -1129,7 +1129,7 @@ void PlanningScene::decoupleParent()
 
   if (!robot_state_)
   {
-    robot_state_.reset(new robot_state::RobotState(parent_->getCurrentState()));
+    robot_state_.reset(new moveit::core::RobotState(parent_->getCurrentState()));
     robot_state_->setAttachedBodyUpdateCallback(current_state_attached_body_callback_);
   }
 
@@ -1388,7 +1388,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
 
   if (!robot_state_)  // there must be a parent in this case
   {
-    robot_state_.reset(new robot_state::RobotState(parent_->getCurrentState()));
+    robot_state_.reset(new moveit::core::RobotState(parent_->getCurrentState()));
     robot_state_->setAttachedBodyUpdateCallback(current_state_attached_body_callback_);
   }
   robot_state_->update();
@@ -1430,7 +1430,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       return false;
     }
 
-    const robot_model::LinkModel* link_model = getRobotModel()->getLinkModel(object.link_name);
+    const moveit::core::LinkModel* link_model = getRobotModel()->getLinkModel(object.link_name);
     if (link_model)
     {
       // items to build the attached object from (filled from existing world object or message)
@@ -1578,7 +1578,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       }
       else  // APPEND: augment to existing attached object
       {
-        const robot_state::AttachedBody* ab = robot_state_->getAttachedBody(object.object.id);
+        const moveit::core::AttachedBody* ab = robot_state_->getAttachedBody(object.object.id);
         shapes.insert(shapes.end(), ab->getShapes().begin(), ab->getShapes().end());
         poses.insert(poses.end(), ab->getFixedTransforms().begin(), ab->getFixedTransforms().end());
         subframe_poses.insert(ab->getSubframeTransforms().begin(), ab->getSubframeTransforms().end());
@@ -1603,21 +1603,21 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
   else if (object.object.operation == moveit_msgs::CollisionObject::REMOVE)  // == DETACH
   {
     // STEP 1: Get info about the object from the RobotState
-    std::vector<const robot_state::AttachedBody*> attached_bodies;
+    std::vector<const moveit::core::AttachedBody*> attached_bodies;
     if (object.link_name.empty())
     {
       if (object.object.id.empty())
         robot_state_->getAttachedBodies(attached_bodies);
       else
       {
-        const robot_state::AttachedBody* body = robot_state_->getAttachedBody(object.object.id);
+        const moveit::core::AttachedBody* body = robot_state_->getAttachedBody(object.object.id);
         if (body)
           attached_bodies.push_back(body);
       }
     }
     else
     {
-      const robot_model::LinkModel* link_model = getRobotModel()->getLinkModel(object.link_name);
+      const moveit::core::LinkModel* link_model = getRobotModel()->getLinkModel(object.link_name);
       if (link_model)
       {
         // If no specific object id is given, then we remove all objects attached to the link_name.
@@ -1627,7 +1627,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         }
         else  // A specific object id will be removed.
         {
-          const robot_state::AttachedBody* body = robot_state_->getAttachedBody(object.object.id);
+          const moveit::core::AttachedBody* body = robot_state_->getAttachedBody(object.object.id);
           if (body)
             attached_bodies.push_back(body);
         }
@@ -1867,7 +1867,7 @@ const Eigen::Isometry3d& PlanningScene::getFrameTransform(const std::string& fra
     return getFrameTransform(getCurrentState(), frame_id);
 }
 
-const Eigen::Isometry3d& PlanningScene::getFrameTransform(const robot_state::RobotState& state,
+const Eigen::Isometry3d& PlanningScene::getFrameTransform(const moveit::core::RobotState& state,
                                                           const std::string& frame_id) const
 {
   if (!frame_id.empty() && frame_id[0] == '/')
@@ -1890,7 +1890,7 @@ bool PlanningScene::knowsFrameTransform(const std::string& frame_id) const
   return knowsFrameTransform(getCurrentState(), frame_id);
 }
 
-bool PlanningScene::knowsFrameTransform(const robot_state::RobotState& state, const std::string& frame_id) const
+bool PlanningScene::knowsFrameTransform(const moveit::core::RobotState& state, const std::string& frame_id) const
 {
   if (!frame_id.empty() && frame_id[0] == '/')
     return knowsFrameTransform(frame_id.substr(1));
@@ -2003,8 +2003,8 @@ void PlanningScene::removeObjectColor(const std::string& object_id)
 
 bool PlanningScene::isStateColliding(const moveit_msgs::RobotState& state, const std::string& group, bool verbose) const
 {
-  robot_state::RobotState s(getCurrentState());
-  robot_state::robotStateMsgToRobotState(getTransforms(), state, s);
+  moveit::core::RobotState s(getCurrentState());
+  moveit::core::robotStateMsgToRobotState(getTransforms(), state, s);
   return isStateColliding(s, group, verbose);
 }
 
@@ -2016,7 +2016,7 @@ bool PlanningScene::isStateColliding(const std::string& group, bool verbose)
     return isStateColliding(getCurrentState(), group, verbose);
 }
 
-bool PlanningScene::isStateColliding(const robot_state::RobotState& state, const std::string& group, bool verbose) const
+bool PlanningScene::isStateColliding(const moveit::core::RobotState& state, const std::string& group, bool verbose) const
 {
   collision_detection::CollisionRequest req;
   req.verbose = verbose;
@@ -2030,14 +2030,14 @@ bool PlanningScene::isStateFeasible(const moveit_msgs::RobotState& state, bool v
 {
   if (state_feasibility_)
   {
-    robot_state::RobotState s(getCurrentState());
-    robot_state::robotStateMsgToRobotState(getTransforms(), state, s);
+    moveit::core::RobotState s(getCurrentState());
+    moveit::core::robotStateMsgToRobotState(getTransforms(), state, s);
     return state_feasibility_(s, verbose);
   }
   return true;
 }
 
-bool PlanningScene::isStateFeasible(const robot_state::RobotState& state, bool verbose) const
+bool PlanningScene::isStateFeasible(const moveit::core::RobotState& state, bool verbose) const
 {
   if (state_feasibility_)
     return state_feasibility_(state, verbose);
@@ -2047,12 +2047,12 @@ bool PlanningScene::isStateFeasible(const robot_state::RobotState& state, bool v
 bool PlanningScene::isStateConstrained(const moveit_msgs::RobotState& state, const moveit_msgs::Constraints& constr,
                                        bool verbose) const
 {
-  robot_state::RobotState s(getCurrentState());
-  robot_state::robotStateMsgToRobotState(getTransforms(), state, s);
+  moveit::core::RobotState s(getCurrentState());
+  moveit::core::robotStateMsgToRobotState(getTransforms(), state, s);
   return isStateConstrained(s, constr, verbose);
 }
 
-bool PlanningScene::isStateConstrained(const robot_state::RobotState& state, const moveit_msgs::Constraints& constr,
+bool PlanningScene::isStateConstrained(const moveit::core::RobotState& state, const moveit_msgs::Constraints& constr,
                                        bool verbose) const
 {
   kinematic_constraints::KinematicConstraintSetPtr ks(
@@ -2067,18 +2067,18 @@ bool PlanningScene::isStateConstrained(const robot_state::RobotState& state, con
 bool PlanningScene::isStateConstrained(const moveit_msgs::RobotState& state,
                                        const kinematic_constraints::KinematicConstraintSet& constr, bool verbose) const
 {
-  robot_state::RobotState s(getCurrentState());
-  robot_state::robotStateMsgToRobotState(getTransforms(), state, s);
+  moveit::core::RobotState s(getCurrentState());
+  moveit::core::robotStateMsgToRobotState(getTransforms(), state, s);
   return isStateConstrained(s, constr, verbose);
 }
 
-bool PlanningScene::isStateConstrained(const robot_state::RobotState& state,
+bool PlanningScene::isStateConstrained(const moveit::core::RobotState& state,
                                        const kinematic_constraints::KinematicConstraintSet& constr, bool verbose) const
 {
   return constr.decide(state, verbose).satisfied;
 }
 
-bool PlanningScene::isStateValid(const robot_state::RobotState& state, const std::string& group, bool verbose) const
+bool PlanningScene::isStateValid(const moveit::core::RobotState& state, const std::string& group, bool verbose) const
 {
   static const moveit_msgs::Constraints EMP_CONSTRAINTS;
   return isStateValid(state, EMP_CONSTRAINTS, group, verbose);
@@ -2093,12 +2093,12 @@ bool PlanningScene::isStateValid(const moveit_msgs::RobotState& state, const std
 bool PlanningScene::isStateValid(const moveit_msgs::RobotState& state, const moveit_msgs::Constraints& constr,
                                  const std::string& group, bool verbose) const
 {
-  robot_state::RobotState s(getCurrentState());
-  robot_state::robotStateMsgToRobotState(getTransforms(), state, s);
+  moveit::core::RobotState s(getCurrentState());
+  moveit::core::robotStateMsgToRobotState(getTransforms(), state, s);
   return isStateValid(s, constr, group, verbose);
 }
 
-bool PlanningScene::isStateValid(const robot_state::RobotState& state, const moveit_msgs::Constraints& constr,
+bool PlanningScene::isStateValid(const moveit::core::RobotState& state, const moveit_msgs::Constraints& constr,
                                  const std::string& group, bool verbose) const
 {
   if (isStateColliding(state, group, verbose))
@@ -2108,7 +2108,7 @@ bool PlanningScene::isStateValid(const robot_state::RobotState& state, const mov
   return isStateConstrained(state, constr, verbose);
 }
 
-bool PlanningScene::isStateValid(const robot_state::RobotState& state,
+bool PlanningScene::isStateValid(const moveit::core::RobotState& state,
                                  const kinematic_constraints::KinematicConstraintSet& constr, const std::string& group,
                                  bool verbose) const
 {
@@ -2154,8 +2154,8 @@ bool PlanningScene::isPathValid(const moveit_msgs::RobotState& start_state,
                                 bool verbose, std::vector<std::size_t>* invalid_index) const
 {
   robot_trajectory::RobotTrajectory t(getRobotModel(), group);
-  robot_state::RobotState start(getCurrentState());
-  robot_state::robotStateMsgToRobotState(getTransforms(), start_state, start);
+  moveit::core::RobotState start(getCurrentState());
+  moveit::core::robotStateMsgToRobotState(getTransforms(), start_state, start);
   t.setRobotTrajectoryMsg(start, trajectory);
   return isPathValid(t, path_constraints, goal_constraints, group, verbose, invalid_index);
 }
@@ -2173,7 +2173,7 @@ bool PlanningScene::isPathValid(const robot_trajectory::RobotTrajectory& traject
   std::size_t n_wp = trajectory.getWayPointCount();
   for (std::size_t i = 0; i < n_wp; ++i)
   {
-    const robot_state::RobotState& st = trajectory.getWayPoint(i);
+    const moveit::core::RobotState& st = trajectory.getWayPoint(i);
 
     bool this_state_valid = true;
     if (isStateColliding(st, group, verbose))
@@ -2282,13 +2282,13 @@ void PlanningScene::getCostSources(const robot_trajectory::RobotTrajectory& traj
   collision_detection::removeOverlapping(costs, overlap_fraction);
 }
 
-void PlanningScene::getCostSources(const robot_state::RobotState& state, std::size_t max_costs,
+void PlanningScene::getCostSources(const moveit::core::RobotState& state, std::size_t max_costs,
                                    std::set<collision_detection::CostSource>& costs) const
 {
   getCostSources(state, max_costs, std::string(), costs);
 }
 
-void PlanningScene::getCostSources(const robot_state::RobotState& state, std::size_t max_costs,
+void PlanningScene::getCostSources(const moveit::core::RobotState& state, std::size_t max_costs,
                                    const std::string& group_name,
                                    std::set<collision_detection::CostSource>& costs) const
 {
@@ -2304,7 +2304,7 @@ void PlanningScene::getCostSources(const robot_state::RobotState& state, std::si
 void PlanningScene::printKnownObjects(std::ostream& out) const
 {
   const std::vector<std::string>& objects = getWorld()->getObjectIds();
-  std::vector<const robot_state::AttachedBody*> attached_bodies;
+  std::vector<const moveit::core::AttachedBody*> attached_bodies;
   getCurrentState().getAttachedBodies(attached_bodies);
 
   // Output
@@ -2317,7 +2317,7 @@ void PlanningScene::printKnownObjects(std::ostream& out) const
   }
 
   out << "  - Attached Bodies:\n";
-  for (const robot_state::AttachedBody* attached_body : attached_bodies)
+  for (const moveit::core::AttachedBody* attached_body : attached_bodies)
   {
     out << "\t- " << attached_body->getName() << "\n";
   }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -165,7 +165,7 @@ void PlanningScene::initialize()
 
 /* return NULL on failure */
 moveit::core::RobotModelPtr PlanningScene::createRobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model,
-                                                           const srdf::ModelConstSharedPtr& srdf_model)
+                                                            const srdf::ModelConstSharedPtr& srdf_model)
 {
   moveit::core::RobotModelPtr robot_model(new moveit::core::RobotModel(urdf_model, srdf_model));
   if (!robot_model || !robot_model->getRootJoint())
@@ -2016,7 +2016,8 @@ bool PlanningScene::isStateColliding(const std::string& group, bool verbose)
     return isStateColliding(getCurrentState(), group, verbose);
 }
 
-bool PlanningScene::isStateColliding(const moveit::core::RobotState& state, const std::string& group, bool verbose) const
+bool PlanningScene::isStateColliding(const moveit::core::RobotState& state, const std::string& group,
+                                     bool verbose) const
 {
   collision_detection::CollisionRequest req;
   req.verbose = verbose;

--- a/moveit_core/planning_scene/test/test_multi_threaded.cpp
+++ b/moveit_core/planning_scene/test/test_multi_threaded.cpp
@@ -49,7 +49,7 @@ const int TRIALS = 1000;
 const int THREADS = 2;
 
 bool runCollisionDetection(unsigned int id, unsigned int trials, const planning_scene::PlanningScene* scene,
-                           const robot_state::RobotState* state)
+                           const moveit::core::RobotState* state)
 {
   collision_detection::CollisionRequest req;
   collision_detection::CollisionResult res;
@@ -62,7 +62,7 @@ bool runCollisionDetection(unsigned int id, unsigned int trials, const planning_
 }
 
 void runCollisionDetectionAssert(unsigned int id, unsigned int trials, const planning_scene::PlanningScene* scene,
-                                 const robot_state::RobotState* state, bool expected_result)
+                                 const moveit::core::RobotState* state, bool expected_result)
 {
   ASSERT_EQ(expected_result, runCollisionDetection(id, trials, scene, state));
 }
@@ -75,7 +75,7 @@ protected:
     robot_model_ = moveit::core::loadTestingRobotModel("panda");
     ASSERT_TRUE(static_cast<bool>(robot_model_));
 
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
+    robot_state_.reset(new moveit::core::RobotState(robot_model_));
     planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
   }
 
@@ -85,13 +85,13 @@ protected:
 
   bool robot_model_ok_;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
   collision_detection::CollisionEnvPtr cenv_;
 
   collision_detection::AllowedCollisionMatrixPtr acm_;
 
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
 
   planning_scene::PlanningScenePtr planning_scene_;
 };
@@ -99,17 +99,17 @@ protected:
 /** \brief Tests the FCL collision detector in multiple threads. */
 TEST_F(CollisionDetectorThreadedTest, FCLThreaded)
 {
-  std::vector<robot_state::RobotStatePtr> states;
+  std::vector<moveit::core::RobotStatePtr> states;
   std::vector<std::thread*> threads;
   std::vector<bool> collisions;
 
   for (unsigned int i = 0; i < THREADS; ++i)
   {
-    robot_state::RobotState* state = new robot_state::RobotState(planning_scene_->getRobotModel());
+    moveit::core::RobotState* state = new moveit::core::RobotState(planning_scene_->getRobotModel());
     collision_detection::CollisionRequest req;
     state->setToRandomPositions();
     state->update();
-    states.push_back(robot_state::RobotStatePtr(state));
+    states.push_back(moveit::core::RobotStatePtr(state));
     collisions.push_back(runCollisionDetection(0, 1, planning_scene_.get(), state));
   }
 

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -162,7 +162,7 @@ TEST(PlanningScene, isStateValid)
   loadRobotModels(urdf_model, srdf_model);
 
   planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
-  robot_state::RobotState current_state = ps->getCurrentState();
+  moveit::core::RobotState current_state = ps->getCurrentState();
   if (ps->isStateColliding(current_state, "left_arm"))
   {
     EXPECT_FALSE(ps->isStateValid(current_state, "left_arm"));

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1149,10 +1149,10 @@ const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel*
 {
   if (!link)
     return link;
-  const robot_model::LinkModel* parent_link = link->getParentLinkModel();
-  const robot_model::JointModel* joint = link->getParentJointModel();
+  const moveit::core::LinkModel* parent_link = link->getParentLinkModel();
+  const moveit::core::JointModel* joint = link->getParentJointModel();
 
-  while (parent_link && joint->getType() == robot_model::JointModel::FIXED)
+  while (parent_link && joint->getType() == moveit::core::JointModel::FIXED)
   {
     link = parent_link;
     joint = link->getParentJointModel();

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -143,7 +143,7 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
     }
 
   traj.clear();
-  traj.push_back(RobotStatePtr(new robot_state::RobotState(*start_state)));
+  traj.push_back(RobotStatePtr(new moveit::core::RobotState(*start_state)));
 
   double last_valid_percentage = 0.0;
   for (std::size_t i = 1; i <= steps; ++i)
@@ -156,7 +156,7 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
     // Explicitly use a single IK attempt only: We want a smooth trajectory.
     // Random seeding (of additional attempts) would probably create IK jumps.
     if (start_state->setFromIK(group, pose, link->getName(), consistency_limits, 0.0, validCallback, options))
-      traj.push_back(RobotStatePtr(new robot_state::RobotState(*start_state)));
+      traj.push_back(RobotStatePtr(new moveit::core::RobotState(*start_state)));
     else
       break;
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1200,8 +1200,8 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     return false;
   }
 
-  const robot_model::JointModel* root_joint_model = group->getJointModels()[0];  // group->getJointRoots()[0];
-  const robot_model::LinkModel* root_link_model = root_joint_model->getParentLinkModel();
+  const moveit::core::JointModel* root_joint_model = group->getJointModels()[0];  // group->getJointRoots()[0];
+  const moveit::core::LinkModel* root_link_model = root_joint_model->getParentLinkModel();
   Eigen::Isometry3d reference_transform =
       root_link_model ? getGlobalLinkTransform(root_link_model).inverse() : Eigen::Isometry3d::Identity();
   int rows = use_quaternion_representation ? 7 : 6;
@@ -1239,21 +1239,21 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
         continue;
       }
       unsigned int joint_index = group->getVariableGroupIndex(pjm->getName());
-      if (pjm->getType() == robot_model::JointModel::REVOLUTE)
+      if (pjm->getType() == moveit::core::JointModel::REVOLUTE)
       {
         joint_transform = reference_transform * getGlobalLinkTransform(link);
-        joint_axis = joint_transform.rotation() * static_cast<const robot_model::RevoluteJointModel*>(pjm)->getAxis();
+        joint_axis = joint_transform.rotation() * static_cast<const moveit::core::RevoluteJointModel*>(pjm)->getAxis();
         jacobian.block<3, 1>(0, joint_index) =
             jacobian.block<3, 1>(0, joint_index) + joint_axis.cross(point_transform - joint_transform.translation());
         jacobian.block<3, 1>(3, joint_index) = jacobian.block<3, 1>(3, joint_index) + joint_axis;
       }
-      else if (pjm->getType() == robot_model::JointModel::PRISMATIC)
+      else if (pjm->getType() == moveit::core::JointModel::PRISMATIC)
       {
         joint_transform = reference_transform * getGlobalLinkTransform(link);
-        joint_axis = joint_transform.rotation() * static_cast<const robot_model::PrismaticJointModel*>(pjm)->getAxis();
+        joint_axis = joint_transform.rotation() * static_cast<const moveit::core::PrismaticJointModel*>(pjm)->getAxis();
         jacobian.block<3, 1>(0, joint_index) = jacobian.block<3, 1>(0, joint_index) + joint_axis;
       }
-      else if (pjm->getType() == robot_model::JointModel::PLANAR)
+      else if (pjm->getType() == moveit::core::JointModel::PLANAR)
       {
         joint_transform = reference_transform * getGlobalLinkTransform(link);
         joint_axis = joint_transform * Eigen::Vector3d(1.0, 0.0, 0.0);
@@ -1595,13 +1595,13 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
         }
         if (pose_frame != solver_tip_frame)
         {
-          const robot_model::LinkModel* link_model = getLinkModel(pose_frame);
+          const moveit::core::LinkModel* link_model = getLinkModel(pose_frame);
           if (!link_model)
           {
             ROS_ERROR_STREAM_NAMED(LOGNAME, "Pose frame '" << pose_frame << "' does not exist.");
             return false;
           }
-          const robot_model::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
+          const moveit::core::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
           for (const std::pair<const LinkModel* const, Eigen::Isometry3d>& fixed_link : fixed_links)
             if (Transforms::sameFrame(fixed_link.first->getName(), solver_tip_frame))
             {
@@ -1806,10 +1806,10 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
       }
       if (pose_frame != solver_tip_frame)
       {
-        const robot_model::LinkModel* link_model = getLinkModel(pose_frame);
+        const moveit::core::LinkModel* link_model = getLinkModel(pose_frame);
         if (!link_model)
           return false;
-        const robot_model::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
+        const moveit::core::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
         for (const std::pair<const LinkModel* const, Eigen::Isometry3d>& fixed_link : fixed_links)
           if (fixed_link.first->getName() == solver_tip_frame)
           {

--- a/moveit_core/robot_state/test/robot_state_benchmark.cpp
+++ b/moveit_core/robot_state/test/robot_state_benchmark.cpp
@@ -95,9 +95,9 @@ public:
 
 TEST_F(Timing, stateUpdate)
 {
-  robot_model::RobotModelPtr model = moveit::core::loadTestingRobotModel("pr2_description");
+  moveit::core::RobotModelPtr model = moveit::core::loadTestingRobotModel("pr2_description");
   ASSERT_TRUE(bool(model));
-  robot_state::RobotState state(model);
+  moveit::core::RobotState state(model);
   ScopedTimer t("RobotState updates: ");
   for (unsigned i = 0; i < 1e5; ++i)
   {

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -535,7 +535,7 @@ TEST_F(OneRobot, FK)
 TEST_F(OneRobot, testPrintCurrentPositionWithJointLimits)
 {
   moveit::core::RobotState state(robot_model_);
-  const robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("base_from_base_to_e");
+  const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("base_from_base_to_e");
   ASSERT_TRUE(joint_model_group);
 
   state.setToDefaultValues();

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -61,15 +61,15 @@ class TestAABB : public testing::Test
 protected:
   void SetUp() override{};
 
-  robot_state::RobotState loadModel(const std::string& robot_name)
+  moveit::core::RobotState loadModel(const std::string& robot_name)
   {
-    robot_model::RobotModelPtr model = moveit::core::loadTestingRobotModel(robot_name);
+    moveit::core::RobotModelPtr model = moveit::core::loadTestingRobotModel(robot_name);
     return loadModel(model);
   }
 
-  robot_state::RobotState loadModel(const robot_model::RobotModelPtr& model)
+  moveit::core::RobotState loadModel(const moveit::core::RobotModelPtr& model)
   {
-    robot_state::RobotState robot_state = robot_state::RobotState(model);
+    moveit::core::RobotState robot_state = moveit::core::RobotState(model);
     robot_state.setToDefaultValues();
     robot_state.update(true);
 
@@ -85,7 +85,7 @@ TEST_F(TestAABB, TestPR2)
 {
   // Contains a link with mesh geometry that is not centered
 
-  robot_state::RobotState pr2_state = this->loadModel("pr2");
+  moveit::core::RobotState pr2_state = this->loadModel("pr2");
 
   const Eigen::Vector3d& extents_base_footprint = pr2_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin();
   // values taken from moveit_resources/pr2_description/urdf/robot.xml
@@ -288,7 +288,7 @@ TEST_F(TestAABB, TestSimple)
   builder.addGroup({}, { "world_joint" }, "base");
 
   ASSERT_TRUE(builder.isValid());
-  robot_state::RobotState simple_state = loadModel(builder.build());
+  moveit::core::RobotState simple_state = loadModel(builder.build());
   std::vector<double> simple_aabb;
   simple_state.computeAABB(simple_aabb);
 
@@ -323,7 +323,7 @@ TEST_F(TestAABB, TestComplex)
   builder.addGroup({}, { "world_joint" }, "base");
 
   ASSERT_TRUE(builder.isValid());
-  robot_state::RobotState complex_state = this->loadModel(builder.build());
+  moveit::core::RobotState complex_state = this->loadModel(builder.build());
 
   EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[0], 0.1, 1e-4);
   EXPECT_NEAR(complex_state.getLinkModel("base_footprint")->getShapeExtentsAtOrigin()[1], 1.0, 1e-4);

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -241,21 +241,21 @@ protected:
   moveit::core::RobotModelConstPtr robot_model_;
 };
 
-std::size_t generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState>>& traj,
+std::size_t generateTestTraj(std::vector<std::shared_ptr<moveit::core::RobotState>>& traj,
                              const moveit::core::RobotModelConstPtr& robot_model_,
                              const moveit::core::JointModelGroup* joint_model_group)
 {
   traj.clear();
 
-  std::shared_ptr<robot_state::RobotState> robot_state(new robot_state::RobotState(robot_model_));
+  std::shared_ptr<moveit::core::RobotState> robot_state(new moveit::core::RobotState(robot_model_));
   robot_state->setToDefaultValues();
   double ja, jc;
 
   // 3 waypoints with default joints
   for (std::size_t traj_ix = 0; traj_ix < 3; ++traj_ix)
   {
-    // robot_state.reset(new robot_state::RobotState(*robot_state));
-    traj.push_back(robot_state::RobotStatePtr(new robot_state::RobotState(*robot_state)));
+    // robot_state.reset(new moveit::core::RobotState(*robot_state));
+    traj.push_back(moveit::core::RobotStatePtr(new moveit::core::RobotState(*robot_state)));
   }
 
   ja = robot_state->getVariablePosition("panda_joint0");
@@ -266,20 +266,20 @@ std::size_t generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState
   robot_state->setVariablePosition("panda_joint0", ja);
   jc = jc - 0.01;
   robot_state->setVariablePosition("panda_joint1", jc);
-  traj.push_back(robot_state::RobotStatePtr(new robot_state::RobotState(*robot_state)));
+  traj.push_back(moveit::core::RobotStatePtr(new moveit::core::RobotState(*robot_state)));
 
   // 5th waypoint with a large jump of 1.01 in first revolute joint
   ja = ja + 1.01;
   robot_state->setVariablePosition("panda_joint0", ja);
-  traj.push_back(robot_state::RobotStatePtr(new robot_state::RobotState(*robot_state)));
+  traj.push_back(moveit::core::RobotStatePtr(new moveit::core::RobotState(*robot_state)));
 
   // 6th waypoint with a large jump of 1.01 in first prismatic joint
   jc = jc + 1.01;
   robot_state->setVariablePosition("panda_joint1", jc);
-  traj.push_back(robot_state::RobotStatePtr(new robot_state::RobotState(*robot_state)));
+  traj.push_back(moveit::core::RobotStatePtr(new moveit::core::RobotState(*robot_state)));
 
   // 7th waypoint with no jump
-  traj.push_back(robot_state::RobotStatePtr(new robot_state::RobotState(*robot_state)));
+  traj.push_back(moveit::core::RobotStatePtr(new moveit::core::RobotState(*robot_state)));
 
   return traj.size();
 }
@@ -287,7 +287,7 @@ std::size_t generateTestTraj(std::vector<std::shared_ptr<robot_state::RobotState
 TEST_F(OneRobot, testGenerateTrajectory)
 {
   const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("arm");
-  std::vector<std::shared_ptr<robot_state::RobotState>> traj;
+  std::vector<std::shared_ptr<moveit::core::RobotState>> traj;
 
   // The full trajectory should be of length 7
   const std::size_t expected_full_traj_len = 7;
@@ -302,7 +302,7 @@ TEST_F(OneRobot, testGenerateTrajectory)
 TEST_F(OneRobot, checkAbsoluteJointSpaceJump)
 {
   const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("arm");
-  std::vector<std::shared_ptr<robot_state::RobotState>> traj;
+  std::vector<std::shared_ptr<moveit::core::RobotState>> traj;
 
   // A revolute joint jumps 1.01 at the 5th waypoint and a prismatic joint jumps 1.01 at the 6th waypoint
   const std::size_t expected_revolute_jump_traj_len = 4;
@@ -353,7 +353,7 @@ TEST_F(OneRobot, checkAbsoluteJointSpaceJump)
 TEST_F(OneRobot, checkRelativeJointSpaceJump)
 {
   const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("arm");
-  std::vector<std::shared_ptr<robot_state::RobotState>> traj;
+  std::vector<std::shared_ptr<moveit::core::RobotState>> traj;
 
   // The first large jump of 1.01 occurs at the 5th waypoint so the test should trim the trajectory to length 4
   const std::size_t expected_relative_jump_traj_len = 4;

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -51,9 +51,9 @@ MOVEIT_CLASS_FORWARD(RobotTrajectory);
 class RobotTrajectory
 {
 public:
-  RobotTrajectory(const robot_model::RobotModelConstPtr& robot_model, const std::string& group);
+  RobotTrajectory(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group);
 
-  RobotTrajectory(const robot_model::RobotModelConstPtr& robot_model, const robot_model::JointModelGroup* group);
+  RobotTrajectory(const moveit::core::RobotModelConstPtr& robot_model, const moveit::core::JointModelGroup* group);
 
   /** Assignment operator, performing a shallow copy, i.e. copying waypoints by pointer */
   RobotTrajectory& operator=(const RobotTrajectory&) = default;
@@ -64,12 +64,12 @@ public:
    */
   RobotTrajectory(const RobotTrajectory& other, bool deepcopy = false);
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
 
-  const robot_model::JointModelGroup* getGroup() const
+  const moveit::core::JointModelGroup* getGroup() const
   {
     return group_;
   }
@@ -83,32 +83,32 @@ public:
     return waypoints_.size();
   }
 
-  const robot_state::RobotState& getWayPoint(std::size_t index) const
+  const moveit::core::RobotState& getWayPoint(std::size_t index) const
   {
     return *waypoints_[index];
   }
 
-  const robot_state::RobotState& getLastWayPoint() const
+  const moveit::core::RobotState& getLastWayPoint() const
   {
     return *waypoints_.back();
   }
 
-  const robot_state::RobotState& getFirstWayPoint() const
+  const moveit::core::RobotState& getFirstWayPoint() const
   {
     return *waypoints_.front();
   }
 
-  robot_state::RobotStatePtr& getWayPointPtr(std::size_t index)
+  moveit::core::RobotStatePtr& getWayPointPtr(std::size_t index)
   {
     return waypoints_[index];
   }
 
-  robot_state::RobotStatePtr& getLastWayPointPtr()
+  moveit::core::RobotStatePtr& getLastWayPointPtr()
   {
     return waypoints_.back();
   }
 
-  robot_state::RobotStatePtr& getFirstWayPointPtr()
+  moveit::core::RobotStatePtr& getFirstWayPointPtr()
   {
     return waypoints_.front();
   }
@@ -151,9 +151,9 @@ public:
    * \param state - current robot state
    * \param dt - duration from previous
    */
-  void addSuffixWayPoint(const robot_state::RobotState& state, double dt)
+  void addSuffixWayPoint(const moveit::core::RobotState& state, double dt)
   {
-    addSuffixWayPoint(robot_state::RobotStatePtr(new robot_state::RobotState(state)), dt);
+    addSuffixWayPoint(moveit::core::RobotStatePtr(new moveit::core::RobotState(state)), dt);
   }
 
   /**
@@ -161,31 +161,31 @@ public:
    * \param state - current robot state
    * \param dt - duration from previous
    */
-  void addSuffixWayPoint(const robot_state::RobotStatePtr& state, double dt)
+  void addSuffixWayPoint(const moveit::core::RobotStatePtr& state, double dt)
   {
     state->update();
     waypoints_.push_back(state);
     duration_from_previous_.push_back(dt);
   }
 
-  void addPrefixWayPoint(const robot_state::RobotState& state, double dt)
+  void addPrefixWayPoint(const moveit::core::RobotState& state, double dt)
   {
-    addPrefixWayPoint(robot_state::RobotStatePtr(new robot_state::RobotState(state)), dt);
+    addPrefixWayPoint(moveit::core::RobotStatePtr(new moveit::core::RobotState(state)), dt);
   }
 
-  void addPrefixWayPoint(const robot_state::RobotStatePtr& state, double dt)
+  void addPrefixWayPoint(const moveit::core::RobotStatePtr& state, double dt)
   {
     state->update();
     waypoints_.push_front(state);
     duration_from_previous_.push_front(dt);
   }
 
-  void insertWayPoint(std::size_t index, const robot_state::RobotState& state, double dt)
+  void insertWayPoint(std::size_t index, const moveit::core::RobotState& state, double dt)
   {
-    insertWayPoint(index, robot_state::RobotStatePtr(new robot_state::RobotState(state)), dt);
+    insertWayPoint(index, moveit::core::RobotStatePtr(new moveit::core::RobotState(state)), dt);
   }
 
-  void insertWayPoint(std::size_t index, const robot_state::RobotStatePtr& state, double dt)
+  void insertWayPoint(std::size_t index, const moveit::core::RobotStatePtr& state, double dt)
   {
     state->update();
     waypoints_.insert(waypoints_.begin() + index, state);
@@ -221,7 +221,7 @@ public:
      point in the trajectory
       to be constructed internally is obtained by copying the reference state and overwriting the content from a
      trajectory point in \e trajectory. */
-  void setRobotTrajectoryMsg(const robot_state::RobotState& reference_state,
+  void setRobotTrajectoryMsg(const moveit::core::RobotState& reference_state,
                              const trajectory_msgs::JointTrajectory& trajectory);
 
   /** \brief Copy the content of the trajectory message into this class. The trajectory message itself is not required
@@ -230,7 +230,7 @@ public:
      point in the trajectory
       to be constructed internally is obtained by copying the reference state and overwriting the content from a
      trajectory point in \e trajectory. */
-  void setRobotTrajectoryMsg(const robot_state::RobotState& reference_state,
+  void setRobotTrajectoryMsg(const moveit::core::RobotState& reference_state,
                              const moveit_msgs::RobotTrajectory& trajectory);
 
   /** \brief Copy the content of the trajectory message into this class. The trajectory message itself is not required
@@ -240,13 +240,13 @@ public:
       using \e state. Each point in the trajectory  to be constructed internally is obtained by copying the reference
      state and overwriting the content
       from a trajectory point in \e trajectory. */
-  void setRobotTrajectoryMsg(const robot_state::RobotState& reference_state, const moveit_msgs::RobotState& state,
+  void setRobotTrajectoryMsg(const moveit::core::RobotState& reference_state, const moveit_msgs::RobotState& state,
                              const moveit_msgs::RobotTrajectory& trajectory);
 
   void reverse();
 
   void unwind();
-  void unwind(const robot_state::RobotState& state);
+  void unwind(const moveit::core::RobotState& state);
 
   /** @brief Finds the waypoint indicies before and after a duration from start.
    *  @param The duration from start.
@@ -263,12 +263,12 @@ public:
    *  @param The resulting robot state.
    *  @return True if state is valid, false otherwise (trajectory is empty).
    */
-  bool getStateAtDurationFromStart(const double request_duration, robot_state::RobotStatePtr& output_state) const;
+  bool getStateAtDurationFromStart(const double request_duration, moveit::core::RobotStatePtr& output_state) const;
 
 private:
-  robot_model::RobotModelConstPtr robot_model_;
-  const robot_model::JointModelGroup* group_;
-  std::deque<robot_state::RobotStatePtr> waypoints_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  const moveit::core::JointModelGroup* group_;
+  std::deque<moveit::core::RobotStatePtr> waypoints_;
   std::deque<double> duration_from_previous_;
 };
 }

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -44,7 +44,7 @@ class RobotTrajectoryTestFixture : public testing::Test
 {
 protected:
   moveit::core::RobotModelConstPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
   const std::string robot_model_name_ = "panda";
   const std::string arm_jmg_name_ = "panda_arm";
 
@@ -52,7 +52,7 @@ protected:
   void SetUp() override
   {
     robot_model_ = moveit::core::loadTestingRobotModel(robot_model_name_);
-    robot_state_ = std::make_shared<robot_state::RobotState>(robot_model_);
+    robot_state_ = std::make_shared<moveit::core::RobotState>(robot_model_);
     robot_state_->setToDefaultValues();
     robot_state_->update();
   }
@@ -99,7 +99,7 @@ protected:
     // Get the first waypoint by POINTER, modify it, and check that the value WAS updated in trajectory
     ///////////////////////////
     // Get the first waypoint by shared pointer
-    robot_state::RobotStatePtr trajectory_first_waypoint = trajectory->getWayPointPtr(0);
+    moveit::core::RobotStatePtr trajectory_first_waypoint = trajectory->getWayPointPtr(0);
     // Get the first waypoint joint values
     std::vector<double> trajectory_first_state;
     trajectory_first_waypoint->copyJointGroupPositions(arm_jmg_name_, trajectory_first_state);
@@ -109,7 +109,7 @@ protected:
     trajectory_first_waypoint->setJointGroupPositions(arm_jmg_name_, trajectory_first_state);
 
     // Check that the trajectory's first waypoint was updated
-    robot_state::RobotStatePtr trajectory_first_waypoint_after_update = trajectory->getWayPointPtr(0);
+    moveit::core::RobotStatePtr trajectory_first_waypoint_after_update = trajectory->getWayPointPtr(0);
     std::vector<double> trajectory_first_state_after_update;
     trajectory_first_waypoint_after_update->copyJointGroupPositions(arm_jmg_name_, trajectory_first_state_after_update);
     EXPECT_EQ(trajectory_first_state[0], trajectory_first_state_after_update[0]);
@@ -121,7 +121,7 @@ protected:
     // Get the first waypoint by VALUE, modify it, and check that the value WAS NOT updated in trajectory
     ///////////////////////////
     // Get the first waypoint by shared pointer
-    robot_state::RobotState trajectory_first_waypoint = trajectory->getWayPoint(0);
+    moveit::core::RobotState trajectory_first_waypoint = trajectory->getWayPoint(0);
     // Get the first waypoint joint values
     std::vector<double> trajectory_first_state;
     trajectory_first_waypoint.copyJointGroupPositions(arm_jmg_name_, trajectory_first_state);
@@ -131,7 +131,7 @@ protected:
     trajectory_first_waypoint.setJointGroupPositions(arm_jmg_name_, trajectory_first_state);
 
     // Check that the trajectory's first waypoint was updated
-    robot_state::RobotState trajectory_first_waypoint_after_update = trajectory->getWayPoint(0);
+    moveit::core::RobotState trajectory_first_waypoint_after_update = trajectory->getWayPoint(0);
     std::vector<double> trajectory_first_state_after_update;
     trajectory_first_waypoint_after_update.copyJointGroupPositions(arm_jmg_name_, trajectory_first_state_after_update);
     EXPECT_NE(trajectory_first_state[0], trajectory_first_state_after_update[0]);
@@ -164,12 +164,12 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryShallowCopy)
   modifyFirstWaypointPtrAndCheckTrajectory(trajectory);
 
   // Check that modifying the waypoint also modified the trajectory
-  robot_state::RobotState trajectory_first_waypoint_after_update = trajectory->getWayPoint(0);
+  moveit::core::RobotState trajectory_first_waypoint_after_update = trajectory->getWayPoint(0);
   std::vector<double> trajectory_first_state_after_update;
   trajectory_first_waypoint_after_update.copyJointGroupPositions(arm_jmg_name_, trajectory_first_state_after_update);
 
   // Get the first waypoint in the modified trajectory_copy
-  robot_state::RobotState trajectory_copy_first_waypoint_after_update = trajectory_copy->getWayPoint(0);
+  moveit::core::RobotState trajectory_copy_first_waypoint_after_update = trajectory_copy->getWayPoint(0);
   std::vector<double> trajectory_copy_first_state_after_update;
   trajectory_copy_first_waypoint_after_update.copyJointGroupPositions(arm_jmg_name_,
                                                                       trajectory_copy_first_state_after_update);
@@ -190,12 +190,12 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDeepCopy)
   modifyFirstWaypointPtrAndCheckTrajectory(trajectory);
 
   // Check that modifying the waypoint also modified the trajectory
-  robot_state::RobotState trajectory_first_waypoint_after_update = trajectory->getWayPoint(0);
+  moveit::core::RobotState trajectory_first_waypoint_after_update = trajectory->getWayPoint(0);
   std::vector<double> trajectory_first_state_after_update;
   trajectory_first_waypoint_after_update.copyJointGroupPositions(arm_jmg_name_, trajectory_first_state_after_update);
 
   // Get the first waypoint in the modified trajectory_copy
-  robot_state::RobotState trajectory_copy_first_waypoint_after_update = trajectory_copy->getWayPoint(0);
+  moveit::core::RobotState trajectory_copy_first_waypoint_after_update = trajectory_copy->getWayPoint(0);
   std::vector<double> trajectory_copy_first_state_after_update;
   trajectory_copy_first_waypoint_after_update.copyJointGroupPositions(arm_jmg_name_,
                                                                       trajectory_copy_first_state_after_update);

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -87,14 +87,14 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
   if (trajectory.empty())
     return true;
 
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
     ROS_ERROR_NAMED("trajectory_processing.iterative_spline_parameterization", "It looks like the planner did not set "
                                                                                "the group the plan was computed for");
     return false;
   }
-  const robot_model::RobotModel& rmodel = group->getParentModel();
+  const moveit::core::RobotModel& rmodel = group->getParentModel();
   const std::vector<int>& idx = group->getVariableIndexList();
   const std::vector<std::string>& vars = group->getVariableNames();
   double velocity_scaling_factor = 1.0;
@@ -134,8 +134,8 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     // (required to force acceleration to specified values at endpoints)
     if (trajectory.getWayPointCount() >= 2)
     {
-      robot_state::RobotState point = trajectory.getWayPoint(1);
-      robot_state::RobotStatePtr p0, p1;
+      moveit::core::RobotState point = trajectory.getWayPoint(1);
+      moveit::core::RobotStatePtr p0, p1;
 
       // 2nd point is 90% of p0, and 10% of p1
       p0 = trajectory.getWayPointPtr(0);
@@ -197,7 +197,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
     t2[j].accelerations_[num_points - 1] = t2[j].final_acceleration_;
 
     // Set bounds based on model, or default limits
-    const robot_model::VariableBounds& bounds = rmodel.getVariableBounds(vars[j]);
+    const moveit::core::VariableBounds& bounds = rmodel.getVariableBounds(vars[j]);
     t2[j].max_velocity_ = VLIMIT;
     t2[j].min_velocity_ = -VLIMIT;
     if (bounds.velocity_bounded_)

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -102,10 +102,10 @@ void IterativeParabolicTimeParameterization::applyVelocityConstraints(robot_traj
                                                                       std::vector<double>& time_diff,
                                                                       const double max_velocity_scaling_factor) const
 {
-  const robot_model::JointModelGroup* group = rob_trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = rob_trajectory.getGroup();
   const std::vector<std::string>& vars = group->getVariableNames();
   const std::vector<int>& idx = group->getVariableIndexList();
-  const robot_model::RobotModel& rmodel = group->getParentModel();
+  const moveit::core::RobotModel& rmodel = group->getParentModel();
   const int num_points = rob_trajectory.getWayPointCount();
 
   double velocity_scaling_factor = 1.0;
@@ -123,13 +123,13 @@ void IterativeParabolicTimeParameterization::applyVelocityConstraints(robot_traj
 
   for (int i = 0; i < num_points - 1; ++i)
   {
-    const robot_state::RobotStatePtr& curr_waypoint = rob_trajectory.getWayPointPtr(i);
-    const robot_state::RobotStatePtr& next_waypoint = rob_trajectory.getWayPointPtr(i + 1);
+    const moveit::core::RobotStatePtr& curr_waypoint = rob_trajectory.getWayPointPtr(i);
+    const moveit::core::RobotStatePtr& next_waypoint = rob_trajectory.getWayPointPtr(i + 1);
 
     for (std::size_t j = 0; j < vars.size(); ++j)
     {
       double v_max = DEFAULT_VEL_MAX;
-      const robot_model::VariableBounds& b = rmodel.getVariableBounds(vars[j]);
+      const moveit::core::VariableBounds& b = rmodel.getVariableBounds(vars[j]);
       if (b.velocity_bounded_)
         v_max =
             std::min(fabs(b.max_velocity_ * velocity_scaling_factor), fabs(b.min_velocity_ * velocity_scaling_factor));
@@ -195,11 +195,11 @@ void updateTrajectory(robot_trajectory::RobotTrajectory& rob_trajectory, const s
 
   double time_sum = 0.0;
 
-  robot_state::RobotStatePtr prev_waypoint;
-  robot_state::RobotStatePtr curr_waypoint;
-  robot_state::RobotStatePtr next_waypoint;
+  moveit::core::RobotStatePtr prev_waypoint;
+  moveit::core::RobotStatePtr curr_waypoint;
+  moveit::core::RobotStatePtr next_waypoint;
 
-  const robot_model::JointModelGroup* group = rob_trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = rob_trajectory.getGroup();
   const std::vector<std::string>& vars = group->getVariableNames();
   const std::vector<int>& idx = group->getVariableIndexList();
 
@@ -301,14 +301,14 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
     robot_trajectory::RobotTrajectory& rob_trajectory, std::vector<double>& time_diff,
     const double max_acceleration_scaling_factor) const
 {
-  robot_state::RobotStatePtr prev_waypoint;
-  robot_state::RobotStatePtr curr_waypoint;
-  robot_state::RobotStatePtr next_waypoint;
+  moveit::core::RobotStatePtr prev_waypoint;
+  moveit::core::RobotStatePtr curr_waypoint;
+  moveit::core::RobotStatePtr next_waypoint;
 
-  const robot_model::JointModelGroup* group = rob_trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = rob_trajectory.getGroup();
   const std::vector<std::string>& vars = group->getVariableNames();
   const std::vector<int>& idx = group->getVariableIndexList();
-  const robot_model::RobotModel& rmodel = group->getParentModel();
+  const moveit::core::RobotModel& rmodel = group->getParentModel();
 
   const int num_points = rob_trajectory.getWayPointCount();
   const unsigned int num_joints = group->getVariableCount();
@@ -363,7 +363,7 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
 
           // Get acceleration limits
           double a_max = DEFAULT_ACCEL_MAX;
-          const robot_model::VariableBounds& b = rmodel.getVariableBounds(vars[j]);
+          const moveit::core::VariableBounds& b = rmodel.getVariableBounds(vars[j]);
           if (b.acceleration_bounded_)
             a_max = std::min(fabs(b.max_acceleration_ * acceleration_scaling_factor),
                              fabs(b.min_acceleration_ * acceleration_scaling_factor));
@@ -464,7 +464,7 @@ bool IterativeParabolicTimeParameterization::computeTimeStamps(robot_trajectory:
   if (trajectory.empty())
     return true;
 
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
     ROS_ERROR_NAMED("trajectory_processing.iterative_time_parameterization", "It looks like the planner did not set "

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -880,7 +880,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   if (trajectory.empty())
     return true;
 
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
     ROS_ERROR_NAMED(LOGNAME, "It looks like the planner did not set the group the plan was computed for");
@@ -926,7 +926,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   // This is pretty much copied from IterativeParabolicTimeParameterization::applyVelocityConstraints
   const std::vector<std::string>& vars = group->getVariableNames();
   const std::vector<int>& idx = group->getVariableIndexList();
-  const robot_model::RobotModel& rmodel = group->getParentModel();
+  const moveit::core::RobotModel& rmodel = group->getParentModel();
   const unsigned num_joints = group->getVariableCount();
   const unsigned num_points = trajectory.getWayPointCount();
 
@@ -935,7 +935,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   Eigen::VectorXd max_acceleration(num_joints);
   for (size_t j = 0; j < num_joints; ++j)
   {
-    const robot_model::VariableBounds& bounds = rmodel.getVariableBounds(vars[j]);
+    const moveit::core::VariableBounds& bounds = rmodel.getVariableBounds(vars[j]);
 
     // Limits need to be non-zero, otherwise we never exit
     max_velocity[j] = 1.0;
@@ -959,7 +959,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   std::list<Eigen::VectorXd> points;
   for (size_t p = 0; p < num_points; ++p)
   {
-    robot_state::RobotStatePtr waypoint = trajectory.getWayPointPtr(p);
+    moveit::core::RobotStatePtr waypoint = trajectory.getWayPointPtr(p);
     Eigen::VectorXd new_point(num_joints);
     bool diverse_point = (p == 0);
 
@@ -978,7 +978,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   if (points.size() == 1)
   {
     ROS_WARN_NAMED(LOGNAME, "Trajectory is not being parameterized since it only contains a single distinct waypoint.");
-    robot_state::RobotState waypoint = robot_state::RobotState(trajectory.getWayPoint(0));
+    moveit::core::RobotState waypoint = moveit::core::RobotState(trajectory.getWayPoint(0));
     trajectory.clear();
     trajectory.addSuffixWayPoint(waypoint, 0.0);
     return true;
@@ -996,7 +996,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   size_t sample_count = std::ceil(parameterized.getDuration() / resample_dt_);
 
   // Resample and fill in trajectory
-  robot_state::RobotState waypoint = robot_state::RobotState(trajectory.getWayPoint(0));
+  moveit::core::RobotState waypoint = moveit::core::RobotState(trajectory.getWayPoint(0));
   trajectory.clear();
   double last_t = 0;
   for (size_t sample = 0; sample <= sample_count; ++sample)

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -53,7 +53,7 @@ int initRepeatedPointTrajectory(robot_trajectory::RobotTrajectory& trajectory)
   const int num = 3;
   unsigned i;
 
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
     ROS_ERROR_NAMED("trajectory_processing", "Need to set the group");
@@ -83,7 +83,7 @@ int initStraightTrajectory(robot_trajectory::RobotTrajectory& trajectory, double
   const double max = 2.0;
   unsigned i;
 
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
   if (!group)
   {
     ROS_ERROR_NAMED("trajectory_processing", "Need to set the group");
@@ -109,7 +109,7 @@ int initStraightTrajectory(robot_trajectory::RobotTrajectory& trajectory, double
 
 void printTrajectory(robot_trajectory::RobotTrajectory& trajectory)
 {
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
   const std::vector<int>& idx = group->getVariableIndexList();
   unsigned int count = trajectory.getWayPointCount();
 
@@ -118,13 +118,13 @@ void printTrajectory(robot_trajectory::RobotTrajectory& trajectory)
   std::cout << "  Trajectory Points" << std::endl;
   for (unsigned i = 0; i < count; i++)
   {
-    robot_state::RobotStatePtr point = trajectory.getWayPointPtr(i);
+    moveit::core::RobotStatePtr point = trajectory.getWayPointPtr(i);
     printf("  waypoint %2d time %6.2f pos %6.2f vel %6.2f acc %6.2f ", i, trajectory.getWayPointDurationFromStart(i),
            point->getVariablePosition(idx[0]), point->getVariableVelocity(idx[0]),
            point->getVariableAcceleration(idx[0]));
     if (i > 0)
     {
-      robot_state::RobotStatePtr prev = trajectory.getWayPointPtr(i - 1);
+      moveit::core::RobotStatePtr prev = trajectory.getWayPointPtr(i - 1);
       printf("jrk %6.2f",
              (point->getVariableAcceleration(idx[0]) - prev->getVariableAcceleration(idx[0])) /
                  (trajectory.getWayPointDurationFromStart(i) - trajectory.getWayPointDurationFromStart(i - 1)));

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
@@ -102,7 +102,7 @@ public:
    *  @param opt Parameters needed for defining the cache workspace
    *  @return False if any error occured during initialization
    */
-  bool initialize(kinematics::KinematicsBaseConstPtr& solver, const robot_model::RobotModelConstPtr& kinematic_model,
+  bool initialize(kinematics::KinematicsBaseConstPtr& solver, const moveit::core::RobotModelConstPtr& kinematic_model,
                   const KinematicsCache::Options& opt);
 
   /** @brief Return the instance of the kinematics solver */
@@ -112,7 +112,7 @@ public:
   }
 
   /** @brief Return the instance of the kinematics model */
-  const robot_model::RobotModelConstPtr& getModelInstance() const
+  const moveit::core::RobotModelConstPtr& getModelInstance() const
   {
     return kinematic_model_;
   }
@@ -168,11 +168,11 @@ private:
 
   kinematics::KinematicsBaseConstPtr kinematics_solver_; /** An instance of the kinematics solver */
 
-  robot_model::RobotModelConstPtr kinematic_model_; /** An instance of the kinematic model */
-  robot_state::RobotStatePtr kinematic_state_;      /** An instance of the kinematic state */
+  moveit::core::RobotModelConstPtr kinematic_model_; /** An instance of the kinematic model */
+  moveit::core::RobotStatePtr kinematic_state_;      /** An instance of the kinematic state */
 
-  const robot_model::JointModelGroup* joint_model_group_;           /** Joint model group associated with this cache */
-  std::shared_ptr<robot_state::JointStateGroup> joint_state_group_; /** Joint state corresponding to cache */
+  const moveit::core::JointModelGroup* joint_model_group_;           /** Joint model group associated with this cache */
+  std::shared_ptr<moveit::core::JointStateGroup> joint_state_group_; /** Joint state corresponding to cache */
 
   //    mutable std::vector<double> solution_local_; /** Local pre-allocated storage */
 

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
@@ -46,15 +46,15 @@ KinematicsCache::KinematicsCache() : min_squared_distance_(1e6), max_squared_dis
 }
 
 bool KinematicsCache::initialize(kinematics::KinematicsBaseConstPtr& kinematics_solver,
-                                 const robot_model::RobotModelConstPtr& kinematic_model,
+                                 const moveit::core::RobotModelConstPtr& kinematic_model,
                                  const KinematicsCache::Options& opt)
 {
   options_ = opt;
   kinematics_solver_ = kinematics_solver;
   kinematic_model_ = kinematic_model;
   joint_model_group_ = kinematic_model_->getJointModelGroup(kinematics_solver_->getGroupName());
-  kinematic_state_.reset(new robot_state::RobotState(kinematic_model));
-  joint_state_group_.reset(new robot_state::JointStateGroup(kinematic_state_.get(), joint_model_group_));
+  kinematic_state_.reset(new moveit::core::RobotState(kinematic_model));
+  joint_state_group_.reset(new moveit::core::JointStateGroup(kinematic_state_.get(), joint_model_group_));
 
   setup(opt);
   return true;

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
@@ -74,7 +74,7 @@ public:
    * @param group_name The name of the group to configure this solver for
    * @return False if any error occurs
    */
-  KinematicsConstraintAware(const robot_model::RobotModelConstPtr& kinematic_model, const std::string& group_name);
+  KinematicsConstraintAware(const moveit::core::RobotModelConstPtr& kinematic_model, const std::string& group_name);
 
   /** @brief Solve the planning problem
    * @param planning_scene A const reference to the planning scene
@@ -101,14 +101,14 @@ public:
     return group_name_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return kinematic_model_;
   }
 
 private:
   EigenSTL::vector_Isometry3d transformPoses(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                             const robot_state::RobotState& kinematic_state,
+                                             const moveit::core::RobotState& kinematic_state,
                                              const std::vector<geometry_msgs::PoseStamped>& poses,
                                              const std::string& target_frame) const;
 
@@ -118,20 +118,20 @@ private:
                              kinematics_constraint_aware::KinematicsResponse& kinematics_response) const;
 
   geometry_msgs::Pose getTipFramePose(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                      const robot_state::RobotState& kinematic_state, const geometry_msgs::Pose& pose,
+                                      const moveit::core::RobotState& kinematic_state, const geometry_msgs::Pose& pose,
                                       const std::string& link_name, unsigned int sub_group_index) const;
 
   bool validityCallbackFn(const planning_scene::PlanningSceneConstPtr& planning_scene,
                           const kinematics_constraint_aware::KinematicsRequest& request,
                           kinematics_constraint_aware::KinematicsResponse& response,
-                          robot_state::JointStateGroup* joint_state_group,
+                          moveit::core::JointStateGroup* joint_state_group,
                           const std::vector<double>& joint_group_variable_values) const;
 
   std::vector<std::string> sub_groups_names_;
 
-  robot_model::RobotModelConstPtr kinematic_model_;
+  moveit::core::RobotModelConstPtr kinematic_model_;
 
-  const robot_model::JointModelGroup* joint_model_group_;
+  const moveit::core::JointModelGroup* joint_model_group_;
 
   std::string group_name_;
 

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_request_response.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_request_response.h
@@ -68,7 +68,7 @@ public:
 
   std::vector<std::string> ik_link_names_;
 
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
 
   kinematic_constraints::KinematicConstraintSetPtr constraints_;
 
@@ -78,7 +78,7 @@ public:
 
   bool check_for_collisions_;
 
-  robot_state::StateValidityCallbackFn constraint_callback_;
+  moveit::core::StateValidityCallbackFn constraint_callback_;
 };
 
 /**
@@ -93,7 +93,7 @@ public:
 
   virtual ~KinematicsResponse(){};
 
-  robot_state::RobotStatePtr solution_;
+  moveit::core::RobotStatePtr solution_;
 
   std::vector<kinematic_constraints::ConstraintEvaluationResult> constraint_eval_results_;
 

--- a/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
+++ b/moveit_experimental/kinematics_constraint_aware/src/kinematics_constraint_aware.cpp
@@ -45,7 +45,7 @@
 
 namespace kinematics_constraint_aware
 {
-KinematicsConstraintAware::KinematicsConstraintAware(const robot_model::RobotModelConstPtr& kinematic_model,
+KinematicsConstraintAware::KinematicsConstraintAware(const moveit::core::RobotModelConstPtr& kinematic_model,
                                                      const std::string& group_name)
 {
   if (!kinematic_model->hasJointModelGroup(group_name))
@@ -118,7 +118,7 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
 
   if (!response.solution_)
   {
-    response.solution_.reset(new robot_state::RobotState(planning_scene->getCurrentState()));
+    response.solution_.reset(new moveit::core::RobotState(planning_scene->getCurrentState()));
   }
 
   ros::WallTime start_time = ros::WallTime::now();
@@ -129,7 +129,7 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
   }
 
   // Setup the seed and the values for all other joints in the robot
-  robot_state::RobotState kinematic_state = *request.robot_state_;
+  moveit::core::RobotState kinematic_state = *request.robot_state_;
   std::vector<std::string> ik_link_names = request.ik_link_names_;
 
   // Transform request to tip frame if necessary
@@ -161,7 +161,7 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
   EigenSTL::vector_Isometry3d goals =
       transformPoses(planning_scene, kinematic_state, request.pose_stamped_vector_, kinematic_model_->getModelFrame());
 
-  robot_state::StateValidityCallbackFn constraint_callback_fn =
+  moveit::core::StateValidityCallbackFn constraint_callback_fn =
       boost::bind(&KinematicsConstraintAware::validityCallbackFn, this, planning_scene, request, response, _1, _2);
 
   bool result = false;
@@ -198,7 +198,7 @@ bool KinematicsConstraintAware::getIK(const planning_scene::PlanningSceneConstPt
 bool KinematicsConstraintAware::validityCallbackFn(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                    const kinematics_constraint_aware::KinematicsRequest& request,
                                                    kinematics_constraint_aware::KinematicsResponse& response,
-                                                   robot_state::JointStateGroup* joint_state_group,
+                                                   moveit::core::JointStateGroup* joint_state_group,
                                                    const std::vector<double>& joint_group_variable_values) const
 {
   joint_state_group->setVariableValues(joint_group_variable_values);
@@ -321,7 +321,7 @@ bool KinematicsConstraintAware::convertServiceRequest(
   else
     kinematics_request.pose_stamped_vector_ = request.ik_request.pose_stamped_vector;
 
-  kinematics_request.robot_state_.reset(new robot_state::RobotState(planning_scene->getCurrentState()));
+  kinematics_request.robot_state_.reset(new moveit::core::RobotState(planning_scene->getCurrentState()));
   kinematics_request.robot_state_->setStateValues(request.ik_request.robot_state.joint_state);
   kinematics_request.constraints_.reset(
       new kinematic_constraints::KinematicConstraintSet(kinematic_model_, planning_scene->getTransforms()));
@@ -330,13 +330,13 @@ bool KinematicsConstraintAware::convertServiceRequest(
   kinematics_request.group_name_ = request.ik_request.group_name;
   kinematics_request.check_for_collisions_ = true;
 
-  kinematics_response.solution_.reset(new robot_state::RobotState(planning_scene->getCurrentState()));
+  kinematics_response.solution_.reset(new moveit::core::RobotState(planning_scene->getCurrentState()));
 
   return true;
 }
 
 EigenSTL::vector_Isometry3d KinematicsConstraintAware::transformPoses(
-    const planning_scene::PlanningSceneConstPtr& planning_scene, const robot_state::RobotState& kinematic_state,
+    const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit::core::RobotState& kinematic_state,
     const std::vector<geometry_msgs::PoseStamped>& poses, const std::string& target_frame) const
 {
   Eigen::Isometry3d eigen_pose, eigen_pose_2;
@@ -358,7 +358,7 @@ EigenSTL::vector_Isometry3d KinematicsConstraintAware::transformPoses(
 }
 
 geometry_msgs::Pose KinematicsConstraintAware::getTipFramePose(
-    const planning_scene::PlanningSceneConstPtr& planning_scene, const robot_state::RobotState& kinematic_state,
+    const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit::core::RobotState& kinematic_state,
     const geometry_msgs::Pose& pose, const std::string& link_name, unsigned int sub_group_index) const
 {
   geometry_msgs::Pose result;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -138,9 +138,9 @@ protected:
    */
   void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, unsigned int row_to_remove);
 
-  const robot_state::JointModelGroup* joint_model_group_;
+  const moveit::core::JointModelGroup* joint_model_group_;
 
-  robot_state::RobotStatePtr kinematic_state_;
+  moveit::core::RobotStatePtr kinematic_state_;
 
   sensor_msgs::JointState joint_state_, original_joint_state_;
   std::map<std::string, std::size_t> joint_state_name_map_;

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -68,7 +68,7 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables, std::mu
   collision_detection::CollisionResult collision_result;
 
   // Copy the planning scene's version of current state into new memory
-  robot_state::RobotState current_state(getLockedPlanningSceneRO()->getCurrentState());
+  moveit::core::RobotState current_state(getLockedPlanningSceneRO()->getCurrentState());
 
   double velocity_scale_coefficient = -log(0.001) / parameters_.collision_proximity_threshold;
   ros::Rate collision_rate(parameters_.collision_check_rate);

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -56,8 +56,8 @@ JogCalcs::JogCalcs(const JogArmParameters& parameters, const robot_model_loader:
     ROS_WARN_THROTTLE_NAMED(5, LOGNAME, "Waiting for a non-null robot_model_loader pointer");
     default_sleep_rate_.sleep();
   }
-  const robot_model::RobotModelPtr& kinematic_model = model_loader_ptr->getModel();
-  kinematic_state_ = std::make_shared<robot_state::RobotState>(kinematic_model);
+  const moveit::core::RobotModelPtr& kinematic_model = model_loader_ptr->getModel();
+  kinematic_state_ = std::make_shared<moveit::core::RobotState>(kinematic_model);
   kinematic_state_->setToDefaultValues();
 
   joint_model_group_ = kinematic_model->getJointModelGroup(parameters_.move_group_name);

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -160,8 +160,8 @@ private:
   unsigned int dimension_;                        ///< Dimension of the group
   moveit_msgs::KinematicSolverInfo solver_info_;  ///< Stores information for the inverse kinematics solver
 
-  const robot_model::JointModelGroup* joint_model_group_;
-  robot_state::RobotStatePtr state_;
+  const moveit::core::JointModelGroup* joint_model_group_;
+  moveit::core::RobotStatePtr state_;
   KDL::Chain kdl_chain_;
   std::unique_ptr<KDL::ChainFkSolverPos> fk_solver_;
   std::vector<JointMimic> mimic_joints_;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -214,7 +214,7 @@ bool KDLKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
   unsigned int joint_counter = 0;
   for (std::size_t i = 0; i < kdl_chain_.getNrOfSegments(); ++i)
   {
-    const robot_model::JointModel* jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
+    const moveit::core::JointModel* jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
 
     // first check whether it belongs to the set of active joints in the group
     if (jm->getMimic() == nullptr && jm->getVariableCount() > 0)
@@ -244,7 +244,7 @@ bool KDLKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
   {
     if (!mimic_joint.active)
     {
-      const robot_model::JointModel* joint_model =
+      const moveit::core::JointModel* joint_model =
           joint_model_group_->getJointModel(mimic_joint.joint_name)->getMimic();
       for (JointMimic& mimic_joint_recal : mimic_joints_)
       {
@@ -257,7 +257,7 @@ bool KDLKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
   }
 
   // Setup the joint state groups that we need
-  state_.reset(new robot_state::RobotState(robot_model_));
+  state_.reset(new moveit::core::RobotState(robot_model_));
 
   fk_solver_.reset(new KDL::ChainFkSolverPos_recursive(kdl_chain_));
 

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
@@ -146,11 +146,11 @@ private:
   unsigned int dimension_;                        ///< Dimension of the group
   moveit_msgs::KinematicSolverInfo solver_info_;  ///< Stores information for the inverse kinematics solver
 
-  const robot_model::JointModelGroup* joint_model_group_;
-  robot_state::RobotStatePtr state_;
+  const moveit::core::JointModelGroup* joint_model_group_;
+  moveit::core::RobotStatePtr state_;
   KDL::Chain kdl_chain_;
   std::unique_ptr<KDL::ChainFkSolverPos> fk_solver_;
-  std::vector<const robot_model::JointModel*> joints_;
+  std::vector<const moveit::core::JointModel*> joints_;
   std::vector<std::string> joint_names_;
 
   int max_solver_iterations_;

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -110,7 +110,7 @@ bool LMAKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
     return false;
   }
 
-  for (const robot_model::JointModel* jm : joint_model_group_->getJointModels())
+  for (const moveit::core::JointModel* jm : joint_model_group_->getJointModels())
   {
     if (jm->getType() == moveit::core::JointModel::REVOLUTE || jm->getType() == moveit::core::JointModel::PRISMATIC)
     {
@@ -133,7 +133,7 @@ bool LMAKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
     ROS_INFO_NAMED("lma", "Using position only ik");
 
   // Setup the joint state groups that we need
-  state_.reset(new robot_state::RobotState(robot_model_));
+  state_.reset(new moveit::core::RobotState(robot_model_));
 
   fk_solver_.reset(new KDL::ChainFkSolverPos_recursive(kdl_chain_));
 

--- a/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -143,9 +143,9 @@ private:
 
   unsigned int dimension_; /** Dimension of the group */
 
-  const robot_model::JointModelGroup* joint_model_group_;
+  const moveit::core::JointModelGroup* joint_model_group_;
 
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
 
   int num_possible_redundant_joints_;
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -109,7 +109,7 @@ bool SrvKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
   lookupParam("kinematics_solver_service_name", ik_service_name, std::string("solve_ik"));
 
   // Setup the joint state groups that we need
-  robot_state_.reset(new robot_state::RobotState(robot_model_));
+  robot_state_.reset(new moveit::core::RobotState(robot_model_));
   robot_state_->setToDefaultValues();
 
   // Create the ROS service client

--- a/moveit_kinematics/test/benchmark_ik.cpp
+++ b/moveit_kinematics/test/benchmark_ik.cpp
@@ -77,14 +77,14 @@ int main(int argc, char* argv[])
   spinner.start();
 
   robot_model_loader::RobotModelLoader robot_model_loader;
-  const robot_model::RobotModelPtr& kinematic_model = robot_model_loader.getModel();
+  const moveit::core::RobotModelPtr& kinematic_model = robot_model_loader.getModel();
   planning_scene::PlanningScene planning_scene(kinematic_model);
-  robot_state::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
+  moveit::core::RobotState& kinematic_state = planning_scene.getCurrentStateNonConst();
   collision_detection::CollisionRequest collision_request;
   collision_detection::CollisionResult collision_result;
   std::chrono::duration<double> ik_time(0);
   std::chrono::time_point<std::chrono::system_clock> start;
-  std::vector<robot_state::JointModelGroup*> groups;
+  std::vector<moveit::core::JointModelGroup*> groups;
   std::vector<std::string> end_effectors;
 
   if (group == "all")

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -77,7 +77,7 @@ class SharedData
   friend class KinematicsTest;
   typedef pluginlib::ClassLoader<kinematics::KinematicsBase> KinematicsLoader;
 
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
   std::unique_ptr<KinematicsLoader> kinematics_loader_;
   std::string root_link_;
   std::string tip_link_;
@@ -104,7 +104,7 @@ class SharedData
     ROS_INFO_STREAM("Loading robot model from " << ros::this_node::getNamespace() << "/" << ROBOT_DESCRIPTION_PARAM);
     // load robot model
     rdf_loader::RDFLoader rdf_loader(ROBOT_DESCRIPTION_PARAM);
-    robot_model_ = std::make_shared<robot_model::RobotModel>(rdf_loader.getURDF(), rdf_loader.getSRDF());
+    robot_model_ = std::make_shared<moveit::core::RobotModel>(rdf_loader.getURDF(), rdf_loader.getSRDF());
     ASSERT_TRUE(bool(robot_model_)) << "Failed to load robot model";
 
     // init ClassLoader
@@ -280,8 +280,8 @@ public:
   }
 
 public:
-  robot_model::RobotModelPtr robot_model_;
-  robot_model::JointModelGroup* jmg_;
+  moveit::core::RobotModelPtr robot_model_;
+  moveit::core::JointModelGroup* jmg_;
   kinematics::KinematicsBasePtr kinematics_solver_;
   random_numbers::RandomNumberGenerator rng_{ 42 };
   std::string root_link_;
@@ -307,7 +307,7 @@ TEST_F(KinematicsTest, getFK)
 {
   std::vector<double> joints(kinematics_solver_->getJointNames().size(), 0.0);
   const std::vector<std::string>& tip_frames = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   for (unsigned int i = 0; i < num_fk_tests_; ++i)
@@ -331,7 +331,7 @@ TEST_F(KinematicsTest, randomWalkIK)
 {
   std::vector<double> seed, goal, solution;
   const std::vector<std::string>& tip_frames = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   if (!seed_.empty())
@@ -466,7 +466,7 @@ TEST_F(KinematicsTest, unitIK)
 
   std::vector<double> seed, sol;
   const std::vector<std::string>& tip_frames = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   // initial joint pose from seed_ or defaults
@@ -539,7 +539,7 @@ TEST_F(KinematicsTest, searchIK)
   moveit_msgs::MoveItErrorCodes error_code;
   solution.resize(kinematics_solver_->getJointNames().size(), 0.0);
   const std::vector<std::string>& fk_names = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   unsigned int success = 0;
@@ -573,7 +573,7 @@ TEST_F(KinematicsTest, searchIKWithCallback)
   moveit_msgs::MoveItErrorCodes error_code;
   solution.resize(kinematics_solver_->getJointNames().size(), 0.0);
   const std::vector<std::string>& fk_names = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   unsigned int success = 0;
@@ -613,7 +613,7 @@ TEST_F(KinematicsTest, getIK)
   moveit_msgs::MoveItErrorCodes error_code;
   solution.resize(kinematics_solver_->getJointNames().size(), 0.0);
   const std::vector<std::string>& fk_names = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   for (unsigned int i = 0; i < num_ik_tests_; ++i)
@@ -642,7 +642,7 @@ TEST_F(KinematicsTest, getIKMultipleSolutions)
   kinematics::KinematicsResult result;
 
   const std::vector<std::string>& fk_names = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   unsigned int success = 0;
@@ -685,7 +685,7 @@ TEST_F(KinematicsTest, getNearestIKSolution)
   std::vector<double> seed, fk_values, solution;
   moveit_msgs::MoveItErrorCodes error_code;
   const std::vector<std::string>& fk_names = kinematics_solver_->getTipFrames();
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   for (unsigned int i = 0; i < num_nearest_ik_tests_; ++i)

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -52,7 +52,8 @@ public:
   void clear() override;
   bool terminate() override;
 
-  CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model);
+  CHOMPPlanningContext(const std::string& name, const std::string& group,
+                       const moveit::core::RobotModelConstPtr& model);
 
   ~CHOMPPlanningContext() override = default;
 

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -52,7 +52,7 @@ public:
   void clear() override;
   bool terminate() override;
 
-  CHOMPPlanningContext(const std::string& name, const std::string& group, const robot_model::RobotModelConstPtr& model);
+  CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model);
 
   ~CHOMPPlanningContext() override = default;
 

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -41,7 +41,7 @@
 namespace chomp_interface
 {
 CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::string& group,
-                                           const robot_model::RobotModelConstPtr& model)
+                                           const moveit::core::RobotModelConstPtr& model)
   : planning_interface::PlanningContext(name, group), robot_model_(model)
 {
   chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface());

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -50,7 +50,7 @@ public:
   {
   }
 
-  bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& /*ns*/) override
+  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& /*ns*/) override
   {
     for (const std::string& group : model->getJointModelGroupNames())
     {

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -56,8 +56,8 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
 
   // get the specified start state
-  robot_state::RobotState start_state = planning_scene->getCurrentState();
-  robot_state::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
+  moveit::core::RobotState start_state = planning_scene->getCurrentState();
+  moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
 
   if (!start_state.satisfiesBounds())
   {
@@ -85,7 +85,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   }
 
   const size_t goal_index = trajectory.getNumPoints() - 1;
-  robot_state::RobotState goal_state(start_state);
+  moveit::core::RobotState goal_state(start_state);
   for (const moveit_msgs::JointConstraint& joint_constraint : req.goal_constraints[0].joint_constraints)
     goal_state.setVariablePosition(joint_constraint.joint_name, joint_constraint.position);
   if (!goal_state.satisfiesBounds())
@@ -223,9 +223,9 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   for (size_t i = 0; i < trajectory.getNumPoints(); i++)
   {
     const Eigen::MatrixXd::RowXpr source = trajectory.getTrajectoryPoint(i);
-    auto state = std::make_shared<robot_state::RobotState>(start_state);
+    auto state = std::make_shared<moveit::core::RobotState>(start_state);
     size_t joint_index = 0;
-    for (const robot_state::JointModel* jm : result->getGroup()->getActiveJointModels())
+    for (const moveit::core::JointModel* jm : result->getGroup()->getActiveJointModels())
     {
       assert(jm->getVariableCount() == 1);
       state->setVariablePosition(jm->getFirstVariableIndex(), source[joint_index++]);
@@ -254,7 +254,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
 
   // check that final state is within goal tolerances
   kinematic_constraints::JointConstraint jc(planning_scene->getRobotModel());
-  const robot_state::RobotState& last_state = result->getLastWayPoint();
+  const moveit::core::RobotState& last_state = result->getLastWayPoint();
   for (const moveit_msgs::JointConstraint& constraint : req.goal_constraints[0].joint_constraints)
   {
     if (!jc.configure(constraint) || !jc.decide(last_state).satisfied)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -197,8 +197,8 @@ bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajecto
   const size_t max_output_index = getNumPoints() - 1;
   const size_t max_input_index = trajectory.getWayPointCount() - 1;
 
-  const robot_model::JointModelGroup* group = trajectory.getGroup();
-  robot_state::RobotState interpolated(trajectory.getRobotModel());
+  const moveit::core::JointModelGroup* group = trajectory.getGroup();
+  moveit::core::RobotState interpolated(trajectory.getRobotModel());
   for (size_t i = 0; i <= max_output_index; i++)
   {
     double fraction = static_cast<double>(i * max_input_index) / max_output_index;
@@ -211,14 +211,14 @@ bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajecto
   return true;
 }
 
-void ChompTrajectory::assignCHOMPTrajectoryPointFromRobotState(const robot_state::RobotState& source,
+void ChompTrajectory::assignCHOMPTrajectoryPointFromRobotState(const moveit::core::RobotState& source,
                                                                size_t chomp_trajectory_point_index,
-                                                               const robot_model::JointModelGroup* group)
+                                                               const moveit::core::JointModelGroup* group)
 {
   Eigen::MatrixXd::RowXpr target = getTrajectoryPoint(chomp_trajectory_point_index);
   assert(group->getActiveJointModels().size() == static_cast<size_t>(target.cols()));
   size_t joint_index = 0;
-  for (const robot_state::JointModel* jm : group->getActiveJointModels())
+  for (const moveit::core::JointModel* jm : group->getActiveJointModels())
   {
     assert(jm->getVariableCount() == 1);
     target[joint_index++] = source.getVariablePosition(jm->getFirstVariableIndex());

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
@@ -57,16 +57,16 @@ public:
 
 private:
   bool sampleUsingConstraintSampler(const ompl::base::GoalLazySamples* gls, ompl::base::State* new_goal);
-  bool stateValidityCallback(ompl::base::State* new_goal, robot_state::RobotState const* state,
-                             const robot_model::JointModelGroup*, const double*, bool verbose = false) const;
-  bool checkStateValidity(ompl::base::State* new_goal, const robot_state::RobotState& state,
+  bool stateValidityCallback(ompl::base::State* new_goal, moveit::core::RobotState const* state,
+                             const moveit::core::JointModelGroup*, const double*, bool verbose = false) const;
+  bool checkStateValidity(ompl::base::State* new_goal, const moveit::core::RobotState& state,
                           bool verbose = false) const;
 
   const ModelBasedPlanningContext* planning_context_;
   kinematic_constraints::KinematicConstraintSetPtr kinematic_constraint_set_;
   constraint_samplers::ConstraintSamplerPtr constraint_sampler_;
   ompl::base::StateSamplerPtr default_sampler_;
-  robot_state::RobotState work_state_;
+  moveit::core::RobotState work_state_;
   unsigned int invalid_sampled_constraints_;
   bool warned_invalid_samples_;
   unsigned int verbose_display_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_sampler.h
@@ -71,7 +71,7 @@ private:
   const ModelBasedPlanningContext* planning_context_;
   ompl::base::StateSamplerPtr default_;
   constraint_samplers::ConstraintSamplerPtr constraint_sampler_;
-  robot_state::RobotState work_state_;
+  moveit::core::RobotState work_state_;
   unsigned int constrained_success_;
   unsigned int constrained_failure_;
   double inv_dim_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_valid_state_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_valid_state_sampler.h
@@ -64,7 +64,7 @@ private:
   kinematic_constraints::KinematicConstraintSetPtr kinematic_constraint_set_;
   constraint_samplers::ConstraintSamplerPtr constraint_sampler_;
   ompl::base::StateSamplerPtr default_sampler_;
-  robot_state::RobotState work_state_;
+  moveit::core::RobotState work_state_;
   double inv_dim_;
   ompl::RNG rng_;
 };

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
@@ -64,7 +64,7 @@ public:
 
 private:
   const ModelBasedPlanningContext* planning_context_;
-  const robot_model::LinkModel* link_;
+  const moveit::core::LinkModel* link_;
   TSStateStorage tss_;
 };
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/threadsafe_state_storage.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/threadsafe_state_storage.h
@@ -45,15 +45,15 @@ namespace ompl_interface
 class TSStateStorage
 {
 public:
-  TSStateStorage(const robot_model::RobotModelPtr& robot_model);
-  TSStateStorage(const robot_state::RobotState& start_state);
+  TSStateStorage(const moveit::core::RobotModelPtr& robot_model);
+  TSStateStorage(const moveit::core::RobotState& start_state);
   ~TSStateStorage();
 
-  robot_state::RobotState* getStateStorage() const;
+  moveit::core::RobotState* getStateStorage() const;
 
 private:
-  robot_state::RobotState start_state_;
-  mutable std::map<std::thread::id, robot_state::RobotState*> thread_states_;
+  moveit::core::RobotState start_state_;
+  mutable std::map<std::thread::id, moveit::core::RobotState*> thread_states_;
   mutable std::mutex lock_;
 };
 }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -102,17 +102,17 @@ public:
     spec_.config_ = config;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return spec_.state_space_->getRobotModel();
   }
 
-  const robot_model::JointModelGroup* getJointModelGroup() const
+  const moveit::core::JointModelGroup* getJointModelGroup() const
   {
     return spec_.state_space_->getJointModelGroup();
   }
 
-  const robot_state::RobotState& getCompleteInitialRobotState() const
+  const moveit::core::RobotState& getCompleteInitialRobotState() const
   {
     return complete_initial_robot_state_;
   }
@@ -234,7 +234,7 @@ public:
 
   void setPlanningVolume(const moveit_msgs::WorkspaceParameters& wparams);
 
-  void setCompleteInitialState(const robot_state::RobotState& complete_initial_robot_state);
+  void setCompleteInitialState(const moveit::core::RobotState& complete_initial_robot_state);
 
   bool setGoalConstraints(const std::vector<moveit_msgs::Constraints>& goal_constraints,
                           const moveit_msgs::Constraints& path_constraints, moveit_msgs::MoveItErrorCodes* error);
@@ -368,7 +368,7 @@ protected:
 
   ModelBasedPlanningContextSpecification spec_;
 
-  robot_state::RobotState complete_initial_robot_state_;
+  moveit::core::RobotState complete_initial_robot_state_;
 
   /// the OMPL planning context; this contains the problem definition and the planner used
   og::SimpleSetupPtr ompl_simple_setup_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -56,13 +56,13 @@ class OMPLInterface
 public:
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
    * NodeHandle */
-  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model, const ros::NodeHandle& nh = ros::NodeHandle("~"));
+  OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model, const ros::NodeHandle& nh = ros::NodeHandle("~"));
 
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
      NodeHandle. However,
       planner configurations are used as specified in \e pconfig instead of reading them from the ROS parameter server
      */
-  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
+  OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model,
                 const planning_interface::PlannerConfigurationMap& pconfig,
                 const ros::NodeHandle& nh = ros::NodeHandle("~"));
 
@@ -150,7 +150,7 @@ protected:
   ros::NodeHandle nh_;  /// The ROS node handle
 
   /** \brief The kinematic model for which motion plans are computed */
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h
@@ -46,7 +46,7 @@ public:
   JointModelStateSpaceFactory();
 
   int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                          const robot_model::RobotModelConstPtr& robot_model) const override;
+                          const moveit::core::RobotModelConstPtr& robot_model) const override;
 
 protected:
   ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const override;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -51,22 +51,22 @@ typedef std::function<double(const ompl::base::State* state1, const ompl::base::
 
 struct ModelBasedStateSpaceSpecification
 {
-  ModelBasedStateSpaceSpecification(const robot_model::RobotModelConstPtr& robot_model,
-                                    const robot_model::JointModelGroup* jmg)
+  ModelBasedStateSpaceSpecification(const moveit::core::RobotModelConstPtr& robot_model,
+                                    const moveit::core::JointModelGroup* jmg)
     : robot_model_(robot_model), joint_model_group_(jmg)
   {
   }
 
-  ModelBasedStateSpaceSpecification(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name)
+  ModelBasedStateSpaceSpecification(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name)
     : robot_model_(robot_model), joint_model_group_(robot_model_->getJointModelGroup(group_name))
   {
     if (!joint_model_group_)
       throw std::runtime_error("Group '" + group_name + "'  was not found");
   }
 
-  robot_model::RobotModelConstPtr robot_model_;
-  const robot_model::JointModelGroup* joint_model_group_;
-  robot_model::JointBoundsVector joint_bounds_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  const moveit::core::JointModelGroup* joint_model_group_;
+  moveit::core::JointBoundsVector joint_bounds_;
 };
 
 OMPL_CLASS_FORWARD(ModelBasedStateSpace);
@@ -202,12 +202,12 @@ public:
 
   virtual const std::string& getParameterizationType() const = 0;
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return spec_.robot_model_;
   }
 
-  const robot_model::JointModelGroup* getJointModelGroup() const
+  const moveit::core::JointModelGroup* getJointModelGroup() const
   {
     return spec_.joint_model_group_;
   }
@@ -228,18 +228,18 @@ public:
   /// Set the planning volume for the possible SE2 and/or SE3 components of the state space
   virtual void setPlanningVolume(double minX, double maxX, double minY, double maxY, double minZ, double maxZ);
 
-  const robot_model::JointBoundsVector& getJointsBounds() const
+  const moveit::core::JointBoundsVector& getJointsBounds() const
   {
     return spec_.joint_bounds_;
   }
 
   /// Copy the data from an OMPL state to a set of joint states.
   // The joint states \b must be specified in the same order as the joint models in the constructor
-  virtual void copyToRobotState(robot_state::RobotState& rstate, const ompl::base::State* state) const;
+  virtual void copyToRobotState(moveit::core::RobotState& rstate, const ompl::base::State* state) const;
 
   /// Copy the data from a set of joint states to an OMPL state.
   //  The joint states \b must be specified in the same order as the joint models in the constructor
-  virtual void copyToOMPLState(ompl::base::State* state, const robot_state::RobotState& rstate) const;
+  virtual void copyToOMPLState(ompl::base::State* state, const moveit::core::RobotState& rstate) const;
 
   /**
    * \brief Copy a single joint's values (which might have multiple variables) from a MoveIt robot_state to an OMPL
@@ -251,7 +251,7 @@ public:
    * cache this index)
    *        e.g. ompl_state_joint_index = joint_model_group_->getVariableGroupIndex("virtual_joint");
    */
-  virtual void copyJointToOMPLState(ompl::base::State* state, const robot_state::RobotState& robot_state,
+  virtual void copyJointToOMPLState(ompl::base::State* state, const moveit::core::RobotState& robot_state,
                                     const moveit::core::JointModel* joint_model, int ompl_state_joint_index) const;
 
   double getTagSnapToSegment() const;
@@ -259,8 +259,8 @@ public:
 
 protected:
   ModelBasedStateSpaceSpecification spec_;
-  std::vector<robot_model::JointModel::Bounds> joint_bounds_storage_;
-  std::vector<const robot_model::JointModel*> joint_model_vector_;
+  std::vector<moveit::core::JointModel::Bounds> joint_bounds_storage_;
+  std::vector<const moveit::core::JointModel*> joint_model_vector_;
   unsigned int variable_count_;
   size_t state_values_size_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
@@ -67,7 +67,7 @@ public:
       request \e req for group \e group. The group \e group must always be specified and takes precedence over \e
      req.group_name, which may be different */
   virtual int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                                  const robot_model::RobotModelConstPtr& robot_model) const = 0;
+                                  const moveit::core::RobotModelConstPtr& robot_model) const = 0;
 
 protected:
   virtual ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const = 0;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -107,7 +107,7 @@ public:
   bool computeStateK(ompl::base::State* state) const;
 
   void setPlanningVolume(double minX, double maxX, double minY, double maxY, double minZ, double maxZ) override;
-  void copyToOMPLState(ompl::base::State* state, const robot_state::RobotState& rstate) const override;
+  void copyToOMPLState(ompl::base::State* state, const moveit::core::RobotState& rstate) const override;
   void sanityChecks() const override;
 
   const std::string& getParameterizationType() const override
@@ -118,8 +118,8 @@ public:
 private:
   struct PoseComponent
   {
-    PoseComponent(const robot_model::JointModelGroup* subgroup,
-                  const robot_model::JointModelGroup::KinematicsSolver& k);
+    PoseComponent(const moveit::core::JointModelGroup* subgroup,
+                  const moveit::core::JointModelGroup::KinematicsSolver& k);
 
     bool computeStateFK(StateType* full_state, unsigned int idx) const;
     bool computeStateIK(StateType* full_state, unsigned int idx) const;
@@ -129,7 +129,7 @@ private:
       return subgroup_->getName() < o.subgroup_->getName();
     }
 
-    const robot_model::JointModelGroup* subgroup_;
+    const moveit::core::JointModelGroup* subgroup_;
     kinematics::KinematicsBasePtr kinematics_solver_;
     std::vector<unsigned int> bijection_;
     ompl::base::StateSpacePtr state_space_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space_factory.h
@@ -46,7 +46,7 @@ public:
   PoseModelStateSpaceFactory();
 
   int canRepresentProblem(const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-                          const robot_model::RobotModelConstPtr& robot_model) const override;
+                          const moveit::core::RobotModelConstPtr& robot_model) const override;
 
 protected:
   ModelBasedStateSpacePtr allocStateSpace(const ModelBasedStateSpaceSpecification& space_spec) const override;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -80,7 +80,7 @@ private:
 class PlanningContextManager
 {
 public:
-  PlanningContextManager(robot_model::RobotModelConstPtr robot_model,
+  PlanningContextManager(moveit::core::RobotModelConstPtr robot_model,
                          constraint_samplers::ConstraintSamplerManagerPtr csm);
   ~PlanningContextManager();
 
@@ -165,7 +165,7 @@ public:
     minimum_waypoint_count_ = mwc;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -219,7 +219,7 @@ protected:
                                                               const moveit_msgs::MotionPlanRequest& req) const;
 
   /** \brief The kinematic model for which motion plans are computed */
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -63,7 +63,7 @@ ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedP
 }
 
 bool ompl_interface::ConstrainedGoalSampler::checkStateValidity(ob::State* new_goal,
-                                                                const robot_state::RobotState& state,
+                                                                const moveit::core::RobotState& state,
                                                                 bool verbose) const
 {
   planning_context_->getOMPLStateSpace()->copyToOMPLState(new_goal, state);
@@ -71,12 +71,12 @@ bool ompl_interface::ConstrainedGoalSampler::checkStateValidity(ob::State* new_g
 }
 
 bool ompl_interface::ConstrainedGoalSampler::stateValidityCallback(ob::State* new_goal,
-                                                                   robot_state::RobotState const* state,
-                                                                   const robot_model::JointModelGroup* jmg,
+                                                                   moveit::core::RobotState const* state,
+                                                                   const moveit::core::JointModelGroup* jmg,
                                                                    const double* jpos, bool verbose) const
 {
   // we copy the state to not change the seed state
-  robot_state::RobotState solution_state(*state);
+  moveit::core::RobotState solution_state(*state);
   solution_state.setJointGroupPositions(jmg, jpos);
   solution_state.update();
   return checkStateValidity(new_goal, solution_state, verbose);
@@ -116,7 +116,7 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
     if (constraint_sampler_)
     {
       // makes the constraint sampler also perform a validity callback
-      robot_state::GroupStateValidityCallbackFn gsvcf =
+      moveit::core::GroupStateValidityCallbackFn gsvcf =
           std::bind(&ompl_interface::ConstrainedGoalSampler::stateValidityCallback, this, new_goal,
                     std::placeholders::_1,  // pointer to state
                     std::placeholders::_2,  // const* joint model group

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -230,7 +230,7 @@ ompl_interface::ConstraintApproximation::getStateSamplerAllocator(const moveit_m
 void ompl_interface::ConstraintApproximation::visualizeDistribution(const std::string &link_name, unsigned int count,
 visualization_msgs::MarkerArray &arr) const
 {
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
 
   ompl::RNG rng;
@@ -459,10 +459,10 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
   // construct a sampler for the sampling constraints
   kinematic_constraints::KinematicConstraintSet kset(pcontext->getRobotModel());
-  robot_state::Transforms no_transforms(pcontext->getRobotModel()->getModelFrame());
+  moveit::core::Transforms no_transforms(pcontext->getRobotModel()->getModelFrame());
   kset.add(constr_hard, no_transforms);
 
-  const robot_state::RobotState& default_state = pcontext->getCompleteInitialRobotState();
+  const moveit::core::RobotState& default_state = pcontext->getCompleteInitialRobotState();
 
   unsigned int attempts = 0;
 
@@ -473,7 +473,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
   // construct the constrained states
 
-  robot_state::RobotState robot_state(default_state);
+  moveit::core::RobotState robot_state(default_state);
   const constraint_samplers::ConstraintSamplerManagerPtr& csmng = pcontext->getConstraintSamplerManager();
   ConstrainedSampler* constrained_sampler = nullptr;
   if (csmng)

--- a/moveit_planners/ompl/ompl_interface/src/detail/projection_evaluators.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/projection_evaluators.cpp
@@ -65,7 +65,7 @@ void ompl_interface::ProjectionEvaluatorLinkPose::defaultCellSizes()
 void ompl_interface::ProjectionEvaluatorLinkPose::project(const ompl::base::State* state,
                                                           OMPLProjection projection) const
 {
-  robot_state::RobotState* s = tss_.getStateStorage();
+  moveit::core::RobotState* s = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*s, state);
 
   const Eigen::Vector3d& o = s->getGlobalLinkTransform(link_).translation();

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -86,7 +86,7 @@ double ompl_interface::StateValidityChecker::cost(const ompl::base::State* state
 {
   double cost = 0.0;
 
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
 
   // Calculates cost from a summation of distance to obstacles times the size of the obstacle
@@ -101,7 +101,7 @@ double ompl_interface::StateValidityChecker::cost(const ompl::base::State* state
 
 double ompl_interface::StateValidityChecker::clearance(const ompl::base::State* state) const
 {
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
 
   collision_detection::CollisionResult res;
@@ -120,7 +120,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   }
 
   // convert ompl state to MoveIt robot state
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
 
   // check path constraints
@@ -149,7 +149,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
     return false;
   }
 
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
 
   // check path constraints
@@ -192,7 +192,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
     return false;
   }
 
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
 
   // check path constraints
@@ -243,7 +243,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
     return false;
   }
 
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
 
   // check path constraints

--- a/moveit_planners/ompl/ompl_interface/src/detail/threadsafe_state_storage.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/threadsafe_state_storage.cpp
@@ -36,13 +36,13 @@
 
 #include <moveit/ompl_interface/detail/threadsafe_state_storage.h>
 
-ompl_interface::TSStateStorage::TSStateStorage(const robot_model::RobotModelPtr& robot_model)
+ompl_interface::TSStateStorage::TSStateStorage(const moveit::core::RobotModelPtr& robot_model)
   : start_state_(robot_model)
 {
   start_state_.setToDefaultValues();
 }
 
-ompl_interface::TSStateStorage::TSStateStorage(const robot_state::RobotState& start_state) : start_state_(start_state)
+ompl_interface::TSStateStorage::TSStateStorage(const moveit::core::RobotState& start_state) : start_state_(start_state)
 {
 }
 
@@ -52,15 +52,15 @@ ompl_interface::TSStateStorage::~TSStateStorage()
     delete thread_state.second;
 }
 
-robot_state::RobotState* ompl_interface::TSStateStorage::getStateStorage() const
+moveit::core::RobotState* ompl_interface::TSStateStorage::getStateStorage() const
 {
-  robot_state::RobotState* st = nullptr;
+  moveit::core::RobotState* st = nullptr;
   std::unique_lock<std::mutex> slock(lock_);  /// \todo use Thread Local Storage?
-  std::map<std::thread::id, robot_state::RobotState*>::const_iterator it =
+  std::map<std::thread::id, moveit::core::RobotState*>::const_iterator it =
       thread_states_.find(std::this_thread::get_id());
   if (it == thread_states_.end())
   {
-    st = new robot_state::RobotState(start_state_);
+    st = new moveit::core::RobotState(start_state_);
     thread_states_[std::this_thread::get_id()] = st;
   }
   else

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -420,7 +420,7 @@ void ompl_interface::ModelBasedPlanningContext::interpolateSolution()
 void ompl_interface::ModelBasedPlanningContext::convertPath(const ompl::geometric::PathGeometric& pg,
                                                             robot_trajectory::RobotTrajectory& traj) const
 {
-  robot_state::RobotState ks = complete_initial_robot_state_;
+  moveit::core::RobotState ks = complete_initial_robot_state_;
   for (std::size_t i = 0; i < pg.getStateCount(); ++i)
   {
     spec_.state_space_->copyToRobotState(ks, pg.getState(i));
@@ -528,7 +528,7 @@ ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContex
 }
 
 void ompl_interface::ModelBasedPlanningContext::setCompleteInitialState(
-    const robot_state::RobotState& complete_initial_robot_state)
+    const moveit::core::RobotState& complete_initial_robot_state)
 {
   complete_initial_robot_state_ = complete_initial_robot_state;
   complete_initial_robot_state_.update();

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,7 +42,7 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
-ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
+ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model,
                                              const ros::NodeHandle& nh)
   : nh_(nh)
   , robot_model_(robot_model)
@@ -56,7 +56,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
   loadConstraintSamplers();
 }
 
-ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
+ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model,
                                              const planning_interface::PlannerConfigurationMap& pconfig,
                                              const ros::NodeHandle& nh)
   : nh_(nh)
@@ -78,7 +78,7 @@ void ompl_interface::OMPLInterface::setPlannerConfigurations(const planning_inte
   planning_interface::PlannerConfigurationMap pconfig2 = pconfig;
 
   // construct default configurations for planning groups that don't have configs already passed in
-  for (const robot_model::JointModelGroup* group : robot_model_->getJointModelGroups())
+  for (const moveit::core::JointModelGroup* group : robot_model_->getJointModelGroups())
   {
     if (pconfig.find(group->getName()) == pconfig.end())
     {

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -102,7 +102,7 @@ public:
     ompl::msg::useOutputHandler(output_handler_.get());
   }
 
-  bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& ns) override
+  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
     if (!ns.empty())
       nh_ = ros::NodeHandle(ns);
@@ -177,7 +177,7 @@ private:
     ROS_INFO_STREAM("Displaying states for context " << pc->getName());
     const og::SimpleSetup &ss = pc->getOMPLSimpleSetup();
     ob::ValidStateSamplerPtr vss = ss.getSpaceInformation()->allocValidStateSampler();
-    robot_state::RobotState robot_state = pc->getPlanningScene()->getCurrentState();
+    moveit::core::RobotState robot_state = pc->getPlanningScene()->getCurrentState();
     ob::ScopedState<> rstate1(ss.getStateSpace());
     ob::ScopedState<> rstate2(ss.getStateSpace());
     ros::WallDuration wait(2);
@@ -191,7 +191,7 @@ private:
         pc->getOMPLStateSpace()->copyToRobotState(robot_state, rstate1.get());
         robot_state.getJointStateGroup(pc->getJointModelGroupName())->updateLinkTransforms();
         moveit_msgs::DisplayRobotState state_msg;
-        robot_state::robotStateToRobotStateMsg(robot_state, state_msg.state);
+        moveit::core::robotStateToRobotStateMsg(robot_state, state_msg.state);
         pub_valid_states_.publish(state_msg);
         n = (n + 1) % 2;
         if (n == 0)
@@ -208,7 +208,7 @@ private:
           msg.model_id = pc->getRobotModel()->getName();
           msg.trajectory.resize(1);
           traj.getRobotTrajectoryMsg(msg.trajectory[0]);
-          robot_state::robotStateToRobotStateMsg(traj.getFirstWayPoint(), msg.trajectory_start);
+          moveit::core::robotStateToRobotStateMsg(traj.getFirstWayPoint(), msg.trajectory_start);
           pub_valid_traj_.publish(msg);
         }
         rstate2 = rstate1;
@@ -224,7 +224,7 @@ private:
     {
       ompl::base::PlannerData pd(pc->getOMPLSimpleSetup()->getSpaceInformation());
       pc->getOMPLSimpleSetup()->getPlannerData(pd);
-      robot_state::RobotState robot_state = planning_scene->getCurrentState();
+      moveit::core::RobotState robot_state = planning_scene->getCurrentState();
       visualization_msgs::MarkerArray arr;
       std_msgs::ColorRGBA color;
       color.r = 1.0f;

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/joint_space/joint_model_state_space_factory.cpp
@@ -44,7 +44,7 @@ ompl_interface::JointModelStateSpaceFactory::JointModelStateSpaceFactory() : Mod
 
 int ompl_interface::JointModelStateSpaceFactory::canRepresentProblem(
     const std::string& /*group*/, const moveit_msgs::MotionPlanRequest& /*req*/,
-    const robot_model::RobotModelConstPtr& /*robot_model*/) const
+    const moveit::core::RobotModelConstPtr& /*robot_model*/) const
 {
   return 100;
 }

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -140,7 +140,7 @@ void ompl_interface::ModelBasedStateSpace::deserialize(ompl::base::State* state,
 unsigned int ompl_interface::ModelBasedStateSpace::getDimension() const
 {
   unsigned int d = 0;
-  for (const robot_model::JointModel* i : joint_model_vector_)
+  for (const moveit::core::JointModel* i : joint_model_vector_)
     d += i->getStateSpaceDimension();
   return d;
 }
@@ -153,7 +153,7 @@ double ompl_interface::ModelBasedStateSpace::getMaximumExtent() const
 double ompl_interface::ModelBasedStateSpace::getMeasure() const
 {
   double m = 1.0;
-  for (const robot_model::JointModel::Bounds* bounds : spec_.joint_bounds_)
+  for (const moveit::core::JointModel::Bounds* bounds : spec_.joint_bounds_)
   {
     for (const moveit::core::VariableBounds& bound : *bounds)
     {
@@ -227,14 +227,14 @@ void ompl_interface::ModelBasedStateSpace::setPlanningVolume(double minX, double
                                                              double minZ, double maxZ)
 {
   for (std::size_t i = 0; i < joint_model_vector_.size(); ++i)
-    if (joint_model_vector_[i]->getType() == robot_model::JointModel::PLANAR)
+    if (joint_model_vector_[i]->getType() == moveit::core::JointModel::PLANAR)
     {
       joint_bounds_storage_[i][0].min_position_ = minX;
       joint_bounds_storage_[i][0].max_position_ = maxX;
       joint_bounds_storage_[i][1].min_position_ = minY;
       joint_bounds_storage_[i][1].max_position_ = maxY;
     }
-    else if (joint_model_vector_[i]->getType() == robot_model::JointModel::FLOATING)
+    else if (joint_model_vector_[i]->getType() == moveit::core::JointModel::FLOATING)
     {
       joint_bounds_storage_[i][0].min_position_ = minX;
       joint_bounds_storage_[i][0].max_position_ = maxX;
@@ -250,8 +250,8 @@ ompl::base::StateSamplerPtr ompl_interface::ModelBasedStateSpace::allocDefaultSt
   class DefaultStateSampler : public ompl::base::StateSampler
   {
   public:
-    DefaultStateSampler(const ompl::base::StateSpace* space, const robot_model::JointModelGroup* group,
-                        const robot_model::JointBoundsVector* joint_bounds)
+    DefaultStateSampler(const ompl::base::StateSpace* space, const moveit::core::JointModelGroup* group,
+                        const moveit::core::JointBoundsVector* joint_bounds)
       : ompl::base::StateSampler(space), joint_model_group_(group), joint_bounds_(joint_bounds)
     {
     }
@@ -276,8 +276,8 @@ ompl::base::StateSamplerPtr ompl_interface::ModelBasedStateSpace::allocDefaultSt
 
   protected:
     random_numbers::RandomNumberGenerator moveit_rng_;
-    const robot_model::JointModelGroup* joint_model_group_;
-    const robot_model::JointBoundsVector* joint_bounds_;
+    const moveit::core::JointModelGroup* joint_model_group_;
+    const moveit::core::JointBoundsVector* joint_bounds_;
   };
 
   return ompl::base::StateSamplerPtr(static_cast<ompl::base::StateSampler*>(
@@ -291,7 +291,7 @@ void ompl_interface::ModelBasedStateSpace::printSettings(std::ostream& out) cons
 
 void ompl_interface::ModelBasedStateSpace::printState(const ompl::base::State* state, std::ostream& out) const
 {
-  for (const robot_model::JointModel* j : joint_model_vector_)
+  for (const moveit::core::JointModel* j : joint_model_vector_)
   {
     out << j->getName() << " = ";
     const int idx = spec_.joint_model_group_->getVariableGroupIndex(j->getName());
@@ -315,7 +315,7 @@ void ompl_interface::ModelBasedStateSpace::printState(const ompl::base::State* s
   out << "Tag: " << state->as<StateType>()->tag << std::endl;
 }
 
-void ompl_interface::ModelBasedStateSpace::copyToRobotState(robot_state::RobotState& rstate,
+void ompl_interface::ModelBasedStateSpace::copyToRobotState(moveit::core::RobotState& rstate,
                                                             const ompl::base::State* state) const
 {
   rstate.setJointGroupPositions(spec_.joint_model_group_, state->as<StateType>()->values);
@@ -323,7 +323,7 @@ void ompl_interface::ModelBasedStateSpace::copyToRobotState(robot_state::RobotSt
 }
 
 void ompl_interface::ModelBasedStateSpace::copyToOMPLState(ompl::base::State* state,
-                                                           const robot_state::RobotState& rstate) const
+                                                           const moveit::core::RobotState& rstate) const
 {
   rstate.copyJointGroupPositions(spec_.joint_model_group_, state->as<StateType>()->values);
   // clear any cached info (such as validity known or not)
@@ -331,7 +331,7 @@ void ompl_interface::ModelBasedStateSpace::copyToOMPLState(ompl::base::State* st
 }
 
 void ompl_interface::ModelBasedStateSpace::copyJointToOMPLState(ompl::base::State* state,
-                                                                const robot_state::RobotState& robot_state,
+                                                                const moveit::core::RobotState& robot_state,
                                                                 const moveit::core::JointModel* joint_model,
                                                                 int ompl_state_joint_index) const
 {

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -51,7 +51,7 @@ ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSp
     poses_.emplace_back(spec.joint_model_group_, spec.joint_model_group_->getGroupKinematics().first);
   else if (!spec.joint_model_group_->getGroupKinematics().second.empty())
   {
-    const robot_model::JointModelGroup::KinematicsSolverMap& m = spec.joint_model_group_->getGroupKinematics().second;
+    const moveit::core::JointModelGroup::KinematicsSolverMap& m = spec.joint_model_group_->getGroupKinematics().second;
     for (const auto& it : m)
       poses_.emplace_back(it.first, it.second);
   }
@@ -177,7 +177,7 @@ void ompl_interface::PoseModelStateSpace::setPlanningVolume(double minX, double 
 }
 
 ompl_interface::PoseModelStateSpace::PoseComponent::PoseComponent(
-    const robot_model::JointModelGroup* subgroup, const robot_model::JointModelGroup::KinematicsSolver& k)
+    const moveit::core::JointModelGroup* subgroup, const moveit::core::JointModelGroup::KinematicsSolver& k)
   : subgroup_(subgroup), kinematics_solver_(k.allocator_(subgroup)), bijection_(k.bijection_)
 {
   state_space_.reset(new ompl::base::SE3StateSpace());
@@ -338,7 +338,7 @@ ompl::base::StateSamplerPtr ompl_interface::PoseModelStateSpace::allocDefaultSta
 }
 
 void ompl_interface::PoseModelStateSpace::copyToOMPLState(ompl::base::State* state,
-                                                          const robot_state::RobotState& rstate) const
+                                                          const moveit::core::RobotState& rstate) const
 {
   ModelBasedStateSpace::copyToOMPLState(state, rstate);
   state->as<StateType>()->setJointsComputed(true);

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
@@ -44,12 +44,12 @@ ompl_interface::PoseModelStateSpaceFactory::PoseModelStateSpaceFactory() : Model
 
 int ompl_interface::PoseModelStateSpaceFactory::canRepresentProblem(
     const std::string& group, const moveit_msgs::MotionPlanRequest& req,
-    const robot_model::RobotModelConstPtr& robot_model) const
+    const moveit::core::RobotModelConstPtr& robot_model) const
 {
-  const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
+  const moveit::core::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
-    const std::pair<robot_model::JointModelGroup::KinematicsSolver, robot_model::JointModelGroup::KinematicsSolverMap>&
+    const std::pair<moveit::core::JointModelGroup::KinematicsSolver, moveit::core::JointModelGroup::KinematicsSolverMap>&
         slv = jmg->getGroupKinematics();
     bool ik = false;
     // check that we have a direct means to compute IK

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space_factory.cpp
@@ -49,8 +49,8 @@ int ompl_interface::PoseModelStateSpaceFactory::canRepresentProblem(
   const moveit::core::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
-    const std::pair<moveit::core::JointModelGroup::KinematicsSolver, moveit::core::JointModelGroup::KinematicsSolverMap>&
-        slv = jmg->getGroupKinematics();
+    const std::pair<moveit::core::JointModelGroup::KinematicsSolver,
+                    moveit::core::JointModelGroup::KinematicsSolverMap>& slv = jmg->getGroupKinematics();
     bool ik = false;
     // check that we have a direct means to compute IK
     if (slv.first)

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -223,7 +223,7 @@ MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::LazyPRMst
 }
 #endif
 
-ompl_interface::PlanningContextManager::PlanningContextManager(robot_model::RobotModelConstPtr robot_model,
+ompl_interface::PlanningContextManager::PlanningContextManager(moveit::core::RobotModelConstPtr robot_model,
                                                                constraint_samplers::ConstraintSamplerManagerPtr csm)
   : robot_model_(std::move(robot_model))
   , constraint_sampler_manager_(std::move(csm))
@@ -497,7 +497,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
   {
     context->clear();
 
-    robot_state::RobotStatePtr start_state = planning_scene->getCurrentStateUpdated(req.start_state);
+    moveit::core::RobotStatePtr start_state = planning_scene->getCurrentStateUpdated(req.start_state);
 
     // Setup the context
     context->setPlanningScene(planning_scene);

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -76,7 +76,7 @@ protected:
   }
 
 protected:
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
   urdf::ModelInterfaceSharedPtr urdf_model_;
   srdf::ModelSharedPtr srdf_model_;
   bool urdf_ok_;
@@ -146,13 +146,13 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   }
   EXPECT_TRUE(passed);
 
-  robot_state::RobotState robot_state(robot_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToRandomPositions();
   EXPECT_TRUE(robot_state.distance(robot_state) < 1e-12);
   ompl::base::State* state = ss.allocState();
   for (int i = 0; i < 10; ++i)
   {
-    robot_state::RobotState robot_state2(robot_state);
+    moveit::core::RobotState robot_state2(robot_state);
     EXPECT_TRUE(robot_state.distance(robot_state2) < 1e-12);
     ss.copyToOMPLState(state, robot_state);
     robot_state.setToRandomPositions(robot_state.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName()));

--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
@@ -13,7 +13,7 @@ class TrajOptPlanningContext : public planning_interface::PlanningContext
 {
 public:
   TrajOptPlanningContext(const std::string& name, const std::string& group,
-                         const robot_model::RobotModelConstPtr& model);
+                         const moveit::core::RobotModelConstPtr& model);
   ~TrajOptPlanningContext() override
   {
   }

--- a/moveit_planners/trajopt/src/problem_description.cpp
+++ b/moveit_planners/trajopt/src/problem_description.cpp
@@ -82,9 +82,9 @@ TrajOptProblem::TrajOptProblem(const ProblemInfo& problem_info)
   , planning_scene_(problem_info.planning_scene)
   , planning_group_(problem_info.planning_group_name)
 {
-  robot_model::RobotModelConstPtr robot_model = planning_scene_->getRobotModel();
-  robot_state::RobotState current_state = planning_scene_->getCurrentState();
-  const robot_state::JointModelGroup* joint_model_group = current_state.getJointModelGroup(planning_group_);
+  moveit::core::RobotModelConstPtr robot_model = planning_scene_->getRobotModel();
+  moveit::core::RobotState current_state = planning_scene_->getCurrentState();
+  const moveit::core::JointModelGroup* joint_model_group = current_state.getJointModelGroup(planning_group_);
 
   moveit::core::JointBoundsVector bounds = joint_model_group->getActiveJointModelsBounds();
   dof_ = joint_model_group->getActiveJointModelNames().size();  // or bounds.size();
@@ -181,10 +181,10 @@ TrajOptProblemPtr ConstructProblem(const ProblemInfo& pci)
   TrajOptProblemPtr prob(new TrajOptProblem(pci));
 
   // Generate initial trajectory and check its size
-  robot_model::RobotModelConstPtr robot_model = pci.planning_scene->getRobotModel();
-  robot_state::RobotState current_state = pci.planning_scene->getCurrentState();
+  moveit::core::RobotModelConstPtr robot_model = pci.planning_scene->getRobotModel();
+  moveit::core::RobotState current_state = pci.planning_scene->getCurrentState();
 
-  const robot_state::JointModelGroup* joint_model_group = current_state.getJointModelGroup(pci.planning_group_name);
+  const moveit::core::JointModelGroup* joint_model_group = current_state.getJointModelGroup(pci.planning_group_name);
   int n_dof = prob->GetNumDOF();
 
   std::vector<double> current_joint_values;

--- a/moveit_planners/trajopt/src/trajopt_interface.cpp
+++ b/moveit_planners/trajopt/src/trajopt_interface.cpp
@@ -83,13 +83,13 @@ bool TrajOptInterface::solve(const planning_scene::PlanningSceneConstPtr& planni
 
   ROS_INFO(" ======================================= Extract current state information");
   ros::WallTime start_time = ros::WallTime::now();
-  robot_model::RobotModelConstPtr robot_model = planning_scene->getRobotModel();
+  moveit::core::RobotModelConstPtr robot_model = planning_scene->getRobotModel();
   bool robot_model_ok = static_cast<bool>(robot_model);
   if (!robot_model_ok)
     ROS_ERROR_STREAM_NAMED(name_, "robot model is not loaded properly");
-  robot_state::RobotStatePtr current_state(new robot_state::RobotState(robot_model));
+  moveit::core::RobotStatePtr current_state(new moveit::core::RobotState(robot_model));
   *current_state = planning_scene->getCurrentState();
-  const robot_state::JointModelGroup* joint_model_group = current_state->getJointModelGroup(req.group_name);
+  const moveit::core::JointModelGroup* joint_model_group = current_state->getJointModelGroup(req.group_name);
   if (joint_model_group == nullptr)
     ROS_ERROR_STREAM_NAMED(name_, "joint model group is empty");
   std::vector<std::string> group_joint_names = joint_model_group->getActiveJointModelNames();
@@ -303,7 +303,7 @@ bool TrajOptInterface::solve(const planning_scene::PlanningSceneConstPtr& planni
 
   ROS_INFO(" ======================================= check if final state is within goal tolerances");
   kinematic_constraints::JointConstraint joint_cnt(planning_scene->getRobotModel());
-  robot_state::RobotState last_state(*current_state);
+  moveit::core::RobotState last_state(*current_state);
   last_state.setJointGroupPositions(req.group_name, res.trajectory[0].joint_trajectory.points.back().positions);
 
   for (int jn = 0; jn < res.trajectory[0].joint_trajectory.points.back().positions.size(); ++jn)

--- a/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
@@ -53,7 +53,7 @@ public:
   {
   }
 
-  bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& ns) override
+  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
     ROS_INFO(" ======================================= initialize gets called");
 

--- a/moveit_planners/trajopt/src/trajopt_planning_context.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planning_context.cpp
@@ -13,7 +13,7 @@
 namespace trajopt_interface
 {
 TrajOptPlanningContext::TrajOptPlanningContext(const std::string& context_name, const std::string& group_name,
-                                               const robot_model::RobotModelConstPtr& model)
+                                               const moveit::core::RobotModelConstPtr& model)
   : planning_interface::PlanningContext(context_name, group_name), robot_model_(model)
 {
   ROS_INFO(" ======================================= TrajOptPlanningContext is constructed");
@@ -32,7 +32,7 @@ bool TrajOptPlanningContext::solve(planning_interface::MotionPlanDetailedRespons
         robot_trajectory::RobotTrajectoryPtr(new robot_trajectory::RobotTrajectory(robot_model_, getGroupName()));
 
     moveit::core::RobotState start_state(robot_model_);
-    robot_state::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
+    moveit::core::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
     res.trajectory_[0]->setRobotTrajectoryMsg(start_state, res_msg.trajectory[0]);
 
     res.description_.push_back("plan");

--- a/moveit_planners/trajopt/test/trajectory_test.cpp
+++ b/moveit_planners/trajopt/test/trajectory_test.cpp
@@ -56,7 +56,7 @@ protected:
   }
 
 protected:
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
   std::vector<std::string> group_joint_names_;
   const std::string PLANNING_GROUP = "panda_arm";
   const double GOAL_TOLERANCE = 0.1;
@@ -91,10 +91,10 @@ TEST_F(TrajectoryTest, goalTolerance)
   const std::string NODE_NAME = "trajectory_test";
 
   // Create a RobotState and JointModelGroup to keep track of the current robot pose and planning group
-  robot_state::RobotStatePtr current_state(new robot_state::RobotState(robot_model_));
+  moveit::core::RobotStatePtr current_state(new moveit::core::RobotState(robot_model_));
   current_state->setToDefaultValues();
 
-  const robot_state::JointModelGroup* joint_model_group = current_state->getJointModelGroup(PLANNING_GROUP);
+  const moveit::core::JointModelGroup* joint_model_group = current_state->getJointModelGroup(PLANNING_GROUP);
   EXPECT_NE(joint_model_group, nullptr);
   const std::vector<std::string>& joint_names = joint_model_group->getActiveJointModelNames();
   EXPECT_EQ(joint_names.size(), 7);
@@ -108,7 +108,7 @@ TEST_F(TrajectoryTest, goalTolerance)
   // Set start state
   // ======================================================================================
   std::vector<double> start_joint_values = { 0.4, 0.3, 0.5, -0.55, 0.88, 1.0, -0.075 };
-  robot_state::RobotStatePtr start_state(new robot_state::RobotState(robot_model_));
+  moveit::core::RobotStatePtr start_state(new moveit::core::RobotState(robot_model_));
   start_state->setJointGroupPositions(joint_model_group, start_joint_values);
   start_state->update();
 
@@ -119,7 +119,7 @@ TEST_F(TrajectoryTest, goalTolerance)
 
   // Set the goal state and joints tolerance
   // ========================================================================================
-  robot_state::RobotStatePtr goal_state(new robot_state::RobotState(robot_model_));
+  moveit::core::RobotStatePtr goal_state(new moveit::core::RobotState(robot_model_));
   std::vector<double> goal_joint_values = { 0.8, 0.7, 1, -1.3, 1.9, 2.2, -0.1 };
   goal_state->setJointGroupPositions(joint_model_group, goal_joint_values);
   goal_state->update();

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controller_manager.cpp
@@ -141,7 +141,7 @@ public:
     }
 
     robot_model_loader::RobotModelLoader robot_model_loader(ROBOT_DESCRIPTION);
-    const robot_model::RobotModelPtr& robot_model = robot_model_loader.getModel();
+    const moveit::core::RobotModelPtr& robot_model = robot_model_loader.getModel();
     moveit::core::RobotState robot_state(robot_model);
     typedef std::map<std::string, double> JointPoseMap;
     JointPoseMap joints;

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -883,8 +883,8 @@ void moveit_benchmarks::BenchmarkExecution::collectMetrics(RunData& rundata,
 
 namespace
 {
-bool isIKSolutionCollisionFree(const planning_scene::PlanningScene* scene, robot_state::RobotState* state,
-                               const robot_model::JointModelGroup* group, const double* ik_solution, bool* reachable)
+bool isIKSolutionCollisionFree(const planning_scene::PlanningScene* scene, moveit::core::RobotState* state,
+                               const moveit::core::JointModelGroup* group, const double* ik_solution, bool* reachable)
 {
   state->setJointGroupPositions(group, ik_solution);
   state->update();
@@ -1270,8 +1270,8 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
     ik_pose.orientation.z = req.motion_plan_request.goal_constraints[0].orientation_constraints[0].orientation.z;
     ik_pose.orientation.w = req.motion_plan_request.goal_constraints[0].orientation_constraints[0].orientation.w;
 
-    robot_state::RobotState robot_state(planning_scene_->getCurrentState());
-    robot_state::robotStateMsgToRobotState(req.motion_plan_request.start_state, robot_state);
+    moveit::core::RobotState robot_state(planning_scene_->getCurrentState());
+    moveit::core::robotStateMsgToRobotState(req.motion_plan_request.start_state, robot_state);
 
     // Compute IK
     ROS_INFO_STREAM("Processing goal " << req.motion_plan_request.goal_constraints[0].name << " ...");
@@ -1358,8 +1358,8 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
       ik_pose.orientation.w =
           req.motion_plan_request.trajectory_constraints.constraints[tc].orientation_constraints[0].orientation.w;
 
-      robot_state::RobotState robot_state(planning_scene_->getCurrentState());
-      robot_state::robotStateMsgToRobotState(req.motion_plan_request.start_state, robot_state);
+      moveit::core::RobotState robot_state(planning_scene_->getCurrentState());
+      moveit::core::robotStateMsgToRobotState(req.motion_plan_request.start_state, robot_state);
 
       // Compute IK
       ROS_INFO_STREAM("Processing trajectory waypoint "

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -63,9 +63,9 @@ struct ManipulationPlanSharedData
   {
   }
 
-  const robot_model::JointModelGroup* planning_group_;
-  const robot_model::JointModelGroup* end_effector_group_;
-  const robot_model::LinkModel* ik_link_;
+  const moveit::core::JointModelGroup* planning_group_;
+  const moveit::core::JointModelGroup* end_effector_group_;
+  const moveit::core::LinkModel* ik_link_;
 
   unsigned int max_goal_sampling_attempts_;
 
@@ -125,9 +125,9 @@ struct ManipulationPlan
   // Allows for the sampling of a kineamtic state for a particular group of a robot
   constraint_samplers::ConstraintSamplerPtr goal_sampler_;
 
-  std::vector<robot_state::RobotStatePtr> possible_goal_states_;
+  std::vector<moveit::core::RobotStatePtr> possible_goal_states_;
 
-  robot_state::RobotStatePtr approach_state_;
+  moveit::core::RobotStatePtr approach_state_;
 
   // The sequence of trajectories produced for execution
   std::vector<plan_execution::ExecutableTrajectory> trajectories_;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
@@ -131,7 +131,7 @@ public:
     return planning_pipeline_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return planning_pipeline_->getRobotModel();
   }

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/reachable_valid_pose_filter.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/reachable_valid_pose_filter.h
@@ -52,7 +52,7 @@ public:
   bool evaluate(const ManipulationPlanPtr& plan) const override;
 
 private:
-  bool isEndEffectorFree(const ManipulationPlanPtr& plan, robot_state::RobotState& token_state) const;
+  bool isEndEffectorFree(const ManipulationPlanPtr& plan, moveit::core::RobotState& token_state) const;
 
   planning_scene::PlanningSceneConstPtr planning_scene_;
   collision_detection::AllowedCollisionMatrixConstPtr collision_matrix_;

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -58,8 +58,8 @@ namespace
 {
 bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
                           const collision_detection::AllowedCollisionMatrix* collision_matrix, bool verbose,
-                          const trajectory_msgs::JointTrajectory* grasp_posture, robot_state::RobotState* state,
-                          const robot_state::JointModelGroup* group, const double* joint_group_variable_values)
+                          const trajectory_msgs::JointTrajectory* grasp_posture, moveit::core::RobotState* state,
+                          const moveit::core::JointModelGroup* group, const double* joint_group_variable_values)
 {
   state->setJointGroupPositions(group, joint_group_variable_values);
 
@@ -90,11 +90,11 @@ bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
   return planning_scene->isStateFeasible(*state);
 }
 
-bool samplePossibleGoalStates(const ManipulationPlanPtr& plan, const robot_state::RobotState& reference_state,
+bool samplePossibleGoalStates(const ManipulationPlanPtr& plan, const moveit::core::RobotState& reference_state,
                               double min_distance, unsigned int attempts)
 {
   // initialize with scene state
-  robot_state::RobotStatePtr token_state(new robot_state::RobotState(reference_state));
+  moveit::core::RobotStatePtr token_state(new moveit::core::RobotState(reference_state));
   for (unsigned int j = 0; j < attempts; ++j)
   {
     double min_d = std::numeric_limits<double>::infinity();
@@ -157,8 +157,8 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
   // Check if a "closed" end effector configuration was specified
   if (!plan->retreat_posture_.joint_names.empty())
   {
-    robot_state::RobotStatePtr ee_closed_state(
-        new robot_state::RobotState(plan->trajectories_.back().trajectory_->getLastWayPoint()));
+    moveit::core::RobotStatePtr ee_closed_state(
+        new moveit::core::RobotState(plan->trajectories_.back().trajectory_->getLastWayPoint()));
 
     robot_trajectory::RobotTrajectoryPtr ee_closed_traj(new robot_trajectory::RobotTrajectory(
         ee_closed_state->getRobotModel(), plan->shared_data_->end_effector_group_->getName()));
@@ -195,7 +195,7 @@ void addGripperTrajectory(const ManipulationPlanPtr& plan,
 
 bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 {
-  const robot_model::JointModelGroup* jmg = plan->shared_data_->planning_group_;
+  const moveit::core::JointModelGroup* jmg = plan->shared_data_->planning_group_;
   // compute what the maximum distance reported between any two states in the planning group could be, and keep 1% of
   // that;
   // this is the minimum distance between sampled goal states
@@ -208,9 +208,9 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 
   // if translation vectors are specified in the frame of the ik link name, then we assume the frame is local;
   // otherwise, the frame is global
-  bool approach_direction_is_global_frame = !robot_state::Transforms::sameFrame(
+  bool approach_direction_is_global_frame = !moveit::core::Transforms::sameFrame(
       plan->approach_.direction.header.frame_id, plan->shared_data_->ik_link_->getName());
-  bool retreat_direction_is_global_frame = !robot_state::Transforms::sameFrame(plan->retreat_.direction.header.frame_id,
+  bool retreat_direction_is_global_frame = !moveit::core::Transforms::sameFrame(plan->retreat_.direction.header.frame_id,
                                                                                plan->shared_data_->ik_link_->getName());
 
   // transform the input vectors in accordance to frame specified in the header;
@@ -222,7 +222,7 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
         planning_scene_->getFrameTransform(plan->retreat_.direction.header.frame_id).rotation() * retreat_direction;
 
   // state validity checking during the approach must ensure that the gripper posture is that for pre-grasping
-  robot_state::GroupStateValidityCallbackFn approach_valid_callback =
+  moveit::core::GroupStateValidityCallbackFn approach_valid_callback =
       boost::bind(&isStateCollisionFree, planning_scene_.get(), collision_matrix_.get(), verbose_,
                   &plan->approach_posture_, _1, _2, _3);
   plan->goal_sampler_->setVerbose(verbose_);
@@ -236,8 +236,8 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
       if (plan->shared_data_->minimize_object_distance_)
       {
         static const double MAX_CLOSE_UP_DIST = 1.0;
-        robot_state::RobotStatePtr close_up_state(new robot_state::RobotState(*plan->possible_goal_states_[i]));
-        std::vector<robot_state::RobotStatePtr> close_up_states;
+        moveit::core::RobotStatePtr close_up_state(new moveit::core::RobotState(*plan->possible_goal_states_[i]));
+        std::vector<moveit::core::RobotStatePtr> close_up_states;
         double d_close_up = moveit::core::CartesianInterpolator::computeCartesianPath(
             close_up_state.get(), plan->shared_data_->planning_group_, close_up_states, plan->shared_data_->ik_link_,
             approach_direction, approach_direction_is_global_frame, MAX_CLOSE_UP_DIST,
@@ -248,9 +248,9 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
       }
 
       // try to compute a straight line path that arrives at the goal using the specified approach direction
-      robot_state::RobotStatePtr first_approach_state(new robot_state::RobotState(*plan->possible_goal_states_[i]));
+      moveit::core::RobotStatePtr first_approach_state(new moveit::core::RobotState(*plan->possible_goal_states_[i]));
 
-      std::vector<robot_state::RobotStatePtr> approach_states;
+      std::vector<moveit::core::RobotStatePtr> approach_states;
       double d_approach = moveit::core::CartesianInterpolator::computeCartesianPath(
           first_approach_state.get(), plan->shared_data_->planning_group_, approach_states,
           plan->shared_data_->ik_link_, -approach_direction, approach_direction_is_global_frame,
@@ -273,14 +273,14 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
 
           // state validity checking during the retreat after the grasp must ensure the gripper posture is that of the
           // actual grasp
-          robot_state::GroupStateValidityCallbackFn retreat_valid_callback =
+          moveit::core::GroupStateValidityCallbackFn retreat_valid_callback =
               boost::bind(&isStateCollisionFree, planning_scene_after_approach.get(), collision_matrix_.get(), verbose_,
                           &plan->retreat_posture_, _1, _2, _3);
 
           // try to compute a straight line path that moves from the goal in a desired direction
-          robot_state::RobotStatePtr last_retreat_state(
-              new robot_state::RobotState(planning_scene_after_approach->getCurrentState()));
-          std::vector<robot_state::RobotStatePtr> retreat_states;
+          moveit::core::RobotStatePtr last_retreat_state(
+              new moveit::core::RobotState(planning_scene_after_approach->getCurrentState()));
+          std::vector<moveit::core::RobotStatePtr> retreat_states;
           double d_retreat = moveit::core::CartesianInterpolator::computeCartesianPath(
               last_retreat_state.get(), plan->shared_data_->planning_group_, retreat_states,
               plan->shared_data_->ik_link_, retreat_direction, retreat_direction_is_global_frame,

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -210,8 +210,8 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
   // otherwise, the frame is global
   bool approach_direction_is_global_frame = !moveit::core::Transforms::sameFrame(
       plan->approach_.direction.header.frame_id, plan->shared_data_->ik_link_->getName());
-  bool retreat_direction_is_global_frame = !moveit::core::Transforms::sameFrame(plan->retreat_.direction.header.frame_id,
-                                                                               plan->shared_data_->ik_link_->getName());
+  bool retreat_direction_is_global_frame = !moveit::core::Transforms::sameFrame(
+      plan->retreat_.direction.header.frame_id, plan->shared_data_->ik_link_->getName());
 
   // transform the input vectors in accordance to frame specified in the header;
   if (approach_direction_is_global_frame)

--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -73,7 +73,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
   std::string end_effector = goal.end_effector;
   if (end_effector.empty() && !planning_group.empty())
   {
-    const robot_model::JointModelGroup* jmg = planning_scene->getRobotModel()->getJointModelGroup(planning_group);
+    const moveit::core::JointModelGroup* jmg = planning_scene->getRobotModel()->getJointModelGroup(planning_group);
     if (!jmg)
     {
       error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
@@ -91,7 +91,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
   }
   else if (!end_effector.empty() && planning_group.empty())
   {
-    const robot_model::JointModelGroup* jmg = planning_scene->getRobotModel()->getEndEffector(end_effector);
+    const moveit::core::JointModelGroup* jmg = planning_scene->getRobotModel()->getEndEffector(end_effector);
     if (!jmg)
     {
       error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
@@ -109,7 +109,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
       ROS_INFO_STREAM_NAMED("manipulation", "Assuming the planning group for end effector '" << end_effector << "' is '"
                                                                                              << planning_group << "'");
   }
-  const robot_model::JointModelGroup* eef =
+  const moveit::core::JointModelGroup* eef =
       end_effector.empty() ? nullptr : planning_scene->getRobotModel()->getEndEffector(end_effector);
   if (!eef)
   {

--- a/moveit_ros/manipulation/pick_place/src/pick_place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick_place.cpp
@@ -125,7 +125,7 @@ void PickPlace::visualizePlan(const ManipulationPlanPtr& plan) const
       continue;
     if (first)
     {
-      robot_state::robotStateToRobotStateMsg(traj.trajectory_->getFirstWayPoint(), dtraj.trajectory_start);
+      moveit::core::robotStateToRobotStateMsg(traj.trajectory_->getFirstWayPoint(), dtraj.trajectory_start);
       first = false;
     }
     dtraj.trajectory.resize(dtraj.trajectory.size() + 1);
@@ -178,14 +178,14 @@ void PickPlace::visualizeGrasps(const std::vector<ManipulationPlanPtr>& plans) c
   if (plans.empty())
     return;
 
-  robot_state::RobotState state(getRobotModel());
+  moveit::core::RobotState state(getRobotModel());
   state.setToDefaultValues();
 
   static std::vector<std_msgs::ColorRGBA> colors(setupDefaultGraspColors());
   visualization_msgs::MarkerArray ma;
   for (const ManipulationPlanPtr& plan : plans)
   {
-    const robot_model::JointModelGroup* jmg = plan->shared_data_->end_effector_group_;
+    const moveit::core::JointModelGroup* jmg = plan->shared_data_->end_effector_group_;
     if (jmg)
     {
       unsigned int type = std::min(plan->processing_stage_, colors.size() - 1);

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -52,7 +52,7 @@ PlacePlan::PlacePlan(const PickPlaceConstPtr& pick_place) : PickPlacePlanBase(pi
 namespace
 {
 bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
-                                const robot_state::AttachedBody* attached_body, geometry_msgs::PoseStamped& place_pose)
+                                const moveit::core::AttachedBody* attached_body, geometry_msgs::PoseStamped& place_pose)
 {
   const EigenSTL::vector_Isometry3d& fixed_transforms = attached_body->getFixedTransforms();
   if (fixed_transforms.empty())
@@ -72,8 +72,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   double timeout = goal.allowed_planning_time;
   ros::WallTime endtime = ros::WallTime::now() + ros::WallDuration(timeout);
   std::string attached_object_name = goal.attached_object_name;
-  const robot_model::JointModelGroup* jmg = nullptr;
-  const robot_model::JointModelGroup* eef = nullptr;
+  const moveit::core::JointModelGroup* jmg = nullptr;
+  const moveit::core::JointModelGroup* eef = nullptr;
 
   // if the group specified is actually an end-effector, we use it as such
   if (planning_scene->getRobotModel()->hasEndEffector(goal.group_name))
@@ -113,8 +113,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
         // check to see if there is an end effector that has attached objects associaded, so we can complete the place
         for (const std::string& eef_name : eef_names)
         {
-          std::vector<const robot_state::AttachedBody*> attached_bodies;
-          const robot_model::JointModelGroup* eg = planning_scene->getRobotModel()->getEndEffector(eef_name);
+          std::vector<const moveit::core::AttachedBody*> attached_bodies;
+          const moveit::core::JointModelGroup* eg = planning_scene->getRobotModel()->getEndEffector(eef_name);
           if (eg)
           {
             // see if there are objects attached to links in the eef
@@ -122,11 +122,11 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
 
             // is is often possible that the objects are attached to the same link that the eef itself is attached,
             // so we check for attached bodies there as well
-            const robot_model::LinkModel* attached_link_model =
+            const moveit::core::LinkModel* attached_link_model =
                 planning_scene->getRobotModel()->getLinkModel(eg->getEndEffectorParentGroup().second);
             if (attached_link_model)
             {
-              std::vector<const robot_state::AttachedBody*> attached_bodies2;
+              std::vector<const moveit::core::AttachedBody*> attached_bodies2;
               planning_scene->getCurrentState().getAttachedBodies(attached_bodies2, attached_link_model);
               attached_bodies.insert(attached_bodies.end(), attached_bodies2.begin(), attached_bodies2.end());
             }
@@ -172,14 +172,14 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   // if we know the attached object, but not the eef, we can try to identify that
   if (!attached_object_name.empty() && !eef)
   {
-    const robot_state::AttachedBody* attached_body =
+    const moveit::core::AttachedBody* attached_body =
         planning_scene->getCurrentState().getAttachedBody(attached_object_name);
     if (attached_body)
     {
       // get the robot model link this attached body is associated to
-      const robot_model::LinkModel* link = attached_body->getAttachedLink();
+      const moveit::core::LinkModel* link = attached_body->getAttachedLink();
       // check to see if there is a unique end effector containing the link
-      const std::vector<const robot_model::JointModelGroup*>& eefs = planning_scene->getRobotModel()->getEndEffectors();
+      const std::vector<const moveit::core::JointModelGroup*>& eefs = planning_scene->getRobotModel()->getEndEffectors();
       for (const moveit::core::JointModelGroup* end_effector : eefs)
         if (end_effector->hasLinkModel(link->getName()))
         {
@@ -224,7 +224,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   {
     // in the first try, look for objects attached to the eef, if the eef is known;
     // otherwise, look for attached bodies in the planning group itself
-    std::vector<const robot_state::AttachedBody*> attached_bodies;
+    std::vector<const moveit::core::AttachedBody*> attached_bodies;
     planning_scene->getCurrentState().getAttachedBodies(attached_bodies, loop_count == 0 ? eef : jmg);
 
     loop_count++;
@@ -240,7 +240,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
       attached_object_name = attached_bodies[0]->getName();
   }
 
-  const robot_state::AttachedBody* attached_body =
+  const moveit::core::AttachedBody* attached_body =
       planning_scene->getCurrentState().getAttachedBody(attached_object_name);
   if (!attached_body)
   {

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -179,7 +179,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
       // get the robot model link this attached body is associated to
       const moveit::core::LinkModel* link = attached_body->getAttachedLink();
       // check to see if there is a unique end effector containing the link
-      const std::vector<const moveit::core::JointModelGroup*>& eefs = planning_scene->getRobotModel()->getEndEffectors();
+      const std::vector<const moveit::core::JointModelGroup*>& eefs =
+          planning_scene->getRobotModel()->getEndEffectors();
       for (const moveit::core::JointModelGroup* end_effector : eefs)
         if (end_effector->hasLinkModel(link->getName()))
         {

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -77,7 +77,7 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
       // We have a valid motion plan, now apply pre-approach end effector posture (open gripper) if applicable
       if (!plan->approach_posture_.joint_names.empty())
       {
-        robot_state::RobotStatePtr pre_approach_state(new robot_state::RobotState(res.trajectory_->getLastWayPoint()));
+        moveit::core::RobotStatePtr pre_approach_state(new moveit::core::RobotState(res.trajectory_->getLastWayPoint()));
         robot_trajectory::RobotTrajectoryPtr pre_approach_traj(new robot_trajectory::RobotTrajectory(
             pre_approach_state->getRobotModel(), plan->shared_data_->end_effector_group_->getName()));
         pre_approach_traj->setRobotTrajectoryMsg(*pre_approach_state, plan->approach_posture_);

--- a/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/plan_stage.cpp
@@ -77,7 +77,8 @@ bool PlanStage::evaluate(const ManipulationPlanPtr& plan) const
       // We have a valid motion plan, now apply pre-approach end effector posture (open gripper) if applicable
       if (!plan->approach_posture_.joint_names.empty())
       {
-        moveit::core::RobotStatePtr pre_approach_state(new moveit::core::RobotState(res.trajectory_->getLastWayPoint()));
+        moveit::core::RobotStatePtr pre_approach_state(
+            new moveit::core::RobotState(res.trajectory_->getLastWayPoint()));
         robot_trajectory::RobotTrajectoryPtr pre_approach_traj(new robot_trajectory::RobotTrajectory(
             pre_approach_state->getRobotModel(), plan->shared_data_->end_effector_group_->getName()));
         pre_approach_traj->setRobotTrajectoryMsg(*pre_approach_state, plan->approach_posture_);

--- a/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
+++ b/moveit_ros/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
@@ -55,8 +55,8 @@ namespace
 {
 bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
                           const collision_detection::AllowedCollisionMatrix* collision_matrix, bool verbose,
-                          const pick_place::ManipulationPlan* manipulation_plan, robot_state::RobotState* state,
-                          const robot_model::JointModelGroup* group, const double* joint_group_variable_values)
+                          const pick_place::ManipulationPlan* manipulation_plan, moveit::core::RobotState* state,
+                          const moveit::core::JointModelGroup* group, const double* joint_group_variable_values)
 {
   collision_detection::CollisionRequest req;
   req.verbose = verbose;
@@ -90,7 +90,7 @@ bool isStateCollisionFree(const planning_scene::PlanningScene* planning_scene,
 }  // namespace
 
 bool pick_place::ReachableAndValidPoseFilter::isEndEffectorFree(const ManipulationPlanPtr& plan,
-                                                                robot_state::RobotState& token_state) const
+                                                                moveit::core::RobotState& token_state) const
 {
   tf2::fromMsg(plan->goal_pose_.pose, plan->transformed_goal_pose_);
   plan->transformed_goal_pose_ =
@@ -107,14 +107,14 @@ bool pick_place::ReachableAndValidPoseFilter::isEndEffectorFree(const Manipulati
 bool pick_place::ReachableAndValidPoseFilter::evaluate(const ManipulationPlanPtr& plan) const
 {
   // initialize with scene state
-  robot_state::RobotStatePtr token_state(new robot_state::RobotState(planning_scene_->getCurrentState()));
+  moveit::core::RobotStatePtr token_state(new moveit::core::RobotState(planning_scene_->getCurrentState()));
   if (isEndEffectorFree(plan, *token_state))
   {
     // update the goal pose message if anything has changed; this is because the name of the frame in the input goal
     // pose
     // can be that of objects in the collision world but most components are unaware of those transforms,
     // so we convert to a frame that is certainly known
-    if (!robot_state::Transforms::sameFrame(planning_scene_->getPlanningFrame(), plan->goal_pose_.header.frame_id))
+    if (!moveit::core::Transforms::sameFrame(planning_scene_->getPlanningFrame(), plan->goal_pose_.header.frame_id))
     {
       plan->goal_pose_.pose = tf2::toMsg(plan->transformed_goal_pose_);
       plan->goal_pose_.header.frame_id = planning_scene_->getPlanningFrame();

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.h
@@ -53,10 +53,10 @@ private:
   bool computeIKService(moveit_msgs::GetPositionIK::Request& req, moveit_msgs::GetPositionIK::Response& res);
   bool computeFKService(moveit_msgs::GetPositionFK::Request& req, moveit_msgs::GetPositionFK::Response& res);
 
-  void computeIK(
-      moveit_msgs::PositionIKRequest& req, moveit_msgs::RobotState& solution, moveit_msgs::MoveItErrorCodes& error_code,
-      moveit::core::RobotState& rs,
-      const moveit::core::GroupStateValidityCallbackFn& constraint = moveit::core::GroupStateValidityCallbackFn()) const;
+  void computeIK(moveit_msgs::PositionIKRequest& req, moveit_msgs::RobotState& solution,
+                 moveit_msgs::MoveItErrorCodes& error_code, moveit::core::RobotState& rs,
+                 const moveit::core::GroupStateValidityCallbackFn& constraint =
+                     moveit::core::GroupStateValidityCallbackFn()) const;
 
   ros::ServiceServer fk_service_;
   ros::ServiceServer ik_service_;

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.h
@@ -55,8 +55,8 @@ private:
 
   void computeIK(
       moveit_msgs::PositionIKRequest& req, moveit_msgs::RobotState& solution, moveit_msgs::MoveItErrorCodes& error_code,
-      robot_state::RobotState& rs,
-      const robot_state::GroupStateValidityCallbackFn& constraint = robot_state::GroupStateValidityCallbackFn()) const;
+      moveit::core::RobotState& rs,
+      const moveit::core::GroupStateValidityCallbackFn& constraint = moveit::core::GroupStateValidityCallbackFn()) const;
 
   ros::ServiceServer fk_service_;
   ros::ServiceServer ik_service_;

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -106,7 +106,7 @@ void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const moveit_msgs::M
   if (moveit::core::isEmpty(goal->planning_options.planning_scene_diff))
   {
     planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
-    const robot_state::RobotState& current_state = lscene->getCurrentState();
+    const moveit::core::RobotState& current_state = lscene->getCurrentState();
 
     // check to see if the desired constraints are already met
     for (std::size_t i = 0; i < goal->request.goal_constraints.size(); ++i)

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -56,8 +56,8 @@ bool MoveGroupStateValidationService::computeService(moveit_msgs::GetStateValidi
                                                      moveit_msgs::GetStateValidity::Response& res)
 {
   planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
-  robot_state::RobotState rs = ls->getCurrentState();
-  robot_state::robotStateMsgToRobotState(req.robot_state, rs);
+  moveit::core::RobotState rs = ls->getCurrentState();
+  moveit::core::robotStateMsgToRobotState(req.robot_state, rs);
 
   res.valid = true;
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -98,10 +98,10 @@ void TfPublisher::publishPlanningSceneFrames()
         publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
 
-      const robot_state::RobotState& rs = locked_planning_scene->getCurrentState();
-      std::vector<const robot_state::AttachedBody*> attached_collision_objects;
+      const moveit::core::RobotState& rs = locked_planning_scene->getCurrentState();
+      std::vector<const moveit::core::AttachedBody*> attached_collision_objects;
       rs.getAttachedBodies(attached_collision_objects);
-      for (const robot_state::AttachedBody* attached_body : attached_collision_objects)
+      for (const moveit::core::AttachedBody* attached_body : attached_collision_objects)
       {
         std::string object_frame = prefix_ + attached_body->getName();
         transform = tf2::eigenToTransform(attached_body->getFixedTransforms()[0]);

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -57,7 +57,7 @@ void move_group::MoveGroupCapability::convertToMsg(const std::vector<plan_execut
       {
         if (first && !trajectory[i].trajectory_->empty())
         {
-          robot_state::robotStateToRobotStateMsg(trajectory[i].trajectory_->getFirstWayPoint(), first_state_msg);
+          moveit::core::robotStateToRobotStateMsg(trajectory[i].trajectory_->getFirstWayPoint(), first_state_msg);
           first = false;
         }
         trajectory[i].trajectory_->getRobotTrajectoryMsg(trajectory_msg[i]);
@@ -72,7 +72,7 @@ void move_group::MoveGroupCapability::convertToMsg(const robot_trajectory::Robot
 {
   if (trajectory && !trajectory->empty())
   {
-    robot_state::robotStateToRobotStateMsg(trajectory->getFirstWayPoint(), first_state_msg);
+    moveit::core::robotStateToRobotStateMsg(trajectory->getFirstWayPoint(), first_state_msg);
     trajectory->getRobotTrajectoryMsg(trajectory_msg);
   }
 }

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -176,8 +176,8 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
 void mesh_filter::DepthSelfFiltering::addMeshes(MeshFilter<StereoCameraModel>& mesh_filter)
 {
   robot_model_loader::RobotModelLoader robotModelLoader("robot_description");
-  robot_model::RobotModelConstPtr robotModel = robotModelLoader.getModel();
-  const vector<robot_model::LinkModel*>& links = robotModel->getLinkModelsWithCollisionGeometry();
+  moveit::core::RobotModelConstPtr robotModel = robotModelLoader.getModel();
+  const vector<moveit::core::LinkModel*>& links = robotModel->getLinkModelsWithCollisionGeometry();
   for (size_t i = 0; i < links.size(); ++i)
   {
     shapes::ShapeConstPtr shape = links[i]->getShape();

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -129,7 +129,7 @@ void TransformProvider::setUpdateInterval(unsigned long usecs)
 void TransformProvider::updateTransforms()
 {
   static tf2::Stamped<Isometry3d> input_transform, output_transform;
-  static robot_state::RobotStatePtr robot_state;
+  static moveit::core::RobotStatePtr robot_state;
   robot_state = psm_->getStateMonitor()->getCurrentState();
   try
   {

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -79,11 +79,11 @@ public:
 
   /** \brief Get a function pointer that allocates and initializes a kinematics solver. If not previously called, this
    * function reads the SRDF and calls the variant below. */
-  robot_model::SolverAllocatorFn getLoaderFunction();
+  moveit::core::SolverAllocatorFn getLoaderFunction();
 
   /** \brief Get a function pointer that allocates and initializes a kinematics solver. If not previously called, this
    * function reads ROS parameters for the groups defined in the SRDF. */
-  robot_model::SolverAllocatorFn getLoaderFunction(const srdf::ModelSharedPtr& srdf_model);
+  moveit::core::SolverAllocatorFn getLoaderFunction(const srdf::ModelSharedPtr& srdf_model);
 
   /** \brief Get the groups for which the function pointer returned by getLoaderFunction() can allocate a solver */
   const std::vector<std::string>& getKnownGroups() const

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -84,7 +84,7 @@ public:
    * \param jmg - joint model group pointer
    * \return tips - list of valid links in a planning group to plan for
    */
-  std::vector<std::string> chooseTipFrames(const robot_model::JointModelGroup* jmg)
+  std::vector<std::string> chooseTipFrames(const moveit::core::JointModelGroup* jmg)
   {
     std::vector<std::string> tips;
     std::map<std::string, std::vector<std::string> >::const_iterator ik_it =
@@ -124,7 +124,7 @@ public:
     return tips;
   }
 
-  kinematics::KinematicsBasePtr allocKinematicsSolver(const robot_model::JointModelGroup* jmg)
+  kinematics::KinematicsBasePtr allocKinematicsSolver(const moveit::core::JointModelGroup* jmg)
   {
     kinematics::KinematicsBasePtr result;
     if (!kinematics_loader_)
@@ -137,7 +137,7 @@ public:
       ROS_ERROR_NAMED(LOGNAME, "Specified group is NULL. Cannot allocate kinematics solver.");
       return result;
     }
-    const std::vector<const robot_model::LinkModel*>& links = jmg->getLinkModels();
+    const std::vector<const moveit::core::LinkModel*>& links = jmg->getLinkModels();
     if (links.empty())
     {
       ROS_ERROR_NAMED(LOGNAME, "No links specified for group '%s'. Cannot allocate kinematics solver.",
@@ -211,7 +211,7 @@ public:
   // cache solver between two consecutive calls
   // first call in RobotModelLoader::loadKinematicsSolvers() is just to check suitability for jmg
   // second call in JointModelGroup::setSolverAllocators() is to actually retrieve the instance for use
-  kinematics::KinematicsBasePtr allocKinematicsSolverWithCache(const robot_model::JointModelGroup* jmg)
+  kinematics::KinematicsBasePtr allocKinematicsSolverWithCache(const moveit::core::JointModelGroup* jmg)
   {
     boost::mutex::scoped_lock slock(cache_lock_);
     kinematics::KinematicsBasePtr& cached = instances_[jmg];
@@ -239,7 +239,7 @@ private:
   std::map<std::string, std::vector<std::string> > iksolver_to_tip_links_;  // a map between each ik solver and a vector
                                                                             // of custom-specified tip link(s)
   std::shared_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> > kinematics_loader_;
-  std::map<const robot_model::JointModelGroup*, kinematics::KinematicsBasePtr> instances_;
+  std::map<const moveit::core::JointModelGroup*, kinematics::KinematicsBasePtr> instances_;
   boost::mutex lock_;
   boost::mutex cache_lock_;
 };
@@ -252,7 +252,7 @@ void KinematicsPluginLoader::status() const
     ROS_INFO_NAMED(LOGNAME, "Loader function was never required");
 }
 
-robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction()
+moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction()
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction");
@@ -265,7 +265,7 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction()
   return getLoaderFunction(rml.getSRDF());
 }
 
-robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const srdf::ModelSharedPtr& srdf_model)
+moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const srdf::ModelSharedPtr& srdf_model)
 {
   moveit::tools::Profiler::ScopedStart prof_start;
   moveit::tools::Profiler::ScopedBlock prof_block("KinematicsPluginLoader::getLoaderFunction(SRDF)");

--- a/moveit_ros/planning/planning_components_tools/src/compare_collision_speed_checking_fcl_bullet.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/compare_collision_speed_checking_fcl_bullet.cpp
@@ -92,7 +92,7 @@ void clutterWorld(const planning_scene::PlanningScenePtr& planning_scene, const 
       planning_scene->getRobotModel()->getLinkModelNames(), true) };
 
   // set the robot state to home position
-  robot_state::RobotState& current_state{ planning_scene->getCurrentStateNonConst() };
+  moveit::core::RobotState& current_state{ planning_scene->getCurrentStateNonConst() };
   collision_detection::CollisionRequest req;
   current_state.setToDefaultValues(current_state.getJointModelGroup("panda_arm"), "home");
   current_state.update();
@@ -170,7 +170,7 @@ void clutterWorld(const planning_scene::PlanningScenePtr& planning_scene, const 
 *   \param CollisionDetector The type of collision detector
 *   \param only_self Flag for only self collision check performed */
 void runCollisionDetection(unsigned int trials, const planning_scene::PlanningScenePtr& scene,
-                           const std::vector<robot_state::RobotState>& states, const CollisionDetector col_detector,
+                           const std::vector<moveit::core::RobotState>& states, const CollisionDetector col_detector,
                            bool only_self, bool distance = false)
 {
   collision_detection::AllowedCollisionMatrix acm{ collision_detection::AllowedCollisionMatrix(
@@ -247,9 +247,9 @@ void runCollisionDetection(unsigned int trials, const planning_scene::PlanningSc
  *  \param scene The planning scene
  *  \param robot_states Result vector */
 void findStates(const RobotStateSelector desired_states, unsigned int num_states,
-                const planning_scene::PlanningScenePtr& scene, std::vector<robot_state::RobotState>& robot_states)
+                const planning_scene::PlanningScenePtr& scene, std::vector<moveit::core::RobotState>& robot_states)
 {
-  robot_state::RobotState& current_state{ scene->getCurrentStateNonConst() };
+  moveit::core::RobotState& current_state{ scene->getCurrentStateNonConst() };
   collision_detection::CollisionRequest req;
 
   size_t i{ 0 };
@@ -290,7 +290,7 @@ void findStates(const RobotStateSelector desired_states, unsigned int num_states
 
 int main(int argc, char** argv)
 {
-  robot_model::RobotModelPtr robot_model;
+  moveit::core::RobotModelPtr robot_model;
   ros::init(argc, argv, "compare_collision_checking_speed");
   ros::NodeHandle node_handle;
 
@@ -322,11 +322,11 @@ int main(int argc, char** argv)
   {
     ros::Duration(0.5).sleep();
 
-    robot_state::RobotState& current_state{ planning_scene->getCurrentStateNonConst() };
+    moveit::core::RobotState& current_state{ planning_scene->getCurrentStateNonConst() };
     current_state.setToDefaultValues(current_state.getJointModelGroup("panda_arm"), "home");
     current_state.update();
 
-    std::vector<robot_state::RobotState> sampled_states;
+    std::vector<moveit::core::RobotState> sampled_states;
     sampled_states.push_back(current_state);
 
     ROS_INFO("Starting benchmark: Robot in empty world, only self collision check");
@@ -346,7 +346,7 @@ int main(int argc, char** argv)
     current_state.setJointPositions("panda_joint2", &joint_2);
     current_state.update();
 
-    std::vector<robot_state::RobotState> sampled_states_2;
+    std::vector<moveit::core::RobotState> sampled_states_2;
     sampled_states_2.push_back(current_state);
 
     ROS_INFO("Starting benchmark: Robot in cluttered world, in collision with world");

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
@@ -41,7 +41,7 @@
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
 void runCollisionDetection(unsigned int id, unsigned int trials, const planning_scene::PlanningScene* scene,
-                           const robot_state::RobotState* state)
+                           const moveit::core::RobotState* state)
 {
   ROS_INFO("Starting thread %u", id);
   collision_detection::CollisionRequest req;
@@ -95,12 +95,12 @@ int main(int argc, char** argv)
     else
       ros::Duration(0.5).sleep();
 
-    std::vector<robot_state::RobotStatePtr> states;
+    std::vector<moveit::core::RobotStatePtr> states;
     ROS_INFO("Sampling %u valid states...", nthreads);
     for (unsigned int i = 0; i < nthreads; ++i)
     {
       // sample a valid state
-      robot_state::RobotState* state = new robot_state::RobotState(psm.getPlanningScene()->getRobotModel());
+      moveit::core::RobotState* state = new moveit::core::RobotState(psm.getPlanningScene()->getRobotModel());
       collision_detection::CollisionRequest req;
       do
       {
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
         if (!res.collision)
           break;
       } while (true);
-      states.push_back(robot_state::RobotStatePtr(state));
+      states.push_back(moveit::core::RobotStatePtr(state));
     }
 
     std::vector<boost::thread*> threads;

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
@@ -51,11 +51,11 @@ int main(int argc, char** argv)
   robot_model_loader::RobotModelLoader rml(ROBOT_DESCRIPTION);
   ros::Duration(0.5).sleep();
 
-  robot_model::RobotModelConstPtr robot_model = rml.getModel();
+  moveit::core::RobotModelConstPtr robot_model = rml.getModel();
   if (robot_model)
   {
     static const int N = 10000;
-    robot_state::RobotState state(robot_model);
+    moveit::core::RobotState state(robot_model);
 
     printf("Evaluating model '%s' using %d trials for each test\n", robot_model->getName().c_str(), N);
 
@@ -80,12 +80,12 @@ int main(int argc, char** argv)
       moveit::tools::Profiler::End("FK Random");
     }
 
-    std::vector<robot_state::RobotState*> copies(N, (robot_state::RobotState*)nullptr);
+    std::vector<moveit::core::RobotState*> copies(N, (moveit::core::RobotState*)nullptr);
     printf("Evaluating Copy State ...\n");
     for (int i = 0; i < N; ++i)
     {
       moveit::tools::Profiler::Begin("Copy State");
-      copies[i] = new robot_state::RobotState(state);
+      copies[i] = new moveit::core::RobotState(state);
       moveit::tools::Profiler::End("Copy State");
     }
 
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
     for (const std::string& group : groups)
     {
       printf("\n");
-      const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
+      const moveit::core::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
 
       printf("%s: Evaluating FK Random ...\n", group.c_str());
       std::string pname = group + ":FK Random";

--- a/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
@@ -56,14 +56,14 @@ int main(int argc, char** argv)
     std::string group = argv[1];
     ROS_INFO_STREAM("Evaluating IK for " << group);
 
-    const robot_model::JointModelGroup* jmg = rml.getModel()->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = rml.getModel()->getJointModelGroup(group);
     if (jmg)
     {
       const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
       if (solver)
       {
         const std::string& tip = solver->getTipFrame();
-        robot_state::RobotState state(rml.getModel());
+        moveit::core::RobotState state(rml.getModel());
         state.setToDefaultValues();
 
         ROS_INFO_STREAM("Tip Frame:  " << solver->getTipFrame());

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -75,7 +75,7 @@ public:
       \param adapter_plugins_param_name The name of the ROS parameter under which the names of the request adapter
      plugins are specified (plugin names separated by space; order matters)
   */
-  PlanningPipeline(const robot_model::RobotModelConstPtr& model, const ros::NodeHandle& nh = ros::NodeHandle("~"),
+  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& nh = ros::NodeHandle("~"),
                    const std::string& planning_plugin_param_name = "planning_plugin",
                    const std::string& adapter_plugins_param_name = "request_adapters");
 
@@ -85,7 +85,7 @@ public:
       \param planning_plugin_name The name of the planning plugin to load
       \param adapter_plugins_names The names of the planning request adapter plugins to load
   */
-  PlanningPipeline(const robot_model::RobotModelConstPtr& model, const ros::NodeHandle& nh,
+  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& nh,
                    const std::string& planning_plugin_name, const std::vector<std::string>& adapter_plugin_names);
 
   /** \brief Pass a flag telling the pipeline whether or not to publish the computed motion plans on DISPLAY_PATH_TOPIC.
@@ -160,7 +160,7 @@ public:
   }
 
   /** \brief Get the robot model that this pipeline is using */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -187,7 +187,7 @@ private:
   std::unique_ptr<planning_request_adapter::PlanningRequestAdapterChain> adapter_chain_;
   std::vector<std::string> adapter_plugin_names_;
 
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
   /// Flag indicating whether the reported plans should be checked once again, by the planning pipeline itself
   bool check_solution_paths_;

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -48,7 +48,7 @@ const std::string planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC = "dis
 const std::string planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC = "motion_plan_request";
 const std::string planning_pipeline::PlanningPipeline::MOTION_CONTACTS_TOPIC = "display_contacts";
 
-planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotModelConstPtr& model,
+planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
                                                       const ros::NodeHandle& nh,
                                                       const std::string& planner_plugin_param_name,
                                                       const std::string& adapter_plugins_param_name)
@@ -70,7 +70,7 @@ planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotMo
   configure();
 }
 
-planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotModelConstPtr& model,
+planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
                                                       const ros::NodeHandle& nh, const std::string& planner_plugin_name,
                                                       const std::vector<std::string>& adapter_plugin_names)
   : nh_(nh), planner_plugin_name_(planner_plugin_name), adapter_plugin_names_(adapter_plugin_names), robot_model_(model)
@@ -298,7 +298,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
             for (std::size_t it : index)
             {
               // check validity with verbose on
-              const robot_state::RobotState& robot_state = res.trajectory_->getWayPoint(it);
+              const moveit::core::RobotState& robot_state = res.trajectory_->getWayPoint(it);
               planning_scene->isStateValid(robot_state, req.path_constraints, req.group_name, true);
 
               // compute the contacts if any
@@ -338,7 +338,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     disp.model_id = robot_model_->getName();
     disp.trajectory.resize(1);
     res.trajectory_->getRobotTrajectoryMsg(disp.trajectory[0]);
-    robot_state::robotStateToRobotStateMsg(res.trajectory_->getFirstWayPoint(), disp.trajectory_start);
+    moveit::core::robotStateToRobotStateMsg(res.trajectory_->getFirstWayPoint(), disp.trajectory_start);
     display_path_publisher_.publish(disp);
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -84,10 +84,10 @@ public:
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 
     // get the specified start state
-    robot_state::RobotState start_state = planning_scene->getCurrentState();
-    robot_state::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
+    moveit::core::RobotState start_state = planning_scene->getCurrentState();
+    moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
 
-    const std::vector<const robot_model::JointModel*>& jmodels =
+    const std::vector<const moveit::core::JointModel*>& jmodels =
         planning_scene->getRobotModel()->hasJointModelGroup(req.group_name) ?
             planning_scene->getRobotModel()->getJointModelGroup(req.group_name)->getJointModels() :
             planning_scene->getRobotModel()->getJointModels();
@@ -101,9 +101,9 @@ public:
       // how many times the joint was wrapped. Because of this, we remember the offsets for continuous
       // joints, and we un-do them when the plan comes from the planner
 
-      if (jm->getType() == robot_model::JointModel::REVOLUTE)
+      if (jm->getType() == moveit::core::JointModel::REVOLUTE)
       {
-        if (static_cast<const robot_model::RevoluteJointModel*>(jm)->isContinuous())
+        if (static_cast<const moveit::core::RevoluteJointModel*>(jm)->isContinuous())
         {
           double initial = start_state.getJointPositions(jm)[0];
           start_state.enforceBounds(jm);
@@ -114,11 +114,11 @@ public:
       }
       else
           // Normalize yaw; no offset needs to be remembered
-          if (jm->getType() == robot_model::JointModel::PLANAR)
+          if (jm->getType() == moveit::core::JointModel::PLANAR)
       {
         const double* p = start_state.getJointPositions(jm);
         double copy[3] = { p[0], p[1], p[2] };
-        if (static_cast<const robot_model::PlanarJointModel*>(jm)->normalizeRotation(copy))
+        if (static_cast<const moveit::core::PlanarJointModel*>(jm)->normalizeRotation(copy))
         {
           start_state.setJointPositions(jm, copy);
           change_req = true;
@@ -126,11 +126,11 @@ public:
       }
       else
           // Normalize quaternions
-          if (jm->getType() == robot_model::JointModel::FLOATING)
+          if (jm->getType() == moveit::core::JointModel::FLOATING)
       {
         const double* p = start_state.getJointPositions(jm);
         double copy[7] = { p[0], p[1], p[2], p[3], p[4], p[5], p[6] };
-        if (static_cast<const robot_model::FloatingJointModel*>(jm)->normalizeRotation(copy))
+        if (static_cast<const moveit::core::FloatingJointModel*>(jm)->normalizeRotation(copy))
         {
           start_state.setJointPositions(jm, copy);
           change_req = true;
@@ -139,7 +139,7 @@ public:
     }
 
     // pointer to a prefix state we could possibly add, if we detect we have to make changes
-    robot_state::RobotStatePtr prefix_state;
+    moveit::core::RobotStatePtr prefix_state;
     for (const moveit::core::JointModel* jmodel : jmodels)
     {
       if (!start_state.satisfiesBounds(jmodel))
@@ -147,7 +147,7 @@ public:
         if (start_state.satisfiesBounds(jmodel, bounds_dist_))
         {
           if (!prefix_state)
-            prefix_state.reset(new robot_state::RobotState(start_state));
+            prefix_state.reset(new moveit::core::RobotState(start_state));
           start_state.enforceBounds(jmodel);
           change_req = true;
           ROS_INFO("Starting state is just outside bounds (joint '%s'). Assuming within bounds.",
@@ -161,7 +161,7 @@ public:
           const double* p = start_state.getJointPositions(jmodel);
           for (std::size_t k = 0; k < jmodel->getVariableCount(); ++k)
             joint_values << p[k] << " ";
-          const robot_model::JointModel::Bounds& b = jmodel->getVariableBounds();
+          const moveit::core::JointModel::Bounds& b = jmodel->getVariableBounds();
           for (const moveit::core::VariableBounds& variable_bounds : b)
           {
             joint_bounds_low << variable_bounds.min_position_ << " ";
@@ -181,7 +181,7 @@ public:
     if (change_req)
     {
       planning_interface::MotionPlanRequest req2 = req;
-      robot_state::robotStateToRobotStateMsg(start_state, req2.start_state, false);
+      moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state, false);
       solved = planner(planning_scene, req2, res);
     }
     else

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -99,8 +99,8 @@ public:
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 
     // get the specified start state
-    robot_state::RobotState start_state = planning_scene->getCurrentState();
-    robot_state::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
+    moveit::core::RobotState start_state = planning_scene->getCurrentState();
+    moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
 
     collision_detection::CollisionRequest creq;
     creq.group_name = req.group_name;
@@ -119,10 +119,10 @@ public:
       else
         ROS_INFO_STREAM("Start state appears to be in collision with respect to group " << creq.group_name);
 
-      robot_state::RobotStatePtr prefix_state(new robot_state::RobotState(start_state));
+      moveit::core::RobotStatePtr prefix_state(new moveit::core::RobotState(start_state));
       random_numbers::RandomNumberGenerator& rng = prefix_state->getRandomNumberGenerator();
 
-      const std::vector<const robot_model::JointModel*>& jmodels =
+      const std::vector<const moveit::core::JointModel*>& jmodels =
           planning_scene->getRobotModel()->hasJointModelGroup(req.group_name) ?
               planning_scene->getRobotModel()->getJointModelGroup(req.group_name)->getJointModels() :
               planning_scene->getRobotModel()->getJointModels();
@@ -151,7 +151,7 @@ public:
       if (found)
       {
         planning_interface::MotionPlanRequest req2 = req;
-        robot_state::robotStateToRobotStateMsg(start_state, req2.start_state);
+        moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
         bool solved = planner(planning_scene, req2, res);
         if (solved && !res.trajectory_->empty())
         {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -66,8 +66,8 @@ public:
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 
     // get the specified start state
-    robot_state::RobotState start_state = planning_scene->getCurrentState();
-    robot_state::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
+    moveit::core::RobotState start_state = planning_scene->getCurrentState();
+    moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
 
     // if the start state is otherwise valid but does not meet path constraints
     if (planning_scene->isStateValid(start_state, req.group_name) &&
@@ -95,7 +95,7 @@ public:
         ROS_INFO("Planned to path constraints. Resuming original planning request.");
 
         // extract the last state of the computed motion plan and set it as the new start state
-        robot_state::robotStateToRobotStateMsg(res2.trajectory_->getLastWayPoint(), req3.start_state);
+        moveit::core::robotStateToRobotStateMsg(res2.trajectory_->getLastWayPoint(), req3.start_state);
         bool solved2 = planner(planning_scene, req3, res);
         res.planning_time_ += res2.planning_time_;
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -60,7 +60,7 @@ public:
    * @param robot_model The current kinematic model to build on
    * @param tf_buffer A pointer to the tf2_ros Buffer to use
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+  CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
   /** @brief Constructor.
@@ -68,7 +68,7 @@ public:
    *  @param tf_buffer A pointer to the tf2_ros Buffer to use
    *  @param nh A ros::NodeHandle to pass node specific options
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+  CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::NodeHandle& nh);
 
   ~CurrentStateMonitor();
@@ -86,7 +86,7 @@ public:
   bool isActive() const;
 
   /** @brief Get the RobotModel for which we are monitoring state */
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -120,17 +120,17 @@ public:
 
   /** @brief Get the current state
    *  @return Returns the current state */
-  robot_state::RobotStatePtr getCurrentState() const;
+  moveit::core::RobotStatePtr getCurrentState() const;
 
   /** @brief Set the state \e upd to the current state maintained by this class. */
-  void setToCurrentState(robot_state::RobotState& upd) const;
+  void setToCurrentState(moveit::core::RobotState& upd) const;
 
   /** @brief Get the time stamp for the current state */
   ros::Time getCurrentStateTime() const;
 
   /** @brief Get the current state and its time stamp
    *  @return Returns a pair of the current state and its time stamp */
-  std::pair<robot_state::RobotStatePtr, ros::Time> getCurrentStateAndTime() const;
+  std::pair<moveit::core::RobotStatePtr, ros::Time> getCurrentStateAndTime() const;
 
   /** @brief Get the current state values as a map from joint names to joint state values
    *  @return Returns the map from joint names to joint state values*/
@@ -193,8 +193,8 @@ private:
 
   ros::NodeHandle nh_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  robot_model::RobotModelConstPtr robot_model_;
-  robot_state::RobotState robot_state_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotState robot_state_;
   std::map<const moveit::core::JointModel*, ros::Time> joint_time_;
   bool state_monitor_started_;
   bool copy_dynamics_;  // Copy velocity and effort from joint_state

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -170,7 +170,7 @@ public:
     return rm_loader_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -437,7 +437,7 @@ protected:
   void attachObjectCallback(const moveit_msgs::AttachedCollisionObjectConstPtr& obj);
 
   /** @brief Callback for a change for an attached object of the current state of the planning scene */
-  void currentStateAttachedBodyUpdateCallback(robot_state::AttachedBody* attached_body, bool just_attached);
+  void currentStateAttachedBodyUpdateCallback(moveit::core::AttachedBody* attached_body, bool just_attached);
 
   /** @brief Callback for a change in the world maintained by the planning scene */
   void currentWorldObjectUpdateCallback(const collision_detection::World::ObjectConstPtr& object,
@@ -453,8 +453,8 @@ protected:
 
   void excludeAttachedBodiesFromOctree();
   void includeAttachedBodiesInOctree();
-  void excludeAttachedBodyFromOctree(const robot_state::AttachedBody* attached_body);
-  void includeAttachedBodyInOctree(const robot_state::AttachedBody* attached_body);
+  void excludeAttachedBodyFromOctree(const moveit::core::AttachedBody* attached_body);
+  void includeAttachedBodyInOctree(const moveit::core::AttachedBody* attached_body);
 
   bool getShapeTransformCache(const std::string& target_frame, const ros::Time& target_time,
                               occupancy_map_monitor::ShapeTransformCache& cache) const;
@@ -516,10 +516,10 @@ protected:
   // include a current state monitor
   CurrentStateMonitorPtr current_state_monitor_;
 
-  typedef std::map<const robot_model::LinkModel*,
+  typedef std::map<const moveit::core::LinkModel*,
                    std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > >
       LinkShapeHandles;
-  typedef std::map<const robot_state::AttachedBody*,
+  typedef std::map<const moveit::core::AttachedBody*,
                    std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > >
       AttachedBodyShapeHandles;
   typedef std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, const Eigen::Isometry3d*> > >
@@ -580,7 +580,7 @@ private:
   ros::WallTime last_robot_state_update_wall_time_;
 
   robot_model_loader::RobotModelLoaderPtr rm_loader_;
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
   collision_detection::CollisionPluginLoader collision_loader_;
 
@@ -596,7 +596,7 @@ private:
  * "operator->" functions.  Therefore you will often see code like this:
  * @code
  *   planning_scene_monitor::LockedPlanningSceneRO ls(planning_scene_monitor);
- *   robot_model::RobotModelConstPtr model = ls->getRobotModel();
+ *   moveit::core::RobotModelConstPtr model = ls->getRobotModel();
  * @endcode
 
  * The function "getRobotModel()" is a member of PlanningScene and not
@@ -688,7 +688,7 @@ protected:
  * "operator->" functions.  Therefore you will often see code like this:
  * @code
  *   planning_scene_monitor::LockedPlanningSceneRW ls(planning_scene_monitor);
- *   robot_model::RobotModelConstPtr model = ls->getRobotModel();
+ *   moveit::core::RobotModelConstPtr model = ls->getRobotModel();
  * @endcode
 
  * The function "getRobotModel()" is a member of PlanningScene and not

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -44,7 +44,7 @@
 
 namespace planning_scene_monitor
 {
-typedef boost::function<void(const robot_state::RobotStateConstPtr& state, const ros::Time& stamp)>
+typedef boost::function<void(const moveit::core::RobotStateConstPtr& state, const ros::Time& stamp)>
     TrajectoryStateAddedCallback;
 
 MOVEIT_CLASS_FORWARD(TrajectoryMonitor);

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -41,13 +41,13 @@
 
 #include <limits>
 
-planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                                                                  const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
   : CurrentStateMonitor(robot_model, tf_buffer, ros::NodeHandle())
 {
 }
 
-planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                                                                  const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                  const ros::NodeHandle& nh)
   : nh_(nh)
@@ -66,11 +66,11 @@ planning_scene_monitor::CurrentStateMonitor::~CurrentStateMonitor()
   stopStateMonitor();
 }
 
-robot_state::RobotStatePtr planning_scene_monitor::CurrentStateMonitor::getCurrentState() const
+moveit::core::RobotStatePtr planning_scene_monitor::CurrentStateMonitor::getCurrentState() const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
-  robot_state::RobotState* result = new robot_state::RobotState(robot_state_);
-  return robot_state::RobotStatePtr(result);
+  moveit::core::RobotState* result = new moveit::core::RobotState(robot_state_);
+  return moveit::core::RobotStatePtr(result);
 }
 
 ros::Time planning_scene_monitor::CurrentStateMonitor::getCurrentStateTime() const
@@ -79,12 +79,12 @@ ros::Time planning_scene_monitor::CurrentStateMonitor::getCurrentStateTime() con
   return current_state_time_;
 }
 
-std::pair<robot_state::RobotStatePtr, ros::Time>
+std::pair<moveit::core::RobotStatePtr, ros::Time>
 planning_scene_monitor::CurrentStateMonitor::getCurrentStateAndTime() const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
-  robot_state::RobotState* result = new robot_state::RobotState(robot_state_);
-  return std::make_pair(robot_state::RobotStatePtr(result), current_state_time_);
+  moveit::core::RobotState* result = new moveit::core::RobotState(robot_state_);
+  return std::make_pair(moveit::core::RobotStatePtr(result), current_state_time_);
 }
 
 std::map<std::string, double> planning_scene_monitor::CurrentStateMonitor::getCurrentStateValues() const
@@ -98,7 +98,7 @@ std::map<std::string, double> planning_scene_monitor::CurrentStateMonitor::getCu
   return m;
 }
 
-void planning_scene_monitor::CurrentStateMonitor::setToCurrentState(robot_state::RobotState& upd) const
+void planning_scene_monitor::CurrentStateMonitor::setToCurrentState(moveit::core::RobotState& upd) const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
   const double* pos = robot_state_.getVariablePositions();
@@ -369,7 +369,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
           if (static_cast<const moveit::core::RevoluteJointModel*>(jm)->isContinuous())
             continue;
 
-        const robot_model::VariableBounds& b =
+        const moveit::core::VariableBounds& b =
             jm->getVariableBounds()[0];  // only one variable in the joint, so we get its bounds
 
         // if the read variable is 'almost' within bounds (up to error_ difference), then consider it to be within
@@ -448,7 +448,7 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
       joint_time_[joint] = latest_common_time;
 
       std::vector<double> new_values(joint->getStateSpaceDimension());
-      const robot_model::LinkModel* link = joint->getChildLinkModel();
+      const moveit::core::LinkModel* link = joint->getChildLinkModel();
       if (link->jointOriginTransformIsIdentity())
         joint->computeVariablePositions(tf2::transformToEigen(transf), new_values.data());
       else

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -113,7 +113,7 @@ void planning_scene_monitor::TrajectoryMonitor::recordStates()
   while (record_states_thread_)
   {
     rate.sleep();
-    std::pair<robot_state::RobotStatePtr, ros::Time> state = current_state_monitor_->getCurrentStateAndTime();
+    std::pair<moveit::core::RobotStatePtr, ros::Time> state = current_state_monitor_->getCurrentStateAndTime();
     if (trajectory_.empty())
     {
       trajectory_.addSuffixWayPoint(state.first, 0.0);

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -84,7 +84,7 @@ public:
   ~RobotModelLoader();
 
   /** @brief Get the constructed planning_models::RobotModel */
-  const robot_model::RobotModelPtr& getModel() const
+  const moveit::core::RobotModelPtr& getModel() const
   {
     return model_;
   }
@@ -128,7 +128,7 @@ public:
 private:
   void configure(const Options& opt);
 
-  robot_model::RobotModelPtr model_;
+  moveit::core::RobotModelPtr model_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
   kinematics_plugin_loader::KinematicsPluginLoaderPtr kinematics_loader_;
 };

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -177,7 +177,8 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
     else
       kinematics_loader_.reset(
           new kinematics_plugin_loader::KinematicsPluginLoader(rdf_loader_->getRobotDescription()));
-    moveit::core::SolverAllocatorFn kinematics_allocator = kinematics_loader_->getLoaderFunction(rdf_loader_->getSRDF());
+    moveit::core::SolverAllocatorFn kinematics_allocator =
+        kinematics_loader_->getLoaderFunction(rdf_loader_->getSRDF());
     const std::vector<std::string>& groups = kinematics_loader_->getKnownGroups();
     std::stringstream ss;
     std::copy(groups.begin(), groups.end(), std::ostream_iterator<std::string>(ss, " "));

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -67,15 +67,15 @@ RobotModelLoader::~RobotModelLoader()
 
 namespace
 {
-bool canSpecifyPosition(const robot_model::JointModel* jmodel, const unsigned int index)
+bool canSpecifyPosition(const moveit::core::JointModel* jmodel, const unsigned int index)
 {
   bool ok = false;
-  if (jmodel->getType() == robot_model::JointModel::PLANAR && index == 2)
+  if (jmodel->getType() == moveit::core::JointModel::PLANAR && index == 2)
     ROS_ERROR("Cannot specify position limits for orientation of planar joint '%s'", jmodel->getName().c_str());
-  else if (jmodel->getType() == robot_model::JointModel::FLOATING && index > 2)
+  else if (jmodel->getType() == moveit::core::JointModel::FLOATING && index > 2)
     ROS_ERROR("Cannot specify position limits for orientation of floating joint '%s'", jmodel->getName().c_str());
-  else if (jmodel->getType() == robot_model::JointModel::REVOLUTE &&
-           static_cast<const robot_model::RevoluteJointModel*>(jmodel)->isContinuous())
+  else if (jmodel->getType() == moveit::core::JointModel::REVOLUTE &&
+           static_cast<const moveit::core::RevoluteJointModel*>(jmodel)->isContinuous())
     ROS_ERROR("Cannot specify position limits for continuous joint '%s'", jmodel->getName().c_str());
   else
     ok = true;
@@ -97,7 +97,7 @@ void RobotModelLoader::configure(const Options& opt)
   {
     const srdf::ModelSharedPtr& srdf =
         rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
-    model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+    model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
   }
 
   if (model_ && !rdf_loader_->getRobotDescription().empty())
@@ -177,7 +177,7 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
     else
       kinematics_loader_.reset(
           new kinematics_plugin_loader::KinematicsPluginLoader(rdf_loader_->getRobotDescription()));
-    robot_model::SolverAllocatorFn kinematics_allocator = kinematics_loader_->getLoaderFunction(rdf_loader_->getSRDF());
+    moveit::core::SolverAllocatorFn kinematics_allocator = kinematics_loader_->getLoaderFunction(rdf_loader_->getSRDF());
     const std::vector<std::string>& groups = kinematics_loader_->getKnownGroups();
     std::stringstream ss;
     std::copy(groups.begin(), groups.end(), std::ostream_iterator<std::string>(ss, " "));
@@ -185,14 +185,14 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
     if (groups.empty() && !model_->getJointModelGroups().empty())
       ROS_WARN("No kinematics plugins defined. Fill and load kinematics.yaml!");
 
-    std::map<std::string, robot_model::SolverAllocatorFn> imap;
+    std::map<std::string, moveit::core::SolverAllocatorFn> imap;
     for (const std::string& group : groups)
     {
       // Check if a group in kinematics.yaml exists in the srdf
       if (!model_->hasJointModelGroup(group))
         continue;
 
-      const robot_model::JointModelGroup* jmg = model_->getJointModelGroup(group);
+      const moveit::core::JointModelGroup* jmg = model_->getJointModelGroup(group);
 
       kinematics::KinematicsBasePtr solver = kinematics_allocator(jmg);
       if (solver)
@@ -221,7 +221,7 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
     {
       if (!model_->hasJointModelGroup(it.first))
         continue;
-      robot_model::JointModelGroup* jmg = model_->getJointModelGroup(it.first);
+      moveit::core::JointModelGroup* jmg = model_->getJointModelGroup(it.first);
       jmg->setDefaultIKTimeout(it.second);
     }
   }

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -81,11 +81,11 @@ public:
   };
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
+  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
                              const planning_scene_monitor::CurrentStateMonitorPtr& csm);
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const robot_model::RobotModelConstPtr& robot_model,
+  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
                              const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)
@@ -303,7 +303,7 @@ private:
   // Name of this class for logging
   const std::string name_ = "trajectory_execution_manager";
 
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -44,10 +44,10 @@ namespace planning_interface
 {
 std::shared_ptr<tf2_ros::Buffer> getSharedTF();
 
-robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_description);
+moveit::core::RobotModelConstPtr getSharedRobotModel(const std::string& robot_description);
 
 /**
-  @brief getSharedStateMonitor is a simpler version of getSharedStateMonitor(const robot_model::RobotModelConstPtr
+  @brief getSharedStateMonitor is a simpler version of getSharedStateMonitor(const moveit::core::RobotModelConstPtr
   &robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
     ros::NodeHandle nh = ros::NodeHandle() ). It calls this function using the default constructed ros::NodeHandle
 
@@ -55,7 +55,7 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_des
   @param tf_buffer
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
 /**
@@ -66,7 +66,7 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot
   @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                                                                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                                                      const ros::NodeHandle& nh);
 

--- a/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -55,8 +55,8 @@ moveit::core::RobotModelConstPtr getSharedRobotModel(const std::string& robot_de
   @param tf_buffer
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
-                                                                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(
+    const moveit::core::RobotModelConstPtr& robot_model, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer);
 
 /**
   @brief getSharedStateMonitor
@@ -66,9 +66,9 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const movei
   @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
   @return
  */
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
-                                                                     const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                                                     const ros::NodeHandle& nh);
+planning_scene_monitor::CurrentStateMonitorPtr
+getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
+                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::NodeHandle& nh);
 
 }  // namespace planning interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -58,7 +58,7 @@ struct SharedStorage
 
   boost::mutex lock_;
   std::weak_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::map<std::string, robot_model::RobotModelWeakPtr> models_;
+  std::map<std::string, moveit::core::RobotModelWeakPtr> models_;
   std::map<std::string, CurrentStateMonitorWeakPtr> state_monitors_;
 };
 
@@ -113,31 +113,31 @@ std::shared_ptr<tf2_ros::Buffer> getSharedTF()
   return buffer;
 }
 
-robot_model::RobotModelConstPtr getSharedRobotModel(const std::string& robot_description)
+moveit::core::RobotModelConstPtr getSharedRobotModel(const std::string& robot_description)
 {
   SharedStorage& s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);
-  auto it = s.models_.insert(std::make_pair(robot_description, robot_model::RobotModelWeakPtr())).first;
-  robot_model::RobotModelPtr model = it->second.lock();
+  auto it = s.models_.insert(std::make_pair(robot_description, moveit::core::RobotModelWeakPtr())).first;
+  moveit::core::RobotModelPtr model = it->second.lock();
   if (!model)
   {
     RobotModelLoader::Options opt(robot_description);
     opt.load_kinematics_solvers_ = true;
     RobotModelLoaderPtr loader(new RobotModelLoader(opt));
     // create an aliasing shared_ptr
-    model = robot_model::RobotModelPtr(loader, loader->getModel().get());
+    model = moveit::core::RobotModelPtr(loader, loader->getModel().get());
     it->second = model;
   }
   return model;
 }
 
-CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+CurrentStateMonitorPtr getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                                              const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
 {
   return getSharedStateMonitor(robot_model, tf_buffer, ros::NodeHandle());
 }
 
-CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr& robot_model,
+CurrentStateMonitorPtr getSharedStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
                                              const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                              const ros::NodeHandle& nh)
 {

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -118,7 +118,7 @@ public:
     std::string robot_description_;
 
     /// Optionally, an instance of the RobotModel to use can be also specified
-    robot_model::RobotModelConstPtr robot_model_;
+    moveit::core::RobotModelConstPtr robot_model_;
 
     ros::NodeHandle node_handle_;
   };
@@ -187,7 +187,7 @@ public:
   const std::vector<std::string>& getNamedTargets() const;
 
   /** \brief Get the RobotModel object. */
-  robot_model::RobotModelConstPtr getRobotModel() const;
+  moveit::core::RobotModelConstPtr getRobotModel() const;
 
   /** \brief Get the ROS node handle of this instance operates on */
   const ros::NodeHandle& getNodeHandle() const;
@@ -303,7 +303,7 @@ public:
 
   /** \brief If a different start state should be considered instead of the current state of the robot, this function
    * sets that state */
-  void setStartState(const robot_state::RobotState& start_state);
+  void setStartState(const moveit::core::RobotState& start_state);
 
   /** \brief Set the starting state for planning to be that reported by the robot's joint state publication */
   void setStartStateToCurrentState();
@@ -386,7 +386,7 @@ public:
 
       If these values are out of bounds then false is returned BUT THE VALUES
       ARE STILL SET AS THE GOAL. */
-  bool setJointValueTarget(const robot_state::RobotState& robot_state);
+  bool setJointValueTarget(const moveit::core::RobotState& robot_state);
 
   /** \brief Set the JointValueTarget and use it for future planning requests.
 
@@ -516,7 +516,7 @@ public:
   void getJointValueTarget(std::vector<double>& group_variable_values) const;
 
   /// Get the currently set joint state goal, replaced by private getTargetRobotState()
-  [[deprecated]] const robot_state::RobotState& getJointValueTarget() const;
+  [[deprecated]] const moveit::core::RobotState& getJointValueTarget() const;
 
   /**@}*/
 
@@ -906,7 +906,7 @@ public:
   std::vector<double> getCurrentJointValues() const;
 
   /** \brief Get the current state of the robot within the duration specified by wait. */
-  robot_state::RobotStatePtr getCurrentState(double wait = 1) const;
+  moveit::core::RobotStatePtr getCurrentState(double wait = 1) const;
 
   /** \brief Get the pose for the end-effector \e end_effector_link.
       If \e end_effector_link is empty (the default value) then the end-effector reported by getEndEffectorLink() is
@@ -994,7 +994,7 @@ public:
 
 protected:
   /** return the full RobotState of the joint-space target, only for internal use */
-  const robot_state::RobotState& getTargetRobotState() const;
+  const moveit::core::RobotState& getTargetRobotState() const;
 
 private:
   std::map<std::string, std::vector<double> > remembered_joint_values_;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -113,7 +113,7 @@ public:
 
     joint_model_group_ = getRobotModel()->getJointModelGroup(opt.group_name_);
 
-    joint_state_target_.reset(new robot_state::RobotState(getRobotModel()));
+    joint_state_target_.reset(new moveit::core::RobotState(getRobotModel()));
     joint_state_target_->setToDefaultValues();
     active_target_ = JOINT;
     can_look_ = false;
@@ -248,12 +248,12 @@ public:
     return opt_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
 
-  const robot_model::JointModelGroup* getJointModelGroup() const
+  const moveit::core::JointModelGroup* getJointModelGroup() const
   {
     return joint_model_group_;
   }
@@ -345,19 +345,19 @@ public:
     max_acceleration_scaling_factor_ = max_acceleration_scaling_factor;
   }
 
-  robot_state::RobotState& getTargetRobotState()
+  moveit::core::RobotState& getTargetRobotState()
   {
     return *joint_state_target_;
   }
 
-  const robot_state::RobotState& getTargetRobotState() const
+  const moveit::core::RobotState& getTargetRobotState() const
   {
     return *joint_state_target_;
   }
 
-  void setStartState(const robot_state::RobotState& start_state)
+  void setStartState(const moveit::core::RobotState& start_state)
   {
-    considered_start_state_.reset(new robot_state::RobotState(start_state));
+    considered_start_state_.reset(new moveit::core::RobotState(start_state));
   }
 
   void setStartStateToCurrentState()
@@ -365,13 +365,13 @@ public:
     considered_start_state_.reset();
   }
 
-  robot_state::RobotStatePtr getStartState()
+  moveit::core::RobotStatePtr getStartState()
   {
     if (considered_start_state_)
       return considered_start_state_;
     else
     {
-      robot_state::RobotStatePtr s;
+      moveit::core::RobotStatePtr s;
       getCurrentState(s);
       return s;
     }
@@ -560,7 +560,7 @@ public:
     return true;
   }
 
-  bool getCurrentState(robot_state::RobotStatePtr& current_state, double wait_seconds = 1.0)
+  bool getCurrentState(moveit::core::RobotStatePtr& current_state, double wait_seconds = 1.0)
   {
     if (!current_state_monitor_)
     {
@@ -842,7 +842,7 @@ public:
     moveit_msgs::GetCartesianPath::Response res;
 
     if (considered_start_state_)
-      robot_state::robotStateToRobotStateMsg(*considered_start_state_, req.start_state);
+      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, req.start_state);
     else
       req.start_state.is_diff = true;
 
@@ -1009,7 +1009,7 @@ public:
     request.workspace_parameters = workspace_parameters_;
 
     if (considered_start_state_)
-      robot_state::robotStateToRobotStateMsg(*considered_start_state_, request.start_state);
+      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, request.start_state);
     else
       request.start_state.is_diff = true;
 
@@ -1226,7 +1226,7 @@ private:
   Options opt_;
   ros::NodeHandle node_handle_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction> > move_action_client_;
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::ExecuteTrajectoryAction> > execute_action_client_;
@@ -1234,7 +1234,7 @@ private:
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction> > place_action_client_;
 
   // general planning params
-  robot_state::RobotStatePtr considered_start_state_;
+  moveit::core::RobotStatePtr considered_start_state_;
   moveit_msgs::WorkspaceParameters workspace_parameters_;
   double allowed_planning_time_;
   std::string planner_id_;
@@ -1249,8 +1249,8 @@ private:
   double replan_delay_;
 
   // joint state goal
-  robot_state::RobotStatePtr joint_state_target_;
-  const robot_model::JointModelGroup* joint_model_group_;
+  moveit::core::RobotStatePtr joint_state_target_;
+  const moveit::core::JointModelGroup* joint_model_group_;
 
   // pose goal;
   // for each link we have a set of possible goal locations;
@@ -1340,7 +1340,7 @@ const std::vector<std::string>& MoveGroupInterface::getNamedTargets() const
   return impl_->getJointModelGroup()->getDefaultStateNames();
 }
 
-robot_model::RobotModelConstPtr MoveGroupInterface::getRobotModel() const
+moveit::core::RobotModelConstPtr MoveGroupInterface::getRobotModel() const
 {
   return impl_->getRobotModel();
 }
@@ -1501,13 +1501,13 @@ void MoveGroupInterface::stop()
 
 void MoveGroupInterface::setStartState(const moveit_msgs::RobotState& start_state)
 {
-  robot_state::RobotStatePtr rs;
+  moveit::core::RobotStatePtr rs;
   impl_->getCurrentState(rs);
-  robot_state::robotStateMsgToRobotState(start_state, *rs);
+  moveit::core::robotStateMsgToRobotState(start_state, *rs);
   setStartState(*rs);
 }
 
-void MoveGroupInterface::setStartState(const robot_state::RobotState& start_state)
+void MoveGroupInterface::setStartState(const moveit::core::RobotState& start_state)
 {
   impl_->setStartState(start_state);
 }
@@ -1623,7 +1623,7 @@ bool MoveGroupInterface::setJointValueTarget(const std::vector<std::string>& var
   return impl_->getTargetRobotState().satisfiesBounds(impl_->getGoalJointTolerance());
 }
 
-bool MoveGroupInterface::setJointValueTarget(const robot_state::RobotState& rstate)
+bool MoveGroupInterface::setJointValueTarget(const moveit::core::RobotState& rstate)
 {
   impl_->setTargetType(JOINT);
   impl_->getTargetRobotState() = rstate;
@@ -1639,7 +1639,7 @@ bool MoveGroupInterface::setJointValueTarget(const std::string& joint_name, doub
 bool MoveGroupInterface::setJointValueTarget(const std::string& joint_name, const std::vector<double>& values)
 {
   impl_->setTargetType(JOINT);
-  const robot_model::JointModel* jm = impl_->getJointModelGroup()->getJointModel(joint_name);
+  const moveit::core::JointModel* jm = impl_->getJointModelGroup()->getJointModel(joint_name);
   if (jm && jm->getVariableCount() == values.size())
   {
     impl_->getTargetRobotState().setJointPositions(jm, values);
@@ -1691,12 +1691,12 @@ bool MoveGroupInterface::setApproximateJointValueTarget(const Eigen::Isometry3d&
   return setApproximateJointValueTarget(msg, end_effector_link);
 }
 
-const robot_state::RobotState& MoveGroupInterface::getJointValueTarget() const
+const moveit::core::RobotState& MoveGroupInterface::getJointValueTarget() const
 {
   return impl_->getTargetRobotState();
 }
 
-const robot_state::RobotState& MoveGroupInterface::getTargetRobotState() const
+const moveit::core::RobotState& MoveGroupInterface::getTargetRobotState() const
 {
   return impl_->getTargetRobotState();
 }
@@ -1722,7 +1722,7 @@ bool MoveGroupInterface::setEndEffectorLink(const std::string& link_name)
 
 bool MoveGroupInterface::setEndEffector(const std::string& eef_name)
 {
-  const robot_model::JointModelGroup* jmg = impl_->getRobotModel()->getEndEffector(eef_name);
+  const moveit::core::JointModelGroup* jmg = impl_->getRobotModel()->getEndEffector(eef_name);
   if (jmg)
     return setEndEffectorLink(jmg->getEndEffectorParentGroup().second);
   return false;
@@ -1965,7 +1965,7 @@ bool MoveGroupInterface::startStateMonitor(double wait)
 
 std::vector<double> MoveGroupInterface::getCurrentJointValues() const
 {
-  robot_state::RobotStatePtr current_state;
+  moveit::core::RobotStatePtr current_state;
   std::vector<double> values;
   if (impl_->getCurrentState(current_state))
     current_state->copyJointGroupPositions(getName(), values);
@@ -1988,11 +1988,11 @@ geometry_msgs::PoseStamped MoveGroupInterface::getRandomPose(const std::string& 
     ROS_ERROR_NAMED("move_group_interface", "No end-effector specified");
   else
   {
-    robot_state::RobotStatePtr current_state;
+    moveit::core::RobotStatePtr current_state;
     if (impl_->getCurrentState(current_state))
     {
       current_state->setToRandomPositions(impl_->getJointModelGroup());
-      const robot_model::LinkModel* lm = current_state->getLinkModel(eef);
+      const moveit::core::LinkModel* lm = current_state->getLinkModel(eef);
       if (lm)
         pose = current_state->getGlobalLinkTransform(lm);
     }
@@ -2013,10 +2013,10 @@ geometry_msgs::PoseStamped MoveGroupInterface::getCurrentPose(const std::string&
     ROS_ERROR_NAMED("move_group_interface", "No end-effector specified");
   else
   {
-    robot_state::RobotStatePtr current_state;
+    moveit::core::RobotStatePtr current_state;
     if (impl_->getCurrentState(current_state))
     {
-      const robot_model::LinkModel* lm = current_state->getLinkModel(eef);
+      const moveit::core::LinkModel* lm = current_state->getLinkModel(eef);
       if (lm)
         pose = current_state->getGlobalLinkTransform(lm);
     }
@@ -2036,10 +2036,10 @@ std::vector<double> MoveGroupInterface::getCurrentRPY(const std::string& end_eff
     ROS_ERROR_NAMED("move_group_interface", "No end-effector specified");
   else
   {
-    robot_state::RobotStatePtr current_state;
+    moveit::core::RobotStatePtr current_state;
     if (impl_->getCurrentState(current_state))
     {
-      const robot_model::LinkModel* lm = current_state->getLinkModel(eef);
+      const moveit::core::LinkModel* lm = current_state->getLinkModel(eef);
       if (lm)
       {
         result.resize(3);
@@ -2070,9 +2070,9 @@ unsigned int MoveGroupInterface::getVariableCount() const
   return impl_->getJointModelGroup()->getVariableCount();
 }
 
-robot_state::RobotStatePtr MoveGroupInterface::getCurrentState(double wait) const
+moveit::core::RobotStatePtr MoveGroupInterface::getCurrentState(double wait) const
 {
-  robot_state::RobotStatePtr current_state;
+  moveit::core::RobotStatePtr current_state;
   impl_->getCurrentState(current_state, wait);
   return current_state;
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -130,7 +130,7 @@ public:
   py_bindings_tools::ByteString getJointValueTarget()
   {
     moveit_msgs::RobotState msg;
-    const robot_state::RobotState state = moveit::planning_interface::MoveGroupInterface::getTargetRobotState();
+    const moveit::core::RobotState state = moveit::planning_interface::MoveGroupInterface::getTargetRobotState();
     moveit::core::robotStateToRobotStateMsg(state, msg);
     return py_bindings_tools::serializeMsg(msg);
   }
@@ -306,10 +306,10 @@ public:
 
   bp::dict getCurrentStateBoundedPython()
   {
-    robot_state::RobotStatePtr current = getCurrentState();
+    moveit::core::RobotStatePtr current = getCurrentState();
     current->enforceBounds();
     moveit_msgs::RobotState rsmv;
-    robot_state::robotStateToRobotStateMsg(*current, rsmv);
+    moveit::core::robotStateToRobotStateMsg(*current, rsmv);
     bp::dict output;
     for (size_t x = 0; x < rsmv.joint_state.name.size(); ++x)
       output[rsmv.joint_state.name[x]] = rsmv.joint_state.position[x];
@@ -549,7 +549,7 @@ public:
     if (ref.size() != 3)
       throw std::invalid_argument("reference point needs to have 3 elements, got " + std::to_string(ref.size()));
 
-    robot_state::RobotState state(getRobotModel());
+    moveit::core::RobotState state(getRobotModel());
     state.setToDefaultValues();
     auto group = state.getJointModelGroup(getName());
     state.setJointGroupPositions(group, v);

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -127,18 +127,18 @@ public:
   ~MoveItCpp();
 
   /** \brief Get the RobotModel object. */
-  robot_model::RobotModelConstPtr getRobotModel() const;
+  moveit::core::RobotModelConstPtr getRobotModel() const;
 
   /** \brief Get the ROS node handle of this instance operates on */
   const ros::NodeHandle& getNodeHandle() const;
 
   /** \brief Get the current state queried from the current state monitor
       \param wait_seconds the time in seconds for the state monitor to wait for a robot state. */
-  bool getCurrentState(robot_state::RobotStatePtr& current_state, double wait_seconds);
+  bool getCurrentState(moveit::core::RobotStatePtr& current_state, double wait_seconds);
 
   /** \brief Get the current state queried from the current state monitor
       \param wait_seconds the time in seconds for the state monitor to wait for a robot state. */
-  robot_state::RobotStatePtr getCurrentState(double wait_seconds = 0.0);
+  moveit::core::RobotStatePtr getCurrentState(double wait_seconds = 0.0);
 
   /** \brief Get all loaded planning pipeline instances mapped to their reference names */
   const std::map<std::string, planning_pipeline::PlanningPipelinePtr>& getPlanningPipelines() const;
@@ -169,7 +169,7 @@ protected:
 private:
   //  Core properties and instances
   ros::NodeHandle node_handle_;
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
   // Planning

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -151,10 +151,10 @@ public:
   void unsetWorkspace();
 
   /** \brief Get the considered start state if defined, otherwise get the current state */
-  robot_state::RobotStatePtr getStartState();
+  moveit::core::RobotStatePtr getStartState();
 
   /** \brief Set the robot state that should be considered as start state for planning */
-  bool setStartState(const robot_state::RobotState& start_state);
+  bool setStartState(const moveit::core::RobotState& start_state);
   /** \brief Set the named robot state that should be considered as start state for planning */
   bool setStartState(const std::string& named_state);
 
@@ -164,7 +164,7 @@ public:
   /** \brief Set the goal constraints used for planning */
   bool setGoal(const std::vector<moveit_msgs::Constraints>& goal_constraints);
   /** \brief Set the goal constraints generated from a target state */
-  bool setGoal(const robot_state::RobotState& goal_state);
+  bool setGoal(const moveit::core::RobotState& goal_state);
   /** \brief Set the goal constraints generated from target pose and robot link */
   bool setGoal(const geometry_msgs::PoseStamped& goal_pose, const std::string& link_name);
   /** \brief Set the goal constraints generated from a named target state */
@@ -195,7 +195,7 @@ private:
   // Planning
   std::set<std::string> planning_pipeline_names_;
   // The start state used in the planning motion request
-  robot_state::RobotStatePtr considered_start_state_;
+  moveit::core::RobotStatePtr considered_start_state_;
   std::vector<moveit_msgs::Constraints> current_goal_constraints_;
   PlanRequestParameters plan_request_parameters_;
   moveit_msgs::WorkspaceParameters workspace_parameters_;

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -203,7 +203,7 @@ bool MoveItCpp::loadPlanningPipelines(const PlanningPipelineOptions& options)
   return true;
 }
 
-robot_model::RobotModelConstPtr MoveItCpp::getRobotModel() const
+moveit::core::RobotModelConstPtr MoveItCpp::getRobotModel() const
 {
   return robot_model_;
 }
@@ -213,7 +213,7 @@ const ros::NodeHandle& MoveItCpp::getNodeHandle() const
   return node_handle_;
 }
 
-bool MoveItCpp::getCurrentState(robot_state::RobotStatePtr& current_state, double wait_seconds)
+bool MoveItCpp::getCurrentState(moveit::core::RobotStatePtr& current_state, double wait_seconds)
 {
   if (wait_seconds > 0.0 &&
       !planning_scene_monitor_->getStateMonitor()->waitForCurrentState(ros::Time::now(), wait_seconds))
@@ -228,9 +228,9 @@ bool MoveItCpp::getCurrentState(robot_state::RobotStatePtr& current_state, doubl
   return true;
 }
 
-robot_state::RobotStatePtr MoveItCpp::getCurrentState(double wait)
+moveit::core::RobotStatePtr MoveItCpp::getCurrentState(double wait)
 {
-  robot_state::RobotStatePtr current_state;
+  moveit::core::RobotStatePtr current_state;
   getCurrentState(current_state, wait);
   return current_state;
 }

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -219,19 +219,19 @@ PlanningComponent::PlanSolution PlanningComponent::plan()
   return plan(default_parameters);
 }
 
-bool PlanningComponent::setStartState(const robot_state::RobotState& start_state)
+bool PlanningComponent::setStartState(const moveit::core::RobotState& start_state)
 {
-  considered_start_state_.reset(new robot_state::RobotState(start_state));
+  considered_start_state_.reset(new moveit::core::RobotState(start_state));
   return true;
 }
 
-robot_state::RobotStatePtr PlanningComponent::getStartState()
+moveit::core::RobotStatePtr PlanningComponent::getStartState()
 {
   if (considered_start_state_)
     return considered_start_state_;
   else
   {
-    robot_state::RobotStatePtr s;
+    moveit::core::RobotStatePtr s;
     moveit_cpp_->getCurrentState(s, 1.0);
     return s;
   }
@@ -245,7 +245,7 @@ bool PlanningComponent::setStartState(const std::string& start_state_name)
     ROS_ERROR_NAMED(LOGNAME, "No predefined joint state found for target name '%s'", start_state_name.c_str());
     return false;
   }
-  robot_state::RobotState start_state(moveit_cpp_->getRobotModel());
+  moveit::core::RobotState start_state(moveit_cpp_->getRobotModel());
   start_state.setToDefaultValues(joint_model_group_, start_state_name);
   return setStartState(start_state);
 }
@@ -287,7 +287,7 @@ bool PlanningComponent::setGoal(const std::vector<moveit_msgs::Constraints>& goa
   return true;
 }
 
-bool PlanningComponent::setGoal(const robot_state::RobotState& goal_state)
+bool PlanningComponent::setGoal(const moveit::core::RobotState& goal_state)
 {
   current_goal_constraints_ = { kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group_) };
   return true;
@@ -307,7 +307,7 @@ bool PlanningComponent::setGoal(const std::string& goal_state_name)
     ROS_ERROR_NAMED(LOGNAME, "No predefined joint state found for target name '%s'", goal_state_name.c_str());
     return false;
   }
-  robot_state::RobotState goal_state(moveit_cpp_->getRobotModel());
+  moveit::core::RobotState goal_state(moveit_cpp_->getRobotModel());
   goal_state.setToDefaultValues(joint_model_group_, goal_state_name);
   return setGoal(goal_state);
 }

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -267,7 +267,7 @@ private:
   ros::ServiceClient planning_scene_service_;
   ros::ServiceClient apply_planning_scene_service_;
   ros::Publisher planning_scene_diff_publisher_;
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 };
 
 PlanningSceneInterface::PlanningSceneInterface(const std::string& ns)

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -77,7 +77,7 @@ public:
 
   bp::list getGroupJointNames(const std::string& group) const
   {
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (jmg)
       return py_bindings_tools::listFromString(jmg->getJointModelNames());
     else
@@ -86,7 +86,7 @@ public:
 
   bp::list getGroupJointTips(const std::string& group) const
   {
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (jmg)
     {
       std::vector<std::string> tips;
@@ -104,7 +104,7 @@ public:
 
   bp::list getGroupLinkNames(const std::string& group) const
   {
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (jmg)
       return py_bindings_tools::listFromString(jmg->getLinkModelNames());
     else
@@ -119,7 +119,7 @@ public:
   bp::list getJointLimits(const std::string& name) const
   {
     bp::list result;
-    const robot_model::JointModel* jm = robot_model_->getJointModel(name);
+    const moveit::core::JointModel* jm = robot_model_->getJointModel(name);
     if (jm)
     {
       const std::vector<moveit_msgs::JointLimits>& lim = jm->getVariableBoundsMsg();
@@ -144,8 +144,8 @@ public:
     bp::list l;
     if (!ensureCurrentState())
       return l;
-    robot_state::RobotStatePtr state = current_state_monitor_->getCurrentState();
-    const robot_model::LinkModel* lm = state->getLinkModel(name);
+    moveit::core::RobotStatePtr state = current_state_monitor_->getCurrentState();
+    const moveit::core::LinkModel* lm = state->getLinkModel(name);
     if (lm)
     {
       const Eigen::Isometry3d& t = state->getGlobalLinkTransform(lm);
@@ -166,7 +166,7 @@ public:
   bp::list getDefaultStateNames(const std::string& group)
   {
     bp::list l;
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (jmg)
     {
       for (auto& known_state : jmg->getDefaultStateNames())
@@ -182,8 +182,8 @@ public:
     bp::list l;
     if (!ensureCurrentState())
       return l;
-    robot_state::RobotStatePtr state = current_state_monitor_->getCurrentState();
-    const robot_model::JointModel* jm = state->getJointModel(name);
+    moveit::core::RobotStatePtr state = current_state_monitor_->getCurrentState();
+    const moveit::core::JointModel* jm = state->getJointModel(name);
     if (jm)
     {
       const double* pos = state->getJointPositions(jm);
@@ -197,7 +197,7 @@ public:
 
   bp::dict getJointValues(const std::string& group, const std::string& named_state)
   {
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (!jmg)
       return boost::python::dict();
     std::map<std::string, double> values;
@@ -227,9 +227,9 @@ public:
   {
     if (!ensureCurrentState())
       return py_bindings_tools::ByteString("");
-    robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
+    moveit::core::RobotStatePtr s = current_state_monitor_->getCurrentState();
     moveit_msgs::RobotState msg;
-    robot_state::robotStateToRobotStateMsg(*s, msg);
+    moveit::core::robotStateToRobotStateMsg(*s, msg);
     return py_bindings_tools::serializeMsg(msg);
   }
 
@@ -237,7 +237,7 @@ public:
   {
     // name of the group that is parent to this end-effector group;
     // Second: the link this in the parent group that this group attaches to
-    const robot_state::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (!jmg)
       return boost::python::make_tuple("", "");
     std::pair<std::string, std::string> parent_group = jmg->getEndEffectorParentGroup();
@@ -246,14 +246,14 @@ public:
 
   py_bindings_tools::ByteString getRobotMarkersPythonDictList(bp::dict& values, bp::list& links)
   {
-    robot_state::RobotStatePtr state;
+    moveit::core::RobotStatePtr state;
     if (ensureCurrentState())
     {
       state = current_state_monitor_->getCurrentState();
     }
     else
     {
-      state.reset(new robot_state::RobotState(robot_model_));
+      state.reset(new moveit::core::RobotState(robot_model_));
     }
 
     bp::list k = values.keys();
@@ -282,7 +282,7 @@ public:
   py_bindings_tools::ByteString getRobotMarkersFromMsg(const py_bindings_tools::ByteString& state_str)
   {
     moveit_msgs::RobotState state_msg;
-    robot_state::RobotState state(robot_model_);
+    moveit::core::RobotState state(robot_model_);
     py_bindings_tools::deserializeMsg(state_str, state_msg);
     moveit::core::robotStateMsgToRobotState(state_msg, state);
 
@@ -296,7 +296,7 @@ public:
   {
     if (!ensureCurrentState())
       return py_bindings_tools::ByteString();
-    robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
+    moveit::core::RobotStatePtr s = current_state_monitor_->getCurrentState();
     visualization_msgs::MarkerArray msg;
     s->getRobotMarkers(msg, s->getRobotModel()->getLinkModelNames());
 
@@ -307,7 +307,7 @@ public:
   {
     if (!ensureCurrentState())
       return py_bindings_tools::ByteString("");
-    robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
+    moveit::core::RobotStatePtr s = current_state_monitor_->getCurrentState();
     visualization_msgs::MarkerArray msg;
     s->getRobotMarkers(msg, py_bindings_tools::stringFromList(links));
 
@@ -318,8 +318,8 @@ public:
   {
     if (!ensureCurrentState())
       return py_bindings_tools::ByteString("");
-    robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    moveit::core::RobotStatePtr s = current_state_monitor_->getCurrentState();
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     visualization_msgs::MarkerArray msg;
     if (jmg)
     {
@@ -331,7 +331,7 @@ public:
 
   py_bindings_tools::ByteString getRobotMarkersGroupPythonDict(const std::string& group, bp::dict& values)
   {
-    const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (!jmg)
       return py_bindings_tools::ByteString("");
     bp::list links = py_bindings_tools::listFromString(jmg->getLinkModelNames());
@@ -363,7 +363,7 @@ public:
   }
 
 private:
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
   ros::NodeHandle nh_;
 };

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
@@ -84,7 +84,7 @@ protected:
   ros::NodeHandle nh_;
   MoveItCppPtr moveit_cpp_ptr;
   PlanningComponentPtr planning_component_ptr;
-  robot_model::RobotModelConstPtr robot_model_ptr;
+  moveit::core::RobotModelConstPtr robot_model_ptr;
   const moveit::core::JointModelGroup* jmg_ptr;
   const std::string PLANNING_GROUP = "panda_arm";
   geometry_msgs::PoseStamped target_pose1;
@@ -97,7 +97,7 @@ TEST_F(MoveItCppTest, GetCurrentStateTest)
 {
   ros::Duration(1.0).sleep();  // Otherwise joint_states will result in an invalid robot state
   auto robot_model = moveit_cpp_ptr->getRobotModel();
-  auto robot_state = std::make_shared<robot_state::RobotState>(robot_model);
+  auto robot_state = std::make_shared<moveit::core::RobotState>(robot_model);
   EXPECT_TRUE(moveit_cpp_ptr->getCurrentState(robot_state, 0.0));
   // Make sure the Panda robot is in "ready" state which is loaded from fake_controller.yaml
   std::vector<double> joints_vals;
@@ -135,7 +135,7 @@ TEST_F(MoveItCppTest, TestSetGoalFromPoseStamped)
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));
 }
 
-// Test setting the plan start state using robot_state::RobotState
+// Test setting the plan start state using moveit::core::RobotState
 TEST_F(MoveItCppTest, TestSetStartStateFromRobotState)
 {
   auto start_state = *(moveit_cpp_ptr->getCurrentState());
@@ -147,7 +147,7 @@ TEST_F(MoveItCppTest, TestSetStartStateFromRobotState)
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));
 }
 
-// Test settting the goal of the plan using a robot_state::RobotState
+// Test settting the goal of the plan using a moveit::core::RobotState
 TEST_F(MoveItCppTest, TestSetGoalFromRobotState)
 {
   auto target_state = *(moveit_cpp_ptr->getCurrentState());

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -84,7 +84,7 @@ enum InteractionStyle
 ///          that will be used to control the interaction.
 ///  @returns true if the function succeeds, false if the function was not able
 ///          to fill in \e marker.
-typedef boost::function<bool(const robot_state::RobotState& state, visualization_msgs::InteractiveMarker& marker)>
+typedef boost::function<bool(const moveit::core::RobotState& state, visualization_msgs::InteractiveMarker& marker)>
     InteractiveMarkerConstructorFn;
 
 /// Type of function for processing marker feedback.
@@ -98,7 +98,7 @@ typedef boost::function<bool(const robot_state::RobotState& state, visualization
 /// @returns false if the state was not successfully updated or the new state
 ///           is somehow invalid or erronious (e.g. in collision).  true if
 ///           everything worked well.
-typedef boost::function<bool(robot_state::RobotState& state,
+typedef boost::function<bool(moveit::core::RobotState& state,
                              const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback)>
     ProcessFeedbackFn;
 
@@ -111,7 +111,7 @@ typedef boost::function<bool(robot_state::RobotState& state,
 ///              marker, given the new state of the robot.
 /// @returns true if the pose was modified, false if no update is needed (i.e.
 ///              if the pose did not change).
-typedef boost::function<bool(const robot_state::RobotState&, geometry_msgs::Pose&)> InteractiveMarkerUpdateFn;
+typedef boost::function<bool(const moveit::core::RobotState&, geometry_msgs::Pose&)> InteractiveMarkerUpdateFn;
 
 /// Representation of a generic interaction.
 /// Displays one interactive marker.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -77,7 +77,7 @@ class InteractionHandler : public LockedRobotState
 public:
   // Use this constructor if you have an initial RobotState already.
   InteractionHandler(const RobotInteractionPtr& robot_interaction, const std::string& name,
-                     const robot_state::RobotState& initial_robot_state,
+                     const moveit::core::RobotState& initial_robot_state,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   // Use this constructor to start with a default state.
@@ -85,10 +85,10 @@ public:
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   // DEPRECATED.
-  InteractionHandler(const std::string& name, const robot_state::RobotState& initial_robot_state,
+  InteractionHandler(const std::string& name, const moveit::core::RobotState& initial_robot_state,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
   // DEPRECATED.
-  InteractionHandler(const std::string& name, const robot_model::RobotModelConstPtr& model,
+  InteractionHandler(const std::string& name, const moveit::core::RobotModelConstPtr& model,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>());
 
   ~InteractionHandler() override
@@ -230,18 +230,18 @@ private:
 
   // Update RobotState using a generic interaction feedback message.
   // YOU MUST LOCK state_lock_ BEFORE CALLING THIS.
-  void updateStateGeneric(robot_state::RobotState* state, const GenericInteraction* g,
+  void updateStateGeneric(moveit::core::RobotState* state, const GenericInteraction* g,
                           const visualization_msgs::InteractiveMarkerFeedbackConstPtr* feedback,
                           StateChangeCallbackFn* callback);
 
   // Update RobotState for a new pose of an eef.
   // YOU MUST LOCK state_lock_ BEFORE CALLING THIS.
-  void updateStateEndEffector(robot_state::RobotState* state, const EndEffectorInteraction* eef,
+  void updateStateEndEffector(moveit::core::RobotState* state, const EndEffectorInteraction* eef,
                               const geometry_msgs::Pose* pose, StateChangeCallbackFn* callback);
 
   // Update RobotState for a new joint position.
   // YOU MUST LOCK state_lock_ BEFORE CALLING THIS.
-  void updateStateJoint(robot_state::RobotState* state, const JointInteraction* vj, const geometry_msgs::Pose* pose,
+  void updateStateJoint(moveit::core::RobotState* state, const JointInteraction* vj, const geometry_msgs::Pose* pose,
                         StateChangeCallbackFn* callback);
 
   // Set the error state for \e name.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -70,7 +70,7 @@ struct KinematicOptions
   /// @param tip link that will be posed
   /// @param pose desired pose of tip link
   /// @param result true if IK succeeded.
-  bool setStateFromIK(robot_state::RobotState& state, const std::string& group, const std::string& tip,
+  bool setStateFromIK(moveit::core::RobotState& state, const std::string& group, const std::string& tip,
                       const geometry_msgs::Pose& pose) const;
 
   /// Copy a subset of source to this.
@@ -82,7 +82,7 @@ struct KinematicOptions
   double timeout_seconds_;
 
   /// This is called to determine if the state is valid
-  robot_state::GroupStateValidityCallbackFn state_validity_callback_;
+  moveit::core::GroupStateValidityCallbackFn state_validity_callback_;
 
   /// other options
   kinematics::KinematicsQueryOptions options_;

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -63,7 +63,7 @@ public:
   /// @param tip link that will be posed
   /// @param pose desired pose of tip link
   /// @param result true if IK succeeded.
-  bool setStateFromIK(robot_state::RobotState& state, const std::string& key, const std::string& group,
+  bool setStateFromIK(moveit::core::RobotState& state, const std::string& key, const std::string& group,
                       const std::string& tip, const geometry_msgs::Pose& pose) const;
 
   /// Get the options to use for a particular key.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -60,8 +60,8 @@ MOVEIT_CLASS_FORWARD(LockedRobotState);
 class LockedRobotState
 {
 public:
-  LockedRobotState(const robot_state::RobotState& state);
-  LockedRobotState(const robot_model::RobotModelPtr& model);
+  LockedRobotState(const moveit::core::RobotState& state);
+  LockedRobotState(const moveit::core::RobotModelPtr& model);
 
   virtual ~LockedRobotState();
 
@@ -72,13 +72,13 @@ public:
   // it.
   //
   // The transforms in the returned state will always be up to date.
-  robot_state::RobotStateConstPtr getState() const;
+  moveit::core::RobotStateConstPtr getState() const;
 
   /// Set the state to the new value.
-  void setState(const robot_state::RobotState& state);
+  void setState(const moveit::core::RobotState& state);
 
   // This is a function that can modify the maintained state.
-  typedef boost::function<void(robot_state::RobotState*)> ModifyStateFunction;
+  typedef boost::function<void(moveit::core::RobotState*)> ModifyStateFunction;
 
   // Modify the state.
   //
@@ -105,6 +105,6 @@ private:
   // The state maintained by this class.
   // When a modify function is being called this is NULL.
   // PROTECTED BY state_lock_
-  robot_state::RobotStatePtr state_;
+  moveit::core::RobotStatePtr state_;
 };
 }

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -76,7 +76,7 @@ public:
   /// The topic name on which the internal Interactive Marker Server operates
   static const std::string INTERACTIVE_MARKER_TOPIC;
 
-  RobotInteraction(const robot_model::RobotModelConstPtr& robot_model, const std::string& ns = "");
+  RobotInteraction(const moveit::core::RobotModelConstPtr& robot_model, const std::string& ns = "");
   virtual ~RobotInteraction();
 
   const std::string& getServerTopic(void) const
@@ -140,7 +140,7 @@ public:
   // is needed to actually remove the markers from the display.
   void clearInteractiveMarkers();
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -180,7 +180,7 @@ private:
   // return the diameter of the sphere that certainly can enclose the AABB of the links in this group
   double computeGroupMarkerSize(const std::string& group);
   void computeMarkerPose(const InteractionHandlerPtr& handler, const EndEffectorInteraction& eef,
-                         const robot_state::RobotState& robot_state, geometry_msgs::Pose& pose,
+                         const moveit::core::RobotState& robot_state, geometry_msgs::Pose& pose,
                          geometry_msgs::Pose& control_to_eef_tf) const;
 
   void addEndEffectorMarkers(const InteractionHandlerPtr& handler, const EndEffectorInteraction& eef,
@@ -199,7 +199,7 @@ private:
   boost::condition_variable new_feedback_condition_;
   std::map<std::string, visualization_msgs::InteractiveMarkerFeedbackConstPtr> feedback_map_;
 
-  robot_model::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_;
 
   std::vector<EndEffectorInteraction> active_eef_;
   std::vector<JointInteraction> active_vj_;

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -56,7 +56,7 @@
 namespace robot_interaction
 {
 InteractionHandler::InteractionHandler(const RobotInteractionPtr& robot_interaction, const std::string& name,
-                                       const robot_state::RobotState& initial_robot_state,
+                                       const moveit::core::RobotState& initial_robot_state,
                                        const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
   : LockedRobotState(initial_robot_state)
   , name_(fixName(name))
@@ -279,7 +279,7 @@ void InteractionHandler::handleJoint(const JointInteraction& vj,
 }
 
 // MUST hold state_lock_ when calling this!
-void InteractionHandler::updateStateGeneric(robot_state::RobotState* state, const GenericInteraction* g,
+void InteractionHandler::updateStateGeneric(moveit::core::RobotState* state, const GenericInteraction* g,
                                             const visualization_msgs::InteractiveMarkerFeedbackConstPtr* feedback,
                                             StateChangeCallbackFn* callback)
 {
@@ -290,7 +290,7 @@ void InteractionHandler::updateStateGeneric(robot_state::RobotState* state, cons
 }
 
 // MUST hold state_lock_ when calling this!
-void InteractionHandler::updateStateEndEffector(robot_state::RobotState* state, const EndEffectorInteraction* eef,
+void InteractionHandler::updateStateEndEffector(moveit::core::RobotState* state, const EndEffectorInteraction* eef,
                                                 const geometry_msgs::Pose* pose, StateChangeCallbackFn* callback)
 {
   // This is called with state_lock_ held, so no additional locking needed to
@@ -304,13 +304,13 @@ void InteractionHandler::updateStateEndEffector(robot_state::RobotState* state, 
 }
 
 // MUST hold state_lock_ when calling this!
-void InteractionHandler::updateStateJoint(robot_state::RobotState* state, const JointInteraction* vj,
+void InteractionHandler::updateStateJoint(moveit::core::RobotState* state, const JointInteraction* vj,
                                           const geometry_msgs::Pose* feedback_pose, StateChangeCallbackFn* callback)
 {
   Eigen::Isometry3d pose;
   tf2::fromMsg(*feedback_pose, pose);
 
-  if (!vj->parent_frame.empty() && !robot_state::Transforms::sameFrame(vj->parent_frame, planning_frame_))
+  if (!vj->parent_frame.empty() && !moveit::core::Transforms::sameFrame(vj->parent_frame, planning_frame_))
     pose = state->getGlobalLinkTransform(vj->parent_frame).inverse() * pose;
 
   state->setJointPositions(vj->joint_name, pose);

--- a/moveit_ros/robot_interaction/src/kinematic_options.cpp
+++ b/moveit_ros/robot_interaction/src/kinematic_options.cpp
@@ -44,10 +44,10 @@ robot_interaction::KinematicOptions::KinematicOptions() : timeout_seconds_(0.0) 
 
 // This is intended to be called as a ModifyStateFunction to modify the state
 // maintained by a LockedRobotState in place.
-bool robot_interaction::KinematicOptions::setStateFromIK(robot_state::RobotState& state, const std::string& group,
+bool robot_interaction::KinematicOptions::setStateFromIK(moveit::core::RobotState& state, const std::string& group,
                                                          const std::string& tip, const geometry_msgs::Pose& pose) const
 {
-  const robot_model::JointModelGroup* jmg = state.getJointModelGroup(group);
+  const moveit::core::JointModelGroup* jmg = state.getJointModelGroup(group);
   if (!jmg)
   {
     ROS_ERROR("No getJointModelGroup('%s') found", group.c_str());
@@ -72,7 +72,7 @@ void robot_interaction::KinematicOptions::setOptions(const KinematicOptions& sou
 // robot_interaction::KinematicOptions except options_
 #define O_FIELDS(F)                                                                                                    \
   F(double, timeout_seconds_, TIMEOUT)                                                                                 \
-  F(robot_state::GroupStateValidityCallbackFn, state_validity_callback_, STATE_VALIDITY_CALLBACK)
+  F(moveit::core::GroupStateValidityCallbackFn, state_validity_callback_, STATE_VALIDITY_CALLBACK)
 
 // This needs to represent all the fields in
 // kinematics::KinematicsQueryOptions

--- a/moveit_ros/robot_interaction/src/kinematic_options_map.cpp
+++ b/moveit_ros/robot_interaction/src/kinematic_options_map.cpp
@@ -131,7 +131,7 @@ void robot_interaction::KinematicOptionsMap::merge(const KinematicOptionsMap& ot
 
 // This is intended to be called as a ModifyStateFunction to modify the state
 // maintained by a LockedRobotState in place.
-bool robot_interaction::KinematicOptionsMap::setStateFromIK(robot_state::RobotState& state, const std::string& key,
+bool robot_interaction::KinematicOptionsMap::setStateFromIK(moveit::core::RobotState& state, const std::string& key,
                                                             const std::string& group, const std::string& tip,
                                                             const geometry_msgs::Pose& pose) const
 {

--- a/moveit_ros/robot_interaction/src/locked_robot_state.cpp
+++ b/moveit_ros/robot_interaction/src/locked_robot_state.cpp
@@ -38,14 +38,14 @@
 
 #include <moveit/robot_interaction/locked_robot_state.h>
 
-robot_interaction::LockedRobotState::LockedRobotState(const robot_state::RobotState& state)
-  : state_(new robot_state::RobotState(state))
+robot_interaction::LockedRobotState::LockedRobotState(const moveit::core::RobotState& state)
+  : state_(new moveit::core::RobotState(state))
 {
   state_->update();
 }
 
-robot_interaction::LockedRobotState::LockedRobotState(const robot_model::RobotModelPtr& model)
-  : state_(new robot_state::RobotState(model))
+robot_interaction::LockedRobotState::LockedRobotState(const moveit::core::RobotModelPtr& model)
+  : state_(new moveit::core::RobotState(model))
 {
   state_->setToDefaultValues();
   state_->update();
@@ -53,13 +53,13 @@ robot_interaction::LockedRobotState::LockedRobotState(const robot_model::RobotMo
 
 robot_interaction::LockedRobotState::~LockedRobotState() = default;
 
-robot_state::RobotStateConstPtr robot_interaction::LockedRobotState::getState() const
+moveit::core::RobotStateConstPtr robot_interaction::LockedRobotState::getState() const
 {
   boost::mutex::scoped_lock lock(state_lock_);
   return state_;
 }
 
-void robot_interaction::LockedRobotState::setState(const robot_state::RobotState& state)
+void robot_interaction::LockedRobotState::setState(const moveit::core::RobotState& state)
 {
   {
     boost::mutex::scoped_lock lock(state_lock_);
@@ -69,7 +69,7 @@ void robot_interaction::LockedRobotState::setState(const robot_state::RobotState
     if (state_.unique())
       *state_ = state;
     else
-      state_.reset(new robot_state::RobotState(state));
+      state_.reset(new moveit::core::RobotState(state));
 
     state_->update();
   }
@@ -84,7 +84,7 @@ void robot_interaction::LockedRobotState::modifyState(const ModifyStateFunction&
     // If someone else has a reference to the state, then make a copy.
     // The old state is orphaned (does not change, but is now out of date).
     if (!state_.unique())
-      state_.reset(new robot_state::RobotState(*state_));
+      state_.reset(new moveit::core::RobotState(*state_));
 
     modify(state_.get());
     state_->update();

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -256,7 +256,7 @@ TEST(LockedRobotState, URDF_sanity)
 class Super1 : public robot_interaction::LockedRobotState
 {
 public:
-  Super1(const robot_model::RobotModelPtr& model) : LockedRobotState(model), cnt_(0)
+  Super1(const moveit::core::RobotModelPtr& model) : LockedRobotState(model), cnt_(0)
   {
   }
 
@@ -268,7 +268,7 @@ public:
   int cnt_;
 };
 
-static void modify1(robot_state::RobotState* state)
+static void modify1(moveit::core::RobotState* state)
 {
   state->setVariablePosition(JOINT_A, 0.00006);
 }
@@ -281,7 +281,7 @@ TEST(LockedRobotState, robotStateChanged)
 
   EXPECT_EQ(ls1.cnt_, 0);
 
-  robot_state::RobotState cp1(*ls1.getState());
+  moveit::core::RobotState cp1(*ls1.getState());
   cp1.setVariablePosition(JOINT_A, 0.00001);
   cp1.setVariablePosition(JOINT_C, 0.00002);
   cp1.setVariablePosition(JOINT_F, 0.00003);
@@ -319,7 +319,7 @@ public:
 
 private:
   // helper function for modifyThreadFunc
-  void modifyFunc(robot_state::RobotState* state, double val);
+  void modifyFunc(moveit::core::RobotState* state, double val);
 
   // Checks state for validity and self-consistancy.
   void checkState(robot_interaction::LockedRobotState& locked_state);
@@ -335,9 +335,9 @@ private:
 // Check the state.  It should always be valid.
 void MyInfo::checkState(robot_interaction::LockedRobotState& locked_state)
 {
-  robot_state::RobotStateConstPtr s = locked_state.getState();
+  moveit::core::RobotStateConstPtr s = locked_state.getState();
 
-  robot_state::RobotState cp1(*s);
+  moveit::core::RobotState cp1(*s);
 
   // take some time
   cnt_lock_.lock();
@@ -350,7 +350,7 @@ void MyInfo::checkState(robot_interaction::LockedRobotState& locked_state)
   // check mim_f == joint_f
   EXPECT_EQ(s->getVariablePositions()[MIM_F], s->getVariablePositions()[JOINT_F] * 1.5 + 0.1);
 
-  robot_state::RobotState cp2(*s);
+  moveit::core::RobotState cp2(*s);
 
   EXPECT_NE(cp1.getVariablePositions(), cp2.getVariablePositions());
   EXPECT_NE(cp1.getVariablePositions(), s->getVariablePositions());
@@ -394,7 +394,7 @@ void MyInfo::setThreadFunc(robot_interaction::LockedRobotState* locked_state, in
     for (int loops = 0; loops < 100; ++loops)
     {
       val += 0.0001;
-      robot_state::RobotState cp1(*locked_state->getState());
+      moveit::core::RobotState cp1(*locked_state->getState());
 
       cp1.setVariablePosition(JOINT_A, val + 0.00001);
       cp1.setVariablePosition(JOINT_C, val + 0.00002);
@@ -415,7 +415,7 @@ void MyInfo::setThreadFunc(robot_interaction::LockedRobotState* locked_state, in
 }
 
 // modify the state in place.  Used by MyInfo::modifyThreadFunc()
-void MyInfo::modifyFunc(robot_state::RobotState* state, double val)
+void MyInfo::modifyFunc(moveit::core::RobotState* state, double val)
 {
   state->setVariablePosition(JOINT_A, val + 0.00001);
   state->setVariablePosition(JOINT_C, val + 0.00002);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -96,17 +96,17 @@ public:
 
   void setName(const QString& name) override;
 
-  robot_state::RobotStateConstPtr getQueryStartState() const
+  moveit::core::RobotStateConstPtr getQueryStartState() const
   {
     return query_start_state_->getState();
   }
 
-  robot_state::RobotStateConstPtr getQueryGoalState() const
+  moveit::core::RobotStateConstPtr getQueryGoalState() const
   {
     return query_goal_state_->getState();
   }
 
-  const robot_state::RobotState& getPreviousState() const
+  const moveit::core::RobotState& getPreviousState() const
   {
     return *previous_state_;
   }
@@ -131,8 +131,8 @@ public:
     trajectory_visual_->dropTrajectory();
   }
 
-  void setQueryStartState(const robot_state::RobotState& start);
-  void setQueryGoalState(const robot_state::RobotState& goal);
+  void setQueryStartState(const moveit::core::RobotState& start);
+  void setQueryGoalState(const moveit::core::RobotState& goal);
 
   void updateQueryStartState();
   void updateQueryGoalState();
@@ -216,14 +216,14 @@ protected:
   void scheduleDrawQueryStartState(robot_interaction::InteractionHandler* handler, bool error_state_changed);
   void scheduleDrawQueryGoalState(robot_interaction::InteractionHandler* handler, bool error_state_changed);
 
-  bool isIKSolutionCollisionFree(robot_state::RobotState* state, const robot_state::JointModelGroup* group,
+  bool isIKSolutionCollisionFree(moveit::core::RobotState* state, const moveit::core::JointModelGroup* group,
                                  const double* ik_solution) const;
 
   void computeMetrics(bool start, const std::string& group, double payload);
   void computeMetricsInternal(std::map<std::string, double>& metrics,
                               const robot_interaction::EndEffectorInteraction& eef,
-                              const robot_state::RobotState& state, double payload);
-  void updateStateExceptModified(robot_state::RobotState& dest, const robot_state::RobotState& src);
+                              const moveit::core::RobotState& state, double payload);
+  void updateStateExceptModified(moveit::core::RobotState& dest, const moveit::core::RobotState& src);
   void updateBackgroundJobProgressBar();
   void backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent event, const std::string& jobname);
 
@@ -264,7 +264,7 @@ protected:
   std::map<std::string, LinkDisplayStatus> status_links_start_;
   std::map<std::string, LinkDisplayStatus> status_links_goal_;
   /// remember previous start state (updated before starting execution)
-  robot_state::RobotStatePtr previous_state_;
+  moveit::core::RobotStatePtr previous_state_;
 
   /// Hold the names of the groups for which the query states have been updated (and should not be altered when new info
   /// is received from the planning scene)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -235,7 +235,7 @@ private:
   void populateConstraintsList(const std::vector<std::string>& constr);
   void configureForPlanning();
   void configureWorkspace();
-  void updateQueryStateHelper(robot_state::RobotState& state, const std::string& v);
+  void updateQueryStateHelper(moveit::core::RobotState& state, const std::string& v);
   void fillStateSelectionOptions();
   void fillPlanningGroupOptions();
   void startStateTextChangedExec(const std::string& start_state);
@@ -266,7 +266,7 @@ private:
   void checkPlanningSceneTreeEnabledButtons();
 
   // States tab
-  void saveRobotStateButtonClicked(const robot_state::RobotState& state);
+  void saveRobotStateButtonClicked(const moveit::core::RobotState& state);
   void populateRobotStatesList();
 
   // Pick and place

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -488,7 +488,7 @@ void MotionPlanningDisplay::computeMetrics(bool start, const std::string& group,
     return;
   boost::mutex::scoped_lock slock(update_metrics_lock_);
 
-  robot_state::RobotStateConstPtr state = start ? getQueryStartState() : getQueryGoalState();
+  moveit::core::RobotStateConstPtr state = start ? getQueryStartState() : getQueryGoalState();
   for (const robot_interaction::EndEffectorInteraction& ee : eef)
     if (ee.parent_group == group)
       computeMetricsInternal(computed_metrics_[std::make_pair(start, group)], ee, *state, payload);
@@ -496,7 +496,7 @@ void MotionPlanningDisplay::computeMetrics(bool start, const std::string& group,
 
 void MotionPlanningDisplay::computeMetricsInternal(std::map<std::string, double>& metrics,
                                                    const robot_interaction::EndEffectorInteraction& ee,
-                                                   const robot_state::RobotState& state, double payload)
+                                                   const moveit::core::RobotState& state, double payload)
 {
   metrics.clear();
   dynamics_solver::DynamicsSolverPtr ds;
@@ -564,7 +564,7 @@ void MotionPlanningDisplay::displayMetrics(bool start)
   if (eef.empty())
     return;
 
-  robot_state::RobotStateConstPtr state = start ? getQueryStartState() : getQueryGoalState();
+  moveit::core::RobotStateConstPtr state = start ? getQueryStartState() : getQueryGoalState();
 
   for (const robot_interaction::EndEffectorInteraction& ee : eef)
   {
@@ -591,8 +591,8 @@ void MotionPlanningDisplay::displayMetrics(bool start)
       }
     }
 
-    const robot_state::LinkModel* lm = nullptr;
-    const robot_model::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(ee.parent_group);
+    const moveit::core::LinkModel* lm = nullptr;
+    const moveit::core::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(ee.parent_group);
     if (jmg)
       if (!jmg->getLinkModelNames().empty())
         lm = state->getLinkModel(jmg->getLinkModelNames().back());
@@ -620,7 +620,7 @@ void MotionPlanningDisplay::drawQueryStartState()
   {
     if (isEnabled())
     {
-      robot_state::RobotStateConstPtr state = getQueryStartState();
+      moveit::core::RobotStateConstPtr state = getQueryStartState();
 
       // update link poses
       query_robot_start_->update(state);
@@ -645,11 +645,11 @@ void MotionPlanningDisplay::drawQueryStartState()
       }
       if (!getCurrentPlanningGroup().empty())
       {
-        const robot_model::JointModelGroup* jmg = state->getJointModelGroup(getCurrentPlanningGroup());
+        const moveit::core::JointModelGroup* jmg = state->getJointModelGroup(getCurrentPlanningGroup());
         if (jmg)
         {
           std::vector<std::string> outside_bounds;
-          const std::vector<const robot_model::JointModel*>& jmodels = jmg->getActiveJointModels();
+          const std::vector<const moveit::core::JointModel*>& jmodels = jmg->getActiveJointModels();
           for (const moveit::core::JointModel* jmodel : jmodels)
             if (!state->satisfiesBounds(jmodel, jmodel->getMaximumExtent() * 1e-2))
             {
@@ -741,7 +741,7 @@ void MotionPlanningDisplay::drawQueryGoalState()
   {
     if (isEnabled())
     {
-      robot_state::RobotStateConstPtr state = getQueryGoalState();
+      moveit::core::RobotStateConstPtr state = getQueryGoalState();
 
       // update link poses
       query_robot_goal_->update(state);
@@ -767,10 +767,10 @@ void MotionPlanningDisplay::drawQueryGoalState()
 
       if (!getCurrentPlanningGroup().empty())
       {
-        const robot_model::JointModelGroup* jmg = state->getJointModelGroup(getCurrentPlanningGroup());
+        const moveit::core::JointModelGroup* jmg = state->getJointModelGroup(getCurrentPlanningGroup());
         if (jmg)
         {
-          const std::vector<const robot_state::JointModel*>& jmodels = jmg->getActiveJointModels();
+          const std::vector<const moveit::core::JointModel*>& jmodels = jmg->getActiveJointModels();
           std::vector<std::string> outside_bounds;
           for (const moveit::core::JointModel* jmodel : jmodels)
             if (!state->satisfiesBounds(jmodel, jmodel->getMaximumExtent() * 1e-2))
@@ -944,13 +944,13 @@ void MotionPlanningDisplay::rememberPreviousStartState()
   *previous_state_ = *query_start_state_->getState();
 }
 
-void MotionPlanningDisplay::setQueryStartState(const robot_state::RobotState& start)
+void MotionPlanningDisplay::setQueryStartState(const moveit::core::RobotState& start)
 {
   query_start_state_->setState(start);
   updateQueryStartState();
 }
 
-void MotionPlanningDisplay::setQueryGoalState(const robot_state::RobotState& goal)
+void MotionPlanningDisplay::setQueryGoalState(const moveit::core::RobotState& goal)
 {
   query_goal_state_->setState(goal);
   updateQueryGoalState();
@@ -968,8 +968,8 @@ void MotionPlanningDisplay::useApproximateIK(bool flag)
   }
 }
 
-bool MotionPlanningDisplay::isIKSolutionCollisionFree(robot_state::RobotState* state,
-                                                      const robot_model::JointModelGroup* group,
+bool MotionPlanningDisplay::isIKSolutionCollisionFree(moveit::core::RobotState* state,
+                                                      const moveit::core::JointModelGroup* group,
                                                       const double* ik_solution) const
 {
   if (frame_->ui_->collision_aware_ik->isChecked() && planning_scene_monitor_)
@@ -1061,13 +1061,13 @@ std::string MotionPlanningDisplay::getCurrentPlanningGroup() const
 
 void MotionPlanningDisplay::setQueryStateHelper(bool use_start_state, const std::string& state_name)
 {
-  robot_state::RobotState state = use_start_state ? *getQueryStartState() : *getQueryGoalState();
+  moveit::core::RobotState state = use_start_state ? *getQueryStartState() : *getQueryGoalState();
 
   std::string v = "<" + state_name + ">";
 
   if (v == "<random>")
   {
-    if (const robot_state::JointModelGroup* jmg = state.getJointModelGroup(getCurrentPlanningGroup()))
+    if (const moveit::core::JointModelGroup* jmg = state.getJointModelGroup(getCurrentPlanningGroup()))
       state.setToRandomPositions(jmg);
   }
   else if (v == "<current>")
@@ -1087,7 +1087,7 @@ void MotionPlanningDisplay::setQueryStateHelper(bool use_start_state, const std:
   else
   {
     // maybe it is a named state
-    if (const robot_model::JointModelGroup* jmg = state.getJointModelGroup(getCurrentPlanningGroup()))
+    if (const moveit::core::JointModelGroup* jmg = state.getJointModelGroup(getCurrentPlanningGroup()))
       state.setToDefaultValues(jmg, state_name);
   }
 
@@ -1144,7 +1144,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   query_robot_goal_->load(*getRobotModel()->getURDF());
 
   // initialize previous state, start state, and goal state to current state
-  previous_state_ = std::make_shared<robot_state::RobotState>(getPlanningSceneRO()->getCurrentState());
+  previous_state_ = std::make_shared<moveit::core::RobotState>(getPlanningSceneRO()->getCurrentState());
   query_start_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "start", *previous_state_,
                                                                      planning_scene_monitor_->getTFClient()));
   query_goal_state_.reset(new robot_interaction::InteractionHandler(robot_interaction_, "goal", *previous_state_,
@@ -1188,12 +1188,12 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::changedPlanningGroup, this));
 }
 
-void MotionPlanningDisplay::updateStateExceptModified(robot_state::RobotState& dest, const robot_state::RobotState& src)
+void MotionPlanningDisplay::updateStateExceptModified(moveit::core::RobotState& dest, const moveit::core::RobotState& src)
 {
-  robot_state::RobotState src_copy = src;
+  moveit::core::RobotState src_copy = src;
   for (const std::string& modified_group : modified_groups_)
   {
-    const robot_model::JointModelGroup* jmg = dest.getJointModelGroup(modified_group);
+    const moveit::core::JointModelGroup* jmg = dest.getJointModelGroup(modified_group);
     if (jmg)
     {
       std::vector<double> values_to_keep;
@@ -1210,19 +1210,19 @@ void MotionPlanningDisplay::onSceneMonitorReceivedUpdate(
     planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type)
 {
   PlanningSceneDisplay::onSceneMonitorReceivedUpdate(update_type);
-  robot_state::RobotState current_state = getPlanningSceneRO()->getCurrentState();
+  moveit::core::RobotState current_state = getPlanningSceneRO()->getCurrentState();
   std::string group = planning_group_property_->getStdString();
 
   if (query_start_state_ && query_start_state_property_->getBool() && !group.empty())
   {
-    robot_state::RobotState start = *getQueryStartState();
+    moveit::core::RobotState start = *getQueryStartState();
     updateStateExceptModified(start, current_state);
     setQueryStartState(start);
   }
 
   if (query_goal_state_ && query_goal_state_property_->getBool() && !group.empty())
   {
-    robot_state::RobotState goal = *getQueryGoalState();
+    moveit::core::RobotState goal = *getQueryGoalState();
     updateStateExceptModified(goal, current_state);
     setQueryGoalState(goal);
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1188,7 +1188,8 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::changedPlanningGroup, this));
 }
 
-void MotionPlanningDisplay::updateStateExceptModified(moveit::core::RobotState& dest, const moveit::core::RobotState& src)
+void MotionPlanningDisplay::updateStateExceptModified(moveit::core::RobotState& dest,
+                                                      const moveit::core::RobotState& src)
 {
   moveit::core::RobotState src_copy = src;
   for (const std::string& modified_group : modified_groups_)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -261,7 +261,7 @@ void MotionPlanningFrame::fillPlanningGroupOptions()
   const QSignalBlocker planning_group_blocker(ui_->planning_group_combo_box);
   ui_->planning_group_combo_box->clear();
 
-  const robot_model::RobotModelConstPtr& kmodel = planning_display_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& kmodel = planning_display_->getRobotModel();
   for (const std::string& group_name : kmodel->getJointModelGroupNames())
     ui_->planning_group_combo_box->addItem(QString::fromStdString(group_name));
 }
@@ -276,11 +276,11 @@ void MotionPlanningFrame::fillStateSelectionOptions()
   if (!planning_display_->getPlanningSceneMonitor())
     return;
 
-  const robot_model::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
   std::string group = planning_display_->getCurrentPlanningGroup();
   if (group.empty())
     return;
-  const robot_model::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
+  const moveit::core::JointModelGroup* jmg = robot_model->getJointModelGroup(group);
   if (jmg)
   {
     ui_->start_state_combo_box->addItem(QString("<random valid>"));
@@ -321,7 +321,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
   planning_display_->addMainLoopJob(
       boost::bind(&MotionPlanningFrame::populateConstraintsList, this, std::vector<std::string>()));
 
-  const robot_model::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& robot_model = planning_display_->getRobotModel();
   std::string group = planning_display_->getCurrentPlanningGroup();
   planning_display_->addMainLoopJob(
       boost::bind(&MotionPlanningParamWidget::setGroupName, ui_->planner_param_treeview, group));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -301,14 +301,14 @@ void MotionPlanningFrame::placeObjectButtonClicked()
   ui_->pick_button->setEnabled(false);
   ui_->place_button->setEnabled(false);
 
-  std::vector<const robot_state::AttachedBody*> attached_bodies;
+  std::vector<const moveit::core::AttachedBody*> attached_bodies;
   const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
   if (!ps)
   {
     ROS_ERROR("No planning scene");
     return;
   }
-  const robot_model::JointModelGroup* jmg = ps->getCurrentState().getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* jmg = ps->getCurrentState().getJointModelGroup(group_name);
   if (jmg)
     ps->getCurrentState().getAttachedBodies(attached_bodies, jmg);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -641,9 +641,10 @@ void MotionPlanningFrame::computeLoadQueryButtonClicked()
 
         if (got_q)
         {
-          moveit::core::RobotStatePtr start_state(new moveit::core::RobotState(*planning_display_->getQueryStartState()));
+          moveit::core::RobotStatePtr start_state(
+              new moveit::core::RobotState(*planning_display_->getQueryStartState()));
           moveit::core::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
-                                                 mp->start_state, *start_state);
+                                                  mp->start_state, *start_state);
           planning_display_->setQueryStartState(*start_state);
 
           moveit::core::RobotStatePtr goal_state(new moveit::core::RobotState(*planning_display_->getQueryGoalState()));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -179,7 +179,7 @@ static QString decideStatusText(const collision_detection::CollisionEnv::ObjectC
   return status_text;
 }
 
-static QString decideStatusText(const robot_state::AttachedBody* attached_body)
+static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
 {
   QString status_text = "'" + QString::fromStdString(attached_body->getName()) + "' is attached to '" +
                         QString::fromStdString(attached_body->getAttachedLinkName()) + "'";
@@ -280,7 +280,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
       // if it is an attached object
       scene_marker_.reset();
       const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
-      const robot_state::AttachedBody* attached_body =
+      const moveit::core::AttachedBody* attached_body =
           ps->getCurrentState().getAttachedBody(sel[0]->text().toStdString());
       if (attached_body)
         ui_->object_status->setText(decideStatusText(attached_body));
@@ -641,12 +641,12 @@ void MotionPlanningFrame::computeLoadQueryButtonClicked()
 
         if (got_q)
         {
-          robot_state::RobotStatePtr start_state(new robot_state::RobotState(*planning_display_->getQueryStartState()));
-          robot_state::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
+          moveit::core::RobotStatePtr start_state(new moveit::core::RobotState(*planning_display_->getQueryStartState()));
+          moveit::core::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
                                                  mp->start_state, *start_state);
           planning_display_->setQueryStartState(*start_state);
 
-          robot_state::RobotStatePtr goal_state(new robot_state::RobotState(*planning_display_->getQueryGoalState()));
+          moveit::core::RobotStatePtr goal_state(new moveit::core::RobotState(*planning_display_->getQueryGoalState()));
           for (const moveit_msgs::Constraints& goal_constraint : mp->goal_constraints)
             if (!goal_constraint.joint_constraints.empty())
             {
@@ -775,12 +775,12 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
   {
     // rename attached body
     planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
-    robot_state::RobotState& cs = ps->getCurrentStateNonConst();
-    const robot_state::AttachedBody* ab = cs.getAttachedBody(known_collision_objects_[item->type()].first);
+    moveit::core::RobotState& cs = ps->getCurrentStateNonConst();
+    const moveit::core::AttachedBody* ab = cs.getAttachedBody(known_collision_objects_[item->type()].first);
     if (ab)
     {
       known_collision_objects_[item->type()].first = item_text;
-      robot_state::AttachedBody* new_ab = new robot_state::AttachedBody(
+      moveit::core::AttachedBody* new_ab = new moveit::core::AttachedBody(
           ab->getAttachedLink(), known_collision_objects_[item->type()].first, ab->getShapes(),
           ab->getFixedTransforms(), ab->getTouchLinks(), ab->getDetachPosture(), ab->getSubframeTransforms());
       cs.clearAttachedBody(ab->getName());
@@ -818,7 +818,7 @@ void MotionPlanningFrame::attachDetachCollisionObject(QListWidgetItem* item)
   else  // we need to detach an attached object
   {
     const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
-    const robot_state::AttachedBody* attached_body = ps->getCurrentState().getAttachedBody(data.first);
+    const moveit::core::AttachedBody* attached_body = ps->getCurrentState().getAttachedBody(data.first);
     if (attached_body)
     {
       aco.link_name = attached_body->getAttachedLinkName();
@@ -876,8 +876,8 @@ void MotionPlanningFrame::populateCollisionObjectsList()
         known_collision_objects_.push_back(std::make_pair(collision_object_names[i], false));
       }
 
-      const robot_state::RobotState& cs = ps->getCurrentState();
-      std::vector<const robot_state::AttachedBody*> attached_bodies;
+      const moveit::core::RobotState& cs = ps->getCurrentState();
+      std::vector<const moveit::core::AttachedBody*> attached_bodies;
       cs.getAttachedBodies(attached_bodies);
       for (std::size_t i = 0; i < attached_bodies.size(); ++i)
       {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -119,7 +119,7 @@ void MotionPlanningFrame::loadStoredStates(const std::string& pattern)
   populateRobotStatesList();
 }
 
-void MotionPlanningFrame::saveRobotStateButtonClicked(const robot_state::RobotState& state)
+void MotionPlanningFrame::saveRobotStateButtonClicked(const moveit::core::RobotState& state)
 {
   bool ok = false;
 
@@ -144,7 +144,7 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const robot_state::RobotSt
       {
         // Store the current start state
         moveit_msgs::RobotState msg;
-        robot_state::robotStateToRobotStateMsg(state, msg);
+        moveit::core::robotStateToRobotStateMsg(state, msg);
         robot_states_.insert(RobotStatePair(name, msg));
 
         // Save to the database if connected
@@ -188,8 +188,8 @@ void MotionPlanningFrame::setAsStartStateButtonClicked()
 
   if (item)
   {
-    robot_state::RobotState robot_state(*planning_display_->getQueryStartState());
-    robot_state::robotStateMsgToRobotState(robot_states_[item->text().toStdString()], robot_state);
+    moveit::core::RobotState robot_state(*planning_display_->getQueryStartState());
+    moveit::core::robotStateMsgToRobotState(robot_states_[item->text().toStdString()], robot_state);
     planning_display_->setQueryStartState(robot_state);
   }
 }
@@ -200,8 +200,8 @@ void MotionPlanningFrame::setAsGoalStateButtonClicked()
 
   if (item)
   {
-    robot_state::RobotState robot_state(*planning_display_->getQueryGoalState());
-    robot_state::robotStateMsgToRobotState(robot_states_[item->text().toStdString()], robot_state);
+    moveit::core::RobotState robot_state(*planning_display_->getQueryGoalState());
+    moveit::core::robotStateMsgToRobotState(robot_states_[item->text().toStdString()], robot_state);
     planning_display_->setQueryGoalState(robot_state);
   }
 }

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -102,7 +102,7 @@ public:
   void clearJobs();
 
   const std::string getMoveGroupNS() const;
-  const robot_model::RobotModelConstPtr& getRobotModel() const;
+  const moveit::core::RobotModelConstPtr& getRobotModel() const;
 
   /// wait for robot state more recent than t
   bool waitForCurrentRobotState(const ros::Time& t = ros::Time::now());

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -268,13 +268,13 @@ const std::string PlanningSceneDisplay::getMoveGroupNS() const
   return move_group_ns_property_->getStdString();
 }
 
-const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() const
+const moveit::core::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() const
 {
   if (planning_scene_monitor_)
     return planning_scene_monitor_->getRobotModel();
   else
   {
-    static robot_model::RobotModelConstPtr empty;
+    static moveit::core::RobotModelConstPtr empty;
     return empty;
   }
 }
@@ -416,7 +416,7 @@ void PlanningSceneDisplay::setGroupColor(rviz::Robot* robot, const std::string& 
 {
   if (getRobotModel())
   {
-    const robot_model::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(group_name);
+    const moveit::core::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(group_name);
     if (jmg)
     {
       const std::vector<std::string>& links = jmg->getLinkModelNamesWithCollisionGeometry();
@@ -440,7 +440,7 @@ void PlanningSceneDisplay::unsetGroupColor(rviz::Robot* robot, const std::string
 {
   if (getRobotModel())
   {
-    const robot_model::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(group_name);
+    const moveit::core::JointModelGroup* jmg = getRobotModel()->getJointModelGroup(group_name);
     if (jmg)
     {
       const std::vector<std::string>& links = jmg->getLinkModelNamesWithCollisionGeometry();
@@ -542,9 +542,9 @@ void PlanningSceneDisplay::onRobotModelLoaded()
   if (planning_scene_robot_)
   {
     planning_scene_robot_->load(*getRobotModel()->getURDF());
-    robot_state::RobotState* rs = new robot_state::RobotState(ps->getCurrentState());
+    moveit::core::RobotState* rs = new moveit::core::RobotState(ps->getCurrentState());
     rs->update();
-    planning_scene_robot_->update(robot_state::RobotStateConstPtr(rs));
+    planning_scene_robot_->update(moveit::core::RobotStateConstPtr(rs));
   }
 
   bool old_state = scene_name_property_->blockSignals(true);

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -75,7 +75,7 @@ public:
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const
+  const moveit::core::RobotModelConstPtr& getRobotModel() const
   {
     return robot_model_;
   }
@@ -130,8 +130,8 @@ protected:
 
   RobotStateVisualizationPtr robot_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
-  robot_model::RobotModelConstPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotStatePtr robot_state_;
   std::map<std::string, std_msgs::ColorRGBA> highlights_;
   bool update_state_;
   bool load_robot_model_;  // for delayed robot initialization

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -306,12 +306,12 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   if (!robot_model_)
     return;
   if (!robot_state_)
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
-  // possibly use TF to construct a robot_state::Transforms object to pass in to the conversion function?
+    robot_state_.reset(new moveit::core::RobotState(robot_model_));
+  // possibly use TF to construct a moveit::core::Transforms object to pass in to the conversion function?
   try
   {
     if (!moveit::core::isEmpty(state_msg->state))
-      robot_state::robotStateMsgToRobotState(state_msg->state, *robot_state_);
+      moveit::core::robotStateMsgToRobotState(state_msg->state, *robot_state_);
     setRobotHighlights(state_msg->highlight_links);
   }
   catch (const moveit::Exception& e)
@@ -381,9 +381,9 @@ void RobotStateDisplay::loadRobotModel()
   {
     const srdf::ModelSharedPtr& srdf =
         rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
-    robot_model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+    robot_model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
     robot_->load(*robot_model_->getURDF());
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
+    robot_state_.reset(new moveit::core::RobotState(robot_model_));
     robot_state_->setToDefaultValues();
     bool old_state = root_link_name_property_->blockSignals(true);
     root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_link_updater.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_link_updater.h
@@ -45,11 +45,11 @@ DIAGNOSTIC_POP
 
 namespace moveit_rviz_plugin
 {
-/** \brief Update the links of an rviz::Robot using a robot_state::RobotState */
+/** \brief Update the links of an rviz::Robot using a moveit::core::RobotState */
 class PlanningLinkUpdater : public rviz::LinkUpdater
 {
 public:
-  PlanningLinkUpdater(const robot_state::RobotStateConstPtr& state) : kinematic_state_(state)
+  PlanningLinkUpdater(const moveit::core::RobotStateConstPtr& state) : kinematic_state_(state)
   {
   }
 
@@ -58,6 +58,6 @@ public:
                          Ogre::Quaternion& collision_orientation) const override;
 
 private:
-  robot_state::RobotStateConstPtr kinematic_state_;
+  moveit::core::RobotStateConstPtr kinematic_state_;
 };
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -50,7 +50,7 @@ namespace moveit_rviz_plugin
 MOVEIT_CLASS_FORWARD(RenderShapes);
 MOVEIT_CLASS_FORWARD(RobotStateVisualization);
 
-/** \brief Update the links of an rviz::Robot using a robot_state::RobotState */
+/** \brief Update the links of an rviz::Robot using a moveit::core::RobotState */
 class RobotStateVisualization
 {
 public:
@@ -65,10 +65,10 @@ public:
   void load(const urdf::ModelInterface& descr, bool visual = true, bool collision = true);
   void clear();
 
-  void update(const robot_state::RobotStateConstPtr& kinematic_state);
-  void update(const robot_state::RobotStateConstPtr& kinematic_state,
+  void update(const moveit::core::RobotStateConstPtr& kinematic_state);
+  void update(const moveit::core::RobotStateConstPtr& kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color);
-  void update(const robot_state::RobotStateConstPtr& kinematic_state,
+  void update(const moveit::core::RobotStateConstPtr& kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color,
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
@@ -101,7 +101,7 @@ public:
   void setAlpha(float alpha);
 
 private:
-  void updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
+  void updateHelper(const moveit::core::RobotStateConstPtr& kinematic_state,
                     const std_msgs::ColorRGBA& default_attached_object_color,
                     const std::map<std::string, std_msgs::ColorRGBA>* color_map);
   rviz::Robot robot_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -89,7 +89,7 @@ public:
   virtual void reset();
 
   void onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context, const ros::NodeHandle& update_nh);
-  void onRobotModelLoaded(const robot_model::RobotModelConstPtr& robot_model);
+  void onRobotModelLoaded(const moveit::core::RobotModelConstPtr& robot_model);
   void onEnable();
   void onDisable();
   void setName(const QString& name);
@@ -143,8 +143,8 @@ protected:
   float current_state_time_;
   boost::mutex update_trajectory_message_;
 
-  robot_model::RobotModelConstPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotStatePtr robot_state_;
 
   // Pointers from parent display taht we save
   rviz::Display* display_;  // the parent display that this class populates

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
@@ -44,7 +44,7 @@ bool moveit_rviz_plugin::PlanningLinkUpdater::getLinkTransforms(const std::strin
                                                                 Ogre::Vector3& collision_position,
                                                                 Ogre::Quaternion& collision_orientation) const
 {
-  const robot_model::LinkModel* link_model = kinematic_state_->getLinkModel(link_name);
+  const moveit::core::LinkModel* link_model = kinematic_state_->getLinkModel(link_name);
 
   if (!link_model)
   {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -74,7 +74,7 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
 
   if (scene_robot_)
   {
-    robot_state::RobotState* rs = new robot_state::RobotState(scene->getCurrentState());
+    moveit::core::RobotState* rs = new moveit::core::RobotState(scene->getCurrentState());
     rs->update();
 
     std_msgs::ColorRGBA color;
@@ -84,7 +84,7 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     color.a = 1.0f;
     planning_scene::ObjectColorMap color_map;
     scene->getKnownObjectColors(color_map);
-    scene_robot_->update(robot_state::RobotStateConstPtr(rs), color, color_map);
+    scene_robot_->update(moveit::core::RobotStateConstPtr(rs), color, color_map);
   }
 
   const std::vector<std::string>& ids = scene->getWorld()->getObjectIds();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -86,34 +86,34 @@ void RobotStateVisualization::updateAttachedObjectColors(const std_msgs::ColorRG
                                     robot_.getAlpha());
 }
 
-void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state)
+void RobotStateVisualization::update(const moveit::core::RobotStateConstPtr& kinematic_state)
 {
   updateHelper(kinematic_state, default_attached_object_color_, nullptr);
 }
 
-void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state,
+void RobotStateVisualization::update(const moveit::core::RobotStateConstPtr& kinematic_state,
                                      const std_msgs::ColorRGBA& default_attached_object_color)
 {
   updateHelper(kinematic_state, default_attached_object_color, nullptr);
 }
 
-void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state,
+void RobotStateVisualization::update(const moveit::core::RobotStateConstPtr& kinematic_state,
                                      const std_msgs::ColorRGBA& default_attached_object_color,
                                      const std::map<std::string, std_msgs::ColorRGBA>& color_map)
 {
   updateHelper(kinematic_state, default_attached_object_color, &color_map);
 }
 
-void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
+void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPtr& kinematic_state,
                                            const std_msgs::ColorRGBA& default_attached_object_color,
                                            const std::map<std::string, std_msgs::ColorRGBA>* color_map)
 {
   robot_.update(PlanningLinkUpdater(kinematic_state));
   render_shapes_->clear();
 
-  std::vector<const robot_state::AttachedBody*> attached_bodies;
+  std::vector<const moveit::core::AttachedBody*> attached_bodies;
   kinematic_state->getAttachedBodies(attached_bodies);
-  for (const robot_state::AttachedBody* attached_body : attached_bodies)
+  for (const moveit::core::AttachedBody* attached_body : attached_bodies)
   {
     std_msgs::ColorRGBA color = default_attached_object_color;
     float alpha = robot_.getAlpha();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -164,7 +164,7 @@ void TrajectoryVisualization::setName(const QString& name)
     trajectory_slider_dock_panel_->setWindowTitle(name + " - Slider");
 }
 
-void TrajectoryVisualization::onRobotModelLoaded(const robot_model::RobotModelConstPtr& robot_model)
+void TrajectoryVisualization::onRobotModelLoaded(const moveit::core::RobotModelConstPtr& robot_model)
 {
   robot_model_ = robot_model;
 
@@ -176,7 +176,7 @@ void TrajectoryVisualization::onRobotModelLoaded(const robot_model::RobotModelCo
   }
 
   // Load robot state
-  robot_state_.reset(new robot_state::RobotState(robot_model_));
+  robot_state_.reset(new moveit::core::RobotState(robot_model_));
   robot_state_->setToDefaultValues();
 
   // Load rviz robot

--- a/moveit_ros/visualization/trajectory_rviz_plugin/include/moveit/trajectory_rviz_plugin/trajectory_display.h
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/include/moveit/trajectory_rviz_plugin/trajectory_display.h
@@ -86,8 +86,8 @@ protected:
 
   // Load robot model
   rdf_loader::RDFLoaderPtr rdf_loader_;
-  robot_model::RobotModelConstPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotStatePtr robot_state_;
   bool load_robot_model_;  // for delayed robot initialization
 
   // Properties

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -76,7 +76,7 @@ void TrajectoryDisplay::loadRobotModel()
 
   const srdf::ModelSharedPtr& srdf =
       rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
-  robot_model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+  robot_model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
 
   // Send to child class
   trajectory_visual_->onRobotModelLoaded(robot_model_);

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -83,10 +83,10 @@ void parseStart(std::istream& in, planning_scene_monitor::PlanningSceneMonitor* 
       }
       if (!v.empty())
       {
-        robot_state::RobotState st = psm->getPlanningScene()->getCurrentState();
+        moveit::core::RobotState st = psm->getPlanningScene()->getCurrentState();
         st.setVariablePositions(v);
         moveit_msgs::RobotState msg;
-        robot_state::robotStateToRobotStateMsg(st, msg);
+        moveit::core::robotStateToRobotStateMsg(st, msg);
         ROS_INFO("Parsed start state '%s'", name.c_str());
         rs->addRobotState(msg, name);
       }

--- a/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
+++ b/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
@@ -101,14 +101,14 @@ int main(int argc, char** argv)
   ROS_INFO("Added default scene: '%s'", psmsg.name.c_str());
 
   moveit_msgs::RobotState rsmsg;
-  robot_state::robotStateToRobotStateMsg(psm.getPlanningScene()->getCurrentState(), rsmsg);
+  moveit::core::robotStateToRobotStateMsg(psm.getPlanningScene()->getCurrentState(), rsmsg);
   rs.addRobotState(rsmsg, "default");
   ROS_INFO("Added default state");
 
   const std::vector<std::string>& gnames = psm.getRobotModel()->getJointModelGroupNames();
   for (const std::string& gname : gnames)
   {
-    const robot_model::JointModelGroup* jmg = psm.getRobotModel()->getJointModelGroup(gname);
+    const moveit::core::JointModelGroup* jmg = psm.getRobotModel()->getJointModelGroup(gname);
     if (!jmg->isChain())
       continue;
     const std::vector<std::string>& lnames = jmg->getLinkModelNames();

--- a/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
       fout.close();
 
       std::vector<std::string> robot_state_names;
-      robot_model::RobotModelConstPtr km = psm.getRobotModel();
+      moveit::core::RobotModelConstPtr km = psm.getRobotModel();
       // Get start states for scene
       std::stringstream rsregex;
       rsregex << ".*" << scene_name << ".*";
@@ -150,8 +150,8 @@ int main(int argc, char** argv)
             qfout << robot_state_name << std::endl;
             moveit_warehouse::RobotStateWithMetadata robot_state;
             rss.getRobotState(robot_state, robot_state_name);
-            robot_state::RobotState ks(km);
-            robot_state::robotStateMsgToRobotState(*robot_state, ks, false);
+            moveit::core::RobotState ks(km);
+            moveit::core::robotStateMsgToRobotState(*robot_state, ks, false);
             ks.printStateInfo(qfout);
             qfout << "." << std::endl;
           }

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -280,7 +280,7 @@ public:
   void setRobotModel(const moveit::core::RobotModelPtr& robot_model);
 
   /// Provide a shared kinematic model loader
-  robot_model::RobotModelConstPtr getRobotModel();
+  moveit::core::RobotModelConstPtr getRobotModel();
 
   /// Update the Kinematic Model with latest SRDF modifications
   void updateRobotModel();
@@ -499,7 +499,7 @@ public:
    */
   struct joint_model_compare
   {
-    bool operator()(const robot_model::JointModel* jm1, const robot_model::JointModel* jm2) const
+    bool operator()(const moveit::core::JointModel* jm1, const moveit::core::JointModel* jm2) const
     {
       return jm1->getName() < jm2->getName();
     }
@@ -514,7 +514,7 @@ private:
   std::vector<std::map<std::string, GenericParameter> > sensors_plugin_config_parameter_list_;
 
   /// Shared kinematic model
-  robot_model::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 
   /// ROS Controllers config data
   std::vector<ROSControlConfig> ros_controllers_config_;

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -84,7 +84,7 @@ struct ThreadComputation
 };
 
 // LinkGraph defines a Link's model and a set of unique links it connects
-typedef std::map<const robot_model::LinkModel*, std::set<const robot_model::LinkModel*> > LinkGraph;
+typedef std::map<const moveit::core::LinkModel*, std::set<const moveit::core::LinkModel*> > LinkGraph;
 
 // ******************************************************************************************
 // Static Prototypes
@@ -106,14 +106,14 @@ static bool setLinkPair(const std::string& linkA, const std::string& linkB, cons
  * \param link The root link to begin a breadth first search on
  * \param link_graph A representation of all bi-direcitonal joint connections between links in robot_description
  */
-static void computeConnectionGraph(const robot_model::LinkModel* link, LinkGraph& link_graph);
+static void computeConnectionGraph(const moveit::core::LinkModel* link, LinkGraph& link_graph);
 
 /**
  * \brief Recursively build the adj list of link connections
  * \param link The root link to begin a breadth first search on
  * \param link_graph A representation of all bi-direcitonal joint connections between links in robot_description
  */
-static void computeConnectionGraphRec(const robot_model::LinkModel* link, LinkGraph& link_graph);
+static void computeConnectionGraphRec(const moveit::core::LinkModel* link, LinkGraph& link_graph);
 
 /**
  * \brief Disable collision checking for adjacent links, or adjacent with no geometry links between them
@@ -339,7 +339,7 @@ void computeLinkPairs(const planning_scene::PlanningScene& scene, LinkPairMap& l
 // ******************************************************************************************
 // Build the robot links connection graph and then check for links with no geomotry
 // ******************************************************************************************
-void computeConnectionGraph(const robot_model::LinkModel* start_link, LinkGraph& link_graph)
+void computeConnectionGraph(const moveit::core::LinkModel* start_link, LinkGraph& link_graph)
 {
   link_graph.clear();  // make sure the edges structure is clear
 
@@ -358,7 +358,7 @@ void computeConnectionGraph(const robot_model::LinkModel* start_link, LinkGraph&
       if (edge_it->first->getShapes().empty())  // link in adjList "link_graph" does not have shape, remove!
       {
         // Temporary list for connected links
-        std::vector<const robot_model::LinkModel*> temp_list;
+        std::vector<const moveit::core::LinkModel*> temp_list;
 
         // Copy link's parent and child links to temp_list
         for (const moveit::core::LinkModel* adj_it : edge_it->second)
@@ -390,14 +390,14 @@ void computeConnectionGraph(const robot_model::LinkModel* start_link, LinkGraph&
 // ******************************************************************************************
 // Recursively build the adj list of link connections
 // ******************************************************************************************
-void computeConnectionGraphRec(const robot_model::LinkModel* start_link, LinkGraph& link_graph)
+void computeConnectionGraphRec(const moveit::core::LinkModel* start_link, LinkGraph& link_graph)
 {
   if (start_link)  // check that the link is a valid pointer
   {
     // Loop through every link attached to start_link
     for (std::size_t i = 0; i < start_link->getChildJointModels().size(); ++i)
     {
-      const robot_model::LinkModel* next = start_link->getChildJointModels()[i]->getChildLinkModel();
+      const moveit::core::LinkModel* next = start_link->getChildJointModels()[i]->getChildLinkModel();
 
       // Bi-directional connection
       link_graph[next].insert(start_link);
@@ -422,7 +422,7 @@ unsigned int disableAdjacentLinks(planning_scene::PlanningScene& scene, LinkGrap
   for (LinkGraph::const_iterator link_graph_it = link_graph.begin(); link_graph_it != link_graph.end(); ++link_graph_it)
   {
     // disable all connected links to current link by looping through them
-    for (std::set<const robot_model::LinkModel*>::const_iterator adj_it = link_graph_it->second.begin();
+    for (std::set<const moveit::core::LinkModel*>::const_iterator adj_it = link_graph_it->second.begin();
          adj_it != link_graph_it->second.end(); ++adj_it)
     {
       // ROS_INFO("Disabled %s to %s", link_graph_it->first->getName().c_str(), (*adj_it)->getName().c_str() );
@@ -613,7 +613,7 @@ void disableNeverInCollisionThread(ThreadComputation tc)
   const unsigned int progress_interval = tc.num_trials_ / 20;  // show progress update every 5%
 
   // Create a new kinematic state for this thread to work on
-  robot_state::RobotState robot_state(tc.scene_.getRobotModel());
+  moveit::core::RobotState robot_state(tc.scene_.getRobotModel());
 
   // Do a large number of tests
   for (unsigned int i = 0; i < tc.num_trials_; ++i)

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -82,7 +82,7 @@ MoveItConfigData::~MoveItConfigData() = default;
 // ******************************************************************************************
 // Load a robot model
 // ******************************************************************************************
-void MoveItConfigData::setRobotModel(const robot_model::RobotModelPtr& robot_model)
+void MoveItConfigData::setRobotModel(const moveit::core::RobotModelPtr& robot_model)
 {
   robot_model_ = robot_model;
 }
@@ -90,12 +90,12 @@ void MoveItConfigData::setRobotModel(const robot_model::RobotModelPtr& robot_mod
 // ******************************************************************************************
 // Provide a kinematic model. Load a new one if necessary
 // ******************************************************************************************
-robot_model::RobotModelConstPtr MoveItConfigData::getRobotModel()
+moveit::core::RobotModelConstPtr MoveItConfigData::getRobotModel()
 {
   if (!robot_model_)
   {
     // Initialize with a URDF Model Interface and a SRDF Model
-    robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_->srdf_model_));
+    robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_->srdf_model_));
   }
 
   return robot_model_;
@@ -112,7 +112,7 @@ void MoveItConfigData::updateRobotModel()
   srdf_->updateSRDFModel(*urdf_model_);
 
   // Create new kin model
-  robot_model_.reset(new robot_model::RobotModel(urdf_model_, srdf_->srdf_model_));
+  robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_->srdf_model_));
 
   // Reset the planning scene
   planning_scene_.reset();
@@ -511,18 +511,18 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
   for (srdf::Model::Group& group : srdf_->groups_)
   {
     // Get list of associated joints
-    const robot_model::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
     emitter << YAML::BeginMap;
-    const std::vector<const robot_model::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
     emitter << YAML::Key << "name";
     emitter << YAML::Value << "fake_" + group.name_ + "_controller";
     emitter << YAML::Key << "joints";
     emitter << YAML::Value << YAML::BeginSeq;
 
     // Iterate through the joints
-    for (const robot_model::JointModel* joint : joint_models)
+    for (const moveit::core::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
         continue;
       emitter << joint->getName();
     }
@@ -841,12 +841,12 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
   for (srdf::Model::Group& group : srdf_->groups_)
   {
     // Get list of associated joints
-    const robot_model::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
-    const std::vector<const robot_model::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
     // Iterate through the joints and push into group_joints vector.
-    for (const robot_model::JointModel* joint : joint_models)
+    for (const moveit::core::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
         continue;
       else
         group_joints.push_back(joint->getName());
@@ -891,7 +891,7 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
     emitter << YAML::Key << "hardware_interface" << YAML::Value << YAML::BeginMap;
     {
       // Get list of all joints for the robot
-      const std::vector<const robot_model::JointModel*>& joint_models = getRobotModel()->getJointModels();
+      const std::vector<const moveit::core::JointModel*>& joint_models = getRobotModel()->getJointModels();
 
       emitter << YAML::Key << "joints";
       {
@@ -899,11 +899,11 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
         {
           emitter << YAML::Value << YAML::BeginSeq;
           // Iterate through the joints
-          for (std::vector<const robot_model::JointModel*>::const_iterator joint_it = joint_models.begin();
+          for (std::vector<const moveit::core::JointModel*>::const_iterator joint_it = joint_models.begin();
                joint_it < joint_models.end(); ++joint_it)
           {
             if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != nullptr ||
-                (*joint_it)->getType() == robot_model::JointModel::FIXED)
+                (*joint_it)->getType() == moveit::core::JointModel::FIXED)
               continue;
             else
               emitter << (*joint_it)->getName();
@@ -1058,15 +1058,15 @@ bool MoveItConfigData::outputJointLimitsYAML(const std::string& file_path)
   emitter << YAML::Value << YAML::BeginMap;
 
   // Union all the joints in groups. Uses a custom comparator to allow the joints to be sorted by name
-  std::set<const robot_model::JointModel*, joint_model_compare> joints;
+  std::set<const moveit::core::JointModel*, joint_model_compare> joints;
 
   // Loop through groups
   for (srdf::Model::Group& group : srdf_->groups_)
   {
     // Get list of associated joints
-    const robot_model::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
 
-    const std::vector<const robot_model::JointModel*>& joint_models = joint_model_group->getJointModels();
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getJointModels();
 
     // Iterate through the joints
     for (const moveit::core::JointModel* joint_model : joint_models)
@@ -1083,7 +1083,7 @@ bool MoveItConfigData::outputJointLimitsYAML(const std::string& file_path)
     emitter << YAML::Key << joint->getName();
     emitter << YAML::Value << YAML::BeginMap;
 
-    const robot_model::VariableBounds& b = joint->getVariableBounds()[0];
+    const moveit::core::VariableBounds& b = joint->getVariableBounds()[0];
 
     // Output property
     emitter << YAML::Key << "has_velocity_limits";
@@ -1193,14 +1193,14 @@ std::string MoveItConfigData::decideProjectionJoints(const std::string& planning
   std::string joint_pair = "";
 
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = getRobotModel();
 
   // Error check
   if (!model->hasJointModelGroup(planning_group))
     return joint_pair;
 
   // Get the joint model group
-  const robot_model::JointModelGroup* group = model->getJointModelGroup(planning_group);
+  const moveit::core::JointModelGroup* group = model->getJointModelGroup(planning_group);
 
   // get vector of joint names
   const std::vector<std::string>& joints = group->getJointModelNames();
@@ -1459,13 +1459,13 @@ bool MoveItConfigData::addDefaultControllers()
   {
     ROSControlConfig group_controller;
     // Get list of associated joints
-    const robot_model::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group_it.name_);
-    const std::vector<const robot_model::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group_it.name_);
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
 
     // Iterate through the joints
-    for (const robot_model::JointModel* joint : joint_models)
+    for (const moveit::core::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
         continue;
       group_controller.joints_.push_back(joint->getName());
     }

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -381,10 +381,10 @@ void EndEffectorsWidget::loadParentComboBox()
   parent_name_field_->clear();
 
   // Get all links in robot model
-  std::vector<const robot_model::LinkModel*> link_models = config_data_->getRobotModel()->getLinkModels();
+  std::vector<const moveit::core::LinkModel*> link_models = config_data_->getRobotModel()->getLinkModels();
 
   // Add all links to combo box
-  for (std::vector<const robot_model::LinkModel*>::const_iterator link_it = link_models.begin();
+  for (std::vector<const moveit::core::LinkModel*>::const_iterator link_it = link_models.begin();
        link_it < link_models.end(); ++link_it)
   {
     parent_name_field_->addItem((*link_it)->getName().c_str());
@@ -515,7 +515,7 @@ void EndEffectorsWidget::doneEditing()
     return;
   }
 
-  const robot_model::JointModelGroup* jmg =
+  const moveit::core::JointModelGroup* jmg =
       config_data_->getRobotModel()->getJointModelGroup(group_name_field_->currentText().toStdString());
   /*
   if (jmg->hasLinkModel(parent_name_field_->currentText().toStdString()))

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.cpp
@@ -146,10 +146,10 @@ void KinematicChainWidget::setAvailable()
     return;
 
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = config_data_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = config_data_->getRobotModel();
 
   // Get the root joint
-  const robot_model::JointModel* root_joint = model->getRootJoint();
+  const moveit::core::JointModel* root_joint = model->getRootJoint();
 
   addLinktoTreeRecursive(root_joint->getChildLinkModel(), nullptr);
 
@@ -160,8 +160,8 @@ void KinematicChainWidget::setAvailable()
 // ******************************************************************************************
 //
 // ******************************************************************************************
-void KinematicChainWidget::addLinktoTreeRecursive(const robot_model::LinkModel* link,
-                                                  const robot_model::LinkModel* parent)
+void KinematicChainWidget::addLinktoTreeRecursive(const moveit::core::LinkModel* link,
+                                                  const moveit::core::LinkModel* parent)
 {
   // Create new tree item
   QTreeWidgetItem* new_item = new QTreeWidgetItem(link_tree_);
@@ -191,7 +191,7 @@ void KinematicChainWidget::addLinktoTreeRecursive(const robot_model::LinkModel* 
 // ******************************************************************************************
 //
 // ******************************************************************************************
-bool KinematicChainWidget::addLinkChildRecursive(QTreeWidgetItem* parent, const robot_model::LinkModel* link,
+bool KinematicChainWidget::addLinkChildRecursive(QTreeWidgetItem* parent, const moveit::core::LinkModel* link,
                                                  const std::string& parent_name)
 {
   if (parent->text(0).toStdString() == parent_name)

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
@@ -68,9 +68,9 @@ public:
   /// Set the link field with previous value
   void setSelected(const std::string& base_link, const std::string& tip_link);
 
-  void addLinktoTreeRecursive(const robot_model::LinkModel* link, const robot_model::LinkModel* parent);
+  void addLinktoTreeRecursive(const moveit::core::LinkModel* link, const moveit::core::LinkModel* parent);
 
-  bool addLinkChildRecursive(QTreeWidgetItem* parent, const robot_model::LinkModel* link,
+  bool addLinkChildRecursive(QTreeWidgetItem* parent, const moveit::core::LinkModel* link,
                              const std::string& parent_name);
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
@@ -84,7 +84,7 @@ void PassiveJointsWidget::focusGiven()
   joints_widget_->clearContents();
 
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = config_data_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = config_data_->getRobotModel();
 
   // Get the names of the all joints
   const std::vector<std::string>& joints = model->getJointModelNames();
@@ -133,7 +133,7 @@ void PassiveJointsWidget::previewSelectedJoints(std::vector<std::string> joints)
 
   for (const std::string& joint : joints)
   {
-    const robot_model::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
+    const moveit::core::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
 
     // Check that a joint model was found
     if (!joint_model)

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -318,7 +318,7 @@ void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it,
   group->addChild(joints);
 
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = config_data_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = config_data_->getRobotModel();
 
   // Loop through all aval. joints
   for (std::vector<std::string>::const_iterator joint_it = group_it.joints_.begin(); joint_it != group_it.joints_.end();
@@ -329,7 +329,7 @@ void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it,
     std::string joint_name;
 
     // Get the type of joint this is
-    const robot_model::JointModel* jm = model->getJointModel(*joint_it);
+    const moveit::core::JointModel* jm = model->getJointModel(*joint_it);
     if (jm)  // check if joint model was found
     {
       joint_name = *joint_it + " - " + jm->getTypeName();
@@ -520,7 +520,7 @@ void PlanningGroupsWidget::editSelected()
 void PlanningGroupsWidget::loadJointsScreen(srdf::Model::Group* this_group)
 {
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = config_data_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = config_data_->getRobotModel();
 
   // Get the names of the all joints
   const std::vector<std::string>& joints = model->getJointModelNames();
@@ -552,7 +552,7 @@ void PlanningGroupsWidget::loadJointsScreen(srdf::Model::Group* this_group)
 void PlanningGroupsWidget::loadLinksScreen(srdf::Model::Group* this_group)
 {
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = config_data_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = config_data_->getRobotModel();
 
   // Get the names of the all links
   const std::vector<std::string>& links = model->getLinkModelNames();
@@ -1428,7 +1428,7 @@ void PlanningGroupsWidget::previewSelectedJoints(std::vector<std::string> joints
 
   for (const std::string& joint : joints)
   {
-    const robot_model::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
+    const moveit::core::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
 
     // Check that a joint model was found
     if (!joint_model)

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -357,10 +357,10 @@ void RobotPosesWidget::showPose(srdf::Model::GroupState* pose)
 void RobotPosesWidget::showDefaultPose()
 {
   // Get list of all joints for the robot
-  std::vector<const robot_model::JointModel*> joint_models = config_data_->getRobotModel()->getJointModels();
+  std::vector<const moveit::core::JointModel*> joint_models = config_data_->getRobotModel()->getJointModels();
 
   // Iterate through the joints
-  for (std::vector<const robot_model::JointModel*>::const_iterator joint_it = joint_models.begin();
+  for (std::vector<const moveit::core::JointModel*>::const_iterator joint_it = joint_models.begin();
        joint_it < joint_models.end(); ++joint_it)
   {
     // Check that this joint only represents 1 variable.
@@ -508,12 +508,12 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
   joint_list_widget_->setMinimumSize(50, 50);  // w, h
 
   // Get list of associated joints
-  const robot_model::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group_name);
   joint_models_ = joint_model_group->getJointModels();
 
   // Iterate through the joints
   int num_joints = 0;
-  for (const robot_model::JointModel* joint_model : joint_models_)
+  for (const moveit::core::JointModel* joint_model : joint_models_)
   {
     if (joint_model->getVariableCount() != 1 ||  // only consider 1-variable joints
         joint_model->isPassive() ||              // ignore passive
@@ -676,7 +676,7 @@ void RobotPosesWidget::doneEditing()
   searched_data->joint_values_.clear();
 
   // Iterate through the current group's joints and add to SRDF
-  for (std::vector<const robot_model::JointModel*>::const_iterator joint_it = joint_models_.begin();
+  for (std::vector<const moveit::core::JointModel*>::const_iterator joint_it = joint_models_.begin();
        joint_it < joint_models_.end(); ++joint_it)
   {
     // Check that this joint only represents 1 variable.
@@ -808,7 +808,7 @@ void RobotPosesWidget::publishJoints()
 
   // Create a planning scene message
   moveit_msgs::DisplayRobotState msg;
-  robot_state::robotStateToRobotStateMsg(config_data_->getPlanningScene()->getCurrentState(), msg.state);
+  moveit::core::robotStateToRobotStateMsg(config_data_->getPlanningScene()->getCurrentState(), msg.state);
 
   // Publish!
   pub_robot_state_.publish(msg);
@@ -840,7 +840,7 @@ void RobotPosesWidget::publishJoints()
 // ******************************************************************************************
 // Simple widget for adjusting joints of a robot
 // ******************************************************************************************
-SliderWidget::SliderWidget(QWidget* parent, const robot_model::JointModel* joint_model, double init_value)
+SliderWidget::SliderWidget(QWidget* parent, const moveit::core::JointModel* joint_model, double init_value)
   : QWidget(parent), joint_model_(joint_model)
 {
   // Create layouts

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -508,7 +508,8 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
   joint_list_widget_->setMinimumSize(50, 50);  // w, h
 
   // Get list of associated joints
-  const moveit::core::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group =
+      config_data_->getRobotModel()->getJointModelGroup(group_name);
   joint_models_ = joint_model_group->getJointModels();
 
   // Iterate through the joints

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.h
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.h
@@ -156,7 +156,7 @@ private:
   std::map<std::string, double> joint_state_map_;
 
   /// The joints currently in the selected planning group
-  std::vector<const robot_model::JointModel*> joint_models_;
+  std::vector<const moveit::core::JointModel*> joint_models_;
 
   /// Remember the publisher for quick publishing later
   ros::Publisher pub_robot_state_;
@@ -237,7 +237,7 @@ public:
    * @param parent - parent QWidget
    * @param joint_model_ - a ptr reference to the joint this widget represents
    */
-  SliderWidget(QWidget* parent, const robot_model::JointModel* joint_model, double init_value);
+  SliderWidget(QWidget* parent, const moveit::core::JointModel* joint_model, double init_value);
 
   /**
    * Deconstructor
@@ -279,7 +279,7 @@ private:
   // ******************************************************************************************
 
   // Ptr to the joint's data
-  const robot_model::JointModel* joint_model_;
+  const moveit::core::JointModel* joint_model_;
 
   // Max & min position
   double max_position_;

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -283,7 +283,7 @@ void ROSControllersWidget::focusGiven()
 void ROSControllersWidget::loadJointsScreen(moveit_setup_assistant::ROSControlConfig* this_controller)
 {
   // Retrieve pointer to the shared kinematic model
-  const robot_model::RobotModelConstPtr& model = config_data_->getRobotModel();
+  const moveit::core::RobotModelConstPtr& model = config_data_->getRobotModel();
 
   // Get the names of the all joints
   const std::vector<std::string>& joints = model->getJointModelNames();
@@ -473,7 +473,7 @@ void ROSControllersWidget::previewSelectedJoints(std::vector<std::string> joints
 
   for (const std::string& joint : joints)
   {
-    const robot_model::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
+    const moveit::core::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
 
     // Check that a joint model was found
     if (!joint_model)
@@ -608,14 +608,14 @@ void ROSControllersWidget::saveJointsGroupsScreen()
   for (int i = 0; i < joint_groups_widget_->selected_data_table_->rowCount(); ++i)
   {
     // Get list of associated joints
-    const robot_model::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(
+    const moveit::core::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(
         joint_groups_widget_->selected_data_table_->item(i, 0)->text().toStdString());
-    const std::vector<const robot_model::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
 
     // Iterate through the joints
-    for (const robot_model::JointModel* joint : joint_models)
+    for (const moveit::core::JointModel* joint : joint_models)
     {
-      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == robot_model::JointModel::FIXED)
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
         continue;
       searched_controller->joints_.push_back(joint->getName());
     }

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -434,7 +434,8 @@ void SetupAssistantWidget::highlightGroup(const std::string& group_name)
   if (!config_data_->getRobotModel()->hasJointModelGroup(group_name))
     return;
 
-  const moveit::core::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group =
+      config_data_->getRobotModel()->getJointModelGroup(group_name);
   if (joint_model_group)
   {
     const std::vector<const moveit::core::LinkModel*>& link_models = joint_model_group->getLinkModels();

--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -420,7 +420,7 @@ void SetupAssistantWidget::loadRviz()
 // ******************************************************************************************
 void SetupAssistantWidget::highlightLink(const std::string& link_name, const QColor& color)
 {
-  const robot_model::LinkModel* lm = config_data_->getRobotModel()->getLinkModel(link_name);
+  const moveit::core::LinkModel* lm = config_data_->getRobotModel()->getLinkModel(link_name);
   if (!lm->getShapes().empty())  // skip links with no geometry
     robot_state_display_->setLinkColor(link_name, color);
 }
@@ -434,12 +434,12 @@ void SetupAssistantWidget::highlightGroup(const std::string& group_name)
   if (!config_data_->getRobotModel()->hasJointModelGroup(group_name))
     return;
 
-  const robot_model::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group_name);
+  const moveit::core::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group_name);
   if (joint_model_group)
   {
-    const std::vector<const robot_model::LinkModel*>& link_models = joint_model_group->getLinkModels();
+    const std::vector<const moveit::core::LinkModel*>& link_models = joint_model_group->getLinkModels();
     // Iterate through the links
-    for (std::vector<const robot_model::LinkModel*>::const_iterator link_it = link_models.begin();
+    for (std::vector<const moveit::core::LinkModel*>::const_iterator link_it = link_models.begin();
          link_it < link_models.end(); ++link_it)
       highlightLink((*link_it)->getName(), QColor(255, 0, 0));
   }

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -359,10 +359,10 @@ void VirtualJointsWidget::loadChildLinksComboBox()
   child_link_field_->clear();
 
   // Get all links in robot model
-  std::vector<const robot_model::LinkModel*> link_models = config_data_->getRobotModel()->getLinkModels();
+  std::vector<const moveit::core::LinkModel*> link_models = config_data_->getRobotModel()->getLinkModels();
 
   // Add all links to combo box
-  for (std::vector<const robot_model::LinkModel*>::const_iterator link_it = link_models.begin();
+  for (std::vector<const moveit::core::LinkModel*>::const_iterator link_it = link_models.begin();
        link_it < link_models.end(); ++link_it)
   {
     child_link_field_->addItem((*link_it)->getName().c_str());


### PR DESCRIPTION
### Description

Fixes issue #1878.
Using `moveit::core` namespace instead of `robot_state` and `robot_model` namespaces. 

These namespaces acted as aliases for backward compatibility defined [here](https://github.com/ros-planning/moveit/blob/e8a4072727abe4c704d009f05baa764bcf106b33/moveit_core/robot_model/include/moveit/robot_model/robot_model.h#L621).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
