### PR TITLE
allow to filter for joints when creating a RobotTrajectory message

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -213,7 +213,8 @@ public:
 
   double getAverageSegmentDuration() const;
 
-  void getRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory) const;
+  void getRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajectory,
+                             const std::vector<std::string>& joint_filter = std::vector<std::string>()) const;
 
   /** \brief Copy the content of the trajectory message into this class. The trajectory message itself is not required
      to contain the values


### PR DESCRIPTION
To execute MTC solutions from the rviz plugin, one needs a possibility to constrain RobotTrajectory messages to the actually moving joints. Usually, this is done via the associated JointModelGroup:
https://github.com/ros-planning/moveit/blob/ece0b7b44da2cfcf178e557557bc9d2693d17d5f/moveit_core/robot_trajectory/src/robot_trajectory.cpp#L226-L227
However, when deserializing received RobotTrajectory messages, I cannot infer the corresponding JointModelGroup anymore. Hence, this information is lost. But, remembering the involved joint names, it's possible to filter the RobotTrajectory for relevant joints during serialization into a message. This is what this PR proposes.