### PR TITLE
MSA: robot poses should be display on selection, not on click

### DIFF
--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -122,7 +122,7 @@ QWidget* RobotPosesWidget::createContentsWidget()
   data_table_->setSortingEnabled(true);
   data_table_->setSelectionBehavior(QAbstractItemView::SelectRows);
   connect(data_table_, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(editDoubleClicked(int, int)));
-  connect(data_table_, SIGNAL(cellClicked(int, int)), this, SLOT(previewClicked(int, int)));
+  connect(data_table_, SIGNAL(currentCellChanged(int, int, int, int)), this, SLOT(previewClicked(int, int, int, int)));
   layout->addWidget(data_table_);
 
   // Set header labels
@@ -317,7 +317,7 @@ void RobotPosesWidget::editDoubleClicked(int /*row*/, int /*column*/)
 // ******************************************************************************************
 // Preview whatever element is selected
 // ******************************************************************************************
-void RobotPosesWidget::previewClicked(int row, int /*column*/)
+void RobotPosesWidget::previewClicked(int row, int /*column*/, int /*previous_row*/, int /*previous_column*/)
 {
   const std::string& name = data_table_->item(row, 0)->text().toStdString();
   const std::string& group = data_table_->item(row, 1)->text().toStdString();

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.h
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.h
@@ -110,7 +110,7 @@ private Q_SLOTS:
   void editDoubleClicked(int row, int column);
 
   /// Preview whatever element is selected
-  void previewClicked(int row, int column);
+  void previewClicked(int row, int column, int previous_row, int previous_column);
 
   /// Delete currently editing ite
   void deleteSelected();


### PR DESCRIPTION
Without this patch, moving through the list with cursor keys
does not trigger the display to show the selected pose.