### PR TITLE
Remove pause when connecting rviz to planning scene monitor

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -370,7 +370,8 @@ void PlanningSceneDisplay::changedPlanningSceneTopic()
     std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
     if (!getMoveGroupNS().empty())
       service_name = ros::names::append(getMoveGroupNS(), service_name);
-    planning_scene_monitor_->requestPlanningSceneState(service_name);
+    auto bg_func = [=]() { planning_scene_monitor_->requestPlanningSceneState(service_name); };
+    addBackgroundJob(bg_func, "planning_scene_monitor_->requestPlanningSceneState");
   }
 }
 


### PR DESCRIPTION
### Description
When calling `PlanningSceneMonitor::requestPlanningSceneState` there is a 5 second wait for the service to be connected to a client.  This causes rviz to freeze for 5 seconds for each planning scene topic it is listening for whenever you try to connect to it, unless you specifically broadcast those topics before starting rviz.  ~~I propose removing this wait entirely, and simply failing if we are not connected.  If it is frequently necessary to wait in order to successfully get the full state of the planning scene when only diffs are being published, I suggest at least reducing the wait to a much lower time.~~

Changes to call the planning scene request as a background thread so that it does not freeze rviz.