### PR TITLE
MSI: use matching group/state name for default state

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -482,14 +482,9 @@ public:
   std::vector<std::map<std::string, GenericParameter> > getSensorPluginConfig();
 
   /**
-   * \brief Helper function to get the default start state group for moveit_sim_hw_interface
-   */
-  std::string getDefaultStartStateGroup();
-
-  /**
    * \brief Helper function to get the default start pose for moveit_sim_hw_interface
    */
-  std::string getDefaultStartPose();
+  srdf::Model::GroupState getDefaultStartPose();
 
   /**
    * \brief Custom std::set comparator, used for sorting the joint_limits.yaml file into alphabetical order

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -847,23 +847,14 @@ void MoveItConfigData::outputFollowJointTrajectoryYAML(YAML::Emitter& emitter,
 }
 
 // ******************************************************************************************
-// Helper function to get the default start state group for moveit_sim_hw_interface
-// ******************************************************************************************
-std::string MoveItConfigData::getDefaultStartStateGroup()
-{
-  if (!srdf_->srdf_model_->getGroups().empty())
-    return srdf_->srdf_model_->getGroups()[0].name_;
-  return "todo_no_group_selected";
-}
-
-// ******************************************************************************************
 // Helper function to get the default start pose for moveit_sim_hw_interface
 // ******************************************************************************************
-std::string MoveItConfigData::getDefaultStartPose()
+srdf::Model::GroupState MoveItConfigData::getDefaultStartPose()
 {
   if (!srdf_->group_states_.empty())
-    return srdf_->group_states_[0].name_;
-  return "todo_no_pose_selected";
+    return srdf_->group_states_[0];
+  else
+    return srdf::Model::GroupState{.name_ = "todo_state_name", .group_ = "todo_group_name", .joint_values_ = {} };
 }
 
 // ******************************************************************************************
@@ -908,11 +899,11 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
     {
       // Use the first planning group if initial joint_model_group was not set, else write a default value
       emitter << YAML::Key << "joint_model_group";
-      emitter << YAML::Value << getDefaultStartStateGroup();
+      emitter << YAML::Value << getDefaultStartPose().group_;
 
       // Use the first robot pose if initial joint_model_group_pose was not set, else write a default value
       emitter << YAML::Key << "joint_model_group_pose";
-      emitter << YAML::Value << getDefaultStartPose();
+      emitter << YAML::Value << getDefaultStartPose().name_;
 
       emitter << YAML::EndMap;
     }


### PR DESCRIPTION
The old logic just picked the first one from each list,
not necessarily matching for non-trivial robots...