### PR TITLE
Fix segfault in RobotStateVisualization: remove processEvents()

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -66,7 +66,6 @@ void RobotStateVisualization::load(const urdf::ModelInterface& descr, bool visua
   robot_.setVisualVisible(visual_visible_);
   robot_.setCollisionVisible(collision_visible_);
   robot_.setVisible(visible_);
-  QApplication::processEvents();
 }
 
 void RobotStateVisualization::clear()


### PR DESCRIPTION
As pointed out in https://github.com/ros-planning/moveit/issues/1940#issuecomment-596104746, calling processEvents() results in an unintended recursion, calling TrajectoryVisualization::update() again from an only partially initialized state.
I wasn't able to reproduce the issue mentioned in https://github.com/ros-planning/moveit/pull/239#issue-86291573, that originally made me introducing this call.