### PR TITLE
[planning_interface] Release Python GIL for C++ calls

### DIFF
--- a/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/gil_releaser.h
+++ b/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/gil_releaser.h
@@ -1,0 +1,111 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, RWTH Aachen University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of RWTH Aachen University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Bjarne von Horn */
+
+#pragma once
+
+#include <utility>
+#include <Python.h>
+
+namespace moveit
+{
+namespace py_bindings_tools
+{
+/** \brief RAII Helper to release the Global Interpreter Lock (GIL)
+ *
+ * Use this helper class to release the GIL before doing long computations
+ * or blocking calls. Note that without the GIL Python-related functions <b>must not</b> be called.
+ * So, before releasing the GIL all \c boost::python variables have to be converted to e.g. \c std::vector<std::string>.
+ * Before converting the result back to e.g. a moveit::py_bindings_tools::ByteString instance, the GIL has to be
+ * reacquired.
+ */
+class GILReleaser
+{
+  PyThreadState* m_thread_state;
+
+public:
+  /** \brief Release the GIL on construction  */
+  GILReleaser() noexcept
+  {
+    m_thread_state = nullptr;
+    release();
+  }
+  /** \brief Reacquire the GIL on destruction  */
+  ~GILReleaser() noexcept
+  {
+    reacquire();
+  }
+
+  GILReleaser(const GILReleaser&) = delete;
+  GILReleaser(GILReleaser&& other) noexcept
+  {
+    m_thread_state = other.m_thread_state;
+    other.m_thread_state = nullptr;
+  }
+
+  GILReleaser& operator=(const GILReleaser&) = delete;
+  GILReleaser& operator=(GILReleaser&& other) noexcept
+  {
+    GILReleaser copy(std::move(other));
+    this->swap(copy);
+    return *this;
+  }
+
+  void swap(GILReleaser& other) noexcept
+  {
+    std::swap(other.m_thread_state, m_thread_state);
+  }
+
+  /** \brief Reacquire the GIL, noop if already acquired */
+  void reacquire() noexcept
+  {
+    if (m_thread_state)
+    {
+      PyEval_RestoreThread(m_thread_state);
+      m_thread_state = nullptr;
+    }
+  }
+  /** \brief Release the GIL (again), noop if already released */
+  void release() noexcept
+  {
+    if (!m_thread_state)
+    {
+      m_thread_state = PyEval_SaveThread();
+    }
+  }
+};
+
+}  // namespace py_bindings_tools
+}  // namespace moveit

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -39,6 +39,7 @@
 #include <moveit/py_bindings_tools/roscpp_initializer.h>
 #include <moveit/py_bindings_tools/py_conversions.h>
 #include <moveit/py_bindings_tools/serialize_msg.h>
+#include <moveit/py_bindings_tools/gil_releaser.h>
 #include <moveit_msgs/RobotState.h>
 #include <visualization_msgs/MarkerArray.h>
 
@@ -49,6 +50,7 @@
 /** @cond IGNORE */
 
 namespace bp = boost::python;
+using moveit::py_bindings_tools::GILReleaser;
 
 namespace moveit
 {
@@ -216,6 +218,7 @@ public:
     // if needed, start the monitor and wait up to 1 second for a full robot state
     if (!current_state_monitor_->isActive())
     {
+      GILReleaser gr;
       current_state_monitor_->startStateMonitor();
       if (!current_state_monitor_->waitForCompleteState(wait))
         ROS_WARN("Joint values for monitored state are requested but the full state is not known");


### PR DESCRIPTION
### Description

Fixes #1580. (C)Python has a Global Interpreter Lock (GIL) which should be released when doing long-lasting C++ calls.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
