### PR TITLE
Fix versioning for jog_arm package

### DIFF
--- a/moveit_experimental/moveit_jog_arm/package.xml
+++ b/moveit_experimental/moveit_jog_arm/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>moveit_jog_arm</name>
-  <version>0.0.3</version>
+  <version>1.0.1</version>
 
   <description>Provides real-time manipulator Cartesian jogging.</description>
 


### PR DESCRIPTION
### Description

I'm working on a build farm that uses the master branch for Debian releases, but running `git-bloom-generate -y rosrelease melodic` gives

```
RuntimeError: Two packages have different version numbers (0.0.3 != 1.0.1):
- /tmp/tmpuEevgo/clone/moveit_experimental/moveit_jog_arm/package.xml
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
