### PR TITLE
Resolve PSI lock-up in RViz display

### DIFF
--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -52,7 +52,12 @@ MOVEIT_CLASS_FORWARD(PlanningSceneInterface);
 class PlanningSceneInterface
 {
 public:
-  explicit PlanningSceneInterface(const std::string& ns = "");
+  /**
+    \param ns. Namespace in which all MoveIt related topics and services are discovered
+    \param wait. Wait for services if they are not announced in ROS.
+    If this is false, the constructor throws std::runtime_error instead.
+  */
+  explicit PlanningSceneInterface(const std::string& ns = "", bool wait = true);
   ~PlanningSceneInterface();
 
   /**

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -50,7 +50,7 @@ static const std::string LOGNAME = "planning_scene_interface";
 class PlanningSceneInterface::PlanningSceneInterfaceImpl
 {
 public:
-  explicit PlanningSceneInterfaceImpl(const std::string& ns = "")
+  explicit PlanningSceneInterfaceImpl(const std::string& ns = "", bool wait = true)
   {
     node_handle_ = ros::NodeHandle(ns);
     planning_scene_diff_publisher_ = node_handle_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
@@ -59,8 +59,18 @@ public:
     apply_planning_scene_service_ =
         node_handle_.serviceClient<moveit_msgs::ApplyPlanningScene>(move_group::APPLY_PLANNING_SCENE_SERVICE_NAME);
 
-    waitForService(planning_scene_service_);
-    waitForService(apply_planning_scene_service_);
+    if (wait)
+    {
+      waitForService(planning_scene_service_);
+      waitForService(apply_planning_scene_service_);
+    }
+    else
+    {
+      if (!planning_scene_service_.exists() || !apply_planning_scene_service_.exists())
+      {
+        throw std::runtime_error("ROS services not available");
+      }
+    }
   }
 
   std::vector<std::string> getKnownObjectNames(bool with_type)
@@ -270,9 +280,9 @@ private:
   moveit::core::RobotModelConstPtr robot_model_;
 };
 
-PlanningSceneInterface::PlanningSceneInterface(const std::string& ns)
+PlanningSceneInterface::PlanningSceneInterface(const std::string& ns, bool wait)
 {
-  impl_ = new PlanningSceneInterfaceImpl(ns);
+  impl_ = new PlanningSceneInterfaceImpl(ns, wait);
 }
 
 PlanningSceneInterface::~PlanningSceneInterface()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -43,7 +43,6 @@
 #ifndef Q_MOC_RUN
 #include <moveit/macros/class_forward.h>
 #include <moveit/move_group_interface/move_group_interface.h>
-#include <moveit/planning_scene_interface/planning_scene_interface.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_interaction/robot_interaction.h>
 #include <moveit/robot_interaction/interaction_handler.h>
@@ -129,7 +128,6 @@ protected:
   MotionPlanningFrameJointsWidget* joints_tab_;
 
   moveit::planning_interface::MoveGroupInterfacePtr move_group_;
-  moveit::planning_interface::PlanningSceneInterfacePtr planning_scene_interface_;
   moveit::semantic_world::SemanticWorldPtr semantic_world_;
 
   moveit::planning_interface::MoveGroupInterface::PlanPtr current_plan_;
@@ -272,7 +270,7 @@ private:
 
   // Pick and place
   void processDetectedObjects();
-  void updateDetectedObjectsList(const std::vector<std::string>& object_ids, const std::vector<std::string>& objects);
+  void updateDetectedObjectsList(const std::vector<std::string>& object_ids);
   void publishTables();
   void updateSupportSurfacesList();
   ros::Publisher object_recognition_trigger_publisher_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -181,14 +181,6 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
       object_recognition_client_.reset();
     }
   }
-  try
-  {
-    planning_scene_interface_.reset(new moveit::planning_interface::PlanningSceneInterface());
-  }
-  catch (std::exception& ex)
-  {
-    ROS_ERROR("%s", ex.what());
-  }
 
   try
   {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -41,6 +41,8 @@
 #include <moveit/robot_state/conversions.h>
 #include <object_recognition_msgs/ObjectRecognitionGoal.h>
 
+#include <tf2_eigen/tf2_eigen.h>
+
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
 namespace moveit_rviz_plugin
@@ -68,7 +70,7 @@ void MotionPlanningFrame::processDetectedObjects()
 {
   pick_object_name_.clear();
 
-  std::vector<std::string> objects, object_ids;
+  std::vector<std::string> object_ids;
   double min_x = ui_->roi_center_x->value() - ui_->roi_size_x->value() / 2.0;
   double min_y = ui_->roi_center_y->value() - ui_->roi_size_y->value() / 2.0;
   double min_z = ui_->roi_center_z->value() - ui_->roi_size_z->value() / 2.0;
@@ -80,13 +82,31 @@ void MotionPlanningFrame::processDetectedObjects()
   ros::Time start_time = ros::Time::now();
   while (object_ids.empty() && ros::Time::now() - start_time <= ros::Duration(3.0))
   {
-    object_ids =
-        planning_scene_interface_->getKnownObjectNamesInROI(min_x, min_y, min_z, max_x, max_y, max_z, true, objects);
+    // collect all objects in region of interest
+    {
+      const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+      const collision_detection::WorldConstPtr& world = ps->getWorld();
+      object_ids.clear();
+      for (const auto& object : *world)
+      {
+        if (!object.second->shape_poses_.empty())
+        {
+          const auto& position = object.second->shape_poses_[0].translation();
+          if (position.x() >= min_x && position.x() <= max_x && position.y() >= min_y && position.y() <= max_y &&
+              position.z() >= min_z && position.z() <= max_z)
+          {
+            object_ids.push_back(object.first);
+          }
+        }
+      }
+      if (!object_ids.empty())
+        break;
+    }
     ros::Duration(0.5).sleep();
   }
 
   ROS_DEBUG("Found %d objects", (int)object_ids.size());
-  updateDetectedObjectsList(object_ids, objects);
+  updateDetectedObjectsList(object_ids);
 }
 
 void MotionPlanningFrame::selectedDetectedObjectChanged()
@@ -153,8 +173,7 @@ void MotionPlanningFrame::listenDetectedObjects(const object_recognition_msgs::R
   planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::processDetectedObjects, this));
 }
 
-void MotionPlanningFrame::updateDetectedObjectsList(const std::vector<std::string>& object_ids,
-                                                    const std::vector<std::string>& /*objects*/)
+void MotionPlanningFrame::updateDetectedObjectsList(const std::vector<std::string>& object_ids)
 {
   ui_->detected_objects_list->setUpdatesEnabled(false);
   bool old_state = ui_->detected_objects_list->blockSignals(true);
@@ -265,13 +284,12 @@ void MotionPlanningFrame::pickObjectButtonClicked()
   {
     if (semantic_world_)
     {
-      std::vector<std::string> object_names;
-      object_names.push_back(pick_object_name_[group_name]);
-      std::map<std::string, geometry_msgs::Pose> object_poses = planning_scene_interface_->getObjectPoses(object_names);
-      if (object_poses.find(pick_object_name_[group_name]) != object_poses.end())
+      const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+      if (ps->getWorld()->hasObject(pick_object_name_[group_name]))
       {
-        ROS_DEBUG("Finding current table for object: %s", pick_object_name_[group_name].c_str());
-        support_surface_name_ = semantic_world_->findObjectTable(object_poses[pick_object_name_[group_name]]);
+        geometry_msgs::Pose object_pose(tf2::toMsg(ps->getWorld()->getTransform(pick_object_name_[group_name])));
+        ROS_DEBUG_STREAM("Finding current table for object: " << pick_object_name_[group_name]);
+        support_surface_name_ = semantic_world_->findObjectTable(object_pose);
       }
       else
         support_surface_name_.clear();


### PR DESCRIPTION
Supersedes #1950 .

I implemented an alternative way to construct a PSI, enabling users to detect issues with the ROS services instead of locking up the thread waiting for them.
It does not harm to have this option around.

Looking at the RViz display code again, I decided against making use of this feature here though.
The display already maintains a PSM, so I rewrote the logic to use this instead and  altogether got rid of the PSI.