### PR TITLE
Fix Condition for Adding current DistanceResultData to DistanceMap for DistanceRequestType::SINGLE

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -258,5 +258,53 @@ TYPED_TEST_P(CollisionDetectorPandaTest, DistanceWorld)
   EXPECT_NEAR(res.distance, 0.029, 0.01);
 }
 
+template <class CollisionAllocatorType>
+class DistanceCheckPandaTest : public CollisionDetectorPandaTest<CollisionAllocatorType>
+{
+};
+
+TYPED_TEST_CASE_P(DistanceCheckPandaTest);
+
+TYPED_TEST_P(DistanceCheckPandaTest, DistanceSingle)
+{
+  std::set<const moveit::core::LinkModel*> active_components{ this->robot_model_->getLinkModel("panda_hand") };
+  collision_detection::DistanceRequest req;
+  req.type = collision_detection::DistanceRequestTypes::SINGLE;
+  req.active_components_only = &active_components;
+  req.enable_signed_distance = true;
+
+  random_numbers::RandomNumberGenerator rng(0x47110815);
+  double min_distance = std::numeric_limits<double>::max();
+  for (int i = 0; i < 10; ++i)
+  {
+    collision_detection::DistanceResult res;
+
+    shapes::ShapeConstPtr shape(new shapes::Cylinder(rng.uniform01(), rng.uniform01()));
+    Eigen::Isometry3d pose{ Eigen::Isometry3d::Identity() };
+    pose.translation() =
+        Eigen::Vector3d(rng.uniformReal(0.1, 2.0), rng.uniformReal(0.1, 2.0), rng.uniformReal(1.2, 1.7));
+    double quat[4];
+    rng.quaternion(quat);
+    pose.linear() = Eigen::Quaterniond(quat[0], quat[1], quat[2], quat[3]).toRotationMatrix();
+
+    this->cenv_->getWorld()->addToObject("collection", shape, pose);
+    this->cenv_->getWorld()->removeObject("object");
+    this->cenv_->getWorld()->addToObject("object", shape, pose);
+
+    this->cenv_->distanceRobot(req, res, *this->robot_state_);
+    auto& distances1 = res.distances[std::pair<std::string, std::string>("collection", "panda_hand")];
+    auto& distances2 = res.distances[std::pair<std::string, std::string>("object", "panda_hand")];
+    ASSERT_EQ(distances1.size(), 1u) << "no distance reported for collection/panda_hand";
+    ASSERT_EQ(distances2.size(), 1u) << "no distance reported for object/panda_hand";
+
+    double collection_distance = distances1[0].distance;
+    min_distance = std::min(min_distance, distances2[0].distance);
+    ASSERT_NEAR(collection_distance, min_distance, 1e-5)
+        << "distance to collection is greater than distance to minimum of individual objects after " << i << " rounds";
+  }
+}
+
 REGISTER_TYPED_TEST_CASE_P(CollisionDetectorPandaTest, InitOK, DefaultNotInCollision, LinksInCollision,
                            RobotWorldCollision_1, RobotWorldCollision_2, PaddingTest, DistanceSelf, DistanceWorld);
+
+REGISTER_TYPED_TEST_CASE_P(DistanceCheckPandaTest, DistanceSingle);

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -610,7 +610,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
         }
         else if (cdata->req->type == DistanceRequestType::SINGLE)
         {
-          if (it->second[0].distance < dist_result.distance)
+          if (dist_result.distance < it->second[0].distance)
             it->second[0] = dist_result;
         }
         else if (cdata->req->type == DistanceRequestType::LIMITED)

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection_panda.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection_panda.cpp
@@ -40,6 +40,9 @@
 INSTANTIATE_TYPED_TEST_CASE_P(FCLCollisionCheckPanda, CollisionDetectorPandaTest,
                               collision_detection::CollisionDetectorAllocatorFCL);
 
+INSTANTIATE_TYPED_TEST_CASE_P(FCLDistanceCheckPanda, DistanceCheckPandaTest,
+                              collision_detection::CollisionDetectorAllocatorFCL);
+
 int main(int argc, char* argv[])
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Description

One line of code is changed in the *collision calculation* interface file for *FCL*.

Within the settings for a [distance request within *MoveIt!*](http://docs.ros.org/melodic/api/moveit_core/html/structcollision__detection_1_1DistanceRequest.html) the user can specify a [DistanceRequestType](http://docs.ros.org/melodic/api/moveit_core/html/namespacecollision__detection_1_1DistanceRequestTypes.html#ac754f7bfd3f776cb02a190e9a0fd893e).
I am using distance requests for avoiding collisions of the robot. Therefore, I want to check every *collision geometry* of a single *robot link* with the *world objects*. I am only interested in the closest point of each *robot link* to the *world object*, i.e. in the *collision geometry* of the *robot link* that is closest to the *world object*. Therefore, I am using *DistanceRequestType::**SINGLE***. However, when using **SINGLE** *MoveIt!* does not store the results for the closest collision object in the *DistanceMap* of the [DistanceResult](http://docs.ros.org/kinetic/api/moveit_core/html/structcollision__detection_1_1DistanceResult.html). Instead, *MoveIt!* stores the distance result for a random *collision geometry* of the *robot link* in the *DistanceMap*, and **not** the results for the closest *collision geometry*. This results in the assumption that a certain *robot link* is far away from an obstacle although collision is very close.

I think, this is due to the wrong condition for replacing the current *DistanceResultData* in the *DistanceMap* in case of *SINGLE* distance request types. If the distance of the current *collision geometry* is smaller than the stored one, the stored one should be replaced.

In my case, I got a more reasonable robot behavior after having applied this change.