### PR TITLE
MP display: change internal shortcut Ctrl+R to Ctrl+I

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -258,7 +258,7 @@ void MotionPlanningDisplay::onInitialize()
   if (context_ && context_->getWindowManager() && context_->getWindowManager()->getParentWindow())
   {
     QShortcut* im_reset_shortcut =
-        new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_R), context_->getWindowManager()->getParentWindow());
+        new QShortcut(QKeySequence("Ctrl+I"), context_->getWindowManager()->getParentWindow());
     connect(im_reset_shortcut, SIGNAL(activated()), this, SLOT(resetInteractiveMarkers()));
   }
 }


### PR DESCRIPTION
Ctrl+R is used by RViz to rename displays.
Overlaying the sequence semi-breaks the behavior
and the rename button gets selected, but not pressed.

This is an internal shortcut used in case the interactive markers
of the display fail to update correctly. This is seldomly (never?)
used, so remapping does not hurt anyone.

To the best of my knowledge Ctrl+I is not used in standard RViz.