### PR TITLE
Export  moveit_py_bindings_tools library

### DIFF
--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -63,6 +63,7 @@ catkin_package(
     moveit_planning_scene_interface
     moveit_move_group_interface
     moveit_cpp
+    moveit_py_bindings_tools
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS


### PR DESCRIPTION
### Description

I'd like to use the py_bindings_tools for my own Python C++ wrappers, but it's not yet included in `catkin_package()`. This results in a linking error (undefined symbol `moveit::py_binding_tools::ROScppInitializer::ROScppInitializer()`) when trying to load the Python C extension.

Btw., should this and #1870 be backported to melodic?

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
