### PR TITLE
Backport #1870 and #1970 to melodic-devel

### DIFF
--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -45,7 +45,7 @@ class SimpleCompleter(object):
         prefix = ""
         if len(cmds) > 0:
             prefix = cmds[0]
-            if not self.options.has_key(prefix):
+            if not prefix in self.options:
                 prefix = ""
 
         if state == 0:

--- a/moveit_commander/src/moveit_commander/conversions.py
+++ b/moveit_commander/src/moveit_commander/conversions.py
@@ -36,8 +36,8 @@ try:
     # Try Python 2.7 behaviour first
     from StringIO import StringIO
 except ImportError:
-    # Use Python 3.x behaviour as fallback
-    from io import StringIO
+    # Use Python 3.x behaviour as fallback and choose the non-unicode version
+    from io import BytesIO as StringIO
 
 from moveit_commander import MoveItCommanderException
 from geometry_msgs.msg import Pose, PoseStamped, Transform

--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -103,7 +103,7 @@ class MoveGroupCommandInterpreter(object):
                         clist[1] = self._prev_group_name
                         if len(clist[1]) == 0:
                             return (MoveGroupInfoLevel.DEBUG, "OK")
-                    if self._gdict.has_key(clist[1]):
+                    if clist[1] in self._gdict:
                         self._prev_group_name = self._group_name
                         self._group_name = clist[1]
                         return (MoveGroupInfoLevel.DEBUG, "OK")
@@ -267,7 +267,7 @@ class MoveGroupCommandInterpreter(object):
         assign_match = re.match(r"^(\w+)\s*=\s*(\w+)$", cmd)
         if assign_match:
             known = g.get_remembered_joint_values()
-            if known.has_key(assign_match.group(2)):
+            if assign_match.group(2) in known:
                 g.remember_joint_values(assign_match.group(1), known[assign_match.group(2)])
                 return (MoveGroupInfoLevel.SUCCESS, assign_match.group(1) + " is now the same as " + assign_match.group(2))
             else:
@@ -286,7 +286,7 @@ class MoveGroupCommandInterpreter(object):
         component_match = re.match(r"^(\w+)\s*\[\s*(\d+)\s*\]\s*=\s*([\d\.e\-\+]+)$", cmd)
         if component_match:
             known = g.get_remembered_joint_values()
-            if known.has_key(component_match.group(1)):
+            if component_match.group(1) in known:
                 try:
                     val = known[component_match.group(1)]
                     val[int(component_match.group(2))] = float(component_match.group(3))
@@ -303,7 +303,7 @@ class MoveGroupCommandInterpreter(object):
         # if this is an unknown one-word command, it is probably a variable
         if len(clist) == 1:
             known = g.get_remembered_joint_values()
-            if known.has_key(cmd):
+            if cmd in known:
                 return (MoveGroupInfoLevel.INFO, "[" + " ".join([str(x) for x in known[cmd]]) + "]")
             else:
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
@@ -381,7 +381,7 @@ class MoveGroupCommandInterpreter(object):
                 return (MoveGroupInfoLevel.SUCCESS, "Forgot joint values under the name " + clist[1])
             elif clist[0] == "show":
                 known = g.get_remembered_joint_values()
-                if known.has_key(clist[1]):
+                if clist[1] in known:
                     return (MoveGroupInfoLevel.INFO, "[" + " ".join([str(x) for x in known[clist[1]]]) + "]")
                 else:
                     return (MoveGroupInfoLevel.WARN, "Joint values for " + clist[1] + " are not known")
@@ -423,7 +423,7 @@ class MoveGroupCommandInterpreter(object):
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
         if len(clist) == 3:
-            if clist[0] == "go" and self.GO_DIRS.has_key(clist[1]):
+            if clist[0] == "go" and clist[1] in self.GO_DIRS:
                 self._last_plan = None
                 try:
                     offset = float(clist[2])

--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -261,7 +261,7 @@ class RobotCommander(object):
         @param name str: Name of movegroup
         @rtype: moveit_commander.MoveGroupCommander
         """
-        if not self._groups.has_key(name):
+        if not name in self._groups:
             if not self.has_group(name):
                 raise MoveItCommanderException("There is no group named %s" % name)
             self._groups[name] = MoveGroupCommander(name, self._robot_description, self._ns)
@@ -279,7 +279,7 @@ class RobotCommander(object):
         Get the name of the smallest group (fewest joints) that includes
         the joint name specified as argument.
         """
-        if not self._joint_owner_groups.has_key(joint_name):
+        if not joint_name in self._joint_owner_groups:
             group = None
             for g in self.get_group_names():
                 if joint_name in self.get_joint_names(g):

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -61,6 +61,7 @@ catkin_package(
     moveit_common_planning_interface_objects
     moveit_planning_scene_interface
     moveit_move_group_interface
+    moveit_py_bindings_tools
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -94,21 +94,23 @@ public:
     return setJointValueTarget(v);
   }
 
-  bool setJointValueTargetFromPosePython(const std::string& pose_str, const std::string& eef, bool approx)
+  bool setJointValueTargetFromPosePython(const py_bindings_tools::ByteString& pose_str, const std::string& eef,
+                                         bool approx)
   {
     geometry_msgs::Pose pose_msg;
     py_bindings_tools::deserializeMsg(pose_str, pose_msg);
     return approx ? setApproximateJointValueTarget(pose_msg, eef) : setJointValueTarget(pose_msg, eef);
   }
 
-  bool setJointValueTargetFromPoseStampedPython(const std::string& pose_str, const std::string& eef, bool approx)
+  bool setJointValueTargetFromPoseStampedPython(const py_bindings_tools::ByteString& pose_str, const std::string& eef,
+                                                bool approx)
   {
     geometry_msgs::PoseStamped pose_msg;
     py_bindings_tools::deserializeMsg(pose_str, pose_msg);
     return approx ? setApproximateJointValueTarget(pose_msg, eef) : setJointValueTarget(pose_msg, eef);
   }
 
-  bool setJointValueTargetFromJointStatePython(const std::string& js_str)
+  bool setJointValueTargetFromJointStatePython(const py_bindings_tools::ByteString& js_str)
   {
     sensor_msgs::JointState js_msg;
     py_bindings_tools::deserializeMsg(js_str, js_msg);
@@ -133,7 +135,7 @@ public:
     return l;
   }
 
-  std::string getJointValueTarget()
+  py_bindings_tools::ByteString getJointValueTarget()
   {
     moveit_msgs::RobotState msg;
     const robot_state::RobotState state = moveit::planning_interface::MoveGroupInterface::getJointValueTarget();
@@ -151,7 +153,7 @@ public:
     return getPlanningFrame().c_str();
   }
 
-  std::string getInterfaceDescriptionPython()
+  py_bindings_tools::ByteString getInterfaceDescriptionPython()
   {
     moveit_msgs::PlannerInterfaceDescription msg;
     getInterfaceDescription(msg);
@@ -268,7 +270,8 @@ public:
     return place(object_name, msg, plan_only) == MoveItErrorCode::SUCCESS;
   }
 
-  bool placeLocation(const std::string& object_name, const std::string& location_str, bool plan_only = false)
+  bool placeLocation(const std::string& object_name, const py_bindings_tools::ByteString& location_str,
+                     bool plan_only = false)
   {
     std::vector<moveit_msgs::PlaceLocation> locations(1);
     py_bindings_tools::deserializeMsg(location_str, locations[0]);
@@ -321,7 +324,7 @@ public:
     return output;
   }
 
-  void setStartStatePython(const std::string& msg_str)
+  void setStartStatePython(const py_bindings_tools::ByteString& msg_str)
   {
     moveit_msgs::RobotState msg;
     py_bindings_tools::deserializeMsg(msg_str, msg);
@@ -334,7 +337,7 @@ public:
     convertListToArrayOfPoses(poses, msg);
     return setPoseTargets(msg, end_effector_link);
   }
-  std::string getPoseTargetPython(const std::string& end_effector_link)
+  py_bindings_tools::ByteString getPoseTargetPython(const std::string& end_effector_link)
   {
     geometry_msgs::PoseStamped pose = moveit::planning_interface::MoveGroupInterface::getPoseTarget(end_effector_link);
     return py_bindings_tools::serializeMsg(pose);
@@ -414,14 +417,14 @@ public:
     return attachObject(object_name, link_name, py_bindings_tools::stringFromList(touch_links));
   }
 
-  bool executePython(const std::string& plan_str)
+  bool executePython(const py_bindings_tools::ByteString& plan_str)
   {
     MoveGroupInterface::Plan plan;
     py_bindings_tools::deserializeMsg(plan_str, plan.trajectory_);
     return execute(plan) == MoveItErrorCode::SUCCESS;
   }
 
-  bool asyncExecutePython(const std::string& plan_str)
+  bool asyncExecutePython(const py_bindings_tools::ByteString& plan_str)
   {
     MoveGroupInterface::Plan plan;
     py_bindings_tools::deserializeMsg(plan_str, plan.trajectory_);
@@ -443,7 +446,8 @@ public:
   }
 
   bp::tuple computeCartesianPathConstrainedPython(const bp::list& waypoints, double eef_step, double jump_threshold,
-                                                  bool avoid_collisions, const std::string& path_constraints_str)
+                                                  bool avoid_collisions,
+                                                  const py_bindings_tools::ByteString& path_constraints_str)
   {
     moveit_msgs::Constraints path_constraints;
     py_bindings_tools::deserializeMsg(path_constraints_str, path_constraints);
@@ -461,7 +465,7 @@ public:
     return bp::make_tuple(py_bindings_tools::serializeMsg(trajectory), fraction);
   }
 
-  int pickGrasp(const std::string& object, const std::string& grasp_str, bool plan_only = false)
+  int pickGrasp(const std::string& object, const py_bindings_tools::ByteString& grasp_str, bool plan_only = false)
   {
     moveit_msgs::Grasp grasp;
     py_bindings_tools::deserializeMsg(grasp_str, grasp);
@@ -473,27 +477,26 @@ public:
     int l = bp::len(grasp_list);
     std::vector<moveit_msgs::Grasp> grasps(l);
     for (int i = 0; i < l; ++i)
-      py_bindings_tools::deserializeMsg(bp::extract<std::string>(grasp_list[i]), grasps[i]);
+      py_bindings_tools::deserializeMsg(py_bindings_tools::ByteString(grasp_list[i]), grasps[i]);
     return pick(object, grasps, plan_only).val;
   }
 
-  void setPathConstraintsFromMsg(const std::string& constraints_str)
+  void setPathConstraintsFromMsg(const py_bindings_tools::ByteString& constraints_str)
   {
     moveit_msgs::Constraints constraints_msg;
     py_bindings_tools::deserializeMsg(constraints_str, constraints_msg);
     setPathConstraints(constraints_msg);
   }
 
-  std::string getPathConstraintsPython()
+  py_bindings_tools::ByteString getPathConstraintsPython()
   {
     moveit_msgs::Constraints constraints_msg(getPathConstraints());
-    std::string constraints_str = py_bindings_tools::serializeMsg(constraints_msg);
-    return constraints_str;
+    return py_bindings_tools::serializeMsg(constraints_msg);
   }
 
-  std::string retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
-                               double velocity_scaling_factor, double acceleration_scaling_factor,
-                               std::string algorithm)
+  py_bindings_tools::ByteString retimeTrajectory(const std::string& ref_state_str, const std::string& traj_str,
+                                                 double velocity_scaling_factor, double acceleration_scaling_factor,
+                                                 std::string algorithm)
   {
     // Convert reference state message to object
     moveit_msgs::RobotState ref_state_msg;
@@ -531,15 +534,12 @@ public:
 
       // Convert the retimed trajectory back into a message
       traj_obj.getRobotTrajectoryMsg(traj_msg);
-      std::string traj_str = py_bindings_tools::serializeMsg(traj_msg);
-
-      // Return it.
-      return traj_str;
+      return py_bindings_tools::serializeMsg(traj_msg);
     }
     else
     {
       ROS_ERROR("Unable to convert RobotState message to RobotState instance.");
-      return "";
+      return py_bindings_tools::ByteString("");
     }
   }
 

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -74,7 +74,7 @@ public:
   bp::dict getObjectPosesPython(const bp::list& object_ids)
   {
     std::map<std::string, geometry_msgs::Pose> ops = getObjectPoses(py_bindings_tools::stringFromList(object_ids));
-    std::map<std::string, std::string> ser_ops;
+    std::map<std::string, py_bindings_tools::ByteString> ser_ops;
     for (std::map<std::string, geometry_msgs::Pose>::const_iterator it = ops.begin(); it != ops.end(); ++it)
       ser_ops[it->first] = py_bindings_tools::serializeMsg(it->second);
 
@@ -85,7 +85,7 @@ public:
   {
     std::map<std::string, moveit_msgs::CollisionObject> objs =
         getObjects(py_bindings_tools::stringFromList(object_ids));
-    std::map<std::string, std::string> ser_objs;
+    std::map<std::string, py_bindings_tools::ByteString> ser_objs;
     for (std::map<std::string, moveit_msgs::CollisionObject>::const_iterator it = objs.begin(); it != objs.end(); ++it)
       ser_objs[it->first] = py_bindings_tools::serializeMsg(it->second);
 
@@ -96,7 +96,7 @@ public:
   {
     std::map<std::string, moveit_msgs::AttachedCollisionObject> aobjs =
         getAttachedObjects(py_bindings_tools::stringFromList(object_ids));
-    std::map<std::string, std::string> ser_aobjs;
+    std::map<std::string, py_bindings_tools::ByteString> ser_aobjs;
     for (std::map<std::string, moveit_msgs::AttachedCollisionObject>::const_iterator it = aobjs.begin();
          it != aobjs.end(); ++it)
       ser_aobjs[it->first] = py_bindings_tools::serializeMsg(it->second);
@@ -104,7 +104,7 @@ public:
     return py_bindings_tools::dictFromType(ser_aobjs);
   }
 
-  bool applyPlanningScenePython(const std::string& ps_str)
+  bool applyPlanningScenePython(const py_bindings_tools::ByteString& ps_str)
   {
     moveit_msgs::PlanningScene ps_msg;
     py_bindings_tools::deserializeMsg(ps_str, ps_msg);

--- a/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/serialize_msg.h
+++ b/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/serialize_msg.h
@@ -38,38 +38,103 @@
 #define MOVEIT_PY_BINDINGS_TOOLS_SERIALIZE_MSG_
 
 #include <ros/ros.h>
+#include <Python.h>
+#include <boost/python.hpp>
+#include <string>
+#include <stdexcept>
+#include <type_traits>
 
 namespace moveit
 {
 namespace py_bindings_tools
 {
-/** \brief Convert a ROS message to a string */
-template <typename T>
-std::string serializeMsg(const T& msg)
+/** \brief C++ Wrapper class for Python 3 \c Bytes Object */
+class ByteString : public boost::python::object
 {
-  // we use the fact char is same size as uint8_t;
-  assert(sizeof(uint8_t) == sizeof(char));
-  std::size_t size = ros::serialization::serializationLength(msg);
-  std::string result(size, '\0');
-  if (size)
+public:
+  // constructors for bp::handle and friends
+  BOOST_PYTHON_FORWARD_OBJECT_CONSTRUCTORS(ByteString, boost::python::object)
+  ByteString() : boost::python::object(boost::python::handle<>(PyBytes_FromString("")))
   {
-    // we convert the message into a string because that is easy to sent back & forth with Python
-    // This is fine since C0x because &string[0] is guaranteed to point to a contiguous block of memory
-    ros::serialization::OStream stream_arg(reinterpret_cast<uint8_t*>(&result[0]), size);
+  }
+  explicit ByteString(const char* s) : boost::python::object(boost::python::handle<>(PyBytes_FromString(s)))
+  {
+  }
+  explicit ByteString(const std::string& s)
+    : boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize(s.c_str(), s.size())))
+  {
+  }
+  // bp::list[] returns a proxy which has to be converted to an object first
+  template <typename T>
+  explicit ByteString(const boost::python::api::proxy<T>& proxy) : boost::python::object(proxy)
+  {
+  }
+  /** \brief Serializes a ROS message into a Python Bytes object
+   * The second template parameter ensures that this overload is only chosen with a ROS message argument
+   */
+  template <typename T, typename std::enable_if<ros::message_traits::IsMessage<T>::value, int>::type = 0>
+  explicit ByteString(const T& msg)
+    : boost::python::object(
+          boost::python::handle<>(PyBytes_FromStringAndSize(nullptr, ros::serialization::serializationLength(msg))))
+  {
+    ros::serialization::OStream stream_arg(reinterpret_cast<uint8_t*>(PyBytes_AS_STRING(ptr())),
+                                           PyBytes_GET_SIZE(ptr()));
     ros::serialization::serialize(stream_arg, msg);
   }
-  return result;
+
+  /** \brief Convert content to a ROS message */
+  template <typename T>
+  void deserialize(T& msg) const
+  {
+    static_assert(sizeof(uint8_t) == sizeof(char), "ros/python buffer layout mismatch");
+    char* buf = PyBytes_AsString(ptr());
+    // buf == NULL on error
+    if (!buf)
+    {
+      throw std::runtime_error("Underlying python object is not a Bytes/String instance");
+    }
+    // unfortunately no constructor with const uint8_t
+    ros::serialization::IStream stream_arg(reinterpret_cast<uint8_t*>(buf), PyBytes_GET_SIZE(ptr()));
+    ros::serialization::deserialize(stream_arg, msg);
+  }
+};
+
+/** \brief Convert a ROS message to a Python Bytestring */
+template <typename T>
+ByteString serializeMsg(const T& msg)
+{
+  return ByteString(msg);
 }
 
-/** \brief Convert a string to a ROS message */
+/** \brief Convert a Python Bytestring to a ROS message */
 template <typename T>
-void deserializeMsg(const std::string& data, T& msg)
+void deserializeMsg(const ByteString& data, T& msg)
 {
-  assert(sizeof(uint8_t) == sizeof(char));
-  ros::serialization::IStream stream_arg(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&data[0])), data.size());
-  ros::serialization::deserialize(stream_arg, msg);
+  data.deserialize(msg);
 }
-}
-}
+
+}  // namespace py_bindings_tools
+}  // namespace moveit
+
+namespace boost
+{
+namespace python
+{
+namespace converter
+{
+// only accept Python 3 Bytes / Python 2 String instance when used as C++ function parameter
+template <>
+struct object_manager_traits<moveit::py_bindings_tools::ByteString>
+#if PY_VERSION_HEX >= 0x03000000
+    : pytype_object_manager_traits<&PyBytes_Type, moveit::py_bindings_tools::ByteString>
+#else
+    : pytype_object_manager_traits<&PyString_Type, moveit::py_bindings_tools::ByteString>
+#endif
+
+{
+};
+}  // namespace converter
+}  // namespace python
+}  // namespace boost
 
 #endif

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -223,10 +223,10 @@ public:
     return true;
   }
 
-  std::string getCurrentState()
+  py_bindings_tools::ByteString getCurrentState()
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString("");
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     moveit_msgs::RobotState msg;
     robot_state::robotStateToRobotStateMsg(*s, msg);
@@ -244,7 +244,7 @@ public:
     return boost::python::make_tuple(parent_group.first, parent_group.second);
   }
 
-  std::string getRobotMarkersPythonDictList(bp::dict& values, bp::list& links)
+  py_bindings_tools::ByteString getRobotMarkersPythonDictList(bp::dict& values, bp::list& links)
   {
     robot_state::RobotStatePtr state;
     if (ensureCurrentState())
@@ -273,13 +273,13 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersPythonDict(bp::dict& values)
+  py_bindings_tools::ByteString getRobotMarkersPythonDict(bp::dict& values)
   {
     bp::list links = py_bindings_tools::listFromString(robot_model_->getLinkModelNames());
     return getRobotMarkersPythonDictList(values, links);
   }
 
-  std::string getRobotMarkersFromMsg(const std::string& state_str)
+  py_bindings_tools::ByteString getRobotMarkersFromMsg(const py_bindings_tools::ByteString& state_str)
   {
     moveit_msgs::RobotState state_msg;
     robot_state::RobotState state(robot_model_);
@@ -292,10 +292,10 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkers()
+  py_bindings_tools::ByteString getRobotMarkers()
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString();
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     visualization_msgs::MarkerArray msg;
     s->getRobotMarkers(msg, s->getRobotModel()->getLinkModelNames());
@@ -303,10 +303,10 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersPythonList(const bp::list& links)
+  py_bindings_tools::ByteString getRobotMarkersPythonList(const bp::list& links)
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString("");
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     visualization_msgs::MarkerArray msg;
     s->getRobotMarkers(msg, py_bindings_tools::stringFromList(links));
@@ -314,10 +314,10 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersGroup(const std::string& group)
+  py_bindings_tools::ByteString getRobotMarkersGroup(const std::string& group)
   {
     if (!ensureCurrentState())
-      return "";
+      return py_bindings_tools::ByteString("");
     robot_state::RobotStatePtr s = current_state_monitor_->getCurrentState();
     const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     visualization_msgs::MarkerArray msg;
@@ -329,11 +329,11 @@ public:
     return py_bindings_tools::serializeMsg(msg);
   }
 
-  std::string getRobotMarkersGroupPythonDict(const std::string& group, bp::dict& values)
+  py_bindings_tools::ByteString getRobotMarkersGroupPythonDict(const std::string& group, bp::dict& values)
   {
     const robot_model::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
     if (!jmg)
-      return "";
+      return py_bindings_tools::ByteString("");
     bp::list links = py_bindings_tools::listFromString(jmg->getLinkModelNames());
     return getRobotMarkersPythonDictList(values, links);
   }

--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -453,7 +453,7 @@ class MoveitJoy:
                 self.marker_lock.acquire()
                 self.initialize_poses = True
                 topic_suffix = next_topic.split("/")[-1]
-                if self.initial_poses.has_key(topic_suffix):
+                if topic_suffix in self.initial_poses:
                     self.pre_pose = PoseStamped(pose=self.initial_poses[topic_suffix])
                     self.initialize_poses = False
                     return True


### PR DESCRIPTION
### Description

Backporting #1870 and #1970 to melodic-devel.

 * moveit_py_bindings_tools is exported with catkin
 * Replaced `has_key()` with `in` statement (not available in Python 3)
 * Message (de-)serialization via `bytes` in Python 3

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
