### PR TITLE
[jog_arm] Add a binary collision check to the main control loop

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -41,7 +41,6 @@
 #include <atomic>
 #include "jog_arm_data.h"
 #include "low_pass_filter.h"
-#include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 namespace moveit_jog_arm
@@ -51,14 +50,11 @@ class CollisionCheckThread
 public:
   /** \brief Constructor
    *  \param parameters: common settings of jog_arm
-   *  \param planning_scene_monitor: PSM should have scene monitor and state monitor
-   *                                 already started when passed into this class
+   *  \param planning_scene_monitor: PSM should have scene monitor and state monitor already started when passed into
+                                     this class
    */
   CollisionCheckThread(const moveit_jog_arm::JogArmParameters& parameters,
                        const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
-
-  // Get thread-safe read-only lock of planning scene
-  planning_scene_monitor::LockedPlanningSceneRO getLockedPlanningSceneRO() const;
 
   void startMainLoop(moveit_jog_arm::JogArmShared& shared_variables);
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -56,7 +56,14 @@ namespace moveit_jog_arm
 class JogCalcs
 {
 public:
-  JogCalcs(const JogArmParameters& parameters, const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
+  /** \brief Constructor
+   *  \param parameters: common settings of jog_arm
+   *  \param model_loader_ptr: pointer to the robot model loader
+   *  \param planning_scene_monitor: PSM should have scene monitor and state monitor already started when passed into
+                                     this class
+   */
+  JogCalcs(const JogArmParameters& parameters, const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr,
+           const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   void startMainLoop(JogArmShared& shared_variables);
 
@@ -194,5 +201,9 @@ protected:
   uint num_joints_;
 
   ros::Rate default_sleep_rate_;
+
+  // Pointer to the collision environment
+  // We do fast, binary collision checking in this thread
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -228,7 +228,8 @@ bool JogInterfaceBase::changeDriftDimensions(moveit_msgs::ChangeDriftDimensions:
 bool JogInterfaceBase::startJogCalcThread()
 {
   if (!jog_calcs_)
-    jog_calcs_.reset(new JogCalcs(ros_parameters_, planning_scene_monitor_->getRobotModelLoader()));
+    jog_calcs_.reset(
+        new JogCalcs(ros_parameters_, planning_scene_monitor_->getRobotModelLoader(), planning_scene_monitor_));
 
   jog_calc_thread_.reset(new std::thread([&]() { jog_calcs_->startMainLoop(shared_variables_); }));
 


### PR DESCRIPTION
Previously there was distance-based collision checking in a separate thread, but some issues with it were noticed. Namely, starting inside another body did not stop motion.

This is kind of a collision check of last resort. Binary collision checking should be fast enough for the main control loop.

I can probably send video of this working if requested, but it's a private project, so I can't share the video publicly.
