### PR TITLE
[jog_arm] Add a binary collision check

### DIFF
--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -52,5 +52,5 @@ command_out_topic: joint_group_position_controller/command # Publish outgoing co
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
-collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+collision_check_rate: 10 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]

--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -54,4 +54,3 @@ command_out_topic: joint_group_position_controller/command # Publish outgoing co
 check_collisions: true # Check collisions?
 collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
-hard_stop_collision_proximity_threshold: 0.0005 # Stop when a collision is this far [m]

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -132,9 +132,8 @@ protected:
    * @param shared_variables data shared between threads, tells how close we are to collision
    * @param delta_theta motion command, used in calculating new_joint_tray
    * @param singularity_scale tells how close we are to a singularity
-   * @return false if very close to collision or singularity
    */
-  bool applyVelocityScaling(JogArmShared& shared_variables, Eigen::ArrayXd& delta_theta, double singularity_scale);
+  void applyVelocityScaling(JogArmShared& shared_variables, Eigen::ArrayXd& delta_theta, double singularity_scale);
 
   /** \brief Compose the outgoing JointTrajectory message */
   trajectory_msgs::JointTrajectory composeJointTrajMessage(sensor_msgs::JointState& joint_state) const;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -48,14 +48,16 @@ enum StatusCode : int8_t
   NO_WARNING = 0,
   DECELERATE_FOR_SINGULARITY = 1,
   HALT_FOR_SINGULARITY = 2,
-  COLLISION = 3,
-  JOINT_BOUND = 4
+  DECELERATE_FOR_COLLISION = 3,
+  HALT_FOR_COLLISION = 4,
+  JOINT_BOUND = 5
 };
 
 const std::unordered_map<uint, std::string>
     JOG_ARM_STATUS_CODE_MAP({ { NO_WARNING, "No warnings" },
                               { DECELERATE_FOR_SINGULARITY, "Close to a singularity, decelerating" },
                               { HALT_FOR_SINGULARITY, "Very close to a singularity, halting" },
-                              { COLLISION, "Close to a collision, halting." },
+                              { DECELERATE_FOR_COLLISION, "Close to a collision, decelerating." },
+                              { HALT_FOR_COLLISION, "Close to a collision, halting." },
                               { JOINT_BOUND, "Close to a joint bound (position or velocity), halting" } });
 }  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/status_codes.h
@@ -56,8 +56,8 @@ enum StatusCode : int8_t
 const std::unordered_map<uint, std::string>
     JOG_ARM_STATUS_CODE_MAP({ { NO_WARNING, "No warnings" },
                               { DECELERATE_FOR_SINGULARITY, "Close to a singularity, decelerating" },
-                              { HALT_FOR_SINGULARITY, "Very close to a singularity, halting" },
-                              { DECELERATE_FOR_COLLISION, "Close to a collision, decelerating." },
-                              { HALT_FOR_COLLISION, "Close to a collision, halting." },
+                              { HALT_FOR_SINGULARITY, "Very close to a singularity, emergency stop" },
+                              { DECELERATE_FOR_COLLISION, "Close to a collision, decelerating" },
+                              { HALT_FOR_COLLISION, "Collision detected, emergency stop" },
                               { JOINT_BOUND, "Close to a joint bound (position or velocity), halting" } });
 }  // end namespace trackjoint

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -64,7 +64,6 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
   // Init collision request
   collision_detection::CollisionRequest collision_request;
   collision_request.group_name = parameters_.move_group_name;
-  collision_request.distance = true;
   collision_detection::CollisionResult collision_result;
 
   // Copy the planning scene's version of current state into new memory
@@ -72,6 +71,14 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
 
   double velocity_scale_coefficient = -log(0.001) / parameters_.collision_proximity_threshold;
   ros::Rate collision_rate(parameters_.collision_check_rate);
+
+  double collision_distance = 0;
+  bool is_in_collision = false;
+
+  // Scale robot velocity according to collision proximity and user-defined thresholds.
+  // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.
+  // Proximity decreasing --> decelerate
+  double velocity_scale = 1;
 
   /////////////////////////////////////////////////
   // Spin while checking collisions
@@ -87,25 +94,33 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
 
     collision_result.clear();
     current_state.updateCollisionBodyTransforms();
-    // Do thread-safe collsion collision checking
+    // Do a thread-safe distance-based collision detection
+    collision_request.distance = true;
     getLockedPlanningSceneRO()->checkCollision(collision_request, collision_result, current_state);
+    collision_distance = collision_result.distance;
 
-    // Scale robot velocity according to collision proximity and user-defined thresholds.
-    // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.
-    // Proximity decreasing --> decelerate
-    double velocity_scale = 1;
+    // Do a binary collision detection (helps with strange edge cases like being in collision initially)
+    collision_request.distance = false;
+    getLockedPlanningSceneRO()->checkCollision(collision_request, collision_result, current_state);
+    is_in_collision = collision_result.collision;
+
+    // If we're definitely in collision, stop immediately
+    if (is_in_collision)
+    {
+      velocity_scale = 0;
+    }
 
     // If we are far from a collision, velocity_scale should be 1.
     // If we are very close to a collision, velocity_scale should be ~zero.
     // When collision_proximity_threshold is breached, start decelerating exponentially.
-    if (collision_result.distance < parameters_.collision_proximity_threshold)
+    else if (collision_distance < parameters_.collision_proximity_threshold)
     {
       // velocity_scale = e ^ k * (collision_distance - threshold)
       // k = - ln(0.001) / collision_proximity_threshold
       // velocity_scale should equal one when collision_distance is at collision_proximity_threshold.
       // velocity_scale should equal 0.001 when collision_distance is at zero.
       velocity_scale =
-          exp(velocity_scale_coefficient * (collision_result.distance - parameters_.collision_proximity_threshold));
+          exp(velocity_scale_coefficient * (collision_distance - parameters_.collision_proximity_threshold));
     }
 
     shared_variables.lock();

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -353,7 +353,7 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
                        velocityScalingFactorForSingularity(delta_x, svd, jacobian, pseudo_inverse));
   if (status_ == HALT_FOR_COLLISION)
   {
-    ROS_ERROR_STREAM("Halting!");
+    ROS_ERROR_STREAM_THROTTLE_NAMED(5, LOGNAME, "Halting for collision!");
     suddenHalt(delta_theta_);
   }
 
@@ -402,6 +402,7 @@ void JogCalcs::updateCachedStatus(JogArmShared& shared_variables)
 
 bool JogCalcs::convertDeltasToOutgoingCmd()
 {
+  internal_joint_state_ = original_joint_state_;
   if (!addJointIncrements(internal_joint_state_, delta_theta_))
     return false;
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -349,7 +349,8 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
     return false;
 
   // If close to a collision or a singularity, decelerate
-  applyVelocityScaling(shared_variables, delta_theta_, velocityScalingFactorForSingularity(delta_x, svd, jacobian, pseudo_inverse));
+  applyVelocityScaling(shared_variables, delta_theta_,
+                       velocityScalingFactorForSingularity(delta_x, svd, jacobian, pseudo_inverse));
   if (status_ == HALT_FOR_COLLISION)
   {
     ROS_ERROR_STREAM("Halting!");

--- a/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
@@ -54,4 +54,3 @@ command_out_topic: jog_server/command # Publish outgoing commands here
 check_collisions: true # Check collisions?
 collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
-hard_stop_collision_proximity_threshold: 0.0005 # Stop when a collision is this far [m]


### PR DESCRIPTION
Add a binary collision check to the distance-based collision check. This helps with edge cases like starting inside another body and reducing overall flakiness.

Also, delete the parameter _hard_stop_singularity_threshold_ which hasn't been used in some time.
