### PR TITLE
Remove @jonbinney as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,7 +55,7 @@
 /moveit_core/planning_request_adapter/                      @rhaschke
 /moveit_core/planning_scene/                                @rhaschke
 /moveit_core/profiler/                                      @tylerjw
-/moveit_core/robot_model/                                   @jonbinney
+/moveit_core/robot_model/                                   @tylerjw
 /moveit_core/robot_state/                                   @rhaschke @mlautman
 /moveit_core/robot_trajectory/                              @mlautman
 /moveit_core/sensor_manager/                                @mlautman
@@ -79,7 +79,7 @@
 /moveit_ros/robot_interaction/	                            @mikeferguson @rhaschke
 /moveit_ros/warehouse/	                                    @mikeferguson @dg-shadow
 /moveit_ros/move_group/	                                    @rhaschke @IanTheEngineer
-/moveit_ros/visualization/	                            @rhaschke @jonbinney @RoboticsYY
+/moveit_ros/visualization/	                            @rhaschke @tylerjw @RoboticsYY
 
 /moveit_ros/planning/collision_plugin_loader/               @j-petit
 /moveit_ros/planning/constraint_sampler_manager_loader/     @nbbrooks


### PR DESCRIPTION
Unfortunately I don't have time to be a maintainer or review pull
requests these days. I'm replacing myself with @tylerjw at the
suggestion of @davetcoleman.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
