### PR TITLE
[jog_arm] Fix low-pass filter initialization

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -62,12 +62,7 @@ public:
 
   void startMainLoop(moveit_jog_arm::JogArmShared& shared_variables);
 
-  void stopMainLoop();
-
 private:
-  // Loop termination flag
-  std::atomic<bool> stop_requested_;
-
   const moveit_jog_arm::JogArmParameters parameters_;
 
   // Pointer to the collision environment

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -95,6 +95,12 @@ struct JogArmShared : public std::mutex
 
   // Status of the jogger. 0 for no warning. The meaning of nonzero values can be seen in status_codes.h
   std::atomic<StatusCode> status;
+
+  // Pause/unpause jog threads - threads are not paused by default
+  std::atomic<bool> paused{ false };
+
+  // Stop jog loop threads - threads are not stopped by default
+  std::atomic<bool> stop_requested{ false };
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -60,14 +60,6 @@ public:
 
   void startMainLoop(JogArmShared& shared_variables);
 
-  void stopMainLoop();
-
-  /** \brief Stop publishing jog commands while keeping the main loop spinning and filters up to date */
-  void pauseOutgoingJogCmds();
-
-  /** \brief Continue publishing jog commands */
-  void unpauseOutgoingJogCmds();
-
   /** \brief Check if the robot state is being updated and the end effector transform is known
    *  @return true if initialized properly
    */
@@ -75,12 +67,6 @@ public:
 
 protected:
   ros::NodeHandle nh_;
-
-  // Loop termination flag
-  std::atomic<bool> stop_jog_loop_requested_;
-
-  // Flag that outgoing commands to the robot should not be published
-  std::atomic<bool> pause_outgoing_jog_cmds_;
 
   // Flag that robot state is up to date, end effector transform is known
   std::atomic<bool> is_initialized_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -62,7 +62,11 @@ public:
 
   void stopMainLoop();
 
-  void haltOutgoingJogCmds();
+  /** \brief Stop publishing jog commands while keeping the main loop spinning and filters up to date */
+  void pauseOutgoingJogCmds();
+
+  /** \brief Continue publishing jog commands */
+  void unpauseOutgoingJogCmds();
 
   /** \brief Check if the robot state is being updated and the end effector transform is known
    *  @return true if initialized properly
@@ -76,7 +80,7 @@ protected:
   std::atomic<bool> stop_jog_loop_requested_;
 
   // Flag that outgoing commands to the robot should not be published
-  std::atomic<bool> halt_outgoing_jog_cmds_;
+  std::atomic<bool> pause_outgoing_jog_cmds_;
 
   // Flag that robot state is up to date, end effector transform is known
   std::atomic<bool> is_initialized_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -59,11 +59,8 @@ public:
 
   void stopMainLoop();
 
-  /** \brief Pause processing jog commands while keeping the main loop alive */
-  void pause();
-
-  /** \brief Continue processing jog commands */
-  void unpause();
+  /** \brief Pause or unpause processing jog commands while keeping the main loop alive */
+  void setPaused(bool paused);
 
   /** \brief Provide a Cartesian velocity command to the jogger.
    * The units are determined by settings in the yaml file.
@@ -99,8 +96,5 @@ public:
 
 private:
   ros::NodeHandle nh_;
-
-  std::atomic<bool> stop_requested_;
-  std::atomic<bool> paused_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -59,6 +59,12 @@ public:
 
   void stopMainLoop();
 
+  /** \brief Pause processing jog commands while keeping the main loop alive */
+  void pause();
+
+  /** \brief Continue processing jog commands */
+  void unpause();
+
   /** \brief Provide a Cartesian velocity command to the jogger.
    * The units are determined by settings in the yaml file.
    */
@@ -95,5 +101,6 @@ private:
   ros::NodeHandle nh_;
 
   std::atomic<bool> stop_requested_;
+  std::atomic<bool> paused_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -326,9 +326,6 @@ bool JogCalcs::cartesianJogCalcs(geometry_msgs::TwistStamped& cmd, JogArmShared&
 
   enforceSRDFAccelVelLimits(delta_theta_);
 
-  if (!addJointIncrements(internal_joint_state_, delta_theta_))
-    return false;
-
   // If close to a collision or a singularity, decelerate
   applyVelocityScaling(shared_variables, delta_theta_,
                        velocityScalingFactorForSingularity(delta_x, svd, jacobian, pseudo_inverse));

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -68,7 +68,7 @@ void JogCalcs::startMainLoop(JogArmShared& shared_variables)
 {
   // Reset flags
   stop_jog_loop_requested_ = false;
-  halt_outgoing_jog_cmds_ = false;
+  pause_outgoing_jog_cmds_ = false;
   is_initialized_ = false;
 
   // Wait for initial messages
@@ -153,7 +153,7 @@ void JogCalcs::startMainLoop(JogArmShared& shared_variables)
 
     // If paused or while waiting for initial jog commands, just keep the low-pass filters up to date with current
     // joints so a jump doesn't occur when restarting
-    if (wait_for_jog_commands || halt_outgoing_jog_cmds_)
+    if (wait_for_jog_commands || pause_outgoing_jog_cmds_)
     {
       for (std::size_t i = 0; i < num_joints_; ++i)
         position_filters_[i].reset(internal_joint_state_.position[i]);
@@ -249,9 +249,14 @@ void JogCalcs::stopMainLoop()
   stop_jog_loop_requested_ = true;
 }
 
-void JogCalcs::haltOutgoingJogCmds()
+void JogCalcs::pauseOutgoingJogCmds()
 {
-  halt_outgoing_jog_cmds_ = true;
+  pause_outgoing_jog_cmds_ = true;
+}
+
+void JogCalcs::unpauseOutgoingJogCmds()
+{
+  pause_outgoing_jog_cmds_ = false;
 }
 
 bool JogCalcs::isInitialized()

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -61,7 +61,7 @@ JogCalcs::JogCalcs(const JogArmParameters& parameters, const robot_model_loader:
   kinematic_state_->setToDefaultValues();
 
   joint_model_group_ = kinematic_model->getJointModelGroup(parameters_.move_group_name);
-  prev_joint_velocity_ = Eigen::ArrayXd::Zero(joint_model_group_->getVariableCount());
+  prev_joint_velocity_ = Eigen::ArrayXd::Zero(joint_model_group_->getActiveJointModels().size());
 }
 
 void JogCalcs::startMainLoop(JogArmShared& shared_variables)
@@ -76,7 +76,7 @@ void JogCalcs::startMainLoop(JogArmShared& shared_variables)
   ros::topic::waitForMessage<sensor_msgs::JointState>(parameters_.joint_topic);
   ROS_INFO_NAMED(LOGNAME, "jog_calcs_thread: Received first joint msg.");
 
-  internal_joint_state_.name = joint_model_group_->getVariableNames();
+  internal_joint_state_.name = joint_model_group_->getActiveJointModelNames();
   num_joints_ = internal_joint_state_.name.size();
   internal_joint_state_.position.resize(num_joints_);
   internal_joint_state_.velocity.resize(num_joints_);
@@ -146,8 +146,8 @@ void JogCalcs::startMainLoop(JogArmShared& shared_variables)
     {
       shared_variables.lock();
       // Check if there are any commands with valid timestamp
-      wait_for_jog_commands = shared_variables.command_deltas.header.stamp == ros::Time(0.)
-        && shared_variables.joint_command_deltas.header.stamp == ros::Time(0.);
+      wait_for_jog_commands = shared_variables.command_deltas.header.stamp == ros::Time(0.) &&
+                              shared_variables.joint_command_deltas.header.stamp == ros::Time(0.);
       shared_variables.unlock();
     }
 
@@ -555,61 +555,70 @@ double JogCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& comm
 void JogCalcs::enforceSRDFAccelVelLimits(Eigen::ArrayXd& delta_theta)
 {
   Eigen::ArrayXd velocity = delta_theta / parameters_.publish_period;
+  const Eigen::ArrayXd acceleration = (velocity - prev_joint_velocity_) / parameters_.publish_period;
 
   std::size_t joint_delta_index = 0;
-  for (auto joint : joint_model_group_->getJointModels())
+  for (auto joint : joint_model_group_->getActiveJointModels())
   {
     // Some joints do not have bounds defined
-    if (kinematic_state_->getJointModel(joint->getName())->hasVariable(joint->getName()))
+    const auto bounds = joint->getVariableBounds(joint->getName());
+    if (bounds.acceleration_bounded_)
     {
-      auto bounds = kinematic_state_->getJointModel(joint->getName())->getVariableBounds(joint->getName());
+      bool clip_acceleration = false;
+      double acceleration_limit = 0.0;
+      if (acceleration(joint_delta_index) < bounds.min_acceleration_)
+      {
+        clip_acceleration = true;
+        acceleration_limit = bounds.min_acceleration_;
+      }
+      else if (acceleration(joint_delta_index) > bounds.max_acceleration_)
+      {
+        clip_acceleration = true;
+        acceleration_limit = bounds.max_acceleration_;
+      }
 
       // Apply acceleration bounds
-      // accel = (vel - vel_prev) / delta_t = ((delta_theta / delta_t) - vel_prev) / delta_t
-      // --> delta_theta = (accel * delta_t _ + vel_prev) * delta_t
-      Eigen::ArrayXd acceleration = (velocity - prev_joint_velocity_) / parameters_.publish_period;
-      if ((bounds.min_acceleration_ != 0) && (acceleration(joint_delta_index) < bounds.min_acceleration_))
+      if (clip_acceleration)
       {
-        double relative_change =
-            ((bounds.min_acceleration_ * parameters_.publish_period + prev_joint_velocity_(joint_delta_index)) *
+        // accel = (vel - vel_prev) / delta_t = ((delta_theta / delta_t) - vel_prev) / delta_t
+        // --> delta_theta = (accel * delta_t _ + vel_prev) * delta_t
+        const double relative_change =
+            ((acceleration_limit * parameters_.publish_period + prev_joint_velocity_(joint_delta_index)) *
              parameters_.publish_period) /
             delta_theta(joint_delta_index);
         // Avoid nan
         if (fabs(relative_change) < 1)
-          delta_theta = relative_change * delta_theta;
+          delta_theta(joint_delta_index) = relative_change * delta_theta(joint_delta_index);
       }
-      else if ((bounds.max_acceleration_ != 0) && (acceleration(joint_delta_index) > bounds.max_acceleration_))
+    }
+
+    if (bounds.velocity_bounded_)
+    {
+      velocity(joint_delta_index) = delta_theta(joint_delta_index) / parameters_.publish_period;
+
+      bool clip_velocity = false;
+      double velocity_limit = 0.0;
+      if (velocity(joint_delta_index) < bounds.min_velocity_)
       {
-        double relative_change =
-            ((bounds.max_acceleration_ * parameters_.publish_period + prev_joint_velocity_(joint_delta_index)) *
-             parameters_.publish_period) /
-            delta_theta(joint_delta_index);
-        // Avoid nan
-        if (fabs(relative_change) < 1)
-          delta_theta = relative_change * delta_theta;
+        clip_velocity = true;
+        velocity_limit = bounds.min_velocity_;
+      }
+      else if (velocity(joint_delta_index) > bounds.max_velocity_)
+      {
+        clip_velocity = true;
+        velocity_limit = bounds.max_velocity_;
       }
 
-      velocity = delta_theta / parameters_.publish_period;
       // Apply velocity bounds
-      // delta_theta = joint_velocity * delta_t
-      if ((bounds.min_velocity_ != 0) && (velocity(joint_delta_index) < bounds.min_velocity_))
+      if (clip_velocity)
       {
-        double relative_change = (bounds.min_velocity_ * parameters_.publish_period) / delta_theta(joint_delta_index);
+        // delta_theta = joint_velocity * delta_t
+        const double relative_change = (velocity_limit * parameters_.publish_period) / delta_theta(joint_delta_index);
         // Avoid nan
         if (fabs(relative_change) < 1)
         {
-          delta_theta = relative_change * delta_theta;
-          velocity = relative_change * velocity;
-        }
-      }
-      else if ((bounds.max_velocity_ != 0) && (velocity(joint_delta_index) > bounds.max_velocity_))
-      {
-        double relative_change = (bounds.max_velocity_ * parameters_.publish_period) / delta_theta(joint_delta_index);
-        // Avoid nan
-        if (fabs(relative_change) < 1)
-        {
-          delta_theta = relative_change * delta_theta;
-          velocity = relative_change * velocity;
+          delta_theta(joint_delta_index) = relative_change * delta_theta(joint_delta_index);
+          velocity(joint_delta_index) = relative_change * velocity(joint_delta_index);
         }
       }
       ++joint_delta_index;
@@ -621,7 +630,7 @@ bool JogCalcs::enforceSRDFPositionLimits(trajectory_msgs::JointTrajectory& new_j
 {
   bool halting = false;
 
-  for (auto joint : joint_model_group_->getJointModels())
+  for (auto joint : joint_model_group_->getActiveJointModels())
   {
     // Halt if we're past a joint margin and joint velocity is moving even farther past
     double joint_angle = 0;
@@ -707,7 +716,7 @@ bool JogCalcs::updateJoints(JogArmShared& shared_variables)
     }
     catch (const std::out_of_range& e)
     {
-      ROS_WARN_STREAM_THROTTLE_NAMED(5, LOGNAME, "Ignoring joint " << incoming_joint_state_.name[m]);
+      ROS_DEBUG_STREAM_THROTTLE_NAMED(5, LOGNAME, "Ignoring joint " << incoming_joint_state_.name[m]);
       continue;
     }
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -60,8 +60,8 @@ JogCppInterface::~JogCppInterface()
 void JogCppInterface::startMainLoop()
 {
   // Reset loop termination flag
-  stop_requested_ = false;
-  paused_ = false;
+  shared_variables_.stop_requested = false;
+  shared_variables_.paused = false;
 
   // Crunch the numbers in this thread
   startJogCalcThread();
@@ -92,11 +92,11 @@ void JogCppInterface::startMainLoop()
 
   ros::Rate main_rate(1. / ros_parameters_.publish_period);
 
-  while (ros::ok() && !stop_requested_)
+  while (ros::ok() && !shared_variables_.stop_requested)
   {
     ros::spinOnce();
 
-    if (!paused_)
+    if (!shared_variables_.paused)
     {
       shared_variables_.lock();
       trajectory_msgs::JointTrajectory outgoing_command = shared_variables_.outgoing_command;
@@ -154,23 +154,12 @@ void JogCppInterface::startMainLoop()
 
 void JogCppInterface::stopMainLoop()
 {
-  stop_requested_ = true;
+  shared_variables_.stop_requested = true;
 }
 
-void JogCppInterface::pause()
+void JogCppInterface::setPaused(bool paused)
 {
-  if (jog_calcs_)
-    jog_calcs_->pauseOutgoingJogCmds();
-
-  paused_ = true;
-}
-
-void JogCppInterface::unpause()
-{
-  if (jog_calcs_)
-    jog_calcs_->unpauseOutgoingJogCmds();
-
-  paused_ = false;
+  shared_variables_.paused = paused;
 }
 
 void JogCppInterface::provideTwistStampedCommand(const geometry_msgs::TwistStamped& velocity_command)

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -237,9 +237,6 @@ bool JogInterfaceBase::startJogCalcThread()
 
 bool JogInterfaceBase::stopJogCalcThread()
 {
-  if (jog_calcs_)
-    jog_calcs_->stopMainLoop();
-
   if (jog_calc_thread_)
   {
     if (jog_calc_thread_->joinable())
@@ -264,9 +261,6 @@ bool JogInterfaceBase::startCollisionCheckThread()
 
 bool JogInterfaceBase::stopCollisionCheckThread()
 {
-  if (collision_checker_)
-    collision_checker_->stopMainLoop();
-
   if (collision_check_thread_)
   {
     if (collision_check_thread_->joinable())

--- a/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_ros_interface.cpp
@@ -167,6 +167,8 @@ JogROSInterface::JogROSInterface()
     main_rate.sleep();
   }
 
+  // Stop JogArm threads
+  shared_variables_.stop_requested = true;
   stopJogCalcThread();
   stopCollisionCheckThread();
 }


### PR DESCRIPTION
I ran into an issue where JogArm would initialize the low-pass position filters before processing the initial jog commands. The issue was that there was a separate "waiting loop" that initialized the filter  joint states which have never been updated. That caused an initial jump if the robot has moved between thread initialization and the first commands. Since the waiting loop and the main loop have a very similar structure, I thought it would be cleaner to just use a bool flag "wait_for_initial_commands" that leads to the same logic as before, just that the joint states are being updated, fixing the described issue. While debugging this issue I touched and refactored several other parts, including:

* Removing a duplicate joint increment with cartesian commands 4f47786
* Simplified the joint validation logic by using the active joints only instead of all variable joints
* Added a pause/unpause flag for jog threads

Please don't squash this PR