### PR TITLE
Fix CATKIN_DEPENDS: catkin_lint 1.6.7

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -32,8 +32,9 @@ catkin_package(
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS
-    pluginlib
     moveit_core
+    pluginlib
+    roscpp
   DEPENDS
     EIGEN3
 )

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -31,7 +31,9 @@ catkin_package(
   INCLUDE_DIRS
     ompl_interface/include
   CATKIN_DEPENDS
+    dynamic_reconfigure
     moveit_core
+    roscpp
   DEPENDS
     OMPL
 )

--- a/moveit_plugins/moveit_fake_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_fake_controller_manager/CMakeLists.txt
@@ -25,6 +25,7 @@ catkin_package(
   CATKIN_DEPENDS
     moveit_core
     moveit_ros_planning
+    roscpp
 )
 
 add_library(${PROJECT_NAME}

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -22,8 +22,9 @@ catkin_package(
     ${PROJECT_NAME}_plugin
     ${PROJECT_NAME}_trajectory_plugin
   CATKIN_DEPENDS
-    moveit_core
+    actionlib
     controller_manager_msgs
+    moveit_core
     trajectory_msgs
   DEPENDS Boost
 )

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -22,9 +22,15 @@ find_package(catkin COMPONENTS
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 catkin_package(
-  LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS moveit_core actionlib control_msgs
+  LIBRARIES
+    ${PROJECT_NAME}
+  INCLUDE_DIRS
+    include
+  CATKIN_DEPENDS
+    actionlib
+    control_msgs
+    moveit_core
+    roscpp
 )
 
 add_library(${PROJECT_NAME}

--- a/moveit_ros/manipulation/CMakeLists.txt
+++ b/moveit_ros/manipulation/CMakeLists.txt
@@ -33,9 +33,12 @@ catkin_package(
   LIBRARIES
     moveit_pick_place_planner
   CATKIN_DEPENDS
+    actionlib
+    dynamic_reconfigure
     moveit_core
     moveit_msgs
     moveit_ros_planning
+    roscpp
   DEPENDS
     EIGEN3
 )

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -28,8 +28,11 @@ catkin_package(
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
+    actionlib
     moveit_core
     moveit_ros_planning
+    roscpp
+    std_srvs
     tf2_geometry_msgs
 )
 

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -67,6 +67,7 @@ catkin_package(
     moveit_msgs
     moveit_ros_occupancy_map_monitor
     object_recognition_msgs
+    roscpp
     sensor_msgs
     tf2_geometry_msgs
   DEPENDS

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -63,10 +63,13 @@ catkin_package(
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS
-    pluginlib
+    actionlib
+    dynamic_reconfigure
     moveit_core
     moveit_ros_occupancy_map_monitor
     moveit_msgs
+    pluginlib
+    roscpp
     tf2_msgs
     tf2_geometry_msgs
   DEPENDS

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -68,12 +68,13 @@ catkin_package(
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS
     actionlib
+    geometry_msgs
+    moveit_msgs
     moveit_ros_planning
     moveit_ros_warehouse
     moveit_ros_manipulation
     moveit_ros_move_group
-    geometry_msgs
-    moveit_msgs
+    roscpp
     tf2_geometry_msgs
   DEPENDS
     EIGEN3

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -28,8 +28,9 @@ catkin_package(
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
-    moveit_ros_planning
     interactive_markers
+    moveit_ros_planning
+    roscpp
     tf2_geometry_msgs
 )
 

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -80,6 +80,7 @@ catkin_package(
     moveit_ros_planning_interface
     moveit_ros_robot_interaction
     object_recognition_msgs
+    roscpp
   DEPENDS
     EIGEN3
 )

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -27,7 +27,9 @@ catkin_package(
     warehouse/include
   CATKIN_DEPENDS
     moveit_ros_planning
-    warehouse_ros)
+    warehouse_ros
+    roscpp
+)
 
 include_directories(warehouse/include)
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -56,6 +56,7 @@ catkin_package(
   CATKIN_DEPENDS
     moveit_ros_planning
     moveit_ros_visualization
+    roscpp
 )
 
 # Header files that need Qt Moc pre-processing for use with Qt signals, etc:


### PR DESCRIPTION
CI was failing because of missing CATKIN_DEPENDS errors from catkin_lint 1.6.7

See https://travis-ci.org/github/ros-planning/moveit/jobs/667658214#L694