### PR TITLE
add tests for move_group interface

### DIFF
--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -40,4 +40,5 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>eigen_conversions</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>eigen_conversions</test_depend>
 </package>

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -6,6 +6,9 @@ if (CATKIN_ENABLE_TESTING)
   add_executable(test_cleanup test_cleanup.cpp)
   target_link_libraries(test_cleanup moveit_move_group_interface)
 
+  add_rostest_gtest(move_group_interface_cpp_test move_group_interface_cpp_test.test move_group_interface_cpp_test.cpp)
+  target_link_libraries(move_group_interface_cpp_test moveit_move_group_interface ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
+
   add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
   target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
 

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -58,8 +58,8 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <eigen_conversions/eigen_msg.h>
 
-// 1mm acuracy tested for position and orientation
-constexpr double EPSILON = 1e-3;
+// 1cm acuracy tested for position and orientation
+constexpr double EPSILON = 1e-2;
 
 static const std::string PLANNING_GROUP = "panda_arm";
 constexpr double PLANNING_TIME_S = 30.0;

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -240,14 +240,6 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
 {
   SCOPED_TRACE("JointSpaceGoalTest");
 
-  // set a custom start state
-  geometry_msgs::Pose start_pose;
-  start_pose.orientation.w = 1.0;
-  start_pose.position.x = 0.55;
-  start_pose.position.y = -0.05;
-  start_pose.position.z = 0.8;
-  PlanAndMoveToPose(start_pose);
-
   // set start state for planning
   move_group_->setStartStateToCurrentState();
 
@@ -258,7 +250,7 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
 
   // Now, let's modify the joint positions.  (radians)
   ASSERT_EQ(plan_joint_positions.size(), std::size_t(7));
-  plan_joint_positions = { 1.0, -0.5, 0.5, -1.0, 2.0, 1.0, -1.0 };
+  plan_joint_positions = { 1.2, -1.0, -0.1, -2.4, 0.0, 1.5, 0.6 };
   move_group_->setJointValueTarget(plan_joint_positions);
 
   // plan and move

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -216,6 +216,10 @@ TEST_F(MoveGroupTestFixture, PathConstraintTest)
   start_pose.position.z = 0.8;
   planAndMoveToPose(start_pose);
 
+  // NOTE: If the link names change this will fail.  This was put here because
+  // the tutorial for C++ move_group usese these links.  If the link names are
+  // change this and the tutorial will have to be updated.
+
   // create an orientation constraint
   moveit_msgs::OrientationConstraint ocm;
   ocm.link_name = "panda_link7";

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -73,21 +73,12 @@ public:
     nh_ = ros::NodeHandle("/move_group_interface_cpp_test");
     move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(PLANNING_GROUP);
 
-    // get the starting pose
-    start_pose_stamped_ = move_group_->getCurrentPose();
-
     // set velocity and acceleration scaling factors (full speed)
     move_group_->setMaxVelocityScalingFactor(MAX_VELOCITY_SCALE);
     move_group_->setMaxAccelerationScalingFactor(MAX_ACCELERATION_SCALE);
 
     // allow more time for planning
     move_group_->setPlanningTime(PLANNING_TIME_S);
-  }
-
-  void retrunToStartPose()
-  {
-    SCOPED_TRACE("retrunToStartPose");
-    planAndMoveToPose(start_pose_stamped_.pose);
   }
 
   void planAndMoveToPose(const geometry_msgs::Pose& pose)
@@ -162,7 +153,6 @@ protected:
   ros::NodeHandle nh_;
   moveit::planning_interface::MoveGroupInterfacePtr move_group_;
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
-  geometry_msgs::PoseStamped start_pose_stamped_;
 };
 
 TEST_F(MoveGroupTestFixture, StartingConditionsTest)
@@ -235,9 +225,6 @@ TEST_F(MoveGroupTestFixture, MoveToPoseTest)
 
   // get the pose after the movement
   testPose(eigen_target_pose);
-
-  // return to start pose for next test
-  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
@@ -262,9 +249,6 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
 
   // test that we moved to the expected joint positions
   testJointPositions(plan_joint_positions);
-
-  // return to start pose for next test
-  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, PathConstraintTest)
@@ -305,9 +289,6 @@ TEST_F(MoveGroupTestFixture, PathConstraintTest)
 
   // get the pose after the movement
   testPose(target_pose);
-
-  // return to start pose for next test
-  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, CartPathTest)
@@ -349,9 +330,6 @@ TEST_F(MoveGroupTestFixture, CartPathTest)
 
   // get the pose after the movement
   testPose(target_waypoint);
-
-  // return to start pose for next test
-  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
@@ -421,9 +399,6 @@ TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
   EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(1));
   planning_scene_interface_.removeCollisionObjects(object_ids);
   EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(0));
-
-  // return to start pose for next test
-  retrunToStartPose();
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -108,7 +108,7 @@ public:
   void testPose(const Eigen::Isometry3d& expected_pose)
   {
     SCOPED_TRACE("testPose(const Eigen::Isometry3d&)");
-    // get the pose after the movement
+    // get the pose of the end effector link after the movement
     geometry_msgs::PoseStamped actual_pose_stamped = move_group_->getCurrentPose();
     Eigen::Isometry3d actual_pose;
     tf::poseMsgToEigen(actual_pose_stamped.pose, actual_pose);

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -79,59 +79,59 @@ public:
     move_group_->setMaxAccelerationScalingFactor(1.0);
   }
 
-  void RetrunToStartPose()
+  void retrunToStartPose()
   {
-    SCOPED_TRACE("RetrunToStartPose");
-    PlanAndMoveToPose(start_pose_stamped_.pose);
+    SCOPED_TRACE("retrunToStartPose");
+    planAndMoveToPose(start_pose_stamped_.pose);
   }
 
-  void PlanAndMoveToPose(const geometry_msgs::Pose& pose)
+  void planAndMoveToPose(const geometry_msgs::Pose& pose)
   {
-    SCOPED_TRACE("PlanAndMoveToPose");
+    SCOPED_TRACE("planAndMoveToPose");
     move_group_->setStartStateToCurrentState();
     ASSERT_TRUE(move_group_->setJointValueTarget(pose));
-    PlanAndMove();
+    planAndMove();
   }
 
-  void PlanAndMove()
+  void planAndMove()
   {
-    SCOPED_TRACE("PlanAndMove");
+    SCOPED_TRACE("planAndMove");
     moveit::planning_interface::MoveGroupInterface::Plan my_plan;
     ASSERT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
     ASSERT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
   }
 
-  void TestEigenPose(const Eigen::Isometry3d& expected, const Eigen::Isometry3d& actual)
+  void testEigenPose(const Eigen::Isometry3d& expected, const Eigen::Isometry3d& actual)
   {
-    SCOPED_TRACE("TestEigenPose");
+    SCOPED_TRACE("testEigenPose");
     std::stringstream ss;
     ss << "expected: \n" << expected.matrix() << "\nactual: \n" << actual.matrix();
     EXPECT_TRUE(actual.isApprox(expected, EPSILON)) << ss.str();
   }
 
-  void TestPose(const Eigen::Isometry3d& expected_pose)
+  void testPose(const Eigen::Isometry3d& expected_pose)
   {
-    SCOPED_TRACE("TestPose(const Eigen::Isometry3d&)");
+    SCOPED_TRACE("testPose(const Eigen::Isometry3d&)");
     // get the pose after the movement
     geometry_msgs::PoseStamped actual_pose_stamped = move_group_->getCurrentPose();
     Eigen::Isometry3d actual_pose;
     tf::poseMsgToEigen(actual_pose_stamped.pose, actual_pose);
 
     // compare to planned pose
-    TestEigenPose(expected_pose, actual_pose);
+    testEigenPose(expected_pose, actual_pose);
   }
 
-  void TestPose(const geometry_msgs::Pose& expected_pose_msg)
+  void testPose(const geometry_msgs::Pose& expected_pose_msg)
   {
-    SCOPED_TRACE("TestPose(const geometry_msgs::Pose&)");
+    SCOPED_TRACE("testPose(const geometry_msgs::Pose&)");
     Eigen::Isometry3d expected_pose;
     tf::poseMsgToEigen(expected_pose_msg, expected_pose);
-    TestPose(expected_pose);
+    testPose(expected_pose);
   }
 
-  void TestJointPositions(const std::vector<double>& expected)
+  void testJointPositions(const std::vector<double>& expected)
   {
-    SCOPED_TRACE("TestJointPositions");
+    SCOPED_TRACE("testJointPositions");
     const robot_state::JointModelGroup* joint_model_group =
         move_group_->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
     std::vector<double> actual;
@@ -144,10 +144,10 @@ public:
     }
   }
 
-  void TestVectorOfStrings(const std::vector<std::string>& expected, const std::vector<std::string>& actual,
-                           const std::string name)
+  void testVectorOfStrings(const std::vector<std::string>& expected, const std::vector<std::string>& actual,
+                           const std::string& name)
   {
-    SCOPED_TRACE("TestVectorOfStrings");
+    SCOPED_TRACE("testVectorOfStrings");
     ASSERT_EQ(expected.size(), actual.size());
     for (size_t i = 0; i < actual.size(); ++i)
       EXPECT_EQ(expected[i], actual[i]) << "(" << name << "[" << i << "])";
@@ -181,19 +181,19 @@ TEST_F(MoveGroupTestFixture, StartingConditionsTest)
   EXPECT_EQ(move_group_->getGoalPositionTolerance(), 0.0001);
   EXPECT_EQ(move_group_->getGoalOrientationTolerance(), 0.001);
 
-  TestVectorOfStrings({ "ready", "extended" }, move_group_->getNamedTargets(), "named_targets");
-  TestVectorOfStrings({ "hand", "panda_arm", "panda_arm_hand" }, move_group_->getJointModelGroupNames(),
+  testVectorOfStrings({ "ready", "extended" }, move_group_->getNamedTargets(), "named_targets");
+  testVectorOfStrings({ "hand", "panda_arm", "panda_arm_hand" }, move_group_->getJointModelGroupNames(),
                       "joint_model_group_names");
-  TestVectorOfStrings({ "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4", "panda_joint5", "panda_joint6",
+  testVectorOfStrings({ "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4", "panda_joint5", "panda_joint6",
                         "panda_joint7" },
                       move_group_->getJointNames(), "joint_names");
-  TestVectorOfStrings({ "panda_link1", "panda_link2", "panda_link3", "panda_link4", "panda_link5", "panda_link6",
+  testVectorOfStrings({ "panda_link1", "panda_link2", "panda_link3", "panda_link4", "panda_link5", "panda_link6",
                         "panda_link7", "panda_link8" },
                       move_group_->getLinkNames(), "link_names");
-  TestVectorOfStrings({ "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4", "panda_joint5", "panda_joint6",
+  testVectorOfStrings({ "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4", "panda_joint5", "panda_joint6",
                         "panda_joint7" },
                       move_group_->getActiveJoints(), "active_joints");
-  TestVectorOfStrings({ "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4", "panda_joint5", "panda_joint6",
+  testVectorOfStrings({ "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4", "panda_joint5", "panda_joint6",
                         "panda_joint7", "panda_joint8" },
                       move_group_->getJoints(), "joints");
 }
@@ -223,16 +223,16 @@ TEST_F(MoveGroupTestFixture, MoveToPoseTest)
   tf::poseMsgToEigen(set_target_pose.pose, eigen_set_target_pose);
 
   // expect that they are identical
-  TestEigenPose(eigen_target_pose, eigen_set_target_pose);
+  testEigenPose(eigen_target_pose, eigen_set_target_pose);
 
   // plan and move
-  PlanAndMove();
+  planAndMove();
 
   // get the pose after the movement
-  TestPose(eigen_target_pose);
+  testPose(eigen_target_pose);
 
   // return to start pose for next test
-  RetrunToStartPose();
+  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
@@ -253,13 +253,13 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
   move_group_->setJointValueTarget(plan_joint_positions);
 
   // plan and move
-  PlanAndMove();
+  planAndMove();
 
   // test that we moved to the expected joint positions
-  TestJointPositions(plan_joint_positions);
+  testJointPositions(plan_joint_positions);
 
   // return to start pose for next test
-  RetrunToStartPose();
+  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, PathConstraintTest)
@@ -272,7 +272,7 @@ TEST_F(MoveGroupTestFixture, PathConstraintTest)
   start_pose.position.x = 0.55;
   start_pose.position.y = -0.05;
   start_pose.position.z = 0.8;
-  PlanAndMoveToPose(start_pose);
+  planAndMoveToPose(start_pose);
 
   // create an orientation constraint
   moveit_msgs::OrientationConstraint ocm;
@@ -293,16 +293,16 @@ TEST_F(MoveGroupTestFixture, PathConstraintTest)
   target_pose.position.x = 0.28;
   target_pose.position.y = -0.2;
   target_pose.position.z = 0.5;
-  PlanAndMoveToPose(target_pose);
+  planAndMoveToPose(target_pose);
 
   // clear path constraints
   move_group_->clearPathConstraints();
 
   // get the pose after the movement
-  TestPose(target_pose);
+  testPose(target_pose);
 
   // return to start pose for next test
-  RetrunToStartPose();
+  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, CartPathTest)
@@ -315,7 +315,7 @@ TEST_F(MoveGroupTestFixture, CartPathTest)
   start_pose.position.x = 0.55;
   start_pose.position.y = -0.05;
   start_pose.position.z = 0.8;
-  PlanAndMoveToPose(start_pose);
+  planAndMoveToPose(start_pose);
 
   std::vector<geometry_msgs::Pose> waypoints;
   waypoints.push_back(start_pose);
@@ -343,10 +343,10 @@ TEST_F(MoveGroupTestFixture, CartPathTest)
   EXPECT_EQ(move_group_->execute(cartesian_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
 
   // get the pose after the movement
-  TestPose(target_waypoint);
+  testPose(target_waypoint);
 
   // return to start pose for next test
-  RetrunToStartPose();
+  retrunToStartPose();
 }
 
 TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
@@ -359,7 +359,7 @@ TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
   start_pose.position.x = 0.28;
   start_pose.position.y = -0.2;
   start_pose.position.z = 0.5;
-  PlanAndMoveToPose(start_pose);
+  planAndMoveToPose(start_pose);
 
   // Define a collision object ROS message.
   moveit_msgs::CollisionObject collision_object;
@@ -399,10 +399,10 @@ TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
   target_pose.position.x = 0.4;
   target_pose.position.y = -0.4;
   target_pose.position.z = 0.7;
-  PlanAndMoveToPose(target_pose);
+  planAndMoveToPose(target_pose);
 
   // get the pose after the movement
-  TestPose(target_pose);
+  testPose(target_pose);
 
   // attach and detach collision object
   EXPECT_TRUE(move_group_->attachObject(collision_object.id));
@@ -418,7 +418,7 @@ TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
   EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(0));
 
   // return to start pose for next test
-  RetrunToStartPose();
+  retrunToStartPose();
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -1,0 +1,463 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2020, Tyler Weaver
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of PickNik Robotics nor the
+*     names of its contributors may be used to endorse or promote
+*     products derived from this software without specific prior
+*     written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Tyler Weaver */
+
+/* These integration tests are based on the tutorials for using move_group:
+ * https://ros-planning.github.io/moveit_tutorials/doc/move_group_interface/move_group_interface_tutorial.html
+ */
+
+// C++
+#include <string>
+#include <vector>
+#include <map>
+
+// ROS
+#include <ros/ros.h>
+
+// The Testing Framework and Utils
+#include <gtest/gtest.h>
+
+// MoveIt
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+
+// TF2
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <eigen_conversions/eigen_msg.h>
+
+constexpr double EPSILON = 1e-2;
+
+static const std::string PLANNING_GROUP = "panda_arm";
+constexpr double PLANNING_TIME_S = 10;
+
+class MoveGroupTestFixture : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    nh_ = ros::NodeHandle("/move_group_interface_cpp_test");
+    move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(PLANNING_GROUP);
+
+    // set velocity and acceleration scaling factors (full speed)
+    move_group_->setMaxVelocityScalingFactor(1.0);
+    move_group_->setMaxAccelerationScalingFactor(1.0);
+  }
+
+  // Helper function to move to a start position
+  void MoveToStart(const geometry_msgs::Pose& pose)
+  {
+    // get the joint model group
+    const robot_state::JointModelGroup* joint_model_group =
+        move_group_->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
+
+    robot_state::RobotState start_state(*move_group_->getCurrentState());
+    start_state.setFromIK(joint_model_group, pose);
+    move_group_->setStartState(start_state);
+
+    // plan and move
+    ASSERT_TRUE(move_group_->setJointValueTarget(start_state));
+    moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+    ASSERT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+    ASSERT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  }
+
+protected:
+  ros::NodeHandle nh_;
+  moveit::planning_interface::MoveGroupInterfacePtr move_group_;
+  moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
+};
+
+TEST_F(MoveGroupTestFixture, StartingConditionsTest)
+{
+  // test that setting the planning time works
+  move_group_->setPlanningTime(PLANNING_TIME_S);
+  EXPECT_EQ(move_group_->getPlanningTime(), PLANNING_TIME_S);
+
+  // test that the world and panda robot is initialized the way we expect by default
+  EXPECT_EQ(move_group_->getNodeHandle().getNamespace(), "/");
+  EXPECT_EQ(move_group_->getEndEffectorLink(), "panda_link8");
+  EXPECT_EQ(move_group_->getEndEffector(), "");
+  EXPECT_EQ(move_group_->getPoseReferenceFrame(), "world");
+  EXPECT_EQ(move_group_->getName(), "panda_arm");
+  EXPECT_EQ(move_group_->getPlanningFrame(), "world");
+  EXPECT_EQ(move_group_->getVariableCount(), std::size_t(7));
+  EXPECT_EQ(move_group_->getDefaultPlannerId(), "");
+  EXPECT_EQ(move_group_->getPlanningTime(), 10.0);
+  EXPECT_EQ(move_group_->getGoalJointTolerance(), 0.0001);
+  EXPECT_EQ(move_group_->getGoalPositionTolerance(), 0.0001);
+  EXPECT_EQ(move_group_->getGoalOrientationTolerance(), 0.001);
+
+  const std::vector<std::string> NAMED_TARGETS = { "ready", "extended" };
+  std::vector<std::string> named_targets = move_group_->getNamedTargets();
+  ASSERT_EQ(named_targets.size(), NAMED_TARGETS.size());
+  for (size_t i = 0; i < named_targets.size(); ++i)
+    EXPECT_EQ(named_targets[i], NAMED_TARGETS[i]) << "index: " << i;
+
+  const std::vector<std::string> JOINT_MODEL_GROUP_NAMES = { "hand", "panda_arm", "panda_arm_hand" };
+  std::vector<std::string> joint_model_group_names = move_group_->getJointModelGroupNames();
+  ASSERT_EQ(joint_model_group_names.size(), JOINT_MODEL_GROUP_NAMES.size());
+  for (size_t i = 0; i < joint_model_group_names.size(); ++i)
+    EXPECT_EQ(joint_model_group_names[i], JOINT_MODEL_GROUP_NAMES[i]) << "index: " << i;
+
+  const std::vector<std::string> JOINT_NAMES = { "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4",
+                                                 "panda_joint5", "panda_joint6", "panda_joint7" };
+  std::vector<std::string> joint_names = move_group_->getJointNames();
+  ASSERT_EQ(joint_names.size(), JOINT_NAMES.size());
+  for (size_t i = 0; i < joint_names.size(); ++i)
+    EXPECT_EQ(joint_names[i], JOINT_NAMES[i]) << "index: " << i;
+
+  const std::vector<std::string> LINK_NAMES = { "panda_link1", "panda_link2", "panda_link3", "panda_link4",
+                                                "panda_link5", "panda_link6", "panda_link7", "panda_link8" };
+  std::vector<std::string> link_names = move_group_->getLinkNames();
+  ASSERT_EQ(link_names.size(), LINK_NAMES.size());
+  for (size_t i = 0; i < link_names.size(); ++i)
+    EXPECT_EQ(link_names[i], LINK_NAMES[i]) << "index: " << i;
+
+  const std::vector<std::string> ACTIVE_JOINTS = { "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4",
+                                                   "panda_joint5", "panda_joint6", "panda_joint7" };
+  std::vector<std::string> active_joints = move_group_->getActiveJoints();
+  ASSERT_EQ(active_joints.size(), ACTIVE_JOINTS.size());
+  for (size_t i = 0; i < active_joints.size(); ++i)
+    EXPECT_EQ(active_joints[i], ACTIVE_JOINTS[i]) << "index: " << i;
+
+  const std::vector<std::string> JOINTS = { "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4",
+                                            "panda_joint5", "panda_joint6", "panda_joint7", "panda_joint8" };
+  std::vector<std::string> joints = move_group_->getJoints();
+  ASSERT_EQ(joints.size(), JOINTS.size());
+  for (size_t i = 0; i < joints.size(); ++i)
+    EXPECT_EQ(joints[i], JOINTS[i]) << "index: " << i;
+}
+
+TEST_F(MoveGroupTestFixture, MoveToPoseTest)
+{
+  // Test setting target pose with eigen and with geometry_msgs
+  geometry_msgs::Pose target_pose;
+  target_pose.orientation.w = 1.0;
+  target_pose.position.x = 0.28;
+  target_pose.position.y = -0.2;
+  target_pose.position.z = 0.5;
+
+  // convert to eigen
+  Eigen::Isometry3d eigen_target_pose;
+  tf::poseMsgToEigen(target_pose, eigen_target_pose);
+
+  // set with eigen, get ros message representation
+  move_group_->setPoseTarget(eigen_target_pose);
+  geometry_msgs::PoseStamped set_target_pose = move_group_->getPoseTarget();
+  Eigen::Isometry3d eigen_set_target_pose;
+  tf::poseMsgToEigen(set_target_pose.pose, eigen_set_target_pose);
+
+  // expect that they are identical
+  {
+    std::stringstream ss;
+    ss << "eigen_target_pose: \n"
+       << eigen_target_pose.matrix() << "\neigen_set_target_pose: \n"
+       << eigen_set_target_pose.matrix();
+    EXPECT_TRUE(eigen_set_target_pose.isApprox(eigen_target_pose, EPSILON)) << ss.str();
+  }
+
+  // plan and move
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+  EXPECT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  EXPECT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // get the pose after the movement
+  geometry_msgs::PoseStamped after_move_pose = move_group_->getCurrentPose();
+  Eigen::Isometry3d eigen_after_move_pose;
+  tf::poseMsgToEigen(after_move_pose.pose, eigen_after_move_pose);
+
+  // compare to planned pose
+  {
+    std::stringstream ss;
+    ss << "eigen_target_pose: \n"
+       << eigen_target_pose.matrix() << "\neigen_after_move_pose: \n"
+       << eigen_after_move_pose.matrix();
+    EXPECT_TRUE(eigen_after_move_pose.isApprox(eigen_target_pose, EPSILON)) << ss.str();
+  }
+}
+
+TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
+{
+  // get the joint model group
+  const robot_state::JointModelGroup* joint_model_group =
+      move_group_->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
+
+  // set velocity and acceleration scaling factors
+  move_group_->setMaxVelocityScalingFactor(0.8);
+  move_group_->setMaxAccelerationScalingFactor(0.8);
+
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.55;
+  start_pose.position.y = -0.05;
+  start_pose.position.z = 0.8;
+  MoveToStart(start_pose);
+
+  // Next get the current set of joint values for the group.
+  std::vector<double> plan_joint_positions;
+  move_group_->getCurrentState()->copyJointGroupPositions(joint_model_group, plan_joint_positions);
+
+  // Now, let's modify the joint positions.  (radians)
+  ASSERT_EQ(plan_joint_positions.size(), std::size_t(7));
+  plan_joint_positions = { 1.0, -1.0, 0.5, -1.0, 2.0, 0.5, -1.0 };
+  move_group_->setJointValueTarget(plan_joint_positions);
+
+  // plan and move
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+  EXPECT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  EXPECT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // test that we moved to the expected joint positions
+  std::vector<double> result_joint_positions;
+  move_group_->getCurrentState()->copyJointGroupPositions(joint_model_group, result_joint_positions);
+  ASSERT_EQ(plan_joint_positions.size(), result_joint_positions.size());
+  for (size_t i = 0; i < result_joint_positions.size(); ++i)
+  {
+    double joint_position_plan_result_delta = std::abs(plan_joint_positions[i] - result_joint_positions[i]);
+    EXPECT_LT(joint_position_plan_result_delta, EPSILON)
+        << "joint index: " << i << ", plan: " << plan_joint_positions[i] << ", result: " << result_joint_positions[i];
+  }
+}
+
+TEST_F(MoveGroupTestFixture, PathConstraintTest)
+{
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.55;
+  start_pose.position.y = -0.05;
+  start_pose.position.z = 0.8;
+  MoveToStart(start_pose);
+
+  // create an orientation constraint
+  moveit_msgs::OrientationConstraint ocm;
+  ocm.link_name = "panda_link7";
+  ocm.header.frame_id = "panda_link0";
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.1;
+  ocm.absolute_y_axis_tolerance = 0.1;
+  ocm.absolute_z_axis_tolerance = 0.1;
+  ocm.weight = 1.0;
+  moveit_msgs::Constraints test_constraints;
+  test_constraints.orientation_constraints.push_back(ocm);
+  move_group_->setPathConstraints(test_constraints);
+
+  // set the target state
+  geometry_msgs::Pose target_pose;
+  target_pose.orientation.w = 1.0;
+  target_pose.position.x = 0.28;
+  target_pose.position.y = -0.2;
+  target_pose.position.z = 0.5;
+  EXPECT_TRUE(move_group_->setPoseTarget(target_pose));
+
+  // set longer planning time
+  move_group_->setPlanningTime(10.0);
+
+  // plan and move
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+  EXPECT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  EXPECT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // clear path constraints
+  move_group_->clearPathConstraints();
+
+  // get the pose after the movement
+  geometry_msgs::PoseStamped after_move_pose = move_group_->getCurrentPose();
+  Eigen::Isometry3d eigen_after_move_pose;
+  tf::poseMsgToEigen(after_move_pose.pose, eigen_after_move_pose);
+  Eigen::Isometry3d eigen_target_pose;
+  tf::poseMsgToEigen(target_pose, eigen_target_pose);
+
+  // compare to planned pose
+  {
+    std::stringstream ss;
+    ss << "eigen_target_pose: \n"
+       << eigen_target_pose.matrix() << "\neigen_after_move_pose: \n"
+       << eigen_after_move_pose.matrix();
+    EXPECT_TRUE(eigen_after_move_pose.isApprox(eigen_target_pose, EPSILON)) << ss.str();
+  }
+}
+
+TEST_F(MoveGroupTestFixture, CartPathTest)
+{
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.55;
+  start_pose.position.y = -0.05;
+  start_pose.position.z = 0.8;
+  MoveToStart(start_pose);
+
+  std::vector<geometry_msgs::Pose> waypoints;
+  waypoints.push_back(start_pose);
+
+  geometry_msgs::Pose target_waypoint = start_pose;
+  target_waypoint.position.z -= 0.2;
+  waypoints.push_back(target_waypoint);  // down
+
+  target_waypoint.position.y -= 0.2;
+  waypoints.push_back(target_waypoint);  // right
+
+  target_waypoint.position.z += 0.2;
+  target_waypoint.position.y += 0.2;
+  target_waypoint.position.x -= 0.2;
+  waypoints.push_back(target_waypoint);  // up and left
+
+  moveit_msgs::RobotTrajectory trajectory;
+  const double jump_threshold = 0.0;
+  const double eef_step = 0.01;
+  move_group_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+
+  // Execute trajectory
+  moveit::planning_interface::MoveGroupInterface::Plan cartesian_plan;
+  cartesian_plan.trajectory_ = trajectory;
+  EXPECT_EQ(move_group_->execute(cartesian_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // get the pose after the movement
+  geometry_msgs::PoseStamped after_move_pose = move_group_->getCurrentPose();
+  Eigen::Isometry3d eigen_after_move_pose;
+  tf::poseMsgToEigen(after_move_pose.pose, eigen_after_move_pose);
+  Eigen::Isometry3d eigen_target_pose;
+  tf::poseMsgToEigen(target_waypoint, eigen_target_pose);
+
+  // compare to planned pose
+  {
+    std::stringstream ss;
+    ss << "eigen_target_pose: \n"
+       << eigen_target_pose.matrix() << "\neigen_after_move_pose: \n"
+       << eigen_after_move_pose.matrix();
+    EXPECT_TRUE(eigen_after_move_pose.isApprox(eigen_target_pose, EPSILON)) << ss.str();
+  }
+}
+
+TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
+{
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.55;
+  start_pose.position.y = -0.05;
+  start_pose.position.z = 0.8;
+  MoveToStart(start_pose);
+
+  // Define a collision object ROS message.
+  moveit_msgs::CollisionObject collision_object;
+  collision_object.header.frame_id = move_group_->getPlanningFrame();
+
+  // The id of the object is used to identify it.
+  collision_object.id = "box1";
+
+  // Define a box to add to the world.
+  shape_msgs::SolidPrimitive primitive;
+  primitive.type = primitive.BOX;
+  primitive.dimensions.resize(3);
+  primitive.dimensions[0] = 0.4;
+  primitive.dimensions[1] = 0.1;
+  primitive.dimensions[2] = 0.4;
+
+  // Define a pose for the box (specified relative to frame_id)
+  geometry_msgs::Pose box_pose;
+  box_pose.orientation.w = 1.0;
+  box_pose.position.x = 0.4;
+  box_pose.position.y = -0.2;
+  box_pose.position.z = 1.0;
+
+  collision_object.primitives.push_back(primitive);
+  collision_object.primitive_poses.push_back(box_pose);
+  collision_object.operation = collision_object.ADD;
+
+  std::vector<moveit_msgs::CollisionObject> collision_objects;
+  collision_objects.push_back(collision_object);
+
+  // Now, let's add the collision object into the world
+  planning_scene_interface_.addCollisionObjects(collision_objects);
+
+  // plan trajectory avoiding object
+  move_group_->setStartState(*move_group_->getCurrentState());
+  geometry_msgs::Pose target_pose;
+  target_pose.orientation.w = 1.0;
+  target_pose.position.x = 0.4;
+  target_pose.position.y = -0.4;
+  target_pose.position.z = 0.9;
+  move_group_->setPoseTarget(target_pose);
+
+  // plan and move
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+  EXPECT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  EXPECT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // get the pose after the movement
+  geometry_msgs::PoseStamped after_move_pose = move_group_->getCurrentPose();
+  Eigen::Isometry3d eigen_after_move_pose;
+  tf::poseMsgToEigen(after_move_pose.pose, eigen_after_move_pose);
+  Eigen::Isometry3d eigen_target_pose;
+  tf::poseMsgToEigen(target_pose, eigen_target_pose);
+
+  // compare to planned pose
+  {
+    std::stringstream ss;
+    ss << "eigen_target_pose: \n"
+       << eigen_target_pose.matrix() << "\neigen_after_move_pose: \n"
+       << eigen_after_move_pose.matrix();
+    EXPECT_TRUE(eigen_after_move_pose.isApprox(eigen_target_pose, EPSILON)) << ss.str();
+  }
+
+  // attach and detach collision object
+  EXPECT_TRUE(move_group_->attachObject(collision_object.id));
+  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(1));
+  EXPECT_TRUE(move_group_->detachObject(collision_object.id));
+  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(0));
+
+  // remove object from world
+  std::vector<std::string> object_ids;
+  object_ids.push_back(collision_object.id);
+  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(1));
+  planning_scene_interface_.removeCollisionObjects(object_ids);
+  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(0));
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "move_group_interface_cpp_test");
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -61,7 +61,7 @@
 constexpr double EPSILON = 1e-2;
 
 static const std::string PLANNING_GROUP = "panda_arm";
-constexpr double PLANNING_TIME_S = 10;
+constexpr double PLANNING_TIME_S = 30.0;
 
 class MoveGroupTestFixture : public ::testing::Test
 {
@@ -177,7 +177,6 @@ TEST_F(MoveGroupTestFixture, StartingConditionsTest)
   EXPECT_EQ(move_group_->getPlanningFrame(), "world");
   EXPECT_EQ(move_group_->getVariableCount(), std::size_t(7));
   EXPECT_EQ(move_group_->getDefaultPlannerId(), "");
-  EXPECT_EQ(move_group_->getPlanningTime(), 10.0);
   EXPECT_EQ(move_group_->getGoalJointTolerance(), 0.0001);
   EXPECT_EQ(move_group_->getGoalPositionTolerance(), 0.0001);
   EXPECT_EQ(move_group_->getGoalOrientationTolerance(), 0.001);

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -62,6 +62,8 @@ constexpr double EPSILON = 1e-2;
 
 static const std::string PLANNING_GROUP = "panda_arm";
 constexpr double PLANNING_TIME_S = 30.0;
+constexpr double MAX_VELOCITY_SCALE = 1.0;
+constexpr double MAX_ACCELERATION_SCALE = 1.0;
 
 class MoveGroupTestFixture : public ::testing::Test
 {
@@ -75,8 +77,11 @@ public:
     start_pose_stamped_ = move_group_->getCurrentPose();
 
     // set velocity and acceleration scaling factors (full speed)
-    move_group_->setMaxVelocityScalingFactor(1.0);
-    move_group_->setMaxAccelerationScalingFactor(1.0);
+    move_group_->setMaxVelocityScalingFactor(MAX_VELOCITY_SCALE);
+    move_group_->setMaxAccelerationScalingFactor(MAX_ACCELERATION_SCALE);
+
+    // allow more time for planning
+    move_group_->setPlanningTime(PLANNING_TIME_S);
   }
 
   void retrunToStartPose()

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
@@ -1,0 +1,29 @@
+<launch>
+  <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- If needed, broadcast static tf for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
+
+  <!-- We do not have a robot connected, so publish fake joint states -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+  </node>
+  <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />
+
+  <!-- Given the published joint states, publish tf for the robot links -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+  <!-- Run the main MoveIt executable with fake trajectory execution -->
+  <include file="$(find panda_moveit_config)/launch/move_group.launch">
+    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="fake_execution" value="true"/>
+    <arg name="info" value="true"/>
+  </include>
+
+  <!-- Subframes test -->
+  <test pkg="moveit_ros_planning_interface" type="move_group_interface_cpp_test" test-name="move_group_interface_cpp_test"
+        time-limit="120" args=""/>
+</launch>

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
@@ -23,7 +23,7 @@
     <arg name="info" value="true"/>
   </include>
 
-  <!-- Subframes test -->
+  <!-- test -->
   <test pkg="moveit_ros_planning_interface" type="move_group_interface_cpp_test" test-name="move_group_interface_cpp_test"
         time-limit="120" args=""/>
 </launch>


### PR DESCRIPTION
### Description

I realized there was no test of the c++ interface of move_group.  This PR fixes that to defend the interface used by our newest users against unintended breakages.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Moves the CodeCov report in the right direction :arrow_up: :arrow_up: :arrow_up: 