### PR TITLE
allow failure for shadow-fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
     - env: ROS_DISTRO=kinetic
     - compiler: clang
       env: TEST=clang-tidy-fix CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
+    - env: ROS_REPO=ros-shadow-fixed
   allow_failures:
     - env: ROS_REPO=ros-shadow-fixed
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ jobs:
   include:
     - env: TEST="clang-format catkin_lint"
     - env: TEST=code-coverage
-    - env: ROS_DISTRO=melodic BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+    - env: ROS_DISTRO=melodic
     - env: ROS_DISTRO=kinetic
     - compiler: clang
-      env: TEST=clang-tidy-fix CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
+      # test_ikfast_plugins takes ~10 minutes. Take the time off clang-tidy to keep the main jobs shorter
+      env: TEST=clang-tidy-fix BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh" CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
     - env: ROS_REPO=ros-shadow-fixed
   allow_failures:
     - env: ROS_REPO=ros-shadow-fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,23 +21,17 @@ env:
     - TEST_BLACKLIST="moveit_ros_perception"
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
     - WARNINGS_OK=false
-  jobs:
-    include:
-      - TEST="clang-format catkin_lint"
-      - TEST=code-coverage
-      - ROS_DISTRO=melodic BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
-      - ROS_DISTRO=kinetic
-    allow_failures:
-      - ROS_REPO=ros-shadow-fixed
 
-env:
-  global:
-    - ROS_REPO=ros
-    - ROS_DISTRO=melodic
-    - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
-  jobs: # Add a separate config to the matrix, using clang as compiler
+jobs:
+  include:
+    - env: TEST="clang-format catkin_lint"
+    - env: TEST=code-coverage
+    - env: ROS_DISTRO=melodic BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+    - env: ROS_DISTRO=kinetic
     - compiler: clang
-      env: TEST=clang-tidy-fix
+      env: TEST=clang-tidy-fix CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
+  allow_failures:
+    - env: ROS_REPO=ros-shadow-fixed
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,22 @@ env:
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
     - WARNINGS_OK=false
   jobs:
-    - TEST="clang-format catkin_lint"
-    - TEST=code-coverage
-    - ROS_DISTRO=melodic
-    - ROS_DISTRO=kinetic
+    include:
+      - TEST="clang-format catkin_lint"
+      - TEST=code-coverage
+      - ROS_DISTRO=melodic BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+      - ROS_DISTRO=kinetic
+    allow_failures:
+      - ROS_REPO=ros-shadow-fixed
 
-jobs: # Add a separate config to the matrix, using clang as compiler
-  include:
-    # add a config to the matrix using clang as compiler and also test ikfast plugin creation
+env:
+  global:
+    - ROS_REPO=ros
+    - ROS_DISTRO=melodic
+    - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
+  jobs: # Add a separate config to the matrix, using clang as compiler
     - compiler: clang
-      env: ROS_REPO=ros-shadow-fixed
-           TEST=clang-tidy-fix
-           BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
-           CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
+      env: TEST=clang-tidy-fix
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ jobs:
     - compiler: clang
       # test_ikfast_plugins takes ~10 minutes. Take the time off clang-tidy to keep the main jobs shorter
       env: TEST=clang-tidy-fix BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh" CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
-    - env: ROS_REPO=ros-shadow-fixed
-  allow_failures:
-    - env: ROS_REPO=ros-shadow-fixed
+#    - env: ROS_REPO=ros-shadow-fixed
+#  allow_failures:
+#    - env: ROS_REPO=ros-shadow-fixed
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ jobs:
     - env: ROS_DISTRO=melodic
     - env: ROS_DISTRO=kinetic
     - compiler: clang
-      # test_ikfast_plugins takes ~10 minutes. Take the time off clang-tidy to keep the main jobs shorter
-      env: TEST=clang-tidy-fix BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh" CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
-#    - env: ROS_REPO=ros-shadow-fixed
-#  allow_failures:
-#    - env: ROS_REPO=ros-shadow-fixed
+      # test_ikfast_plugins takes ~10 minutes: include here to keep the main jobs shorter
+      env: TEST=clang-tidy-fix
+           BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+           CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
+#           ROS_REPO=ros-shadow-fixed
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci


### PR DESCRIPTION
As we see once more at the moment, we *don't* **ever** want our CI to block because someone broke shadow-fixed. Assuming I didn't break anything, this should mitigate half [of your worries](https://github.com/ros-planning/moveit/pull/1999#issuecomment-606048430) @rhaschke ?
The other half being the incomplete migration to github apps that leads to github's guards waiting for completed CI jobs.

add a separate gcc shadow-fixed job as we still want the required clang check.

also adjust clang job to use global variables.
Job-variables are *all* included in the jobname on the website.