### PR TITLE
Fix TfPublisher subframe publishing

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -111,7 +111,7 @@ void TfPublisher::publishPlanningSceneFrames()
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframeTransforms();
-        publishSubframes(broadcaster, subframes, object_frame, object_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, attached_body->getAttachedLinkName(), stamp);
       }
     }
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -95,7 +95,7 @@ void TfPublisher::publishPlanningSceneFrames()
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = obj.second->subframe_poses_;
-        publishSubframes(broadcaster, subframes, object_frame, stamp);
+        publishSubframes(broadcaster, subframes, planning_frame, stamp);
       }
 
       const moveit::core::RobotState& rs = locked_planning_scene->getCurrentState();

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -57,13 +57,13 @@ TfPublisher::~TfPublisher()
 namespace
 {
 void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::core::FixedTransformsMap& subframes,
-                      const std::string& parent_frame, const ros::Time& stamp)
+                      const std::string& parent_object, const std::string& parent_frame, const ros::Time& stamp)
 {
   geometry_msgs::TransformStamped transform;
   for (auto& subframe : subframes)
   {
     transform = tf2::eigenToTransform(subframe.second);
-    transform.child_frame_id = parent_frame + "/" + subframe.first;
+    transform.child_frame_id = parent_object + "/" + subframe.first;
     transform.header.stamp = stamp;
     transform.header.frame_id = parent_frame;
     broadcaster.sendTransform(transform);
@@ -95,7 +95,7 @@ void TfPublisher::publishPlanningSceneFrames()
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = obj.second->subframe_poses_;
-        publishSubframes(broadcaster, subframes, planning_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, planning_frame, stamp);
       }
 
       const moveit::core::RobotState& rs = locked_planning_scene->getCurrentState();
@@ -111,7 +111,7 @@ void TfPublisher::publishPlanningSceneFrames()
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframeTransforms();
-        publishSubframes(broadcaster, subframes, object_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, object_frame, stamp);
       }
     }
 


### PR DESCRIPTION
A silly mistake got through in #1792 . Without this PR, the scene looks like this:

![Screenshot from 2020-03-31 21-04-15](https://user-images.githubusercontent.com/4535737/78025329-d25ebe80-7394-11ea-8c44-41a99c9c0c3b.png)

After the change, it looks as expected.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers