### PR TITLE
Remove the "Goal Constraints" RViz GUI field

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1330,8 +1330,6 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
       frame_->ui_->velocity_scaling_factor->setValue(d);
     if (config.mapGetFloat("Acceleration_Scaling_Factor", &d))
       frame_->ui_->acceleration_scaling_factor->setValue(d);
-    if (config.mapGetFloat("MoveIt_Goal_Tolerance", &d))
-      frame_->ui_->goal_tolerance->setValue(d);
 
     bool b;
     if (config.mapGetBool("MoveIt_Allow_Replanning", &b))
@@ -1389,8 +1387,6 @@ void MotionPlanningDisplay::save(rviz::Config config) const
   {
     config.mapSetValue("MoveIt_Warehouse_Host", frame_->ui_->database_host->text());
     config.mapSetValue("MoveIt_Warehouse_Port", frame_->ui_->database_port->value());
-
-    config.mapSetValue("MoveIt_Goal_Tolerance", frame_->ui_->goal_tolerance->value());
 
     // "Options" Section
     config.mapSetValue("MoveIt_Planning_Time", frame_->ui_->planning_time->value());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -153,8 +153,6 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->database_host, SIGNAL(textChanged(QString)), this, SIGNAL(configChanged()));
   connect(ui_->database_port, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
 
-  connect(ui_->goal_tolerance, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
-
   connect(ui_->planning_time, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
   connect(ui_->planning_attempts, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
   connect(ui_->velocity_scaling_factor, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -519,20 +519,6 @@
             <item>
              <widget class="QComboBox" name="path_constraints_combo_box"/>
             </item>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_11">
-              <item>
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>Goal Tolerance:</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QDoubleSpinBox" name="goal_tolerance"/>
-              </item>
-             </layout>
-            </item>
            </layout>
           </widget>
          </item>
@@ -1646,7 +1632,6 @@
   <tabstop>collision_aware_ik</tabstop>
   <tabstop>approximate_ik</tabstop>
   <tabstop>path_constraints_combo_box</tabstop>
-  <tabstop>goal_tolerance</tabstop>
   <tabstop>place_button</tabstop>
   <tabstop>roi_center_x</tabstop>
   <tabstop>roi_center_y</tabstop>


### PR DESCRIPTION
As described in issue #1957, the Goal Constraints field in the RViz plugin didn't make sense. This just removes it.
