### PR TITLE
WIP: Alignment of vectorizable Eigen member variables

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -64,7 +64,7 @@ enum Type
   /** \brief A body in the environment */
   WORLD_OBJECT
 };
-}
+}  // namespace BodyTypes
 
 /** \brief The types of bodies that are considered for collision */
 typedef BodyTypes::Type BodyType;
@@ -73,6 +73,7 @@ typedef BodyTypes::Type BodyType;
 struct Contact
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  using AlignedVector = std::vector<Contact, Eigen::aligned_allocator<Contact>>;
 
   /** \brief contact position */
   Eigen::Vector3d pos;
@@ -147,7 +148,7 @@ struct CollisionResult
   CollisionResult() : collision(false), distance(std::numeric_limits<double>::max()), contact_count(0)
   {
   }
-  typedef std::map<std::pair<std::string, std::string>, std::vector<Contact> > ContactMap;
+  typedef std::map<std::pair<std::string, std::string>, Contact::AlignedVector> ContactMap;
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -366,7 +367,7 @@ struct DistanceResultsData
 };
 
 /** \brief Mapping between the names of the collision objects and the DistanceResultData. */
-typedef std::map<const std::pair<std::string, std::string>, std::vector<DistanceResultsData> > DistanceMap;
+typedef std::map<const std::pair<std::string, std::string>, std::vector<DistanceResultsData>> DistanceMap;
 
 /** \brief Result of a distance request. */
 struct DistanceResult
@@ -392,4 +393,4 @@ struct DistanceResult
     distances.clear();
   }
 };
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -80,7 +80,7 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
     std::string contact1 = contact.first.first;
     std::string contact2 = contact.first.second;
     std::string octomap_name = "";
-    std::vector<collision_detection::Contact>& contact_vector = contact.second;
+    collision_detection::Contact::AlignedVector& contact_vector = contact.second;
 
     if (contact1.find("octomap") != std::string::npos)
       octomap_name = contact1;

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h
@@ -77,7 +77,7 @@ inline collision_detection::Contact* processResult(ContactTestData& cdata, colli
       cdata.res.collision = true;
     }
 
-    std::vector<collision_detection::Contact> data;
+    collision_detection::Contact::AlignedVector data;
 
     // if we dont want contacts we are done here
     if (!cdata.req.contacts)
@@ -112,7 +112,7 @@ inline collision_detection::Contact* processResult(ContactTestData& cdata, colli
   }
   else
   {
-    std::vector<collision_detection::Contact>& dr = cdata.res.contacts[key];
+    collision_detection::Contact::AlignedVector& dr = cdata.res.contacts[key];
     dr.emplace_back(contact);
     cdata.res.contact_count++;
 

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -196,7 +196,7 @@ void addCollisionObjectsMesh(cb::BulletCastBVHManager& checker)
 }
 
 void runTest(cb::BulletCastBVHManager& checker, collision_detection::CollisionResult& result,
-             std::vector<collision_detection::Contact>& result_vector, Eigen::Isometry3d& start_pos,
+             collision_detection::Contact::AlignedVector& result_vector, Eigen::Isometry3d& start_pos,
              Eigen::Isometry3d& end_pos)
 {
   //////////////////////////////////////
@@ -318,7 +318,7 @@ TEST_F(BulletCollisionDetectionTester, ContinuousCollisionWorld)
 TEST(ContinuousCollisionUnit, BulletCastBVHCollisionBoxBoxUnit)
 {
   collision_detection::CollisionResult result;
-  std::vector<collision_detection::Contact> result_vector;
+  collision_detection::Contact::AlignedVector result_vector;
 
   Eigen::Isometry3d start_pos, end_pos;
   start_pos.setIdentity();
@@ -347,7 +347,7 @@ TEST(ContinuousCollisionUnit, BulletCastMeshVsBox)
   end_pos.translation().x() = 1.9;
 
   collision_detection::CollisionResult result;
-  std::vector<collision_detection::Contact> result_vector;
+  collision_detection::Contact::AlignedVector result_vector;
 
   runTest(checker, result, result_vector, start_pos, end_pos);
 

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -98,7 +98,7 @@ struct GroupStateRepresentation
   /** information about detected collisions, collected during collision
    * detection.  One entry for each link and one entry for each attached
    * object. */
-  std::vector<GradientInfo> gradients_;
+  GradientInfo::AlignedVector gradients_;
 };
 
 /** collision volume representation for a particular link group of a robot
@@ -178,4 +178,4 @@ PosedBodyPointDecompositionVectorPtr getAttachedBodyPointDecomposition(const mov
 
 void getBodySphereVisualizationMarkers(const GroupStateRepresentationPtr& gsr, const std::string& reference_frame,
                                        visualization_msgs::MarkerArray& body_marker_array);
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -69,6 +69,7 @@ enum CollisionType
 
 struct CollisionSphere
 {
+  using AlignedVector = std::vector<CollisionSphere, Eigen::aligned_allocator<CollisionSphere>>;
   CollisionSphere(const Eigen::Vector3d& rel, double radius)
   {
     relative_vec_ = rel;
@@ -187,7 +188,7 @@ public:
    * @param stop_at_first_collision when true the computation is terminated when
    * the first collision is found
    */
-  bool getCollisionSphereGradients(const std::vector<CollisionSphere>& sphere_list,
+  bool getCollisionSphereGradients(const CollisionSphere::AlignedVector& sphere_list,
                                    const EigenSTL::vector_Vector3d& sphere_centers, GradientInfo& gradient,
                                    const CollisionType& type, double tolerance, bool subtract_radii,
                                    double maximum_value, bool stop_at_first_collision);
@@ -199,23 +200,24 @@ protected:
 // determines set of collision spheres given a posed body; this is BAD!
 // Allocation erorrs will happen; change this function so it does not return
 // that vector by value
-std::vector<CollisionSphere> determineCollisionSpheres(const bodies::Body* body, Eigen::Isometry3d& relativeTransform);
+CollisionSphere::AlignedVector determineCollisionSpheres(const bodies::Body* body,
+                                                         Eigen::Isometry3d& relativeTransform);
 
 // determines a set of gradients of the given collision spheres in the distance
 // field
 bool getCollisionSphereGradients(const distance_field::DistanceField* distance_field,
-                                 const std::vector<CollisionSphere>& sphere_list,
+                                 const CollisionSphere::AlignedVector& sphere_list,
                                  const EigenSTL::vector_Vector3d& sphere_centers, GradientInfo& gradient,
                                  const CollisionType& type, double tolerance, bool subtract_radii, double maximum_value,
                                  bool stop_at_first_collision);
 
 bool getCollisionSphereCollision(const distance_field::DistanceField* distance_field,
-                                 const std::vector<CollisionSphere>& sphere_list,
+                                 const CollisionSphere::AlignedVector& sphere_list,
                                  const EigenSTL::vector_Vector3d& sphere_centers, double maximum_value,
                                  double tolerance);
 
 bool getCollisionSphereCollision(const distance_field::DistanceField* distance_field,
-                                 const std::vector<CollisionSphere>& sphere_list,
+                                 const CollisionSphere::AlignedVector& sphere_list,
                                  const EigenSTL::vector_Vector3d& sphere_centers, double maximum_value,
                                  double tolerance, unsigned int num_coll, std::vector<unsigned int>& colls);
 
@@ -238,7 +240,7 @@ public:
 
   Eigen::Isometry3d relative_cylinder_pose_;
 
-  void replaceCollisionSpheres(const std::vector<CollisionSphere>& new_collision_spheres,
+  void replaceCollisionSpheres(const CollisionSphere::AlignedVector& new_collision_spheres,
                                const Eigen::Isometry3d& new_relative_cylinder_pose)
   {
     // std::cerr << "Replacing " << collision_spheres_.size() << " with " <<
@@ -247,7 +249,7 @@ public:
     relative_cylinder_pose_ = new_relative_cylinder_pose;
   }
 
-  const std::vector<CollisionSphere>& getCollisionSpheres() const
+  const CollisionSphere::AlignedVector& getCollisionSpheres() const
   {
     return collision_spheres_;
   }
@@ -291,7 +293,7 @@ protected:
 
   bodies::BoundingSphere relative_bounding_sphere_;
   std::vector<double> sphere_radii_;
-  std::vector<CollisionSphere> collision_spheres_;
+  CollisionSphere::AlignedVector collision_spheres_;
   EigenSTL::vector_Vector3d relative_collision_points_;
 };
 
@@ -302,7 +304,7 @@ public:
 
   PosedBodySphereDecomposition(const BodyDecompositionConstPtr& body_decomposition);
 
-  const std::vector<CollisionSphere>& getCollisionSpheres() const
+  const CollisionSphere::AlignedVector& getCollisionSpheres() const
   {
     return body_decomposition_->getCollisionSpheres();
   }
@@ -374,7 +376,7 @@ public:
   {
   }
 
-  const std::vector<CollisionSphere>& getCollisionSpheres() const
+  const CollisionSphere::AlignedVector& getCollisionSpheres() const
   {
     return collision_spheres_;
   }
@@ -432,7 +434,7 @@ public:
 private:
   PosedBodySphereDecompositionConstPtr empty_ptr_;
   std::vector<PosedBodySphereDecompositionPtr> decomp_vector_;
-  std::vector<CollisionSphere> collision_spheres_;
+  CollisionSphere::AlignedVector collision_spheres_;
   EigenSTL::vector_Vector3d posed_collision_spheres_;
   std::vector<double> sphere_radii_;
   std::map<unsigned int, unsigned int> sphere_index_map_;
@@ -526,4 +528,4 @@ void getCollisionMarkers(const std::string& frame_id, const std::string& ns, con
                          const std::vector<PosedBodySphereDecompositionPtr>& posed_decompositions,
                          const std::vector<PosedBodySphereDecompositionVectorPtr>& posed_vector_decompositions,
                          const std::vector<GradientInfo>& gradients, visualization_msgs::MarkerArray& arr);
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -88,6 +88,7 @@ struct GradientInfo
   }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  using AlignedVector = std::vector<GradientInfo, Eigen::aligned_allocator<GradientInfo>>;
 
   double closest_distance;
   bool collision;
@@ -522,10 +523,10 @@ void getCollisionSphereMarkers(const std_msgs::ColorRGBA& color, const std::stri
 void getProximityGradientMarkers(const std::string& frame_id, const std::string& ns, const ros::Duration& dur,
                                  const std::vector<PosedBodySphereDecompositionPtr>& posed_decompositions,
                                  const std::vector<PosedBodySphereDecompositionVectorPtr>& posed_vector_decompositions,
-                                 const std::vector<GradientInfo>& gradients, visualization_msgs::MarkerArray& arr);
+                                 const GradientInfo::AlignedVector& gradients, visualization_msgs::MarkerArray& arr);
 
 void getCollisionMarkers(const std::string& frame_id, const std::string& ns, const ros::Duration& dur,
                          const std::vector<PosedBodySphereDecompositionPtr>& posed_decompositions,
                          const std::vector<PosedBodySphereDecompositionVectorPtr>& posed_vector_decompositions,
-                         const std::vector<GradientInfo>& gradients, visualization_msgs::MarkerArray& arr);
+                         const GradientInfo::AlignedVector& gradients, visualization_msgs::MarkerArray& arr);
 }  // namespace collision_detection

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -61,8 +61,8 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CollisionEnvDistanceField(const moveit::core::RobotModelConstPtr& robot_model,
-                            const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
-                                std::map<std::string, std::vector<CollisionSphere>>(),
+                            const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions =
+                                std::map<std::string, CollisionSphere::AlignedVector>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
                             double size_z = DEFAULT_SIZE_Z, const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                             bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
@@ -72,8 +72,8 @@ public:
                             double scale = 1.0);
 
   CollisionEnvDistanceField(const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
-                            const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
-                                std::map<std::string, std::vector<CollisionSphere>>(),
+                            const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions =
+                                std::map<std::string, CollisionSphere::AlignedVector>(),
                             double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y,
                             double size_z = DEFAULT_SIZE_Z, const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                             bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
@@ -84,7 +84,7 @@ public:
 
   CollisionEnvDistanceField(const CollisionEnvDistanceField& other, const WorldPtr& world);
 
-  void initialize(const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
+  void initialize(const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions,
                   const Eigen::Vector3d& size, const Eigen::Vector3d& origin, bool use_signed_distance_field,
                   double resolution, double collision_tolerance, double max_propogation_distance);
 
@@ -252,7 +252,7 @@ protected:
   void addLinkBodyDecompositions(double resolution);
 
   void addLinkBodyDecompositions(double resolution,
-                                 const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions);
+                                 const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions);
 
   PosedBodySphereDecompositionPtr getPosedLinkBodySphereDecomposition(const moveit::core::LinkModel* ls,
                                                                       unsigned int ind) const;
@@ -306,4 +306,4 @@ protected:
   GroupStateRepresentationPtr last_gsr_;
   World::ObserverHandle observer_handle_;
 };
-}
+}  // namespace collision_detection

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_hybrid.h
@@ -53,8 +53,8 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CollisionEnvHybrid(const moveit::core::RobotModelConstPtr& robot_model,
-                     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
-                         std::map<std::string, std::vector<CollisionSphere>>(),
+                     const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions =
+                         std::map<std::string, CollisionSphere::AlignedVector>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
                      const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                      bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
@@ -63,8 +63,8 @@ public:
                      double scale = 1.0);
 
   CollisionEnvHybrid(const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
-                     const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions =
-                         std::map<std::string, std::vector<CollisionSphere>>(),
+                     const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions =
+                         std::map<std::string, CollisionSphere::AlignedVector>(),
                      double size_x = DEFAULT_SIZE_X, double size_y = DEFAULT_SIZE_Y, double size_z = DEFAULT_SIZE_Z,
                      const Eigen::Vector3d& origin = Eigen::Vector3d(0, 0, 0),
                      bool use_signed_distance_field = DEFAULT_USE_SIGNED_DISTANCE_FIELD,
@@ -78,9 +78,10 @@ public:
   {
   }
 
-  void initializeRobotDistanceField(const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions,
-                                    double size_x, double size_y, double size_z, bool use_signed_distance_field,
-                                    double resolution, double collision_tolerance, double max_propogation_distance)
+  void
+  initializeRobotDistanceField(const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions,
+                               double size_x, double size_y, double size_z, bool use_signed_distance_field,
+                               double resolution, double collision_tolerance, double max_propogation_distance)
   {
     cenv_distance_->initialize(link_body_decompositions, Eigen::Vector3d(size_x, size_y, size_z),
                                Eigen::Vector3d(0, 0, 0), use_signed_distance_field, resolution, collision_tolerance,
@@ -150,4 +151,4 @@ public:
 protected:
   CollisionEnvDistanceFieldPtr cenv_distance_;
 };
-};
+};  // namespace collision_detection

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -43,10 +43,10 @@
 
 const static double EPSILON = 0.0001;
 
-std::vector<collision_detection::CollisionSphere>
+collision_detection::CollisionSphere::AlignedVector
 collision_detection::determineCollisionSpheres(const bodies::Body* body, Eigen::Isometry3d& relative_transform)
 {
-  std::vector<collision_detection::CollisionSphere> css;
+  collision_detection::CollisionSphere::AlignedVector css;
 
   bodies::BoundingCylinder cyl;
   body->computeBoundingCylinder(cyl);
@@ -65,7 +65,7 @@ collision_detection::determineCollisionSpheres(const bodies::Body* body, Eigen::
 }
 
 bool collision_detection::PosedDistanceField::getCollisionSphereGradients(
-    const std::vector<CollisionSphere>& sphere_list, const EigenSTL::vector_Vector3d& sphere_centers,
+    const CollisionSphere::AlignedVector& sphere_list, const EigenSTL::vector_Vector3d& sphere_centers,
     GradientInfo& gradient, const collision_detection::CollisionType& type, double tolerance, bool subtract_radii,
     double maximum_value, bool stop_at_first_collision)
 {
@@ -127,7 +127,7 @@ bool collision_detection::PosedDistanceField::getCollisionSphereGradients(
 }
 
 bool collision_detection::getCollisionSphereGradients(const distance_field::DistanceField* distance_field,
-                                                      const std::vector<CollisionSphere>& sphere_list,
+                                                      const CollisionSphere::AlignedVector& sphere_list,
                                                       const EigenSTL::vector_Vector3d& sphere_centers,
                                                       GradientInfo& gradient,
                                                       const collision_detection::CollisionType& type, double tolerance,
@@ -190,7 +190,7 @@ bool collision_detection::getCollisionSphereGradients(const distance_field::Dist
 }
 
 bool collision_detection::getCollisionSphereCollision(const distance_field::DistanceField* distance_field,
-                                                      const std::vector<CollisionSphere>& sphere_list,
+                                                      const CollisionSphere::AlignedVector& sphere_list,
                                                       const EigenSTL::vector_Vector3d& sphere_centers,
                                                       double maximum_value, double tolerance)
 {
@@ -217,7 +217,7 @@ bool collision_detection::getCollisionSphereCollision(const distance_field::Dist
 }
 
 bool collision_detection::getCollisionSphereCollision(const distance_field::DistanceField* distance_field,
-                                                      const std::vector<CollisionSphere>& sphere_list,
+                                                      const CollisionSphere::AlignedVector& sphere_list,
                                                       const EigenSTL::vector_Vector3d& sphere_centers,
                                                       double maximum_value, double tolerance, unsigned int num_coll,
                                                       std::vector<unsigned int>& colls)
@@ -286,7 +286,7 @@ void collision_detection::BodyDecomposition::init(const std::vector<shapes::Shap
   // collecting collision spheres
   collision_spheres_.clear();
   relative_collision_points_.clear();
-  std::vector<CollisionSphere> body_spheres;
+  CollisionSphere::AlignedVector body_spheres;
   EigenSTL::vector_Vector3d body_collision_points;
   for (unsigned int i = 0; i < bodies_.getCount(); i++)
   {

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -438,7 +438,7 @@ void collision_detection::getProximityGradientMarkers(
     const std::string& frame_id, const std::string& ns, const ros::Duration& dur,
     const std::vector<PosedBodySphereDecompositionPtr>& posed_decompositions,
     const std::vector<PosedBodySphereDecompositionVectorPtr>& posed_vector_decompositions,
-    const std::vector<GradientInfo>& gradients, visualization_msgs::MarkerArray& arr)
+    const GradientInfo::AlignedVector& gradients, visualization_msgs::MarkerArray& arr)
 {
   if (gradients.size() != posed_decompositions.size() + posed_vector_decompositions.size())
   {
@@ -541,7 +541,7 @@ void collision_detection::getCollisionMarkers(
     const std::string& frame_id, const std::string& ns, const ros::Duration& dur,
     const std::vector<PosedBodySphereDecompositionPtr>& posed_decompositions,
     const std::vector<PosedBodySphereDecompositionVectorPtr>& posed_vector_decompositions,
-    const std::vector<GradientInfo>& gradients, visualization_msgs::MarkerArray& arr)
+    const GradientInfo::AlignedVector& gradients, visualization_msgs::MarkerArray& arr)
 {
   if (gradients.size() != posed_decompositions.size() + posed_vector_decompositions.size())
   {

--- a/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_hybrid.cpp
@@ -44,7 +44,7 @@ const std::string collision_detection::CollisionDetectorAllocatorHybrid::NAME("H
 
 CollisionEnvHybrid::CollisionEnvHybrid(
     const moveit::core::RobotModelConstPtr& robot_model,
-    const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
+    const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions, double size_x, double size_y,
     double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
   : CollisionEnvFCL(robot_model)
@@ -56,7 +56,7 @@ CollisionEnvHybrid::CollisionEnvHybrid(
 
 CollisionEnvHybrid::CollisionEnvHybrid(
     const moveit::core::RobotModelConstPtr& robot_model, const WorldPtr& world,
-    const std::map<std::string, std::vector<CollisionSphere>>& link_body_decompositions, double size_x, double size_y,
+    const std::map<std::string, CollisionSphere::AlignedVector>& link_body_decompositions, double size_x, double size_y,
     double size_z, const Eigen::Vector3d& origin, bool use_signed_distance_field, double resolution,
     double collision_tolerance, double max_propogation_distance, double padding, double scale)
   : CollisionEnvFCL(robot_model, world, padding, scale)

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -84,7 +84,7 @@ protected:
 
     acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 
-    std::map<std::string, std::vector<collision_detection::CollisionSphere>> link_body_decompositions;
+    std::map<std::string, collision_detection::CollisionSphere::AlignedVector> link_body_decompositions;
     cenv_.reset(new DefaultCEnvType(robot_model_, link_body_decompositions));
   }
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -292,6 +292,8 @@ MOVEIT_CLASS_FORWARD(IKConstraintSampler);
 class IKConstraintSampler : public ConstraintSampler
 {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   /**
    * \brief Constructor
    *

--- a/moveit_core/robot_state/test/robot_state_benchmark.cpp
+++ b/moveit_core/robot_state/test/robot_state_benchmark.cpp
@@ -86,7 +86,6 @@ protected:
   }
 
 public:
-  const Eigen::Isometry3d id = Eigen::Isometry3d::Identity();
   // put transforms into a vector to avoid compiler optimization on variables
   EigenSTL::vector_Isometry3d transforms_;
   volatile size_t result_idx_ = 0;

--- a/moveit_core/utils/include/moveit/utils/aligned_make_shared.h
+++ b/moveit_core/utils/include/moveit/utils/aligned_make_shared.h
@@ -1,0 +1,58 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, RWTH Aachen University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/** Author: Bjarne von Horn */
+
+#pragma once
+
+#include <memory>
+#include <Eigen/Core>
+
+namespace moveit
+{
+namespace core
+{
+/**
+ * \brief memory-aligned version of std::make_shared
+ * This function uses Eigen::aligned_allocator to provide a memory-aligned shared_ptr
+ */
+template <class T, class... Args>
+::std::shared_ptr<T> aligned_make_shared(Args&&... args)
+{
+  // class for allocator must not be const
+  typedef typename std::remove_const<T>::type T_nc;
+  return ::std::allocate_shared<T>(::Eigen::aligned_allocator<T_nc>(), ::std::forward<Args>(args)...);
+}
+}  // namespace core
+}  // namespace moveit

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_distance_field_ros_helpers.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_distance_field_ros_helpers.h
@@ -44,7 +44,7 @@ namespace collision_detection
 {
 static inline bool loadLinkBodySphereDecompositions(
     ros::NodeHandle& nh, const planning_models::RobotModelConstPtr& robot_model,
-    std::map<std::string, std::vector<collision_detection::CollisionSphere> >& link_body_spheres)
+    std::map<std::string, collision_detection::CollisionSphere::AlignedVector>& link_body_spheres)
 {
   if (!nh.hasParam("link_spheres"))
   {
@@ -84,12 +84,12 @@ static inline bool loadLinkBodySphereDecompositions(
       if (std::string(spheres) == "none")
       {
         ROS_DEBUG_STREAM("No spheres for " << link);
-        std::vector<collision_detection::CollisionSphere> coll_spheres;
+        collision_detection::CollisionSphere::AlignedVector coll_spheres;
         link_body_spheres[link_spheres[i]["link"]] = coll_spheres;
         continue;
       }
     }
-    std::vector<collision_detection::CollisionSphere> coll_spheres;
+    collision_detection::CollisionSphere::AlignedVector coll_spheres;
     for (int j = 0; j < spheres.size(); j++)
     {
       if (!spheres[j].hasMember("x"))
@@ -124,4 +124,4 @@ static inline bool loadLinkBodySphereDecompositions(
   }
   return true;
 }
-}
+}  // namespace collision_detection

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_robot_distance_field_ros.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/collision_robot_distance_field_ros.h
@@ -55,10 +55,10 @@ public:
     : CollisionRobotDistanceField(robot_model)
   {
     ros::NodeHandle nh;
-    std::map<std::string, std::vector<CollisionSphere> > coll_spheres;
+    std::map<std::string, CollisionSphere::AlignedVector> coll_spheres;
     collision_detection::loadLinkBodySphereDecompositions(nh, getRobotModel(), coll_spheres);
     initialize(coll_spheres, size_x, size_y, size_z, use_signed_distance_field, resolution, collision_tolerance,
                max_propogation_distance);
   }
 };
-}
+}  // namespace collision_detection

--- a/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/hybrid_collision_robot_ros.h
+++ b/moveit_experimental/collision_distance_field_ros/include/collision_distance_field_ros/hybrid_collision_robot_ros.h
@@ -55,10 +55,10 @@ public:
     : CollisionRobotHybrid(robot_model)
   {
     ros::NodeHandle nh;
-    std::map<std::string, std::vector<CollisionSphere> > coll_spheres;
+    std::map<std::string, CollisionSphere::AlignedVector> coll_spheres;
     collision_detection::loadLinkBodySphereDecompositions(nh, getRobotModel(), coll_spheres);
     initializeRobotDistanceField(coll_spheres, size_x, size_y, size_z, use_signed_distance_field, resolution,
                                  collision_tolerance, max_propogation_distance);
   }
 };
-}
+}  // namespace collision_detection

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -60,6 +60,7 @@ namespace moveit_jog_arm
 // Inherit from a mutex so the struct can be locked/unlocked easily
 struct JogArmShared : public std::mutex
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   geometry_msgs::TwistStamped command_deltas;
 
   control_msgs::JointJog joint_command_deltas;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -56,6 +56,7 @@ namespace moveit_jog_arm
 class JogCalcs
 {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   JogCalcs(const JogArmParameters& parameters, const robot_model_loader::RobotModelLoaderPtr& model_loader_ptr);
 
   void startMainLoop(JogArmShared& shared_variables);

--- a/moveit_planners/trajopt/include/trajopt_interface/problem_description.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/problem_description.h
@@ -262,7 +262,7 @@ private:
 */
 struct CartPoseTermInfo : public TermInfo
 {
-  //  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /** @brief Timestep at which to apply term */
   int timestep;


### PR DESCRIPTION
### Description

According to the [Eigen docs](http://eigen.tuxfamily.org/dox-devel/group__TopicFixedSizeVectorizable.html), fixed-size Eigen members which sizes are a multiple of 16 have to be memory-aligned to be vectorized. Related issues: #1385, #1902

For instances on the stack, the alignment  is expressed in the Eigen classes (probably with `alignas` and friends), the compiler then adds padding to classes which have Eigen members. So this works out of the box, no changes needed. <del>`alignas(EIGEN_MAX_ALIGN_BYTES)` (There is a bunch of macros in Eigen, so I don't know if that's the correct one). </del> In addition, dynamic allocation on the heap requires a custom allocator, provided by Eigen (`Eigen::aligned_allocator<T>`).
IMPORTANT: If these classes are stored in a container, e.g. `std::vector`, the aligned allocator has to be used too.

Furthermore, `std::make_shared` (which creates a shared pointer to a new instance) also does not respect the alignment. This PR provides <del>template specializations</del> the function `aligned_make_shared()` which behaves like `std::make_shared` but with alignment.

<del>To be done: Verify that all containers containing aligned classes use the aligned allocator.</del>

To be discussed: CPU Extensions like AVX512 require further alignment than 16 bytes, the value of the Eigen memory macros depend on the platform. So, alignment issues could occur if Eigen Objects are passed between libraries which were compiled on different platforms. The alignment has to be the same in all compilation units, for example by adding and exporting some Eigen macro definitions in CMakeLists.txt.
So far, I discovered that both `EIGEN_MAX_STATIC_ALIGN_BYTES` and `EIGEN_MAX_ALIGN_BYTES` need to be defined to the same value (16, 32, 64) to hide the platform.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
