### PR TITLE
run shadow-fixed for main branches only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ jobs:
       env: TEST=clang-tidy-fix
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
-           ROS_REPO=ros-shadow-fixed
+    - if: branch =~ /^(.*-devel|master)$/
+      env: ROS_REPO=ros-shadow-fixed
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci


### PR DESCRIPTION
Followup to #2003 .

I disapprove of shadow-fixed as a required CI check. Yes, we want to know about problems with shadow-fixed early, but not at the cost of contributors who see their jobs failing for no reason.

Instead, this pull-request adds a conditional job for the main branches only, so we still notice breakage after merge.

Here's my playground travis [with the additional job](https://travis-ci.com/github/v4hn/moveit/builds/158638495) and [without it for other branches](https://travis-ci.com/github/v4hn/moveit/builds/158638459).

Receiving email notifications for this particular job, [@rhaschke was worried](https://github.com/ros-planning/moveit/pull/2003#issuecomment-609445786), is not a problem in my opinion. All main web page on GitHub related to MoveIt as well as its travis pages will show a red indicator if the main job breaks.

In addition to this job for new commits, [@gavanderhoorn](https://github.com/ros-planning/moveit/pull/2003#issuecomment-607216991) proposed to add a cron entry on travis.
This acts as a rebuild of the same commit and failure will show up the same way as for new commits.
We can just add the cron build on their web page once this is merged.
We can set it to `Do not run if there has been a build in the last 24 hours` and run it for the main development branches.

We could also further restrict the cron build jobs to shadow-fixed only, but I'm not sure that would play well with the associated update of the commit status. If some other job failed, cron might override the overall status if we do not run all jobs.