### PR TITLE
Revert "display robot state: do not clutter rviz with default robot o…

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -371,6 +371,7 @@ void RobotStateDisplay::loadRobotModel()
 
     changedEnableVisualVisible();
     changedEnableCollisionVisible();
+    robot_->setVisible(true);
   }
   else
     setStatus(rviz::StatusProperty::Error, "RobotState", "No Planning Model Loaded");


### PR DESCRIPTION
…n enable"

This reverts commit 73e6c409c097b5a87a1811b8f39263680fda1a9a.

The patch works together with af106bed1f1188ce85b4c7b6558c9d26ea773a65 which is not backported.

We could write a melodic version of this without the message change, but I don't think we need to backport this with changes.