### PR TITLE
fix param logic bug for self- and scene-collision proximity thresholds

### DIFF
--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -104,9 +104,15 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
                             "'self_collision_proximity_threshold' and 'scene_collision_proximity_threshold' "
                             "parameters. Please update the jogging yaml file.");
     if (!have_self_collision_proximity_threshold)
+    {
       ros_parameters_.self_collision_proximity_threshold;
+      have_self_collision_proximity_threshold = true;
+    }
     if (!have_scene_collision_proximity_threshold)
+    {
       ros_parameters_.scene_collision_proximity_threshold;
+      have_scene_collision_proximity_threshold = true;
+    }
   }
   error += !(have_self_collision_proximity_threshold && have_scene_collision_proximity_threshold);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/move_group_name", ros_parameters_.move_group_name);

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -114,7 +114,8 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
       have_scene_collision_proximity_threshold = true;
     }
   }
-  error += !(have_self_collision_proximity_threshold && have_scene_collision_proximity_threshold);
+  error += !have_self_collision_proximity_threshold;
+  error += !have_scene_collision_proximity_threshold;
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/move_group_name", ros_parameters_.move_group_name);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/planning_frame", ros_parameters_.planning_frame);
   error += !rosparam_shortcuts::get("", n, parameter_ns + "/use_gazebo", ros_parameters_.use_gazebo);

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -91,10 +91,10 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
   // parameter was removed, replaced with separate self- and scene-collision proximity thresholds; if old parameter
   // exists, print warning and use old parameter for both new parameter values
   // TODO(JStech): remove this deprecation warning in ROS Noetic
-  if (!rosparam_shortcuts::get("", n, parameter_ns + "/self_collision_proximity_threshold",
-                               ros_parameters_.self_collision_proximity_threshold) &&
-      !rosparam_shortcuts::get("", n, parameter_ns + "/scene_collision_proximity_threshold",
-                               ros_parameters_.scene_collision_proximity_threshold))
+  if (!(rosparam_shortcuts::get("", n, parameter_ns + "/self_collision_proximity_threshold",
+                                ros_parameters_.self_collision_proximity_threshold) &&
+        rosparam_shortcuts::get("", n, parameter_ns + "/scene_collision_proximity_threshold",
+                                ros_parameters_.scene_collision_proximity_threshold)))
   {
     if (rosparam_shortcuts::get("", n, parameter_ns + "/collision_proximity_threshold",
                                 ros_parameters_.self_collision_proximity_threshold))

--- a/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_interface_base.cpp
@@ -105,12 +105,12 @@ bool JogInterfaceBase::readParameters(ros::NodeHandle& n)
                             "parameters. Please update the jogging yaml file.");
     if (!have_self_collision_proximity_threshold)
     {
-      ros_parameters_.self_collision_proximity_threshold;
+      ros_parameters_.self_collision_proximity_threshold = collision_proximity_threshold;
       have_self_collision_proximity_threshold = true;
     }
     if (!have_scene_collision_proximity_threshold)
     {
-      ros_parameters_.scene_collision_proximity_threshold;
+      ros_parameters_.scene_collision_proximity_threshold = collision_proximity_threshold;
       have_scene_collision_proximity_threshold = true;
     }
   }

--- a/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
@@ -53,4 +53,5 @@ command_out_topic: jog_server/command # Publish outgoing commands here
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
+self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
+scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]


### PR DESCRIPTION
### Description

This is a fix to a logic error in my PR that was just merged (#2008). I had `!A && !B` where `!(A && B)` is correct.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
