### PR TITLE
Allow dynamic adjustment of the low-pass filter

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_data.h
@@ -40,6 +40,7 @@
 
 // System
 #include <mutex>
+#include <boost/lockfree/queue.hpp>  // boost::lockfree::queue, share data in a lock-free way
 #include <thread>
 
 // Eigen
@@ -101,6 +102,9 @@ struct JogArmShared : public std::mutex
 
   // Stop jog loop threads - threads are not stopped by default
   std::atomic<bool> stop_requested{ false };
+
+  // Use a lock-free queue to update filter coefficients from other threads
+  boost::lockfree::queue<double> filter_coefficient_queue;
 };
 
 // ROS params to be read. See the yaml file in /config for a description of each.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -129,7 +129,7 @@ protected:
   trajectory_msgs::JointTrajectory composeJointTrajMessage(sensor_msgs::JointState& joint_state) const;
 
   /** \brief Smooth position commands with a lowpass filter */
-  void lowPassFilterPositions(sensor_msgs::JointState& joint_state);
+  void lowPassFilterPositions(sensor_msgs::JointState& joint_state, JogArmShared& shared_variables);
 
   /** \brief Convert an incremental position command to joint velocity message */
   void calculateJointVelocities(sensor_msgs::JointState& joint_state, const Eigen::ArrayXd& delta_theta);
@@ -137,7 +137,7 @@ protected:
   /** \brief Convert joint deltas to an outgoing JointTrajectory command.
     * This happens for joint commands and Cartesian commands.
     */
-  bool convertDeltasToOutgoingCmd();
+  bool convertDeltasToOutgoingCmd(JogArmShared& shared_variables);
 
   /** \brief Gazebo simulations have very strict message timestamp requirements.
    * Satisfy Gazebo by stuffing multiple messages into one.
@@ -152,6 +152,13 @@ protected:
    * @param row_to_remove Dimension that will be allowed to drift, e.g. row_to_remove = 2 allows z-translation drift.
    */
   void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, unsigned int row_to_remove);
+
+  /**
+   * Update the filter coefficient to change the degree of smoothing.
+   *
+   * @param new_filter_coeff Must be greater than 1. A larger number will cause more smoothing but a longer delay.
+   */
+  void updateFilterCoeff(double new_filter_coeff);
 
   const moveit::core::JointModelGroup* joint_model_group_;
 

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_cpp_interface.h
@@ -94,6 +94,15 @@ public:
    */
   StatusCode getJoggerStatus();
 
+  /**
+   * Update the low-pass filter coefficients for all joints.
+   * The new coefficient should be > 1.
+   * A larger number will cause more smoothing but a longer delay.
+   *
+   * @return true for no error.
+   */
+  bool updateLowPassFilterCoefficients(double new_filter_coefficient);
+
 private:
   ros::NodeHandle nh_;
 };

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/low_pass_filter.h
@@ -57,13 +57,14 @@ public:
   explicit LowPassFilter(double low_pass_filter_coeff);
   double filter(double new_measurement);
   void reset(double data);
+  void updateFilterCoeff(double new_filter_coeff);
 
 private:
   static constexpr std::size_t FILTER_LENGTH = 2;
   double previous_measurements_[FILTER_LENGTH];
   double previous_filtered_measurement_;
-  // Scale and feedback term are calculated from supplied filter coefficient
-  const double scale_term_;
-  const double feedback_term_;
+  // Scale and feedback term are calculated from supplied filter coefficient.
+  double scale_term_;
+  double feedback_term_;
 };
 }  // namespace moveit_jog_arm

--- a/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_cpp_interface.cpp
@@ -229,4 +229,14 @@ StatusCode JogCppInterface::getJoggerStatus()
 {
   return shared_variables_.status;
 }
+
+bool JogCppInterface::updateLowPassFilterCoefficients(double new_filter_coefficient)
+{
+  if (!jog_calcs_)
+    return false;
+
+  shared_variables_.filter_coefficient_queue.push(new_filter_coefficient);
+
+  return true;
+}
 }  // namespace moveit_jog_arm


### PR DESCRIPTION
So that you can adjust the degree of smoothing on the fly.

It also fixes a nasty bug where the low-pass-filtered positions weren't updated if jog commands stopped coming in. That fix is at jog_calcs.cpp L205