### PR TITLE
Display subframes in Rviz plugin

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -177,7 +177,7 @@ static QString decideStatusText(const collision_detection::CollisionEnv::ObjectC
     }
     status_text += ".";
   }
-  if (obj->subframe_poses_.size() > 0)
+  if (!obj->subframe_poses_.empty())
   {
     status_text += "\nIt has the subframes '";
     for (auto subframe : obj->subframe_poses_)
@@ -194,7 +194,7 @@ static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
 {
   QString status_text = "'" + QString::fromStdString(attached_body->getName()) + "' is attached to '" +
                         QString::fromStdString(attached_body->getAttachedLinkName()) + "'.";
-  if (attached_body->getSubframeTransforms().size() > 0)
+  if (!attached_body->getSubframeTransforms().empty())
   {
     status_text += "\nIt has the subframes '";
     for (auto ab : attached_body->getSubframeTransforms())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -67,6 +67,7 @@ QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subfra
   }
   status_text.chop(3);
   status_text += ".";
+  return status_text;
 }
 }  // namespace
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -56,6 +56,20 @@
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
+namespace
+{
+QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subframes)
+{
+  QString status_text = "\nIt has the subframes '";
+  for (auto subframe : subframes)
+  {
+    status_text += QString::fromStdString(subframe.first) + "', '";
+  }
+  status_text.chop(3);
+  status_text += ".";
+}
+}  // namespace
+
 namespace moveit_rviz_plugin
 {
 void MotionPlanningFrame::importFileButtonClicked()
@@ -179,13 +193,7 @@ static QString decideStatusText(const collision_detection::CollisionEnv::ObjectC
   }
   if (!obj->subframe_poses_.empty())
   {
-    status_text += "\nIt has the subframes '";
-    for (auto subframe : obj->subframe_poses_)
-    {
-      status_text += QString::fromStdString(subframe.first) + "', '";
-    }
-    status_text.chop(3);
-    status_text += ".";
+    status_text += subframe_poses_to_qstring(obj->subframe_poses_);
   }
   return status_text;
 }
@@ -196,13 +204,7 @@ static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
                         QString::fromStdString(attached_body->getAttachedLinkName()) + "'.";
   if (!attached_body->getSubframeTransforms().empty())
   {
-    status_text += "\nIt has the subframes '";
-    for (auto ab : attached_body->getSubframeTransforms())
-    {
-      status_text += QString::fromStdString(ab.first) + "', '";
-    }
-    status_text.chop(3);
-    status_text += ".";
+    status_text += subframe_poses_to_qstring(attached_body->getSubframeTransforms());
   }
   return status_text;
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -175,6 +175,17 @@ static QString decideStatusText(const collision_detection::CollisionEnv::ObjectC
       for (const QString& shape_name : shape_names)
         status_text += " " + shape_name;
     }
+    status_text += ".";
+  }
+  if (obj->subframe_poses_.size() > 0)
+  {
+    status_text += "\nIt has the subframes '";
+    for (auto subframe : obj->subframe_poses_)
+    {
+      status_text += QString::fromStdString(subframe.first) + "', '";
+    }
+    status_text.chop(3);
+    status_text += ".";
   }
   return status_text;
 }
@@ -182,7 +193,17 @@ static QString decideStatusText(const collision_detection::CollisionEnv::ObjectC
 static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
 {
   QString status_text = "'" + QString::fromStdString(attached_body->getName()) + "' is attached to '" +
-                        QString::fromStdString(attached_body->getAttachedLinkName()) + "'";
+                        QString::fromStdString(attached_body->getAttachedLinkName()) + "'.";
+  if (attached_body->getSubframeTransforms().size() > 0)
+  {
+    status_text += "\nIt has the subframes '";
+    for (auto ab : attached_body->getSubframeTransforms())
+    {
+      status_text += QString::fromStdString(ab.first) + "', '";
+    }
+    status_text.chop(3);
+    status_text += ".";
+  }
   return status_text;
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -938,37 +938,9 @@
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
        <item row="0" column="1">
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="title">
-          <string>Object Status</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_12">
-          <item>
-           <widget class="QLabel" name="object_status">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <property name="text">
-             <string>Status</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::AutoText</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="1">
         <widget class="QGroupBox" name="pose_scale_group_box">
          <property name="title">
-          <string>Manage Pose and Scale</string>
+          <string>Change Object Pose and Scale</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
@@ -1126,6 +1098,40 @@
              </widget>
             </item>
            </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Object Status</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_12">
+          <item>
+           <widget class="QLabel" name="object_status">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <property name="text">
+             <string>Status</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::AutoText</enum>
+            </property>
+            <property name="WordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="TextInteractionFlags">
+             <enum>Qt::TextBrowserInteraction</enum>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
This adds the subframes to the text of the Rviz "Scene Objects" panel, makes the text copyable, increases its contrast and places it below the elements that move the selected object. 

![moveit_rviz_plugin](https://user-images.githubusercontent.com/4535737/79322720-2dbdae80-7f48-11ea-9a76-252d733b3506.png)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
