### PR TITLE
commander: python3 fix

### DIFF
--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -587,7 +587,7 @@ class MoveGroupCommandInterpreter(object):
             known_vars = self.get_active_group().get_remembered_joint_values().keys()
             known_constr = self.get_active_group().get_known_constraints()
         groups = self._robot.get_group_names()
-        return {'go':['up', 'down', 'left', 'right', 'backward', 'forward', 'random'] + known_vars,
+        return {'go':['up', 'down', 'left', 'right', 'backward', 'forward', 'random'] + list(known_vars),
                 'help':[],
                 'record':known_vars,
                 'show':known_vars,


### PR DESCRIPTION
There is certainly more, but this allows to `use <group>\ngo <named_state>`