### PR TITLE
[test] move_group pick place test

### DIFF
--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -45,6 +45,12 @@ namespace moveit
 {
 namespace core
 {
+namespace
+{
+constexpr size_t STATE_SPACE_DIMENSION = 7;
+
+}  // namespace
+
 FloatingJointModel::FloatingJointModel(const std::string& name) : JointModel(name), angular_distance_weight_(1.0)
 {
   type_ = FLOATING;
@@ -55,7 +61,7 @@ FloatingJointModel::FloatingJointModel(const std::string& name) : JointModel(nam
   local_variable_names_.push_back("rot_y");
   local_variable_names_.push_back("rot_z");
   local_variable_names_.push_back("rot_w");
-  for (int i = 0; i < 7; ++i)
+  for (size_t i = 0; i < STATE_SPACE_DIMENSION; ++i)
   {
     variable_names_.push_back(name_ + "/" + local_variable_names_[i]);
     variable_index_map_[variable_names_.back()] = i;
@@ -192,7 +198,7 @@ bool FloatingJointModel::normalizeRotation(double* values) const
 
 unsigned int FloatingJointModel::getStateSpaceDimension() const
 {
-  return 6;
+  return STATE_SPACE_DIMENSION;
 }
 
 bool FloatingJointModel::enforcePositionBounds(double* values, const Bounds& bounds) const

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -9,6 +9,9 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(move_group_interface_cpp_test move_group_interface_cpp_test.test move_group_interface_cpp_test.cpp)
   target_link_libraries(move_group_interface_cpp_test moveit_move_group_interface ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
 
+  add_rostest_gtest(move_group_pick_place_test move_group_pick_place_test.test move_group_pick_place_test.cpp)
+  target_link_libraries(move_group_pick_place_test moveit_move_group_interface ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
+
   add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
   target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
 

--- a/moveit_ros/planning_interface/test/move_group_pick_place_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_pick_place_test.cpp
@@ -1,0 +1,290 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2020, Tyler Weaver
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of PickNik Robotics nor the
+*     names of its contributors may be used to endorse or promote
+*     products derived from this software without specific prior
+*     written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Tyler Weaver */
+
+/* These integration tests are based on the tutorials for using move_group to do a pick and place:
+ * https://ros-planning.github.io/moveit_tutorials/doc/pick_place/pick_place_tutorial.html
+ */
+
+// C++
+#include <vector>
+
+// ROS
+#include <ros/ros.h>
+
+// The Testing Framework and Utils
+#include <gtest/gtest.h>
+
+// MoveIt
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+
+// TF2
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+static const std::string PLANNING_GROUP = "panda_arm";
+constexpr double PLANNING_TIME_S = 45.0;
+constexpr double MAX_VELOCITY_SCALE = 1.0;
+constexpr double MAX_ACCELERATION_SCALE = 1.0;
+
+class PickPlaceTestFixture : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    nh_ = ros::NodeHandle("/move_group_pick_place_test");
+    move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(PLANNING_GROUP);
+
+    // set velocity and acceleration scaling factors (full speed)
+    move_group_->setMaxVelocityScalingFactor(MAX_VELOCITY_SCALE);
+    move_group_->setMaxAccelerationScalingFactor(MAX_ACCELERATION_SCALE);
+
+    // allow more time for planning
+    move_group_->setPlanningTime(PLANNING_TIME_S);
+  }
+
+protected:
+  ros::NodeHandle nh_;
+  moveit::planning_interface::MoveGroupInterfacePtr move_group_;
+  moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
+};
+
+TEST_F(PickPlaceTestFixture, PickPlaceTest)
+{
+  // Create vector to hold 3 collision objects.
+  std::vector<moveit_msgs::CollisionObject> collision_objects;
+  collision_objects.resize(3);
+
+  // Add the first table where the cube will originally be kept.
+  collision_objects[0].id = "table1";
+  collision_objects[0].header.frame_id = "panda_link0";
+
+  /* Create identity rotation quaternion */
+  tf2::Quaternion zero_orientation;
+  zero_orientation.setRPY(0, 0, 0);
+  geometry_msgs::Quaternion zero_orientation_msg = tf2::toMsg(zero_orientation);
+
+  /* Define the primitive and its dimensions. */
+  collision_objects[0].primitives.resize(1);
+  collision_objects[0].primitives[0].type = collision_objects[0].primitives[0].BOX;
+  collision_objects[0].primitives[0].dimensions.resize(3);
+  collision_objects[0].primitives[0].dimensions[0] = 0.2;
+  collision_objects[0].primitives[0].dimensions[1] = 0.4;
+  collision_objects[0].primitives[0].dimensions[2] = 0.4;
+
+  /* Define the pose of the table. */
+  collision_objects[0].primitive_poses.resize(1);
+  collision_objects[0].primitive_poses[0].position.x = 0.5;
+  collision_objects[0].primitive_poses[0].position.y = 0;
+  collision_objects[0].primitive_poses[0].position.z = 0.2;
+  collision_objects[0].primitive_poses[0].orientation = zero_orientation_msg;
+
+  collision_objects[0].operation = collision_objects[0].ADD;
+
+  // Add the second table where we will be placing the cube.
+  collision_objects[1].id = "table2";
+  collision_objects[1].header.frame_id = "panda_link0";
+
+  /* Define the primitive and its dimensions. */
+  collision_objects[1].primitives.resize(1);
+  collision_objects[1].primitives[0].type = collision_objects[1].primitives[0].BOX;
+  collision_objects[1].primitives[0].dimensions.resize(3);
+  collision_objects[1].primitives[0].dimensions[0] = 0.4;
+  collision_objects[1].primitives[0].dimensions[1] = 0.2;
+  collision_objects[1].primitives[0].dimensions[2] = 0.4;
+
+  /* Define the pose of the table. */
+  collision_objects[1].primitive_poses.resize(1);
+  collision_objects[1].primitive_poses[0].position.x = 0;
+  collision_objects[1].primitive_poses[0].position.y = 0.5;
+  collision_objects[1].primitive_poses[0].position.z = 0.2;
+  collision_objects[1].primitive_poses[0].orientation = zero_orientation_msg;
+
+  collision_objects[1].operation = collision_objects[1].ADD;
+
+  // Define the object that we will be manipulating
+  collision_objects[2].header.frame_id = "panda_link0";
+  collision_objects[2].id = "object";
+
+  /* Define the primitive and its dimensions. */
+  collision_objects[2].primitives.resize(1);
+  collision_objects[2].primitives[0].type = collision_objects[1].primitives[0].BOX;
+  collision_objects[2].primitives[0].dimensions.resize(3);
+  collision_objects[2].primitives[0].dimensions[0] = 0.02;
+  collision_objects[2].primitives[0].dimensions[1] = 0.02;
+  collision_objects[2].primitives[0].dimensions[2] = 0.2;
+
+  /* Define the pose of the object. */
+  collision_objects[2].primitive_poses.resize(1);
+  collision_objects[2].primitive_poses[0].position.x = 0.5;
+  collision_objects[2].primitive_poses[0].position.y = 0;
+  collision_objects[2].primitive_poses[0].position.z = 0.5;
+  collision_objects[2].primitive_poses[0].orientation = zero_orientation_msg;
+
+  collision_objects[2].operation = collision_objects[2].ADD;
+
+  planning_scene_interface_.applyCollisionObjects(collision_objects);
+
+  // Create a vector of grasps to be attempted, currently only creating single grasp.
+  // This is essentially useful when using a grasp generator to generate and test multiple grasps.
+  std::vector<moveit_msgs::Grasp> grasps;
+  grasps.resize(1);
+
+  // Setting grasp pose
+  // ++++++++++++++++++++++
+  // This is the pose of panda_link8. |br|
+  // Make sure that when you set the grasp_pose, you are setting it to be the pose of the last link in
+  // your manipulator which in this case would be `"panda_link8"` You will have to compensate for the
+  // transform from `"panda_link8"` to the palm of the end effector.
+  grasps[0].grasp_pose.header.frame_id = "panda_link0";
+  tf2::Quaternion grasp_orientation;
+  grasp_orientation.setRPY(-M_PI / 2, -M_PI / 4, -M_PI / 2);
+  grasps[0].grasp_pose.pose.orientation = tf2::toMsg(grasp_orientation);
+  grasps[0].grasp_pose.pose.position.x = 0.415;
+  grasps[0].grasp_pose.pose.position.y = 0;
+  grasps[0].grasp_pose.pose.position.z = 0.5;
+
+  // Setting pre-grasp approach
+  // ++++++++++++++++++++++++++
+  /* Defined with respect to frame_id */
+  grasps[0].pre_grasp_approach.direction.header.frame_id = "panda_link0";
+  /* Direction is set as positive x axis */
+  grasps[0].pre_grasp_approach.direction.vector.x = 1.0;
+  grasps[0].pre_grasp_approach.min_distance = 0.095;
+  grasps[0].pre_grasp_approach.desired_distance = 0.115;
+
+  // Setting post-grasp retreat
+  // ++++++++++++++++++++++++++
+  /* Defined with respect to frame_id */
+  grasps[0].post_grasp_retreat.direction.header.frame_id = "panda_link0";
+  /* Direction is set as positive z axis */
+  grasps[0].post_grasp_retreat.direction.vector.z = 1.0;
+  grasps[0].post_grasp_retreat.min_distance = 0.1;
+  grasps[0].post_grasp_retreat.desired_distance = 0.25;
+
+  // Setting posture of eef before grasp
+  // +++++++++++++++++++++++++++++++++++
+  /* Add both finger joints of panda robot. */
+  grasps[0].pre_grasp_posture.joint_names.resize(2);
+  grasps[0].pre_grasp_posture.joint_names[0] = "panda_finger_joint1";
+  grasps[0].pre_grasp_posture.joint_names[1] = "panda_finger_joint2";
+
+  /* Set them as open, wide enough for the object to fit. */
+  grasps[0].pre_grasp_posture.points.resize(1);
+  grasps[0].pre_grasp_posture.points[0].positions.resize(2);
+  grasps[0].pre_grasp_posture.points[0].positions[0] = 0.04;
+  grasps[0].pre_grasp_posture.points[0].positions[1] = 0.04;
+  grasps[0].pre_grasp_posture.points[0].time_from_start = ros::Duration(0.5);
+
+  // Setting posture of eef during grasp
+  // +++++++++++++++++++++++++++++++++++
+  /* Add both finger joints of panda robot and set them as closed. */
+  grasps[0].grasp_posture = grasps[0].pre_grasp_posture;
+  grasps[0].grasp_posture.points[0].positions[0] = 0.00;
+  grasps[0].grasp_posture.points[0].positions[1] = 0.00;
+
+  // Set support surface as table1.
+  move_group_->setSupportSurfaceName("table1");
+  // Call pick to pick up the object using the grasps given
+  ASSERT_EQ(move_group_->pick("object", grasps), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // Ideally, you would create a vector of place locations to be attempted although in this example, we only create
+  // a single place location.
+  std::vector<moveit_msgs::PlaceLocation> place_location;
+  place_location.resize(1);
+
+  // Setting place location pose
+  // +++++++++++++++++++++++++++
+  place_location[0].place_pose.header.frame_id = "panda_link0";
+  tf2::Quaternion place_orientation;
+  place_orientation.setRPY(0, 0, M_PI / 2);
+  place_location[0].place_pose.pose.orientation = tf2::toMsg(place_orientation);
+
+  /* For place location, we set the value to the exact location of the center of the object. */
+  place_location[0].place_pose.pose.position.x = 0;
+  place_location[0].place_pose.pose.position.y = 0.5;
+  place_location[0].place_pose.pose.position.z = 0.5;
+
+  // Setting pre-place approach
+  // ++++++++++++++++++++++++++
+  /* Defined with respect to frame_id */
+  place_location[0].pre_place_approach.direction.header.frame_id = "panda_link0";
+  /* Direction is set as negative z axis */
+  place_location[0].pre_place_approach.direction.vector.z = -1.0;
+  place_location[0].pre_place_approach.min_distance = 0.095;
+  place_location[0].pre_place_approach.desired_distance = 0.115;
+
+  // Setting post-grasp retreat
+  // ++++++++++++++++++++++++++
+  /* Defined with respect to frame_id */
+  place_location[0].post_place_retreat.direction.header.frame_id = "panda_link0";
+  /* Direction is set as negative y axis */
+  place_location[0].post_place_retreat.direction.vector.y = -1.0;
+  place_location[0].post_place_retreat.min_distance = 0.1;
+  place_location[0].post_place_retreat.desired_distance = 0.25;
+
+  // Setting posture of eef after placing object
+  // +++++++++++++++++++++++++++++++++++++++++++
+  /* Similar to the pick case */
+  /* Add both finger joints of panda robot. */
+  place_location[0].post_place_posture.joint_names.resize(2);
+  place_location[0].post_place_posture.joint_names[0] = "panda_finger_joint1";
+  place_location[0].post_place_posture.joint_names[1] = "panda_finger_joint2";
+
+  /* Set them as open, wide enough for the object to fit. */
+  place_location[0].post_place_posture.points.resize(1);
+  place_location[0].post_place_posture.points[0].positions.resize(2);
+  place_location[0].post_place_posture.points[0].positions[0] = 0.04;
+  place_location[0].post_place_posture.points[0].positions[1] = 0.04;
+  place_location[0].post_place_posture.points[0].time_from_start = ros::Duration(0.5);
+
+  // Set support surface as table2.
+  move_group_->setSupportSurfaceName("table2");
+  // Call place to place the object using the place locations given.
+  ASSERT_EQ(move_group_->place("object", place_location), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "move_group_pick_place_test");
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/moveit_ros/planning_interface/test/move_group_pick_place_test.test
+++ b/moveit_ros/planning_interface/test/move_group_pick_place_test.test
@@ -1,0 +1,29 @@
+<launch>
+  <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- If needed, broadcast static tf for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
+
+  <!-- We do not have a robot connected, so publish fake joint states -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+  </node>
+  <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />
+
+  <!-- Given the published joint states, publish tf for the robot links -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+  <!-- Run the main MoveIt executable with fake trajectory execution -->
+  <include file="$(find moveit_resources)/panda_moveit_config/launch/move_group.launch">
+    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="fake_execution" value="true"/>
+    <arg name="info" value="true"/>
+  </include>
+
+  <!-- test -->
+  <test pkg="moveit_ros_planning_interface" type="move_group_pick_place_test" test-name="move_group_pick_place_test"
+        time-limit="60" args=""/>
+</launch>


### PR DESCRIPTION
### Description

Another test for basic functionality from our tutorials to protect the experience of new users.

There is a bunch of hard coded strings and magic numbers for the geometry for this test.  I would appreciate any way to reduce the complexity of the test code.  Most of the code for this was copied from the [tutorial](https://github.com/ros-planning/moveit_tutorials/blob/master/doc/pick_place/src/pick_place_tutorial.cpp) that does the same thing.  @mlautman do you see anyway to reduce the complexity of this test and the tutorial?

The actual test itself is just the return values of the `pick` and `place` method calls in the move_group.  Another potential improvement to this test would be to get the new location of the object that was placed and validate it is in the correct new position.  I'm not sure what the return value of the move_group methods actually mean (I'm assuming it means the trajectory ran without error) and if testing the location of the moved object would be redundant.

The last thing is the tutorial sets the planning time to 45s so I did that here too.  I'm assuming needs to be long because on a debug build (what the codecov build is) planning takes a long time.  Is there a good way to know how long to set this to avoid the test being flaky?

Another thing to point out is that I'm using `moveit_resources` but I have tested this with my PR to update it to the current state of the upstream `panda_moveit_config` which is what the tutorial uses so this test should work after my change to `moveit_resources` is updated.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Moves the CodeCov report in the right direction :arrow_up: :arrow_up: :arrow_up: 