### PR TITLE
PlanningComponent: Load plan_request_params and use it when calling p…

### DIFF
--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -113,11 +113,11 @@ public:
     double max_velocity_scaling_factor;
     double max_acceleration_scaling_factor;
 
-    void load(const ros::NodeHandle& nh, const std::string& default_planning_pipeline)
+    void load(const ros::NodeHandle& nh)
     {
       std::string ns = "plan_request_params/";
       nh.param(ns + "planner_id", planner_id, std::string(""));
-      nh.param(ns + "planning_pipeline", planning_pipeline, default_planning_pipeline);
+      nh.param(ns + "planning_pipeline", planning_pipeline, std::string(""));
       nh.param(ns + "planning_time", planning_attempts, 1);
       nh.param(ns + "planning_attempts", planning_time, 5.0);
       nh.param(ns + "max_velocity_scaling_factor", max_velocity_scaling_factor, 1.0);

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -108,10 +108,21 @@ public:
   {
     std::string planner_id;
     std::string planning_pipeline;
-    size_t planning_attempts;
+    int planning_attempts;
     double planning_time;
     double max_velocity_scaling_factor;
     double max_acceleration_scaling_factor;
+
+    void load(const ros::NodeHandle& nh, const std::string& default_planning_pipeline)
+    {
+      std::string ns = "plan_request_params/";
+      nh.param(ns + "planner_id", planner_id, std::string(""));
+      nh.param(ns + "planning_pipeline", planning_pipeline, default_planning_pipeline);
+      nh.param(ns + "planning_time", planning_attempts, 1);
+      nh.param(ns + "planning_attempts", planning_time, 5.0);
+      nh.param(ns + "max_velocity_scaling_factor", max_velocity_scaling_factor, 1.0);
+      nh.param(ns + "max_acceleration_scaling_factor", max_acceleration_scaling_factor, 1.0);
+    }
   };
 
   /** \brief Constructor */

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -57,9 +57,9 @@ MoveItCpp::MoveItCpp(const ros::NodeHandle& nh, const std::shared_ptr<tf2_ros::B
 {
 }
 
-MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& /*unused*/,
+MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
-  : tf_buffer_(tf_buffer)
+  : tf_buffer_(tf_buffer), node_handle_(nh)
 {
   if (!tf_buffer_)
     tf_buffer_.reset(new tf2_ros::Buffer());

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -81,7 +81,7 @@ PlanningComponent::PlanningComponent(const std::string& group_name, const MoveIt
     throw std::runtime_error(error);
   }
   planning_pipeline_names_ = moveit_cpp_->getPlanningPipelineNames(group_name);
-  plan_request_parameters_.load(nh_, !planning_pipeline_names_.empty() ? *planning_pipeline_names_.begin() : "");
+  plan_request_parameters_.load(nh_);
   ROS_DEBUG_STREAM_NAMED(
       LOGNAME, "Plan request parameters loaded with --"
                    << " planning_pipeline: " << plan_request_parameters_.planning_pipeline << ","

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -81,10 +81,19 @@ PlanningComponent::PlanningComponent(const std::string& group_name, const MoveIt
     throw std::runtime_error(error);
   }
   planning_pipeline_names_ = moveit_cpp_->getPlanningPipelineNames(group_name);
+  plan_request_parameters_.load(nh_, !planning_pipeline_names_.empty() ? *planning_pipeline_names_.begin() : "");
+  ROS_DEBUG_STREAM_NAMED(
+      LOGNAME, "Plan request parameters loaded with --"
+                   << " planning_pipeline: " << plan_request_parameters_.planning_pipeline << ","
+                   << " planner_id: " << plan_request_parameters_.planner_id << ","
+                   << " planning_time: " << plan_request_parameters_.planning_time << ","
+                   << " planning_attempts: " << plan_request_parameters_.planning_attempts << ","
+                   << " max_velocity_scaling_factor: " << plan_request_parameters_.max_velocity_scaling_factor << ","
+                   << " max_acceleration_scaling_factor: " << plan_request_parameters_.max_acceleration_scaling_factor);
 }
 
 PlanningComponent::PlanningComponent(const std::string& group_name, const ros::NodeHandle& nh)
-  : nh_(nh), moveit_cpp_(new MoveItCpp(nh)), group_name_(group_name)
+  : PlanningComponent(group_name, std::make_shared<MoveItCpp>(nh))
 {
 }
 
@@ -138,6 +147,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   ::planning_interface::MotionPlanRequest req;
   req.group_name = group_name_;
   req.planner_id = parameters.planner_id;
+  req.num_planning_attempts = std::max(1, parameters.planning_attempts);
   req.allowed_planning_time = parameters.planning_time;
   req.max_velocity_scaling_factor = parameters.max_velocity_scaling_factor;
   req.max_acceleration_scaling_factor = parameters.max_acceleration_scaling_factor;
@@ -197,14 +207,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
 
 PlanningComponent::PlanSolution PlanningComponent::plan()
 {
-  PlanRequestParameters default_parameters;
-  default_parameters.planning_attempts = 1;
-  default_parameters.planning_time = 5.0;
-  default_parameters.max_velocity_scaling_factor = 1.0;
-  default_parameters.max_acceleration_scaling_factor = 1.0;
-  if (!planning_pipeline_names_.empty())
-    default_parameters.planning_pipeline = *planning_pipeline_names_.begin();
-  return plan(default_parameters);
+  return plan(plan_request_parameters_);
 }
 
 bool PlanningComponent::setStartState(const moveit::core::RobotState& start_state)

--- a/moveit_ros/planning_interface/test/moveit_cpp.yaml
+++ b/moveit_ros/planning_interface/test/moveit_cpp.yaml
@@ -11,7 +11,8 @@ planning_pipelines:
   pipeline_names:
     - ompl
 
-default_planner_options:
+plan_request_params:
   planning_attempts: 1
+  planning_pipeline: ompl
   max_velocity_scaling_factor: 1.0
   max_acceleration_scaling_factor: 1.0


### PR DESCRIPTION
This PR do the following:

1- Load the `plan_request_params` parameters and use them as default when calling `PlanningComponent::plan()` if a parameter is not loaded it uses the previous default value
2- Constructs `MoveItCpp`'s node_handle_ member variable with the input nh
3- It uses delegating constructor when no `MoveItCpp` object is passed to `PlanningComponent`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
