### PR TITLE
Add object pose

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,10 @@
 API changes in MoveIt releases
 
 ## ROS Noetic
+- `CollisionObject` messages are now defined with a `Pose`, and shapes and subframes are defined relative to the object's pose. This makes it easier to place objects with subframes and multiple shapes in the scene. This causes several changes:
+    - `getFrameTransform()` now returns this pose instead of the first shape's pose.
+    - The Rviz plugin's manipulation tab now uses the object's pose instead of the shape pose to evaluate if object's are in the region of interest.
+    - Planning scene geometry text files (`.scene`) have changed format. Add a line `0 0 0 0 0 0 1` under each line with an asterisk to upgrade old files if required.
 - Static member variable interface of the CollisionDetectorAllocatorTemplate for the string NAME was replaced with a virtual method `getName`.
 - RobotModel no longer overrides empty URDF collision geometry by matching the visual geometry of the link.
 - Planned trajectories are *slow* by default.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -153,7 +153,7 @@ TYPED_TEST_P(CollisionDetectorPandaTest, RobotWorldCollision_1)
 
   Eigen::Isometry3d pos1 = Eigen::Isometry3d::Identity();
   pos1.translation().z() = 0.3;
-  this->cenv_->getWorld()->addToObject("box", shape_ptr, pos1);
+  this->cenv_->getWorld()->addToObject("box", pos1, shape_ptr, Eigen::Isometry3d::Identity());
 
   this->cenv_->checkSelfCollision(req, res, *this->robot_state_, *this->acm_);
   ASSERT_FALSE(res.collision);
@@ -186,7 +186,8 @@ TYPED_TEST_P(CollisionDetectorPandaTest, RobotWorldCollision_2)
 
   Eigen::Isometry3d pos1 = Eigen::Isometry3d::Identity();
   pos1.translation().z() = 0.3;
-  this->cenv_->getWorld()->addToObject("box", shape_ptr, pos1);
+  this->cenv_->getWorld()->addToObject("box", pos1, shape_ptr, Eigen::Isometry3d::Identity());
+
   this->cenv_->checkRobotCollision(req, res, *this->robot_state_, *this->acm_);
   ASSERT_TRUE(res.collision);
   ASSERT_GE(res.contact_count, 3u);
@@ -213,7 +214,7 @@ TYPED_TEST_P(CollisionDetectorPandaTest, PaddingTest)
   pos.translation().x() = 0.43;
   pos.translation().y() = 0;
   pos.translation().z() = 0.55;
-  this->cenv_->getWorld()->addToObject("box", shape_ptr, pos);
+  this->cenv_->getWorld()->addToObject("box", pos, shape_ptr, Eigen::Isometry3d::Identity());
 
   this->cenv_->setLinkPadding("panda_hand", 0.08);
   this->cenv_->checkRobotCollision(req, res, *this->robot_state_, *this->acm_);
@@ -250,7 +251,7 @@ TYPED_TEST_P(CollisionDetectorPandaTest, DistanceWorld)
   pos.translation().x() = 0.43;
   pos.translation().y() = 0;
   pos.translation().z() = 0.55;
-  this->cenv_->getWorld()->addToObject("box", shape_ptr, pos);
+  this->cenv_->getWorld()->addToObject("box", pos, shape_ptr, Eigen::Isometry3d::Identity());
 
   this->cenv_->setLinkPadding("panda_hand", 0.0);
   this->cenv_->checkRobotCollision(req, res, *this->robot_state_, *this->acm_);
@@ -287,9 +288,9 @@ TYPED_TEST_P(DistanceCheckPandaTest, DistanceSingle)
     rng.quaternion(quat);
     pose.linear() = Eigen::Quaterniond(quat[0], quat[1], quat[2], quat[3]).toRotationMatrix();
 
-    this->cenv_->getWorld()->addToObject("collection", shape, pose);
+    this->cenv_->getWorld()->addToObject("collection", Eigen::Isometry3d::Identity(), shape, pose);
     this->cenv_->getWorld()->removeObject("object");
-    this->cenv_->getWorld()->addToObject("object", shape, pose);
+    this->cenv_->getWorld()->addToObject("object", pose, shape, Eigen::Isometry3d::Identity());
 
     this->cenv_->distanceRobot(req, res, *this->robot_state_);
     auto& distances1 = res.distances[std::pair<std::string, std::string>("collection", "panda_hand")];

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
@@ -296,7 +296,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
   ASSERT_FALSE(res.collision);
 
   shapes::Shape* shape = new shapes::Box(.1, .1, .1);
-  this->cenv_->getWorld()->addToObject("box", shapes::ShapeConstPtr(shape), pos1);
+  this->cenv_->getWorld()->addToObject("box", pos1, shapes::ShapeConstPtr(shape), Eigen::Isometry3d::Identity());
 
   res = collision_detection::CollisionResult();
   this->cenv_->checkRobotCollision(req, res, robot_state, *this->acm_);
@@ -311,7 +311,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
   shapes.push_back(shapes::ShapeConstPtr(shape));
   poses.push_back(Eigen::Isometry3d::Identity());
   std::vector<std::string> touch_links;
-  robot_state.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("box", poses[0], shapes, poses, touch_links, "r_gripper_palm_link");
 
   res = collision_detection::CollisionResult();
   this->cenv_->checkSelfCollision(req, res, robot_state, *this->acm_);
@@ -323,7 +323,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
   touch_links.push_back("r_gripper_palm_link");
   touch_links.push_back("r_gripper_motor_accelerometer_link");
   shapes[0] = std::make_shared<shapes::Box>(.1, .1, .1);
-  robot_state.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("box", poses[0], shapes, poses, touch_links, "r_gripper_palm_link");
   robot_state.update();
 
   res = collision_detection::CollisionResult();
@@ -332,7 +332,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
 
   pos1.translation().x() = 5.01;
   shapes::Shape* coll = new shapes::Box(.1, .1, .1);
-  this->cenv_->getWorld()->addToObject("coll", shapes::ShapeConstPtr(coll), pos1);
+  this->cenv_->getWorld()->addToObject("coll", pos1, shapes::ShapeConstPtr(coll), Eigen::Isometry3d::Identity());
   res = collision_detection::CollisionResult();
   this->cenv_->checkRobotCollision(req, res, robot_state, *this->acm_);
   ASSERT_TRUE(res.collision);
@@ -372,7 +372,7 @@ TYPED_TEST_P(CollisionDetectorTest, DiffSceneTester)
   poses.push_back(Eigen::Isometry3d::Identity());
 
   std::vector<std::string> touch_links;
-  robot_state.attachBody("kinect", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("kinect", poses[0], shapes, poses, touch_links, "r_gripper_palm_link");
 
   before = ros::WallTime::now();
   new_cenv->checkSelfCollision(req, res, robot_state);
@@ -405,7 +405,7 @@ TYPED_TEST_P(CollisionDetectorTest, ConvertObjectToAttached)
   Eigen::Isometry3d pos2 = Eigen::Isometry3d::Identity();
   pos2.translation().x() = 10.0;
 
-  this->cenv_->getWorld()->addToObject("kinect", shape, pos1);
+  this->cenv_->getWorld()->addToObject("kinect", pos1, shape, Eigen::Isometry3d::Identity());
 
   moveit::core::RobotState robot_state(this->robot_model_);
   robot_state.setToDefaultValues();
@@ -431,13 +431,16 @@ TYPED_TEST_P(CollisionDetectorTest, ConvertObjectToAttached)
   robot_state2.update();
 
   std::vector<std::string> touch_links;
-  robot_state1.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
+  Eigen::Isometry3d identity_transform{ Eigen::Isometry3d::Identity() };
+  robot_state1.attachBody("kinect", identity_transform, object->shapes_, object->shape_poses_, touch_links,
+                          "r_gripper_palm_link");
 
   EigenSTL::vector_Isometry3d other_poses;
   other_poses.push_back(pos2);
 
   // This creates a new set of constant properties for the attached body, which happens to be the same as the one above;
-  robot_state2.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
+  robot_state2.attachBody("kinect", identity_transform, object->shapes_, object->shape_poses_, touch_links,
+                          "r_gripper_palm_link");
 
   // going to take a while, but that's fine
   res = collision_detection::CollisionResult();
@@ -470,7 +473,7 @@ TYPED_TEST_P(CollisionDetectorTest, TestCollisionMapAdditionSpeed)
   ros::WallTime start = ros::WallTime::now();
   this->cenv_->getWorld()->addToObject("map", shapes, poses);
   double t = (ros::WallTime::now() - start).toSec();
-  // TODO: investigate why bullet collision checking is considerably slower here
+  // TODO (j-petit): investigate why bullet collision checking is considerably slower here
   EXPECT_GE(5.0, t);
   // this is not really a failure; it is just that slow;
   // looking into doing collision checking with a voxel grid.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -168,11 +168,12 @@ public:
   const Eigen::Isometry3d& getTransform(const std::string& name, bool& frame_found) const;
 
   /** \brief Get the global transform to a shape of an object with multiple shapes.
-   * shape_number is the index of the object (counting from 0) and needs to be valid. */
+   * shape_index is the index of the object (counting from 0) and needs to be valid.
+   * This function is used to construct the collision environment. */
   const Eigen::Isometry3d& getGlobalShapeTransform(const std::string& object_id, int shape_index) const;
 
-  /** \brief Get the global transform to a shape of an object with multiple shapes.
-   * shape_number is the index of the object (counting from 0) and needs to be valid. */
+  /** \brief Get the global transforms to the shapes of an object.
+   * This function is used to construct the collision environment. */
   const EigenSTL::vector_Isometry3d& getGlobalShapeTransforms(const std::string& object_id) const;
 
   /** \brief Add a pose and shapes to an object in the map.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -78,7 +78,7 @@ public:
   /** \brief A representation of an object */
   struct Object
   {
-    Object(const std::string& id) : id_(id)
+    Object(const std::string& object_id) : id_(object_id)
     {
     }
 
@@ -136,9 +136,9 @@ public:
     return objects_.size();
   }
   /** find changes for a named object */
-  const_iterator find(const std::string& id) const
+  const_iterator find(const std::string& object_id) const
   {
-    return objects_.find(id);
+    return objects_.find(object_id);
   }
 
   /** \brief Check if a particular object exists in the collision world*/
@@ -166,18 +166,19 @@ public:
    *  \note This function does NOT call the addToObject() variant that takes
    * a single shape and a single pose as input. */
   void addToObject(const std::string& object_id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                   const EigenSTL::vector_Isometry3d& poses);
+                   const EigenSTL::vector_Isometry3d& shape_poses);
 
   /** \brief Add a shape to an object.
    * If the object already exists, this call will add the shape to the object
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal(). */
-  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose);
+  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
+                   const Eigen::Isometry3d& shape_pose);
 
   /** \brief Update the pose of a shape in an object. Shape equality is
    * verified by comparing pointers. Returns true on success. */
   bool moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
-                         const Eigen::Isometry3d& pose);
+                         const Eigen::Isometry3d& shape_pose);
 
   /** \brief Move all shapes in an object according to the given transform specified in world frame */
   bool moveObject(const std::string& object_id, const Eigen::Isometry3d& transform);
@@ -283,7 +284,7 @@ private:
 
   /* Add a shape with no checking */
   virtual void addToObjectInternal(const ObjectPtr& obj, const shapes::ShapeConstPtr& shape,
-                                   const Eigen::Isometry3d& pose);
+                                   const Eigen::Isometry3d& shape_pose);
 
   /** The objects maintained in the world */
   std::map<std::string, ObjectPtr> objects_;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -199,7 +199,7 @@ public:
   void addToObject(const std::string& object_id, const Eigen::Isometry3d& pose, const shapes::ShapeConstPtr& shape,
                    const Eigen::Isometry3d& shape_pose)
   {
-    addToObject(object_id, pose, { shape }, { shape_pose });
+    addToObject(object_id, pose, std::vector<shapes::ShapeConstPtr>{ shape }, EigenSTL::vector_Isometry3d{ shape_pose });
   }
 
   /** \brief Add a shape to an object.
@@ -209,7 +209,8 @@ public:
    * shape_pose is defined relative to the object's pose, not to the world frame. */
   void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& shape_pose)
   {
-    addToObject(object_id, Eigen::Isometry3d::Identity(), { shape }, { shape_pose });
+    addToObject(object_id, Eigen::Isometry3d::Identity(), std::vector<shapes::ShapeConstPtr>{ shape },
+                EigenSTL::vector_Isometry3d{ shape_pose });
   }
 
   /** \brief Update the pose of a shape in an object. Shape equality is

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -223,10 +223,8 @@ public:
    */
   bool moveObject(const std::string& object_id, const Eigen::Isometry3d& transform);
 
-  /** \brief Move the object pose (thus moving all shapes and subframes in the object)
-   * to the given transform specified in world frame. The transform replaces the old pose.
-   */
-  bool moveObjectAbsolute(const std::string& object_id, const Eigen::Isometry3d& transform);
+  /** \brief Set the pose of an object. The pose is specified in the world frame. */
+  bool setObjectPose(const std::string& object_id, const Eigen::Isometry3d& pose);
 
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the
@@ -244,9 +242,6 @@ public:
 
   /** \brief Set subframes on an object. The frames are relative to the object pose. */
   bool setSubframesOfObject(const std::string& object_id, const moveit::core::FixedTransformsMap& subframe_poses);
-
-  /** \brief Set the pose of an object. The pose is specified in the world frame. */
-  bool setObjectPose(const std::string& object_id, const Eigen::Isometry3d& pose);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -186,7 +186,10 @@ public:
    * This function makes repeated calls to addToObjectInternal() to add the
    * shapes one by one. */
   void addToObject(const std::string& object_id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                   const EigenSTL::vector_Isometry3d& shape_poses);
+                   const EigenSTL::vector_Isometry3d& shape_poses)
+  {
+    addToObject(object_id, Eigen::Isometry3d::Identity(), shapes, shape_poses);
+  }
 
   /** \brief Add a pose and shape to an object.
    * If the object already exists, this call will add the shape to the object
@@ -194,15 +197,20 @@ public:
    * specified shape is added. This calls addToObjectInternal().
    * shape_pose is defined relative to the object's pose, not to the world frame. */
   void addToObject(const std::string& object_id, const Eigen::Isometry3d& pose, const shapes::ShapeConstPtr& shape,
-                   const Eigen::Isometry3d& shape_pose);
+                   const Eigen::Isometry3d& shape_pose)
+  {
+    addToObject(object_id, pose, { shape }, { shape_pose });
+  }
 
   /** \brief Add a shape to an object.
    * If the object already exists, this call will add the shape to the object
    * at the specified pose. Otherwise, the object is created and the
    * specified shape is added. This calls addToObjectInternal().
    * shape_pose is defined relative to the object's pose, not to the world frame. */
-  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
-                   const Eigen::Isometry3d& shape_pose);
+  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& shape_pose)
+  {
+    addToObject(object_id, Eigen::Isometry3d::Identity(), { shape }, { shape_pose });
+  }
 
   /** \brief Update the pose of a shape in an object. Shape equality is
    * verified by comparing pointers. Returns true on success. */

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -94,40 +94,7 @@ void World::addToObject(const std::string& object_id, const Eigen::Isometry3d& p
   for (std::size_t i = 0; i < shapes.size(); ++i)
     addToObjectInternal(obj, shapes[i], shape_poses[i]);
 
-  updateGlobalPosesInternal(obj, true, false);
   notify(obj, Action(action));
-}
-
-void World::addToObject(const std::string& object_id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                        const EigenSTL::vector_Isometry3d& shape_poses)
-{
-  addToObject(object_id, Eigen::Isometry3d::Identity(), shapes, shape_poses);
-}
-
-void World::addToObject(const std::string& object_id, const Eigen::Isometry3d& pose, const shapes::ShapeConstPtr& shape,
-                        const Eigen::Isometry3d& shape_pose)
-{
-  int action = ADD_SHAPE;
-
-  ObjectPtr& obj = objects_[object_id];
-  if (!obj)
-  {
-    obj = std::make_shared<Object>(object_id);
-    action |= CREATE;
-    obj->pose_ = pose;
-  }
-
-  ensureUnique(obj);
-  addToObjectInternal(obj, shape, shape_pose);
-  updateGlobalPosesInternal(obj, true, false);
-
-  notify(obj, Action(action));
-}
-
-void World::addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
-                        const Eigen::Isometry3d& shape_pose)
-{
-  addToObject(object_id, Eigen::Isometry3d::Identity(), shape, shape_pose);
 }
 
 std::vector<std::string> World::getObjectIds() const

--- a/moveit_core/collision_detection/test/test_world.cpp
+++ b/moveit_core/collision_detection/test/test_world.cpp
@@ -443,7 +443,7 @@ TEST(World, ObjectPoseAndSubframes)
   EXPECT_EQ(2.0, obj->shape_poses_[1](2, 3));
 
   // Move object absolute, check object pose
-  world.moveObjectAbsolute("mix1", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)));
+  world.setObjectPose("mix1", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)));
   pose = world.getTransform("mix1", found_ok);
   EXPECT_TRUE(found_ok);
   EXPECT_EQ(1.0, pose(2, 3));  // z

--- a/moveit_core/collision_detection/test/test_world.cpp
+++ b/moveit_core/collision_detection/test/test_world.cpp
@@ -365,6 +365,90 @@ TEST(World, TrackChanges)
   EXPECT_EQ(4, ta3.cnt_);
 }
 
+TEST(World, ObjectPoseAndSubframes)
+{
+  collision_detection::World world;
+
+  TestAction ta;
+  collision_detection::World::ObserverHandle observer_ta;
+  observer_ta = world.addObserver(boost::bind(TrackChangesNotify, &ta, _1, _2));
+
+  // Create shapes
+  shapes::ShapePtr ball(new shapes::Sphere(1.0));
+  shapes::ShapePtr box(new shapes::Box(1, 1, 1));
+  shapes::ShapePtr cyl(new shapes::Cylinder(0.5, 3));  // radius, length
+
+  // Confirm that setting object pose creates an object
+  world.setObjectPose("mix1", Eigen::Isometry3d::Identity());
+
+  EXPECT_EQ(1, ta.cnt_);
+  EXPECT_EQ("mix1", ta.obj_.id_);
+  EXPECT_EQ(collision_detection::World::CREATE, ta.action_);
+
+  // Move multi-shape objects, use object pose, use subframes
+  world.addToObject("mix1", box, Eigen::Isometry3d::Identity());
+  world.addToObject("mix1", cyl, Eigen::Isometry3d(Eigen::Translation3d(0, 0, 2)));
+
+  moveit::core::FixedTransformsMap subframes;
+  subframes["frame1"] = Eigen::Isometry3d(Eigen::Translation3d(0, 0, 2));
+  subframes["frame2"] = Eigen::Isometry3d(Eigen::Translation3d(0, 1, 0));
+  world.setSubframesOfObject("mix1", subframes);
+
+  // Check subframes and shape poses
+  bool found_ok, found_bad;
+  Eigen::Isometry3d pose = world.getTransform("mix1/frame1", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(2.0, pose(2, 3));  // check translation.z
+
+  pose = world.getTransform("mix1/frame2", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(1.0, pose(1, 3));  // check translation.y
+  EXPECT_EQ(0.0, pose(2, 3));  // z
+
+  pose = world.getTransform("mix1/frame3", found_bad);
+  EXPECT_FALSE(found_bad);
+
+  // Set new object pose, check that all shapes and subframes moved
+  world.setObjectPose("mix1", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)));
+
+  pose = world.getTransform("mix1/frame1", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(3.0, pose(2, 3));  // z
+
+  pose = world.getTransform("mix1/frame2", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(1.0, pose(1, 3));  // y
+  EXPECT_EQ(1.0, pose(2, 3));  // z
+
+  pose = world.getGlobalShapeTransform("mix1", 0);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(1.0, pose(2, 3));  // z
+
+  collision_detection::World::ObjectConstPtr obj = world.getObject("mix1");
+  EXPECT_EQ(0.0, obj->shape_poses_[0](2, 3));  // Internal shape poses do *not* change
+  EXPECT_EQ(2.0, obj->shape_poses_[1](2, 3));
+
+  // Shift object, check that object pose changed
+  world.moveObject("mix1", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)));
+
+  pose = world.getTransform("mix1", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(2.0, pose(2, 3));  // z
+
+  pose = world.getTransform("mix1/frame1", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(4.0, pose(2, 3));  // z
+
+  EXPECT_EQ(0.0, obj->shape_poses_[0](2, 3));  // Internal shape poses should still be constant
+  EXPECT_EQ(2.0, obj->shape_poses_[1](2, 3));
+
+  // Move object absolute, check object pose
+  world.moveObjectAbsolute("mix1", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)));
+  pose = world.getTransform("mix1", found_ok);
+  EXPECT_TRUE(found_ok);
+  EXPECT_EQ(1.0, pose(2, 3));  // z
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
@@ -153,7 +153,9 @@ public:
                          const AlignedVector<Eigen::Isometry3d>& shape_poses,
                          const std::vector<CollisionObjectType>& collision_object_types, bool active = true);
 
-  /** \brief Constructor for attached robot objects */
+  /** \brief Constructor for attached robot objects
+   *
+   *  \param shape_poses These poses are in the global (planning) frame */
   CollisionObjectWrapper(const std::string& name, const collision_detection::BodyType& type_id,
                          const std::vector<shapes::ShapeConstPtr>& shapes,
                          const AlignedVector<Eigen::Isometry3d>& shape_poses,

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -259,8 +259,8 @@ void CollisionEnvBullet::addToManager(const World::Object* obj)
   }
 
   collision_detection_bullet::CollisionObjectWrapperPtr cow(new collision_detection_bullet::CollisionObjectWrapper(
-      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_, obj->shape_poses_, collision_object_types,
-      false));
+      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_,
+      getWorld()->getGlobalShapeTransforms(obj->id_), collision_object_types, false));
 
   manager_->addCollisionObject(cow);
   manager_CCD_->addCollisionObject(cow->clone());

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -258,9 +258,9 @@ void CollisionEnvBullet::addToManager(const World::Object* obj)
       collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::USE_SHAPE_TYPE);
   }
 
-  collision_detection_bullet::CollisionObjectWrapperPtr cow(new collision_detection_bullet::CollisionObjectWrapper(
-      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_,
-      getWorld()->getGlobalShapeTransforms(obj->id_), collision_object_types, false));
+  auto cow = std::make_shared<collision_detection_bullet::CollisionObjectWrapper>(
+      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_, obj->global_shape_poses_,
+      collision_object_types, false);
 
   manager_->addCollisionObject(cow);
   manager_CCD_->addCollisionObject(cow->clone());

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -185,8 +185,7 @@ void CollisionEnvFCL::constructFCLObjectWorld(const World::Object* obj, FCLObjec
     FCLGeometryConstPtr g = createCollisionGeometry(obj->shapes_[i], obj);
     if (g)
     {
-      auto co = new fcl::CollisionObjectd(g->collision_geometry_,
-                                          transform2fcl(getWorld()->getGlobalShapeTransform(obj->id_, i)));
+      auto co = new fcl::CollisionObjectd(g->collision_geometry_, transform2fcl(obj->global_shape_poses_[i]));
       fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(co));
       fcl_obj.collision_geometry_.push_back(g);
     }

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -185,7 +185,8 @@ void CollisionEnvFCL::constructFCLObjectWorld(const World::Object* obj, FCLObjec
     FCLGeometryConstPtr g = createCollisionGeometry(obj->shapes_[i], obj);
     if (g)
     {
-      auto co = new fcl::CollisionObjectd(g->collision_geometry_, transform2fcl(obj->shape_poses_[i]));
+      auto co = new fcl::CollisionObjectd(g->collision_geometry_,
+                                          transform2fcl(getWorld()->getGlobalShapeTransform(obj->id_, i)));
       fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(co));
       fcl_obj.collision_geometry_.push_back(g);
     }

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -95,7 +95,7 @@ PosedBodyPointDecompositionVectorPtr getCollisionObjectPointDecomposition(const 
     PosedBodyPointDecompositionPtr pbd(
         new PosedBodyPointDecomposition(getBodyDecompositionCacheEntry(obj.shapes_[i], resolution)));
     ret->addToVector(pbd);
-    ret->updatePose(ret->getSize() - 1, obj.shape_poses_[i]);
+    ret->updatePose(ret->getSize() - 1, obj.global_shape_poses_[i]);
   }
   return ret;
 }

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -1771,8 +1771,8 @@ void CollisionEnvDistanceField::updateDistanceObject(const std::string& id, Dist
       else
       {
         BodyDecompositionConstPtr bd = getBodyDecompositionCacheEntry(shape, resolution_);
-
-        shape_points.push_back(std::make_shared<PosedBodyPointDecomposition>(bd, object->shape_poses_[i]));
+        shape_points.push_back(
+            std::make_shared<PosedBodyPointDecomposition>(bd, getWorld()->getGlobalShapeTransform(id, i)));
       }
 
       add_points.insert(add_points.end(), shape_points.back()->getCollisionPoints().begin(),

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -299,7 +299,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   std::set<std::string> touch_links;
   trajectory_msgs::JointTrajectory empty_state;
   moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", poses[0], shapes, poses, touch_links, empty_state);
 
   robot_state.attachBody(attached_body);
 
@@ -314,7 +314,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   shapes[0] = std::make_shared<shapes::Box>(.1, .1, .1);
 
   moveit::core::AttachedBody* attached_body_1 = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", poses[0], shapes, poses, touch_links, empty_state);
   robot_state.attachBody(attached_body_1);
 
   res = collision_detection::CollisionResult();

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -292,14 +292,15 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   // deletes shape
   cenv_->getWorld()->removeObject("box");
 
+  const auto identity = Eigen::Isometry3d::Identity();
   std::vector<shapes::ShapeConstPtr> shapes;
   EigenSTL::vector_Isometry3d poses;
   shapes.push_back(shapes::ShapeConstPtr(new shapes::Box(.25, .25, .25)));
-  poses.push_back(Eigen::Isometry3d::Identity());
+  poses.push_back(identity);
   std::set<std::string> touch_links;
   trajectory_msgs::JointTrajectory empty_state;
   moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", poses[0], shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
 
   robot_state.attachBody(attached_body);
 
@@ -314,7 +315,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   shapes[0] = std::make_shared<shapes::Box>(.1, .1, .1);
 
   moveit::core::AttachedBody* attached_body_1 = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", poses[0], shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
   robot_state.attachBody(attached_body_1);
 
   res = collision_detection::CollisionResult();

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -974,6 +974,10 @@ private:
   bool processCollisionObjectRemove(const moveit_msgs::CollisionObject& object);
   bool processCollisionObjectMove(const moveit_msgs::CollisionObject& object);
 
+  /* For exporting and importing the planning scene */
+  bool readPoseFromText(std::istream& in, Eigen::Isometry3d& pose) const;
+  void writePoseToText(std::ostream& out, const Eigen::Isometry3d& pose) const;
+
   /** convert Pose msg to Eigen::Isometry, normalizing the quaternion part if necessary. */
   static void poseMsgToEigen(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out);
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -455,8 +455,7 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
       {
         const collision_detection::World::Object& obj = *world_->getObject(it.first);
         scene->world_->removeObject(obj.id_);
-        scene->world_->setObjectPose(obj.id_, obj.pose_);
-        scene->world_->addToObject(obj.id_, obj.shapes_, obj.shape_poses_);
+        scene->world_->addToObject(obj.id_, obj.pose_, obj.shapes_, obj.shape_poses_);
         if (hasObjectColor(it.first))
           scene->setObjectColor(it.first, getObjectColor(it.first));
         if (hasObjectType(it.first))

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1616,11 +1616,12 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
       {
         const moveit::core::AttachedBody* ab = robot_state_->getAttachedBody(object.object.id);
 
-        bool pose_msg_is_populated = (object.object.pose.position.x == 0 && object.object.pose.position.y == 0 &&
-                                      object.object.pose.position.z == 0 && object.object.pose.orientation.x == 0 &&
-                                      object.object.pose.orientation.y == 0 && object.object.pose.orientation.z == 0 &&
-                                      object.object.pose.orientation.w == 0);
-        object_pose_in_link = pose_msg_is_populated ? ab->getPose() : object_pose_in_link;
+        // Allow overriding the body's pose if provided, otherwise keep the old one
+        if (object.object.pose.position.x == 0 && object.object.pose.position.y == 0 &&
+            object.object.pose.position.z == 0 && object.object.pose.orientation.x == 0 &&
+            object.object.pose.orientation.y == 0 && object.object.pose.orientation.z == 0 &&
+            object.object.pose.orientation.w == 0)
+          object_pose_in_link = ab->getPose();  // Keep old pose
 
         shapes.insert(shapes.end(), ab->getShapes().begin(), ab->getShapes().end());
         shape_poses.insert(shape_poses.end(), ab->getShapePoses().begin(), ab->getShapePoses().end());

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1677,11 +1677,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
     // STEP 2+3: Remove the attached object(s) from the RobotState and put them in the world
     for (const moveit::core::AttachedBody* attached_body : attached_bodies)
     {
-      const std::vector<shapes::ShapeConstPtr>& shapes = attached_body->getShapes();
-      const EigenSTL::vector_Isometry3d& shape_poses = attached_body->getShapePoses();
       const std::string& name = attached_body->getName();
-      const Eigen::Isometry3d& pose = attached_body->getGlobalPose();
-
       if (world_->hasObject(name))
         ROS_WARN_NAMED(LOGNAME,
                        "The collision world already has an object with the same name as the body about to be detached. "
@@ -1689,7 +1685,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
                        object.object.id.c_str());
       else
       {
-        world_->addToObject(name, pose, shapes, shape_poses);
+        const Eigen::Isometry3d& pose = attached_body->getGlobalPose();
+        world_->addToObject(name, pose, attached_body->getShapes(), attached_body->getShapePoses());
         world_->setSubframesOfObject(name, attached_body->getSubframes());
         ROS_DEBUG_NAMED(LOGNAME, "Detached object '%s' from link '%s' and added it back in the collision world",
                         name.c_str(), object.link_name.c_str());
@@ -1797,38 +1794,30 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::CollisionObject
   PlanningScene::poseMsgToEigen(object.pose, header_to_pose_transform);
   const Eigen::Isometry3d object_frame_transform = world_to_object_header_transform * header_to_pose_transform;
 
-  world_->setObjectPose(object.id, object_frame_transform);
+  std::vector<shapes::ShapeConstPtr> shapes;
+  EigenSTL::vector_Isometry3d shape_poses;
+  const auto num_shapes = object.primitives.size() + object.meshes.size() + object.planes.size();
+  shapes.reserve(num_shapes);
+  shape_poses.reserve(num_shapes);
+
+  auto append = [&shapes, &shape_poses](shapes::Shape* s, const geometry_msgs::Pose& pose_msg) {
+    if (!s)
+      return;
+    Eigen::Isometry3d pose;
+    PlanningScene::poseMsgToEigen(pose_msg, pose);
+    shapes.emplace_back(shapes::ShapeConstPtr(s));
+    shape_poses.emplace_back(std::move(pose));
+  };
 
   for (std::size_t i = 0; i < object.primitives.size(); ++i)
-  {
-    shapes::Shape* s = shapes::constructShapeFromMsg(object.primitives[i]);
-    if (s)
-    {
-      Eigen::Isometry3d shape_pose;
-      PlanningScene::poseMsgToEigen(object.primitive_poses[i], shape_pose);
-      world_->addToObject(object.id, shapes::ShapeConstPtr(s), shape_pose);
-    }
-  }
+    append(shapes::constructShapeFromMsg(object.primitives[i]), object.primitive_poses[i]);
   for (std::size_t i = 0; i < object.meshes.size(); ++i)
-  {
-    shapes::Shape* s = shapes::constructShapeFromMsg(object.meshes[i]);
-    if (s)
-    {
-      Eigen::Isometry3d shape_pose;
-      PlanningScene::poseMsgToEigen(object.mesh_poses[i], shape_pose);
-      world_->addToObject(object.id, shapes::ShapeConstPtr(s), shape_pose);
-    }
-  }
+    append(shapes::constructShapeFromMsg(object.meshes[i]), object.mesh_poses[i]);
   for (std::size_t i = 0; i < object.planes.size(); ++i)
-  {
-    shapes::Shape* s = shapes::constructShapeFromMsg(object.planes[i]);
-    if (s)
-    {
-      Eigen::Isometry3d shape_pose;
-      PlanningScene::poseMsgToEigen(object.plane_poses[i], shape_pose);
-      world_->addToObject(object.id, shapes::ShapeConstPtr(s), shape_pose);
-    }
-  }
+    append(shapes::constructShapeFromMsg(object.planes[i]), object.plane_poses[i]);
+
+  world_->addToObject(object.id, object_frame_transform, shapes, shape_poses);
+
   if (!object.type.key.empty() || !object.type.db.empty())
     setObjectType(object.id, object.type);
 

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -169,19 +169,25 @@ TEST(PlanningScene, loadGoodSceneGeometry)
   std::istringstream good_scene_geometry;
   good_scene_geometry.str("foobar_scene\n"
                           "* foo\n"
+                          "0 0 0\n"
+                          "0 0 0 1\n"
                           "1\n"
                           "box\n"
                           "2.58 1.36 0.31\n"
                           "1.49257 1.00222 0.170051\n"
                           "0 0 4.16377e-05 1\n"
                           "0 0 1 0.3\n"
+                          "0\n"
                           "* bar\n"
+                          "0 0 0\n"
+                          "0 0 0 1\n"
                           "1\n"
                           "cylinder\n"
                           "0.02 0.0001\n"
                           "0.453709 0.499136 0.355051\n"
                           "0 0 4.16377e-05 1\n"
                           "1 0 0 1\n"
+                          "0\n"
                           ".\n");
   EXPECT_TRUE(ps->loadGeometryFromStream(good_scene_geometry));
   EXPECT_EQ(ps->getName(), "foobar_scene");

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -60,10 +60,11 @@ public:
   /** \brief Construct an attached body for a specified \e link.
    *
    * The name of this body is \e id and it consists of \e shapes that attach to the link by the transforms
-   * \e shape_poses. The set of links that are allowed to be touched by this object is specified by \e touch_links. */
-  AttachedBody(const LinkModel* link, const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-               const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
-               const trajectory_msgs::JointTrajectory& attach_posture,
+   * \e shape_poses. The set of links that are allowed to be touched by this object is specified by \e touch_links.
+   * The shape and subframe poses are relative to the \e pose, and \e pose is relative to the parent link. */
+  AttachedBody(const LinkModel* link, const std::string& id, const Eigen::Isometry3d& pose,
+               const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses,
+               const std::set<std::string>& touch_links, const trajectory_msgs::JointTrajectory& attach_posture,
                const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap());
 
   ~AttachedBody();
@@ -72,6 +73,18 @@ public:
   const std::string& getName() const
   {
     return id_;
+  }
+
+  /** \brief Get the pose of the attached body relative to the parent link */
+  const Eigen::Isometry3d& getPose() const
+  {
+    return pose_;
+  }
+
+  /** \brief Get the pose of the attached body, relative to the world */
+  const Eigen::Isometry3d& getGlobalPose() const
+  {
+    return global_pose_;
   }
 
   /** \brief Get the name of the link this body is attached to */
@@ -92,6 +105,13 @@ public:
     return shapes_;
   }
 
+  /** \brief Get the shape poses (the transforms to the shapes of this body, relative to the pose). The returned
+   *  transforms are guaranteed to be valid isometries. */
+  const EigenSTL::vector_Isometry3d& getShapePoses() const
+  {
+    return shape_poses_;
+  }
+
   /** \brief Get the links that the attached body is allowed to touch */
   const std::set<std::string>& getTouchLinks() const
   {
@@ -99,8 +119,7 @@ public:
   }
 
   /** \brief Return the posture that is necessary for the object to be released, (if any). This is useful for example
-     when storing
-      the configuration of a gripper holding an object */
+     when storing the configuration of a gripper holding an object */
   const trajectory_msgs::JointTrajectory& getDetachPosture() const
   {
     return detach_posture_;
@@ -108,13 +127,21 @@ public:
 
   /** \brief Get the fixed transforms (the transforms to the shapes of this body, relative to the link). The returned
    *  transforms are guaranteed to be valid isometries. */
-  const EigenSTL::vector_Isometry3d& getFixedTransforms() const
+  const EigenSTL::vector_Isometry3d& getShapePosesInLinkFrame() const
   {
-    return shape_poses_;
+    return shape_poses_in_link_frame_;
   }
 
-  /** \brief Get subframes of this object (relative to the link). The returned transforms are guaranteed to be valid
-   *  isometries. */
+  /** \brief Get the fixed transforms (the transforms to the shapes of this body, relative to the link). The returned
+   *  transforms are guaranteed to be valid isometries.
+   * Deprecated. Use getShapePosesInLinkFrame instead. */
+  [[deprecated]] const EigenSTL::vector_Isometry3d& getFixedTransforms() const
+  {
+    return shape_poses_in_link_frame_;
+  }
+
+  /** \brief Get subframes of this object (relative to the object pose). The returned transforms are guaranteed to be
+   * valid isometries. */
   const moveit::core::FixedTransformsMap& getSubframes() const
   {
     return subframe_poses_;
@@ -140,14 +167,21 @@ public:
     subframe_poses_ = subframe_poses;
   }
 
-  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
+  /** \brief Get the fixed transform to a named subframe on this body (relative to the body's pose)
    *
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
 
-  /** \brief Get the fixed transform to a named subframe on this body.
+  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
+   *
+   * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
+   * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
+   * The returned transform is guaranteed to be a valid isometry. */
+  const Eigen::Isometry3d& getSubframeTransformInLinkFrame(const std::string& frame_name, bool* found = nullptr) const;
+
+  /** \brief Get the fixed transform to a named subframe on this body, relative to the world frame.
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
    * The returned transform is guaranteed to be a valid isometry. */
@@ -159,8 +193,8 @@ public:
    * name is "screwdriver"). */
   bool hasSubframeTransform(const std::string& frame_name) const;
 
-  /** \brief Get the global transforms for the collision bodies. The returned transforms are guaranteed to be valid
-   *  isometries. */
+  /** \brief Get the global transforms (in world frame) for the collision bodies. The returned transforms are
+   *  guaranteed to be valid isometries. */
   const EigenSTL::vector_Isometry3d& getGlobalCollisionBodyTransforms() const
   {
     return global_collision_body_transforms_;
@@ -182,11 +216,23 @@ private:
   /** \brief string id for reference */
   std::string id_;
 
+  /** \brief The transform from the parent link to the attached body's pose*/
+  Eigen::Isometry3d pose_;
+
+  /** \brief The transform from the model frame to the attached body's pose  */
+  Eigen::Isometry3d global_pose_;
+
   /** \brief The geometries of the attached body */
   std::vector<shapes::ShapeConstPtr> shapes_;
 
-  /** \brief The constant transforms applied to the link (needs to be specified by user) */
+  /** \brief The transforms from the object's pose to the object's geometries*/
   EigenSTL::vector_Isometry3d shape_poses_;
+
+  /** \brief The transforms from the link to the object's geometries*/
+  EigenSTL::vector_Isometry3d shape_poses_in_link_frame_;
+
+  /** \brief The global transforms for the attached bodies (computed by forward kinematics) */
+  EigenSTL::vector_Isometry3d global_collision_body_transforms_;
 
   /** \brief The set of links this body is allowed to touch */
   std::set<std::string> touch_links_;
@@ -195,10 +241,7 @@ private:
       the configuration of a gripper holding an object */
   trajectory_msgs::JointTrajectory detach_posture_;
 
-  /** \brief The global transforms for these attached bodies (computed by forward kinematics) */
-  EigenSTL::vector_Isometry3d global_collision_body_transforms_;
-
-  /** \brief Transforms to subframes on the object. Transforms are relative to the link. */
+  /** \brief Transforms to subframes on the object, relative to the object's pose. */
   moveit::core::FixedTransformsMap subframe_poses_;
 
   /** \brief Transforms to subframes on the object, relative to the model frame. */

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -60,9 +60,9 @@ public:
   /** \brief Construct an attached body for a specified \e link.
    *
    * The name of this body is \e id and it consists of \e shapes that attach to the link by the transforms
-   * \e attach_trans. The set of links that are allowed to be touched by this object is specified by \e touch_links. */
+   * \e shape_poses. The set of links that are allowed to be touched by this object is specified by \e touch_links. */
   AttachedBody(const LinkModel* link, const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-               const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
+               const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                const trajectory_msgs::JointTrajectory& attach_posture,
                const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap());
 
@@ -110,12 +110,12 @@ public:
    *  transforms are guaranteed to be valid isometries. */
   const EigenSTL::vector_Isometry3d& getFixedTransforms() const
   {
-    return attach_trans_;
+    return shape_poses_;
   }
 
   /** \brief Get subframes of this object (relative to the link). The returned transforms are guaranteed to be valid
    *  isometries. */
-  const moveit::core::FixedTransformsMap& getSubframeTransforms() const
+  const moveit::core::FixedTransformsMap& getSubframes() const
   {
     return subframe_poses_;
   }
@@ -186,7 +186,7 @@ private:
   std::vector<shapes::ShapeConstPtr> shapes_;
 
   /** \brief The constant transforms applied to the link (needs to be specified by user) */
-  EigenSTL::vector_Isometry3d attach_trans_;
+  EigenSTL::vector_Isometry3d shape_poses_;
 
   /** \brief The set of links this body is allowed to touch */
   std::set<std::string> touch_links_;

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1618,7 +1618,7 @@ public:
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
    * @param shapes The shapes that make up the attached body
-   * @param attach_trans The desired transform between this link and the attached body
+   * @param shape_poses The desired transform between this link and the attached body
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
@@ -1640,7 +1640,7 @@ public:
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
    * @param shapes The shapes that make up the attached body
-   * @param attach_trans The desired transform between this link and the attached body
+   * @param shape_poses The desired transform between this link and the attached body
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1617,8 +1617,9 @@ public:
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
+   * @param pose The pose associated with the attached body
    * @param shapes The shapes that make up the attached body
-   * @param shape_poses The desired transform between this link and the attached body
+   * @param shape_poses The transforms between the object pose and the attached body's shapes
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
@@ -1631,16 +1632,17 @@ public:
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
-                  const std::string& link_name,
+  void attachBody(const std::string& id, const Eigen::Isometry3d& pose,
+                  const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses,
+                  const std::set<std::string>& touch_links, const std::string& link_name,
                   const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
                   const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
+   * @param pose The pose associated with the attached body
    * @param shapes The shapes that make up the attached body
-   * @param shape_poses The desired transform between this link and the attached body
+   * @param shape_poses The transforms between the object pose and the attached body's shapes
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
@@ -1653,14 +1655,14 @@ public:
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Isometry3d& shape_poses, const std::vector<std::string>& touch_links,
-                  const std::string& link_name,
+  void attachBody(const std::string& id, const Eigen::Isometry3d& pose,
+                  const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses,
+                  const std::vector<std::string>& touch_links, const std::string& link_name,
                   const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory(),
                   const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap())
   {
     std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
-    attachBody(id, shapes, shape_poses, touch_links_set, link_name, detach_posture, subframe_poses);
+    attachBody(id, pose, shapes, shape_poses, touch_links_set, link_name, detach_posture, subframe_poses);
   }
 
   /** \brief Get all bodies attached to the model corresponding to this state */

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -68,9 +68,7 @@ AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string
     ASSERT_ISOMETRY(t.second)  // unsanitized input, could contain a non-isometry
   }
 
-  // TODO(felixvd): These are initialized as identity because the parent link transform is not
-  //                known to the AttachedBody. Is computeTransform called before they are used?
-  //                Otherwise they will not be correct.
+  // Global poses are initialized to identity to allow efficient Isometry calculations
   global_pose_.setIdentity();
   global_collision_body_transforms_.resize(shape_poses.size());
   for (Eigen::Isometry3d& global_collision_body_transform : global_collision_body_transforms_)

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -43,13 +43,14 @@ namespace moveit
 {
 namespace core
 {
-AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id,
+AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id, const Eigen::Isometry3d& pose,
                            const std::vector<shapes::ShapeConstPtr>& shapes,
                            const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                            const trajectory_msgs::JointTrajectory& detach_posture,
                            const FixedTransformsMap& subframe_poses)
   : parent_link_model_(parent_link_model)
   , id_(id)
+  , pose_(pose)
   , shapes_(shapes)
   , shape_poses_(shape_poses)
   , touch_links_(touch_links)
@@ -57,6 +58,7 @@ AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string
   , subframe_poses_(subframe_poses)
   , global_subframe_poses_(subframe_poses)
 {
+  ASSERT_ISOMETRY(pose)  // unsanitized input, could contain a non-isometry
   for (const auto& t : shape_poses_)
   {
     ASSERT_ISOMETRY(t)  // unsanitized input, could contain a non-isometry
@@ -65,9 +67,21 @@ AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string
   {
     ASSERT_ISOMETRY(t.second)  // unsanitized input, could contain a non-isometry
   }
+
+  // TODO(felixvd): These are initialized as identity because the parent link transform is not
+  //                known to the AttachedBody. Is computeTransform called before they are used?
+  //                Otherwise they will not be correct.
+  global_pose_.setIdentity();
   global_collision_body_transforms_.resize(shape_poses.size());
   for (Eigen::Isometry3d& global_collision_body_transform : global_collision_body_transforms_)
     global_collision_body_transform.setIdentity();
+
+  shape_poses_in_link_frame_.clear();
+  shape_poses_in_link_frame_.reserve(shape_poses_.size());
+  for (const auto& shape_pose : shape_poses_)
+  {
+    shape_poses_in_link_frame_.push_back(pose_ * shape_pose);
+  }
 }
 
 AttachedBody::~AttachedBody() = default;
@@ -92,15 +106,16 @@ void AttachedBody::setScale(double scale)
 void AttachedBody::computeTransform(const Eigen::Isometry3d& parent_link_global_transform)
 {
   ASSERT_ISOMETRY(parent_link_global_transform)  // unsanitized input, could contain a non-isometry
+  global_pose_ = parent_link_global_transform * pose_;
 
   // update collision body transforms
   for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)
-    global_collision_body_transforms_[i] = parent_link_global_transform * shape_poses_[i];  // valid isometry
+    global_collision_body_transforms_[i] = global_pose_ * shape_poses_[i];  // valid isometry
 
   // update subframe transforms
   for (auto global = global_subframe_poses_.begin(), end = global_subframe_poses_.end(), local = subframe_poses_.begin();
        global != end; ++global, ++local)
-    global->second = parent_link_global_transform * local->second;  // valid isometry
+    global->second = global_pose_ * local->second;  // valid isometry
 }
 
 void AttachedBody::setPadding(double padding)

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -45,19 +45,19 @@ namespace core
 {
 AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id,
                            const std::vector<shapes::ShapeConstPtr>& shapes,
-                           const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
+                           const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                            const trajectory_msgs::JointTrajectory& detach_posture,
                            const FixedTransformsMap& subframe_poses)
   : parent_link_model_(parent_link_model)
   , id_(id)
   , shapes_(shapes)
-  , attach_trans_(attach_trans)
+  , shape_poses_(shape_poses)
   , touch_links_(touch_links)
   , detach_posture_(detach_posture)
   , subframe_poses_(subframe_poses)
   , global_subframe_poses_(subframe_poses)
 {
-  for (const auto& t : attach_trans_)
+  for (const auto& t : shape_poses_)
   {
     ASSERT_ISOMETRY(t)  // unsanitized input, could contain a non-isometry
   }
@@ -65,7 +65,7 @@ AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string
   {
     ASSERT_ISOMETRY(t.second)  // unsanitized input, could contain a non-isometry
   }
-  global_collision_body_transforms_.resize(attach_trans.size());
+  global_collision_body_transforms_.resize(shape_poses.size());
   for (Eigen::Isometry3d& global_collision_body_transform : global_collision_body_transforms_)
     global_collision_body_transform.setIdentity();
 }
@@ -95,7 +95,7 @@ void AttachedBody::computeTransform(const Eigen::Isometry3d& parent_link_global_
 
   // update collision body transforms
   for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)
-    global_collision_body_transforms_[i] = parent_link_global_transform * attach_trans_[i];  // valid isometry
+    global_collision_body_transforms_[i] = parent_link_global_transform * shape_poses_[i];  // valid isometry
 
   // update subframe transforms
   for (auto global = global_subframe_poses_.begin(), end = global_subframe_poses_.end(), local = subframe_poses_.begin();

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -267,42 +267,26 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
         tf2::fromMsg(aco.object.pose, object_pose);
 
         std::vector<shapes::ShapeConstPtr> shapes;
-        EigenSTL::vector_Isometry3d poses;
+        EigenSTL::vector_Isometry3d shape_poses;
+        const auto num_shapes = aco.object.primitives.size() + aco.object.meshes.size() + aco.object.planes.size();
+        shapes.reserve(num_shapes);
+        shape_poses.reserve(num_shapes);
+
+        auto append = [&shapes, &shape_poses](shapes::Shape* s, const geometry_msgs::Pose& pose_msg) {
+          if (!s)
+            return;
+          Eigen::Isometry3d pose;
+          tf2::fromMsg(pose_msg, pose);
+          shapes.emplace_back(shapes::ShapeConstPtr(s));
+          shape_poses.emplace_back(std::move(pose));
+        };
 
         for (std::size_t i = 0; i < aco.object.primitives.size(); ++i)
-        {
-          shapes::Shape* s = shapes::constructShapeFromMsg(aco.object.primitives[i]);
-          if (s)
-          {
-            Eigen::Isometry3d p;
-            tf2::fromMsg(aco.object.primitive_poses[i], p);
-            shapes.push_back(shapes::ShapeConstPtr(s));
-            poses.push_back(p);
-          }
-        }
+          append(shapes::constructShapeFromMsg(aco.object.primitives[i]), aco.object.primitive_poses[i]);
         for (std::size_t i = 0; i < aco.object.meshes.size(); ++i)
-        {
-          shapes::Shape* s = shapes::constructShapeFromMsg(aco.object.meshes[i]);
-          if (s)
-          {
-            Eigen::Isometry3d p;
-            tf2::fromMsg(aco.object.mesh_poses[i], p);
-            shapes.push_back(shapes::ShapeConstPtr(s));
-            poses.push_back(p);
-          }
-        }
+          append(shapes::constructShapeFromMsg(aco.object.meshes[i]), aco.object.mesh_poses[i]);
         for (std::size_t i = 0; i < aco.object.planes.size(); ++i)
-        {
-          shapes::Shape* s = shapes::constructShapeFromMsg(aco.object.planes[i]);
-          if (s)
-          {
-            Eigen::Isometry3d p;
-            tf2::fromMsg(aco.object.plane_poses[i], p);
-
-            shapes.push_back(shapes::ShapeConstPtr(s));
-            poses.push_back(p);
-          }
-        }
+          append(shapes::constructShapeFromMsg(aco.object.planes[i]), aco.object.plane_poses[i]);
 
         moveit::core::FixedTransformsMap subframe_poses;
         for (std::size_t i = 0; i < aco.object.subframe_poses.size(); ++i)
@@ -313,7 +297,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           subframe_poses[name] = p;
         }
 
-        // Transform shape poses and subframes to link frame
+        // Transform shape pose to link frame
         if (!Transforms::sameFrame(aco.object.header.frame_id, aco.link_name))
         {
           bool frame_found = false;
@@ -346,7 +330,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
                             "The robot state already had an object named '%s' attached to link '%s'. "
                             "The object was replaced.",
                             aco.object.id.c_str(), aco.link_name.c_str());
-          state.attachBody(aco.object.id, object_pose, shapes, poses, aco.touch_links, aco.link_name,
+          state.attachBody(aco.object.id, object_pose, shapes, shape_poses, aco.touch_links, aco.link_name,
                            aco.detach_posture, subframe_poses);
           ROS_DEBUG_NAMED(LOGNAME, "Attached object '%s' to link '%s'", aco.object.id.c_str(), aco.link_name.c_str());
         }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -219,7 +219,7 @@ static void _attachedBodyToMsg(const AttachedBody& attached_body, moveit_msgs::A
   }
   aco.object.subframe_names.clear();
   aco.object.subframe_poses.clear();
-  for (const auto& frame_pair : attached_body.getSubframeTransforms())
+  for (const auto& frame_pair : attached_body.getSubframes())
   {
     aco.object.subframe_names.push_back(frame_pair.first);
     geometry_msgs::Pose pose;

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -316,8 +316,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
                               aco.object.header.frame_id.c_str());
             }
           }
-          Eigen::Isometry3d t = world_to_header_frame.inverse() * state.getGlobalLinkTransform(lm);
-          object_pose = object_pose * t;
+          object_pose = state.getGlobalLinkTransform(lm).inverse() * world_to_header_frame * object_pose;
         }
 
         if (shapes.empty())

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -173,7 +173,7 @@ void RobotState::copyFrom(const RobotState& other)
   for (const std::pair<const std::string, AttachedBody*>& it : other.attached_body_map_)
     attachBody(it.second->getName(), it.second->getShapes(), it.second->getFixedTransforms(),
                it.second->getTouchLinks(), it.second->getAttachedLinkName(), it.second->getDetachPosture(),
-               it.second->getSubframeTransforms());
+               it.second->getSubframes());
 }
 
 bool RobotState::checkJointTransforms(const JointModel* joint) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1108,7 +1108,7 @@ const Eigen::Isometry3d& RobotState::getFrameInfo(const std::string& frame_id, c
   // Check if an AttachedBody has a subframe with name frame_id
   for (const std::pair<const std::string, AttachedBody*>& body : attached_body_map_)
   {
-    const auto& transform = body.second->getGlobalSubframeTransform(frame_id, &frame_found);
+    const Eigen::Isometry3d& transform = body.second->getGlobalSubframeTransform(frame_id, &frame_found);
     if (frame_found)
     {
       robot_link = body.second->getAttachedLink();
@@ -1584,7 +1584,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
     }
   }
 
-  // Check that no, or only one set of consistency limits have been passed in, and choose that one
+  // Check that no, or only one set of consistency limits has been passed in, and choose that one
   std::vector<double> consistency_limits;
   if (consistency_limit_sets.size() > 1)
   {

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -233,16 +233,17 @@ TEST_F(LoadPlanningModelsPr2, FullTest)
   moveit::core::RobotState ks2(robot_model);
   ks2.setToDefaultValues();
 
+  const auto identity = Eigen::Isometry3d::Identity();
   std::vector<shapes::ShapeConstPtr> shapes;
   EigenSTL::vector_Isometry3d poses;
   shapes::Shape* shape = new shapes::Box(.1, .1, .1);
   shapes.push_back(shapes::ShapeConstPtr(shape));
-  poses.push_back(Eigen::Isometry3d::Identity());
+  poses.push_back(identity);
   std::set<std::string> touch_links;
 
   trajectory_msgs::JointTrajectory empty_state;
   moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_model->getLinkModel("r_gripper_palm_link"), "box", poses[0], shapes, poses, touch_links, empty_state);
+      robot_model->getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
   ks.attachBody(attached_body);
 
   std::vector<const moveit::core::AttachedBody*> attached_bodies_1;

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -68,7 +68,7 @@ struct OrderPlaceLocationQuality
 bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
                                 const moveit::core::AttachedBody* attached_body, geometry_msgs::PoseStamped& place_pose)
 {
-  const EigenSTL::vector_Isometry3d& fixed_transforms = attached_body->getFixedTransforms();
+  const EigenSTL::vector_Isometry3d& fixed_transforms = attached_body->getShapePosesInLinkFrame();
   if (fixed_transforms.empty())
     return false;
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -110,7 +110,7 @@ void TfPublisher::publishPlanningSceneFrames()
         transform.header.frame_id = attached_body->getAttachedLinkName();
         broadcaster.sendTransform(transform);
 
-        const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframeTransforms();
+        const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframes();
         publishSubframes(broadcaster, subframes, object_frame, attached_body->getAttachedLinkName(), stamp);
       }
     }

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -57,7 +57,7 @@ TfPublisher::~TfPublisher()
 namespace
 {
 void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::core::FixedTransformsMap& subframes,
-                      const std::string& parent_object, const std::string& parent_frame, const ros::Time& stamp)
+                      const std::string& parent_object, const ros::Time& stamp)
 {
   geometry_msgs::TransformStamped transform;
   for (auto& subframe : subframes)
@@ -65,7 +65,7 @@ void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::
     transform = tf2::eigenToTransform(subframe.second);
     transform.child_frame_id = parent_object + "/" + subframe.first;
     transform.header.stamp = stamp;
-    transform.header.frame_id = parent_frame;
+    transform.header.frame_id = parent_object;
     broadcaster.sendTransform(transform);
   }
 }
@@ -88,14 +88,14 @@ void TfPublisher::publishPlanningSceneFrames()
       for (const auto& obj : *world)
       {
         std::string object_frame = prefix_ + obj.second->id_;
-        transform = tf2::eigenToTransform(obj.second->shape_poses_[0]);
+        transform = tf2::eigenToTransform(obj.second->pose_);
         transform.child_frame_id = object_frame;
         transform.header.stamp = stamp;
         transform.header.frame_id = planning_frame;
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = obj.second->subframe_poses_;
-        publishSubframes(broadcaster, subframes, object_frame, planning_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
 
       const moveit::core::RobotState& rs = locked_planning_scene->getCurrentState();
@@ -104,14 +104,14 @@ void TfPublisher::publishPlanningSceneFrames()
       for (const moveit::core::AttachedBody* attached_body : attached_collision_objects)
       {
         std::string object_frame = prefix_ + attached_body->getName();
-        transform = tf2::eigenToTransform(attached_body->getFixedTransforms()[0]);
+        transform = tf2::eigenToTransform(attached_body->getPose());
         transform.child_frame_id = object_frame;
         transform.header.stamp = stamp;
         transform.header.frame_id = attached_body->getAttachedLinkName();
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframes();
-        publishSubframes(broadcaster, subframes, object_frame, attached_body->getAttachedLinkName(), stamp);
+        publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
     }
 

--- a/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
@@ -63,6 +63,7 @@ void sendKnife()
   co.id = "knife";
   co.header.stamp = ros::Time::now();
   co.header.frame_id = aco.link_name;
+  co.pose.orientation.w = 1.0;
   co.operation = moveit_msgs::CollisionObject::ADD;
   co.primitives.resize(1);
   co.primitives[0].type = shape_msgs::SolidPrimitive::BOX;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -605,7 +605,7 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningSc
     }
   }
 
-  // if we have a diff, try to more accuratelly determine the update type
+  // if we have a diff, try to more accurately determine the update type
   if (scene.is_diff)
   {
     bool no_other_scene_upd = (scene.name.empty() || scene.name == old_scene_name) &&

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -843,6 +843,7 @@ void PlanningSceneMonitor::excludeWorldObjectFromOctree(const collision_detectio
     occupancy_map_monitor::ShapeHandle h = octomap_monitor_->excludeShape(obj->shapes_[i]);
     if (h)
     {
+      // TODO (felixvd): Do these shape poses have to be in the world frame?
       collision_body_shape_handles_[obj->id_].push_back(std::make_pair(h, &obj->shape_poses_[i]));
       found = true;
     }

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -843,8 +843,7 @@ void PlanningSceneMonitor::excludeWorldObjectFromOctree(const collision_detectio
     occupancy_map_monitor::ShapeHandle h = octomap_monitor_->excludeShape(obj->shapes_[i]);
     if (h)
     {
-      // TODO (felixvd): Do these shape poses have to be in the world frame?
-      collision_body_shape_handles_[obj->id_].push_back(std::make_pair(h, &obj->shape_poses_[i]));
+      collision_body_shape_handles_[obj->id_].push_back(std::make_pair(h, &obj->global_shape_poses_[i]));
       found = true;
     }
   }
@@ -1040,7 +1039,7 @@ bool PlanningSceneMonitor::getShapeTransformCache(const std::string& target_fram
       for (std::size_t k = 0; k < attached_body_shape_handle.second.size(); ++k)
         cache[attached_body_shape_handle.second[k].first] =
             transform *
-            attached_body_shape_handle.first->getFixedTransforms()[attached_body_shape_handle.second[k].second];
+            attached_body_shape_handle.first->getShapePosesInLinkFrame()[attached_body_shape_handle.second[k].second];
     }
     {
       tf_buffer_->canTransform(target_frame, scene_->getPlanningFrame(), target_time,

--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -95,6 +95,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   moveit_msgs::CollisionObject box;
   box.id = "box";
   box.header.frame_id = "panda_hand";
+  box.pose.orientation.w = 1.0;
   box.primitives.resize(1);
   box.primitive_poses.resize(1);
   box.primitives[0].type = box.primitives[0].BOX;
@@ -118,6 +119,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   moveit_msgs::CollisionObject cylinder;
   cylinder.id = "cylinder";
   cylinder.header.frame_id = "panda_hand";
+  cylinder.pose.orientation.w = 1.0;
   cylinder.primitives.resize(1);
   cylinder.primitive_poses.resize(1);
   cylinder.primitives[0].type = box.primitives[0].CYLINDER;
@@ -160,6 +162,7 @@ TEST(TestPlanUsingSubframes, SubframesTests)
   att_coll_object.object.id = "cylinder";
   att_coll_object.link_name = "panda_hand";
   att_coll_object.object.operation = att_coll_object.object.ADD;
+  att_coll_object.object.pose.orientation.w = 1.0;
   planning_scene_interface.applyAttachedCollisionObject(att_coll_object);
 
   tf2::Quaternion target_orientation;

--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -62,6 +62,8 @@ constexpr double EPSILON = 1e-2;
 constexpr double Z_OFFSET = 0.05;
 constexpr double PLANNING_TIME_S = 30.0;
 
+const double TAU = 2 * M_PI;  // One turn (360°) in radians
+
 // Function copied from tutorial
 // a small helper function to create our planning requests and move the robot.
 bool moveToCartPose(const geometry_msgs::PoseStamped& pose, moveit::planning_interface::MoveGroupInterface& group,
@@ -82,20 +84,20 @@ bool moveToCartPose(const geometry_msgs::PoseStamped& pose, moveit::planning_int
   return false;
 }
 
-// Function copied from tutorial
+// Function copied from subframes tutorial
 // This helper function creates two objects and publishes them to the PlanningScene: a box and a cylinder.
 // The box spawns in front of the gripper, the cylinder at the tip of the gripper, as if it had been grasped.
 void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& planning_scene_interface)
 {
-  const std::string log_name = "spawn_collision_objects";
   double z_offset_box = .25;  // The z-axis points away from the gripper
   double z_offset_cylinder = .1;
 
-  // First, we start defining the CollisionObject as usual.
   moveit_msgs::CollisionObject box;
   box.id = "box";
   box.header.frame_id = "panda_hand";
-  box.pose.orientation.w = 1.0;
+  box.pose.position.z = z_offset_box;
+  box.pose.orientation.w = 1.0;  // Neutral orientation
+
   box.primitives.resize(1);
   box.primitive_poses.resize(1);
   box.primitives[0].type = box.primitives[0].BOX;
@@ -103,43 +105,39 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   box.primitives[0].dimensions[0] = 0.05;
   box.primitives[0].dimensions[1] = 0.1;
   box.primitives[0].dimensions[2] = 0.02;
-  box.primitive_poses[0].position.z = z_offset_box;
+  box.primitive_poses[0].orientation.w = 1.0;  // Neutral orientation
 
-  // Then, we define the subframes of the CollisionObject.
   box.subframe_names.resize(1);
   box.subframe_poses.resize(1);
+
   box.subframe_names[0] = "bottom";
   box.subframe_poses[0].position.y = -.05;
-  box.subframe_poses[0].position.z = 0.0 + z_offset_box;
+
   tf2::Quaternion orientation;
-  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
+  orientation.setRPY(TAU / 4.0, 0, 0);  // 1/4 turn
   box.subframe_poses[0].orientation = tf2::toMsg(orientation);
 
   // Next, define the cylinder
   moveit_msgs::CollisionObject cylinder;
   cylinder.id = "cylinder";
   cylinder.header.frame_id = "panda_hand";
-  cylinder.pose.orientation.w = 1.0;
+  cylinder.pose.position.z = z_offset_cylinder;
+  orientation.setRPY(0, TAU / 4.0, 0);
+  cylinder.pose.orientation = tf2::toMsg(orientation);
+
   cylinder.primitives.resize(1);
   cylinder.primitive_poses.resize(1);
   cylinder.primitives[0].type = box.primitives[0].CYLINDER;
   cylinder.primitives[0].dimensions.resize(2);
-  cylinder.primitives[0].dimensions[0] = 0.06;   // height (along x)
-  cylinder.primitives[0].dimensions[1] = 0.005;  // radius
-  cylinder.primitive_poses[0].position.x = 0.0;
-  cylinder.primitive_poses[0].position.y = 0.0;
-  cylinder.primitive_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
-  cylinder.primitive_poses[0].orientation = tf2::toMsg(orientation);
+  cylinder.primitives[0].dimensions[0] = 0.06;      // height (along x)
+  cylinder.primitives[0].dimensions[1] = 0.005;     // radius
+  cylinder.primitive_poses[0].orientation.w = 1.0;  // Neutral orientation
 
   cylinder.subframe_poses.resize(1);
   cylinder.subframe_names.resize(1);
   cylinder.subframe_names[0] = "tip";
-  cylinder.subframe_poses[0].position.x = 0.03;
-  cylinder.subframe_poses[0].position.y = 0.0;
-  cylinder.subframe_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
-  cylinder.subframe_poses[0].orientation = tf2::toMsg(orientation);
+  cylinder.subframe_poses[0].position.z = 0.03;
+  cylinder.subframe_poses[0].orientation.w = 1.0;  // Neutral orientation
 
   // Lastly, the objects are published to the PlanningScene. In this tutorial, we publish a box and a cylinder.
   box.operation = moveit_msgs::CollisionObject::ADD;
@@ -166,7 +164,7 @@ TEST(TestPlanUsingSubframes, SubframesTests)
   planning_scene_interface.applyAttachedCollisionObject(att_coll_object);
 
   tf2::Quaternion target_orientation;
-  target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+  target_orientation.setRPY(0, TAU / 2.0, TAU / 4.0);
   geometry_msgs::PoseStamped target_pose_stamped;
   target_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
   target_pose_stamped.pose.position.z = Z_OFFSET;
@@ -179,15 +177,25 @@ TEST(TestPlanUsingSubframes, SubframesTests)
     planning_scene_monitor::LockedPlanningSceneRO planning_scene(planning_scene_monitor);
 
     // get the tip and box subframe locations in world
-    Eigen::Isometry3d eef = planning_scene->getFrameTransform("cylinder/tip");
+    // TODO (felixvd): Get these from the plan's goal state instead, so we don't have to execute the motion in CI
+    Eigen::Isometry3d cyl_tip = planning_scene->getFrameTransform("cylinder/tip");
     Eigen::Isometry3d box_subframe = planning_scene->getFrameTransform(target_pose_stamped.header.frame_id);
     Eigen::Isometry3d target_pose;
     tf2::fromMsg(target_pose_stamped.pose, target_pose);
 
     // expect that they are identical
     std::stringstream ss;
-    ss << "target frame: \n" << (box_subframe * target_pose).matrix() << "\ncylinder frame: \n" << eef.matrix();
-    EXPECT_TRUE(eef.isApprox(box_subframe * target_pose, EPSILON)) << ss.str();
+    ss << "target frame: \n" << (box_subframe * target_pose).matrix() << "\ncylinder frame: \n" << cyl_tip.matrix();
+    EXPECT_TRUE(cyl_tip.isApprox(box_subframe * target_pose, EPSILON)) << ss.str();
+
+    // Check that robot wrist is where we expect it to be
+    Eigen::Isometry3d panda_link = planning_scene->getFrameTransform("panda_link8");
+    Eigen::Isometry3d expected_pose = Eigen::Isometry3d(Eigen::Translation3d(0.307, 0.13, 0.44)) *
+                                      Eigen::Isometry3d(Eigen::Quaterniond(0.0003809, -0.38303, 0.92373, 0.00028097));
+
+    ss.str("");
+    ss << "panda link frame: \n" << panda_link.matrix() << "\nexpected pose: \n" << expected_pose.matrix();
+    EXPECT_TRUE(panda_link.isApprox(expected_pose, EPSILON)) << ss.str();
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -326,6 +326,8 @@ private:
   ros::Publisher planning_scene_world_publisher_;
 
   collision_detection::CollisionEnv::ObjectConstPtr scaled_object_;
+  moveit::core::FixedTransformsMap scaled_object_subframes_;
+  EigenSTL::vector_Isometry3d scaled_object_shape_poses_;
 
   std::vector<std::pair<std::string, bool> > known_collision_objects_;
   long unsigned int known_collision_objects_version_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -89,14 +89,11 @@ void MotionPlanningFrame::processDetectedObjects()
       object_ids.clear();
       for (const auto& object : *world)
       {
-        if (!object.second->shape_poses_.empty())
+        const auto& position = object.second->pose_.translation();
+        if (position.x() >= min_x && position.x() <= max_x && position.y() >= min_y && position.y() <= max_y &&
+            position.z() >= min_z && position.z() <= max_z)
         {
-          const auto& position = object.second->shape_poses_[0].translation();
-          if (position.x() >= min_x && position.x() <= max_x && position.y() >= min_y && position.y() <= max_y &&
-              position.z() >= min_z && position.z() <= max_z)
-          {
-            object_ids.push_back(object.first);
-          }
+          object_ids.push_back(object.first);
         }
       }
       if (!object_ids.empty())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -855,7 +855,7 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       known_collision_objects_[item->type()].first = item_text;
       moveit::core::AttachedBody* new_ab =
           new moveit::core::AttachedBody(ab->getAttachedLink(), known_collision_objects_[item->type()].first,
-                                         ab->getShapes(), ab->getFixedTransforms(), ab->getTouchLinks(),
+                                         ab->getPose(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
                                          ab->getDetachPosture(), ab->getSubframes());
       cs.clearAttachedBody(ab->getName());
       cs.attachBody(new_ab);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -401,7 +401,7 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
            Eigen::AngleAxisd(ui_->object_ry->value(), Eigen::Vector3d::UnitY()) *
            Eigen::AngleAxisd(ui_->object_rz->value(), Eigen::Vector3d::UnitZ()));
 
-      ps->getWorldNonConst()->moveObjectAbsolute(obj->id_, p);
+      ps->getWorldNonConst()->setObjectPose(obj->id_, p);
       planning_display_->queueRenderSceneGeometry();
       setLocalSceneEdited();
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -255,9 +255,9 @@ static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
 {
   QString status_text = "'" + QString::fromStdString(attached_body->getName()) + "' is attached to '" +
                         QString::fromStdString(attached_body->getAttachedLinkName()) + "'.";
-  if (!attached_body->getSubframeTransforms().empty())
+  if (!attached_body->getSubframes().empty())
   {
-    status_text += subframe_poses_to_qstring(attached_body->getSubframeTransforms());
+    status_text += subframe_poses_to_qstring(attached_body->getSubframes());
   }
   return status_text;
 }
@@ -851,7 +851,7 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       moveit::core::AttachedBody* new_ab =
           new moveit::core::AttachedBody(ab->getAttachedLink(), known_collision_objects_[item->type()].first,
                                          ab->getShapes(), ab->getFixedTransforms(), ab->getTouchLinks(),
-                                         ab->getDetachPosture(), ab->getSubframeTransforms());
+                                         ab->getDetachPosture(), ab->getSubframes());
       cs.clearAttachedBody(ab->getName());
       cs.attachBody(new_ab);
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -840,13 +840,10 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
     if (obj)
     {
       known_collision_objects_[item->type()].first = item_text;
-      const Eigen::Isometry3d pose = obj->pose_;
-      const moveit::core::FixedTransformsMap subframes = obj->subframe_poses_;  // Keep subframes
-
       ps->getWorldNonConst()->removeObject(obj->id_);
-      ps->getWorldNonConst()->addToObject(known_collision_objects_[item->type()].first, obj->shapes_, obj->shape_poses_);
-      ps->getWorldNonConst()->setObjectPose(obj->id_, pose);
-      ps->getWorldNonConst()->setSubframesOfObject(obj->id_, subframes);
+      ps->getWorldNonConst()->addToObject(known_collision_objects_[item->type()].first, obj->pose_, obj->shapes_,
+                                          obj->shape_poses_);
+      ps->getWorldNonConst()->setSubframesOfObject(obj->id_, obj->subframe_poses_);
       if (scene_marker_)
       {
         scene_marker_.reset();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1496,7 +1496,7 @@ This is usually achieved by random seeding, which can flip the robot configurati
                </size>
               </property>
               <property name="toolTip">
-               <string>Export scene geometry to a .scene file (only geometry information is preserved)</string>
+               <string>Export scene geometry to a .scene file (only world object information is preserved)</string>
               </property>
               <property name="text">
                <string>&amp;Export</string>
@@ -1518,7 +1518,7 @@ This is usually achieved by random seeding, which can flip the robot configurati
                </size>
               </property>
               <property name="toolTip">
-               <string>Import scene geometry from a .scene file (only geometry information is preserved)</string>
+               <string>Import scene geometry from a .scene file (only world object information is preserved)</string>
               </property>
               <property name="text">
                <string>&amp;Import</string>

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -114,8 +114,8 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     for (std::size_t j = 0; j < object->shapes_.size(); ++j)
     {
       render_shapes_->renderShape(planning_scene_geometry_node_, object->shapes_[j].get(),
-                                  scene->getWorld()->getGlobalShapeTransform(id, j), octree_voxel_rendering,
-                                  octree_color_mode, color, alpha);
+                                  object->global_shape_poses_[j], octree_voxel_rendering, octree_color_mode, color,
+                                  alpha);
     }
   }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -112,7 +112,6 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
       alpha = c.a;
     }
     for (std::size_t j = 0; j < object->shapes_.size(); ++j)
-    // TODO (felixvd): Make these shape poses global somehow
     {
       render_shapes_->renderShape(planning_scene_geometry_node_, object->shapes_[j].get(),
                                   scene->getWorld()->getGlobalShapeTransform(id, j), octree_voxel_rendering,

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -112,8 +112,12 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
       alpha = c.a;
     }
     for (std::size_t j = 0; j < object->shapes_.size(); ++j)
-      render_shapes_->renderShape(planning_scene_geometry_node_, object->shapes_[j].get(), object->shape_poses_[j],
-                                  octree_voxel_rendering, octree_color_mode, color, alpha);
+    // TODO (felixvd): Make these shape poses global somehow
+    {
+      render_shapes_->renderShape(planning_scene_geometry_node_, object->shapes_[j].get(),
+                                  scene->getWorld()->getGlobalShapeTransform(id, j), octree_voxel_rendering,
+                                  octree_color_mode, color, alpha);
+    }
   }
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -135,7 +135,8 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
       continue;
     }
     rviz::Color rcolor(color.r, color.g, color.b);
-    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getFixedTransforms();
+    const EigenSTL::vector_Isometry3d& ab_t =
+        attached_body->getShapePosesInLinkFrame();  // TODO(felixvd): Check if this can be done via getShapePoses()
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)
     {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -135,8 +135,7 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
       continue;
     }
     rviz::Color rcolor(color.r, color.g, color.b);
-    const EigenSTL::vector_Isometry3d& ab_t =
-        attached_body->getShapePosesInLinkFrame();  // TODO(felixvd): Check if this can be done via getShapePoses()
+    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getShapePosesInLinkFrame();
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)
     {


### PR DESCRIPTION
~As discussed in https://github.com/ros-planning/moveit/issues/2025, this defines `CollisionObject`s with a `PoseStamped` instead of a `header`, so that an object can be moved together with its subframes and shapes.~

~I would like to get this in before the Noetic release and make it easy to review, so this PR includes only the very minimum that I believe this functionality needs. The tests passed locally, so I'd like to hear your thoughts.~

~Depends on https://github.com/ros-planning/moveit_msgs/pull/69.~

### New summary [here](https://github.com/ros-planning/moveit/pull/2037#issuecomment-709442682).

---

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [X] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers