### PR TITLE
Utilize setScaleDirty() and setPaddingDirty() to improve performance

### DIFF
--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -208,8 +208,10 @@ bool DistanceField::getShapePoints(const shapes::Shape* shape, const Eigen::Isom
   }
   else
   {
-    bodies::Body* body = bodies::createBodyFromShape(shape);
-    body->setPose(pose);
+    bodies::Body* body = bodies::createEmptyBodyFromShapeType(shape->type);
+    body->setDimensionsDirty(shape);
+    body->setPoseDirty(pose);
+    body->updateInternalData();
     findInternalPointsConvex(*body, resolution_, *points);
     delete body;
   }
@@ -292,8 +294,10 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const Eigen::Is
     ROS_WARN_NAMED("distance_field", "Move shape not supported for Octree");
     return;
   }
-  bodies::Body* body = bodies::createBodyFromShape(shape);
-  body->setPose(old_pose);
+  bodies::Body* body = bodies::createEmptyBodyFromShapeType(shape->type);
+  body->setDimensionsDirty(shape);
+  body->setPoseDirty(old_pose);
+  body->updateInternalData();
   EigenSTL::vector_Vector3d old_point_vec;
   findInternalPointsConvex(*body, resolution_, old_point_vec);
   body->setPose(new_pose);
@@ -315,8 +319,10 @@ void DistanceField::moveShapeInField(const shapes::Shape* shape, const geometry_
 
 void DistanceField::removeShapeFromField(const shapes::Shape* shape, const Eigen::Isometry3d& pose)
 {
-  bodies::Body* body = bodies::createBodyFromShape(shape);
-  body->setPose(pose);
+  bodies::Body* body = bodies::createEmptyBodyFromShapeType(shape->type);
+  body->setDimensionsDirty(shape);
+  body->setPoseDirty(pose);
+  body->updateInternalData();
   EigenSTL::vector_Vector3d point_vec;
   findInternalPointsConvex(*body, resolution_, point_vec);
   delete body;

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -315,17 +315,17 @@ bool PositionConstraint::configure(const moveit_msgs::PositionConstraint& pc, co
         ROS_WARN_NAMED("kinematic_constraints", "Constraint region message does not contain enough primitive poses");
         continue;
       }
-      constraint_region_.push_back(bodies::BodyPtr(bodies::createBodyFromShape(shape.get())));
       Eigen::Isometry3d t;
       tf2::fromMsg(pc.constraint_region.primitive_poses[i], t);
       constraint_region_pose_.push_back(t);
-      if (mobile_frame_)
-        constraint_region_.back()->setPose(constraint_region_pose_.back());
-      else
-      {
+      if (!mobile_frame_)
         tf.transformPose(pc.header.frame_id, constraint_region_pose_.back(), constraint_region_pose_.back());
-        constraint_region_.back()->setPose(constraint_region_pose_.back());
-      }
+
+      const bodies::BodyPtr body(bodies::createEmptyBodyFromShapeType(shape->type));
+      body->setDimensionsDirty(shape.get());
+      body->setPoseDirty(constraint_region_pose_.back());
+      body->updateInternalData();
+      constraint_region_.push_back(body);
     }
     else
       ROS_WARN_NAMED("kinematic_constraints", "Could not construct primitive shape %zu", i);
@@ -342,17 +342,16 @@ bool PositionConstraint::configure(const moveit_msgs::PositionConstraint& pc, co
         ROS_WARN_NAMED("kinematic_constraints", "Constraint region message does not contain enough primitive poses");
         continue;
       }
-      constraint_region_.push_back(bodies::BodyPtr(bodies::createBodyFromShape(shape.get())));
       Eigen::Isometry3d t;
       tf2::fromMsg(pc.constraint_region.mesh_poses[i], t);
       constraint_region_pose_.push_back(t);
-      if (mobile_frame_)
-        constraint_region_.back()->setPose(constraint_region_pose_.back());
-      else
-      {
+      if (!mobile_frame_)
         tf.transformPose(pc.header.frame_id, constraint_region_pose_.back(), constraint_region_pose_.back());
-        constraint_region_.back()->setPose(constraint_region_pose_.back());
-      }
+      const bodies::BodyPtr body(bodies::createEmptyBodyFromShapeType(shape->type));
+      body->setDimensionsDirty(shape.get());
+      body->setPoseDirty(constraint_region_pose_.back());
+      body->updateInternalData();
+      constraint_region_.push_back(body);
     }
     else
     {

--- a/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
+++ b/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
@@ -69,9 +69,10 @@ point_containment_filter::ShapeHandle point_containment_filter::ShapeMask::addSh
 {
   boost::mutex::scoped_lock _(shapes_lock_);
   SeeShape ss;
-  ss.body = bodies::createBodyFromShape(shape.get());
+  ss.body = bodies::createEmptyBodyFromShapeType(shape->type);
   if (ss.body)
   {
+    ss.body->setDimensionsDirty(shape.get());
     ss.body->setScaleDirty(scale);
     ss.body->setPaddingDirty(padding);
     ss.body->updateInternalData();

--- a/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
+++ b/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
@@ -72,8 +72,9 @@ point_containment_filter::ShapeHandle point_containment_filter::ShapeMask::addSh
   ss.body = bodies::createBodyFromShape(shape.get());
   if (ss.body)
   {
-    ss.body->setScale(scale);
-    ss.body->setPadding(padding);
+    ss.body->setScaleDirty(scale);
+    ss.body->setPaddingDirty(padding);
+    ss.body->updateInternalData();
     ss.volume = ss.body->computeVolume();
     ss.handle = next_handle_;
     std::pair<std::set<SeeShape, SortBodies>::iterator, bool> insert_op = bodies_.insert(ss);


### PR DESCRIPTION
### Description

As requested in https://github.com/ros-planning/geometric_shapes/pull/109#issuecomment-619560363.

I only found one candidate usage...

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
