### PR TITLE
[ci] configure travis to report success before code-coverage finishes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
     - WARNINGS_OK=false
 
 jobs:
+  fast_finish: true
   include:
     - env: TEST="clang-format catkin_lint"
-    - env: TEST=code-coverage
     - env: ROS_DISTRO=melodic
     - env: ROS_DISTRO=kinetic
     - compiler: clang
@@ -34,6 +34,8 @@ jobs:
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
     - if: branch =~ /^(.*-devel|master)$/
       env: ROS_REPO=ros-shadow-fixed
+  allow_failures:
+    - env: TEST=code-coverage
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
   fast_finish: true
   include:
     - env: TEST="clang-format catkin_lint"
+    - env: TEST=code-coverage
     - env: ROS_DISTRO=melodic
     - env: ROS_DISTRO=kinetic
     - compiler: clang


### PR DESCRIPTION
### Description

This should speed up builds by configuring travis to report success before code-coverage job finishes.  This shouldn't reduce the effectiveness of the testing as we are only using code-coverage for reporting and are not failing CI based on that report.