### PR TITLE
PlanningSceneDisplay speedup

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -240,7 +240,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
 
   last_update_time_ = last_robot_motion_time_ = ros::Time::now();
   last_robot_state_update_wall_time_ = ros::WallTime::now();
-  dt_state_update_ = ros::WallDuration(0.1);
+  dt_state_update_ = ros::WallDuration(0.03);
 
   double temp_wait_time = 0.05;
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -410,7 +410,6 @@ void PlanningSceneMonitor::scenePublishingThread()
     }
     if (publish_msg)
     {
-      rate.reset();
       planning_scene_publisher_.publish(msg);
       if (is_full)
         ROS_DEBUG_NAMED(LOGNAME, "Published full planning scene: '%s'", msg.name.c_str());

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -370,6 +370,11 @@ void PlanningSceneMonitor::scenePublishingThread()
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
+            if (new_scene_update_ == UPDATE_STATE)
+            {
+              msg.robot_state.attached_collision_objects.clear();
+              msg.robot_state.is_diff = true;
+            }
           }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_);  // we don't want the
                                                                                                  // transform cache to

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -191,7 +191,10 @@ protected:
   RobotStateVisualizationPtr planning_scene_robot_;
   PlanningSceneRenderPtr planning_scene_render_;
 
+  // full update required
   bool planning_scene_needs_render_;
+  // or only the robot position (excluding attached object changes)
+  bool robot_state_needs_render_;
   float current_scene_time_;
 
   rviz::Property* scene_category_;

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -115,8 +115,8 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   octree_coloring_property_->addOption("Cell Probability", OCTOMAP_PROBABLILTY_COLOR);
 
   scene_display_time_property_ =
-      new rviz::FloatProperty("Scene Display Time", 0.2f, "The amount of wall-time to wait in between rendering "
-                                                          "updates to the planning scene (if any)",
+      new rviz::FloatProperty("Scene Display Time", 0.01f, "The amount of wall-time to wait in between rendering "
+                                                           "updates to the planning scene (if any)",
                               scene_category_, SLOT(changedSceneDisplayTime()), this);
   scene_display_time_property_->setMin(0.0001);
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
@@ -75,6 +75,8 @@ public:
     return scene_robot_;
   }
 
+  void updateRobotPosition(const planning_scene::PlanningSceneConstPtr& scene);
+
   void renderPlanningScene(const planning_scene::PlanningSceneConstPtr& scene, const rviz::Color& default_scene_color,
                            const rviz::Color& default_attached_color, OctreeVoxelRenderMode voxel_render_mode,
                            OctreeVoxelColorMode voxel_color_mode, float default_scene_alpha);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -71,6 +71,7 @@ public:
   void update(const moveit::core::RobotStateConstPtr& kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color,
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
+  void updateKinematicState(const robot_state::RobotStateConstPtr& kinematic_state);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
   /// update color of all attached object shapes
   void updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -56,6 +56,16 @@ PlanningSceneRender::~PlanningSceneRender()
   context_->getSceneManager()->destroySceneNode(planning_scene_geometry_node_);
 }
 
+void PlanningSceneRender::updateRobotPosition(const planning_scene::PlanningSceneConstPtr& scene)
+{
+  if (scene_robot_)
+  {
+    robot_state::RobotStatePtr rs = std::make_shared<robot_state::RobotState>(scene->getCurrentState());
+    rs->update();
+    scene_robot_->updateKinematicState(rs);
+  }
+}
+
 void PlanningSceneRender::clear()
 {
   render_shapes_->clear();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -100,7 +100,7 @@ void RobotStateVisualization::update(const moveit::core::RobotStateConstPtr& kin
                                      const std_msgs::ColorRGBA& default_attached_object_color,
                                      const std::map<std::string, std_msgs::ColorRGBA>& color_map)
 {
-  updateHelper(kinematic_state, default_attached_object_color, &color_map);
+    updateHelper(kinematic_state, default_attached_object_color, &color_map);
 }
 
 void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPtr& kinematic_state,
@@ -127,14 +127,20 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
         alpha = color.a = it->second.a;
       }
     }
+    rviz::RobotLink* link = robot_.getLink(attached_body->getAttachedLinkName());
+    if (!link)
+    {
+        ROS_ERROR_STREAM("Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
+        continue;
+    }
     rviz::Color rcolor(color.r, color.g, color.b);
-    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getGlobalCollisionBodyTransforms();
+    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getFixedTransforms();
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)
     {
-      render_shapes_->renderShape(robot_.getVisualNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
+      render_shapes_->renderShape(link->getVisualNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, rcolor, alpha);
-      render_shapes_->renderShape(robot_.getCollisionNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
+      render_shapes_->renderShape(link->getCollisionNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, rcolor, alpha);
     }
   }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -37,6 +37,7 @@
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>
 #include <moveit/rviz_plugin_render_tools/render_shapes.h>
+#include <rviz/robot/robot_link.h>
 #include <QApplication>
 
 namespace moveit_rviz_plugin
@@ -100,7 +101,7 @@ void RobotStateVisualization::update(const moveit::core::RobotStateConstPtr& kin
                                      const std_msgs::ColorRGBA& default_attached_object_color,
                                      const std::map<std::string, std_msgs::ColorRGBA>& color_map)
 {
-    updateHelper(kinematic_state, default_attached_object_color, &color_map);
+  updateHelper(kinematic_state, default_attached_object_color, &color_map);
 }
 
 void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPtr& kinematic_state,
@@ -130,8 +131,8 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
     rviz::RobotLink* link = robot_.getLink(attached_body->getAttachedLinkName());
     if (!link)
     {
-        ROS_ERROR_STREAM("Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
-        continue;
+      ROS_ERROR_STREAM("Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
+      continue;
     }
     rviz::Color rcolor(color.r, color.g, color.b);
     const EigenSTL::vector_Isometry3d& ab_t = attached_body->getFixedTransforms();
@@ -147,6 +148,11 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
   robot_.setVisualVisible(visual_visible_);
   robot_.setCollisionVisible(collision_visible_);
   robot_.setVisible(visible_);
+}
+
+void RobotStateVisualization::updateKinematicState(const moveit::core::RobotStateConstPtr& kinematic_state)
+{
+  robot_.update(PlanningLinkUpdater(kinematic_state));
 }
 
 void RobotStateVisualization::setVisible(bool visible)


### PR DESCRIPTION
Alternative title: "MoveIt like it's 2020!"

This utilizes the `robot_state.is_diff` field in `PlanningScene` messages to send only joint state updates and teaches `PlanningSceneDisplay` to simply update the transforms in OGRE's scene graph instead of rebuilding the representation of both attached objects and collision objects. This reduces the time required for handling one update from 150-250ms down to 0.5ms in a simple scene typical for us. (one attached object (240kb), a couple more of those as collision objects, two boxes (few vertices) and  an octomap) (Note that updates where the scene geometry changes are still slow ...)

`AttachedObjects` are now attached to the corresponding link in OGRE as well, so their position no longer needs to be updated manually.

Furthermore this increases the default rate limit for joint state updates to ca 33hz, the publishing rate to 30hz and the incoming update limit in `PlanningSceneDisplay` to 100hz. This allows for smooth animations at 30fps