### PR TITLE
fix ordering of request adapters

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -6,12 +6,12 @@
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
   <arg name="planning_adapters"
-       value="default_planner_request_adapters/FixWorkspaceBounds
+       value="default_planner_request_adapters/AddTimeParameterization
+              default_planner_request_adapters/ResolveConstraintFrames
+              default_planner_request_adapters/FixWorkspaceBounds
               default_planner_request_adapters/FixStartStateBounds
               default_planner_request_adapters/FixStartStateCollision
-              default_planner_request_adapters/FixStartStatePathConstraints
-              default_planner_request_adapters/ResolveConstraintFrames
-              default_planner_request_adapters/AddTimeParameterization"
+              default_planner_request_adapters/FixStartStatePathConstraints"
               />
 
   <arg name="start_state_max_bounds_error" value="0.1" />


### PR DESCRIPTION
Some auxiliary PRAs can create additional waypoints,
so time parameterization must run *after* them on return of a successful plan,
which means it has to be loaded *before* them in the PRA chain.

Additionally, constraint names have to be resolved *before* fixing the input state w.r.t. them.

Look up the source code and documentation if you don't believe it.

This came up in https://github.com/ros-planning/moveit/issues/2052 .