### PR TITLE
TOTG: add zero parameterization for single-waypoint trajectories

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -246,6 +246,9 @@ public:
     return velocity_;
   }
 
+  /** \brief Set all velocities to 0.0 */
+  void zeroVelocities();
+
   /** \brief Given an array with velocity values for all variables, set those values as the velocities in this state */
   void setVariableVelocities(const double* velocity)
   {
@@ -303,6 +306,9 @@ public:
     return velocity_[index];
   }
 
+  /** \brief Remove velocities from this state (this differs from setting them to zero) */
+  void dropVelocities();
+
   /** @} */
 
   /** \name Getting and setting variable acceleration
@@ -333,6 +339,9 @@ public:
   {
     return acceleration_;
   }
+
+  /** \brief Set all accelerations to 0.0 */
+  void zeroAccelerations();
 
   /** \brief Given an array with acceleration values for all variables, set those values as the accelerations in this
    * state */
@@ -396,6 +405,9 @@ public:
     return acceleration_[index];
   }
 
+  /** \brief Remove accelerations from this state (this differs from setting them to zero) */
+  void dropAccelerations();
+
   /** @} */
 
   /** \name Getting and setting variable effort
@@ -425,6 +437,9 @@ public:
   {
     return effort_;
   }
+
+  /** \brief Set all effort values to 0.0 */
+  void zeroEffort();
 
   /** \brief Given an array with effort values for all variables, set those values as the effort in this state */
   void setVariableEffort(const double* effort)
@@ -481,6 +496,12 @@ public:
   {
     return effort_[index];
   }
+
+  /** \brief Remove effort values from this state (this differs from setting them to zero) */
+  void dropEffort();
+
+  /** \brief Reduce RobotState to kinematic information (remove velocity, acceleration and effort, if present) */
+  void dropDynamics();
 
   /** \brief Invert velocity if present. */
   void invertVelocity();

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -232,6 +232,46 @@ void RobotState::markEffort()
   }
 }
 
+void RobotState::zeroVelocities()
+{
+  has_velocity_ = false;
+  markVelocity();
+}
+
+void RobotState::zeroAccelerations()
+{
+  has_acceleration_ = false;
+  markAcceleration();
+}
+
+void RobotState::zeroEffort()
+{
+  has_effort_ = false;
+  markEffort();
+}
+
+void RobotState::dropVelocities()
+{
+  has_velocity_ = false;
+}
+
+void RobotState::dropAccelerations()
+{
+  has_velocity_ = false;
+}
+
+void RobotState::dropEffort()
+{
+  has_velocity_ = false;
+}
+
+void RobotState::dropDynamics()
+{
+  dropVelocities();
+  dropAccelerations();
+  dropEffort();
+}
+
 void RobotState::setToRandomPositions()
 {
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -976,8 +976,11 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   // Return trajectory with only the first waypoint if there are not multiple diverse points
   if (points.size() == 1)
   {
-    ROS_WARN_NAMED(LOGNAME, "Trajectory is not being parameterized since it only contains a single distinct waypoint.");
+    ROS_DEBUG_NAMED(LOGNAME,
+                    "Trajectory is parameterized with 0.0 dynamics since it only contains a single distinct waypoint.");
     moveit::core::RobotState waypoint = moveit::core::RobotState(trajectory.getWayPoint(0));
+    waypoint.zeroVelocities();
+    waypoint.zeroAccelerations();
     trajectory.clear();
     trajectory.addSuffixWayPoint(waypoint, 0.0);
     return true;


### PR DESCRIPTION
Also add some overdue helpers to `RobotState` while I was at it.
I'm happy to discuss naming if someone disagrees with my terminology.

The actual TOTG issue came up in:
https://github.com/ros-planning/moveit/issues/2052#issuecomment-624104306