### PR TITLE
move NOLINT instructions to intended positions

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
@@ -79,11 +79,11 @@ public:
                      Eigen::Matrix<double, 6, 1>::Constant(1.0));
   }
 
-  // NOLINTNEXTLINE(readability-identifier-naming)
   /** Compute qdot_out = W_q * (W_x * J * W_q)^# * W_x * v_in
    *
    * where W_q and W_x are joint- and Cartesian weights respectively.
    * A smaller joint weight (< 1.0) will reduce the contribution of this joint to the solution. */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int CartToJnt(const JntArray& q_in, const Twist& v_in, JntArray& qdot_out, const Eigen::VectorXd& joint_weights,
                 const Eigen::Matrix<double, 6, 1>& cartesian_weights);
 

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -124,8 +124,8 @@ public:
 protected:
   typedef Eigen::Matrix<double, 6, 1> Twist;
 
-  // NOLINTNEXTLINE(readability-identifier-naming)
   /// Solve position IK given initial joint values
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int CartToJnt(KDL::ChainIkSolverVelMimicSVD& ik_solver, const KDL::JntArray& q_init, const KDL::Frame& p_in,
                 KDL::JntArray& q_out, const unsigned int max_iter, const Eigen::VectorXd& joint_weights,
                 const Twist& cartesian_weights) const;


### PR DESCRIPTION
Running locally, doxygen still manages to extract the correct comment.

See https://github.com/ros-planning/moveit/pull/2050/files#r420826217