### PR TITLE
depend on geometric_shapes `noetic-devel` branch

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -7,7 +7,7 @@
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
-    version: melodic-devel
+    version: noetic-devel
 - git:
     local-name: moveit
     uri: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
`master` should always depend on our latest version of dependencies, although it pays to stay compatible with older versions.