### PR TITLE
MP display: planning attempts are natural numbers

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -603,7 +603,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="planning_attempts">
+             <widget class="QSpinBox" name="planning_attempts">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -611,10 +611,10 @@
                </sizepolicy>
               </property>
               <property name="maximum">
-               <double>1000.000000000000000</double>
+               <number>1000</number>
               </property>
               <property name="value">
-               <double>10.000000000000000</double>
+               <number>10</number>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
The value is treated as an integer internally and having a double for it in the GUI is just confusing...