### PR TITLE
[melodic-devel] bug fix backport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - WARNINGS_OK=false
 
 jobs:
+  fast_finish: true
   include:
     - env: TEST="clang-format catkin_lint"
     - env: TEST=code-coverage
@@ -31,7 +32,10 @@ jobs:
       env: TEST=clang-tidy-fix
            BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
-#           ROS_REPO=ros-shadow-fixed
+    - if: branch =~ /^(.*-devel|master)$/
+      env: ROS_REPO=ros-shadow-fixed
+  allow_failures:
+    - env: TEST=code-coverage
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ jobs:
       env: ROS_REPO=ros-shadow-fixed
   allow_failures:
     - env: TEST=code-coverage
+    - env: TEST=clang-tidy-fix
+           BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+           CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual"
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - ROS_DISTRO=melodic
     - ROS_REPO=ros
     - UPSTREAM_WORKSPACE=moveit.rosinstall
-    - TEST_BLACKLIST=moveit_ros_perception  # mesh_filter_test fails due to broken Mesa OpenGL
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-unused-function"
     - WARNINGS_OK=false
 

--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -587,7 +587,7 @@ class MoveGroupCommandInterpreter(object):
             known_vars = self.get_active_group().get_remembered_joint_values().keys()
             known_constr = self.get_active_group().get_known_constraints()
         groups = self._robot.get_group_names()
-        return {'go':['up', 'down', 'left', 'right', 'backward', 'forward', 'random'] + known_vars,
+        return {'go':['up', 'down', 'left', 'right', 'backward', 'forward', 'random'] + list(known_vars),
                 'help':[],
                 'record':known_vars,
                 'show':known_vars,

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -43,8 +43,6 @@
 #include <kdl/tree.hpp>
 #include <kdl_parser/kdl_parser.hpp>
 
-#include <angles/angles.h>
-
 #include <moveit/macros/class_forward.h>
 #include <moveit_msgs/GetPositionFK.h>
 #include <moveit_msgs/GetPositionIK.h>

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1718,7 +1718,15 @@ void PlanningScene::poseMsgToEigen(const geometry_msgs::Pose& msg, Eigen::Isomet
 {
   Eigen::Translation3d translation(msg.position.x, msg.position.y, msg.position.z);
   Eigen::Quaterniond quaternion(msg.orientation.w, msg.orientation.x, msg.orientation.y, msg.orientation.z);
-  quaternion.normalize();
+  if ((quaternion.x() == 0) && (quaternion.y() == 0) && (quaternion.z() == 0) && (quaternion.w() == 0))
+  {
+    ROS_WARN_NAMED(LOGNAME, "Empty quaternion found in pose message. Setting to neutral orientation.");
+    quaternion.setIdentity();
+  }
+  else
+  {
+    quaternion.normalize();
+  }
   out = translation * quaternion;
 }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -279,6 +279,9 @@ public:
     return velocity_;
   }
 
+  /** \brief Set all velocities to 0.0 */
+  void zeroVelocities();
+
   /** \brief Given an array with velocity values for all variables, set those values as the velocities in this state */
   void setVariableVelocities(const double* velocity)
   {
@@ -336,6 +339,9 @@ public:
     return velocity_[index];
   }
 
+  /** \brief Remove velocities from this state (this differs from setting them to zero) */
+  void dropVelocities();
+
   /** @} */
 
   /** \name Getting and setting variable acceleration
@@ -366,6 +372,9 @@ public:
   {
     return acceleration_;
   }
+
+  /** \brief Set all accelerations to 0.0 */
+  void zeroAccelerations();
 
   /** \brief Given an array with acceleration values for all variables, set those values as the accelerations in this
    * state */
@@ -429,6 +438,9 @@ public:
     return acceleration_[index];
   }
 
+  /** \brief Remove accelerations from this state (this differs from setting them to zero) */
+  void dropAccelerations();
+
   /** @} */
 
   /** \name Getting and setting variable effort
@@ -458,6 +470,9 @@ public:
   {
     return effort_;
   }
+
+  /** \brief Set all effort values to 0.0 */
+  void zeroEffort();
 
   /** \brief Given an array with effort values for all variables, set those values as the effort in this state */
   void setVariableEffort(const double* effort)
@@ -514,6 +529,12 @@ public:
   {
     return effort_[index];
   }
+
+  /** \brief Remove effort values from this state (this differs from setting them to zero) */
+  void dropEffort();
+
+  /** \brief Reduce RobotState to kinematic information (remove velocity, acceleration and effort, if present) */
+  void dropDynamics();
 
   /** \brief Invert velocity if present. */
   void invertVelocity();

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -237,6 +237,46 @@ void RobotState::markEffort()
   }
 }
 
+void RobotState::zeroVelocities()
+{
+  has_velocity_ = false;
+  markVelocity();
+}
+
+void RobotState::zeroAccelerations()
+{
+  has_acceleration_ = false;
+  markAcceleration();
+}
+
+void RobotState::zeroEffort()
+{
+  has_effort_ = false;
+  markEffort();
+}
+
+void RobotState::dropVelocities()
+{
+  has_velocity_ = false;
+}
+
+void RobotState::dropAccelerations()
+{
+  has_velocity_ = false;
+}
+
+void RobotState::dropEffort()
+{
+  has_velocity_ = false;
+}
+
+void RobotState::dropDynamics()
+{
+  dropVelocities();
+  dropAccelerations();
+  dropEffort();
+}
+
 void RobotState::setToRandomPositions()
 {
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -39,7 +39,6 @@
 #include <limits>
 #include <Eigen/Geometry>
 #include <algorithm>
-#include <angles/angles.h>
 #include <cmath>
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <ros/console.h>

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -978,8 +978,11 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   // Return trajectory with only the first waypoint if there are not multiple diverse points
   if (points.size() == 1)
   {
-    ROS_WARN_NAMED(LOGNAME, "Trajectory is not being parameterized since it only contains a single distinct waypoint.");
-    robot_state::RobotState waypoint = robot_state::RobotState(trajectory.getWayPoint(0));
+    ROS_DEBUG_NAMED(LOGNAME,
+                    "Trajectory is parameterized with 0.0 dynamics since it only contains a single distinct waypoint.");
+    moveit::core::RobotState waypoint = moveit::core::RobotState(trajectory.getWayPoint(0));
+    waypoint.zeroVelocities();
+    waypoint.zeroAccelerations();
     trajectory.clear();
     trajectory.addSuffixWayPoint(waypoint, 0.0);
     return true;

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_params.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/sbpl_params.h
@@ -40,7 +40,6 @@
 #include <vector>
 #include <iterator>
 #include <ros/ros.h>
-#include <angles/angles.h>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 

--- a/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
+++ b/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
@@ -231,7 +231,7 @@ void MeshFilterTest<Type>::test()
     float sensor_depth = sensor_data_[idx] * FilterTraits<Type>::ToMetricScale;
     if (fabs(sensor_depth - distance_ - shadow_) > epsilon_ && fabs(sensor_depth - distance_) > epsilon_)
     {
-      ASSERT_FLOAT_EQ(filtered_depth[idx], gt_depth[idx]);
+      ASSERT_NEAR(filtered_depth[idx], gt_depth[idx], 1e-6);
       ASSERT_EQ(filtered_labels[idx], gt_labels[idx]);
     }
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -685,7 +685,7 @@ public:
 
   MoveItErrorCode planGraspsAndPick(const moveit_msgs::CollisionObject& object, bool plan_only = false)
   {
-    if (!plan_grasps_service_)
+    if (!plan_grasps_service_.exists())
     {
       ROS_ERROR_STREAM_NAMED("move_group_interface", "Grasp planning service '"
                                                          << GRASP_PLANNING_SERVICE_NAME

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -796,8 +796,14 @@ public:
 
   MoveItErrorCode execute(const moveit_msgs::RobotTrajectory& trajectory, bool wait)
   {
+    if (!execute_action_client_)
+    {
+      ROS_ERROR_STREAM_NAMED("move_group_interface", "execute action client not found");
+      return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
+    }
     if (!execute_action_client_->isServerConnected())
     {
+      ROS_WARN_STREAM_NAMED("move_group_interface", "execute action server not connected");
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
     }
 

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -38,5 +38,7 @@
   <build_depend>eigen</build_depend>
 
   <test_depend>moveit_resources</test_depend>
+  <test_depend>eigen_conversions</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>eigen_conversions</test_depend>
 </package>

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -1,9 +1,13 @@
 if (CATKIN_ENABLE_TESTING)
   find_package(moveit_resources REQUIRED)
   find_package(rostest REQUIRED)
+  find_package(eigen_conversions REQUIRED)
 
   add_executable(test_cleanup test_cleanup.cpp)
   target_link_libraries(test_cleanup moveit_move_group_interface)
+
+  add_rostest_gtest(move_group_interface_cpp_test move_group_interface_cpp_test.test move_group_interface_cpp_test.cpp)
+  target_link_libraries(move_group_interface_cpp_test moveit_move_group_interface ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
 
   add_rostest(python_move_group.test)
   add_rostest(python_move_group_ns.test)

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -1,0 +1,363 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2020, Tyler Weaver
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of PickNik Robotics nor the
+*     names of its contributors may be used to endorse or promote
+*     products derived from this software without specific prior
+*     written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Tyler Weaver */
+
+/* These integration tests are based on the tutorials for using move_group:
+ * https://ros-planning.github.io/moveit_tutorials/doc/move_group_interface/move_group_interface_tutorial.html
+ */
+
+// C++
+#include <string>
+#include <vector>
+#include <map>
+
+// ROS
+#include <ros/ros.h>
+
+// The Testing Framework and Utils
+#include <gtest/gtest.h>
+
+// MoveIt
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+
+// TF2
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <eigen_conversions/eigen_msg.h>
+
+// 10um acuracy tested for position and orientation
+constexpr double EPSILON = 1e-5;
+
+static const std::string PLANNING_GROUP = "panda_arm";
+constexpr double PLANNING_TIME_S = 30.0;
+constexpr double MAX_VELOCITY_SCALE = 1.0;
+constexpr double MAX_ACCELERATION_SCALE = 1.0;
+constexpr double GOAL_TOLERANCE = 1e-6;
+
+class MoveGroupTestFixture : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    nh_ = ros::NodeHandle("/move_group_interface_cpp_test");
+    move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(PLANNING_GROUP);
+
+    // set velocity and acceleration scaling factors (full speed)
+    move_group_->setMaxVelocityScalingFactor(MAX_VELOCITY_SCALE);
+    move_group_->setMaxAccelerationScalingFactor(MAX_ACCELERATION_SCALE);
+
+    // allow more time for planning
+    move_group_->setPlanningTime(PLANNING_TIME_S);
+
+    // set the tolerance for the goals to be smaller than epsilon
+    move_group_->setGoalTolerance(GOAL_TOLERANCE);
+  }
+
+  void planAndMoveToPose(const geometry_msgs::Pose& pose)
+  {
+    SCOPED_TRACE("planAndMoveToPose");
+    ASSERT_TRUE(move_group_->setJointValueTarget(pose));
+    planAndMove();
+  }
+
+  void planAndMove()
+  {
+    SCOPED_TRACE("planAndMove");
+    moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+    ASSERT_EQ(move_group_->plan(my_plan), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+    ASSERT_EQ(move_group_->move(), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  }
+
+  void testEigenPose(const Eigen::Isometry3d& expected, const Eigen::Isometry3d& actual)
+  {
+    SCOPED_TRACE("testEigenPose");
+    std::stringstream ss;
+    ss << "expected: \n" << expected.matrix() << "\nactual: \n" << actual.matrix();
+    EXPECT_TRUE(actual.isApprox(expected, EPSILON)) << ss.str();
+  }
+
+  void testPose(const Eigen::Isometry3d& expected_pose)
+  {
+    SCOPED_TRACE("testPose(const Eigen::Isometry3d&)");
+    // get the pose of the end effector link after the movement
+    geometry_msgs::PoseStamped actual_pose_stamped = move_group_->getCurrentPose();
+    Eigen::Isometry3d actual_pose;
+    tf::poseMsgToEigen(actual_pose_stamped.pose, actual_pose);
+
+    // compare to planned pose
+    testEigenPose(expected_pose, actual_pose);
+  }
+
+  void testPose(const geometry_msgs::Pose& expected_pose_msg)
+  {
+    SCOPED_TRACE("testPose(const geometry_msgs::Pose&)");
+    Eigen::Isometry3d expected_pose;
+    tf::poseMsgToEigen(expected_pose_msg, expected_pose);
+    testPose(expected_pose);
+  }
+
+  void testJointPositions(const std::vector<double>& expected)
+  {
+    SCOPED_TRACE("testJointPositions");
+    const robot_state::JointModelGroup* joint_model_group =
+        move_group_->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
+    std::vector<double> actual;
+    move_group_->getCurrentState()->copyJointGroupPositions(joint_model_group, actual);
+    ASSERT_EQ(expected.size(), actual.size());
+    for (size_t i = 0; i < actual.size(); ++i)
+    {
+      double delta = std::abs(expected[i] - actual[i]);
+      EXPECT_LT(delta, EPSILON) << "joint index: " << i << ", plan: " << expected[i] << ", result: " << actual[i];
+    }
+  }
+
+protected:
+  ros::NodeHandle nh_;
+  moveit::planning_interface::MoveGroupInterfacePtr move_group_;
+  moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
+};
+
+TEST_F(MoveGroupTestFixture, MoveToPoseTest)
+{
+  SCOPED_TRACE("MoveToPoseTest");
+
+  // Test setting target pose with eigen and with geometry_msgs
+  geometry_msgs::Pose target_pose;
+  target_pose.orientation.w = 1.0;
+  target_pose.position.x = 0.28;
+  target_pose.position.y = -0.2;
+  target_pose.position.z = 0.5;
+
+  // convert to eigen
+  Eigen::Isometry3d eigen_target_pose;
+  tf::poseMsgToEigen(target_pose, eigen_target_pose);
+
+  // set with eigen, get ros message representation
+  move_group_->setPoseTarget(eigen_target_pose);
+  geometry_msgs::PoseStamped set_target_pose = move_group_->getPoseTarget();
+  Eigen::Isometry3d eigen_set_target_pose;
+  tf::poseMsgToEigen(set_target_pose.pose, eigen_set_target_pose);
+
+  // expect that they are identical
+  testEigenPose(eigen_target_pose, eigen_set_target_pose);
+
+  // plan and move
+  planAndMove();
+
+  // get the pose after the movement
+  testPose(eigen_target_pose);
+}
+
+TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
+{
+  SCOPED_TRACE("JointSpaceGoalTest");
+
+  // Next get the current set of joint values for the group.
+  std::vector<double> plan_joint_positions;
+  move_group_->getCurrentState()->copyJointGroupPositions(
+      move_group_->getCurrentState()->getJointModelGroup(PLANNING_GROUP), plan_joint_positions);
+
+  // Now, let's modify the joint positions.  (radians)
+  ASSERT_EQ(plan_joint_positions.size(), std::size_t(7));
+  plan_joint_positions = { 1.2, -1.0, -0.1, -2.4, 0.0, 1.5, 0.6 };
+  move_group_->setJointValueTarget(plan_joint_positions);
+
+  // plan and move
+  planAndMove();
+
+  // test that we moved to the expected joint positions
+  testJointPositions(plan_joint_positions);
+}
+
+TEST_F(MoveGroupTestFixture, PathConstraintTest)
+{
+  SCOPED_TRACE("PathConstraintTest");
+
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.55;
+  start_pose.position.y = -0.05;
+  start_pose.position.z = 0.8;
+  planAndMoveToPose(start_pose);
+
+  // create an orientation constraint
+  moveit_msgs::OrientationConstraint ocm;
+  ocm.link_name = move_group_->getEndEffectorLink();
+  ocm.header.frame_id = move_group_->getPlanningFrame();
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.1;
+  ocm.absolute_y_axis_tolerance = 0.1;
+  ocm.absolute_z_axis_tolerance = 0.1;
+  ocm.weight = 1.0;
+  moveit_msgs::Constraints test_constraints;
+  test_constraints.orientation_constraints.push_back(ocm);
+  move_group_->setPathConstraints(test_constraints);
+
+  // move to a custom target pose
+  geometry_msgs::Pose target_pose;
+  target_pose.orientation.w = 1.0;
+  target_pose.position.x = 0.28;
+  target_pose.position.y = -0.2;
+  target_pose.position.z = 0.5;
+  planAndMoveToPose(target_pose);
+
+  // clear path constraints
+  move_group_->clearPathConstraints();
+
+  // get the pose after the movement
+  testPose(target_pose);
+}
+
+TEST_F(MoveGroupTestFixture, CartPathTest)
+{
+  SCOPED_TRACE("CartPathTest");
+
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.55;
+  start_pose.position.y = -0.05;
+  start_pose.position.z = 0.8;
+  planAndMoveToPose(start_pose);
+
+  std::vector<geometry_msgs::Pose> waypoints;
+  waypoints.push_back(start_pose);
+
+  geometry_msgs::Pose target_waypoint = start_pose;
+  target_waypoint.position.z -= 0.2;
+  waypoints.push_back(target_waypoint);  // down
+
+  target_waypoint.position.y -= 0.2;
+  waypoints.push_back(target_waypoint);  // right
+
+  target_waypoint.position.z += 0.2;
+  target_waypoint.position.y += 0.2;
+  target_waypoint.position.x -= 0.2;
+  waypoints.push_back(target_waypoint);  // up and left
+
+  moveit_msgs::RobotTrajectory trajectory;
+  const double jump_threshold = 0.0;
+  const double eef_step = 0.01;
+  move_group_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+
+  // Execute trajectory
+  EXPECT_EQ(move_group_->execute(trajectory), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // get the pose after the movement
+  testPose(target_waypoint);
+}
+
+TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
+{
+  SCOPED_TRACE("CollisionObjectsTest");
+
+  // set a custom start state
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.28;
+  start_pose.position.y = -0.2;
+  start_pose.position.z = 0.5;
+  planAndMoveToPose(start_pose);
+
+  // Define a collision object ROS message.
+  moveit_msgs::CollisionObject collision_object;
+  collision_object.header.frame_id = move_group_->getPlanningFrame();
+
+  // The id of the object is used to identify it.
+  collision_object.id = "box1";
+
+  // Define a box to add to the world.
+  shape_msgs::SolidPrimitive primitive;
+  primitive.type = primitive.BOX;
+  primitive.dimensions.resize(3);
+  primitive.dimensions[0] = 0.4;
+  primitive.dimensions[1] = 0.1;
+  primitive.dimensions[2] = 0.1;
+
+  // Define a pose for the box (specified relative to frame_id)
+  geometry_msgs::Pose box_pose;
+  box_pose.orientation.w = 1.0;
+  box_pose.position.x = 0.4;
+  box_pose.position.y = -0.2;
+  box_pose.position.z = 0.8;
+
+  collision_object.primitives.push_back(primitive);
+  collision_object.primitive_poses.push_back(box_pose);
+  collision_object.operation = collision_object.ADD;
+
+  std::vector<moveit_msgs::CollisionObject> collision_objects;
+  collision_objects.push_back(collision_object);
+
+  // Now, let's add the collision object into the world
+  planning_scene_interface_.addCollisionObjects(collision_objects);
+
+  // plan trajectory avoiding object
+  geometry_msgs::Pose target_pose;
+  target_pose.orientation.w = 0.0;
+  target_pose.position.x = 0.4;
+  target_pose.position.y = -0.4;
+  target_pose.position.z = 0.7;
+  planAndMoveToPose(target_pose);
+
+  // get the pose after the movement
+  testPose(target_pose);
+
+  // attach and detach collision object
+  EXPECT_TRUE(move_group_->attachObject(collision_object.id));
+  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(1));
+  EXPECT_TRUE(move_group_->detachObject(collision_object.id));
+  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(0));
+
+  // remove object from world
+  std::vector<std::string> object_ids;
+  object_ids.push_back(collision_object.id);
+  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(1));
+  planning_scene_interface_.removeCollisionObjects(object_ids);
+  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(0));
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "move_group_interface_cpp_test");
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
@@ -1,0 +1,29 @@
+<launch>
+  <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- If needed, broadcast static tf for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
+
+  <!-- We do not have a robot connected, so publish fake joint states -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+  </node>
+  <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />
+
+  <!-- Given the published joint states, publish tf for the robot links -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+  <!-- Run the main MoveIt executable with fake trajectory execution -->
+  <include file="$(find panda_moveit_config)/launch/move_group.launch">
+    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="fake_execution" value="true"/>
+    <arg name="info" value="true"/>
+  </include>
+
+  <!-- test -->
+  <test pkg="moveit_ros_planning_interface" type="move_group_interface_cpp_test" test-name="move_group_interface_cpp_test"
+        time-limit="120" args=""/>
+</launch>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -149,7 +149,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->goal_tolerance, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
 
   connect(ui_->planning_time, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
-  connect(ui_->planning_attempts, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
+  connect(ui_->planning_attempts, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
   connect(ui_->velocity_scaling_factor, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
   connect(ui_->acceleration_scaling_factor, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -603,7 +603,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="planning_attempts">
+             <widget class="QSpinBox" name="planning_attempts">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -611,10 +611,10 @@
                </sizepolicy>
               </property>
               <property name="maximum">
-               <double>1000.000000000000000</double>
+               <number>1000</number>
               </property>
               <property name="value">
-               <double>10.000000000000000</double>
+               <number>10</number>
               </property>
              </widget>
             </item>

--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -322,6 +322,163 @@ class PS3WiredStatus(JoyStatus):
         self.right_analog_y = msg.axes[3]
         self.orig_msg = msg
 
+class PS4Status(JoyStatus):
+    def __init__(self, msg):
+        JoyStatus.__init__(self)
+        #creating from sensor_msg/Joy
+        if msg.buttons[12] == 1:
+            self.center = True
+        else:
+            self.center = False
+        if msg.buttons[8] == 1:
+            self.select = True
+        else:
+            self.select = False
+        if msg.buttons[9] == 1:
+            self.start = True
+        else:
+            self.start = False
+        if msg.buttons[10] == 1:
+            self.L3 = True
+        else:
+            self.L3 = False
+        if msg.buttons[11] == 1:
+            self.R3 = True
+        else:
+            self.R3 = False
+        if msg.buttons[0] == 1:
+            self.square = True
+        else:
+            self.square = False
+        if msg.axes[10] < 0:
+            self.up = True
+        else:
+            self.up = False
+        if msg.axes[10] > 0:
+            self.down = True
+        else:
+            self.down = False
+        if msg.axes[9] < 0:
+            self.left = True
+        else:
+            self.left = False
+        if msg.axes[9] > 0:
+            self.right = True
+        else:
+            self.right = False
+        if msg.buttons[3] == 1:
+            self.triangle = True
+        else:
+            self.triangle = False
+        if msg.buttons[1] == 1:
+            self.cross = True
+        else:
+            self.cross = False
+        if msg.buttons[2] == 1:
+            self.circle = True
+        else:
+            self.circle = False
+        if msg.buttons[4] == 1:
+            self.L1 = True
+        else:
+            self.L1 = False
+        if msg.buttons[5] == 1:
+            self.R1 = True
+        else:
+            self.R1 = False
+        if msg.buttons[6] == 1:
+            self.L2 = True
+        else:
+            self.L2 = False
+        if msg.buttons[7] == 1:
+            self.R2 = True
+        else:
+            self.R2 = False
+        self.left_analog_x = msg.axes[0]
+        self.left_analog_y = msg.axes[1]
+        self.right_analog_x = msg.axes[5]
+        self.right_analog_y = msg.axes[2]
+        self.orig_msg = msg
+
+class PS4WiredStatus(JoyStatus):
+    def __init__(self, msg):
+        JoyStatus.__init__(self)
+        #creating from sensor_msg/Joy
+        if msg.buttons[10] == 1:
+            self.center = True
+        else:
+            self.center = False
+        if msg.buttons[8] == 1:
+            self.select = True
+        else:
+            self.select = False
+        if msg.buttons[9] == 1:
+            self.start = True
+        else:
+            self.start = False
+        if msg.buttons[11] == 1:
+            self.L3 = True
+        else:
+            self.L3 = False
+        if msg.buttons[12] == 1:
+            self.R3 = True
+        else:
+            self.R3 = False
+        if msg.buttons[3] == 1:
+            self.square = True
+        else:
+            self.square = False
+        if msg.axes[7] < 0:
+            self.up = True
+        else:
+            self.up = False
+        if msg.axes[7] > 0:
+            self.down = True
+        else:
+            self.down = False
+        if msg.axes[6] < 0:
+            self.left = True
+        else:
+            self.left = False
+        if msg.axes[6] > 0:
+            self.right = True
+        else:
+            self.right = False
+        if msg.buttons[2] == 1:
+            self.triangle = True
+        else:
+            self.triangle = False
+        if msg.buttons[0] == 1:
+            self.cross = True
+        else:
+            self.cross = False
+        if msg.buttons[1] == 1:
+            self.circle = True
+        else:
+            self.circle = False
+        if msg.buttons[4] == 1:
+            self.L1 = True
+        else:
+            self.L1 = False
+        if msg.buttons[5] == 1:
+            self.R1 = True
+        else:
+            self.R1 = False
+        if msg.buttons[6] == 1:
+            self.L2 = True
+        else:
+            self.L2 = False
+        if msg.buttons[7] == 1:
+            self.R2 = True
+        else:
+            self.R2 = False
+        self.left_analog_x = msg.axes[0]
+        self.left_analog_y = msg.axes[1]
+        self.right_analog_x = msg.axes[3]
+        self.right_analog_y = msg.axes[4]
+        self.orig_msg = msg
+
+
 class StatusHistory():
   def __init__(self, max_length=10):
     self.max_length = max_length
@@ -471,6 +628,10 @@ class MoveitJoy:
             status = XBoxStatus(msg)
         elif len(msg.axes) == 20 and len(msg.buttons) == 17:
             status = PS3Status(msg)
+        elif len(msg.axes) == 14 and len(msg.buttons) == 14:
+            status = PS4Status(msg)
+        elif len(msg.axes) == 8 and len(msg.buttons) == 13:
+            status = PS4WiredStatus(msg)
         else:
             raise Exception("Unknown joystick")
         self.run(status)

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -20,6 +20,7 @@
   This corresponds to moving around the real robot without the use of MoveIt.
   -->
   <arg name="use_gui" default="false" />
+  <arg name="use_rviz" default="true" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
   <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
@@ -48,7 +49,7 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch">
+  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch" if="$(arg use_rviz)">
     <arg name="rviz_config" value="$(find [GENERATED_PACKAGE_NAME])/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -5,11 +5,14 @@
 
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
-				       default_planner_request_adapters/FixWorkspaceBounds
-				       default_planner_request_adapters/FixStartStateBounds
-				       default_planner_request_adapters/FixStartStateCollision
-				       default_planner_request_adapters/FixStartStatePathConstraints" />
+  <arg name="planning_adapters"
+       value="default_planner_request_adapters/AddTimeParameterization
+              default_planner_request_adapters/ResolveConstraintFrames
+              default_planner_request_adapters/FixWorkspaceBounds
+              default_planner_request_adapters/FixStartStateBounds
+              default_planner_request_adapters/FixStartStateCollision
+              default_planner_request_adapters/FixStartStatePathConstraints"
+              />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
 


### PR DESCRIPTION
### Description

These are bug fixes for merging into melodic_devel for the upcoming release.

* remove unused angles.h includes (#1985)
* [ci] configure travis to report success before code-coverage finishes (#2041)
* Fix mesh_filter test (#2044)
* add tests for move_group interface (#1995)
* run shadow-fixed for main branches (#2012)
* fix ordering of request adapters (#2053)
* RS: add interfaces to zero and remove dynamics (#2054)
* totg: add a correct time parameterization for 1-waypoint trajectories (#2054)
* commander: python3 fix (#2030)
* add use_rviz to demo.launch in setup_assistant (#2019)
* MP display: planning attempts are natural numbers (#2076)
* fix signal for planning_attempts (#2082) 
* Wait and check for the grasp service (#2077)
* add aux check for shared-ptr (#2077)
* Added support for PS4 joystick (#2060)
* Check for empty quaternion message (#2089)

Merge or rebase should be done to preserve the history of these commits.

@v4hn: reviewed-for-backport should be fast-forwarded to 091bdfb after merging this.