### PR TITLE
Minor logic cleanup

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -220,7 +220,7 @@ MultiQueryPlannerAllocator::allocatePersistentPlanner<ompl::geometric::LazyPRMst
 {
   return new og::LazyPRMstar(data);
 };
-}
+}  // namespace ompl_interface
 #endif
 
 ompl_interface::PlanningContextManager::PlanningContextManager(moveit::core::RobotModelConstPtr robot_model,
@@ -406,16 +406,15 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
 {
   // find the problem representation to use
   auto best = state_space_factories_.end();
-  int prev_priority = -1;
+  int prev_priority = 0;
   for (auto it = state_space_factories_.begin(); it != state_space_factories_.end(); ++it)
   {
     int priority = it->second->canRepresentProblem(group, req, robot_model_);
-    if (priority > 0)
-      if (best == state_space_factories_.end() || priority > prev_priority)
-      {
-        best = it;
-        prev_priority = priority;
-      }
+    if (priority > prev_priority)
+    {
+      best = it;
+      prev_priority = priority;
+    }
   }
 
   if (best == state_space_factories_.end())


### PR DESCRIPTION
### Description

I was skimming through the internals and noticed this bit of logic which I think can be cleaned up.

Due to the check `priority > 0`, there is no time when `best == state_space_factories_.end()` while `priority <= prev_priority`, so `best == state_space_factories_.end()` is unnecessary. Then if you change the starting value of `prev_priority` then you don't need to separately check if `priority > 0`. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
