### PR TITLE
[jog_arm] Fix crash on empty jog msgs

### DIFF
--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -78,7 +78,6 @@ void JogCalcs::startMainLoop(JogArmShared& shared_variables)
   num_joints_ = internal_joint_state_.name.size();
   internal_joint_state_.position.resize(num_joints_);
   internal_joint_state_.velocity.resize(num_joints_);
-  internal_joint_state_.effort.resize(num_joints_);
   // A map for the indices of incoming joint commands
   for (std::size_t i = 0; i < internal_joint_state_.name.size(); ++i)
   {

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -674,6 +674,13 @@ void JogCalcs::suddenHalt(Eigen::ArrayXd& delta_theta)
 // Is handled differently for position vs. velocity control.
 void JogCalcs::suddenHalt(trajectory_msgs::JointTrajectory& joint_traj)
 {
+  if (joint_traj.points.empty())
+  {
+    joint_traj.points.push_back(trajectory_msgs::JointTrajectoryPoint());
+    joint_traj.points[0].positions.resize(num_joints_);
+    joint_traj.points[0].velocities.resize(num_joints_);
+  }
+
   for (std::size_t i = 0; i < num_joints_; ++i)
   {
     // For position-controlled robots, can reset the joints to a known, good state


### PR DESCRIPTION
### Description

Added a Point message to an empty joint_trajectory to prevent the jog server to crash on icall of invalid index.

- fixes #2047

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
