### PR TITLE
[jog_arm] time-based collision avoidance

### DIFF
--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -52,12 +52,12 @@ command_out_topic: joint_group_position_controller/command # Publish outgoing co
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
+collision_check_rate: 50 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 # Two collision check algorithms are available:
 # "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
 # "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
 collision_check_type: stop_distance
 # Parameters for "threshold_distance"-type collision checking
-collision_check_rate: 50 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.05 # Start decelerating when a scene collision is this far [m]
 # Parameters for "minimum_stop_distance"-type collision checking

--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -60,6 +60,6 @@ collision_check_type: stop_distance
 # Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.05 # Start decelerating when a scene collision is this far [m]
-# Parameters for "minimum_stop_distance"-type collision checking
+# Parameters for "stop_distance"-type collision checking
 collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -52,6 +52,14 @@ command_out_topic: joint_group_position_controller/command # Publish outgoing co
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
-collision_check_rate: 10 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+# Two collision check algorithms are available:
+# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
+# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
+collision_check_type: stop_distance
+# Parameters for "threshold_distance"-type collision checking
+collision_check_rate: 50 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.05 # Start decelerating when a scene collision is this far [m]
+# Parameters for "minimum_stop_distance"-type collision checking
+collision_distance_safety_factor: 5000 # Must be >= 1. A large safety factor is recommended to account for latency
+min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
+++ b/moveit_experimental/moveit_jog_arm/config/ur_simulated_config.yaml
@@ -61,5 +61,5 @@ collision_check_rate: 50 # [Hz] Collision-checking can easily bog down a CPU if 
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.05 # Start decelerating when a scene collision is this far [m]
 # Parameters for "minimum_stop_distance"-type collision checking
-collision_distance_safety_factor: 5000 # Must be >= 1. A large safety factor is recommended to account for latency
+collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -46,6 +46,12 @@
 
 namespace moveit_jog_arm
 {
+enum CollisionCheckType
+{
+  kThresholdDistance = 1,
+  kStopDistance = 2
+};
+
 class CollisionCheckThread
 {
 public:
@@ -64,6 +70,8 @@ public:
 
 private:
   const moveit_jog_arm::JogArmParameters parameters_;
+
+  CollisionCheckType collision_check_type_;
 
   // Pointer to the collision environment
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/collision_check_thread.h
@@ -48,8 +48,8 @@ namespace moveit_jog_arm
 {
 enum CollisionCheckType
 {
-  kThresholdDistance = 1,
-  kStopDistance = 2
+  K_THRESHOLD_DISTANCE = 1,
+  K_STOP_DISTANCE = 2
 };
 
 class CollisionCheckThread

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -83,7 +83,7 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
   double velocity_scale = 1;
 
   collision_check_type_ =
-      (parameters_.collision_check_type == "threshold_distance" ? kThresholdDistance : kStopDistance);
+      (parameters_.collision_check_type == "threshold_distance" ? K_THRESHOLD_DISTANCE : K_STOP_DISTANCE);
 
   // Variables for stop-distance-based collision checking
   double current_collision_distance = 0;
@@ -131,7 +131,7 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
         velocity_scale = 0;
       }
       // If threshold distances were specified
-      else if (collision_check_type_ == kThresholdDistance)
+      else if (collision_check_type_ == K_THRESHOLD_DISTANCE)
       {
         // If we are far from a collision, velocity_scale should be 1.
         // If we are very close to a collision, velocity_scale should be ~zero.

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -78,10 +78,19 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
   double scene_collision_distance = 0;
   bool collision_detected;
 
-  // Scale robot velocity according to collision proximity and user-defined thresholds.
-  // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.
-  // Proximity decreasing --> decelerate
+  // This variable scales the robot velocity when a collision is close
   double velocity_scale = 1;
+
+  collision_check_type_ =
+      (parameters_.collision_check_type == "threshold_distance" ? kThresholdDistance : kStopDistance);
+
+  // Variables for stop-distance-based collision checking
+  double current_collision_distance = 0;
+  double derivative_of_collision_distance = 0;
+  double prev_collision_distance = 0;
+  double est_time_to_collision = 0;
+  bool have_updated_derivative = false;
+  double safety_factor = parameters_.collision_distance_safety_factor;
 
   collision_detection::AllowedCollisionMatrix acm = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
   /////////////////////////////////////////////////
@@ -115,36 +124,72 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
       collision_detected |= collision_result.collision;
 
       velocity_scale = 1;
-      // If we're definitely in collision, stop immediately
-      if (collision_detected)
+
+      // If threshold distances were specified
+      if (collision_check_type_ == kThresholdDistance)
       {
-        velocity_scale = 0;
+        // If we're definitely in collision, stop immediately
+        if (collision_detected)
+        {
+          velocity_scale = 0;
+        }
+
+        // If we are far from a collision, velocity_scale should be 1.
+        // If we are very close to a collision, velocity_scale should be ~zero.
+        // When scene_collision_proximity_threshold is breached, start decelerating exponentially.
+        if (scene_collision_distance < parameters_.scene_collision_proximity_threshold)
+        {
+          // velocity_scale = e ^ k * (collision_distance - threshold)
+          // k = - ln(0.001) / collision_proximity_threshold
+          // velocity_scale should equal one when collision_distance is at collision_proximity_threshold.
+          // velocity_scale should equal 0.001 when collision_distance is at zero.
+          velocity_scale = std::min(velocity_scale,
+                                    exp(scene_velocity_scale_coefficient *
+                                        (scene_collision_distance - parameters_.scene_collision_proximity_threshold)));
+        }
+
+        if (self_collision_distance < parameters_.self_collision_proximity_threshold)
+        {
+          velocity_scale =
+              std::min(velocity_scale, exp(self_velocity_scale_coefficient *
+                                           (self_collision_distance - parameters_.self_collision_proximity_threshold)));
+        }
+      }
+      // Else, we stop based on worst-case stopping distance
+      else
+      {
+        // Retrieve the worst-case time to stop, based on current joint velocities
+
+        // Calculate rate of change of distance to nearest collision
+        current_collision_distance = std::min(scene_collision_distance, self_collision_distance);
+        derivative_of_collision_distance =
+            (current_collision_distance - prev_collision_distance) / collision_rate.expectedCycleTime().toSec();
+
+        if (current_collision_distance < parameters_.min_allowable_collision_distance &&
+            derivative_of_collision_distance <= 0)
+        {
+          velocity_scale = 0;
+        }
+        // Only bother doing calculations if we are moving toward the nearest collision
+        else if (derivative_of_collision_distance < 0)
+        {
+          // At the rate the collision distance is decreasing, how long until we collide?
+          est_time_to_collision = fabs(current_collision_distance / derivative_of_collision_distance);
+
+          // halt if we can't stop fast enough (including the safety factor)
+          if (est_time_to_collision < (safety_factor * shared_variables.worst_case_stop_time))
+          {
+            velocity_scale = 0;
+          }
+        }
+
+        // Update for the next iteration
+        prev_collision_distance = current_collision_distance;
+        have_updated_derivative = true;
       }
 
-      // If we are far from a collision, velocity_scale should be 1.
-      // If we are very close to a collision, velocity_scale should be ~zero.
-      // When scene_collision_proximity_threshold is breached, start decelerating exponentially.
-      if (scene_collision_distance < parameters_.scene_collision_proximity_threshold)
-      {
-        // velocity_scale = e ^ k * (collision_distance - threshold)
-        // k = - ln(0.001) / collision_proximity_threshold
-        // velocity_scale should equal one when collision_distance is at collision_proximity_threshold.
-        // velocity_scale should equal 0.001 when collision_distance is at zero.
-        velocity_scale =
-            std::min(velocity_scale, exp(scene_velocity_scale_coefficient *
-                                         (scene_collision_distance - parameters_.scene_collision_proximity_threshold)));
-      }
-
-      if (self_collision_distance < parameters_.self_collision_proximity_threshold)
-      {
-        velocity_scale =
-            std::min(velocity_scale, exp(self_velocity_scale_coefficient *
-                                         (self_collision_distance - parameters_.self_collision_proximity_threshold)));
-      }
-
-      shared_variables.lock();
+      // Communicate a velocity-scaling factor back to the other threads
       shared_variables.collision_velocity_scale = velocity_scale;
-      shared_variables.unlock();
     }
 
     collision_rate.sleep();

--- a/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check_thread.cpp
@@ -90,7 +90,6 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
   double derivative_of_collision_distance = 0;
   double prev_collision_distance = 0;
   double est_time_to_collision = 0;
-  bool have_updated_derivative = false;
   double safety_factor = parameters_.collision_distance_safety_factor;
 
   collision_detection::AllowedCollisionMatrix acm = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
@@ -185,7 +184,6 @@ void CollisionCheckThread::startMainLoop(JogArmShared& shared_variables)
 
         // Update for the next iteration
         prev_collision_distance = current_collision_distance;
-        have_updated_derivative = true;
       }
 
       // Communicate a velocity-scaling factor back to the other threads

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -477,9 +477,7 @@ trajectory_msgs::JointTrajectory JogCalcs::composeJointTrajMessage(sensor_msgs::
 void JogCalcs::applyVelocityScaling(JogArmShared& shared_variables, Eigen::ArrayXd& delta_theta,
                                     double singularity_scale)
 {
-  shared_variables.lock();
   double collision_scale = shared_variables.collision_velocity_scale;
-  shared_variables.unlock();
 
   if (collision_scale > 0 && collision_scale < 1)
   {
@@ -742,6 +740,47 @@ bool JogCalcs::updateJoints(JogArmShared& shared_variables)
 
   // Cache the original joints in case they need to be reset
   original_joint_state_ = internal_joint_state_;
+
+  // Calculate worst case joint stop time, for collision checking
+  std::string joint_name = "";
+  shared_variables.worst_case_stop_time = std::numeric_limits<double>::max();
+  moveit::core::JointModel::Bounds kinematic_bounds;
+  double accel_limit = 0;
+  double joint_velocity = 0;
+  double worst_case_stop_time = 0;
+  for (size_t jt_state_idx = 0; jt_state_idx < incoming_joint_state_.velocity.size(); ++jt_state_idx)
+  {
+    joint_name = incoming_joint_state_.name[jt_state_idx];
+
+    // Get acceleration limit for this joint
+    for (auto joint_model : joint_model_group_->getActiveJointModels())
+    {
+      if (joint_model->getName() == joint_name)
+      {
+        // Some joints do not have acceleration limits
+        try
+        {
+          kinematic_bounds = joint_model->getVariableBounds();
+          // Be conservative when calculating overall acceleration limit from min and max limits
+          accel_limit =
+              std::min(fabs(kinematic_bounds[0].min_acceleration_), fabs(kinematic_bounds[0].max_acceleration_));
+        }
+        catch (const std::exception& ex)
+        {
+          ROS_WARN_STREAM_NAMED(LOGNAME, "An acceleration limit is not defined for this joint; minimum stop distance "
+                                         "should not be used for collision checking");
+        }
+        break;
+      }
+    }
+
+    // Get the current joint velocity
+    joint_velocity = incoming_joint_state_.velocity[jt_state_idx];
+
+    // Calculate worst case stop time
+    worst_case_stop_time = std::max(worst_case_stop_time, fabs(joint_velocity / accel_limit));
+  }
+  shared_variables.worst_case_stop_time = worst_case_stop_time;
 
   return true;
 }

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -757,15 +757,15 @@ bool JogCalcs::updateJoints(JogArmShared& shared_variables)
     {
       if (joint_model->getName() == joint_name)
       {
+        kinematic_bounds = joint_model->getVariableBounds();
         // Some joints do not have acceleration limits
-        try
+        if (kinematic_bounds[0].acceleration_bounded_)
         {
-          kinematic_bounds = joint_model->getVariableBounds();
           // Be conservative when calculating overall acceleration limit from min and max limits
           accel_limit =
               std::min(fabs(kinematic_bounds[0].min_acceleration_), fabs(kinematic_bounds[0].max_acceleration_));
         }
-        catch (const std::exception& ex)
+        else
         {
           ROS_WARN_STREAM_NAMED(LOGNAME, "An acceleration limit is not defined for this joint; minimum stop distance "
                                          "should not be used for collision checking");

--- a/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
@@ -52,6 +52,14 @@ command_out_topic: jog_server/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
+# Two collision check algorithms are available:
+# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
+# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
+collision_check_type: stop_distance
+# Parameters for "threshold_distance"-type collision checking
 collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
+# Parameters for "minimum_stop_distance"-type collision checking
+collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
+min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
@@ -52,12 +52,12 @@ command_out_topic: jog_server/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
+collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 # Two collision check algorithms are available:
 # "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
 # "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
 collision_check_type: stop_distance
 # Parameters for "threshold_distance"-type collision checking
-collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
 # Parameters for "minimum_stop_distance"-type collision checking

--- a/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
+++ b/moveit_experimental/moveit_jog_arm/test/config/jog_settings.yaml
@@ -60,6 +60,6 @@ collision_check_type: stop_distance
 # Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
-# Parameters for "minimum_stop_distance"-type collision checking
+# Parameters for "stop_distance"-type collision checking
 collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]


### PR DESCRIPTION
The old collision avoidance algorithm used manually-defined thresholds. This adds a new algorithm based on how fast the collision is approaching. It's optional, as you can see from the yaml file.

Video of it in action:

https://drive.google.com/file/d/1vMrrtflJme3Hexfo-685rKVS7uWIy14s/view?usp=sharing
