### PR TITLE
[moveit_core] PropagationDistanceField: Speed-up insertion & update

### DIFF
--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -539,16 +539,6 @@ private:
    */
   void print(const EigenSTL::vector_Vector3d& points);
 
-  /**
-   * \brief Computes squared distance between two 3D integer points
-   *
-   * @param point1 Point 1 for distance
-   * @param point2 Point 2 for distance
-   *
-   * @return Distance between points squared
-   */
-  static int eucDistSq(Eigen::Vector3i point1, Eigen::Vector3i point2);
-
   bool propagate_negative_; /**< \brief Whether or not to propagate negative distances */
 
   VoxelGrid<PropDistanceFieldVoxel>::Ptr voxel_grid_; /**< \brief Actual container for distance data */

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -92,14 +92,6 @@ void PropagationDistanceField::initialize()
   reset();
 }
 
-int PropagationDistanceField::eucDistSq(Eigen::Vector3i point1, Eigen::Vector3i point2)
-{
-  int dx = point1.x() - point2.x();
-  int dy = point1.y() - point2.y();
-  int dz = point1.z() - point2.z();
-  return dx * dx + dy * dy + dz * dz;
-}
-
 void PropagationDistanceField::print(const VoxelSet& set)
 {
   ROS_DEBUG_NAMED("distance_field", "[");
@@ -430,7 +422,7 @@ void PropagationDistanceField::propagatePositive()
         // the real update code:
         // calculate the neighbor's new distance based on my closest filled voxel:
         PropDistanceFieldVoxel* neighbor = &voxel_grid_->getCell(nloc.x(), nloc.y(), nloc.z());
-        int new_distance_sq = eucDistSq(vptr->closest_point_, nloc);
+        int new_distance_sq = (vptr->closest_point_ - nloc).squaredNorm();
         if (new_distance_sq > max_distance_sq_)
           continue;
 
@@ -488,7 +480,7 @@ void PropagationDistanceField::propagateNegative()
         // the real update code:
         // calculate the neighbor's new distance based on my closest filled voxel:
         PropDistanceFieldVoxel* neighbor = &voxel_grid_->getCell(nloc.x(), nloc.y(), nloc.z());
-        int new_distance_sq = eucDistSq(vptr->closest_negative_point_, nloc);
+        int new_distance_sq = (vptr->closest_negative_point_ - nloc).squaredNorm();
         if (new_distance_sq > max_distance_sq_)
           continue;
         // std::cout << "Looking at " << nloc.x() << " " << nloc.y() << " " << nloc.z() << " " << new_distance_sq << " "


### PR DESCRIPTION
This PR replaces `eucDistSq` with Eigen's built-in `squaredNorm`. This innocuous-looking change results in a speed-up of 25% for me when tested with a large set of points (benchmarked with >400k points).

Before: 1248ms
After: 956ms