### PR TITLE
[melodic-devel] PlanningSceneDisplay speedup backport 

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -371,6 +371,11 @@ void PlanningSceneMonitor::scenePublishingThread()
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
+            if (new_scene_update_ == UPDATE_STATE)
+            {
+              msg.robot_state.attached_collision_objects.clear();
+              msg.robot_state.is_diff = true;
+            }
           }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_);  // we don't want the
                                                                                                  // transform cache to

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -411,7 +411,6 @@ void PlanningSceneMonitor::scenePublishingThread()
     }
     if (publish_msg)
     {
-      rate.reset();
       planning_scene_publisher_.publish(msg);
       if (is_full)
         ROS_DEBUG_NAMED(LOGNAME, "Published full planning scene: '%s'", msg.name.c_str());

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -241,7 +241,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
 
   last_update_time_ = last_robot_motion_time_ = ros::Time::now();
   last_robot_state_update_wall_time_ = ros::WallTime::now();
-  dt_state_update_ = ros::WallDuration(0.1);
+  dt_state_update_ = ros::WallDuration(0.03);
 
   double temp_wait_time = 0.05;
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -192,7 +192,10 @@ protected:
   RobotStateVisualizationPtr planning_scene_robot_;
   PlanningSceneRenderPtr planning_scene_render_;
 
+  // full update required
   bool planning_scene_needs_render_;
+  // or only the robot position (excluding attached object changes)
+  bool robot_state_needs_render_;
   float current_scene_time_;
 
   rviz::Property* scene_category_;

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -115,8 +115,8 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   octree_coloring_property_->addOption("Cell Probability", OCTOMAP_PROBABLILTY_COLOR);
 
   scene_display_time_property_ =
-      new rviz::FloatProperty("Scene Display Time", 0.2f, "The amount of wall-time to wait in between rendering "
-                                                          "updates to the planning scene (if any)",
+      new rviz::FloatProperty("Scene Display Time", 0.01f, "The amount of wall-time to wait in between rendering "
+                                                           "updates to the planning scene (if any)",
                               scene_category_, SLOT(changedSceneDisplayTime()), this);
   scene_display_time_property_->setMin(0.0001);
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -336,10 +336,17 @@ void PlanningSceneDisplay::renderPlanningScene()
   try
   {
     const planning_scene_monitor::LockedPlanningSceneRO& ps = getPlanningSceneRO();
-    planning_scene_render_->renderPlanningScene(
-        ps, env_color, attached_color, static_cast<OctreeVoxelRenderMode>(octree_render_property_->getOptionInt()),
-        static_cast<OctreeVoxelColorMode>(octree_coloring_property_->getOptionInt()),
-        scene_alpha_property_->getFloat());
+    if (planning_scene_needs_render_)
+    {
+      planning_scene_render_->renderPlanningScene(
+          ps, env_color, attached_color, static_cast<OctreeVoxelRenderMode>(octree_render_property_->getOptionInt()),
+          static_cast<OctreeVoxelColorMode>(octree_coloring_property_->getOptionInt()),
+          scene_alpha_property_->getFloat());
+    }
+    else
+    {
+      planning_scene_render_->updateRobotPosition(ps);
+    }
   }
   catch (std::exception& ex)
   {
@@ -633,12 +640,14 @@ void PlanningSceneDisplay::update(float wall_dt, float ros_dt)
 void PlanningSceneDisplay::updateInternal(float wall_dt, float ros_dt)
 {
   current_scene_time_ += wall_dt;
-  if (current_scene_time_ > scene_display_time_property_->getFloat() && planning_scene_render_ &&
+  if ((current_scene_time_ > scene_display_time_property_->getFloat() && planning_scene_render_ &&
+       robot_state_needs_render_) ||
       planning_scene_needs_render_)
   {
     renderPlanningScene();
     calculateOffsetPosition();
     current_scene_time_ = 0.0f;
+    robot_state_needs_render_ = false;
     planning_scene_needs_render_ = false;
   }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
@@ -76,6 +76,8 @@ public:
     return scene_robot_;
   }
 
+  void updateRobotPosition(const planning_scene::PlanningSceneConstPtr& scene);
+
   void renderPlanningScene(const planning_scene::PlanningSceneConstPtr& scene, const rviz::Color& default_scene_color,
                            const rviz::Color& default_attached_color, OctreeVoxelRenderMode voxel_render_mode,
                            OctreeVoxelColorMode voxel_color_mode, float default_scene_alpha);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -68,6 +68,7 @@ public:
   void update(const robot_state::RobotStateConstPtr& kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color,
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
+  void updateKinematicState(const robot_state::RobotStateConstPtr& kinematic_state);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
   /// update color of all attached object shapes
   void updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -56,6 +56,16 @@ PlanningSceneRender::~PlanningSceneRender()
   context_->getSceneManager()->destroySceneNode(planning_scene_geometry_node_->getName());
 }
 
+void PlanningSceneRender::updateRobotPosition(const planning_scene::PlanningSceneConstPtr& scene)
+{
+  if (scene_robot_)
+  {
+    robot_state::RobotStatePtr rs = std::make_shared<robot_state::RobotState>(scene->getCurrentState());
+    rs->update();
+    scene_robot_->updateKinematicState(rs);
+  }
+}
+
 void PlanningSceneRender::clear()
 {
   render_shapes_->clear();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -100,7 +100,7 @@ void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kine
                                      const std_msgs::ColorRGBA& default_attached_object_color,
                                      const std::map<std::string, std_msgs::ColorRGBA>& color_map)
 {
-  updateHelper(kinematic_state, default_attached_object_color, &color_map);
+    updateHelper(kinematic_state, default_attached_object_color, &color_map);
 }
 
 void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
@@ -127,14 +127,20 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
         alpha = color.a = it->second.a;
       }
     }
+    rviz::RobotLink* link = robot_.getLink(attached_body->getAttachedLinkName());
+    if (!link)
+    {
+        ROS_ERROR_STREAM("Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
+        continue;
+    }
     rviz::Color rcolor(color.r, color.g, color.b);
-    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getGlobalCollisionBodyTransforms();
+    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getFixedTransforms();
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)
     {
-      render_shapes_->renderShape(robot_.getVisualNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
+      render_shapes_->renderShape(link->getVisualNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, rcolor, alpha);
-      render_shapes_->renderShape(robot_.getCollisionNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
+      render_shapes_->renderShape(link->getCollisionNode(), ab_shapes[j].get(), ab_t[j], octree_voxel_render_mode_,
                                   octree_voxel_color_mode_, rcolor, alpha);
     }
   }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -37,6 +37,7 @@
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>
 #include <moveit/rviz_plugin_render_tools/render_shapes.h>
+#include <rviz/robot/robot_link.h>
 #include <QApplication>
 
 namespace moveit_rviz_plugin
@@ -100,7 +101,7 @@ void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kine
                                      const std_msgs::ColorRGBA& default_attached_object_color,
                                      const std::map<std::string, std_msgs::ColorRGBA>& color_map)
 {
-    updateHelper(kinematic_state, default_attached_object_color, &color_map);
+  updateHelper(kinematic_state, default_attached_object_color, &color_map);
 }
 
 void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
@@ -130,8 +131,8 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
     rviz::RobotLink* link = robot_.getLink(attached_body->getAttachedLinkName());
     if (!link)
     {
-        ROS_ERROR_STREAM("Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
-        continue;
+      ROS_ERROR_STREAM("Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
+      continue;
     }
     rviz::Color rcolor(color.r, color.g, color.b);
     const EigenSTL::vector_Isometry3d& ab_t = attached_body->getFixedTransforms();
@@ -147,6 +148,11 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
   robot_.setVisualVisible(visual_visible_);
   robot_.setCollisionVisible(collision_visible_);
   robot_.setVisible(visible_);
+}
+
+void RobotStateVisualization::updateKinematicState(const moveit::core::RobotStateConstPtr& kinematic_state)
+{
+  robot_.update(PlanningLinkUpdater(kinematic_state));
 }
 
 void RobotStateVisualization::setVisible(bool visible)


### PR DESCRIPTION
This is a backport of #2049 done using

`git cherry-pick `26ec92850d4bae71bab1daf193981f66b0ad8beb`^..`2fc28767be58920fc74bdf57282b92424249a6b0

I'm including the command because I wasn't sure whether to include 736219d8a5d55d952b85eebf52ae6ea4e3220da8  as well

discussed also in #2066 