### PR TITLE
prevent collision checking segfault if octomap has NULL root pointer

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -517,10 +517,11 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   }
 
   fcl_result.min_distance = dist_threshold;
+  // fcl::distance segfaults when given an octree with a null root pointer (using FCL 0.6.1)
   if ((o1->getObjectType() == fcl::OT_OCTREE &&
        !std::static_pointer_cast<const fcl::OcTreed>(o1->collisionGeometry())->getRoot()) ||
-      (o1->getObjectType() == fcl::OT_OCTREE &&
-       !std::static_pointer_cast<const fcl::OcTreed>(o1->collisionGeometry())->getRoot()))
+      (o2->getObjectType() == fcl::OT_OCTREE &&
+       !std::static_pointer_cast<const fcl::OcTreed>(o2->collisionGeometry())->getRoot()))
   {
     return false;
   }

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -517,7 +517,18 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   }
 
   fcl_result.min_distance = dist_threshold;
-  double d = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
+  double d;
+  if ((o1->getObjectType() == fcl::OT_OCTREE &&
+       std::dynamic_pointer_cast<const fcl::OcTree<double>>(o1->collisionGeometry())->getRoot() == NULL) ||
+      (o1->getObjectType() == fcl::OT_OCTREE &&
+       std::dynamic_pointer_cast<const fcl::OcTree<double>>(o1->collisionGeometry())->getRoot() == NULL))
+  {
+    d = 1e300;
+  }
+  else
+  {
+    d = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
+  }
 
   // Check if either object is already in the map. If not add it or if present
   // check to see if the new distance is closer. If closer remove the existing

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -517,18 +517,14 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   }
 
   fcl_result.min_distance = dist_threshold;
-  double d;
   if ((o1->getObjectType() == fcl::OT_OCTREE &&
-       std::dynamic_pointer_cast<const fcl::OcTree<double>>(o1->collisionGeometry())->getRoot() == NULL) ||
+       !std::static_pointer_cast<const OcTreed>(o1->collisionGeometry())->getRoot()) ||
       (o1->getObjectType() == fcl::OT_OCTREE &&
-       std::dynamic_pointer_cast<const fcl::OcTree<double>>(o1->collisionGeometry())->getRoot() == NULL))
+       !std::static_pointer_cast<const OcTreed>(o1->collisionGeometry())->getRoot()))
   {
-    d = std::numeric_limits<double>::max();
+    return false;
   }
-  else
-  {
-    d = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
-  }
+  double d = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
 
   // Check if either object is already in the map. If not add it or if present
   // check to see if the new distance is closer. If closer remove the existing

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -523,7 +523,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       (o1->getObjectType() == fcl::OT_OCTREE &&
        std::dynamic_pointer_cast<const fcl::OcTree<double>>(o1->collisionGeometry())->getRoot() == NULL))
   {
-    d = 1e300;
+    d = std::numeric_limits<double>::max();
   }
   else
   {

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -518,9 +518,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
   fcl_result.min_distance = dist_threshold;
   if ((o1->getObjectType() == fcl::OT_OCTREE &&
-       !std::static_pointer_cast<const OcTreed>(o1->collisionGeometry())->getRoot()) ||
+       !std::static_pointer_cast<const fcl::OcTreed>(o1->collisionGeometry())->getRoot()) ||
       (o1->getObjectType() == fcl::OT_OCTREE &&
-       !std::static_pointer_cast<const OcTreed>(o1->collisionGeometry())->getRoot()))
+       !std::static_pointer_cast<const fcl::OcTreed>(o1->collisionGeometry())->getRoot()))
   {
     return false;
   }


### PR DESCRIPTION
### Description

After clearing the octomap, the root node is set to NULL, which then causes FCL to segfault in collision checking. Maybe it's actually an FCL bug, but this was the most straightforward way I found to work around it.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
