### PR TITLE
checking collision between two sets of objects in the world

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,7 @@ API changes in MoveIt releases
 - Requests to `get_planning_scene` service without explicitly setting "components" now return full scene
 - `moveit_ros_planning` no longer depends on `moveit_ros_perception`
 - `CollisionRobot` and `CollisionWorld` are combined into a single `CollisionEnv` class. This applies for all derived collision checkers as `FCL`, `ALL_VALID`, `HYBRID` and `DISTANCE_FIELD`. Consequently, `getCollisionRobot[Unpadded] / getCollisionWorld` functions are replaced through a `getCollisionEnv` in the planning scene and return the new combined environment. This unified collision environment provides the union of all member functions of `CollisionRobot` and `CollisionWorld`. Note that calling `checkRobotCollision` of the `CollisionEnv` does not take a `CollisionRobot` as an argument anymore as it is implicitly contained in the `CollisionEnv`.
+- `CollisionEnv` provides a function `checkCollisionBetweenObjectGroups` that allows collision detection between two sets of objects that are already part of the world ([2097](https://github.com/ros-planning/moveit/issues/2097)).
 - `RobotTrajectory` provides a copy constructor that allows a shallow (default) and deep copy of waypoints
 
 ## ROS Melodic

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -156,6 +156,13 @@ public:
                                    const moveit::core::RobotState& state1,
                                    const moveit::core::RobotState& state2) const = 0;
 
+  virtual bool checkCollisionBetweenObjectGroups(std::vector<std::string> const& object_group1,
+                                                 std::vector<std::string> const& object_group2) const
+  {
+    ROS_ERROR_STREAM_NAMED("collision_detection", "checkObjectPairCollision is unimplemented");
+    return false;
+  }
+
   /** \brief The distance to self-collision given the robot is at state \e state.
       @param req A DistanceRequest object that encapsulates the distance request
       @param res A DistanceResult object that encapsulates the distance result

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan, Jens Petit */
+/* Author: Ioan Sucan, Jens Petit, Pradeep Rajendran*/
 
 #pragma once
 
@@ -156,6 +156,10 @@ public:
                                    const moveit::core::RobotState& state1,
                                    const moveit::core::RobotState& state2) const = 0;
 
+  /** \brief Check whether there is a collision between any object in group 1 and any object in group 2. Only names of
+   *  object is required to be in the group. These names correspond to objects that are already in the world.
+   *  @param object_group1 A vector of string containing the names of objects in group1.
+   *  @param object_group2 A vector of string containing the names of objects in group2. */
   virtual bool checkCollisionBetweenObjectGroups(std::vector<std::string> const& object_group1,
                                                  std::vector<std::string> const& object_group2) const
   {

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -82,6 +82,9 @@ public:
   void checkRobotCollision(const CollisionRequest& req, CollisionResult& res, const moveit::core::RobotState& state1,
                            const moveit::core::RobotState& state2) const override;
 
+  bool checkCollisionBetweenObjectGroups(std::vector<std::string> const& object_group1,
+                                       std::vector<std::string> const& object_group2) const override;
+
   void distanceSelf(const DistanceRequest& req, DistanceResult& res,
                     const moveit::core::RobotState& state) const override;
 

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan, Jens Petit */
+/* Author: Ioan Sucan, Jens Petit, Pradeep Rajendran */
 
 #pragma once
 
@@ -83,7 +83,7 @@ public:
                            const moveit::core::RobotState& state2) const override;
 
   bool checkCollisionBetweenObjectGroups(std::vector<std::string> const& object_group1,
-                                       std::vector<std::string> const& object_group2) const override;
+                                         std::vector<std::string> const& object_group2) const override;
 
   void distanceSelf(const DistanceRequest& req, DistanceResult& res,
                     const moveit::core::RobotState& state) const override;
@@ -95,12 +95,12 @@ public:
 
 protected:
   /** \brief Updates the FCL collision geometry and objects saved in the CollisionRobotFCL members to reflect a new
-  *   padding or scaling of the robot links.
-  *
-  *   It searches for the link through the pointed-to robot model of the CollisionRobot and then constructs new FCL
-  *   collision objects and geometries depending on the changed robot model.
-  *
-  *   \param links The names of the links which have been updated in the robot model */
+   *   padding or scaling of the robot links.
+   *
+   *   It searches for the link through the pointed-to robot model of the CollisionRobot and then constructs new FCL
+   *   collision objects and geometries depending on the changed robot model.
+   *
+   *   \param links The names of the links which have been updated in the robot model */
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
 
   /** \brief Bundles the different checkSelfCollision functions into a single function */
@@ -120,26 +120,27 @@ protected:
   void updateFCLObject(const std::string& id);
 
   /** \brief Out of the current robot state and its attached bodies construct an FCLObject which can then be used to
-  *   check for collision.
-  *
-  *   The current state is used to recalculate the AABB of the FCL collision objects. However they are not computed from
-  *   scratch (which would require call to computeLocalAABB()) but are only transformed according to the joint states.
-  *
-  *   \param state The current robot state
-  *   \param fcl_obj The newly filled object */
+   *   check for collision.
+   *
+   *   The current state is used to recalculate the AABB of the FCL collision objects. However they are not computed
+   * from scratch (which would require call to computeLocalAABB()) but are only transformed according to the joint
+   * states.
+   *
+   *   \param state The current robot state
+   *   \param fcl_obj The newly filled object */
   void constructFCLObjectRobot(const moveit::core::RobotState& state, FCLObject& fcl_obj) const;
 
   /** \brief Prepares for the collision check through constructing an FCL collision object out of the current robot
-  *   state and specifying a broadphase collision manager of FCL where the constructed object is registered to. */
+   *   state and specifying a broadphase collision manager of FCL where the constructed object is registered to. */
   void allocSelfCollisionBroadPhase(const moveit::core::RobotState& state, FCLManager& manager) const;
 
   /** \brief Converts all shapes which make up an atttached body into a vector of FCLGeometryConstPtr.
-  *
-  *   When they are converted, they can be added to the FCL representation of the robot for collision checking.
-  *
-  *   \param ab Pointer to the attached body
-  *   \param geoms Output vector of geometries
-  */
+   *
+   *   When they are converted, they can be added to the FCL representation of the robot for collision checking.
+   *
+   *   \param ab Pointer to the attached body
+   *   \param geoms Output vector of geometries
+   */
   void getAttachedBodyObjects(const moveit::core::AttachedBody* ab, std::vector<FCLGeometryConstPtr>& geoms) const;
 
   /** \brief Vector of shared pointers to the FCL geometry for the objects in fcl_objs_. */

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -319,12 +319,20 @@ bool CollisionEnvFCL::checkCollisionBetweenObjectGroups(std::vector<std::string>
   for (auto it = object_group1.begin(); it != object_group1.end(); ++it)
   {
     auto const& object_name = *it;
+    if (fcl_objs_.count(object_name) == 0)
+      ROS_ERROR_STREAM_NAMED("collision_detection.fcl",
+                             "FCL object by the name: " << object_name << " does not exist.");
+
     auto fcl_obj = fcl_objs_.at(object_name);
     fcl_obj.registerTo(manager1.get());
   }
   for (auto it = object_group2.begin(); it != object_group2.end(); ++it)
   {
     auto const& object_name = *it;
+    if (fcl_objs_.count(object_name) == 0)
+      ROS_ERROR_STREAM_NAMED("collision_detection.fcl",
+                             "FCL object by the name: " << object_name << " does not exist.");
+
     auto fcl_obj = fcl_objs_.at(object_name);
     fcl_obj.registerTo(manager2.get());
   }

--- a/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Jens Petit */
+/* Author: Jens Petit, Pradeep Rajendran */
 
 #include <gtest/gtest.h>
 #include <ros/ros.h>
@@ -315,6 +315,68 @@ TEST_F(CollisionDetectionEnvTest, DISABLED_ContinuousCollisionWorld)
   ASSERT_TRUE(res.collision);
   ASSERT_EQ(res.contact_count, 4u);
   res.clear();
+}
+
+/** \brief Tests the correctness of collision between two sets of objects in the world. */
+TEST_F(CollisionDetectionEnvTest, CollisionBetweenTwoObjectSetsTest)
+{
+  // Add a box shape to the world
+  shapes::Shape* shape = new shapes::Box(0.1, 0.1, 0.1);
+  shapes::ShapeConstPtr shape_ptr(shape);
+
+  // case 1) Expected: No collision between group 1 and group 2
+  {
+    Eigen::Isometry3d pos{ Eigen::Isometry3d::Identity() };
+    pos.translation().x() = 0;
+    pos.translation().y() = 0;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp1_box_A", shape_ptr, pos);
+    pos.translation().x() = 0.3;
+    pos.translation().y() = 0;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp1_box_B", shape_ptr, pos);
+
+    pos.translation().x() = 0;
+    pos.translation().y() = 0.3;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp2_box_A", shape_ptr, pos);
+    pos.translation().x() = 0.3;
+    pos.translation().y() = 0.3;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp2_box_B", shape_ptr, pos);
+
+    std::vector<std::string> object_group1 = { "grp1_box_A", "grp1_box_B" };
+    std::vector<std::string> object_group2 = { "grp2_box_A", "grp2_box_B" };
+    bool collision_flag = c_env_->checkCollisionBetweenObjectGroups(object_group1, object_group2);
+    ASSERT_FALSE(collision_flag);
+  }
+
+  // case 2) Expected: Collision between group 1 and group 2
+  {
+    Eigen::Isometry3d pos{ Eigen::Isometry3d::Identity() };
+    pos.translation().x() = 0;
+    pos.translation().y() = 0;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp1_box_A", shape_ptr, pos);
+    pos.translation().x() = 0.3;
+    pos.translation().y() = 0;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp1_box_B", shape_ptr, pos);
+
+    pos.translation().x() = 0;
+    pos.translation().y() = 0.0;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp2_box_A", shape_ptr, pos);
+    pos.translation().x() = 0.3;
+    pos.translation().y() = 0.3;
+    pos.translation().z() = 0;
+    c_env_->getWorld()->addToObject("grp2_box_B", shape_ptr, pos);
+
+    std::vector<std::string> object_group1 = { "grp1_box_A", "grp1_box_B" };
+    std::vector<std::string> object_group2 = { "grp2_box_A", "grp2_box_B" };
+    bool collision_flag = c_env_->checkCollisionBetweenObjectGroups(object_group1, object_group2);
+    ASSERT_TRUE(collision_flag);
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

This PR is related to #2097 .
Here are the changes made:

A new virtual public function (checkCollisionBetweenObjectGroups) was added to collision_env.h.
This function provides the Boolean result of a collision check between objects of one group and another group. Each group is a vector of strings denoting the name of the objects in the group.

A concrete implementation is provided in "collision_env_fcl.cpp" for the new function.
The implementation instantiates a FCL CollisionManager for each group and populates the collision manager with the corresponding objects.
Finally, a collision query is made to the CollisionManager and the result is returned.

A test case is also provided in "test_fcl_env.cpp".
 
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
