### PR TITLE
Fix Melodic 1.0.3 release

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -957,8 +957,8 @@ as the new values that correspond to the group */
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
-  setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, unsigned int attempts, double timeout = 0.0,
-            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, unsigned int /*attempts*/,
+            double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
     return setFromIK(group, pose, timeout, constraint, options);
@@ -976,7 +976,7 @@ as the new values that correspond to the group */
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIK(const JointModelGroup* group, const geometry_msgs::Pose& pose, const std::string& tip,
-            unsigned int attempts, double timeout = 0.0,
+            unsigned int /*attempts*/, double timeout = 0.0,
             const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
@@ -993,8 +993,8 @@ as the new values that correspond to the group */
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
-  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, unsigned int attempts, double timeout = 0.0,
-            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, unsigned int /*attempts*/,
+            double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
     return setFromIK(group, pose, timeout, constraint, options);
@@ -1010,8 +1010,9 @@ as the new values that correspond to the group */
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
-  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip, unsigned int attempts,
-            double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
+  setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
+            unsigned int /*attempts*/, double timeout = 0.0,
+            const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
     return setFromIK(group, pose, tip, timeout, constraint, options);
@@ -1031,7 +1032,7 @@ as the new values that correspond to the group */
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
-            const std::vector<double>& consistency_limits, unsigned int attempts, double timeout = 0.0,
+            const std::vector<double>& consistency_limits, unsigned int /*attempts*/, double timeout = 0.0,
             const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
@@ -1053,7 +1054,7 @@ as the new values that correspond to the group */
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-            const std::vector<std::string>& tips, unsigned int attempts, double timeout = 0.0,
+            const std::vector<std::string>& tips, unsigned int /*attempts*/, double timeout = 0.0,
             const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
@@ -1077,7 +1078,7 @@ as the new values that correspond to the group */
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
             const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
-            unsigned int attempts, double timeout = 0.0,
+            unsigned int /*attempts*/, double timeout = 0.0,
             const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {
@@ -1100,7 +1101,7 @@ as the new values that correspond to the group */
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIKSubgroups(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
                      const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
-                     unsigned int attempts, double timeout = 0.0,
+                     unsigned int /*attempts*/, double timeout = 0.0,
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
   {

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -380,9 +380,8 @@ bool IKFastKinematicsPlugin::computeRelativeTransform(const std::string& from, c
   robot_state.reset(new RobotState(robot_model_));
   robot_state->setToDefaultValues();
 
-  bool has_link;  // to suppress ROS_ERRORs for non-existent frames
-  auto* from_link = robot_model_->getLinkModel(from, &has_link);
-  auto* to_link = robot_model_->getLinkModel(to, &has_link);
+  auto* from_link = robot_model_->getLinkModel(from);
+  auto* to_link = robot_model_->getLinkModel(to);
   if (!from_link || !to_link)
     return false;
 

--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -15,6 +15,8 @@ panda=/tmp/resources/panda_description/urdf/panda.urdf
 # Translate environment variable QUIET=[0 | 1] into actual option
 test ${QUIET:-1} -eq 0 && QUIET="" || QUIET="--quiet"
 
+travis_run --retry sudo apt-get -q install python-lxml
+
 # Create ikfast plugins for Fanuc and Panda
 travis_run moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
 	$QUIET --name fanuc --pkg $PWD/fanuc_ikfast_plugin $fanuc manipulator base_link tool0


### PR DESCRIPTION
This attempts to fix broken API in the IKfast plugins, which slipped in with the backport merge #1998.
Unfortunately, it was missed by Travis, because of other issues (missing python-lxml).