### PR TITLE
MoveItCpp: Use csm to get robot's current state

### DIFF
--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -138,7 +138,7 @@ public:
 
   /** \brief Get the current state queried from the current state monitor
       \param wait_seconds the time in seconds for the state monitor to wait for a robot state. */
-  moveit::core::RobotStatePtr getCurrentState(double wait_seconds = 0.0);
+  moveit::core::RobotStatePtr getCurrentState(double wait_seconds = 1.0);
 
   /** \brief Get all loaded planning pipeline instances mapped to their reference names */
   const std::map<std::string, planning_pipeline::PlanningPipelinePtr>& getPlanningPipelines() const;

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -195,16 +195,12 @@ const ros::NodeHandle& MoveItCpp::getNodeHandle() const
 
 bool MoveItCpp::getCurrentState(moveit::core::RobotStatePtr& current_state, double wait_seconds)
 {
-  if (wait_seconds > 0.0 &&
-      !planning_scene_monitor_->getStateMonitor()->waitForCurrentState(ros::Time::now(), wait_seconds))
+  auto csm = planning_scene_monitor_->getStateMonitor();
+  if (!csm->waitForCurrentState(ros::Time::now(), wait_seconds) || !(current_state = csm->getCurrentState()))
   {
-    ROS_ERROR_NAMED(LOGNAME, "Did not receive robot state");
+    ROS_WARN_NAMED(LOGNAME, "Failed to receive current robot state");
     return false;
   }
-  {  // Lock planning scene
-    planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor_);
-    current_state.reset(new moveit::core::RobotState(scene->getCurrentState()));
-  }  // Unlock planning scene
   return true;
 }
 


### PR DESCRIPTION
### Description

I'm sometime getting `ros.moveit_ros_planning.trajectory_execution_manager: 
Invalid Trajectory: start point deviates from current robot state more than 0.01` and after debugging it I found that it is caused by getting not up-to-date robot state when I call `MoveItCpp::getCurrentState`

In the current implementation if wait_seconds is set to zero (which is the default value) it returns the PlanningScene's robot state without checking its time, this PR

1- Use current state monitor directly to get the current state
2- Set default wait time to 1.0 to reflect the default value for the current state monitor's waitForCurrentState function

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
