### PR TITLE
Fix catkin_lint

### DIFF
--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -81,6 +81,7 @@ catkin_package(
     moveit_ros_robot_interaction
     object_recognition_msgs
     roscpp
+    rviz
   DEPENDS
     EIGEN3
 )

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -57,7 +57,6 @@ catkin_package(
     moveit_ros_planning
     moveit_ros_visualization
     roscpp
-    rviz
 )
 
 # Header files that need Qt Moc pre-processing for use with Qt signals, etc:

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -57,6 +57,7 @@ catkin_package(
     moveit_ros_planning
     moveit_ros_visualization
     roscpp
+    rviz
 )
 
 # Header files that need Qt Moc pre-processing for use with Qt signals, etc:

--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -22,13 +22,13 @@
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
   <build_depend>ompl</build_depend>
+  <build_depend>rviz</build_depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_visualization</depend>
   <depend>rosconsole</depend>
   <depend>roscpp</depend>
-  <depend>rviz</depend>
   <depend>urdf</depend>
   <depend>yaml-cpp</depend>
   <depend version_gt="0.3.1">srdfdom</depend>

--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -34,6 +34,7 @@
   <depend version_gt="0.3.1">srdfdom</depend>
 
   <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz</exec_depend>
 
   <test_depend>moveit_resources</test_depend>
   <test_depend>rosunit</test_depend>


### PR DESCRIPTION
### Description

As you can see, right now the master branch is failing due to catkin_lint -- example: https://travis-ci.org/github/ros-planning/moveit/jobs/692499448

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
