### PR TITLE
Fixed Issue: RViz panel-Planner Parameters move right without scrollbars

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>692</width>
-    <height>414</height>
+    <height>424</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -96,6 +96,9 @@
             </item>
             <item>
              <widget class="moveit_rviz_plugin::MotionPlanningParamWidget" name="planner_param_treeview">
+              <property name="autoScroll">
+               <bool>false</bool>
+              </property>
               <property name="indentation">
                <number>0</number>
               </property>


### PR DESCRIPTION
As mentioned in #2062 , RViz panel list will auto-scroll to the right. 

- Disabled the properties of "autoScroll" of planner_param_treeview 