### PR TITLE
Remove support for Indigo's ros_control

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -27,11 +27,6 @@ catkin_package(
   DEPENDS Boost
 )
 
-# support indigo's ros_control - This can be removed upon EOL indigo
-if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")
-  add_definitions(-DMOVEIT_ROS_CONTROL_INTERFACE_OLD_ROS_CONTROL)
-endif()
-
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}_plugin


### PR DESCRIPTION
Code states "This can be removed upon EOL Indigo", which MoveIt has EOL'd for master. Preparing for Noetic support instead.

Original PR: https://github.com/ros-planning/moveit/pull/551
