### PR TITLE
update dependencies for python3 in noetic

### DIFF
--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -1,4 +1,5 @@
-<package format="2">
+<?xml version="1.0"?>
+<package format="3">
   <name>moveit_commander</name>
   <version>1.1.0</version>
   <description>Python interfaces to MoveIt</description>
@@ -18,13 +19,14 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>python-catkin-pkg</buildtool_depend>
 
-  <build_depend>python</build_depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>moveit_ros_planning_interface</exec_depend>
-  <exec_depend>python</exec_depend>
-  <exec_depend>python-pyassimp</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pyassimp</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pyassimp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>shape_msgs</exec_depend>

--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -17,7 +17,8 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>python-catkin-pkg</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</buildtool_depend>
 
   <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -1,4 +1,5 @@
-<package format="2">
+<?xml version="1.0"?>
+<package format="3">
   <name>moveit_core</name>
   <version>1.1.0</version>
   <description>Core libraries used by MoveIt</description>
@@ -53,7 +54,8 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
-  <test_depend>orocos_kdl</test_depend>
+  <test_depend condition="$ROS_DISTRO != noetic">orocos_kdl</test_depend>
+  <test_depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</test_depend>
   <test_depend>rosunit</test_depend>
 
   <export>

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>moveit_kinematics</name>
   <version>1.1.0</version>
   <description>Package for all inverse kinematics solvers in MoveIt</description>
@@ -27,7 +27,8 @@
   <depend>eigen</depend>
   <depend>tf2</depend>
   <depend>tf2_kdl</depend>
-  <depend>orocos_kdl</depend>
+  <depend condition="$ROS_DISTRO != noetic">orocos_kdl</depend>
+  <depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</depend>
 
   <exec_depend>python-lxml</exec_depend>
   <exec_depend>liburdfdom-tools</exec_depend> <!-- provides check_urdf required by ikfast scripts -->

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -1,4 +1,5 @@
-<package format="2">
+<?xml version="1.0"?>
+<package format="3">
   <name>moveit_ros_planning_interface</name>
   <version>1.1.0</version>
   <description>Components of MoveIt that offer simpler interfaces to planning and execution</description>
@@ -16,7 +17,8 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>python-catkin-pkg</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</buildtool_depend>
 
   <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_warehouse</depend>
@@ -32,7 +34,8 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
   <depend>eigenpy</depend>
 
   <build_depend>eigen</build_depend>


### PR DESCRIPTION
### Description

This updates some packages to package.xml format 3 and sets up Python3 dependencies for noetic. It requires https://github.com/ros/rosdistro/pull/25263 to be merged before the new python3-pyassimp key will be available.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code) (N/A - all package.xml changes)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) - also N/A
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
