### PR TITLE
remove robot_model:: and robot_state::

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,6 +16,7 @@ API changes in MoveIt releases
 - `moveit_ros_planning` no longer depends on `moveit_ros_perception`
 - `CollisionRobot` and `CollisionWorld` are combined into a single `CollisionEnv` class. This applies for all derived collision checkers as `FCL`, `ALL_VALID`, `HYBRID` and `DISTANCE_FIELD`. Consequently, `getCollisionRobot[Unpadded] / getCollisionWorld` functions are replaced through a `getCollisionEnv` in the planning scene and return the new combined environment. This unified collision environment provides the union of all member functions of `CollisionRobot` and `CollisionWorld`. Note that calling `checkRobotCollision` of the `CollisionEnv` does not take a `CollisionRobot` as an argument anymore as it is implicitly contained in the `CollisionEnv`.
 - `RobotTrajectory` provides a copy constructor that allows a shallow (default) and deep copy of waypoints
+- Replace the redundant namespaces `robot_state::` and `robot_model::` with the actual namespace `moveit::core::`. The additional namespaces will disappear in the future (ROS2).
 
 ## ROS Melodic
 

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -132,7 +132,7 @@ public:
   void testJointPositions(const std::vector<double>& expected)
   {
     SCOPED_TRACE("testJointPositions");
-    const robot_state::JointModelGroup* joint_model_group =
+    const moveit::core::JointModelGroup* joint_model_group =
         move_group_->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
     std::vector<double> actual;
     move_group_->getCurrentState()->copyJointGroupPositions(joint_model_group, actual);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -71,7 +71,7 @@ public:
   void update(const moveit::core::RobotStateConstPtr& kinematic_state,
               const std_msgs::ColorRGBA& default_attached_object_color,
               const std::map<std::string, std_msgs::ColorRGBA>& color_map);
-  void updateKinematicState(const robot_state::RobotStateConstPtr& kinematic_state);
+  void updateKinematicState(const moveit::core::RobotStateConstPtr& kinematic_state);
   void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
   /// update color of all attached object shapes
   void updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -60,7 +60,7 @@ void PlanningSceneRender::updateRobotPosition(const planning_scene::PlanningScen
 {
   if (scene_robot_)
   {
-    robot_state::RobotStatePtr rs = std::make_shared<robot_state::RobotState>(scene->getCurrentState());
+    auto rs = std::make_shared<moveit::core::RobotState>(scene->getCurrentState());
     rs->update();
     scene_robot_->updateKinematicState(rs);
   }


### PR DESCRIPTION
Fixes #1878 .

Please merge this as two commits, as we should only backport the internal usage, but not the API change.