### PR TITLE
Add primitive shapes widgets

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -304,6 +304,7 @@ private:
   ros::Subscriber update_custom_goal_state_subscriber_;
   // General
   void changePlanningGroupHelper();
+  void addPrimitiveShape();
   void importResource(const std::string& path);
   void loadStoredStates(const std::string& pattern);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -97,6 +97,11 @@ static const std::string TAB_SCENES = "Stored Scenes";
 static const std::string TAB_STATES = "Stored States";
 static const std::string TAB_STATUS = "Status";
 
+static const std::map<std::string, shapes::ShapeType> SHAPES_MAP = { { "box", shapes::BOX },
+                                                                     { "sphere", shapes::SPHERE },
+                                                                     { "cone", shapes::CONE },
+                                                                     { "cylinder", shapes::CYLINDER } };
+
 class MotionPlanningFrame : public QWidget
 {
   friend class MotionPlanningDisplay;
@@ -172,6 +177,7 @@ private Q_SLOTS:
   void onClearOctomapClicked();
 
   // Scene Objects tab
+  void shapesComboBoxChanged(const QString& text);
   void importFileButtonClicked();
   void importUrlButtonClicked();
   void clearSceneButtonClicked();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -128,6 +128,9 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->planning_scene_tree, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this,
           SLOT(warehouseItemNameChanged(QTreeWidgetItem*, int)));
   connect(ui_->reset_db_button, SIGNAL(clicked()), this, SLOT(resetDbButtonClicked()));
+  connect(ui_->add_shape_button,&QPushButton::clicked, [this](){
+    addPrimitiveShape();
+  });
   connect(ui_->export_scene_text_button, SIGNAL(clicked()), this, SLOT(exportAsTextButtonClicked()));
   connect(ui_->import_scene_text_button, SIGNAL(clicked()), this, SLOT(importFromTextButtonClicked()));
   connect(ui_->load_state_button, SIGNAL(clicked()), this, SLOT(loadStateButtonClicked()));
@@ -424,6 +427,62 @@ void MotionPlanningFrame::sceneUpdate(planning_scene_monitor::PlanningSceneMonit
 {
   if (update_type & planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY)
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+}
+
+void MotionPlanningFrame::addPrimitiveShape()
+{
+	if (!planning_display_->getPlanningSceneMonitor())
+	{
+		return;
+	}
+	static const double DEFAULT_SIDE_LENGHT = 1.0;
+	static const std::map<std::string,shapes::ShapeType> SHAPES_MAP = {{"box",shapes::BOX},
+	                                                                   {"sphere",shapes::SPHERE},
+	                                                                   {"cone",shapes::CONE},
+	                                                                   {"cylinder",shapes::CYLINDER}};
+
+	// get selected shape
+	std::string selected_shape = ui_->shapes_combo_box->currentText().toStdString();
+	if(SHAPES_MAP.count(selected_shape) == 0)
+	{
+    QMessageBox::warning(this, QString("Unsupported shape"), QString("The '")
+                                                               .append(selected_shape.c_str())
+                                                               .append("' is not supported."));
+    return;
+	}
+	shapes::ShapeType shape_type = SHAPES_MAP.at(selected_shape);
+	shapes::ShapeConstPtr shape;
+	switch(shape_type)
+	{
+	  case shapes::BOX:
+	    shape = std::make_shared<shapes::Box>(DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT);
+	    break;
+	  case shapes::SPHERE:
+	    shape = std::make_shared<shapes::Sphere>(0.5 * DEFAULT_SIDE_LENGHT);
+	        break;
+	  case shapes::CONE:
+	    shape = std::make_shared<shapes::Cone>(0.5 * DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT);
+      break;
+	  case shapes::CYLINDER:
+	    shape = std::make_shared<shapes::Cylinder>(0.5 * DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT);
+      break;
+	}
+
+	// naming object
+	int idx = 0;
+	std::string shape_name = selected_shape + "_" + std::to_string(idx);
+	while(planning_display_->getPlanningSceneRO()->getWorld()->hasObject(shape_name))
+	{
+	  idx++;
+	  shape_name = selected_shape + "_" + std::to_string(idx);
+	}
+
+	// adding object
+  Eigen::Isometry3d pose;
+  pose.setIdentity();
+  planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
+  if (ps)
+    addObject(ps->getWorldNonConst(), shape_name, shape, pose);
 }
 
 void MotionPlanningFrame::importResource(const std::string& path)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -128,9 +128,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->planning_scene_tree, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this,
           SLOT(warehouseItemNameChanged(QTreeWidgetItem*, int)));
   connect(ui_->reset_db_button, SIGNAL(clicked()), this, SLOT(resetDbButtonClicked()));
-  connect(ui_->add_shape_button,&QPushButton::clicked, [this](){
-    addPrimitiveShape();
-  });
+  connect(ui_->add_shape_button, &QPushButton::clicked, [this]() { addPrimitiveShape(); });
   connect(ui_->export_scene_text_button, SIGNAL(clicked()), this, SLOT(exportAsTextButtonClicked()));
   connect(ui_->import_scene_text_button, SIGNAL(clicked()), this, SLOT(importFromTextButtonClicked()));
   connect(ui_->load_state_button, SIGNAL(clicked()), this, SLOT(loadStateButtonClicked()));
@@ -431,53 +429,61 @@ void MotionPlanningFrame::sceneUpdate(planning_scene_monitor::PlanningSceneMonit
 
 void MotionPlanningFrame::addPrimitiveShape()
 {
-	if (!planning_display_->getPlanningSceneMonitor())
-	{
-		return;
-	}
-	static const double DEFAULT_SIDE_LENGHT = 1.0;
-	static const std::map<std::string,shapes::ShapeType> SHAPES_MAP = {{"box",shapes::BOX},
-	                                                                   {"sphere",shapes::SPHERE},
-	                                                                   {"cone",shapes::CONE},
-	                                                                   {"cylinder",shapes::CYLINDER}};
+  static const double MIN_VAL = 1e-6;
+  static const std::map<std::string, shapes::ShapeType> SHAPES_MAP = {
+    { "box", shapes::BOX }, { "sphere", shapes::SPHERE }, { "cone", shapes::CONE }, { "cylinder", shapes::CYLINDER }
+  };
 
-	// get selected shape
-	std::string selected_shape = ui_->shapes_combo_box->currentText().toStdString();
-	if(SHAPES_MAP.count(selected_shape) == 0)
-	{
-    QMessageBox::warning(this, QString("Unsupported shape"), QString("The '")
-                                                               .append(selected_shape.c_str())
-                                                               .append("' is not supported."));
+  if (!planning_display_->getPlanningSceneMonitor())
+  {
     return;
-	}
-	shapes::ShapeType shape_type = SHAPES_MAP.at(selected_shape);
-	shapes::ShapeConstPtr shape;
-	switch(shape_type)
-	{
-	  case shapes::BOX:
-	    shape = std::make_shared<shapes::Box>(DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT);
-	    break;
-	  case shapes::SPHERE:
-	    shape = std::make_shared<shapes::Sphere>(0.5 * DEFAULT_SIDE_LENGHT);
-	        break;
-	  case shapes::CONE:
-	    shape = std::make_shared<shapes::Cone>(0.5 * DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT);
-      break;
-	  case shapes::CYLINDER:
-	    shape = std::make_shared<shapes::Cylinder>(0.5 * DEFAULT_SIDE_LENGHT,DEFAULT_SIDE_LENGHT);
-      break;
-	}
+  }
 
-	// naming object
-	int idx = 0;
-	std::string shape_name = selected_shape + "_" + std::to_string(idx);
-	while(planning_display_->getPlanningSceneRO()->getWorld()->hasObject(shape_name))
-	{
-	  idx++;
-	  shape_name = selected_shape + "_" + std::to_string(idx);
-	}
+  // get side length
+  double side_length = ui_->shape_size_spin_box->value();
+  if (side_length < MIN_VAL)
+  {
+    QMessageBox::warning(this, QString("Side length value is too small"),
+                         QString("Value needs to be  >= '").append(std::to_string(MIN_VAL).c_str()).append("'"));
+    return;
+  }
 
-	// adding object
+  // get selected shape
+  std::string selected_shape = ui_->shapes_combo_box->currentText().toStdString();
+  if (SHAPES_MAP.count(selected_shape) == 0)
+  {
+    QMessageBox::warning(this, QString("Unsupported shape"),
+                         QString("The '").append(selected_shape.c_str()).append("' is not supported."));
+    return;
+  }
+  shapes::ShapeType shape_type = SHAPES_MAP.at(selected_shape);
+  shapes::ShapeConstPtr shape;
+  switch (shape_type)
+  {
+    case shapes::BOX:
+      shape = std::make_shared<shapes::Box>(side_length, side_length, side_length);
+      break;
+    case shapes::SPHERE:
+      shape = std::make_shared<shapes::Sphere>(0.5 * side_length);
+      break;
+    case shapes::CONE:
+      shape = std::make_shared<shapes::Cone>(0.5 * side_length, side_length);
+      break;
+    case shapes::CYLINDER:
+      shape = std::make_shared<shapes::Cylinder>(0.5 * side_length, side_length);
+      break;
+  }
+
+  // naming object
+  int idx = 0;
+  std::string shape_name = selected_shape + "_" + std::to_string(idx);
+  while (planning_display_->getPlanningSceneRO()->getWorld()->hasObject(shape_name))
+  {
+    idx++;
+    shape_name = selected_shape + "_" + std::to_string(idx);
+  }
+
+  // adding object
   Eigen::Isometry3d pose;
   pose.setIdentity();
   planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -73,6 +73,45 @@ QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subfra
 
 namespace moveit_rviz_plugin
 {
+void MotionPlanningFrame::shapesComboBoxChanged(const QString& text)
+{
+  const std::string selected_shape = text.toStdString();
+  if (SHAPES_MAP.find(selected_shape) == SHAPES_MAP.end())
+  {
+    return;
+  }
+
+  shapes::ShapeType shape_type = SHAPES_MAP.at(selected_shape);
+  switch (shape_type)
+  {
+    case shapes::BOX:
+      ui_->shape_size_x_spin_box->setEnabled(true);
+      ui_->shape_size_y_spin_box->setEnabled(true);
+      ui_->shape_size_z_spin_box->setEnabled(true);
+      break;
+    case shapes::SPHERE:
+      ui_->shape_size_x_spin_box->setEnabled(true);
+      ui_->shape_size_y_spin_box->setEnabled(false);
+      ui_->shape_size_z_spin_box->setEnabled(false);
+      break;
+    case shapes::CONE:
+      ui_->shape_size_x_spin_box->setEnabled(true);
+      ui_->shape_size_y_spin_box->setEnabled(false);
+      ui_->shape_size_z_spin_box->setEnabled(true);
+      break;
+    case shapes::CYLINDER:
+      ui_->shape_size_x_spin_box->setEnabled(true);
+      ui_->shape_size_y_spin_box->setEnabled(false);
+      ui_->shape_size_z_spin_box->setEnabled(true);
+      break;
+    default:
+      ui_->shape_size_x_spin_box->setEnabled(false);
+      ui_->shape_size_y_spin_box->setEnabled(false);
+      ui_->shape_size_z_spin_box->setEnabled(false);
+      QMessageBox::warning(this, QString("Unsupported shape"),
+                           QString("The '%1' is not supported.").arg(selected_shape.c_str()));
+  }
+}
 void MotionPlanningFrame::importFileButtonClicked()
 {
   QString path = QFileDialog::getOpenFileName(this, tr("Import Object"));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>692</width>
-    <height>414</height>
+    <height>424</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,7 +26,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="context">
       <attribute name="title">
@@ -1125,11 +1125,8 @@
             <property name="textFormat">
              <enum>Qt::AutoText</enum>
             </property>
-            <property name="WordWrap">
+            <property name="WordWrap" stdset="0">
              <bool>true</bool>
-            </property>
-            <property name="TextInteractionFlags">
-             <enum>Qt::TextBrowserInteraction</enum>
             </property>
            </widget>
           </item>
@@ -1194,28 +1191,21 @@
           <string>Current Scene Objects</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_8">
-          <item row="1" column="1">
-           <widget class="QPushButton" name="import_url_button">
-            <property name="text">
-             <string>Import &amp;URL</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QPushButton" name="clear_scene_button">
-            <property name="text">
-             <string>Clear</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QPushButton" name="remove_object_button">
             <property name="text">
              <string>Remove</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="4" column="1">
+           <widget class="QPushButton" name="clear_scene_button">
+            <property name="text">
+             <string>Clear</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QPushButton" name="import_file_button">
             <property name="text">
              <string>Import &amp;File</string>
@@ -1227,6 +1217,53 @@
             <property name="editTriggers">
              <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
             </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="import_url_button">
+            <property name="text">
+             <string>Import &amp;URL</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2" alignment="Qt::AlignTop">
+           <widget class="QGroupBox" name="groupBox_4">
+            <property name="title">
+             <string>Primitive Shapes</string>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_12">
+             <item>
+              <widget class="QComboBox" name="shapes_combo_box">
+               <item>
+                <property name="text">
+                 <string>box</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>sphere</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>cone</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>cylinder</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="add_shape_button">
+               <property name="text">
+                <string>Add</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1257,6 +1257,16 @@
               </widget>
              </item>
              <item>
+              <widget class="QDoubleSpinBox" name="shape_size_spin_box">
+               <property name="singleStep">
+                <double>0.500000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QPushButton" name="add_shape_button">
                <property name="text">
                 <string>Add</string>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1287,30 +1287,30 @@
           <item>
            <widget class="QDoubleSpinBox" name="shape_size_x_spin_box">
             <property name="singleStep">
-             <double>0.100000000000000</double>
+             <double>0.050000000000000</double>
             </property>
             <property name="value">
-             <double>1.000000000000000</double>
+             <double>0.200000000000000</double>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QDoubleSpinBox" name="shape_size_y_spin_box">
             <property name="singleStep">
-             <double>0.100000000000000</double>
+             <double>0.050000000000000</double>
             </property>
             <property name="value">
-             <double>1.000000000000000</double>
+             <double>0.200000000000000</double>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QDoubleSpinBox" name="shape_size_z_spin_box">
             <property name="singleStep">
-             <double>0.100000000000000</double>
+             <double>0.050000000000000</double>
             </property>
             <property name="value">
-             <double>1.000000000000000</double>
+             <double>0.200000000000000</double>
             </property>
            </widget>
           </item>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1102,31 +1102,53 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="title">
-          <string>Object Status</string>
+       <item row="0" column="0" rowspan="5">
+        <widget class="QGroupBox" name="groupBox_8">
+         <property name="toolTip">
+          <string>Press Ctrl+C to duplicate an object</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_12">
-          <item>
-           <widget class="QLabel" name="object_status">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
+         <property name="title">
+          <string>Current Scene Objects</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_8">
+          <item row="4" column="0">
+           <widget class="QPushButton" name="remove_object_button">
             <property name="text">
-             <string>Status</string>
+             <string>Remove</string>
             </property>
-            <property name="textFormat">
-             <enum>Qt::AutoText</enum>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QPushButton" name="clear_scene_button">
+            <property name="text">
+             <string>Clear</string>
             </property>
-            <property name="WordWrap" stdset="0">
-             <bool>true</bool>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="import_file_button">
+            <property name="text">
+             <string>Import &amp;File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QListWidget" name="collision_objects_list">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="editTriggers">
+             <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="import_url_button">
+            <property name="text">
+             <string>Import &amp;URL</string>
             </property>
            </widget>
           </item>
@@ -1182,104 +1204,7 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="0" rowspan="4">
-        <widget class="QGroupBox" name="groupBox_8">
-         <property name="toolTip">
-          <string>Press Ctrl+C to duplicate an object</string>
-         </property>
-         <property name="title">
-          <string>Current Scene Objects</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_8">
-          <item row="4" column="0">
-           <widget class="QPushButton" name="remove_object_button">
-            <property name="text">
-             <string>Remove</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QPushButton" name="clear_scene_button">
-            <property name="text">
-             <string>Clear</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QPushButton" name="import_file_button">
-            <property name="text">
-             <string>Import &amp;File</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QListWidget" name="collision_objects_list">
-            <property name="editTriggers">
-             <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="import_url_button">
-            <property name="text">
-             <string>Import &amp;URL</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="2" alignment="Qt::AlignTop">
-           <widget class="QGroupBox" name="groupBox_4">
-            <property name="title">
-             <string>Primitive Shapes</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_12">
-             <item>
-              <widget class="QComboBox" name="shapes_combo_box">
-               <item>
-                <property name="text">
-                 <string>box</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>sphere</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>cone</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>cylinder</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-             <item>
-              <widget class="QDoubleSpinBox" name="shape_size_spin_box">
-               <property name="singleStep">
-                <double>0.500000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="add_shape_button">
-               <property name="text">
-                <string>Add</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -1291,6 +1216,93 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Object Status</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_12">
+          <item>
+           <widget class="QLabel" name="object_status">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <property name="text">
+             <string>Status</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::AutoText</enum>
+            </property>
+            <property name="WordWrap" stdset="0">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Primitive Shapes</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_12">
+          <item>
+           <widget class="QComboBox" name="shapes_combo_box">
+            <item>
+             <property name="text">
+              <string>box</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>sphere</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>cone</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>cylinder</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="shape_size_spin_box">
+            <property name="singleStep">
+             <double>0.500000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="add_shape_button">
+            <property name="text">
+             <string>Add</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>692</width>
-    <height>424</height>
+    <height>437</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1285,9 +1285,29 @@
            </widget>
           </item>
           <item>
-           <widget class="QDoubleSpinBox" name="shape_size_spin_box">
+           <widget class="QDoubleSpinBox" name="shape_size_x_spin_box">
             <property name="singleStep">
-             <double>0.500000000000000</double>
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="shape_size_y_spin_box">
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="shape_size_z_spin_box">
+            <property name="singleStep">
+             <double>0.100000000000000</double>
             </property>
             <property name="value">
              <double>1.000000000000000</double>
@@ -1296,6 +1316,12 @@
           </item>
           <item>
            <widget class="QPushButton" name="add_shape_button">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Add</string>
             </property>


### PR DESCRIPTION
### Description
Addresses issue #2063 

Adds widgets into the moveit motion planning plugin that allows adding primitive shapes into the planning scene
![rviz_screenshot_2020_06_02-16_13_31](https://user-images.githubusercontent.com/3279718/83571126-cd310380-a4ec-11ea-819f-cc062615036f.png)


### Checklist
- [x ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
