### PR TITLE
Fix geometric shapes related memory leaks

### DIFF
--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -280,7 +280,7 @@ void collision_detection::BodyDecomposition::init(const std::vector<shapes::Shap
   bodies_.clear();
   for (unsigned int i = 0; i < shapes.size(); i++)
   {
-    bodies_.addBody(shapes[i]->clone(), poses[i], padding);
+    bodies_.addBody(shapes[i].get(), poses[i], padding);
   }
 
   // collecting collision spheres

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1018,8 +1018,8 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Isomet
       in >> shape_count;
       for (std::size_t i = 0; i < shape_count && in.good() && !in.eof(); ++i)
       {
-        shapes::Shape* s = shapes::constructShapeFromText(in);
-        if (!s)
+        const auto shape = shapes::ShapeConstPtr(shapes::constructShapeFromText(in));
+        if (!shape)
         {
           ROS_ERROR_NAMED(LOGNAME, "Failed to load shape from scene file");
           return false;
@@ -1041,12 +1041,12 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Isomet
           ROS_ERROR_NAMED(LOGNAME, "Improperly formatted color in scene geometry file");
           return false;
         }
-        if (s)
+        if (shape)
         {
           Eigen::Isometry3d pose = Eigen::Translation3d(x, y, z) * Eigen::Quaterniond(rw, rx, ry, rz);
           // Transform pose by input pose offset
           pose = offset * pose;
-          world_->addToObject(ns, shapes::ShapePtr(s), pose);
+          world_->addToObject(ns, shape, pose);
           if (r > 0.0f || g > 0.0f || b > 0.0f || a > 0.0f)
           {
             std_msgs::ColorRGBA color;


### PR DESCRIPTION
### Couple fixes to memory leaks caused by raw pointer usage with `geometric_shapes` objects.

These fixes are related to the efforts and finding in this issue [https://github.com/ros-planning/moveit/issues/2075](https://github.com/ros-planning/moveit/issues/2075). However, this PR does not fix the leaks reported by @tylerjw, but rather these are new findings made using address sanitizer.

Running address sanitizer revealed couple memory leaks related raw pointer usage with `geometric_shapes` objects. I added two fixes to this PR since they are both very small.

First fix is wrapping return value of `shapes::constructShapeFromText(in)` in shared_ptr so that if the geometry being loaded is corrupted or malformed, the constructed shape will always be freed undepending on the code path.

Second fix is removing call to `clone()` in `BodyDecomposition::init()`. Prior to the fix, each of the cloned objects was heap allocated and raw pointer was passed to `addBody` without calling free on the objects at any point, which caused every single object to leak. Looking more closely at the `addBody` function I realized that there doesn't seem to be any reason to call clone there so I removed the operation altogether. Now, the raw pointers passed to the function point to the `shared_ptr<Shape>` objects which will get freed correctly eventually thanks to reference counting.
