### PR TITLE
Added throttle to jogarm accel limit warning

### DIFF
--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -767,9 +767,9 @@ bool JogCalcs::updateJoints(JogArmShared& shared_variables)
         }
         else
         {
-          ROS_WARN_STREAM_THROTTLE_NAMED(1.0, LOGNAME,
-                                         "An acceleration limit is not defined for this joint; minimum stop distance "
-                                         "should not be used for collision checking");
+          ROS_ERROR_STREAM_ONCE_NAMED(LOGNAME, "An acceleration limit is not defined for this joint, '"
+                                                   << joint_model->getName() << "'; minimum stop distance should not "
+                                                                                "be used for collision checking");
         }
         break;
       }

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -767,7 +767,8 @@ bool JogCalcs::updateJoints(JogArmShared& shared_variables)
         }
         else
         {
-          ROS_WARN_STREAM_NAMED(LOGNAME, "An acceleration limit is not defined for this joint; minimum stop distance "
+          ROS_WARN_STREAM_THROTTLE_NAMED(1.0, LOGNAME,
+                                         "An acceleration limit is not defined for this joint; minimum stop distance "
                                          "should not be used for collision checking");
         }
         break;


### PR DESCRIPTION
### Description

Minor change to add throttle to warning message, which is currently printed for every joint in every iteration of the control loop.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
