### PR TITLE
Clean up Rviz plugin, fix mesh scaling

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -172,8 +172,8 @@ private Q_SLOTS:
   void onClearOctomapClicked();
 
   // Scene Objects tab
-  void import3DObjectFromFileButtonClicked();
-  void import3DObjectFromUrlButtonClicked();
+  void importObjectFromFileButtonClicked();
+  void importObjectFromUrlButtonClicked();
   void clearSceneButtonClicked();
   void sceneScaleChanged(int value);
   void sceneScaleStartChange();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -97,6 +97,8 @@ static const std::string TAB_SCENES = "Stored Scenes";
 static const std::string TAB_STATES = "Stored States";
 static const std::string TAB_STATUS = "Status";
 
+static const double LARGE_MESH_THRESHOLD = 10.0;
+
 class MotionPlanningFrame : public QWidget
 {
   friend class MotionPlanningDisplay;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -186,8 +186,8 @@ private Q_SLOTS:
   void collisionObjectChanged(QListWidgetItem* item);
   void imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback& feedback);
   void copySelectedCollisionObject();
-  void exportAsTextButtonClicked();
-  void importFromTextButtonClicked();
+  void exportGeometryAsTextButtonClicked();
+  void importGeometryFromTextButtonClicked();
 
   // Stored scenes tab
   void saveSceneButtonClicked();
@@ -251,8 +251,8 @@ private:
   void renameCollisionObject(QListWidgetItem* item);
   void attachDetachCollisionObject(QListWidgetItem* item);
   void populateCollisionObjectsList();
-  void computeImportFromText(const std::string& path);
-  void computeExportAsText(const std::string& path);
+  void computeImportGeometryFromText(const std::string& path);
+  void computeExportGeometryAsText(const std::string& path);
   visualization_msgs::InteractiveMarker
   createObjectMarkerMsg(const collision_detection::CollisionEnv::ObjectConstPtr& obj);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -172,8 +172,8 @@ private Q_SLOTS:
   void onClearOctomapClicked();
 
   // Scene Objects tab
-  void importFileButtonClicked();
-  void importUrlButtonClicked();
+  void import3DObjectFromFileButtonClicked();
+  void import3DObjectFromUrlButtonClicked();
   void clearSceneButtonClicked();
   void sceneScaleChanged(int value);
   void sceneScaleStartChange();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -128,8 +128,8 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->planning_scene_tree, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this,
           SLOT(warehouseItemNameChanged(QTreeWidgetItem*, int)));
   connect(ui_->reset_db_button, SIGNAL(clicked()), this, SLOT(resetDbButtonClicked()));
-  connect(ui_->export_scene_text_button, SIGNAL(clicked()), this, SLOT(exportAsTextButtonClicked()));
-  connect(ui_->import_scene_text_button, SIGNAL(clicked()), this, SLOT(importFromTextButtonClicked()));
+  connect(ui_->export_scene_geometry_text_button, SIGNAL(clicked()), this, SLOT(exportGeometryAsTextButtonClicked()));
+  connect(ui_->import_scene_geometry_text_button, SIGNAL(clicked()), this, SLOT(importGeometryFromTextButtonClicked()));
   connect(ui_->load_state_button, SIGNAL(clicked()), this, SLOT(loadStateButtonClicked()));
   connect(ui_->save_start_state_button, SIGNAL(clicked()), this, SLOT(saveStartStateButtonClicked()));
   connect(ui_->save_goal_state_button, SIGNAL(clicked()), this, SLOT(saveGoalStateButtonClicked()));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -460,7 +460,8 @@ void MotionPlanningFrame::importResource(const std::string& path)
       if (object_is_very_large)
       {
         QMessageBox msg_box;
-        msg_box.setText("The object is very large (greater than 10 m). The file may be in millimeters instead of meters.");
+        msg_box.setText(
+            "The object is very large (greater than 10 m). The file may be in millimeters instead of meters.");
         msg_box.setInformativeText("Attempt to fix the size by shrinking the object?");
         msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
         msg_box.setDefaultButton(QMessageBox::Yes);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -445,6 +445,26 @@ void MotionPlanningFrame::importResource(const std::string& path)
         return;
       }
 
+      // Center the mesh so scaling applies correctly
+      double sx = 0.0, sy = 0.0, sz = 0.0;
+      for (unsigned int i = 0; i < mesh->vertex_count; ++i)
+      {
+        unsigned int i3 = i * 3;
+        sx += mesh->vertices[i3];
+        sy += mesh->vertices[i3 + 1];
+        sz += mesh->vertices[i3 + 2];
+      }
+      sx /= (double)mesh->vertex_count;
+      sy /= (double)mesh->vertex_count;
+      sz /= (double)mesh->vertex_count;
+      for (unsigned int i = 0; i < mesh->vertex_count; ++i)
+      {
+        unsigned int i3 = i * 3;
+        mesh->vertices[i3] -= sx;
+        mesh->vertices[i3 + 1] -= sy;
+        mesh->vertices[i3 + 2] -= sz;
+      }
+
       // If the object is very large, ask the user if the scale should be reduced.
       bool object_is_very_large = false;
       for (unsigned int i = 0; i < mesh->vertex_count; i++)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -463,39 +463,17 @@ void MotionPlanningFrame::importResource(const std::string& path)
         msg_box.setText(
             "The object is very large (greater than 10 m). The file may be in millimeters instead of meters.");
         msg_box.setInformativeText("Attempt to fix the size by shrinking the object?");
-        msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+        msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
         msg_box.setDefaultButton(QMessageBox::Yes);
-        int ret = msg_box.exec();
-        switch (ret)
+        if (msg_box.exec() == QMessageBox::Yes)
         {
-          case QMessageBox::Yes:
-            // Center the mesh so scaling applies correctly
-            {
-              double sx = 0.0, sy = 0.0, sz = 0.0;
-              for (unsigned int i = 0; i < mesh->vertex_count; ++i)
-              {
-                unsigned int i3 = i * 3;
-                sx += mesh->vertices[i3];
-                sy += mesh->vertices[i3 + 1];
-                sz += mesh->vertices[i3 + 2];
-              }
-              sx /= (double)mesh->vertex_count;
-              sy /= (double)mesh->vertex_count;
-              sz /= (double)mesh->vertex_count;
-              for (unsigned int i = 0; i < mesh->vertex_count; ++i)
-              {
-                unsigned int i3 = i * 3;
-                mesh->vertices[i3] -= sx;
-                mesh->vertices[i3 + 1] -= sy;
-                mesh->vertices[i3 + 2] -= sz;
-              }
-              mesh->scaleAndPadd(0.001, 0);
-            }
-            break;
-          case QMessageBox::No:
-            break;
-          default:
-            return;  // Pressed cancel, do nothing
+          for (unsigned int i = 0; i < mesh->vertex_count; ++i)
+          {
+            unsigned int i3 = i * 3;
+            mesh->vertices[i3] *= 0.001;
+            mesh->vertices[i3 + 1] *= 0.001;
+            mesh->vertices[i3 + 2] *= 0.001;
+          }
         }
       }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -449,8 +449,9 @@ void MotionPlanningFrame::importResource(const std::string& path)
       bool object_is_very_large = false;
       for (unsigned int i = 0; i < mesh->vertex_count; i++)
       {
-        if ((abs(mesh->vertices[i * 3 + 0]) > 10) || (abs(mesh->vertices[i * 3 + 1]) > 10) ||
-            (abs(mesh->vertices[i * 3 + 2]) > 10))
+        if ((abs(mesh->vertices[i * 3 + 0]) > LARGE_MESH_THRESHOLD) ||
+            (abs(mesh->vertices[i * 3 + 1]) > LARGE_MESH_THRESHOLD) ||
+            (abs(mesh->vertices[i * 3 + 2]) > LARGE_MESH_THRESHOLD))
         {
           object_is_very_large = true;
           break;
@@ -459,7 +460,7 @@ void MotionPlanningFrame::importResource(const std::string& path)
       if (object_is_very_large)
       {
         QMessageBox msg_box;
-        msg_box.setText("The object is very large. The file may be in millimeters instead of meters.");
+        msg_box.setText("The object is very large (greater than 10 m). The file may be in millimeters instead of meters.");
         msg_box.setInformativeText("Attempt to fix the size by shrinking the object?");
         msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
         msg_box.setDefaultButton(QMessageBox::Yes);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -445,26 +445,6 @@ void MotionPlanningFrame::importResource(const std::string& path)
         return;
       }
 
-      // Center the mesh so scaling applies correctly
-      double sx = 0.0, sy = 0.0, sz = 0.0;
-      for (unsigned int i = 0; i < mesh->vertex_count; ++i)
-      {
-        unsigned int i3 = i * 3;
-        sx += mesh->vertices[i3];
-        sy += mesh->vertices[i3 + 1];
-        sz += mesh->vertices[i3 + 2];
-      }
-      sx /= (double)mesh->vertex_count;
-      sy /= (double)mesh->vertex_count;
-      sz /= (double)mesh->vertex_count;
-      for (unsigned int i = 0; i < mesh->vertex_count; ++i)
-      {
-        unsigned int i3 = i * 3;
-        mesh->vertices[i3] -= sx;
-        mesh->vertices[i3 + 1] -= sy;
-        mesh->vertices[i3 + 2] -= sz;
-      }
-
       // If the object is very large, ask the user if the scale should be reduced.
       bool object_is_very_large = false;
       for (unsigned int i = 0; i < mesh->vertex_count; i++)
@@ -489,8 +469,28 @@ void MotionPlanningFrame::importResource(const std::string& path)
         switch (ret)
         {
           case QMessageBox::Yes:
-            mesh->scaleAndPadd(0.001, 0);
-            // mesh = shapes::createMeshFromResource(path);
+            // Center the mesh so scaling applies correctly
+            {
+              double sx = 0.0, sy = 0.0, sz = 0.0;
+              for (unsigned int i = 0; i < mesh->vertex_count; ++i)
+              {
+                unsigned int i3 = i * 3;
+                sx += mesh->vertices[i3];
+                sy += mesh->vertices[i3 + 1];
+                sz += mesh->vertices[i3 + 2];
+              }
+              sx /= (double)mesh->vertex_count;
+              sy /= (double)mesh->vertex_count;
+              sz /= (double)mesh->vertex_count;
+              for (unsigned int i = 0; i < mesh->vertex_count; ++i)
+              {
+                unsigned int i3 = i * 3;
+                mesh->vertices[i3] -= sx;
+                mesh->vertices[i3 + 1] -= sy;
+                mesh->vertices[i3 + 2] -= sz;
+              }
+              mesh->scaleAndPadd(0.001, 0);
+            }
             break;
           case QMessageBox::No:
             break;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -105,8 +105,8 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
           SLOT(planningAlgorithmIndexChanged(int)));
   connect(ui_->planning_algorithm_combo_box, SIGNAL(currentIndexChanged(int)), this,
           SLOT(planningAlgorithmIndexChanged(int)));
-  connect(ui_->import_3d_obj_file_button, SIGNAL(clicked()), this, SLOT(import3DObjectFromFileButtonClicked()));
-  connect(ui_->import_3d_obj_url_button, SIGNAL(clicked()), this, SLOT(import3DObjectFromUrlButtonClicked()));
+  connect(ui_->import_object_file_button, SIGNAL(clicked()), this, SLOT(importObjectFromFileButtonClicked()));
+  connect(ui_->import_object_url_button, SIGNAL(clicked()), this, SLOT(importObjectFromUrlButtonClicked()));
   connect(ui_->clear_scene_button, SIGNAL(clicked()), this, SLOT(clearSceneButtonClicked()));
   connect(ui_->scene_scale, SIGNAL(valueChanged(int)), this, SLOT(sceneScaleChanged(int)));
   connect(ui_->scene_scale, SIGNAL(sliderPressed()), this, SLOT(sceneScaleStartChange()));
@@ -548,7 +548,7 @@ void MotionPlanningFrame::importResource(const std::string& path)
     }
     else
     {
-      QMessageBox::warning(this, QString("Import error"), QString("Unable to import 3D object"));
+      QMessageBox::warning(this, QString("Import error"), QString("Unable to import object"));
       return;
     }
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -75,7 +75,8 @@ namespace moveit_rviz_plugin
 {
 void MotionPlanningFrame::importObjectFromFileButtonClicked()
 {
-  QString path = QFileDialog::getOpenFileName(this, tr("Import Object Mesh (e.g. .stl, .obj)"));
+  QString path = QFileDialog::getOpenFileName(this, tr("Import Object Mesh"), QString(),
+                                              "CAD files (*.stl *.obj *.dae);;All files (*.*)");
   if (!path.isEmpty())
     importResource("file://" + path.toStdString());
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -73,17 +73,17 @@ QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subfra
 
 namespace moveit_rviz_plugin
 {
-void MotionPlanningFrame::import3DObjectFromFileButtonClicked()
+void MotionPlanningFrame::importObjectFromFileButtonClicked()
 {
-  QString path = QFileDialog::getOpenFileName(this, tr("Import 3D Object (e.g. .stl, "));
+  QString path = QFileDialog::getOpenFileName(this, tr("Import Object Mesh (e.g. .stl, .obj)"));
   if (!path.isEmpty())
     importResource("file://" + path.toStdString());
 }
 
-void MotionPlanningFrame::import3DObjectFromUrlButtonClicked()
+void MotionPlanningFrame::importObjectFromUrlButtonClicked()
 {
   bool ok = false;
-  QString url = QInputDialog::getText(this, tr("Import 3D Object"), tr("URL for file to import:"), QLineEdit::Normal,
+  QString url = QInputDialog::getText(this, tr("Import Object"), tr("URL for file to import:"), QLineEdit::Normal,
                                       QString("http://"), &ok);
   if (ok && !url.isEmpty())
     importResource(url.toStdString());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -73,17 +73,17 @@ QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subfra
 
 namespace moveit_rviz_plugin
 {
-void MotionPlanningFrame::importFileButtonClicked()
+void MotionPlanningFrame::import3DObjectFromFileButtonClicked()
 {
-  QString path = QFileDialog::getOpenFileName(this, tr("Import Object"));
+  QString path = QFileDialog::getOpenFileName(this, tr("Import 3D Object (e.g. .stl, "));
   if (!path.isEmpty())
     importResource("file://" + path.toStdString());
 }
 
-void MotionPlanningFrame::importUrlButtonClicked()
+void MotionPlanningFrame::import3DObjectFromUrlButtonClicked()
 {
   bool ok = false;
-  QString url = QInputDialog::getText(this, tr("Import Object"), tr("URL for file to import:"), QLineEdit::Normal,
+  QString url = QInputDialog::getText(this, tr("Import 3D Object"), tr("URL for file to import:"), QLineEdit::Normal,
                                       QString("http://"), &ok);
   if (ok && !url.isEmpty())
     importResource(url.toStdString());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -927,16 +927,16 @@ void MotionPlanningFrame::populateCollisionObjectsList()
   selectedCollisionObjectChanged();
 }
 
-void MotionPlanningFrame::exportAsTextButtonClicked()
+void MotionPlanningFrame::exportGeometryAsTextButtonClicked()
 {
   QString path =
       QFileDialog::getSaveFileName(this, tr("Export Scene Geometry"), tr(""), tr("Scene Geometry (*.scene)"));
   if (!path.isEmpty())
     planning_display_->addBackgroundJob(
-        boost::bind(&MotionPlanningFrame::computeExportAsText, this, path.toStdString()), "export as text");
+        boost::bind(&MotionPlanningFrame::computeExportGeometryAsText, this, path.toStdString()), "export as text");
 }
 
-void MotionPlanningFrame::computeExportAsText(const std::string& path)
+void MotionPlanningFrame::computeExportGeometryAsText(const std::string& path)
 {
   planning_scene_monitor::LockedPlanningSceneRO ps = planning_display_->getPlanningSceneRO();
   if (ps)
@@ -954,7 +954,7 @@ void MotionPlanningFrame::computeExportAsText(const std::string& path)
   }
 }
 
-void MotionPlanningFrame::computeImportFromText(const std::string& path)
+void MotionPlanningFrame::computeImportGeometryFromText(const std::string& path)
 {
   planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
   if (ps)
@@ -974,12 +974,12 @@ void MotionPlanningFrame::computeImportFromText(const std::string& path)
   }
 }
 
-void MotionPlanningFrame::importFromTextButtonClicked()
+void MotionPlanningFrame::importGeometryFromTextButtonClicked()
 {
   QString path =
       QFileDialog::getOpenFileName(this, tr("Import Scene Geometry"), tr(""), tr("Scene Geometry (*.scene)"));
   if (!path.isEmpty())
     planning_display_->addBackgroundJob(
-        boost::bind(&MotionPlanningFrame::computeImportFromText, this, path.toStdString()), "import from text");
+        boost::bind(&MotionPlanningFrame::computeImportGeometryFromText, this, path.toStdString()), "import from text");
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -245,8 +245,21 @@ void MotionPlanningFrame::removeStateButtonClicked()
 
 void MotionPlanningFrame::clearStatesButtonClicked()
 {
-  robot_states_.clear();
-  populateRobotStatesList();
+  QMessageBox msg_box;
+  msg_box.setText("Clear all stored robot states (from memory, not from the database)?");
+  msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+  msg_box.setDefaultButton(QMessageBox::Yes);
+  int ret = msg_box.exec();
+  switch (ret)
+  {
+    case QMessageBox::Yes:
+    {
+      robot_states_.clear();
+      populateRobotStatesList();
+    }
+    break;
+  }
+  return;
 }
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1195,7 +1195,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_8">
           <item row="1" column="1">
-           <widget class="QPushButton" name="import_url_button">
+           <widget class="QPushButton" name="import_3d_obj_url_button">
             <property name="text">
              <string>Import &amp;URL</string>
             </property>
@@ -1216,9 +1216,9 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QPushButton" name="import_file_button">
+           <widget class="QPushButton" name="import_3d_obj_file_button">
             <property name="text">
-             <string>Import &amp;File</string>
+             <string>Import &amp;Object</string>
             </property>
            </widget>
           </item>
@@ -1661,8 +1661,8 @@
   <tabstop>roi_size_y</tabstop>
   <tabstop>roi_size_z</tabstop>
   <tabstop>collision_objects_list</tabstop>
-  <tabstop>import_file_button</tabstop>
-  <tabstop>import_url_button</tabstop>
+  <tabstop>import_3d_obj_file_button</tabstop>
+  <tabstop>import_3d_obj_url_button</tabstop>
   <tabstop>remove_object_button</tabstop>
   <tabstop>clear_scene_button</tabstop>
   <tabstop>object_x</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1195,7 +1195,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_8">
           <item row="1" column="1">
-           <widget class="QPushButton" name="import_3d_obj_url_button">
+           <widget class="QPushButton" name="import_object_url_button">
             <property name="text">
              <string>Import &amp;URL</string>
             </property>
@@ -1216,9 +1216,9 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QPushButton" name="import_3d_obj_file_button">
+           <widget class="QPushButton" name="import_object_file_button">
             <property name="text">
-             <string>Import &amp;Object</string>
+             <string>Import &amp;Mesh</string>
             </property>
            </widget>
           </item>
@@ -1661,8 +1661,8 @@
   <tabstop>roi_size_y</tabstop>
   <tabstop>roi_size_z</tabstop>
   <tabstop>collision_objects_list</tabstop>
-  <tabstop>import_3d_obj_file_button</tabstop>
-  <tabstop>import_3d_obj_url_button</tabstop>
+  <tabstop>import_object_file_button</tabstop>
+  <tabstop>import_object_url_button</tabstop>
   <tabstop>remove_object_button</tabstop>
   <tabstop>clear_scene_button</tabstop>
   <tabstop>object_x</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1169,9 +1169,9 @@
            </spacer>
           </item>
           <item>
-           <widget class="QPushButton" name="export_scene_text_button">
+           <widget class="QPushButton" name="export_scene_geometry_text_button">
             <property name="text">
-             <string>&amp;Export Scene Objects</string>
+             <string>&amp;Export Objects</string>
             </property>
             <property name="toolTip">
              <string>Export scene geometry to a .scene file (only geometry information is preserved)</string>
@@ -1179,9 +1179,9 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="import_scene_text_button">
+           <widget class="QPushButton" name="import_scene_geometry_text_button">
             <property name="text">
-             <string>&amp;Import Scene Objects</string>
+             <string>&amp;Import Objects</string>
             </property>
             <property name="toolTip">
              <string>Import scene geometry from a .scene file (only geometry information is preserved)</string>
@@ -1421,6 +1421,9 @@
              <widget class="QPushButton" name="load_state_button">
               <property name="text">
                <string>Filter</string>
+              </property>
+              <property name="toolTip">
+               <string>Load a robot state</string>
               </property>
              </widget>
             </item>
@@ -1685,8 +1688,8 @@
   <tabstop>object_rz</tabstop>
   <tabstop>scene_scale</tabstop>
   <tabstop>publish_current_scene_button</tabstop>
-  <tabstop>export_scene_text_button</tabstop>
-  <tabstop>import_scene_text_button</tabstop>
+  <tabstop>export_scene_geometry_text_button</tabstop>
+  <tabstop>import_scene_geometry_text_button</tabstop>
   <tabstop>planning_scene_tree</tabstop>
   <tabstop>load_scene_button</tabstop>
   <tabstop>load_query_button</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1414,13 +1414,13 @@
          <item>
           <widget class="QGroupBox" name="groupBox_15">
            <property name="title">
-            <string>Stored States</string>
+            <string>Stored Robot States</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_17">
             <item row="0" column="0">
              <widget class="QPushButton" name="load_state_button">
               <property name="text">
-               <string>Filter</string>
+               <string>Load</string>
               </property>
               <property name="toolTip">
                <string>Load a robot state</string>
@@ -1432,6 +1432,9 @@
               <property name="text">
                <string>Clear</string>
               </property>
+              <property name="toolTip">
+               <string>Clear robot states from list</string>
+              </property>
              </widget>
             </item>
            </layout>
@@ -1440,7 +1443,7 @@
          <item>
           <widget class="QGroupBox" name="groupBox_16">
            <property name="title">
-            <string>Selected State</string>
+            <string>Selected Robot State</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_15">
             <item row="0" column="0">
@@ -1470,7 +1473,7 @@
          <item>
           <widget class="QGroupBox" name="groupBox_17">
            <property name="title">
-            <string>Current State</string>
+            <string>Current Robot State</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_16">
             <item row="0" column="0">
@@ -1478,12 +1481,18 @@
               <property name="text">
                <string>Save Start</string>
               </property>
+              <property name="toolTip">
+               <string>Save the current start state</string>
+              </property>
              </widget>
             </item>
             <item row="0" column="1">
              <widget class="QPushButton" name="save_goal_state_button">
               <property name="text">
                <string>Save Goal</string>
+              </property>
+              <property name="toolTip">
+               <string>Save the current goal state</string>
               </property>
              </widget>
             </item>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1171,7 +1171,7 @@
           <item>
            <widget class="QPushButton" name="export_scene_geometry_text_button">
             <property name="text">
-             <string>&amp;Export Objects</string>
+             <string>&amp;Export</string>
             </property>
             <property name="toolTip">
              <string>Export scene geometry to a .scene file (only geometry information is preserved)</string>
@@ -1181,7 +1181,7 @@
           <item>
            <widget class="QPushButton" name="import_scene_geometry_text_button">
             <property name="text">
-             <string>&amp;Import Objects</string>
+             <string>&amp;Import</string>
             </property>
             <property name="toolTip">
              <string>Import scene geometry from a .scene file (only geometry information is preserved)</string>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1171,14 +1171,20 @@
           <item>
            <widget class="QPushButton" name="export_scene_text_button">
             <property name="text">
-             <string>&amp;Export As Text</string>
+             <string>&amp;Export Scene Objects</string>
+            </property>
+            <property name="toolTip">
+             <string>Export scene geometry to a .scene file (only geometry information is preserved)</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QPushButton" name="import_scene_text_button">
             <property name="text">
-             <string>&amp;Import From Text</string>
+             <string>&amp;Import Scene Objects</string>
+            </property>
+            <property name="toolTip">
+             <string>Import scene geometry from a .scene file (only geometry information is preserved)</string>
             </property>
            </widget>
           </item>
@@ -1197,7 +1203,10 @@
           <item row="1" column="1">
            <widget class="QPushButton" name="import_object_url_button">
             <property name="text">
-             <string>Import &amp;URL</string>
+             <string>From &amp;URL</string>
+            </property>
+            <property name="toolTip">
+             <string>Import a mesh from a URL</string>
             </property>
            </widget>
           </item>
@@ -1219,6 +1228,9 @@
            <widget class="QPushButton" name="import_object_file_button">
             <property name="text">
              <string>Import &amp;Mesh</string>
+            </property>
+            <property name="toolTip">
+             <string>Import a mesh from a file</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
### Description

While reviewing #2137, I realized that the Rviz panel has an option to import meshes that I have never discovered, because the buttons and dialog windows are not very instructive.

This PR should clarify the interface as shown in the screenshot below, and adds a dialog to fix STL files that are encoded with mm units. Sadly, scaling the mesh did not work as I expected, as described [here](https://github.com/ros-planning/geometric_shapes/issues/148). I will remove the WIP when that's fixed.

![gui](https://user-images.githubusercontent.com/4535737/84033608-180eb780-a9d4-11ea-9c80-30dfdb5d689d.png)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers