### PR TITLE
[jog_arm] Changes before porting to ROS2

### DIFF
--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_parameters.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_arm_parameters.h
@@ -43,9 +43,6 @@ namespace moveit_jog_arm
 // Size of queues used in ros pub/sub/service
 constexpr size_t ROS_QUEUE_SIZE = 2;
 
-// Seconds to throttle logs inside loops
-constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30;
-
 // ROS params to be read. See the yaml file in /config for a description of each.
 struct JogArmParameters
 {

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -126,7 +126,7 @@ private:
    */
   double velocityScalingFactorForSingularity(const Eigen::VectorXd& commanded_velocity,
                                              const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
-                                             const Eigen::MatrixXd& jacobian, const Eigen::MatrixXd& pseudo_inverse);
+                                             const Eigen::MatrixXd& pseudo_inverse);
 
   /**
    * Slow motion down if close to singularity or collision.

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -83,7 +83,7 @@ public:
   bool getCommandFrameTransform(Eigen::Isometry3d& transform);
 
   /** \brief Pause or unpause processing jog commands while keeping the timers alive */
-  void setPaused(const bool paused);
+  void setPaused(bool paused);
 
 private:
   /** \brief Timer method */
@@ -133,7 +133,7 @@ private:
    * @param delta_theta motion command, used in calculating new_joint_tray
    * @param singularity_scale tells how close we are to a singularity
    */
-  void applyVelocityScaling(Eigen::ArrayXd& delta_theta, const double singularity_scale);
+  void applyVelocityScaling(Eigen::ArrayXd& delta_theta, double singularity_scale);
 
   /** \brief Compose the outgoing JointTrajectory message */
   void composeJointTrajMessage(const sensor_msgs::JointState& joint_state,
@@ -165,7 +165,7 @@ private:
    * @param delta_x Vector of Cartesian delta commands, should be the same size as matrix.rows()
    * @param row_to_remove Dimension that will be allowed to drift, e.g. row_to_remove = 2 allows z-translation drift.
    */
-  void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, const unsigned int row_to_remove);
+  void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, unsigned int row_to_remove);
 
   /* \brief Callback for joint subsription */
   void jointStateCB(const sensor_msgs::JointStateConstPtr& msg);
@@ -274,7 +274,7 @@ private:
 
   // latest_state_mutex_ is used to protect the state below it
   mutable std::mutex latest_state_mutex_;
-  Eigen::Isometry3d tf_moveit_to_cmd_frame_;
+  Eigen::Isometry3d tf_moveit_to_robot_cmd_frame_;
   geometry_msgs::TwistStampedConstPtr latest_twist_stamped_;
   control_msgs::JointJogConstPtr latest_joint_jog_;
   ros::Time latest_command_stamp_ = ros::Time(0.);

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -234,6 +234,8 @@ private:
 
   std::vector<LowPassFilter> position_filters_;
 
+  trajectory_msgs::JointTrajectoryConstPtr last_sent_command_;
+
   // ROS
   ros::Timer timer_;
   ros::Duration period_;

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -251,7 +251,8 @@ private:
   StatusCode status_ = StatusCode::NO_WARNING;
   bool stop_requested_ = false;
   bool paused_ = false;
-  bool command_is_stale_ = false;
+  bool twist_command_is_stale_ = false;
+  bool joint_command_is_stale_ = false;
   bool ok_to_publish_ = false;
   double collision_velocity_scale_ = 1.0;
 
@@ -277,7 +278,8 @@ private:
   Eigen::Isometry3d tf_moveit_to_robot_cmd_frame_;
   geometry_msgs::TwistStampedConstPtr latest_twist_stamped_;
   control_msgs::JointJogConstPtr latest_joint_jog_;
-  ros::Time latest_command_stamp_ = ros::Time(0.);
+  ros::Time latest_twist_command_stamp_ = ros::Time(0.);
+  ros::Time latest_joint_command_stamp_ = ros::Time(0.);
   bool latest_nonzero_twist_stamped_ = false;
   bool latest_nonzero_joint_jog_ = false;
 };

--- a/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
+++ b/moveit_experimental/moveit_jog_arm/include/moveit_jog_arm/jog_calcs.h
@@ -218,8 +218,8 @@ private:
   bool have_nonzero_command_ = false;
 
   // Incoming command messages
-  geometry_msgs::TwistStamped twist_stamped_;
-  control_msgs::JointJog joint_jog_;
+  geometry_msgs::TwistStamped twist_stamped_cmd_;
+  control_msgs::JointJog joint_jog_cmd_;
 
   const moveit::core::JointModelGroup* joint_model_group_;
 

--- a/moveit_experimental/moveit_jog_arm/src/collision_check.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check.cpp
@@ -44,9 +44,8 @@
 
 static const char LOGNAME[] = "collision_check";
 static const double MIN_RECOMMENDED_COLLISION_RATE = 10;
-constexpr double EPSILON = 1e-6;  // For very small numeric comparisons
-constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30; // Seconds to throttle logs inside loops
-
+constexpr double EPSILON = 1e-6;                // For very small numeric comparisons
+constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30;  // Seconds to throttle logs inside loops
 
 namespace moveit_jog_arm
 {

--- a/moveit_experimental/moveit_jog_arm/src/collision_check.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/collision_check.cpp
@@ -45,6 +45,8 @@
 static const char LOGNAME[] = "collision_check";
 static const double MIN_RECOMMENDED_COLLISION_RATE = 10;
 constexpr double EPSILON = 1e-6;  // For very small numeric comparisons
+constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30; // Seconds to throttle logs inside loops
+
 
 namespace moveit_jog_arm
 {

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -44,6 +44,7 @@
 #include <moveit_jog_arm/make_shared_from_pool.h>
 
 static const std::string LOGNAME = "jog_calcs";
+constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30; // Seconds to throttle logs inside loops
 
 namespace moveit_jog_arm
 {

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -44,7 +44,7 @@
 #include <moveit_jog_arm/make_shared_from_pool.h>
 
 static const std::string LOGNAME = "jog_calcs";
-constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30; // Seconds to throttle logs inside loops
+constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30;  // Seconds to throttle logs inside loops
 
 namespace moveit_jog_arm
 {

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -801,9 +801,9 @@ bool JogCalcs::updateJoints()
         }
         else
         {
-          ROS_ERROR_STREAM_ONCE_NAMED(LOGNAME, "An acceleration limit is not defined for this joint, '"
-                                                   << joint_model->getName() << "'; minimum stop distance should not "
-                                                                                "be used for collision checking");
+          ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME,
+                                         "An acceleration limit is not defined for this joint; minimum stop distance "
+                                         "should not be used for collision checking");
         }
         break;
       }

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -492,10 +492,10 @@ void JogCalcs::insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTraject
   joint_trajectory.points.resize(count);
   auto point = joint_trajectory.points[0];
   // Start from 2 because we already have the first point. End at count+1 so (total #) == count
-  for (int i = 2; i < count + 1; ++i)
+  for (int i = 2; i < count; ++i)
   {
     point.time_from_start = ros::Duration(i * parameters_.publish_period);
-    joint_trajectory.points.push_back(point);
+    joint_trajectory.points[i] = point;
   }
 }
 

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -245,6 +245,15 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
       return;
     }
   }
+  else
+  {
+    // Joint trajectory is not populated with anything, so set it to the last positions and 0 velocity
+    *joint_trajectory = *last_sent_command_;
+    for (auto point : joint_trajectory->points)
+    {
+      point.velocities.assign(point.velocities.size(), 0);
+    }
+  }
 
   // Print a warning to the user if both are stale
   if (!twist_command_is_stale_ || !joint_command_is_stale_)
@@ -305,6 +314,8 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
         joints->data = joint_trajectory->points[0].velocities;
       outgoing_cmd_pub_.publish(joints);
     }
+
+    last_sent_command_ = joint_trajectory;
   }
 
   // Update the filters if we haven't yet

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -211,9 +211,9 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     if (latest_twist_stamped_)
-      twist_stamped_ = *latest_twist_stamped_;
+      twist_stamped_cmd_ = *latest_twist_stamped_;
     if (latest_joint_jog_)
-      joint_jog_ = *latest_joint_jog_;
+      joint_jog_cmd_ = *latest_joint_jog_;
 
     // Check for stale cmds
     twist_command_is_stale_ =
@@ -243,7 +243,8 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
     resetLowPassFilters(original_joint_state_);
 
     // Check if there are any new commands with valid timestamp
-    wait_for_jog_commands_ = twist_stamped_.header.stamp == ros::Time(0.) && joint_jog_.header.stamp == ros::Time(0.);
+    wait_for_jog_commands_ =
+        twist_stamped_cmd_.header.stamp == ros::Time(0.) && joint_jog_cmd_.header.stamp == ros::Time(0.);
 
     // Early exit
     return;
@@ -258,7 +259,7 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
   // Only run commands if not stale and nonzero
   if (have_nonzero_twist_stamped_ && !twist_command_is_stale_)
   {
-    if (!cartesianJogCalcs(twist_stamped_, *joint_trajectory))
+    if (!cartesianJogCalcs(twist_stamped_cmd_, *joint_trajectory))
     {
       resetLowPassFilters(original_joint_state_);
       return;
@@ -266,7 +267,7 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
   }
   else if (have_nonzero_joint_jog_ && !joint_command_is_stale_)
   {
-    if (!jointJogCalcs(joint_jog_, *joint_trajectory))
+    if (!jointJogCalcs(joint_jog_cmd_, *joint_trajectory))
     {
       resetLowPassFilters(original_joint_state_);
       return;

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -888,6 +888,7 @@ Eigen::VectorXd JogCalcs::scaleCartesianCommand(const geometry_msgs::TwistStampe
 Eigen::VectorXd JogCalcs::scaleJointCommand(const control_msgs::JointJog& command) const
 {
   Eigen::VectorXd result(num_joints_);
+  result.setZero();
 
   std::size_t c;
   for (std::size_t m = 0; m < command.joint_names.size(); ++m)

--- a/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
+++ b/moveit_experimental/moveit_jog_arm/src/jog_calcs.cpp
@@ -226,6 +226,7 @@ void JogCalcs::run(const ros::TimerEvent& timer_event)
   }
 
   // Get the transform from MoveIt planning frame to jogging command frame
+  // Calculate this transform to ensure it is available via C++ API
   // We solve (planning_frame -> base -> robot_link_command_frame)
   // by computing (base->planning_frame)^-1 * (base->robot_link_command_frame)
   tf_moveit_to_robot_cmd_frame_ = kinematic_state_->getGlobalLinkTransform(parameters_.planning_frame).inverse() *


### PR DESCRIPTION
### Description

These are changes I wanted to make (in addition to [https://github.com/ros-planning/moveit/pull/2103](https://github.com/ros-planning/moveit/pull/2103)) before starting on porting the jogger to ROS2 because I want these changes there as well. 

The changes consist of a lot of minor changes, see list below for details. Note that discussion and reviews exist here already: [https://github.com/PickNikRobotics/moveit/pull/8](https://github.com/PickNikRobotics/moveit/pull/8), because I wanted to start the review process before #2103 landed.

- General cleanup: defining `const` in functions where applicable, fixing comments, combining if statements and making them flow better
- I found a stale but nonzero command could make it through the timer callback function without updating the joint position filters, so fixed that and made **sure** the filters are updated every cycle
- Removed the `suddenHalt(Eigen::ArrayXd& delta_theta)` overload. It included comments saying position and velocity controlled robots were handled differently, but this function did not handle them differently (and only set `delta_theta` to all 0 which could be **really bad** for a position controlled robot). It was only called one place with the Eigen Array, and I replaced the call with a `setZero()` there and deleted the function so future users don't use it and accidentally send the robot to 0's. 
- Small fixes in the drift dimensions use and in singularity scaling. Previously the singularity scaling wasn't doing what the algorithm in the comments said it was. Tested after fixing and it looks really good
- Small changes around the `have_nonzero_twist_stamped_` and `have_nonzero_joint_jog_` which were used intermittently in the `run()` timer callback but also set in the command subscriber callbacks. Moved them to mutex protected implementation similar to the rest of subscriber callback variables
- Avoid recalculating the planning -> command transform if the incoming command is empty or in the command frame

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
