### PR TITLE
Add missing Boost component

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 if(WIN32)
   set(EXTRA_BOOST_COMPONENTS zlib)
 endif()
-find_package(Boost REQUIRED system filesystem date_time thread iostreams ${EXTRA_BOOST_COMPONENTS})
+find_package(Boost REQUIRED system filesystem date_time thread iostreams regex ${EXTRA_BOOST_COMPONENTS})
 find_package(Eigen3 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")


### PR DESCRIPTION
Backport fix from https://github.com/ros-planning/moveit2/pull/226.
The others (missing dependencies) don't apply here since `${catkin_LIBRARIES}` covers all of them. 