### PR TITLE
Added hybridize/interpolate_flags for ompl planning

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -275,6 +275,16 @@ public:
     simplify_solutions_ = flag;
   }
 
+  void setInterpolation(bool flag)
+  {
+    interpolate_ = flag;
+  }
+
+  void setHybridize(bool flag)
+  {
+    hybridize_ = flag;
+  }
+
   /* @brief Solve the planning problem. Return true if the problem is solved
      @param timeout The time to spend on solving
      @param count The number of runs to combine the paths of, in an attempt to generate better quality paths
@@ -424,5 +434,11 @@ protected:
   ConstraintsLibraryPtr constraints_library_;
 
   bool simplify_solutions_;
+
+  // if false the final solution is not interpolated
+  bool interpolate_;
+
+  // if false parallel plan returns the first solution found
+  bool hybridize_;
 };
 }  // namespace ompl_interface


### PR DESCRIPTION
### Description
This PR simply adds two flags in model_based_planning context to give more control to the user over planning settings. 

- Flag `interpolate_` gives the user the ability to return non-interpolated trajectories when set to False. Default behavior is the old one which is true.
- Flag `hybridize_`  applies to `ompl_parallel_plan_`. When false, `ompl_parallel_plan_` returns the first solution found instead of waiting for all threads to terminate and hybridize between the found paths. Default behavior is the old one which is true.

- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
