### PR TITLE
add support for setting interpolate_ and hybridize_ flags in ModelBasedPlanningContext via ompl_planning.yaml

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -340,6 +340,22 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it != cfg.end())
     multi_query_planning_enabled_ = boost::lexical_cast<bool>(it->second);
 
+  // check whether the path returned by the planner should be interpolated
+  it = cfg.find("interpolate");
+  if (it != cfg.end())
+  {
+    interpolate_ = boost::lexical_cast<bool>(it->second);
+    cfg.erase(it);
+  }
+
+  // check whether solution paths from parallel planning should be hybridized
+  it = cfg.find("hybridize");
+  if (it != cfg.end())
+  {
+    hybridize_ = boost::lexical_cast<bool>(it->second);
+    cfg.erase(it);
+  }
+
   // remove the 'type' parameter; the rest are parameters for the planner itself
   it = cfg.find("type");
   if (it == cfg.end())


### PR DESCRIPTION
### Description

Follow-up pr for PR #2171 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
