### PR TITLE
Pr ompl interpolate hybridize backport

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -267,6 +267,16 @@ public:
     simplify_solutions_ = flag;
   }
 
+  void setInterpolation(bool flag)
+  {
+    interpolate_ = flag;
+  }
+
+  void setHybridize(bool flag)
+  {
+    hybridize_ = flag;
+  }
+
   /* @brief Solve the planning problem. Return true if the problem is solved
      @param timeout The time to spend on solving
      @param count The number of runs to combine the paths of, in an attempt to generate better quality paths
@@ -375,6 +385,12 @@ protected:
   bool use_state_validity_cache_;
 
   bool simplify_solutions_;
+
+  // if false the final solution is not interpolated
+  bool interpolate_;
+
+  // if false parallel plan returns the first solution found
+  bool hybridize_;
 };
 }  // namespace ompl_interface
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -316,6 +316,22 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
 
   ompl_simple_setup_->setOptimizationObjective(objective);
 
+  // check whether the path returned by the planner should be interpolated
+  it = cfg.find("interpolate");
+  if (it != cfg.end())
+  {
+    interpolate_ = boost::lexical_cast<bool>(it->second);
+    cfg.erase(it);
+  }
+
+  // check whether solution paths from parallel planning should be hybridized
+  it = cfg.find("hybridize");
+  if (it != cfg.end())
+  {
+    hybridize_ = boost::lexical_cast<bool>(it->second);
+    cfg.erase(it);
+  }
+
   // remove the 'type' parameter; the rest are parameters for the planner itself
   it = cfg.find("type");
   if (it == cfg.end())


### PR DESCRIPTION
### Description

This is a backport that exposes two parameters of the ompl_interface to the user API and ompl_planning.yaml

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
