### PR TITLE
Update API to take in revolute and prismatic params for Cartesian Paths

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -143,7 +143,7 @@ bool MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath
           }
           bool global_frame = !moveit::core::Transforms::sameFrame(link_name, req.header.frame_id);
           ROS_INFO_NAMED(getName(), "Attempting to follow %u waypoints for link '%s' using a step of %lf m "
-                                    "and a jump theshold of %lf, and absolute jump thresholds %lf (revolute) and "
+                                    "and a jump threshold of %lf, and absolute jump thresholds %lf (revolute) and "
                                     "%lf (prismatic) (in %s reference frame)",
                          (unsigned int)waypoints.size(), link_name.c_str(), req.max_step, req.jump_threshold,
                          req.revolute_jump_threshold, req.prismatic_jump_threshold, global_frame ? "global" : "link");

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -143,13 +143,20 @@ bool MoveGroupCartesianPathService::computeService(moveit_msgs::GetCartesianPath
           }
           bool global_frame = !moveit::core::Transforms::sameFrame(link_name, req.header.frame_id);
           ROS_INFO_NAMED(getName(), "Attempting to follow %u waypoints for link '%s' using a step of %lf m "
-                                    "and jump threshold %lf (in %s reference frame)",
+                                    "and a jump theshold of %lf, and absolute jump thresholds %lf (revolute) and "
+                                    "%lf (prismatic) (in %s reference frame)",
                          (unsigned int)waypoints.size(), link_name.c_str(), req.max_step, req.jump_threshold,
-                         global_frame ? "global" : "link");
+                         req.revolute_jump_threshold, req.prismatic_jump_threshold, global_frame ? "global" : "link");
           std::vector<moveit::core::RobotStatePtr> traj;
+
+          moveit::core::JumpThreshold jt;
+          jt.revolute = req.revolute_jump_threshold;
+          jt.prismatic = req.prismatic_jump_threshold;
+          jt.factor = req.jump_threshold;
+
           res.fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
               &start_state, jmg, traj, start_state.getLinkModel(link_name), waypoints, global_frame,
-              moveit::core::MaxEEFStep(req.max_step), moveit::core::JumpThreshold(req.jump_threshold), constraint_fn);
+              moveit::core::MaxEEFStep(req.max_step), jt, constraint_fn);
           moveit::core::robotStateToRobotStateMsg(start_state, res.start_state);
 
           robot_trajectory::RobotTrajectory rt(context_->planning_scene_monitor_->getRobotModel(), req.group_name);

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -741,9 +741,8 @@ public:
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
       waypoints is that specified by setPoseReferenceFrame(). \e jump_threshold defines a factor off the average
-     configuration
-      space distance between waypoints that is acceptable between any two waypoints (this is to prevent 'jumps' in IK
-      solutions).
+      configuration space distance between waypoints that is acceptable between any two waypoints (this is to prevent
+      'jumps' in IK solutions).
       Collisions are avoided if \e avoid_collisions is set to true. If collisions cannot be avoided, the function fails.
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
       waypoints.
@@ -758,9 +757,8 @@ public:
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
       waypoints is that specified by setPoseReferenceFrame(). \e jump_threshold defines a factor off the average
-     configuration
-      space distance between waypoints that is acceptable between any two waypoints (this is to prevent 'jumps' in IK
-      solutions).
+      configuration space distance between waypoints that is acceptable between any two waypoints (this is to prevent
+      'jumps' in IK solutions).
       Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory,
       if they are not met, a partial solution will be returned.
       Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be
@@ -826,7 +824,7 @@ public:
       acceptable between any two waypoints.
       Collisions are avoided if \e avoid_collisions is set to true. If collisions cannot be avoided, the function fails.
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
-     waypoints.
+      waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
                               double revolute_jump_threshold, double prismatic_jump_threshold,

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -740,30 +740,115 @@ public:
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
-      waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold
-      is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK
-     solutions).
+      waypoints is that specified by setPoseReferenceFrame(). \e jump_threshold defines a factor off the average
+     configuration
+      space distance between waypoints that is acceptable between any two waypoints (this is to prevent 'jumps' in IK
+      solutions).
+      Collisions are avoided if \e avoid_collisions is set to true. If collisions cannot be avoided, the function fails.
+      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
+      waypoints.
+      Return -1.0 in case of error. */
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
+                              moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
+                              moveit_msgs::MoveItErrorCodes* error_code = nullptr)
+  {
+    return computeCartesianPath(waypoints, eef_step, jump_threshold, 0, 0, trajectory, avoid_collisions, error_code);
+  }
+
+  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
+      between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
+      waypoints is that specified by setPoseReferenceFrame(). \e jump_threshold defines a factor off the average
+     configuration
+      space distance between waypoints that is acceptable between any two waypoints (this is to prevent 'jumps' in IK
+      solutions).
+      Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory,
+      if they are not met, a partial solution will be returned.
+      Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be
+      met, the function fails.
+      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
+      waypoints.
+      Return -1.0 in case of error. */
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
+                              moveit_msgs::RobotTrajectory& trajectory,
+                              const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
+                              moveit_msgs::MoveItErrorCodes* error_code = nullptr)
+  {
+    return computeCartesianPath(waypoints, eef_step, jump_threshold, 0, 0, trajectory, path_constraints,
+                                avoid_collisions, error_code);
+  }
+
+  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
+      between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
+      waypoints is that specified by setPoseReferenceFrame(). No more than \e revolute_jump_threshold radians
+      is allowed on each joint as change in distance in the configuration space of the robot.  Similarly, no more than
+      \e prismatic_jump_threshold m between waypoints is allowed. This is to prevent 'jumps' in IK solutions.
+      Collisions are avoided if \e avoid_collisions is set to true. If collisions cannot be avoided, the function fails.
+      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
+      waypoints.
+      Return -1.0 in case of error. */
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
+                              moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
+                              moveit_msgs::MoveItErrorCodes* error_code = nullptr)
+  {
+    return computeCartesianPath(waypoints, eef_step, 0, revolute_jump_threshold, prismatic_jump_threshold, trajectory,
+                                avoid_collisions, error_code);
+  }
+
+  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
+      between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
+      waypoints is that specified by setPoseReferenceFrame(). No more than \e revolute_jump_threshold radians
+      is allowed on each joint as change in distance in the configuration space of the robot.  Similarly, no more than
+      \e prismatic_jump_threshold m between waypoints is allowed. This is to prevent 'jumps' in IK solutions.
+      Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory,
+      if they are not met, a partial solution will be returned.
+      Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be
+      met, the function fails.
+      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
+      waypoints.
+      Return -1.0 in case of error. */
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
+                              moveit_msgs::RobotTrajectory& trajectory,
+                              const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
+                              moveit_msgs::MoveItErrorCodes* error_code = nullptr)
+  {
+    return computeCartesianPath(waypoints, eef_step, 0, revolute_jump_threshold, prismatic_jump_threshold, trajectory,
+                                path_constraints, avoid_collisions, error_code);
+  }
+
+  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
+      between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
+      waypoints is that specified by setPoseReferenceFrame(). No more than \e revolute_jump_threshold radians
+      is allowed on each joint as change in distance in the configuration space of the robot.  Similarly, no more than
+      \e prismatic_jump_threshold m between waypoints is allowed. This is to prevent 'jumps' in IK solutions.
+      \e jump_threshold defines a factor off the average configuration space distance between waypoints that is
+      acceptable between any two waypoints.
       Collisions are avoided if \e avoid_collisions is set to true. If collisions cannot be avoided, the function fails.
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
      waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
                               moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = nullptr);
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
-      waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold
-      is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK
-     solutions).
+      waypoints is that specified by setPoseReferenceFrame(). No more than \e revolute_jump_threshold radians
+      is allowed on each joint as change in distance in the configuration space of the robot.  Similarly, no more than
+      \e prismatic_jump_threshold m between waypoints is allowed. This is to prevent 'jumps' in IK solutions.
+      \e jump_threshold defines a factor off the average configuration space distance between waypoints that is
+      acceptable between any two waypoints.
       Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory,
-     if they are not met, a partial solution will be returned.
+      if they are not met, a partial solution will be returned.
       Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be
-     met, the function fails.
+      met, the function fails.
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the
-     waypoints.
+      waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
                               moveit_msgs::RobotTrajectory& trajectory,
                               const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
                               moveit_msgs::MoveItErrorCodes* error_code = nullptr);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -869,6 +869,7 @@ public:
   }
 
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double step, double jump_threshold,
+                              double revolute_jump_threshold, double prismatic_jump_threshold,
                               moveit_msgs::RobotTrajectory& msg, const moveit_msgs::Constraints& path_constraints,
                               bool avoid_collisions, moveit_msgs::MoveItErrorCodes& error_code)
   {
@@ -886,6 +887,8 @@ public:
     req.waypoints = waypoints;
     req.max_step = step;
     req.jump_threshold = jump_threshold;
+    req.revolute_jump_threshold = revolute_jump_threshold;
+    req.prismatic_jump_threshold = prismatic_jump_threshold;
     req.path_constraints = path_constraints;
     req.avoid_collisions = avoid_collisions;
     req.link_name = getEndEffectorLink();
@@ -1512,29 +1515,35 @@ MoveItErrorCode MoveGroupInterface::place(const moveit_msgs::PlaceGoal& goal)
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
-                                                double jump_threshold, moveit_msgs::RobotTrajectory& trajectory,
-                                                bool avoid_collisions, moveit_msgs::MoveItErrorCodes* error_code)
+                                                double jump_threshold, double revolute_jump_threshold,
+                                                double prismatic_jump_threshold,
+                                                moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions,
+                                                moveit_msgs::MoveItErrorCodes* error_code)
 {
   moveit_msgs::Constraints path_constraints_tmp;
-  return computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints_tmp, avoid_collisions,
-                              error_code);
+  return computeCartesianPath(waypoints, eef_step, jump_threshold, revolute_jump_threshold, prismatic_jump_threshold,
+                              trajectory, path_constraints_tmp, avoid_collisions, error_code);
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
-                                                double jump_threshold, moveit_msgs::RobotTrajectory& trajectory,
+                                                double jump_threshold, double revolute_jump_threshold,
+                                                double prismatic_jump_threshold,
+                                                moveit_msgs::RobotTrajectory& trajectory,
                                                 const moveit_msgs::Constraints& path_constraints, bool avoid_collisions,
                                                 moveit_msgs::MoveItErrorCodes* error_code)
 {
   if (error_code)
   {
-    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
-                                       avoid_collisions, *error_code);
+    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, revolute_jump_threshold,
+                                       prismatic_jump_threshold, trajectory, path_constraints, avoid_collisions,
+                                       *error_code);
   }
   else
   {
     moveit_msgs::MoveItErrorCodes error_code_tmp;
-    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
-                                       avoid_collisions, error_code_tmp);
+    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, revolute_jump_threshold,
+                                       prismatic_jump_threshold, trajectory, path_constraints, avoid_collisions,
+                                       error_code_tmp);
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -128,12 +128,14 @@ bool MotionPlanningFrame::computeCartesianPlan()
   // setup default params
   double cart_step_size = 0.01;
   double cart_jump_thresh = 0.0;
+  double cart_rev_jump_thresh = 0.0;
+  double cart_prism_jump_thresh = 0.0;
   bool avoid_collisions = true;
 
   // compute trajectory
   moveit_msgs::RobotTrajectory trajectory;
-  double fraction =
-      move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, trajectory, avoid_collisions);
+  double fraction = move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, cart_rev_jump_thresh,
+                                                      cart_prism_jump_thresh, trajectory, avoid_collisions);
 
   if (fraction >= 1.0)
   {


### PR DESCRIPTION
### Description

Updates the computeCartesianPath() interface of MoveGroup to allow the original jump_threshold but also revolute_jump_threhsold and prismatic_jump_threshold if desired.  This is turn uses the JumpThreshold class of @davetcoleman 
under the hood in the capability in order to first ensure any absolute thresholds are constrained then the "Factor" based relative threshold is still applied if its set. 

This is coded to ensure backwards compatibility with MoveIt APIs, so it will not break existing user code, but allows new code to leverage Dave's work on the absolute joint limiting.

### Checklist
- [ x ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
