### PR TITLE
Parameterize input trajectory density of Time Optimal trajectory generation

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -162,7 +162,8 @@ private:
 class TimeOptimalTrajectoryGeneration
 {
 public:
-  TimeOptimalTrajectoryGeneration(const double path_tolerance = 0.1, const double resample_dt = 0.1);
+  TimeOptimalTrajectoryGeneration(const double path_tolerance = 0.1, const double resample_dt = 0.1,
+                                  const double min_angle_change = 0.001);
   ~TimeOptimalTrajectoryGeneration();
 
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
@@ -171,5 +172,6 @@ public:
 private:
   const double path_tolerance_;
   const double resample_dt_;
+  const double min_angle_change_;
 };
 }  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -863,8 +863,9 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
   return path_acc;
 }
 
-TimeOptimalTrajectoryGeneration::TimeOptimalTrajectoryGeneration(const double path_tolerance, const double resample_dt)
-  : path_tolerance_(path_tolerance), resample_dt_(resample_dt)
+TimeOptimalTrajectoryGeneration::TimeOptimalTrajectoryGeneration(const double path_tolerance, const double resample_dt,
+                                                                 const double min_angle_change)
+  : path_tolerance_(path_tolerance), resample_dt_(resample_dt), min_angle_change_(min_angle_change)
 {
 }
 
@@ -965,7 +966,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     for (size_t j = 0; j < num_joints; j++)
     {
       new_point[j] = waypoint->getVariablePosition(idx[j]);
-      if (p > 0 && std::abs(new_point[j] - points.back()[j]) > 0.001)
+      if (p > 0 && std::abs(new_point[j] - points.back()[j]) > min_angle_change_)
         diverse_point = true;
     }
 


### PR DESCRIPTION
### Description

MoveIt wrapper to Time Optimal Trajectory Generation downsamples trajectory, but its hard coded to keep waypoints with at least 0.001 radians of motion on a joint.  For very long and/or dense input trajectories, the downsampled trajectory is still way too large for the iterative optimization algorithm to finish in reasonable time.  I was seeing 3000 point trajectory taking ~15 seconds.  This fix allows the user to set this downsampling density in minimum radians of motion between two waypoints to something else (presumably higher like 0.5 degrees [0.00875 radians]) in order to drastically improve the speed of this algorithm.

### Checklist
- [ x ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
