### PR TITLE
Fix a parameter switch in moveit_cpp loading

### DIFF
--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -118,8 +118,8 @@ public:
       std::string ns = "plan_request_params/";
       nh.param(ns + "planner_id", planner_id, std::string(""));
       nh.param(ns + "planning_pipeline", planning_pipeline, std::string(""));
-      nh.param(ns + "planning_time", planning_attempts, 1);
-      nh.param(ns + "planning_attempts", planning_time, 5.0);
+      nh.param(ns + "planning_time", planning_time, 1.0);
+      nh.param(ns + "planning_attempts", planning_attempts, 5);
       nh.param(ns + "max_velocity_scaling_factor", max_velocity_scaling_factor, 1.0);
       nh.param(ns + "max_acceleration_scaling_factor", max_acceleration_scaling_factor, 1.0);
     }


### PR DESCRIPTION
A simple bug fix. Caught by Michael W, not me (not sure he has a Github account)
