### PR TITLE
Revert "fix ordering of request adapters (#2053)"

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -5,14 +5,11 @@
 
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
-  <arg name="planning_adapters"
-       value="default_planner_request_adapters/AddTimeParameterization
-              default_planner_request_adapters/ResolveConstraintFrames
-              default_planner_request_adapters/FixWorkspaceBounds
-              default_planner_request_adapters/FixStartStateBounds
-              default_planner_request_adapters/FixStartStateCollision
-              default_planner_request_adapters/FixStartStatePathConstraints"
-              />
+  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+				       default_planner_request_adapters/FixWorkspaceBounds
+				       default_planner_request_adapters/FixStartStateBounds
+				       default_planner_request_adapters/FixStartStateCollision
+				       default_planner_request_adapters/FixStartStatePathConstraints" />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
 


### PR DESCRIPTION
This should never have been backported. The adapter is not available in melodic yet.

This reverts commit 7ae80b7a87c82a08f61554eb99a573ec51a906d6.

Yet another hot bugfix.
Should be merged before the release.
