### PR TITLE
use moveit_resources in moveit_cpp_test

### DIFF
--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -3,18 +3,18 @@
     <rosparam ns="moveit_cpp_test" command="load" file="$(find moveit_ros_planning_interface)/test/moveit_cpp.yaml" />
 
     <!-- Planning Pipeline -->
-    <include ns="/moveit_cpp_test/ompl" file="$(find panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml"/>
+    <include ns="/moveit_cpp_test/ompl" file="$(find moveit_resources)/panda_moveit_config/launch/ompl_planning_pipeline.launch.xml"/>
 
     <!-- Trajectory execution  -->
-    <!--include ns="moveit_cpp_test" file="$(find panda_moveit_config)/launch/trajectory_execution.launch.xml">
+    <!--include ns="moveit_cpp_test" file="$(find moveit_resources)/panda_moveit_config/launch/trajectory_execution.launch.xml">
       <arg name="moveit_controller_manager" value="fake"/>
     </include-->
 
     <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
-    <include ns="moveit_cpp_test" file="$(find panda_moveit_config)/launch/fake_moveit_controller_manager.launch.xml" />
+    <include ns="moveit_cpp_test" file="$(find moveit_resources)/panda_moveit_config/launch/fake_moveit_controller_manager.launch.xml" />
 
     <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-    <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+    <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
       <arg name="load_robot_description" value="true"/>
     </include>
 


### PR DESCRIPTION
### Description

This change is in master and was made here: 2de8471b8ffa8ae2be907c3d820b4144b87c2f4b

I wasn't able to get that commit to nicely apply no melodic-devel and only need the change to the one file so I created this.  This should be all that is needed to get melodic-devel to pass the pre-release tests.