### PR TITLE
Adapt repository for new moveit_resources layout

### DIFF
--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -34,5 +34,5 @@
   <exec_depend>tf</exec_depend>
 
   <test_depend>rostest</test_depend>
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_fanuc_moveit_config</test_depend>
 </package>

--- a/moveit_commander/test/CMakeLists.txt
+++ b/moveit_commander/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 if (CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
   find_package(rostest REQUIRED)
 
   add_rostest(python_moveit_commander.test)

--- a/moveit_commander/test/python_moveit_commander.test
+++ b/moveit_commander/test/python_moveit_commander.test
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
   <test pkg="moveit_commander" type="python_moveit_commander.py" test-name="python_moveit_commander"
         time-limit="300" args=""/>
 </launch>

--- a/moveit_commander/test/python_moveit_commander_ns.test
+++ b/moveit_commander/test/python_moveit_commander_ns.test
@@ -1,5 +1,5 @@
 <launch>
-  <include ns="test_ns" file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <include ns="test_ns" file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
   <test pkg="moveit_commander" type="python_moveit_commander_ns.py" test-name="python_moveit_commander_ns"
         time-limit="300" args=""/>
 </launch>

--- a/moveit_commander/test/python_time_parameterization.test
+++ b/moveit_commander/test/python_time_parameterization.test
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
   <test pkg="moveit_commander" type="python_time_parameterization.py" test-name="python_time_parameterization"
         time-limit="300" args=""/>
 </launch>

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -233,7 +233,7 @@ TYPED_TEST_P(CollisionDetectorPandaTest, DistanceSelf)
   collision_detection::CollisionResult res;
   this->cenv_->checkSelfCollision(req, res, *this->robot_state_, *this->acm_);
   ASSERT_FALSE(res.collision);
-  EXPECT_NEAR(res.distance, 0.13, 0.01);
+  EXPECT_NEAR(res.distance, 0.022, 0.001);
 }
 
 TYPED_TEST_P(CollisionDetectorPandaTest, DistanceWorld)

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
@@ -65,7 +65,7 @@ protected:
     value_.reset(new CollisionAllocatorType);
     robot_model_ = moveit::core::loadTestingRobotModel("pr2");
     robot_model_ok_ = static_cast<bool>(robot_model_);
-    kinect_dae_resource_ = "package://moveit_resources/pr2_description/urdf/meshes/sensors/kinect_v0/kinect.dae";
+    kinect_dae_resource_ = "package://moveit_resources_pr2_description/urdf/meshes/sensors/kinect_v0/kinect.dae";
 
     acm_.reset(new collision_detection::AllowedCollisionMatrix(robot_model_->getLinkModelNames(), true));
 

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -28,9 +28,6 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 install(FILES ../collision_detector_bullet_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_bullet_collision_detection test/test_bullet_collision_detection_pr2.cpp)
   target_link_libraries(test_bullet_collision_detection moveit_test_utils ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
 

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -183,7 +183,7 @@ void addCollisionObjectsMesh(cb::BulletCastBVHManager& checker)
   Eigen::Isometry3d s_pose;
   s_pose.setIdentity();
 
-  std::string kinect = "package://moveit_resources/panda_description/meshes/collision/hand.stl";
+  std::string kinect = "package://moveit_resources_panda_description/meshes/collision/hand.stl";
   shapes::ShapeConstPtr s;
   s.reset(shapes::createMeshFromResource(kinect));
   obj2_shapes.push_back(s);

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -24,9 +24,6 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 install(FILES ../collision_detector_fcl_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_fcl_collision_detection test/test_fcl_collision_detection_pr2.cpp)
   target_link_libraries(test_fcl_collision_detection moveit_test_utils ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
 

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -18,9 +18,6 @@ target_link_libraries(${MOVEIT_LIB_NAME}
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp)
   target_link_libraries(test_collision_distance_field  ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -19,7 +19,7 @@ add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp)
-  target_link_libraries(test_collision_distance_field  ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_collision_distance_field ${MOVEIT_LIB_NAME} moveit_test_utils)
 endif()
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -61,7 +61,7 @@ protected:
   {
     srdf_model_.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file(ros::package::getPath("moveit_resources") + "/pr2_description/urdf/robot.xml",
+    std::fstream xml_file(ros::package::getPath("moveit_resources_pr2_description") + "/urdf/robot.xml",
                           std::fstream::in);
     if (xml_file.is_open())
     {
@@ -78,7 +78,7 @@ protected:
     else
       urdf_ok_ = false;
     srdf_ok_ = srdf_model_->initFile(*urdf_model_,
-                                     ros::package::getPath("moveit_resources") + "/pr2_description/srdf/robot.xml");
+                                     ros::package::getPath("moveit_resources_pr2_description") + "/srdf/robot.xml");
 
     robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_model_));
 

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -28,9 +28,8 @@ if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl REQUIRED)
   find_package(angles REQUIRED)
   find_package(tf2_kdl REQUIRED)
-  find_package(moveit_resources REQUIRED)
 
-  include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS} ${moveit_resources_INCLUDE_DIRS})
+  include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
 
   catkin_add_gtest(test_constraint_samplers
     test/test_constraint_samplers.cpp

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -18,9 +18,6 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_constraints test/test_constraints.cpp)
   target_link_libraries(test_constraints moveit_test_utils ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -51,7 +51,8 @@
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
 
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
+  <test_depend>moveit_resources_pr2_description</test_depend>
   <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
   <test_depend condition="$ROS_DISTRO != noetic">orocos_kdl</test_depend>

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -23,9 +23,6 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_planning_scene test/test_planning_scene.cpp)
   target_link_libraries(test_planning_scene ${MOVEIT_LIB_NAME})
 

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -24,8 +24,8 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_planning_scene test/test_planning_scene.cpp)
-  target_link_libraries(test_planning_scene ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_planning_scene ${MOVEIT_LIB_NAME} moveit_test_utils)
 
   catkin_add_gtest(test_multi_threaded test/test_multi_threaded.cpp)
-  target_link_libraries(test_multi_threaded moveit_planning_scene moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES})
+  target_link_libraries(test_multi_threaded ${MOVEIT_LIB_NAME} moveit_test_utils)
 endif()

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -18,9 +18,6 @@ target_link_libraries(${MOVEIT_LIB_NAME} moveit_profiler moveit_exceptions movei
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_robot_model test/test.cpp)
   target_link_libraries(test_robot_model moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -26,18 +26,18 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 # Unit tests
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
-  target_link_libraries(test_robot_state moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils)
 
   # As an executable, this benchmark is not run as a test by default
   add_executable(robot_state_benchmark test/robot_state_benchmark.cpp)
-  target_link_libraries(robot_state_benchmark moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME} ${GTEST_LIBRARIES})
+  target_link_libraries(robot_state_benchmark ${MOVEIT_LIB_NAME} moveit_test_utils ${GTEST_LIBRARIES})
 
   catkin_add_gtest(test_cartesian_interpolator test/test_cartesian_interpolator.cpp)
-  target_link_libraries(test_cartesian_interpolator moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_cartesian_interpolator ${MOVEIT_LIB_NAME} moveit_test_utils)
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)
-  target_link_libraries(test_robot_state_complex moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_robot_state_complex ${MOVEIT_LIB_NAME} moveit_test_utils)
 
   catkin_add_gtest(test_aabb test/test_aabb.cpp)
-  target_link_libraries(test_aabb moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_aabb ${MOVEIT_LIB_NAME} moveit_test_utils)
 endif()

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -25,9 +25,6 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 # Unit tests
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
   target_link_libraries(test_robot_state moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -278,7 +278,7 @@ TEST_F(TestAABB, TestSimple)
   builder.addChain("base_footprint->base_link", "fixed", { origin });
 
   tf2::toMsg(tf2::Vector3(0, 0, 0), origin.position);
-  builder.addCollisionMesh("base_link", "package://moveit_resources/pr2_description/urdf/meshes/base_v0/base_L.stl",
+  builder.addCollisionMesh("base_link", "package://moveit_resources_pr2_description/urdf/meshes/base_v0/base_L.stl",
                            origin);
 
   tf2::toMsg(tf2::Vector3(0, 0, 0.071), origin.position);

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -34,7 +34,6 @@
 
 /* Author: Michael Lautman */
 
-#include <moveit_resources/config.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/cartesian_interpolator.h>

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -43,6 +43,7 @@
 #include <boost/filesystem/path.hpp>
 #include <geometric_shapes/shapes.h>
 #include <moveit/profiler/profiler.h>
+#include <moveit/utils/robot_model_test_utils.h>
 #include <ros/package.h>
 
 class LoadPlanningModelsPr2 : public testing::Test
@@ -50,24 +51,10 @@ class LoadPlanningModelsPr2 : public testing::Test
 protected:
   void SetUp() override
   {
-    boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
-
-    srdf_model_.reset(new srdf::Model());
-    std::string xml_string;
-    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
-    if (xml_file.is_open())
-    {
-      while (xml_file.good())
-      {
-        std::string line;
-        std::getline(xml_file, line);
-        xml_string += (line + "\n");
-      }
-      xml_file.close();
-      urdf_model_ = urdf::parseURDF(xml_string);
-    }
-    srdf_model_->initFile(*urdf_model_, (res_path / "pr2_description/srdf/robot.xml").string());
-    robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_model_));
+    std::string robot_name = "pr2";
+    urdf_model_ = moveit::core::loadModelInterface(robot_name);
+    srdf_model_ = moveit::core::loadSRDFModel(robot_name);
+    robot_model_ = std::make_shared<moveit::core::RobotModel>(urdf_model_, srdf_model_);
   };
 
   void TearDown() override
@@ -77,7 +64,7 @@ protected:
 protected:
   urdf::ModelInterfaceSharedPtr urdf_model_;
   srdf::ModelSharedPtr srdf_model_;
-  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelPtr robot_model_;
 };
 
 TEST_F(LoadPlanningModelsPr2, InitOK)

--- a/moveit_core/robot_trajectory/CMakeLists.txt
+++ b/moveit_core/robot_trajectory/CMakeLists.txt
@@ -14,9 +14,6 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_robot_trajectory test/test_robot_trajectory.cpp)
   target_link_libraries(test_robot_trajectory moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -19,8 +19,6 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
   catkin_add_gtest(test_time_parameterization test/test_time_parameterization.cpp)
   target_link_libraries(test_time_parameterization moveit_test_utils ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${MOVEIT_LIB_NAME})
   catkin_add_gtest(test_time_optimal_trajectory_generation test/test_time_optimal_trajectory_generation.cpp)

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -37,13 +37,8 @@
 
 #pragma once
 
-#include <urdf_parser/urdf_parser.h>
-#include <urdf_model/model.h>
-#include <urdf_model/joint.h>
 #include <srdfdom/srdf_writer.h>
 #include <urdf/model.h>
-#include <fstream>
-#include <boost/filesystem/path.hpp>
 #include <moveit/robot_model/robot_model.h>
 #include <geometry_msgs/Pose.h>
 

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -113,7 +113,7 @@ public:
   /** \brief Adds a collision mesh to a specific link.
    *  \param[in] link_name The name of the link to which the mesh will be added. Must already be in the builder
    *  \param[in] filename The path to the mesh file, e.g.
-   * "package://moveit_resources/pr2_description/urdf/meshes/base_v0/base_L.stl"
+   * "package://moveit_resources_pr2_description/urdf/meshes/base_v0/base_L.stl"
    *  \param[in] origin The origin pose of this collision mesh relative to the link origin
    */
   void addCollisionMesh(const std::string& link_name, const std::string& filename, geometry_msgs::Pose origin);

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -39,7 +39,8 @@
 #include <boost/math/constants/constants.hpp>
 #include <geometry_msgs/Pose.h>
 
-#include "moveit/utils/robot_model_test_utils.h"
+#include <urdf_parser/urdf_parser.h>
+#include <moveit/utils/robot_model_test_utils.h>
 #include <ros/package.h>
 
 namespace moveit
@@ -58,15 +59,15 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name)
 
 urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 {
-  boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
   std::string urdf_path;
   if (robot_name == "pr2")
   {
-    urdf_path = (res_path / "pr2_description/urdf/robot.xml").string();
+    urdf_path = ros::package::getPath("moveit_resources_pr2_description") + "/urdf/robot.xml";
   }
   else
   {
-    urdf_path = (res_path / (robot_name + "_description") / "urdf" / (robot_name + ".urdf")).string();
+    urdf_path =
+        ros::package::getPath("moveit_resources_" + robot_name + "_description") + "/urdf/" + robot_name + ".urdf";
   }
   urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDFFile(urdf_path);
   if (urdf_model == nullptr)
@@ -79,17 +80,17 @@ urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 
 srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
 {
-  boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
   urdf::ModelInterfaceSharedPtr urdf_model = loadModelInterface(robot_name);
   srdf::ModelSharedPtr srdf_model(new srdf::Model());
   std::string srdf_path;
   if (robot_name == "pr2")
   {
-    srdf_path = (res_path / "pr2_description/srdf/robot.xml").string();
+    srdf_path = ros::package::getPath("moveit_resources_pr2_description") + "/srdf/robot.xml";
   }
   else
   {
-    srdf_path = (res_path / (robot_name + "_moveit_config") / "config" / (robot_name + ".srdf")).string();
+    srdf_path =
+        ros::package::getPath("moveit_resources_" + robot_name + "_moveit_config") + "/config/" + robot_name + ".srdf";
   }
   srdf_model->initFile(*urdf_model, srdf_path);
   return srdf_model;

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -35,7 +35,10 @@
 
   <test_depend>rostest</test_depend>
   <test_depend>moveit_ros_planning</test_depend>
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_fanuc_description</test_depend>
+  <test_depend>moveit_resources_fanuc_moveit_config</test_depend>
+  <test_depend>moveit_resources_panda_description</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>xmlrpcpp</test_depend>
 
   <export>

--- a/moveit_kinematics/test/CMakeLists.txt
+++ b/moveit_kinematics/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
   find_package(rostest REQUIRED)
   find_package(xmlrpcpp REQUIRED)
   find_package(moveit_ros_planning REQUIRED)

--- a/moveit_kinematics/test/fanuc-ikfast.test
+++ b/moveit_kinematics/test/fanuc-ikfast.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 	<group ns="fanuc">
-		<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+		<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
 			<arg name="load_robot_description" value="true"/>
 		</include>
 

--- a/moveit_kinematics/test/fanuc-kdl.test
+++ b/moveit_kinematics/test/fanuc-kdl.test
@@ -6,7 +6,7 @@
 	<arg name="name" value="$(eval 'fanuc_' + arg('ik_plugin')[0:3])"/>
 
 	<group ns="fanuc">
-		<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+		<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
 			<arg name="load_robot_description" value="true"/>
 		</include>
 

--- a/moveit_kinematics/test/panda-ikfast.test
+++ b/moveit_kinematics/test/panda-ikfast.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 	<group ns="panda">
-		<include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+		<include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
 			<arg name="load_robot_description" value="true"/>
 		</include>
 

--- a/moveit_kinematics/test/panda-kdl.test
+++ b/moveit_kinematics/test/panda-kdl.test
@@ -6,7 +6,7 @@
 	<arg name="name" value="$(eval 'panda_' + arg('ik_plugin')[0:3])"/>
 
 	<group ns="panda">
-		<include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+		<include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
 			<arg name="load_robot_description" value="true"/>
 		</include>
 

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -45,9 +45,6 @@ install(TARGETS moveit_generate_state_database
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(test_state_space test/test_state_space.cpp)
   target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -46,6 +46,6 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_state_space test/test_state_space.cpp)
-  target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+  target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES})
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 endif()

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -43,6 +43,7 @@
 
 #include <ompl/util/Exception.h>
 #include <moveit/robot_state/conversions.h>
+#include <moveit/utils/robot_model_test_utils.h>
 #include <gtest/gtest.h>
 #include <fstream>
 #include <boost/filesystem/path.hpp>
@@ -55,24 +56,7 @@ class LoadPlanningModelsPr2 : public testing::Test
 protected:
   void SetUp() override
   {
-    boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
-
-    srdf_model_.reset(new srdf::Model());
-    std::string xml_string;
-    std::fstream xml_file((res_path / "pr2_description/urdf/robot.xml").string().c_str(), std::fstream::in);
-    if (xml_file.is_open())
-    {
-      while (xml_file.good())
-      {
-        std::string line;
-        std::getline(xml_file, line);
-        xml_string += (line + "\n");
-      }
-      xml_file.close();
-      urdf_model_ = urdf::parseURDF(xml_string);
-    }
-    srdf_model_->initFile(*urdf_model_, (res_path / "pr2_description/srdf/robot.xml").string());
-    robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_model_));
+    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
   };
 
   void TearDown() override
@@ -81,10 +65,6 @@ protected:
 
 protected:
   moveit::core::RobotModelPtr robot_model_;
-  urdf::ModelInterfaceSharedPtr urdf_model_;
-  srdf::ModelSharedPtr srdf_model_;
-  bool urdf_ok_;
-  bool srdf_ok_;
 };
 
 TEST_F(LoadPlanningModelsPr2, StateSpace)

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -25,7 +25,7 @@
   <depend>tf2_ros</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
 
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_pr2_description</test_depend>
   <test_depend>rosunit</test_depend>
 
   <export>

--- a/moveit_planners/trajopt/test/trajectory_test.test
+++ b/moveit_planners/trajopt/test/trajectory_test.test
@@ -3,7 +3,7 @@
 
   <test pkg="moveit_planners_trajopt" type="trajectory_test" test-name="trajectory_test" time-limit="300" args="">
 
-    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/trajopt_planning.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/trajopt_planning.yaml"/>
 
   </test>
 

--- a/moveit_ros/benchmarks/examples/demo_fanuc.launch
+++ b/moveit_ros/benchmarks/examples/demo_fanuc.launch
@@ -3,17 +3,17 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo1.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/default_warehouse_db.launch" />
 
   <!-- Launch benchmark node -->
   <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">

--- a/moveit_ros/benchmarks/examples/demo_panda.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda.launch
@@ -3,17 +3,17 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo1.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/default_warehouse_db.launch" />
 
   <!-- Launch benchmark node -->
   <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners.launch
@@ -3,24 +3,24 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_panda_all_planners.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/default_warehouse_db.launch" />
 
   <!-- Load all planning pipelines that will be benchmarked -->
   <group ns="moveit_run_benchmark">
-    <include ns="ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="stomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="stomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="stomp" />
     </include>
   </group>

--- a/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_all_planners_obstacles.launch
@@ -3,24 +3,24 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_obstacles.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/default_warehouse_db.launch" />
 
   <!-- Load all planning pipelines that will be benchmarked -->
   <group ns="moveit_run_benchmark">
-    <include ns="ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="stomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="stomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="stomp" />
     </include>
   </group>

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch
@@ -3,24 +3,24 @@
   <arg name="bench_opts" default="$(find moveit_ros_benchmarks)/examples/demo_panda_predefined_poses.yaml"/>
 
   <!-- Load robot settings -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Load warehouse containing scenes and queries to benchmark -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/default_warehouse_db.launch" />
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/default_warehouse_db.launch" />
 
   <!-- Load all planning pipelines that will be benchmarked -->
   <group ns="moveit_run_benchmark">
-    <include ns="ompl" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="stomp" file="$(find moveit_resources)/panda_moveit_config/launch/planning_pipeline.launch.xml">
+    <include ns="stomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="stomp" />
     </include>
   </group>
@@ -30,4 +30,3 @@
     <rosparam command="load" file="$(arg bench_opts)"/>
   </node>
 </launch>
-

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -30,7 +30,7 @@
   <exec_depend>moveit_kinematics</exec_depend>
 
   <test_depend>rostest</test_depend>
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_fanuc_moveit_config</test_depend>
 
   <export>
     <moveit_ros_move_group plugin="${prefix}/default_capabilities_plugin_description.xml"/>

--- a/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
+++ b/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
@@ -1,6 +1,6 @@
 <launch>
 	<!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+	<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
 		<arg name="load_robot_description" value="true"/>
 	</include>
 
@@ -14,7 +14,7 @@
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
 	<!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/move_group.launch">
+	<include file="$(find moveit_resources_fanuc_moveit_config)/launch/move_group.launch">
 		<arg name="allow_trajectory_execution" value="true"/>
 		<arg name="fake_execution" value="true"/>
 		<arg name="info" value="true"/>

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -33,7 +33,7 @@
   <exec_depend>spacenav_node</exec_depend>
 
   <test_depend>rostest</test_depend>
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
 
   <export>
   </export>

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.test
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <!-- Load URDF, SRDF -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch" >
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true"/>
   </include>
 

--- a/moveit_ros/planning/launch/collision_checker_compare.launch
+++ b/moveit_ros/planning/launch/collision_checker_compare.launch
@@ -2,15 +2,15 @@
   <arg name="visualization" default="false" doc="turns on and off visualization with rviz"/>
 
   <!-- send Panda urdf to parameter server -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'" />
+  <param name="robot_description" textfile="$(find moveit_resources_panda_description)/urdf/panda.urdf" />
 
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch"/>
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch"/>
 
   <node name="compare_collision_checking_speed" pkg="moveit_ros_planning" type="moveit_compare_collision_checking_speed_fcl_bullet" respawn="false" output="screen">
-    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/kinematics.yaml"/>
     <param name="visualization" value="$(arg visualization)" type="bool"/>
   </node>
 
-  <include if="$(arg visualization)" file="$(find moveit_resources)/panda_moveit_config/launch/demo.launch"/>
+  <include if="$(arg visualization)" file="$(find moveit_resources_panda_moveit_config)/launch/demo.launch"/>
 
 </launch>

--- a/moveit_ros/planning/planning_components_tools/src/compare_collision_speed_checking_fcl_bullet.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/compare_collision_speed_checking_fcl_bullet.cpp
@@ -100,7 +100,7 @@ void clutterWorld(const planning_scene::PlanningScenePtr& planning_scene, const 
   // load panda link5 as world collision object
   std::string name;
   shapes::ShapeConstPtr shape;
-  std::string kinect = "package://moveit_resources/panda_description/meshes/collision/link5.stl";
+  std::string kinect = "package://moveit_resources_panda_description/meshes/collision/link5.stl";
 
   Eigen::Quaterniond quat;
   Eigen::Isometry3d pos{ Eigen::Isometry3d::Identity() };

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -40,7 +40,8 @@
 
   <build_depend>eigen</build_depend>
 
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_fanuc_moveit_config</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>eigen_conversions</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>eigen_conversions</test_depend>

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 if (CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
   find_package(rostest REQUIRED)
   find_package(eigen_conversions REQUIRED)
 

--- a/moveit_ros/planning_interface/test/cleanup.test
+++ b/moveit_ros/planning_interface/test/cleanup.test
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
   <test pkg="moveit_ros_planning_interface" type="cleanup.py" test-name="cleanup_tests"
         time-limit="300" args=""/>
 </launch>

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.test
@@ -1,6 +1,6 @@
 <launch>
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
@@ -17,7 +17,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   <!-- Run the main MoveIt executable with fake trajectory execution -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/move_group.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>

--- a/moveit_ros/planning_interface/test/move_group_pick_place_test.test
+++ b/moveit_ros/planning_interface/test/move_group_pick_place_test.test
@@ -1,6 +1,6 @@
 <launch>
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
@@ -17,7 +17,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   <!-- Run the main MoveIt executable with fake trajectory execution -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/move_group.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -3,18 +3,18 @@
     <rosparam ns="moveit_cpp_test" command="load" file="$(find moveit_ros_planning_interface)/test/moveit_cpp.yaml" />
 
     <!-- Planning Pipeline -->
-    <include ns="/moveit_cpp_test/ompl" file="$(find moveit_resources)/panda_moveit_config/launch/ompl_planning_pipeline.launch.xml"/>
+    <include ns="/moveit_cpp_test/ompl" file="$(find moveit_resources_panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml"/>
 
     <!-- Trajectory execution  -->
-    <!--include ns="moveit_cpp_test" file="$(find moveit_resources)/panda_moveit_config/launch/trajectory_execution.launch.xml">
+    <!--include ns="moveit_cpp_test" file="$(find moveit_resources_panda_moveit_config)/launch/trajectory_execution.launch.xml">
       <arg name="moveit_controller_manager" value="fake"/>
     </include-->
 
     <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
-    <include ns="moveit_cpp_test" file="$(find moveit_resources)/panda_moveit_config/launch/fake_moveit_controller_manager.launch.xml" />
+    <include ns="moveit_cpp_test" file="$(find moveit_resources_panda_moveit_config)/launch/fake_moveit_controller_manager.launch.xml" />
 
     <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-    <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+    <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
       <arg name="load_robot_description" value="true"/>
     </include>
 

--- a/moveit_ros/planning_interface/test/python_move_group.test
+++ b/moveit_ros/planning_interface/test/python_move_group.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <!-- Start joint_state_publisher, robot_state_publisher, and MoveGroup -->
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
 
   <!-- Test MoveGroupInterface for Python -->
   <test pkg="moveit_ros_planning_interface" type="python_move_group.py" test-name="python_move_group"

--- a/moveit_ros/planning_interface/test/python_move_group_ns.test
+++ b/moveit_ros/planning_interface/test/python_move_group_ns.test
@@ -1,6 +1,6 @@
 <launch>
   <group  ns="test_ns">
-    <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+    <include file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
     <test pkg="moveit_ros_planning_interface" type="python_move_group.py" test-name="python_move_group"
           time-limit="300" args=""/>
   </group>

--- a/moveit_ros/planning_interface/test/robot_state_update.test
+++ b/moveit_ros/planning_interface/test/robot_state_update.test
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find moveit_resources)/fanuc_moveit_config/launch/test_environment.launch"/>
+  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/test_environment.launch"/>
   <test pkg="moveit_ros_planning_interface" type="robot_state_update.py" test-name="robot_state_update"
         time-limit="300" args=""/>
 </launch>

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -164,6 +164,5 @@ install(DIRECTORY templates DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 # Unit tests
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_reading_writing_config test/moveit_config_data_test.cpp)
-  target_link_libraries(test_reading_writing_config
-    ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_reading_writing_config ${PROJECT_NAME}_tools)
 endif()

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -163,8 +163,6 @@ install(DIRECTORY templates DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 # Unit tests
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
   catkin_add_gtest(test_reading_writing_config test/moveit_config_data_test.cpp)
   target_link_libraries(test_reading_writing_config
     ${PROJECT_NAME}_tools ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${MOVEIT_LIB_NAME})

--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -36,6 +36,6 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>rviz</exec_depend>
 
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>rosunit</test_depend>
 </package>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_trajopt.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_trajopt.launch
@@ -4,19 +4,19 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find moveit_resources)/panda_moveit_config/launch/warehouse.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_trajopt_benchmark_warehouse"/>
   </include>
 
   <!-- Start Benchmark Executable -->
   <node name="$(anon moveit_benchmark)" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" args="$(arg cfg) --benchmark-planners" respawn="false" output="screen">
-    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/kinematics.yaml"/>
-    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/trajopt_planning.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/trajopt_planning.yaml"/>
   </node>
 
 </launch>

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -51,11 +51,11 @@ class MoveItConfigData : public testing::Test
 protected:
   void SetUp() override
   {
-    boost::filesystem::path res_path(ros::package::getPath("moveit_resources"));
+    boost::filesystem::path res_path(ros::package::getPath("moveit_resources_panda_description"));
 
     srdf_model.reset(new srdf::Model());
     std::string xml_string;
-    std::fstream xml_file((res_path / "panda_description/urdf/panda.urdf").string().c_str(), std::fstream::in);
+    std::fstream xml_file((res_path / "urdf/panda.urdf").string().c_str(), std::fstream::in);
     if (xml_file.is_open())
     {
       while (xml_file.good())
@@ -67,7 +67,8 @@ protected:
       xml_file.close();
       urdf_model = urdf::parseURDF(xml_string);
     }
-    srdf_model->initFile(*urdf_model, (res_path / "panda_moveit_config/config/panda.srdf").string());
+    res_path = ros::package::getPath("moveit_resources_panda_moveit_config");
+    srdf_model->initFile(*urdf_model, (res_path / "config/panda.srdf").string());
     robot_model.reset(new moveit::core::RobotModel(urdf_model, srdf_model));
   };
 


### PR DESCRIPTION
Related to https://github.com/ros-planning/moveit_resources/pull/36 .

There is no reason to include them from cmake anymore.
The resources are not in a single path anymore and there is no header exposed anymore.