### PR TITLE
Exposed missing parameters from the MoveGroup Pyhton interface

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -448,7 +448,7 @@ class MoveGroupCommander(object):
 
     def get_planner_id(self):
         """ Get the current planner_id """
-        self._g.get_planner_id()
+        return self._g.get_planner_id()
 
     def set_num_planning_attempts(self, num_planning_attempts):
         """ Set the number of times the motion plan is to be computed from scratch before the shortest solution is returned. The default value is 1. """

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -48,9 +48,9 @@ class MoveGroupCommander(object):
     Execution of simple commands for a particular group
     """
 
-    def __init__(self, name, robot_description="robot_description", ns=""):
+    def __init__(self, name, robot_description="robot_description", ns="", wait_for_servers=5.0):
         """ Specify the group name for which to construct this commander instance. Throws an exception if there is an initialization error. """
-        self._g = _moveit_move_group_interface.MoveGroupInterface(name, robot_description, ns)
+        self._g = _moveit_move_group_interface.MoveGroupInterface(name, robot_description, ns, wait_for_servers)
 
     def get_name(self):
         """ Get the name of the group this instance was initialized for """

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -381,6 +381,11 @@ public:
     return getName().c_str();
   }
 
+  const char* getPlannerIdCStr() const
+  {
+    return getPlannerId().c_str();
+  }
+
   bp::dict getNamedTargetValuesPython(const std::string& name)
   {
     bp::dict output;
@@ -695,6 +700,7 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("set_max_acceleration_scaling_factor",
                                  &MoveGroupInterfaceWrapper::setMaxAccelerationScalingFactor);
   move_group_interface_class.def("set_planner_id", &MoveGroupInterfaceWrapper::setPlannerId);
+  move_group_interface_class.def("get_planner_id", &MoveGroupInterfaceWrapper::getPlannerIdCStr);
   move_group_interface_class.def("set_num_planning_attempts", &MoveGroupInterfaceWrapper::setNumPlanningAttempts);
   move_group_interface_class.def("plan", &MoveGroupInterfaceWrapper::planPython);
   move_group_interface_class.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathPython);

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -576,7 +576,7 @@ static void wrap_move_group_interface()
   eigenpy::enableEigenPy();
 
   bp::class_<MoveGroupInterfaceWrapper, boost::noncopyable> move_group_interface_class(
-      "MoveGroupInterface", bp::init<std::string, std::string, bp::optional<std::string>>());
+      "MoveGroupInterface", bp::init<std::string, std::string, bp::optional<std::string, double>>());
 
   move_group_interface_class.def("async_move", &MoveGroupInterfaceWrapper::asyncMovePython);
   move_group_interface_class.def("move", &MoveGroupInterfaceWrapper::movePython);


### PR DESCRIPTION
### Description
The Python interface to MoveCommander was not exposing the `wait_for_servers` parameter as it does in C++. The wrapper already had it, so the only missing part was to add it to the Python interface. This should handle #1807 as now the timeout can be extended from the Python interface.

Edit: I also found that the getPlannerId python method was created but not interfaced, so I added it to too. 

I tested it in ROS melodic, so if this is merged it would be good if it could be ported to melodic too.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
