### PR TITLE
MSA: Remove urdf package as build_depend from package.xml

### DIFF
--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1099,7 +1099,6 @@ void ConfigurationFilesWidget::loadTemplateStrings()
   else
   {
     std::stringstream deps;
-    deps << "<build_depend>" << config_data_->urdf_pkg_name_ << "</build_depend>\n";
     deps << "  <run_depend>" << config_data_->urdf_pkg_name_ << "</run_depend>\n";
     addTemplateString("[OTHER_DEPENDENCIES]", deps.str());  // not relative to a ROS package
   }


### PR DESCRIPTION
### Description

Every time I use MSA to generate config files for a package and use catkin_lint in the workspace I get [unconfigured-build_depend-on-pkg](https://fkie.github.io/catkin_lint/messages/#unconfigured-build_depend-on-pkg) error, grepping through the MSA's source code shows that urdf_pkg_name_ is only used as a run depend

Reproduce:
1- `sudo apt install ros-melodic-franka-description` (or any ROBOT-description package)
2- Select `Create New MoveIt Configuration Package`
3- Use `/opt/ros/melodic/share/franka_description/robots/panda_arm_hand.urdf.xacro` as URDF URL
4- Generate config files
5- Run `catkin_lint -W0 .`

```
catkin_lint: downloading melodic package index from https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
catkin_lint: downloading package manifest for 'warehouse_ros_mongo'
pkg_test: CMakeLists.txt: error: unconfigured build_depend on 'franka_description'
catkin_lint: checked 1 packages and found 1 problems
catkin_lint: option -W1 will show 8 additional warnings
```
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
