### PR TITLE
Add named logging with LOGNAME to OMPL interface

### DIFF
--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -49,7 +49,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <sstream>
 
-static const std::string LOGNAME = "generate_state_database";
+constexpr char LOGNAME[] = "generate_state_database";
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -41,7 +41,7 @@
 
 #include <utility>
 
-static const std::string LOGNAME{ "constrained_goal_sampler" };
+constexpr char LOGNAME[] = "constrained_goal_sampler";
 
 ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedPlanningContext* pc,
                                                                kinematic_constraints::KinematicConstraintSetPtr ks,

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -41,7 +41,10 @@
 
 #include <utility>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "constrained_goal_sampler";
+}  // namespace ompl_interface
 
 ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedPlanningContext* pc,
                                                                kinematic_constraints::KinematicConstraintSetPtr ks,

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -41,6 +41,8 @@
 
 #include <utility>
 
+static const std::string LOGNAME{ "constrained_goal_sampler" };
+
 ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedPlanningContext* pc,
                                                                kinematic_constraints::KinematicConstraintSetPtr ks,
                                                                constraint_samplers::ConstraintSamplerPtr cs)
@@ -58,7 +60,7 @@ ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedP
 {
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
-  ROS_DEBUG_NAMED("constrained_goal_sampler", "Constructed a ConstrainedGoalSampler instance at address %p", this);
+  ROS_DEBUG_NAMED(LOGNAME, "Constructed a ConstrainedGoalSampler instance at address %p", this);
   startSampling();
 }
 
@@ -138,9 +140,9 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
           if (!warned_invalid_samples_ && invalid_sampled_constraints_ >= (attempts_so_far * 8) / 10)
           {
             warned_invalid_samples_ = true;
-            ROS_WARN_NAMED("constrained_goal_sampler", "More than 80%% of the sampled goal states "
-                                                       "fail to satisfy the constraints imposed on the goal sampler. "
-                                                       "Is the constrained sampler working correctly?");
+            ROS_WARN_NAMED(LOGNAME, "More than 80%% of the sampled goal states "
+                                    "fail to satisfy the constraints imposed on the goal sampler. "
+                                    "Is the constrained sampler working correctly?");
           }
         }
       }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -40,7 +40,7 @@
 
 #include <utility>
 
-static const std::string LOGNAME{ "constrained_valid_state_sampler" };
+constexpr char LOGNAME[] = "constrained_valid_state_sampler";
 
 ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBasedPlanningContext* pc,
                                                                  kinematic_constraints::KinematicConstraintSetPtr ks,

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -40,6 +40,8 @@
 
 #include <utility>
 
+static const std::string LOGNAME{ "constrained_valid_state_sampler" };
+
 ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBasedPlanningContext* pc,
                                                                  kinematic_constraints::KinematicConstraintSetPtr ks,
                                                                  constraint_samplers::ConstraintSamplerPtr cs)
@@ -52,8 +54,7 @@ ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBase
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
   inv_dim_ = si_->getStateSpace()->getDimension() > 0 ? 1.0 / (double)si_->getStateSpace()->getDimension() : 1.0;
-  ROS_DEBUG_NAMED("constrained_valid_state_sampler", "Constructed a ValidConstrainedSampler instance at address %p",
-                  this);
+  ROS_DEBUG_NAMED(LOGNAME, "Constructed a ValidConstrainedSampler instance at address %p", this);
 }
 
 bool ompl_interface::ValidConstrainedSampler::project(ompl::base::State* state)

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -40,7 +40,10 @@
 
 #include <utility>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "constrained_valid_state_sampler";
+}  // namespace ompl_interface
 
 ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBasedPlanningContext* pc,
                                                                  kinematic_constraints::KinematicConstraintSetPtr ks,

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -34,13 +34,13 @@
 
 /* Author: Ioan Sucan */
 
-#include <moveit/ompl_interface/detail/constraints_library.h>
-#include <moveit/ompl_interface/detail/constrained_sampler.h>
-#include <moveit/profiler/profiler.h>
-#include <ompl/tools/config/SelfConfig.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem.hpp>
 #include <fstream>
+#include <moveit/ompl_interface/detail/constrained_sampler.h>
+#include <moveit/ompl_interface/detail/constraints_library.h>
+#include <moveit/profiler/profiler.h>
+#include <ompl/tools/config/SelfConfig.h>
 #include <utility>
 
 static const std::string LOGNAME{ "constraints_library" };
@@ -229,7 +229,8 @@ ompl_interface::ConstraintApproximation::getStateSamplerAllocator(const moveit_m
                    milestones_);
 }
 /*
-void ompl_interface::ConstraintApproximation::visualizeDistribution(const std::string &link_name, unsigned int count,
+void ompl_interface::ConstraintApproximation::visualizeDistribution(const
+std::string &link_name, unsigned int count,
 visualization_msgs::MarkerArray &arr) const
 {
   moveit::core::RobotState robot_state(robot_model_);
@@ -248,7 +249,8 @@ visualization_msgs::MarkerArray &arr) const
   {
     state_storage_->getStateSpace()->as<ModelBasedStateSpace>()->copyToRobotState(robot_state,
 state_storage_->getState(rng.uniformInt(0, state_storage_->size() - 1)));
-    const Eigen::Vector3d &pos = robot_state.getLinkState(link_name)->getGlobalLinkTransform().translation();
+    const Eigen::Vector3d &pos =
+robot_state.getLinkState(link_name)->getGlobalLinkTransform().translation();
 
     visualization_msgs::Marker mk;
     mk.header.stamp = ros::Time::now();
@@ -275,7 +277,9 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
   std::ifstream fin((path + "/manifest").c_str());
   if (!fin.good())
   {
-    ROS_WARN_NAMED(LOGNAME, "Manifest not found in folder '%s'. Not loading constraint approximations.", path.c_str());
+    ROS_WARN_NAMED(LOGNAME, "Manifest not found in folder '%s'. Not loading "
+                            "constraint approximations.",
+                   path.c_str());
     return;
   }
 
@@ -306,12 +310,14 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     if (context_->getGroupName() != group &&
         context_->getOMPLStateSpace()->getParameterizationType() != state_space_parameterization)
     {
-      ROS_INFO_NAMED(LOGNAME, "Ignoring constraint approximation of type '%s' for group '%s' from '%s'...",
+      ROS_INFO_NAMED(LOGNAME, "Ignoring constraint approximation of type '%s' "
+                              "for group '%s' from '%s'...",
                      state_space_parameterization.c_str(), group.c_str(), filename.c_str());
       continue;
     }
 
-    ROS_INFO_NAMED(LOGNAME, "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
+    ROS_INFO_NAMED(LOGNAME, "Loading constraint approximation of type '%s' for "
+                            "group '%s' from '%s'...",
                    state_space_parameterization.c_str(), group.c_str(), filename.c_str());
     moveit_msgs::Constraints msg;
     hexToMsg(serialization, msg);
@@ -326,9 +332,9 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     std::size_t sum = 0;
     for (std::size_t i = 0; i < cass->size(); ++i)
       sum += cass->getMetadata(i).first.size();
-    ROS_INFO_NAMED(LOGNAME,
-                   "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) "
-                   "for constraint named '%s'%s",
+    ROS_INFO_NAMED(LOGNAME, "Loaded %lu states (%lu milestones) and %lu "
+                            "connections (%0.1lf per state) "
+                            "for constraint named '%s'%s",
                    cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
                    msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
   }
@@ -617,7 +623,8 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     return state_storage;
   }
 
-  // TODO(davetcoleman): this function did not originally return a value, causing compiler warnings in ROS Melodic
+  // TODO(davetcoleman): this function did not originally return a value,
+  // causing compiler warnings in ROS Melodic
   // Update with more intelligent logic as needed
   ROS_ERROR_NAMED(LOGNAME, "No StateStoragePtr found - implement better solution here.");
   return state_storage;

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -43,7 +43,7 @@
 #include <ompl/tools/config/SelfConfig.h>
 #include <utility>
 
-static const std::string LOGNAME{ "constraints_library" };
+constexpr char LOGNAME[] = "constraints_library";
 
 namespace ompl_interface
 {

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -43,6 +43,8 @@
 #include <fstream>
 #include <utility>
 
+static const std::string LOGNAME{ "constraints_library" };
+
 namespace ompl_interface
 {
 namespace
@@ -273,12 +275,11 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
   std::ifstream fin((path + "/manifest").c_str());
   if (!fin.good())
   {
-    ROS_WARN_NAMED("constraints_library", "Manifest not found in folder '%s'. Not loading constraint approximations.",
-                   path.c_str());
+    ROS_WARN_NAMED(LOGNAME, "Manifest not found in folder '%s'. Not loading constraint approximations.", path.c_str());
     return;
   }
 
-  ROS_INFO_NAMED("constraints_library", "Loading constrained space approximations from '%s'...", path.c_str());
+  ROS_INFO_NAMED(LOGNAME, "Loading constrained space approximations from '%s'...", path.c_str());
 
   while (fin.good() && !fin.eof())
   {
@@ -305,13 +306,12 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     if (context_->getGroupName() != group &&
         context_->getOMPLStateSpace()->getParameterizationType() != state_space_parameterization)
     {
-      ROS_INFO_NAMED("constraints_library",
-                     "Ignoring constraint approximation of type '%s' for group '%s' from '%s'...",
+      ROS_INFO_NAMED(LOGNAME, "Ignoring constraint approximation of type '%s' for group '%s' from '%s'...",
                      state_space_parameterization.c_str(), group.c_str(), filename.c_str());
       continue;
     }
 
-    ROS_INFO_NAMED("constraints_library", "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
+    ROS_INFO_NAMED(LOGNAME, "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
                    state_space_parameterization.c_str(), group.c_str(), filename.c_str());
     moveit_msgs::Constraints msg;
     hexToMsg(serialization, msg);
@@ -321,22 +321,23 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
                                                                msg, filename, ompl::base::StateStoragePtr(cass),
                                                                milestones));
     if (constraint_approximations_.find(cap->getName()) != constraint_approximations_.end())
-      ROS_WARN_NAMED("constraints_library", "Overwriting constraint approximation named '%s'", cap->getName().c_str());
+      ROS_WARN_NAMED(LOGNAME, "Overwriting constraint approximation named '%s'", cap->getName().c_str());
     constraint_approximations_[cap->getName()] = cap;
     std::size_t sum = 0;
     for (std::size_t i = 0; i < cass->size(); ++i)
       sum += cass->getMetadata(i).first.size();
-    ROS_INFO_NAMED("constraints_library", "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) "
-                                          "for constraint named '%s'%s",
+    ROS_INFO_NAMED(LOGNAME,
+                   "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) "
+                   "for constraint named '%s'%s",
                    cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
                    msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
   }
-  ROS_INFO_NAMED("constraints_library", "Done loading constrained space approximations.");
+  ROS_INFO_NAMED(LOGNAME, "Done loading constrained space approximations.");
 }
 
 void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std::string& path)
 {
-  ROS_INFO_NAMED("constraints_library", "Saving %u constrained space approximations to '%s'",
+  ROS_INFO_NAMED(LOGNAME, "Saving %u constrained space approximations to '%s'",
                  (unsigned int)constraint_approximations_.size(), path.c_str());
   try
   {
@@ -363,7 +364,7 @@ void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std:
         it->second->getStateStorage()->store((path + "/" + it->second->getFilename()).c_str());
     }
   else
-    ROS_ERROR_NAMED("constraints_library", "Unable to save constraint approximation to '%s'", path.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unable to save constraint approximation to '%s'", path.c_str());
   fout.close();
 }
 
@@ -415,7 +416,7 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
   if (context_->getGroupName() != group &&
       context_->getOMPLStateSpace()->getParameterizationType() != options.state_space_parameterization)
   {
-    ROS_INFO_NAMED("constraints_library", "Ignoring constraint approximation of type '%s' for group '%s'...",
+    ROS_INFO_NAMED(LOGNAME, "Ignoring constraint approximation of type '%s' for group '%s'...",
                    options.state_space_parameterization.c_str(), group.c_str());
     return res;
   }
@@ -427,8 +428,7 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
   ros::WallTime start = ros::WallTime::now();
   ompl::base::StateStoragePtr state_storage =
       constructConstraintApproximation(context_, constr_sampling, constr_hard, options, res);
-  ROS_INFO_NAMED("constraints_library", "Spent %lf seconds constructing the database",
-                 (ros::WallTime::now() - start).toSec());
+  ROS_INFO_NAMED(LOGNAME, "Spent %lf seconds constructing the database", (ros::WallTime::now() - start).toSec());
   if (state_storage)
   {
     ConstraintApproximationPtr constraint_approx(new ConstraintApproximation(
@@ -437,14 +437,12 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(
             ".ompldb",
         state_storage, res.milestones));
     if (constraint_approximations_.find(constraint_approx->getName()) != constraint_approximations_.end())
-      ROS_WARN_NAMED("constraints_library", "Overwriting constraint approximation named '%s'",
-                     constraint_approx->getName().c_str());
+      ROS_WARN_NAMED(LOGNAME, "Overwriting constraint approximation named '%s'", constraint_approx->getName().c_str());
     constraint_approximations_[constraint_approx->getName()] = constraint_approx;
     res.approx = constraint_approx;
   }
   else
-    ROS_ERROR_NAMED("constraints_library", "Unable to construct constraint approximation for group '%s'",
-                    group.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unable to construct constraint approximation for group '%s'", group.c_str());
   return res;
 }
 
@@ -498,19 +496,19 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     if (done != done_now)
     {
       done = done_now;
-      ROS_INFO_NAMED("constraints_library", "%d%% complete (kept %0.1lf%% sampled states)", done,
+      ROS_INFO_NAMED(LOGNAME, "%d%% complete (kept %0.1lf%% sampled states)", done,
                      100.0 * (double)state_storage->size() / (double)attempts);
     }
 
     if (!slow_warn && attempts > 10 && attempts > state_storage->size() * 100)
     {
       slow_warn = true;
-      ROS_WARN_NAMED("constraints_library", "Computation of valid state database is very slow...");
+      ROS_WARN_NAMED(LOGNAME, "Computation of valid state database is very slow...");
     }
 
     if (attempts > options.samples && state_storage->size() == 0)
     {
-      ROS_ERROR_NAMED("constraints_library", "Unable to generate any samples");
+      ROS_ERROR_NAMED(LOGNAME, "Unable to generate any samples");
       break;
     }
 
@@ -527,19 +525,18 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
   }
 
   result.state_sampling_time = ompl::time::seconds(ompl::time::now() - start);
-  ROS_INFO_NAMED("constraints_library", "Generated %u states in %lf seconds", (unsigned int)state_storage->size(),
+  ROS_INFO_NAMED(LOGNAME, "Generated %u states in %lf seconds", (unsigned int)state_storage->size(),
                  result.state_sampling_time);
   if (constrained_sampler)
   {
     result.sampling_success_rate = constrained_sampler->getConstrainedSamplingRate();
-    ROS_INFO_NAMED("constraints_library", "Constrained sampling rate: %lf", result.sampling_success_rate);
+    ROS_INFO_NAMED(LOGNAME, "Constrained sampling rate: %lf", result.sampling_success_rate);
   }
 
   result.milestones = state_storage->size();
   if (options.edges_per_sample > 0)
   {
-    ROS_INFO_NAMED("constraints_library", "Computing graph connections (max %u edges per sample) ...",
-                   options.edges_per_sample);
+    ROS_INFO_NAMED(LOGNAME, "Computing graph connections (max %u edges per sample) ...", options.edges_per_sample);
 
     // construct connexions
     const ob::StateSpacePtr& space = pcontext->getOMPLSimpleSetup()->getStateSpace();
@@ -557,7 +554,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
       if (done != done_now)
       {
         done = done_now;
-        ROS_INFO_NAMED("constraints_library", "%d%% complete", done);
+        ROS_INFO_NAMED(LOGNAME, "%d%% complete", done);
       }
       if (cass->getMetadata(j).first.size() >= options.edges_per_sample)
         continue;
@@ -613,7 +610,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     }
 
     result.state_connection_time = ompl::time::seconds(ompl::time::now() - start);
-    ROS_INFO_NAMED("constraints_library", "Computed possible connexions in %lf seconds. Added %d connexions",
+    ROS_INFO_NAMED(LOGNAME, "Computed possible connexions in %lf seconds. Added %d connexions",
                    result.state_connection_time, good);
     pcontext->getOMPLSimpleSetup()->getSpaceInformation()->freeStates(int_states);
 
@@ -622,6 +619,6 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
   // TODO(davetcoleman): this function did not originally return a value, causing compiler warnings in ROS Melodic
   // Update with more intelligent logic as needed
-  ROS_ERROR_NAMED("constraints_library", "No StateStoragePtr found - implement better solution here.");
+  ROS_ERROR_NAMED(LOGNAME, "No StateStoragePtr found - implement better solution here.");
   return state_storage;
 }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -43,10 +43,10 @@
 #include <ompl/tools/config/SelfConfig.h>
 #include <utility>
 
-constexpr char LOGNAME[] = "constraints_library";
-
 namespace ompl_interface
 {
+constexpr char LOGNAME[] = "constraints_library";
+
 namespace
 {
 template <typename T>

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2011, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -39,7 +39,10 @@
 #include <moveit/profiler/profiler.h>
 #include <ros/ros.h>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "state_validity_checker";
+}  // namespace ompl_interface
 
 ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlanningContext* pc)
   : ompl::base::StateValidityChecker(pc->getOMPLSimpleSetup()->getSpaceInformation())

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -39,7 +39,7 @@
 #include <moveit/profiler/profiler.h>
 #include <ros/ros.h>
 
-static const std::string LOGNAME{ "state_validity_checker" };
+constexpr char LOGNAME[] = "state_validity_checker";
 
 ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlanningContext* pc)
   : ompl::base::StateValidityChecker(pc->getOMPLSimpleSetup()->getSpaceInformation())

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -39,6 +39,8 @@
 #include <moveit/profiler/profiler.h>
 #include <ros/ros.h>
 
+static const std::string LOGNAME{ "state_validity_checker" };
+
 ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlanningContext* pc)
   : ompl::base::StateValidityChecker(pc->getOMPLSimpleSetup()->getSpaceInformation())
   , planning_context_(pc)
@@ -115,7 +117,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
+      ROS_INFO_NAMED(LOGNAME, "State outside bounds");
     return false;
   }
 
@@ -145,7 +147,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
+      ROS_INFO_NAMED(LOGNAME, "State outside bounds");
     return false;
   }
 
@@ -187,7 +189,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
+      ROS_INFO_NAMED(LOGNAME, "State outside bounds");
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
@@ -238,7 +240,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
+      ROS_INFO_NAMED(LOGNAME, "State outside bounds");
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(0.0);
     return false;
   }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -72,7 +72,10 @@
 #include "ompl/base/objectives/MaximizeMinClearanceObjective.h"
 #include <ompl/geometric/planners/prm/LazyPRM.h>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "model_based_planning_context";
+}  // namespace ompl_interface
 
 ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::string& name,
                                                                      const ModelBasedPlanningContextSpecification& spec)

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -72,6 +72,8 @@
 #include "ompl/base/objectives/MaximizeMinClearanceObjective.h"
 #include <ompl/geometric/planners/prm/LazyPRM.h>
 
+static const std::string LOGNAME{ "model_based_planning_context" };
+
 ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::string& name,
                                                                      const ModelBasedPlanningContextSpecification& spec)
   : planning_interface::PlanningContext(name, spec.state_space_->getJointModelGroup()->getName())
@@ -126,7 +128,7 @@ void ompl_interface::ModelBasedPlanningContext::configure(const ros::NodeHandle&
     if (constraint_approx)
     {
       getOMPLStateSpace()->setInterpolationFunction(constraint_approx->getInterpolationFunction());
-      ROS_INFO_NAMED("model_based_planning_context", "Using precomputed interpolation states");
+      ROS_INFO_NAMED(LOGNAME, "Using precomputed interpolation states");
     }
   }
 
@@ -139,7 +141,7 @@ void ompl_interface::ModelBasedPlanningContext::setProjectionEvaluator(const std
 {
   if (!spec_.state_space_)
   {
-    ROS_ERROR_NAMED("model_based_planning_context", "No state space is configured yet");
+    ROS_ERROR_NAMED(LOGNAME, "No state space is configured yet");
     return;
   }
   ob::ProjectionEvaluatorPtr projection_eval = getProjectionEvaluator(peval);
@@ -156,7 +158,7 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
     if (getRobotModel()->hasLinkModel(link_name))
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorLinkPose(this, link_name));
     else
-      ROS_ERROR_NAMED("model_based_planning_context",
+      ROS_ERROR_NAMED(LOGNAME,
                       "Attempted to set projection evaluator with respect to position of link '%s', "
                       "but that link is not known to the kinematic model.",
                       link_name.c_str());
@@ -181,24 +183,22 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
             j.push_back(idx + q);
         }
         else
-          ROS_WARN_NAMED("model_based_planning_context", "%s: Ignoring joint '%s' in projection since it has 0 DOF",
-                         name_.c_str(), joint.c_str());
+          ROS_WARN_NAMED(LOGNAME, "%s: Ignoring joint '%s' in projection since it has 0 DOF", name_.c_str(),
+                         joint.c_str());
       }
       else
-        ROS_ERROR_NAMED("model_based_planning_context",
+        ROS_ERROR_NAMED(LOGNAME,
                         "%s: Attempted to set projection evaluator with respect to value of joint "
                         "'%s', but that joint is not known to the group '%s'.",
                         name_.c_str(), joint.c_str(), getGroupName().c_str());
     }
     if (j.empty())
-      ROS_ERROR_NAMED("model_based_planning_context", "%s: No valid joints specified for joint projection",
-                      name_.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "%s: No valid joints specified for joint projection", name_.c_str());
     else
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorJointValue(this, j));
   }
   else
-    ROS_ERROR_NAMED("model_based_planning_context",
-                    "Unable to allocate projection evaluator based on description: '%s'", peval.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unable to allocate projection evaluator based on description: '%s'", peval.c_str());
   return ob::ProjectionEvaluatorPtr();
 }
 
@@ -207,13 +207,11 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 {
   if (spec_.state_space_.get() != state_space)
   {
-    ROS_ERROR_NAMED("model_based_planning_context",
-                    "%s: Attempted to allocate a state sampler for an unknown state space", name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "%s: Attempted to allocate a state sampler for an unknown state space", name_.c_str());
     return ompl::base::StateSamplerPtr();
   }
 
-  ROS_DEBUG_NAMED("model_based_planning_context",
-                  "%s: Allocating a new state sampler (attempts to use path constraints)", name_.c_str());
+  ROS_DEBUG_NAMED(LOGNAME, "%s: Allocating a new state sampler (attempts to use path constraints)", name_.c_str());
 
   if (path_constraints_)
   {
@@ -230,7 +228,7 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
           ompl::base::StateSamplerPtr state_sampler = state_sampler_allocator(state_space);
           if (state_sampler)
           {
-            ROS_INFO_NAMED("model_based_planning_context",
+            ROS_INFO_NAMED(LOGNAME,
                            "%s: Using precomputed state sampler (approximated constraint space) for constraint '%s'",
                            name_.c_str(), path_constraints_msg_.name.c_str());
             return state_sampler;
@@ -246,13 +244,11 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 
     if (constraint_sampler)
     {
-      ROS_INFO_NAMED("model_based_planning_context", "%s: Allocating specialized state sampler for state space",
-                     name_.c_str());
+      ROS_INFO_NAMED(LOGNAME, "%s: Allocating specialized state sampler for state space", name_.c_str());
       return ob::StateSamplerPtr(new ConstrainedSampler(this, constraint_sampler));
     }
   }
-  ROS_DEBUG_NAMED("model_based_planning_context", "%s: Allocating default state sampler for state space",
-                  name_.c_str());
+  ROS_DEBUG_NAMED(LOGNAME, "%s: Allocating default state sampler for state space", name_.c_str());
   return state_space->allocDefaultStateSampler();
 }
 
@@ -361,8 +357,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     if (name_ != getGroupName())
-      ROS_WARN_NAMED("model_based_planning_context", "%s: Attribute 'type' not specified in planner configuration",
-                     name_.c_str());
+      ROS_WARN_NAMED(LOGNAME, "%s: Attribute 'type' not specified in planner configuration", name_.c_str());
   }
   else
   {
@@ -371,7 +366,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     const std::string planner_name = getGroupName() + "/" + name_;
     ompl_simple_setup_->setPlannerAllocator(
         std::bind(spec_.planner_selector_(type), std::placeholders::_1, planner_name, std::cref(spec_)));
-    ROS_INFO_NAMED("model_based_planning_context",
+    ROS_INFO_NAMED(LOGNAME,
                    "Planner configuration '%s' will use planner '%s'. "
                    "Additional configuration parameters will be set when the planner is constructed.",
                    name_.c_str(), type.c_str());
@@ -389,9 +384,9 @@ void ompl_interface::ModelBasedPlanningContext::setPlanningVolume(const moveit_m
   if (wparams.min_corner.x == wparams.max_corner.x && wparams.min_corner.x == 0.0 &&
       wparams.min_corner.y == wparams.max_corner.y && wparams.min_corner.y == 0.0 &&
       wparams.min_corner.z == wparams.max_corner.z && wparams.min_corner.z == 0.0)
-    ROS_WARN_NAMED("model_based_planning_context", "It looks like the planning volume was not specified.");
+    ROS_WARN_NAMED(LOGNAME, "It looks like the planning volume was not specified.");
 
-  ROS_DEBUG_NAMED("model_based_planning_context",
+  ROS_DEBUG_NAMED(LOGNAME,
                   "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
                   "[%f, %f], z = [%f, %f]",
                   name_.c_str(), wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y, wparams.max_corner.y,
@@ -481,7 +476,7 @@ ompl::base::GoalPtr ompl_interface::ModelBasedPlanningContext::constructGoal()
   if (!goals.empty())
     return goals.size() == 1 ? goals[0] : ompl::base::GoalPtr(new GoalSampleableRegionMux(goals));
   else
-    ROS_ERROR_NAMED("model_based_planning_context", "Unable to construct goal representation");
+    ROS_ERROR_NAMED(LOGNAME, "Unable to construct goal representation");
 
   return ob::GoalPtr();
 }
@@ -497,7 +492,7 @@ ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContex
   boost::split(termination_and_params, termination_string, boost::is_any_of("[ ,]"));
 
   if (termination_and_params.empty())
-    ROS_ERROR_NAMED("model_based_planning_context", "Termination condition not specified");
+    ROS_ERROR_NAMED(LOGNAME, "Termination condition not specified");
   // Terminate if a maximum number of iterations is exceeded or a timeout occurs.
   // The semantics of "iterations" are planner-specific, but typically it corresponds to the number of times
   // an attempt was made to grow a roadmap/tree.
@@ -508,7 +503,7 @@ ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContex
           ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start)),
           ob::IterationTerminationCondition(std::stoul(termination_and_params[1])));
     else
-      ROS_ERROR_NAMED("model_based_planning_context", "Missing argument to Iteration termination condition");
+      ROS_ERROR_NAMED(LOGNAME, "Missing argument to Iteration termination condition");
   }
 // TODO: remove when ROS Melodic and older are no longer supported
 #if OMPL_VERSION_VALUE >= 1005000
@@ -539,7 +534,7 @@ ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContex
         ob::exactSolnPlannerTerminationCondition(ompl_simple_setup_->getProblemDefinition()));
   }
   else
-    ROS_ERROR_NAMED("model_based_planning_context", "Unknown planner termination condition");
+    ROS_ERROR_NAMED(LOGNAME, "Unknown planner termination condition");
 
   // return a planner termination condition to suppress compiler warning
   return ob::plannerAlwaysTerminatingCondition();
@@ -606,8 +601,7 @@ bool ompl_interface::ModelBasedPlanningContext::setGoalConstraints(
 
   if (goal_constraints_.empty())
   {
-    ROS_WARN_NAMED("model_based_planning_context", "%s: No goal constraints specified. There is no problem to solve.",
-                   name_.c_str());
+    ROS_WARN_NAMED(LOGNAME, "%s: No goal constraints specified. There is no problem to solve.", name_.c_str());
     if (error)
       error->val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
@@ -672,10 +666,10 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
   stopSampling();
   int v = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getValidMotionCount();
   int iv = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getInvalidMotionCount();
-  ROS_DEBUG_NAMED("model_based_planning_context", "There were %d valid motions and %d invalid motions.", v, iv);
+  ROS_DEBUG_NAMED(LOGNAME, "There were %d valid motions and %d invalid motions.", v, iv);
 
   if (ompl_simple_setup_->getProblemDefinition()->hasApproximateSolution())
-    ROS_WARN_NAMED("model_based_planning_context", "Computed solution is approximate");
+    ROS_WARN_NAMED(LOGNAME, "Computed solution is approximate");
 }
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)
@@ -693,8 +687,8 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
       interpolateSolution();
 
     // fill the response
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Returning successful solution with %lu states",
-                    getName().c_str(), getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Returning successful solution with %lu states", getName().c_str(),
+                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
 
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(getRobotModel(), getGroupName()));
     getSolutionPath(*res.trajectory_);
@@ -703,7 +697,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
   }
   else
   {
-    ROS_INFO_NAMED("model_based_planning_context", "Unable to solve the planning problem");
+    ROS_INFO_NAMED(LOGNAME, "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -746,13 +740,13 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
     }
 
     // fill the response
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Returning successful solution with %lu states",
-                    getName().c_str(), getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Returning successful solution with %lu states", getName().c_str(),
+                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
     return true;
   }
   else
   {
-    ROS_INFO_NAMED("model_based_planning_context", "Unable to solve the planning problem");
+    ROS_INFO_NAMED(LOGNAME, "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -767,7 +761,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   bool result = false;
   if (count <= 1 || multi_query_planning_enabled_)  // multi-query planners should always run in single instances
   {
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Solving the planning problem once...", name_.c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Solving the planning problem once...", name_.c_str());
     ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
     registerTerminationCondition(ptc);
     result = ompl_simple_setup_->solve(ptc) == ompl::base::PlannerStatus::EXACT_SOLUTION;
@@ -776,8 +770,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   }
   else
   {
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Solving the planning problem %u times...", name_.c_str(),
-                    count);
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Solving the planning problem %u times...", name_.c_str(), count);
     ompl_parallel_plan_.clearHybridizationPaths();
     if (count <= max_planning_threads_)
     {
@@ -864,7 +857,7 @@ bool ompl_interface::ModelBasedPlanningContext::saveConstraintApproximations(con
     constraints_library_->saveConstraintApproximations(constraint_path);
     return true;
   }
-  ROS_WARN("ROS param 'constraint_approximations' not found. Unable to save constraint approximations");
+  ROS_WARN_NAMED(LOGNAME, "ROS param 'constraint_approximations' not found. Unable to save constraint approximations");
   return false;
 }
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -158,9 +158,8 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
     if (getRobotModel()->hasLinkModel(link_name))
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorLinkPose(this, link_name));
     else
-      ROS_ERROR_NAMED(LOGNAME,
-                      "Attempted to set projection evaluator with respect to position of link '%s', "
-                      "but that link is not known to the kinematic model.",
+      ROS_ERROR_NAMED(LOGNAME, "Attempted to set projection evaluator with respect to position of link '%s', "
+                               "but that link is not known to the kinematic model.",
                       link_name.c_str());
   }
   else if (peval.find_first_of("joints(") == 0 && peval[peval.length() - 1] == ')')
@@ -187,9 +186,8 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
                          joint.c_str());
       }
       else
-        ROS_ERROR_NAMED(LOGNAME,
-                        "%s: Attempted to set projection evaluator with respect to value of joint "
-                        "'%s', but that joint is not known to the group '%s'.",
+        ROS_ERROR_NAMED(LOGNAME, "%s: Attempted to set projection evaluator with respect to value of joint "
+                                 "'%s', but that joint is not known to the group '%s'.",
                         name_.c_str(), joint.c_str(), getGroupName().c_str());
     }
     if (j.empty())
@@ -366,9 +364,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     const std::string planner_name = getGroupName() + "/" + name_;
     ompl_simple_setup_->setPlannerAllocator(
         std::bind(spec_.planner_selector_(type), std::placeholders::_1, planner_name, std::cref(spec_)));
-    ROS_INFO_NAMED(LOGNAME,
-                   "Planner configuration '%s' will use planner '%s'. "
-                   "Additional configuration parameters will be set when the planner is constructed.",
+    ROS_INFO_NAMED(LOGNAME, "Planner configuration '%s' will use planner '%s'. "
+                            "Additional configuration parameters will be set when the planner is constructed.",
                    name_.c_str(), type.c_str());
   }
 
@@ -386,9 +383,8 @@ void ompl_interface::ModelBasedPlanningContext::setPlanningVolume(const moveit_m
       wparams.min_corner.z == wparams.max_corner.z && wparams.min_corner.z == 0.0)
     ROS_WARN_NAMED(LOGNAME, "It looks like the planning volume was not specified.");
 
-  ROS_DEBUG_NAMED(LOGNAME,
-                  "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
-                  "[%f, %f], z = [%f, %f]",
+  ROS_DEBUG_NAMED(LOGNAME, "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
+                           "[%f, %f], z = [%f, %f]",
                   name_.c_str(), wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y, wparams.max_corner.y,
                   wparams.min_corner.z, wparams.max_corner.z);
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -72,7 +72,7 @@
 #include "ompl/base/objectives/MaximizeMinClearanceObjective.h"
 #include <ompl/geometric/planners/prm/LazyPRM.h>
 
-static const std::string LOGNAME{ "model_based_planning_context" };
+constexpr char LOGNAME[] = "model_based_planning_context";
 
 ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::string& name,
                                                                      const ModelBasedPlanningContextSpecification& spec)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,7 +42,7 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
-static const std::string LOGNAME{ "ompl_interface" };
+constexpr char LOGNAME[] = "ompl_interface";
 
 ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model,
                                              const ros::NodeHandle& nh)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -239,9 +239,8 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     {
       if (config_names.getType() != XmlRpc::XmlRpcValue::TypeArray)
       {
-        ROS_ERROR_NAMED(LOGNAME,
-                        "The planner_configs argument of a group configuration "
-                        "should be an array of strings (for group '%s')",
+        ROS_ERROR_NAMED(LOGNAME, "The planner_configs argument of a group configuration "
+                                 "should be an array of strings (for group '%s')",
                         group_name.c_str());
         continue;
       }

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,7 +42,10 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "ompl_interface";
+}  // namespace ompl_interface
 
 ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model,
                                              const ros::NodeHandle& nh)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,6 +42,8 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
+static const std::string LOGNAME{ "ompl_interface" };
+
 ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConstPtr& robot_model,
                                              const ros::NodeHandle& nh)
   : nh_(nh)
@@ -51,7 +53,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConst
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
 {
-  ROS_DEBUG("Initializing OMPL interface using ROS parameters");
+  ROS_DEBUG_NAMED(LOGNAME, "Initializing OMPL interface using ROS parameters");
   loadPlannerConfigurations();
   loadConstraintSamplers();
 }
@@ -66,7 +68,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const moveit::core::RobotModelConst
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
 {
-  ROS_DEBUG("Initializing OMPL interface using specified configuration");
+  ROS_DEBUG_NAMED(LOGNAME, "Initializing OMPL interface using specified configuration");
   setPlannerConfigurations(pconfig);
   loadConstraintSamplers();
 }
@@ -129,14 +131,14 @@ bool ompl_interface::OMPLInterface::loadPlannerConfiguration(
   XmlRpc::XmlRpcValue xml_config;
   if (!nh_.getParam("planner_configs/" + planner_id, xml_config))
   {
-    ROS_ERROR("Could not find the planner configuration '%s' on the param server", planner_id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Could not find the planner configuration '%s' on the param server", planner_id.c_str());
     return false;
   }
 
   if (xml_config.getType() != XmlRpc::XmlRpcValue::TypeStruct)
   {
-    ROS_ERROR("A planning configuration should be of type XmlRpc Struct type (for configuration '%s')",
-              planner_id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "A planning configuration should be of type XmlRpc Struct type (for configuration '%s')",
+                    planner_id.c_str());
     return false;
   }
 
@@ -237,9 +239,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     {
       if (config_names.getType() != XmlRpc::XmlRpcValue::TypeArray)
       {
-        ROS_ERROR("The planner_configs argument of a group configuration "
-                  "should be an array of strings (for group '%s')",
-                  group_name.c_str());
+        ROS_ERROR_NAMED(LOGNAME,
+                        "The planner_configs argument of a group configuration "
+                        "should be an array of strings (for group '%s')",
+                        group_name.c_str());
         continue;
       }
 
@@ -247,7 +250,8 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
       {
         if (config_names[j].getType() != XmlRpc::XmlRpcValue::TypeString)
         {
-          ROS_ERROR("Planner configuration names must be of type string (for group '%s')", group_name.c_str());
+          ROS_ERROR_NAMED(LOGNAME, "Planner configuration names must be of type string (for group '%s')",
+                          group_name.c_str());
           continue;
         }
 
@@ -262,10 +266,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
 
   for (const std::pair<const std::string, planning_interface::PlannerConfigurationSettings>& config : pconfig)
   {
-    ROS_DEBUG_STREAM_NAMED("parameters", "Parameters for configuration '" << config.first << "'");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Parameters for configuration '" << config.first << "'");
 
     for (const std::pair<const std::string, std::string>& parameters : config.second.config)
-      ROS_DEBUG_STREAM_NAMED("parameters", " - " << parameters.first << " = " << parameters.second);
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, " - " << parameters.first << " = " << parameters.second);
   }
 
   setPlannerConfigurations(pconfig);
@@ -273,5 +277,5 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
 
 void ompl_interface::OMPLInterface::printStatus()
 {
-  ROS_INFO("OMPL ROS interface is running.");
+  ROS_INFO_NAMED(LOGNAME, "OMPL ROS interface is running.");
 }

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -52,6 +52,8 @@
 #include <thread>
 #include <memory>
 
+static const std::string LOGNAME{ "ompl_planner_manager" };
+
 namespace ompl_interface
 {
 using namespace moveit_planners_ompl;
@@ -265,13 +267,13 @@ private:
     {
       pub_markers_.shutdown();
       planner_data_link_name_.clear();
-      ROS_INFO("Not displaying OMPL exploration data structures.");
+      ROS_INFO_NAMED(LOGNAME, "Not displaying OMPL exploration data structures.");
     }
     else if (!config.link_for_exploration_tree.empty() && planner_data_link_name_.empty())
     {
       pub_markers_ = nh_.advertise<visualization_msgs::MarkerArray>("ompl_planner_data_marker_array", 5);
       planner_data_link_name_ = config.link_for_exploration_tree;
-      ROS_INFO("Displaying OMPL exploration data structures for %s", planner_data_link_name_.c_str());
+      ROS_INFO_NAMED(LOGNAME, "Displaying OMPL exploration data structures for %s", planner_data_link_name_.c_str());
     }
 
     ompl_interface_->simplifySolutions(config.simplify_solutions);

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -52,11 +52,11 @@
 #include <thread>
 #include <memory>
 
-constexpr char LOGNAME[] = "ompl_planner_manager";
-
 namespace ompl_interface
 {
 using namespace moveit_planners_ompl;
+
+constexpr char LOGNAME[] = "ompl_planner_manager";
 
 #define OMPL_ROS_LOG(ros_log_level)                                                                                    \
   {                                                                                                                    \

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -52,7 +52,7 @@
 #include <thread>
 #include <memory>
 
-static const std::string LOGNAME{ "ompl_planner_manager" };
+constexpr char LOGNAME[] = "ompl_planner_manager";
 
 namespace ompl_interface
 {

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2012, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -87,9 +87,8 @@ double ompl_interface::ModelBasedStateSpace::getTagSnapToSegment() const
 void ompl_interface::ModelBasedStateSpace::setTagSnapToSegment(double snap)
 {
   if (snap < 0.0 || snap > 1.0)
-    ROS_WARN_NAMED(LOGNAME,
-                   "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
-                   "Value remains as previously set (%lf)",
+    ROS_WARN_NAMED(LOGNAME, "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
+                            "Value remains as previously set (%lf)",
                    tag_snap_to_segment_);
   else
   {

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -37,6 +37,8 @@
 #include <moveit/ompl_interface/parameterization/model_based_state_space.h>
 #include <utility>
 
+static const std::string LOGNAME{ "model_based_state_space" };
+
 ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceSpecification spec)
   : ompl::base::StateSpace(), spec_(std::move(spec))
 {
@@ -49,8 +51,7 @@ ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceS
   // make sure we have bounds for every joint stored within the spec (use default bounds if not specified)
   if (!spec_.joint_bounds_.empty() && spec_.joint_bounds_.size() != joint_model_vector_.size())
   {
-    ROS_ERROR_NAMED("model_based_state_space",
-                    "Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
+    ROS_ERROR_NAMED(LOGNAME, "Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
                     spec_.joint_model_group_->getName().c_str());
     spec_.joint_bounds_.clear();
   }
@@ -86,7 +87,7 @@ double ompl_interface::ModelBasedStateSpace::getTagSnapToSegment() const
 void ompl_interface::ModelBasedStateSpace::setTagSnapToSegment(double snap)
 {
   if (snap < 0.0 || snap > 1.0)
-    ROS_WARN_NAMED("model_based_state_space",
+    ROS_WARN_NAMED(LOGNAME,
                    "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
                    "Value remains as previously set (%lf)",
                    tag_snap_to_segment_);

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -37,7 +37,10 @@
 #include <moveit/ompl_interface/parameterization/model_based_state_space.h>
 #include <utility>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "model_based_state_space";
+}  // namespace ompl_interface
 
 ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceSpecification spec)
   : ompl::base::StateSpace(), spec_(std::move(spec))

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -37,7 +37,7 @@
 #include <moveit/ompl_interface/parameterization/model_based_state_space.h>
 #include <utility>
 
-static const std::string LOGNAME{ "model_based_state_space" };
+constexpr char LOGNAME[] = "model_based_state_space";
 
 ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceSpecification spec)
   : ompl::base::StateSpace(), spec_(std::move(spec))

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2012, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -40,7 +40,10 @@
 
 #include <utility>
 
+namespace ompl_interface
+{
 constexpr char LOGNAME[] = "pose_model_state_space";
+}  // namespace ompl_interface
 
 const std::string ompl_interface::PoseModelStateSpace::PARAMETERIZATION_TYPE = "PoseModel";
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -40,7 +40,7 @@
 
 #include <utility>
 
-static const std::string LOGNAME{ "pose_model_state_space" };
+constexpr char LOGNAME[] = "pose_model_state_space";
 
 const std::string ompl_interface::PoseModelStateSpace::PARAMETERIZATION_TYPE = "PoseModel";
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -40,6 +40,8 @@
 
 #include <utility>
 
+static const std::string LOGNAME{ "pose_model_state_space" };
+
 const std::string ompl_interface::PoseModelStateSpace::PARAMETERIZATION_TYPE = "PoseModel";
 
 ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSpaceSpecification& spec)
@@ -56,8 +58,8 @@ ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSp
       poses_.emplace_back(it.first, it.second);
   }
   if (poses_.empty())
-    ROS_ERROR_NAMED("pose_model_state_space", "No kinematics solvers specified. Unable to construct a "
-                                              "PoseModelStateSpace");
+    ROS_ERROR_NAMED(LOGNAME, "No kinematics solvers specified. Unable to construct a "
+                             "PoseModelStateSpace");
   else
     std::sort(poses_.begin(), poses_.end());
   setName(getName() + "_" + PARAMETERIZATION_TYPE);

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -75,6 +75,8 @@
 
 using namespace std::placeholders;
 
+static const std::string LOGNAME{ "planning_context_manager" };
+
 namespace ompl_interface
 {
 struct PlanningContextManager::CachedContexts
@@ -169,7 +171,7 @@ ompl::base::PlannerPtr ompl_interface::MultiQueryPlannerAllocator::allocatePlann
     storage_.load(file_path.c_str(), data);
     planner.reset(allocatePersistentPlanner<T>(data));
     if (!planner)
-      ROS_ERROR_NAMED("planning_context_manager",
+      ROS_ERROR_NAMED(LOGNAME,
                       "Creating a '%s' planner from persistent data is not supported. Going to create a new instance.",
                       new_name.c_str());
   }
@@ -249,7 +251,7 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
     return it->second;
   else
   {
-    ROS_ERROR_NAMED("planning_context_manager", "Unknown planner: '%s'", planner.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unknown planner: '%s'", planner.c_str());
     return ConfiguredPlannerAllocator();
   }
 }
@@ -326,7 +328,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       for (const ModelBasedPlanningContextPtr& cached_context : cached_contexts->second)
         if (cached_context.unique())
         {
-          ROS_DEBUG_NAMED("planning_context_manager", "Reusing cached planning context");
+          ROS_DEBUG_NAMED(LOGNAME, "Reusing cached planning context");
           context = cached_context;
           break;
         }
@@ -365,7 +367,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       }
     }
 
-    ROS_DEBUG_NAMED("planning_context_manager", "Creating new planning context");
+    ROS_DEBUG_NAMED(LOGNAME, "Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
     context->useStateValidityCache(state_validity_cache);
     {
@@ -395,7 +397,7 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
     return f->second;
   else
   {
-    ROS_ERROR_NAMED("planning_context_manager", "Factory of type '%s' was not found", factory_type.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Factory of type '%s' was not found", factory_type.c_str());
     static const ModelBasedStateSpaceFactoryPtr EMPTY;
     return EMPTY;
   }
@@ -419,14 +421,14 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
 
   if (best == state_space_factories_.end())
   {
-    ROS_ERROR_NAMED("planning_context_manager", "There are no known state spaces that can represent the given planning "
-                                                "problem");
+    ROS_ERROR_NAMED(LOGNAME, "There are no known state spaces that can represent the given planning "
+                             "problem");
     static const ModelBasedStateSpaceFactoryPtr EMPTY;
     return EMPTY;
   }
   else
   {
-    ROS_DEBUG_NAMED("planning_context_manager", "Using '%s' parameterization for solving problem", best->first.c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "Using '%s' parameterization for solving problem", best->first.c_str());
     return best->second;
   }
 }
@@ -437,7 +439,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 {
   if (req.group_name.empty())
   {
-    ROS_ERROR_NAMED("planning_context_manager", "No group specified to plan for");
+    ROS_ERROR_NAMED(LOGNAME, "No group specified to plan for");
     error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
     return ModelBasedPlanningContextPtr();
   }
@@ -446,7 +448,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
 
   if (!planning_scene)
   {
-    ROS_ERROR_NAMED("planning_context_manager", "No planning scene supplied as input");
+    ROS_ERROR_NAMED(LOGNAME, "No planning scene supplied as input");
     return ModelBasedPlanningContextPtr();
   }
 
@@ -458,7 +460,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
                                    req.group_name + "[" + req.planner_id + "]" :
                                    req.planner_id);
     if (pc == planner_configs_.end())
-      ROS_WARN_NAMED("planning_context_manager",
+      ROS_WARN_NAMED(LOGNAME,
                      "Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
                      req.group_name.c_str(), req.planner_id.c_str());
   }
@@ -468,8 +470,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     pc = planner_configs_.find(req.group_name);
     if (pc == planner_configs_.end())
     {
-      ROS_ERROR_NAMED("planning_context_manager", "Cannot find planning configuration for group '%s'",
-                      req.group_name.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "Cannot find planning configuration for group '%s'", req.group_name.c_str());
       return ModelBasedPlanningContextPtr();
     }
   }
@@ -513,12 +514,12 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     try
     {
       context->configure(nh, use_constraints_approximation);
-      ROS_DEBUG_NAMED("planning_context_manager", "%s: New planning context is set.", context->getName().c_str());
+      ROS_DEBUG_NAMED(LOGNAME, "%s: New planning context is set.", context->getName().c_str());
       error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     }
     catch (ompl::Exception& ex)
     {
-      ROS_ERROR_NAMED("planning_context_manager", "OMPL encountered an error: %s", ex.what());
+      ROS_ERROR_NAMED(LOGNAME, "OMPL encountered an error: %s", ex.what());
       context.reset();
     }
   }

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -75,10 +75,10 @@
 
 using namespace std::placeholders;
 
-constexpr char LOGNAME[] = "planning_context_manager";
-
 namespace ompl_interface
 {
+constexpr char LOGNAME[] = "planning_context_manager";
+
 struct PlanningContextManager::CachedContexts
 {
   std::map<std::pair<std::string, std::string>, std::vector<ModelBasedPlanningContextPtr> > contexts_;

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -75,7 +75,7 @@
 
 using namespace std::placeholders;
 
-static const std::string LOGNAME{ "planning_context_manager" };
+constexpr char LOGNAME[] = "planning_context_manager";
 
 namespace ompl_interface
 {


### PR DESCRIPTION
### Description

As is done in other parts of MoveIt #1079 #1179, this pull request adds named logging to all source files of the `moveit_planners_ompl` package. (For some files with a single log statement, it might be overkill, but it is consistent...)

**Important** I'm not confident whether it is ok to put this outside a namespace. But in most source files of the OMPL interface, all code is put outside of a namespace and all names are prepended with `ompl_interface::`. Maybe this is worth another cleanup? Or is there a reason for this?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
