### PR TITLE
Remove dead code from ompl interface (related to subspaces)

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
@@ -70,12 +70,6 @@ public:
   void setVerbose(bool flag);
 
 protected:
-  bool isValidWithoutCache(const ompl::base::State* state, bool verbose) const;
-  bool isValidWithoutCache(const ompl::base::State* state, double& dist, bool verbose) const;
-
-  bool isValidWithCache(const ompl::base::State* state, bool verbose) const;
-  bool isValidWithCache(const ompl::base::State* state, double& dist, bool verbose) const;
-
   const ModelBasedPlanningContext* planning_context_;
   std::string group_name_;
   TSStateStorage tss_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -68,7 +68,6 @@ struct ModelBasedPlanningContextSpecification
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 
   ModelBasedStateSpacePtr state_space_;
-  std::vector<ModelBasedStateSpacePtr> subspaces_;
   og::SimpleSetupPtr ompl_simple_setup_;  // pass in the correct simple setup type
 };
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -254,16 +254,6 @@ public:
     return constraints_library_;
   }
 
-  bool useStateValidityCache() const
-  {
-    return use_state_validity_cache_;
-  }
-
-  void useStateValidityCache(bool flag)
-  {
-    use_state_validity_cache_ = flag;
-  }
-
   bool simplifySolutions() const
   {
     return simplify_solutions_;
@@ -424,8 +414,6 @@ protected:
   /// the minimum number of points to include on the solution path (interpolation is used to reach this number, if
   /// needed)
   unsigned int minimum_waypoint_count_;
-
-  bool use_state_validity_cache_;
 
   /// when false, clears planners before running solve()
   bool multi_query_planning_enabled_;

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -75,117 +75,7 @@ void ompl_interface::StateValidityChecker::setVerbose(bool flag)
 
 bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, bool verbose) const
 {
-  //  moveit::Profiler::ScopedBlock sblock("isValid");
-  return planning_context_->useStateValidityCache() ? isValidWithCache(state, verbose) :
-                                                      isValidWithoutCache(state, verbose);
-}
-
-bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, double& dist, bool verbose) const
-{
-  //  moveit::Profiler::ScopedBlock sblock("isValid");
-  return planning_context_->useStateValidityCache() ? isValidWithCache(state, dist, verbose) :
-                                                      isValidWithoutCache(state, dist, verbose);
-}
-
-double ompl_interface::StateValidityChecker::cost(const ompl::base::State* state) const
-{
-  double cost = 0.0;
-
-  moveit::core::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  // Calculates cost from a summation of distance to obstacles times the size of the obstacle
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(collision_request_with_cost_, res, *robot_state);
-
-  for (const collision_detection::CostSource& cost_source : res.cost_sources)
-    cost += cost_source.cost * cost_source.getVolume();
-
-  return cost;
-}
-
-double ompl_interface::StateValidityChecker::clearance(const ompl::base::State* state) const
-{
-  moveit::core::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(collision_request_with_distance_, res, *robot_state);
-  return res.collision ? 0.0 : (res.distance < 0.0 ? std::numeric_limits<double>::infinity() : res.distance);
-}
-
-bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base::State* state, bool verbose) const
-{
-  // check bounds
-  if (!si_->satisfiesBounds(state))
-  {
-    if (verbose)
-      ROS_INFO_NAMED(LOGNAME, "State outside bounds");
-    return false;
-  }
-
-  // convert ompl state to MoveIt robot state
-  moveit::core::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  // check path constraints
-  const kinematic_constraints::KinematicConstraintSetPtr& kset = planning_context_->getPathConstraints();
-  if (kset && !kset->decide(*robot_state, verbose).satisfied)
-    return false;
-
-  // check feasibility
-  if (!planning_context_->getPlanningScene()->isStateFeasible(*robot_state, verbose))
-    return false;
-
-  // check collision avoidance
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(
-      verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *robot_state);
-  return !res.collision;
-}
-
-bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base::State* state, double& dist,
-                                                               bool verbose) const
-{
-  if (!si_->satisfiesBounds(state))
-  {
-    if (verbose)
-      ROS_INFO_NAMED(LOGNAME, "State outside bounds");
-    return false;
-  }
-
-  moveit::core::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  // check path constraints
-  const kinematic_constraints::KinematicConstraintSetPtr& kset = planning_context_->getPathConstraints();
-  if (kset)
-  {
-    kinematic_constraints::ConstraintEvaluationResult cer = kset->decide(*robot_state, verbose);
-    if (!cer.satisfied)
-    {
-      dist = cer.distance;
-      return false;
-    }
-  }
-
-  // check feasibility
-  if (!planning_context_->getPlanningScene()->isStateFeasible(*robot_state, verbose))
-  {
-    dist = 0.0;
-    return false;
-  }
-
-  // check collision avoidance
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(
-      verbose ? collision_request_with_distance_verbose_ : collision_request_with_distance_, res, *robot_state);
-  dist = res.distance;
-  return !res.collision;
-}
-
-bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State* state, bool verbose) const
-{
+  // Use cached validity if it is available
   if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown())
     return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();
 
@@ -230,9 +120,9 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   return !res.collision;
 }
 
-bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State* state, double& dist,
-                                                            bool verbose) const
+bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, double& dist, bool verbose) const
 {
+  // Use cached validity and distance if they are available
   if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown() &&
       state->as<ModelBasedStateSpace::StateType>()->isGoalDistanceKnown())
   {
@@ -277,4 +167,31 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
       verbose ? collision_request_with_distance_verbose_ : collision_request_with_distance_, res, *robot_state);
   dist = res.distance;
   return !res.collision;
+}
+
+double ompl_interface::StateValidityChecker::cost(const ompl::base::State* state) const
+{
+  double cost = 0.0;
+
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
+  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
+
+  // Calculates cost from a summation of distance to obstacles times the size of the obstacle
+  collision_detection::CollisionResult res;
+  planning_context_->getPlanningScene()->checkCollision(collision_request_with_cost_, res, *robot_state);
+
+  for (const collision_detection::CostSource& cost_source : res.cost_sources)
+    cost += cost_source.cost * cost_source.getVolume();
+
+  return cost;
+}
+
+double ompl_interface::StateValidityChecker::clearance(const ompl::base::State* state) const
+{
+  moveit::core::RobotState* robot_state = tss_.getStateStorage();
+  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
+
+  collision_detection::CollisionResult res;
+  planning_context_->getPlanningScene()->checkCollision(collision_request_with_distance_, res, *robot_state);
+  return res.collision ? 0.0 : (res.distance < 0.0 ? std::numeric_limits<double>::infinity() : res.distance);
 }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -94,7 +94,6 @@ ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::
   , max_planning_threads_(0)
   , max_solution_segment_length_(0.0)
   , minimum_waypoint_count_(0)
-  , use_state_validity_cache_(true)
   , multi_query_planning_enabled_(false)  // maintain "old" behavior by default
   , simplify_solutions_(true)
   , interpolate_(true)

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -348,28 +348,8 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     // Choose the correct simple setup type to load
     context_spec.ompl_simple_setup_.reset(new ompl::geometric::SimpleSetup(context_spec.state_space_));
 
-    bool state_validity_cache = true;
-    if (config.config.find("subspaces") != config.config.end())
-    {
-      context_spec.config_.erase("subspaces");
-      // if the planner operates at subspace level the cache may be unsafe
-      state_validity_cache = false;
-      boost::char_separator<char> sep(" ");
-      boost::tokenizer<boost::char_separator<char> > tok(config.config.at("subspaces"), sep);
-      for (boost::tokenizer<boost::char_separator<char> >::iterator beg = tok.begin(); beg != tok.end(); ++beg)
-      {
-        const ompl_interface::ModelBasedStateSpaceFactoryPtr& sub_fact = factory_selector(*beg);
-        if (sub_fact)
-        {
-          ModelBasedStateSpaceSpecification sub_space_spec(robot_model_, *beg);
-          context_spec.subspaces_.push_back(sub_fact->getNewStateSpace(sub_space_spec));
-        }
-      }
-    }
-
     ROS_DEBUG_NAMED(LOGNAME, "Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
-    context->useStateValidityCache(state_validity_cache);
     {
       std::unique_lock<std::mutex> slock(cached_contexts_->lock_);
       cached_contexts_->contexts_[std::make_pair(config.name, factory->getType())].push_back(context);


### PR DESCRIPTION
### Description

Addresses issue #2209.

The attribute `std::vector<ModelBasedStateSpacePtr> subspaces_` inside [ModelBasedPlanningContextSpecification](https://github.com/JeroenDM/moveit/blob/d6666a9aee734acd1891a43657cf162c9ca4e9b7/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h#L71) is never used as far as I can tell. It is created in created in [PlanningContextManager::getPlanningContext](https://github.com/JeroenDM/moveit/blob/d6666a9aee734acd1891a43657cf162c9ca4e9b7/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp#L363).

I suspect it was added with support for OMPL's [CompoundStateSpace](https://ompl.kavrakilab.org/classompl_1_1base_1_1CompoundStateSpace.html) in mind, but this is speculation.

**Note that I am biased**, as I plan to add things here in the context of #2092. It would make my life much easier if this piece of code was not there... :)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
