### PR TITLE
Fix mismatch between docstring and code in robot_state.h

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1172,8 +1172,8 @@ public:
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for
-   * \param link_name The name of the link
-   * \param reference_point_position The reference point position (with respect to the link specified in link_name)
+   * \param link The link model to compute the Jacobian for
+   * \param reference_point_position The reference point position (with respect to the link specified in link)
    * \param jacobian The resultant jacobian
    * \param use_quaternion_representation Flag indicating if the Jacobian should use a quaternion representation
    * (default is false)
@@ -1184,8 +1184,8 @@ public:
 
   /** \brief Compute the Jacobian with reference to a particular point on a given link, for a specified group.
    * \param group The group to compute the Jacobian for
-   * \param link_name The name of the link
-   * \param reference_point_position The reference point position (with respect to the link specified in link_name)
+   * \param link The link model to compute the Jacobian for
+   * \param reference_point_position The reference point position (with respect to the link specified in link)
    * \param jacobian The resultant jacobian
    * \param use_quaternion_representation Flag indicating if the Jacobian should use a quaternion representation
    * (default is false)


### PR DESCRIPTION
### Description

In `robot_state.h`, there was a mismatch between the docstring and the code. I updated the docstring to match the code.

I could also rename it to `link_model`, as in other parts of MoveIt. But I'm not sure this is necessary.

(I quickly tried to look for the reason of this change in git history but could not find it. But the why is not really relevant as long as the documentation and the code match I guess :) )

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
