### PR TITLE
WIP: OMPL Constrained Planning (Part 1)

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
@@ -67,6 +67,14 @@ public:
   virtual double cost(const ompl::base::State* state) const;
   double clearance(const ompl::base::State* state) const override;
 
+  /** \brief Enable / disable checking path constraints in isValid method.
+   * 
+   * (default) Set true for rejection sampling of path constraints.
+   * Set false if the path constraints are handled by OMPL's state space.
+   * 
+   * */
+  void setCheckPathConstraints(bool flag);
+
   void setVerbose(bool flag);
 
 protected:
@@ -85,6 +93,7 @@ protected:
   collision_detection::CollisionRequest collision_request_with_distance_verbose_;
 
   collision_detection::CollisionRequest collision_request_with_cost_;
+  bool check_path_constraints_;
   bool verbose_;
 };
 }  // namespace ompl_interface


### PR DESCRIPTION
### Description

This pull request is part of a larger effort to support [OMPL's Constrained planning capabilities](http://ompl.kavrakilab.org/constrainedPlanning.html) in MoveIt.

In the current OMPL interface, the [StateValidityChecker](https://github.com/ros-planning/moveit/blob/edc9cf6e55ffcd2f3dbe18f2eb8602d913fdde48/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h) decides which state is valid and can be used in a solution path. It [checks](https://github.com/ros-planning/moveit/blob/edc9cf6e55ffcd2f3dbe18f2eb8602d913fdde48/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp#L126) whether the state is:

- within the joint limits
- satisfies the path constraints
- is collision free
- is feasible. (Based on a user provides feasibility metric?)

This pull request adds the option to disable checking the path constraints. This is necessary to integrate OMPL’s constrained planners, where the path constraints are handled by the state space and do not need to be checked by the StateValidityChecker.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
