### PR TITLE
WIP: OMPL Constrained Planning (Part 3) 

### DIFF
--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/detail/constrained_sampler.cpp
   src/detail/constrained_valid_state_sampler.cpp
   src/detail/constrained_goal_sampler.cpp
+  src/detail/ompl_constraints.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
@@ -51,4 +52,7 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_state_space test/test_state_space.cpp)
   target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+
+  catkin_add_gtest(test_ompl_constraints test/test_ompl_constraints.cpp)
+  target_link_libraries(test_ompl_constraints ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES})
 endif()

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraints.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraints.h
@@ -1,0 +1,264 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Jeroen De Maeyer
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jeroen De Maeyer */
+
+#pragma once
+
+#include <ompl/base/Constraint.h>
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit_msgs/Constraints.h>
+
+namespace ompl_interface
+{
+namespace ob = ompl::base;
+
+/** \brief Represents upper and lower bound on a scalar value (double).
+ *
+ * Equality constraints can be represented by setting
+ * the upper bound and lower bound almost equal.
+ * I (jeroendm) assume that it is better to not have them exactly equal
+ * for numerical reasons. Not sure.
+ * **/
+struct Bounds
+{
+  double lower, upper;
+
+  /** \brief Distance to region inside bounds
+   *
+   * Distance of a given value outside the bounds,
+   * zero inside the bounds.
+   *
+   * Creates a penalty function that looks like this:
+   *
+   *  \         /
+   *   \       /
+   *    \_____/
+   * (how does ascii art work??)
+   * */
+  double distance(double value) const;
+};
+
+/** \brief Abstract base class for differen types of constraints, implementations of ompl::base::Constraint
+ *
+ * To create a constrained state space in OMPL, we need a model of the constraints.
+ * Any generic model that can be written in the form of equality constraints F(joint_positions) = 0
+ * will work. In this code we use bounds on scalar values:
+ *    lower_bound < scalar value < upper bound
+ * and convert them to equality constraints using the distance function explained in the class Bounds above.
+ *
+ * The 'scalar value' can be any error in general.
+ * For planning in MoveIt, this can be error on the position or orientation of a link relative to a
+ * desired reference position.
+ * */
+class BaseConstraint : public ob::Constraint
+{
+public:
+  BaseConstraint(robot_model::RobotModelConstPtr robot_model, const std::string& group, const unsigned int num_dofs,
+                 const unsigned int num_cons_ = 3);
+
+  /** \brief initialize constraint based on message content.
+   *
+   * This is necessary because we cannot call the pure virtual
+   * parseConstraintsMsg method from the constructor of this class.
+   * */
+  void init(const moveit_msgs::Constraints& constraints);
+
+  /** OMPL's main constraint evaluation function.
+   *
+   *  OMPL requires you to override at least "function" which represents the constraint F(q) = 0
+   * */
+  virtual void function(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::Ref<Eigen::VectorXd> out) const;
+
+  /** Optionally you can also provide dF(q)/dq, the Jacobian of  the constriants.
+   *
+   * */
+  virtual void jacobian(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::Ref<Eigen::MatrixXd> out) const;
+
+  /** \brief Wrapper for forward kinematics calculated by MoveIt's Robot State.
+   *
+   * TODO(jeroendm) Are these actually const, as the robot state is modified? How come it works?
+   * Also, output arguments could be significantly more performant,
+   * but MoveIt's robot state does not support passing Eigen::Ref objects at the moment.
+   * */
+  Eigen::Isometry3d forwardKinematics(const Eigen::Ref<const Eigen::VectorXd>& joint_values) const;
+
+  /** \brief Calculate the geometric Jacobian using MoveIt's Robot State.
+   *
+   * Ideally I would pass the output agrument from OMPL's jacobian function directly,
+   * but I cannot pass an object of type , Eigen::Ref<Eigen::MatrixXd> to MoveIt's
+   * Jacobian method.
+   * */
+  Eigen::MatrixXd geometricJacobian(const Eigen::Ref<const Eigen::VectorXd>& joint_values) const;
+
+  /** \brief Parse bounds on position and orientation parameters from MoveIt's constraint message.
+   *
+   * This can be non-trivial given the often complex structure of these messages.
+   * For the current example with equality constraints it could be to simple
+   * to have this separate function instead of using the init function directly.
+   * */
+  virtual void parseConstraintMsg(const moveit_msgs::Constraints& constraints) = 0;
+
+  /** \brief For inequality constraints: calculate the value of the parameter that is being constraint by the bounds.
+   *
+   * In this Position constraints case, it calculates the x, y and z position
+   * of the end-effector. This error is then converted in generic equality constraints in the implementation of
+   * BaseConstraint::function.
+   * */
+  virtual Eigen::VectorXd calcError(const Eigen::Ref<const Eigen::VectorXd>& x) const
+  {
+    ROS_ERROR_STREAM("Constraint method calcError was not overridded, so it should not be used.");
+    return Eigen::VectorXd::Zero(getCoDimension());
+  }
+
+  /** \brief For inequality constraints: calculate the Jacobian for the current parameters that are being constraints.
+   *
+   * TODO(jeroendm), maybe also provide output agruments similar to the jacobian function
+   * so we can default to ob::Constraint::jacobian(x, out) when needed.
+   *
+   * This error jacobian, as the name suggests, is only the jacobian of the position / orientation / ... error.
+   * It does not take into acount the derivative of the distance functions defined in the Bounds class.
+   * This correction is added in the implementation of of BaseConstraint::jacobian.
+   * */
+  virtual Eigen::MatrixXd calcErrorJacobian(const Eigen::Ref<const Eigen::VectorXd>& x) const
+  {
+    ROS_ERROR_STREAM("Constraint method calcErrorJacobian was not overridded, so it should not be used.");
+    return Eigen::MatrixXd::Zero(getCoDimension(), n_);
+  }
+
+protected:
+  // MoveIt's robot representation for kinematic calculations
+  robot_model::RobotModelConstPtr robot_model_;
+  robot_state::RobotStatePtr robot_state_;
+  const robot_state::JointModelGroup* joint_model_group_;
+
+  /** \brief Robot link the constraints are applied to. */
+  std::string link_name_;
+
+  /** \brief Upper and lower bounds on constrained variables. */
+  std::vector<Bounds> bounds_;
+
+  /** \brief target for equality constraints, nominal value for inequality constraints. */
+  Eigen::Vector3d target_position_;
+
+  /** \brief target for equality constraints, nominal value for inequality constraints. */
+  Eigen::Quaterniond target_orientation_;
+};
+
+/** \brief Box shaped position constraints
+ *
+ * Reads bounds on x, y and z position from a position constraint
+ * at constraint_region.primitives[0].dimensions.
+ * Where the primitive has to be of type BOX.
+ *
+ * These bounds are applied around the nominal position and orientation
+ * of the box.
+ *
+ * */
+class PositionConstraint : public BaseConstraint
+{
+public:
+  PositionConstraint(robot_model::RobotModelConstPtr robot_model, const std::string& group, const unsigned int num_dofs)
+    : BaseConstraint(robot_model, group, num_dofs)
+  {
+  }
+  virtual void parseConstraintMsg(const moveit_msgs::Constraints& constraints) override;
+  virtual Eigen::VectorXd calcError(const Eigen::Ref<const Eigen::VectorXd>& x) const override;
+  virtual Eigen::MatrixXd calcErrorJacobian(const Eigen::Ref<const Eigen::VectorXd>& x) const override;
+};
+
+/** \brief orientation constraints based on angle-axis error.
+ *
+ * (aka exponential coordinates)
+ * This is analog to how orientation Error is calculated in the TrajOpt motion planner.
+ * It is NOT how orientation error is handled in the default MoveIt constraint samplers.
+ * (There, XYZ intrinsic euler angles are used.)
+ *
+ * */
+class AngleAxisConstraint : public BaseConstraint
+{
+public:
+  AngleAxisConstraint(robot_model::RobotModelConstPtr robot_model, const std::string& group,
+                      const unsigned int num_dofs)
+    : BaseConstraint(robot_model, group, num_dofs)
+  {
+  }
+
+  virtual void parseConstraintMsg(const moveit_msgs::Constraints& constraints) override;
+  virtual Eigen::VectorXd calcError(const Eigen::Ref<const Eigen::VectorXd>& x) const override;
+  virtual Eigen::MatrixXd calcErrorJacobian(const Eigen::Ref<const Eigen::VectorXd>& x) const override;
+};
+
+/** \brief Extract position constraints from the MoveIt message.
+ *
+ * Assumes there is a single primitive of type box.
+ * Only the dimensions of this box are used here.
+ * These are bounds on the deviation of the end-effector from
+ * the desired position given as the position of the box in the field
+ * constraint_regions.primitive_poses[0].position.
+ *
+ * @todo: also use the link name in future?
+ * Now we assume the constraints are for the end-effector link.
+ * */
+std::vector<Bounds> positionConstraintMsgToBoundVector(const moveit_msgs::PositionConstraint& pos_con);
+
+/** \brief Extract orientation constraints from the MoveIt message
+ *
+ * These bounds are assumed to be centered around the nominal orientation / desired orientation
+ * given in the field "orientation" in the message.
+ * These bounds are therefore bounds on the orientation error between the desired orientation
+ * and the current orientation of the end-effector.
+ *
+ * The three bounds x, y, and z, can be applied to different parameterizations of the rotation error.
+ * (Roll, pithc, and yaw or exponential coordinates or something else.)
+ *
+ * */
+std::vector<Bounds> orientationConstraintMsgToBoundVector(const moveit_msgs::OrientationConstraint& ori_con);
+
+/** \brief Factory to create constraints based on what is in the MoveIt constraint message. **/
+std::shared_ptr<BaseConstraint> createConstraint(robot_model::RobotModelConstPtr robot_model, const std::string& group,
+                                                 const moveit_msgs::Constraints& constraints);
+
+/** \brief Conversion matrix to go from angular velocity in the world frame to
+ * angle axis equivalent.
+ *
+ * Based on:
+ * https://ethz.ch/content/dam/ethz/special-interest/mavt/robotics-n-intelligent-systems/rsl-dam/documents/RobotDynamics2016/RD2016script.pdf
+ *
+ * */
+Eigen::Matrix3d angularVelocityToAngleAxis(double angle, const Eigen::Vector3d& axis);
+
+}  // namespace ompl_interface

--- a/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
@@ -1,0 +1,291 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Jeroen De Maeyer
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jeroen De Maeyer */
+
+#include <moveit/ompl_interface/detail/ompl_constraints.h>
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit_msgs/Constraints.h>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "ompl_constraint";
+
+double Bounds::distance(double value) const
+{
+  if (value < lower)
+    return lower - value;
+  else if (value > upper)
+    return value - upper;
+  else
+    return 0.0;
+}
+
+/****************************
+ * Base class for constraints
+ * **************************/
+
+BaseConstraint::BaseConstraint(robot_model::RobotModelConstPtr robot_model, const std::string& group,
+                               const unsigned int num_dofs, const unsigned int num_cons_)
+  : robot_model_(std::move(robot_model)), ob::Constraint(num_dofs, num_cons_)
+{
+  // Setup Moveit's robot model for kinematic calculations
+  robot_state_.reset(new robot_state::RobotState(robot_model_));
+  robot_state_->setToDefaultValues();
+  joint_model_group_ = robot_state_->getJointModelGroup(group);
+}
+
+void BaseConstraint::init(const moveit_msgs::Constraints& constraints)
+{
+  parseConstraintMsg(constraints);
+}
+
+Eigen::Isometry3d BaseConstraint::forwardKinematics(const Eigen::Ref<const Eigen::VectorXd>& joint_values) const
+{
+  robot_state_->setJointGroupPositions(joint_model_group_, joint_values);
+  return robot_state_->getGlobalLinkTransform(link_name_);
+}
+
+Eigen::MatrixXd BaseConstraint::geometricJacobian(const Eigen::Ref<const Eigen::VectorXd>& joint_values) const
+{
+  robot_state_->setJointGroupPositions(joint_model_group_, joint_values);
+  Eigen::MatrixXd jacobian;
+  bool success = robot_state_->getJacobian(joint_model_group_, joint_model_group_->getLinkModel(link_name_),
+                                           Eigen::Vector3d(0.0, 0.0, 0.0), jacobian);
+  assert(success);
+  return jacobian;
+}
+
+void BaseConstraint::function(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::Ref<Eigen::VectorXd> out) const
+{
+  auto current_values = calcError(x);
+  for (std::size_t i{ 0 }; i < bounds_.size(); ++i)
+  {
+    out[i] = bounds_[i].distance(current_values[i]);
+  }
+}
+
+void BaseConstraint::jacobian(const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::Ref<Eigen::MatrixXd> out) const
+{
+  auto current_values = calcError(x);
+  auto current_jacobian = calcErrorJacobian(x);
+
+  for (std::size_t i{ 0 }; i < bounds_.size(); ++i)
+  {
+    if (current_values[i] > bounds_[i].upper + getTolerance())
+    {
+      out.row(i) = current_jacobian.row(i);
+    }
+    else if (current_values[i] < bounds_[i].lower - getTolerance())
+    {
+      out.row(i) = -current_jacobian.row(i);
+    }
+    else
+    {
+      out.row(i) = Eigen::VectorXd::Zero(n_);
+    }
+  }
+}
+
+/******************************************
+ * Position constraints
+ * ****************************************/
+
+void PositionConstraint::parseConstraintMsg(const moveit_msgs::Constraints& constraints)
+{
+  bounds_.clear();
+  bounds_ = positionConstraintMsgToBoundVector(constraints.position_constraints.at(0));
+  // ROS_INFO_STREAM("Parsed x constraints" << bounds_[0]);
+  // ROS_INFO_STREAM("Parsed y constraints" << bounds_[1]);
+  // ROS_INFO_STREAM("Parsed z constraints" << bounds_[2]);
+
+  // extract target / nominal value
+  geometry_msgs::Point position =
+      constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).position;
+  target_position_ << position.x, position.y, position.z;
+
+  tf::quaternionMsgToEigen(constraints.position_constraints[0].constraint_region.primitive_poses[0].orientation,
+                           target_orientation_);
+
+  link_name_ = constraints.position_constraints.at(0).link_name;
+}
+
+Eigen::VectorXd PositionConstraint::calcError(const Eigen::Ref<const Eigen::VectorXd>& x) const
+{
+  return target_orientation_.matrix().transpose() * (forwardKinematics(x).translation() - target_position_);
+}
+
+Eigen::MatrixXd PositionConstraint::calcErrorJacobian(const Eigen::Ref<const Eigen::VectorXd>& x) const
+{
+  return target_orientation_.matrix().transpose() * geometricJacobian(x).topRows(3);
+}
+
+/******************************************
+ * Angle-axis error constraints
+ * ****************************************/
+void AngleAxisConstraint::parseConstraintMsg(const moveit_msgs::Constraints& constraints)
+{
+  bounds_.clear();
+  bounds_ = orientationConstraintMsgToBoundVector(constraints.orientation_constraints.at(0));
+  // ROS_INFO_STREAM("Parsing angle-axis constraints");
+  // ROS_INFO_STREAM("Parsed rx / roll constraints" << bounds_[0]);
+  // ROS_INFO_STREAM("Parsed ry / pitch constraints" << bounds_[1]);
+  // ROS_INFO_STREAM("Parsed rz / yaw constraints" << bounds_[2]);
+
+  tf::quaternionMsgToEigen(constraints.orientation_constraints.at(0).orientation, target_orientation_);
+
+  link_name_ = constraints.orientation_constraints.at(0).link_name;
+}
+
+Eigen::VectorXd AngleAxisConstraint::calcError(const Eigen::Ref<const Eigen::VectorXd>& x) const
+{
+  // TODO(jeroendm) I'm not sure yet whether I want the error expressed in the current ee_frame, or target_frame,
+  // or world frame. This implementation expressed the error in the end-effector frame.
+  Eigen::Matrix3d orientation_difference = forwardKinematics(x).rotation().transpose() * target_orientation_;
+  Eigen::AngleAxisd aa(orientation_difference);
+  double angle = aa.angle();
+  assert(std::abs(angle) < M_PI);
+  return aa.axis() * angle;
+}
+
+Eigen::MatrixXd AngleAxisConstraint::calcErrorJacobian(const Eigen::Ref<const Eigen::VectorXd>& x) const
+{
+  // Eigen::AngleAxisd aa {forwardKinematics(x).rotation().transpose() * target_as_quat_};
+
+  Eigen::AngleAxisd aa{ forwardKinematics(x).rotation() };
+  // TODO(jeroendm) Find out where the mysterious minus sign comes from
+  return -angularVelocityToAngleAxis(aa.angle(), aa.axis()) * geometricJacobian(x).bottomRows(3);
+}
+
+/************************************
+ * Message conversion functions
+ * **********************************/
+std::vector<Bounds> positionConstraintMsgToBoundVector(const moveit_msgs::PositionConstraint& pos_con)
+{
+  auto dims = pos_con.constraint_region.primitives.at(0).dimensions;
+
+  // dimension of -1 signifies unconstrained parameter, so set to infinity
+  for (auto& dim : dims)
+  {
+    if (dim == -1)
+      dim = std::numeric_limits<double>::infinity();
+  }
+
+  return { { -dims[0] / 2, dims[0] / 2 }, { -dims[1] / 2, dims[1] / 2 }, { -dims[2] / 2, dims[2] / 2 } };
+}
+
+std::vector<Bounds> orientationConstraintMsgToBoundVector(const moveit_msgs::OrientationConstraint& ori_con)
+{
+  std::vector<double> dims{ ori_con.absolute_x_axis_tolerance, ori_con.absolute_y_axis_tolerance,
+                            ori_con.absolute_z_axis_tolerance };
+
+  // dimension of -1 signifies unconstrained parameter, so set to infinity
+  for (auto& dim : dims)
+  {
+    if (dim == -1)
+      dim = std::numeric_limits<double>::infinity();
+  }
+  return { { -dims[0] / 2, dims[0] / 2 }, { -dims[1] / 2, dims[1] / 2 }, { -dims[2] / 2, dims[2] / 2 } };
+}
+
+/******************************************
+ * Constraint Factory
+ * ****************************************/
+
+std::shared_ptr<BaseConstraint> createConstraint(robot_model::RobotModelConstPtr robot_model, const std::string& group,
+                                                 const moveit_msgs::Constraints constraints)
+{
+  std::size_t num_dofs = robot_model->getJointModelGroup(group)->getVariableCount();
+  std::size_t num_pos_con = constraints.position_constraints.size();
+  std::size_t num_ori_con = constraints.orientation_constraints.size();
+
+  if (num_pos_con > 0 && num_ori_con > 0)
+  {
+    ROS_ERROR_NAMED(LOGNAME, "Combining position and orientation constraints not implemented yet.");
+    return nullptr;
+  }
+  else if (num_pos_con > 0)
+  {
+    if (num_pos_con > 1)
+    {
+      ROS_WARN_NAMED(LOGNAME, "Only a single position constraints supported. Using the first one.");
+    }
+    auto pos_con = std::make_shared<PositionConstraint>(robot_model, group, num_dofs);
+    // auto pos_con = std::make_shared<XPositionConstraint>(robot_model, group, num_dofs);
+    pos_con->init(constraints);
+    return pos_con;
+  }
+  else if (num_ori_con > 0)
+  {
+    if (num_ori_con > 1)
+    {
+      ROS_WARN_NAMED(LOGNAME, "Only a single orientation constraints supported. Using the first one.");
+    }
+
+    auto ori_con = std::make_shared<AngleAxisConstraint>(robot_model, group, num_dofs);
+    ori_con->init(constraints);
+    return ori_con;
+  }
+  else
+  {
+    ROS_ERROR_NAMED(LOGNAME, "No path constraints found in planning request.");
+    return nullptr;
+  }
+}
+
+/******************************************
+ * Angular velocity conversion
+ * ****************************************/
+Eigen::Matrix3d angularVelocityToAngleAxis(double angle, const Eigen::Vector3d& axis)
+{
+  // (short variable names to make math expression readable)
+  // calculate exponential coordinates representation from the angle axis representation
+  Eigen::Vector3d r{ axis * angle };
+
+  // put the exponential coordinates in a skew symmetric matrix
+  Eigen::Matrix3d r_skew;
+  r_skew << 0, -r[2], r[1], r[2], 0, -r[0], -r[1], r[0], 0;
+
+  // calculate the absolute value of the rotation angle as an intermediate value for the complex expression below
+  double t{ std::abs(angle) };
+
+  // calculate to 3x3 conversion matrix to convert an angular velocity into exponential coordinates
+  return Eigen::Matrix3d::Identity() - 0.5 * r_skew +
+         r_skew * r_skew / (t * t) * (1 - 0.5 * t * std::sin(t) / (1 - std::cos(t)));
+}
+
+}  // namespace ompl_interface

--- a/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
@@ -1,0 +1,401 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Jeroen De Maeyer
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jeroen De Maeyer */
+
+/** This file tests the implementation of constriants inheriting from
+ * the ompl::base::Constraint class in the file /detail/ompl_constraint.h/cpp.
+ * These are used to create an ompl::base::ConstrainedStateSpace to plan with path constraints.
+ **/
+
+#include <moveit/ompl_interface/detail/ompl_constraints.h>
+
+#include <memory>
+#include <string>
+#include <iostream>
+
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit_msgs/Constraints.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit/utils/robot_model_test_utils.h>
+
+#include <ompl/util/Exception.h>
+#include <ompl/base/spaces/RealVectorStateSpace.h>
+#include <ompl/base/spaces/constraint/ProjectedStateSpace.h>
+#include <ompl/base/ConstrainedSpaceInformation.h>
+
+/** \brief Number of times to run a test that uses randomly generated input. **/
+constexpr int NUM_RANDOM_TESTS{ 10 };
+
+/** \brief For failing tests, some extra print statements are useful. **/
+constexpr bool VERBOSE{ false };
+
+/** \brief Allowed error when comparing Jacobian matrix error.
+ *
+ * High tolerance because of high finite difference error.
+ * (And it is the L1-norm over the whole matrix difference.)
+ **/
+constexpr double JAC_ERROR_TOLERANCE{ 1e-4 };
+
+/** \brief Helper function to create a specific position constraint. **/
+moveit_msgs::PositionConstraint createPositionConstraint(std::string& base_link, std::string& ee_link_name)
+{
+  shape_msgs::SolidPrimitive box_constraint;
+  box_constraint.type = shape_msgs::SolidPrimitive::BOX;
+  box_constraint.dimensions = { 0.05, 0.4, 0.05 }; /* use -1 to indicate no constraints. */
+
+  geometry_msgs::Pose box_pose;
+  box_pose.position.x = 0.9;
+  box_pose.position.y = 0.0;
+  box_pose.position.z = 0.2;
+  box_pose.orientation.w = 1.0;
+
+  moveit_msgs::PositionConstraint position_constraint;
+  position_constraint.header.frame_id = base_link;
+  position_constraint.link_name = ee_link_name;
+  position_constraint.constraint_region.primitives.push_back(box_constraint);
+  position_constraint.constraint_region.primitive_poses.push_back(box_pose);
+
+  return position_constraint;
+}
+
+moveit_msgs::OrientationConstraint createOrientationConstraint(std::string& base_link, std::string& ee_link_name)
+{
+  moveit_msgs::OrientationConstraint orientation_constraint;
+  orientation_constraint.header.frame_id = base_link;
+  orientation_constraint.link_name = ee_link_name;
+  orientation_constraint.orientation.w = 1.0;
+  orientation_constraint.absolute_x_axis_tolerance = 0.1;
+  orientation_constraint.absolute_y_axis_tolerance = 0.1;
+  orientation_constraint.absolute_z_axis_tolerance = -1.0;
+  return orientation_constraint;
+}
+
+/** \brief Robot indepentent test class implementing all tests
+ *
+ * All tests are implemented in a generic test fixture, so it is
+ * easy to run them on different robots.
+ *
+ * based on
+ * https://stackoverflow.com/questions/38207346/specify-constructor-arguments-for-a-google-test-fixture/38218657
+ * (answer by PiotrNycz)
+ *
+ * It is implemented this way to avoid the ros specific test framework
+ * outside moveit_ros.
+ *
+ * (This is an (uglier) alternative to using the rostest framework
+ * and reading the robot settings from the parameter server.
+ * Then we have several rostest launch files that load the parameters
+ * for a specific robot and run the same compiled tests for all robots.)
+ * */
+class ConstraintTestBaseClass : public testing::Test
+{
+protected:
+  ConstraintTestBaseClass(const std::string& robot_name, const std::string& group_name)
+    : robot_name_(robot_name), group_name_(group_name)
+  {
+  }
+
+  void SetUp() override
+  {
+    // load robot
+    robot_model_ = moveit::core::loadTestingRobotModel(robot_name_);
+    robot_state_ = std::make_shared<robot_state::RobotState>(robot_model_);
+    joint_model_group_ = robot_state_->getJointModelGroup(group_name_);
+
+    // extract useful parameters for tests
+    num_dofs_ = joint_model_group_->getVariableCount();
+    ee_link_name_ = joint_model_group_->getLinkModelNames().back();
+    base_link_name_ = robot_model_->getRootLinkName();
+  };
+
+  void TearDown() override
+  {
+  }
+
+  const Eigen::Isometry3d fk(const Eigen::VectorXd q) const
+  {
+    robot_state_->setJointGroupPositions(joint_model_group_, q);
+    return robot_state_->getGlobalLinkTransform(ee_link_name_);
+  }
+
+  Eigen::VectorXd getRandomState()
+  {
+    robot_state_->setToRandomPositions(joint_model_group_);
+    Eigen::VectorXd joint_positions;
+    robot_state_->copyJointGroupPositions(joint_model_group_, joint_positions);
+    return joint_positions;
+  }
+
+  Eigen::MatrixXd numericalJacobianPosition(const Eigen::VectorXd q)
+  {
+    const double h{ 1e-6 }; /* step size for numerical derivation */
+
+    Eigen::MatrixXd jacobian = Eigen::MatrixXd::Zero(3, num_dofs_);
+
+    // helper matrix for differentiation.
+    Eigen::MatrixXd m_helper = h * Eigen::MatrixXd::Identity(num_dofs_, num_dofs_);
+
+    for (std::size_t dim{ 0 }; dim < num_dofs_; ++dim)
+    {
+      Eigen::Vector3d pos = fk(q).translation();
+      Eigen::Vector3d pos_plus_h = fk(q + m_helper.col(dim)).translation();
+      Eigen::Vector3d col = (pos_plus_h - pos) / h;
+      jacobian.col(dim) = col;
+    }
+    return jacobian;
+  }
+
+  void setPositionConstraints()
+  {
+    moveit_msgs::Constraints constraint_msgs;
+    constraint_msgs.position_constraints.push_back(createPositionConstraint(base_link_name_, ee_link_name_));
+
+    constraint_ = std::make_shared<ompl_interface::PositionConstraint>(robot_model_, group_name_, num_dofs_);
+    constraint_->init(constraint_msgs);
+  }
+
+  void setOrientationConstraints()
+  {
+    moveit_msgs::Constraints constraint_msgs;
+    constraint_msgs.orientation_constraints.push_back(createOrientationConstraint(base_link_name_, ee_link_name_));
+
+    constraint_ = std::make_shared<ompl_interface::AngleAxisConstraint>(robot_model_, group_name_, num_dofs_);
+    constraint_->init(constraint_msgs);
+  }
+
+  void testJacobian()
+  {
+    double total_error{ 999.9 };
+
+    for (int i{ 0 }; i < NUM_RANDOM_TESTS; ++i)
+    {
+      auto q = getRandomState();
+      auto jac_exact = constraint_->calcErrorJacobian(q);
+      auto jac_approx = numericalJacobianPosition(q);
+
+      if (VERBOSE)
+      {
+        std::cout << "Analytical jacobian: \n";
+        std::cout << jac_exact << std::endl;
+        std::cout << "Finite difference jacobian: \n";
+        std::cout << jac_approx << std::endl;
+      }
+
+      total_error = (jac_exact - jac_approx).lpNorm<1>();
+      EXPECT_LT(total_error, JAC_ERROR_TOLERANCE);
+    }
+  }
+
+  void testOMPLProjectedStateSpaceConstruction()
+  {
+    auto state_space = std::make_shared<ompl::base::RealVectorStateSpace>(num_dofs_);
+    ompl::base::RealVectorBounds bounds(num_dofs_);
+
+    // get joint limits from the joint model group
+    auto joint_limits = joint_model_group_->getActiveJointModelsBounds();
+    EXPECT_EQ(joint_limits.size(), num_dofs_);
+    for (std::size_t i{ 0 }; i < num_dofs_; ++i)
+    {
+      EXPECT_EQ(joint_limits[i]->size(), 1);
+      bounds.setLow(i, joint_limits[i]->at(0).min_position_);
+      bounds.setHigh(i, joint_limits[i]->at(0).max_position_);
+    }
+
+    state_space->setBounds(bounds);
+
+    auto constrained_state_space = std::make_shared<ompl::base::ProjectedStateSpace>(state_space, constraint_);
+
+    auto constrained_state_space_info =
+        std::make_shared<ompl::base::ConstrainedSpaceInformation>(constrained_state_space);
+
+    // TODO(jeroendm) Fix issues with sanity checks.
+    // The jacobian test is expected to fail because of the discontinuous constraint derivative.
+    // The issue with the state sampler is unresolved.
+    // int flags = 1 & ompl::base::ConstrainedStateSpace::CONSTRAINED_STATESPACE_JACOBIAN;
+    // flags = flags & ompl::base::ConstrainedStateSpace::CONSTRAINED_STATESPACE_SAMPLERS;
+    try
+    {
+      constrained_state_space->sanityChecks();
+    }
+    catch (ompl::Exception& ex)
+    {
+      ROS_ERROR("Sanity checks did not pass: %s", ex.what());
+    }
+  }
+
+protected:
+  const std::string group_name_;
+  const std::string robot_name_;
+
+  moveit::core::RobotModelPtr robot_model_;
+  robot_state::RobotStatePtr robot_state_;
+  const robot_state::JointModelGroup* joint_model_group_;
+
+  std::shared_ptr<ompl_interface::BaseConstraint> constraint_;
+
+  std::size_t num_dofs_;
+  std::string base_link_name_;
+  std::string ee_link_name_;
+};
+
+/***************************************************************************
+ * Run all tests on the Panda robot
+ * ************************************************************************/
+class PandaConstraintTest : public ConstraintTestBaseClass
+{
+protected:
+  PandaConstraintTest() : ConstraintTestBaseClass("panda", "panda_arm")
+  {
+  }
+};
+
+TEST_F(PandaConstraintTest, InitPositionConstraint)
+{
+  setPositionConstraints();
+}
+
+TEST_F(PandaConstraintTest, PositionConstraintJacobian)
+{
+  setPositionConstraints();
+  testJacobian();
+}
+
+TEST_F(PandaConstraintTest, PositionConstraintOMPLCheck)
+{
+  setPositionConstraints();
+  testOMPLProjectedStateSpaceConstruction();
+}
+
+TEST_F(PandaConstraintTest, InitAngleAxisConstraint)
+{
+  setOrientationConstraints();
+}
+
+TEST_F(PandaConstraintTest, AngleAxisConstraintOMPLCheck)
+{
+  setOrientationConstraints();
+  testOMPLProjectedStateSpaceConstruction();
+}
+
+/***************************************************************************
+ * Run all tests on the Fanuc robot
+ * ************************************************************************/
+class FanucConstraintTest : public ConstraintTestBaseClass
+{
+protected:
+  FanucConstraintTest() : ConstraintTestBaseClass("fanuc", "manipulator")
+  {
+  }
+};
+
+TEST_F(FanucConstraintTest, InitPositionConstraint)
+{
+  setPositionConstraints();
+}
+
+TEST_F(FanucConstraintTest, PositionConstraintJacobian)
+{
+  setPositionConstraints();
+  testJacobian();
+}
+
+TEST_F(FanucConstraintTest, PositionConstraintOMPLCheck)
+{
+  setPositionConstraints();
+  testOMPLProjectedStateSpaceConstruction();
+}
+
+TEST_F(FanucConstraintTest, InitAngleAxisConstraint)
+{
+  setOrientationConstraints();
+}
+
+TEST_F(FanucConstraintTest, AngleAxisConstraintOMPLCheck)
+{
+  setOrientationConstraints();
+  testOMPLProjectedStateSpaceConstruction();
+}
+
+/***************************************************************************
+ * Run all tests on the PR2's left arm
+ * ************************************************************************/
+class PR2LeftArmConstraintTest : public ConstraintTestBaseClass
+{
+protected:
+  PR2LeftArmConstraintTest() : ConstraintTestBaseClass("pr2", "left_arm")
+  {
+  }
+};
+
+TEST_F(PR2LeftArmConstraintTest, InitPositionConstraint)
+{
+  setPositionConstraints();
+}
+
+TEST_F(PR2LeftArmConstraintTest, PositionConstraintJacobian)
+{
+  setPositionConstraints();
+  testJacobian();
+}
+
+TEST_F(PR2LeftArmConstraintTest, PositionConstraintOMPLCheck)
+{
+  setPositionConstraints();
+  testOMPLProjectedStateSpaceConstruction();
+}
+
+TEST_F(PR2LeftArmConstraintTest, InitAngleAxisConstraint)
+{
+  setOrientationConstraints();
+}
+
+TEST_F(PR2LeftArmConstraintTest, AngleAxisConstraintOMPLCheck)
+{
+  setOrientationConstraints();
+  testOMPLProjectedStateSpaceConstruction();
+}
+
+/***************************************************************************
+ * MAIN
+ * ************************************************************************/
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Description

**This is only intended to be merged after discussing the overall approach in the main discussion thread: #2219.**

This pull request is part of a larger effort to support [OMPL's Constrained planning capabilities](http://ompl.kavrakilab.org/constrainedPlanning.html) in MoveIt.

To integrate OMPL's constrained state space, we need a model of the constraints that inherits from [ompl::base::Constraint](http://ompl.kavrakilab.org/classompl_1_1base_1_1Constraint.html). In general, this can be any equality constraint. However, many interesting constraints are **not** equality constraints (==), but inequality constraints (< >). This pull request provides a base class `BaseConstraint` and a class `Bounds` that together model bounds on a scalar variable as an equality constraint. That is, a generic vector-valued function `F(joint_positions) = 0`. For a more detailed description, see [this pdf document](https://github.com/ros-planning/moveit/files/4960396/constraints_model.pdf).

Using this base class, two specific types of constraints are implemented:

- **Position constraints**: specify constraints on the position of the link by passing in a primitive shape of type `BOX` into the motion planning request. A specific dimension can be left unconstrained by setting it to `-1`.
- **Orientation constraints**: this turned out to be a rabbit hole of different possibilities. For the first version, I've chosen to adopt the orientation error used in [TrajOpt](https://github.com/ros-industrial-consortium/trajopt_ros), using exponential coordinates, because this seemed to perform reasonable, in contrast to roll-pitch-yaw angles.

### Examples
**Position constraints**: Using a very slender box to get line following.
![kuka_boxes2](https://user-images.githubusercontent.com/11537861/88187756-3a346000-cc37-11ea-999b-08e7c9072758.gif)

**Orientation constraints** (slightly cheating / future work, as this uses a [specific implementation](https://github.com/JeroenDM/elion/commit/3b981fc8d3ac007aeef40bdfae6e3ced9813b83a) of orientation constraints in combination with `AtlasStateSpace` and `RRTstar`.)
![kuka_aa_con_atlas_prmstar](https://user-images.githubusercontent.com/11537861/88187883-618b2d00-cc37-11ea-8aa6-ea0b33c7b021.gif)

**Position and orientation constraints** (I'll be adding the code for this soon)
![welding_example_collision](https://user-images.githubusercontent.com/11537861/88188992-d743c880-cc38-11ea-977e-ab6767f51b12.gif)

**Blooper** Orientation constrained sometimes behaves strangely, especially with collision objects close to the path and using roll-pitch-yaw angles for orientation error. I left out the robot for artistic purposes.)
![art1](https://user-images.githubusercontent.com/11537861/88189005-dc087c80-cc38-11ea-978a-8568fb18445b.png)

### Future possibilities

Combine position and orientation constraints. This is in progress, I just have to push the code to this branch and add some tests.

To create an equality constraint on a link's position you can set a dimension of the box to a very small value. However, it will be far more efficient to bypass the `Bounds` for equality constraints and implement them directly in a new class that inherits from `ompl::base::Constraint`. I [have done this](https://github.com/JeroenDM/moveit/blob/39cbff77b5ccd62c6630dfc1e73718d1256d3187/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraint.h#L222) for a specific example, but have not found a clean way to integrate it yet. The logic to select the right constraint model could become overly complex.

In general, it would be cool if we could pass any user-defined constraint to OMPL through some C++ interface but gets us too far off track for now.

The current constrained model only supports OMPL's `ProjectedStateSpace` and not `AtlasStateSpace` or `TangentBundleStateSpace`. This is an issue that is probably not trivial to solve for now. (If you're interested, you can search for the word "atlas" in my GSoC thread #2092 for more info.)

Different ways to express orientation error could be more appropriate for certain types of applications. MoveIt already has the functionality to calculate the Jacobian for unit Quaternions, so this could be straightforward to add.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
