### PR TITLE
OMPL interface: add documentation

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -320,6 +320,13 @@ public:
    * approximations to */
   bool saveConstraintApproximations(const ros::NodeHandle& nh);
 
+  /** \brief Configure ompl_simple_setup_ and optionally the constraints_library_.
+   *
+   * ompl_simple_setup_ gets a start state, state sampler, and state validity checker.
+   *
+   * \param nh ROS node handle used to load the constraint approximations.
+   * \param use_constraints_approximations Set to true if we want to load the constraint approximation.
+   * */
   virtual void configure(const ros::NodeHandle& nh, bool use_constraints_approximations);
 
 protected:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -170,6 +170,15 @@ public:
     return robot_model_;
   }
 
+  /** \brief Returns a planning context to OMPLInterface, which in turn passes it to OMPLPlannerManager.
+   *
+   * This function checks the input and reads planner specific configurations.
+   * Then it creates the planning context with PlanningContextManager::createPlanningContext.
+   * Finally, it puts the context into a state appropriate for planning.
+   * This last step involves setting the start, goal, and state validity checker using the method
+   * ModelBasedPlanningContext::configure.
+   *
+   * */
   ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                   const planning_interface::MotionPlanRequest& req,
                                                   moveit_msgs::MoveItErrorCodes& error_code, const ros::NodeHandle& nh,


### PR DESCRIPTION
### Description

The `ompl_interface::ModelBasedPlanningContext` has two methods with the same name `getPlanningContext`. I think this is confusing because they do different things. Especially given that the `planning_interface::PlannerManager` also has [two of such methods](https://github.com/ros-planning/moveit/blob/dc909df5d2cf93868a1773db869e6767e339cf7a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h#L182), where overloading is used for a completely different purpose (both versions are public).

I also added docstrings to the header, to hopefully clarify a bit was is going on in these methods.

An alternative name could be `constructPlanningContext`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
