### PR TITLE
OMPL interface: fix / ignore clang-tidy warnings

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -344,8 +344,8 @@ protected:
 
      * `Iteration[num]`: Terminate after `num` iterations. Here, `num` should be replaced
        with a positive integer.
-     * `CostConvergence[solutionsWindow,epsilon]`: Terminate after the cost (as specified
-       by an optimization objective) has converged. The parameter `solutionsWindow`
+     * `CostConvergence[solutions_window,epsilon]`: Terminate after the cost (as specified
+       by an optimization objective) has converged. The parameter `solutions_window`
        specifies the minimum number of solutions to use in deciding whether a planner has
        converged. The parameter `epsilon`	is the threshold to consider for convergence.
        This should be a positive number close to 0. If the cumulative moving average does

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -322,7 +322,7 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     moveit_msgs::Constraints msg;
     hexToMsg(serialization, msg);
     auto* cass = new ConstraintApproximationStateStorage(context_->getOMPLSimpleSetup()->getStateSpace());
-    cass->load((path + "/" + filename).c_str());  // NOLINT(performance-inefficient-string-concatenation)
+    cass->load((std::string{ path }.append("/").append(filename)).c_str());
     ConstraintApproximationPtr cap(new ConstraintApproximation(group, state_space_parameterization, explicit_motions,
                                                                msg, filename, ompl::base::StateStoragePtr(cass),
                                                                milestones));

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -322,7 +322,7 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     moveit_msgs::Constraints msg;
     hexToMsg(serialization, msg);
     auto* cass = new ConstraintApproximationStateStorage(context_->getOMPLSimpleSetup()->getStateSpace());
-    cass->load((path + "/" + filename).c_str());
+    cass->load((path + "/" + filename).c_str());  // NOLINT(performance-inefficient-string-concatenation)
     ConstraintApproximationPtr cap(new ConstraintApproximation(group, state_space_parameterization, explicit_motions,
                                                                msg, filename, ompl::base::StateStoragePtr(cass),
                                                                milestones));

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -509,17 +509,17 @@ ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContex
   // Only useful for anytime/optimizing planners.
   else if (termination_and_params[0] == "CostConvergence")
   {
-    std::size_t solutionsWindow = 10u;
+    std::size_t solutions_window = 10u;
     double epsilon = 0.1;
     if (termination_and_params.size() > 1)
     {
-      solutionsWindow = std::stoul(termination_and_params[1]);
+      solutions_window = std::stoul(termination_and_params[1]);
       if (termination_and_params.size() > 2)
         epsilon = moveit::core::toDouble(termination_and_params[2]);
     }
     return ob::plannerOrTerminationCondition(
         ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start)),
-        ob::CostConvergenceTerminationCondition(ompl_simple_setup_->getProblemDefinition(), solutionsWindow, epsilon));
+        ob::CostConvergenceTerminationCondition(ompl_simple_setup_->getProblemDefinition(), solutions_window, epsilon));
   }
 #endif
   // Terminate as soon as an exact solution is found or a timeout occurs.

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -183,10 +183,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     std::map<std::string, std::string> specific_group_params;
     for (const std::string& k : KNOWN_GROUP_PARAMS)
     {
-      if (nh_.hasParam(group_name + "/" + k))
+      if (nh_.hasParam(group_name + "/" + k))  // NOLINT(performance-inefficient-string-concatenation)
       {
         std::string value;
-        if (nh_.getParam(group_name + "/" + k, value))
+        if (nh_.getParam(group_name + "/" + k, value))  // NOLINT(performance-inefficient-string-concatenation)
         {
           if (!value.empty())
             specific_group_params[k] = value;
@@ -194,7 +194,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         double value_d;
-        if (nh_.getParam(group_name + "/" + k, value_d))
+        if (nh_.getParam(group_name + "/" + k, value_d))  // NOLINT(performance-inefficient-string-concatenation)
         {
           // convert to string using no locale
           specific_group_params[k] = moveit::core::toString(value_d);
@@ -202,14 +202,14 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         int value_i;
-        if (nh_.getParam(group_name + "/" + k, value_i))
+        if (nh_.getParam(group_name, value_i))  // NOLINT(performance-inefficient-string-concatenation)
         {
           specific_group_params[k] = std::to_string(value_i);
           continue;
         }
 
         bool value_b;
-        if (nh_.getParam(group_name + "/" + k, value_b))
+        if (nh_.getParam(group_name + "/" + k, value_b))  // NOLINT(performance-inefficient-string-concatenation)
         {
           specific_group_params[k] = std::to_string(value_b);
           continue;

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -183,10 +183,14 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     std::map<std::string, std::string> specific_group_params;
     for (const std::string& k : KNOWN_GROUP_PARAMS)
     {
-      if (nh_.hasParam(group_name + "/" + k))  // NOLINT(performance-inefficient-string-concatenation)
+      std::string param_name{ group_name };
+      param_name += "/";
+      param_name += k;
+
+      if (nh_.hasParam(param_name))
       {
         std::string value;
-        if (nh_.getParam(group_name + "/" + k, value))  // NOLINT(performance-inefficient-string-concatenation)
+        if (nh_.getParam(param_name, value))
         {
           if (!value.empty())
             specific_group_params[k] = value;
@@ -194,7 +198,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         double value_d;
-        if (nh_.getParam(group_name + "/" + k, value_d))  // NOLINT(performance-inefficient-string-concatenation)
+        if (nh_.getParam(param_name, value_d))
         {
           // convert to string using no locale
           specific_group_params[k] = moveit::core::toString(value_d);
@@ -202,14 +206,14 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         int value_i;
-        if (nh_.getParam(group_name, value_i))  // NOLINT(performance-inefficient-string-concatenation)
+        if (nh_.getParam(param_name, value_i))
         {
           specific_group_params[k] = std::to_string(value_i);
           continue;
         }
 
         bool value_b;
-        if (nh_.getParam(group_name + "/" + k, value_b))  // NOLINT(performance-inefficient-string-concatenation)
+        if (nh_.getParam(param_name, value_b))
         {
           specific_group_params[k] = std::to_string(value_b);
           continue;


### PR DESCRIPTION
### Description

This makes it easier to spot new warnings when adding code.

Fix a single warning related to a variable name `solutionsWindow`.
```
warning: invalid case style for variable 'solutionsWindow' [readability-identifier-naming]
    std::size_t solutionsWindow = 10u;
                ^~~~~~~~~~~~~~~
                solutions_window
```

Ignore 6 warnings like this:
```
warning: string concatenation results in allocation of unnecessary temporary strings; consider using 'operator+=' or 'string::append()' instead [performance-inefficient-string-concatenation]
      if (nh_.hasParam(group_name + "/" + k))
```
because I think fixing it would make it less readable, and the code is not in a performance-critical path. A simple `group_name.append("/").append(k)` does not work because `group_name` is `const`. Or *is* there a readable way to fix this?

PS: I promise I will soon start working on the pull requests that actually add new functionality :)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
