### PR TITLE
fix memcpy bug in copyJointToOMPLState in ompl interface

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -340,7 +340,7 @@ void ompl_interface::ModelBasedStateSpace::copyJointToOMPLState(ompl::base::Stat
 {
   // Copy one joint (multiple variables possibly)
   memcpy(getValueAddressAtIndex(state, ompl_state_joint_index),
-         robot_state.getVariablePositions() + joint_model->getFirstVariableIndex() * sizeof(double),
+         robot_state.getVariablePositions() + joint_model->getFirstVariableIndex(),
          joint_model->getVariableCount() * sizeof(double));
 
   // clear any cached info (such as validity known or not)

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -172,7 +172,7 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   {
     // create two equal states
     moveit::core::RobotState robot_state2(robot_state);
-    EXPECT_TRUE(robot_state.distance(robot_state2) < 1e-12);
+    EXPECT_LT(robot_state.distance(robot_state2), 1e-12);
 
     // copy the first state to OMPL as backup (this is where the 'different' method comes into play)
     const moveit::core::JointModelGroup* joint_model_group =
@@ -181,18 +181,18 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
     for (std::size_t joint_index = 0; joint_index < joint_model_group->getVariableCount(); ++joint_index)
     {
       const moveit::core::JointModel* joint_model = joint_model_group->getJointModel(joint_model_names[joint_index]);
-      EXPECT_TRUE(joint_model != nullptr);
+      EXPECT_NE(joint_model, nullptr);
       ss.copyJointToOMPLState(state, robot_state, joint_model, joint_index);
     }
 
     // and change the joint values of the moveit state, so it is different that robot_state2
     robot_state.setToRandomPositions(robot_state.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName()));
-    EXPECT_TRUE(robot_state.distance(robot_state2) > 1e-12);
+    EXPECT_GT(robot_state.distance(robot_state2), 1e-12);
 
     // copy the backup values in the OMPL state back to the first state,
     // and check if it is still equal to the second
     ss.copyToRobotState(robot_state, state);
-    EXPECT_TRUE(robot_state.distance(robot_state2) < 1e-12);
+    EXPECT_LT(robot_state.distance(robot_state2), 1e-12);
   }
 
   ss.freeState(state);

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -129,15 +129,15 @@ TEST_F(LoadPlanningModelsPr2, StateSpaces)
 TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
 {
   ompl_interface::ModelBasedStateSpaceSpecification spec(robot_model_, "right_arm");
-  ompl_interface::JointModelStateSpace ss(spec);
-  ss.setPlanningVolume(-1, 1, -1, 1, -1, 1);
-  ss.setup();
+  ompl_interface::JointModelStateSpace joint_model_state_space(spec);
+  joint_model_state_space.setPlanningVolume(-1, 1, -1, 1, -1, 1);
+  joint_model_state_space.setup();
   std::ofstream fout("ompl_interface_test_state_space_diagram1.dot");
-  ss.diagram(fout);
+  joint_model_state_space.diagram(fout);
   bool passed = false;
   try
   {
-    ss.sanityChecks();
+    joint_model_state_space.sanityChecks();
     passed = true;
   }
   catch (ompl::Exception& ex)
@@ -149,18 +149,19 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToRandomPositions();
   EXPECT_TRUE(robot_state.distance(robot_state) < 1e-12);
-  ompl::base::State* state = ss.allocState();
+  ompl::base::State* state = joint_model_state_space.allocState();
   for (int i = 0; i < 10; ++i)
   {
     moveit::core::RobotState robot_state2(robot_state);
     EXPECT_TRUE(robot_state.distance(robot_state2) < 1e-12);
-    ss.copyToOMPLState(state, robot_state);
-    robot_state.setToRandomPositions(robot_state.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName()));
+    joint_model_state_space.copyToOMPLState(state, robot_state);
+    robot_state.setToRandomPositions(
+        robot_state.getRobotModel()->getJointModelGroup(joint_model_state_space.getJointModelGroupName()));
     std::cout << (robot_state.getGlobalLinkTransform("r_wrist_roll_link").translation() -
                   robot_state2.getGlobalLinkTransform("r_wrist_roll_link").translation())
               << std::endl;
     EXPECT_TRUE(robot_state.distance(robot_state2) > 1e-12);
-    ss.copyToRobotState(robot_state, state);
+    joint_model_state_space.copyToRobotState(robot_state, state);
     std::cout << (robot_state.getGlobalLinkTransform("r_wrist_roll_link").translation() -
                   robot_state2.getGlobalLinkTransform("r_wrist_roll_link").translation())
               << std::endl;
@@ -176,26 +177,27 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
 
     // copy the first state to OMPL as backup (this is where the 'different' method comes into play)
     const moveit::core::JointModelGroup* joint_model_group =
-        robot_state.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName());
+        robot_state.getRobotModel()->getJointModelGroup(joint_model_state_space.getJointModelGroupName());
     std::vector<std::string> joint_model_names = joint_model_group->getActiveJointModelNames();
     for (std::size_t joint_index = 0; joint_index < joint_model_group->getVariableCount(); ++joint_index)
     {
       const moveit::core::JointModel* joint_model = joint_model_group->getJointModel(joint_model_names[joint_index]);
       EXPECT_NE(joint_model, nullptr);
-      ss.copyJointToOMPLState(state, robot_state, joint_model, joint_index);
+      joint_model_state_space.copyJointToOMPLState(state, robot_state, joint_model, joint_index);
     }
 
     // and change the joint values of the moveit state, so it is different that robot_state2
-    robot_state.setToRandomPositions(robot_state.getRobotModel()->getJointModelGroup(ss.getJointModelGroupName()));
+    robot_state.setToRandomPositions(
+        robot_state.getRobotModel()->getJointModelGroup(joint_model_state_space.getJointModelGroupName()));
     EXPECT_GT(robot_state.distance(robot_state2), 1e-12);
 
     // copy the backup values in the OMPL state back to the first state,
     // and check if it is still equal to the second
-    ss.copyToRobotState(robot_state, state);
+    joint_model_state_space.copyToRobotState(robot_state, state);
     EXPECT_LT(robot_state.distance(robot_state2), 1e-12);
   }
 
-  ss.freeState(state);
+  joint_model_state_space.freeState(state);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

A single line bug fix (that was punching far above its weight class in terms of causing debugging fun.)

Example of the issue in [an online C++ shell](http://cpp.sh/6snnu).
Previous [related discussion](https://github.com/JeroenDM/moveit/pull/3) with @tylerjw, where he created the example that I use in the C++ shell link above.

### What (I think) happens in this piece of code

The joint data for a specific joint is copied from MoveIt to OMPL, it looks something like this:

Robot model memory (array of doubles), the bold values are copied.
| x1 | x2 | ... | ... **| y1 | y2 | y3|** ... | ... | ... | z1 | .. |

Copies into OMPL state memory (also an array of doubles)
| x1 | x2 **| y1 | y2 | y3 |** z1 |

The | ... | represent joint values for fixed joints (or mimic joints?) that are not relevant for OMPL.

### Test
I extended an existing test in `test_state_space.cpp` to make it fail without this fix. I mirrored the approach of the other tests. But maybe it is not the best way to test this. If anyone agrees, I can add another test that just copies fixed, known joint values.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
