### PR TITLE
Add planning_adapters for chomp in setup assistant

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
@@ -2,8 +2,19 @@
    <!-- CHOMP Plugin for MoveIt -->
    <arg name="planning_plugin" value="chomp_interface/CHOMPPlanner" />
    <arg name="start_state_max_bounds_error" value="0.1" />
+   <!-- The request adapters (plugins) used when planning.
+        ORDER MATTERS -->
+   <arg name="planning_adapters"
+        value="default_planner_request_adapters/AddTimeParameterization
+               default_planner_request_adapters/ResolveConstraintFrames
+               default_planner_request_adapters/FixWorkspaceBounds
+               default_planner_request_adapters/FixStartStateBounds
+               default_planner_request_adapters/FixStartStateCollision
+               default_planner_request_adapters/FixStartStatePathConstraints"
+               />
 
    <param name="planning_plugin" value="$(arg planning_plugin)" />
+   <param name="request_adapters" value="$(arg planning_adapters)" />
    <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
    <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/chomp_planning.yaml" />


### PR DESCRIPTION
## Description

CHOMPPlanner doesn't fill velocity, acc or time in a generated trajectory.
We need AddTimeParameterization to use this planner with ros_control (for gazebo simulation etc.).
I added the same planning adapters as in ompl_planning_pipeline.launch.xml.
As a reference https://github.com/ros-planning/panda_moveit_config/pull/31 adds these planning adapters in chomp's launch file.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
