### PR TITLE
A ROS service to reset the Servo status

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(catkin REQUIRED COMPONENTS
   rosparam_shortcuts
   sensor_msgs
   std_msgs
+  std_srvs
   trajectory_msgs
 )
 find_package(Eigen3 REQUIRED)
@@ -40,6 +41,7 @@ catkin_package(
     rosparam_shortcuts
     sensor_msgs
     std_msgs
+    std_srvs
     trajectory_msgs
   DEPENDS
     EIGEN3

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -44,8 +44,9 @@
 #include <moveit_msgs/ChangeDriftDimensions.h>
 #include <moveit_msgs/ChangeControlDimensions.h>
 #include <sensor_msgs/JointState.h>
-#include <std_msgs/Int8.h>
 #include <std_msgs/Float64.h>
+#include <std_msgs/Int8.h>
+#include <std_srvs/Empty.h>
 #include <control_msgs/JointJog.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <trajectory_msgs/JointTrajectory.h>
@@ -186,6 +187,9 @@ private:
   bool changeControlDimensions(moveit_msgs::ChangeControlDimensions::Request& req,
                                moveit_msgs::ChangeControlDimensions::Response& res);
 
+  /** \brief Service callback to reset Servo status, e.g. so the arm can move again after a collision */
+  bool resetServoStatus(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
+
   ros::NodeHandle nh_;
 
   // Parameters from yaml
@@ -244,6 +248,7 @@ private:
   ros::Publisher outgoing_cmd_pub_;
   ros::ServiceServer drift_dimensions_server_;
   ros::ServiceServer control_dimensions_server_;
+  ros::ServiceServer reset_servo_status_;
 
   // Status
   StatusCode status_ = StatusCode::NO_WARNING;

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -24,6 +24,7 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>trajectory_msgs</depend>
   <depend>moveit_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -108,6 +108,11 @@ ServoCalcs::ServoCalcs(ros::NodeHandle& nh, const ServoParameters& parameters,
       nh_.advertiseService(nh_.getNamespace() + "/" + ros::this_node::getName() + "/change_control_dimensions",
                            &ServoCalcs::changeControlDimensions, this);
 
+  // ROS Server to reset the status, e.g. so the arm can move again after a collision
+  reset_servo_status_ =
+      nh_.advertiseService(nh_.getNamespace() + "/" + ros::this_node::getName() + "/reset_servo_status",
+                           &ServoCalcs::resetServoStatus, this);
+
   // Publish and Subscribe to internal namespace topics
   ros::NodeHandle internal_nh("~internal");
   collision_velocity_scale_sub_ =
@@ -1047,6 +1052,12 @@ bool ServoCalcs::changeControlDimensions(moveit_msgs::ChangeControlDimensions::R
   control_dimensions_[5] = req.control_z_rotation;
 
   res.success = true;
+  return true;
+}
+
+bool ServoCalcs::resetServoStatus(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res)
+{
+  status_ = StatusCode::NO_WARNING;
   return true;
 }
 


### PR DESCRIPTION
We were experiencing an issue where the arm starts in contact with a table. That initial collision needs to be reset before Servo works. This adds a ROS service to perform that reset.
