### PR TITLE
Add test for PlanningContextManager in ompl interface

### DIFF
--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -49,10 +49,11 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES})
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
-  find_package(eigen_conversions rostest REQUIRED)
+  find_package(rostest REQUIRED)
+  find_package(eigen_conversions REQUIRED)
 
   add_rostest_gtest(test_planning_context_manager
     test/test_planning_context_manager.test
     test/test_planning_context_manager.cpp)
-  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} eigen_conversions)
+  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
 endif()

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -48,4 +48,11 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_state_space test/test_state_space.cpp)
   target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES})
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+
+  find_package(catkin REQUIRED COMPONENTS eigen_conversions rostest)
+
+  add_rostest_gtest(test_planning_context_manager
+    test/test_planning_context_manager.test
+    test/test_planning_context_manager.cpp)
+  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES})
 endif()

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -49,10 +49,10 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES})
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
-  find_package(catkin REQUIRED COMPONENTS eigen_conversions rostest)
+  find_package(eigen_conversions rostest REQUIRED)
 
   add_rostest_gtest(test_planning_context_manager
     test/test_planning_context_manager.test
     test/test_planning_context_manager.cpp)
-  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES})
+  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} eigen_conversions)
 endif()

--- a/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
+++ b/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of KU Leuven nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
+++ b/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
@@ -1,0 +1,130 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, KU Leuven
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jeroen De Maeyer */
+
+#pragma once
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/utils/robot_model_test_utils.h>
+
+namespace ompl_interface_testing
+{
+/** \brief Robot indepentent test class setup
+ *
+ * The desired robot tests can be impelmented in a derived class in a generic way.
+ *
+ * It is implemented this way to avoid the ros specific test framework
+ * outside moveit_ros.
+ *
+ * (This is an (uglier) alternative to using the rostest framework
+ * and reading the robot settings from the parameter server.
+ * Then we have several rostest launch files that load the parameters
+ * for a specific robot and run the same compiled tests for all robots.)
+ *
+ * based on
+ * https://stackoverflow.com/questions/38207346/specify-constructor-arguments-for-a-google-test-fixture/38218657
+ * (answer by PiotrNycz)
+ *
+ *   --- example.cpp ---
+ *
+ *   #include <gtest/gtest.h>
+ *   #include "load_test_robot.h"
+ *
+ *   class GenericTests : public ompl_interface_testing::LoadTestRobot, public testing::Test
+ *   {
+ *   public:
+ *     GenericTests(const std::string& robot_name, const std::string& group_name)
+ *        : LoadTestRobot(robot_name, group_name) { }
+ *     void SetUp() override { }
+ *     void TearDown() override  { }
+ *
+ *     void someTest()
+ *     {
+ *       // use robot_model_, robot_state_, .. here
+ *       EXPECT_TRUE(true);
+ *     }
+ *   };
+ *
+ *   // now you can run `someTest()` on different robots:
+ *
+ *   class PandaTest : public GenericTests
+ *   {
+ *   protected:
+ *     PandaTest() : GenericTests("panda", "panda_arm") { }
+ *   };
+ *
+ *   TEST_F(PandaTest, someTest)
+ *   {
+ *     someTest();
+ *   }
+ *
+ *   --- end example.cpp ---
+ *
+ *
+ * */
+class LoadTestRobot
+{
+protected:
+  LoadTestRobot(const std::string& robot_name, const std::string& group_name)
+    : group_name_(group_name), robot_name_(robot_name)
+  {
+    // load robot
+    robot_model_ = moveit::core::loadTestingRobotModel(robot_name_);
+    robot_state_ = std::make_shared<robot_state::RobotState>(robot_model_);
+    robot_state_->setToDefaultValues();
+    joint_model_group_ = robot_state_->getJointModelGroup(group_name_);
+
+    // extract useful parameters for tests
+    num_dofs_ = joint_model_group_->getVariableCount();
+    ee_link_name_ = joint_model_group_->getLinkModelNames().back();
+    base_link_name_ = robot_model_->getRootLinkName();
+
+    ROS_INFO_STREAM("Created test robot named: " << robot_name_ << " for planning group " << group_name_);
+  }
+
+protected:
+  const std::string group_name_;
+  const std::string robot_name_;
+
+  moveit::core::RobotModelPtr robot_model_;
+  robot_state::RobotStatePtr robot_state_;
+  const robot_state::JointModelGroup* joint_model_group_;
+
+  std::size_t num_dofs_;
+  std::string base_link_name_;
+  std::string ee_link_name_;
+};
+}  // namespace ompl_interface_testing

--- a/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
+++ b/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
@@ -42,7 +42,7 @@
 
 namespace ompl_interface_testing
 {
-/** \brief Robot indepentent test class setup
+/** \brief Robot independent test class setup
  *
  * The desired robot tests can be impelmented in a derived class in a generic way.
  *

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
+ *   * Neither the name of KU Leuven nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -154,7 +154,7 @@ public:
     // Are the path constraints created in the planning context?
     auto path_constraints = pc->getPathConstraints();
     EXPECT_FALSE(path_constraints->empty());
-    EXPECT_EQ(path_constraints->getOrientationConstraints().size(), 1);
+    EXPECT_EQ(path_constraints->getOrientationConstraints().size(), 1u);
     EXPECT_TRUE(path_constraints->getPositionConstraints().empty());
     EXPECT_TRUE(path_constraints->getJointConstraints().empty());
     EXPECT_TRUE(path_constraints->getVisibilityConstraints().empty());
@@ -191,7 +191,7 @@ public:
     // Are the path constraints created in the planning context?
     path_constraints = pc->getPathConstraints();
     EXPECT_FALSE(path_constraints->empty());
-    EXPECT_EQ(path_constraints->getPositionConstraints().size(), 1);
+    EXPECT_EQ(path_constraints->getPositionConstraints().size(), 1u);
     EXPECT_TRUE(path_constraints->getOrientationConstraints().empty());
 
     // Check if all the states in the solution satisfy the path constraints.

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -96,15 +96,14 @@ public:
 
     // see if it returns the expected planning context
     auto pc = pcm.getPlanningContext(planning_scene_, request, error_code, node_handle_, false);
-
+    // the planning context should have a simple setup created
     EXPECT_NE(pc->getOMPLSimpleSetup(), nullptr);
-    auto ss = dynamic_cast<ompl_interface::JointModelStateSpace*>(pc->getOMPLStateSpace().get());
-    EXPECT_NE(ss, nullptr);
+    // the OMPL state space in the planning context should be of type JointModelStateSpace
+    EXPECT_NE(dynamic_cast<ompl_interface::JointModelStateSpace*>(pc->getOMPLStateSpace().get()), nullptr);
 
     // solve the planning problem
     planning_interface::MotionPlanDetailedResponse res;
-    bool success = pc->solve(res);
-    EXPECT_TRUE(success);
+    ASSERT_TRUE(pc->solve(res));
   }
 
   void testPathConstraints(const std::vector<double>& start, const std::vector<double>& goal)
@@ -148,8 +147,7 @@ public:
     EXPECT_NE(ss, nullptr);
 
     planning_interface::MotionPlanDetailedResponse res;
-    bool success = pc->solve(res);
-    EXPECT_TRUE(success);
+    ASSERT_TRUE(pc->solve(res));
   }
 
   // /***************************************************************************

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -145,7 +145,7 @@ public:
 
     EXPECT_NE(pc->getOMPLSimpleSetup(), nullptr);
 
-    // As the joint_model_group_ has no IK solver initialized, we still get a joint model state space
+    // As the joint_model_group_ has no IK solver initialized, we expect a joint model state space
     EXPECT_NE(dynamic_cast<ompl_interface::JointModelStateSpace*>(pc->getOMPLStateSpace().get()), nullptr);
 
     planning_interface::MotionPlanDetailedResponse response;
@@ -181,7 +181,7 @@ public:
 
     EXPECT_NE(pc->getOMPLSimpleSetup(), nullptr);
 
-    // As the joint_model_group_ has no IK solver initialized, we still get a joint model state space
+    // As the joint_model_group_ has no IK solver initialized, we expect a joint model state space
     EXPECT_NE(dynamic_cast<ompl_interface::JointModelStateSpace*>(pc->getOMPLStateSpace().get()), nullptr);
 
     // Create a new response, because the solve method does not clear the given respone

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -36,7 +36,7 @@
 
 /** Test the creation of a ModelBasedPlanningContext through the PlanningContextManager.
  *
- * The tests use a default robot state as start state, and then moves the last joint 0.1 radions/meters to create a
+ * The tests use a default robot state as start state, and then moves the last joint 0.1 radians/meters to create a
  * joint goal. This creates an extremely simple planning problem to test general mechanics of the interface.
  *
  * In the test with path constraints, we create an orientation constraint around the start orientation of the
@@ -129,7 +129,7 @@ public:
     tf::quaternionEigenToMsg(Eigen::Quaterniond(ee_pose.rotation()), ee_orientation);
     request.path_constraints.orientation_constraints.push_back(createOrientationConstraint(ee_orientation));
 
-    // TODO(jeroendm) As explained at the top of this file, path constraints don't work yet
+    // TODO(jeroendm) As explained at the top of this file, position path constraints don't work yet
     // request.path_constraints.position_constraints.push_back(createPositionConstraint(
     //     { ee_pose.translation().x(), ee_pose.translation().y(), ee_pose.translation().z() }, { 0.1, 0.1, 0.1 }));
 

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -1,0 +1,304 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, KU Leuven
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jeroen De Maeyer */
+
+/** Test the creation of a ModelBasedPlanningContext through the PlanningContextManager.
+ *
+ * The tests use a default robot state as start state, and then moves the last joint 0.1 radions/meters to create a
+ * joint goal. This creates an extremely simple planning problem to test general mechanics of the interface.
+ *
+ * In the test with path constraints, we create an orientation constraint around the start orientation of the
+ * end-effector, with a tolerance on the rotation larger than the change in the last joint of the goal state.
+ * This makes sure the path constraints are easy to satisfy.
+ *
+ * TODO(jeroendm) I also tried something similar with position constraints, but get a segmentation fault
+ * that occurs in the 'geometric_shapes' package, in the method 'useDimensions' in 'bodies.h'.
+ * git permalink:
+ * https://github.com/ros-planning/geometric_shapes/blob/df0478870b8592ce789ee1919f3124058c4327d7/include/geometric_shapes/bodies.h#L196
+ *
+ **/
+
+#include "load_test_robot.h"
+
+#include <gtest/gtest.h>
+
+#include <eigen_conversions/eigen_msg.h>
+
+#include <moveit/ompl_interface/planning_context_manager.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/planning_interface/planning_request.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/constraint_samplers/constraint_sampler_manager.h>
+
+#include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
+
+/** \brief Generic implementation of the tests that can be executed on different robots. **/
+class TestPlanningContext : public ompl_interface_testing::LoadTestRobot, public testing::Test
+{
+public:
+  TestPlanningContext(const std::string& robot_name, const std::string& group_name)
+    : LoadTestRobot(robot_name, group_name)
+  {
+  }
+
+  // /***************************************************************************
+  //  * START Test implementations
+  //  * ************************************************************************/
+
+  void testSimpleRequest(const std::vector<double>& start, const std::vector<double>& goal)
+  {
+    // create all the test specific input necessary to make the getPlanningContext call possible
+    planning_interface::PlannerConfigurationSettings pconfig_settings;
+    pconfig_settings.group = group_name_;
+    pconfig_settings.name = group_name_;
+    pconfig_settings.config = { { "enforce_joint_model_state_space", "0" }, { "use_ompl_constrained_planning", "0" } };
+
+    planning_interface::PlannerConfigurationMap pconfig_map{ { pconfig_settings.name, pconfig_settings } };
+    moveit_msgs::MoveItErrorCodes error_code;
+    planning_interface::MotionPlanRequest request = createRequest(start, goal);
+
+    // setup the planning context manager
+    ompl_interface::PlanningContextManager pcm(robot_model_, constraint_sampler_manager_);
+    pcm.setPlannerConfigurations(pconfig_map);
+
+    // see if it returns the expected planning context
+    auto pc = pcm.getPlanningContext(planning_scene_, request, error_code, node_handle_, false);
+
+    EXPECT_NE(pc->getOMPLSimpleSetup(), nullptr);
+    auto ss = dynamic_cast<ompl_interface::JointModelStateSpace*>(pc->getOMPLStateSpace().get());
+    EXPECT_NE(ss, nullptr);
+
+    // solve the planning problem
+    planning_interface::MotionPlanDetailedResponse res;
+    bool success = pc->solve(res);
+    EXPECT_TRUE(success);
+  }
+
+  void testPathConstraints(const std::vector<double>& start, const std::vector<double>& goal)
+  {
+    // create all the test specific input necessary to make the getPlanningContext call possible
+    planning_interface::PlannerConfigurationSettings pconfig_settings;
+    pconfig_settings.group = group_name_;
+    pconfig_settings.name = group_name_;
+    pconfig_settings.config = { { "enforce_joint_model_state_space", "0" }, { "use_ompl_constrained_planning", "0" } };
+
+    planning_interface::PlannerConfigurationMap pconfig_map{ { pconfig_settings.name, pconfig_settings } };
+    moveit_msgs::MoveItErrorCodes error_code;
+    planning_interface::MotionPlanRequest request = createRequest(start, goal);
+
+    // give it some more time, as rejection sampling of the path constraints occasionally takes some time
+    request.allowed_planning_time = 10.0;
+
+    // create path constraints around start state,  to make sure they are satisfied
+    robot_state_->setJointGroupPositions(joint_model_group_, start);
+    Eigen::Isometry3d ee_pose = robot_state_->getGlobalLinkTransform(ee_link_name_);
+    geometry_msgs::Quaternion ee_orientation;
+    tf::quaternionEigenToMsg(Eigen::Quaterniond(ee_pose.rotation()), ee_orientation);
+    request.path_constraints.orientation_constraints.push_back(createOrientationConstraint(ee_orientation));
+
+    // TODO(jeroendm) As explained at the top of this file, path constraints don't work yet
+    // request.path_constraints.position_constraints.push_back(createPositionConstraint(
+    //     { ee_pose.translation().x(), ee_pose.translation().y(), ee_pose.translation().z() }, { 0.1, 0.1, 0.1 }));
+
+    // setup the planning context manager
+    ompl_interface::PlanningContextManager pcm(robot_model_, constraint_sampler_manager_);
+    pcm.setPlannerConfigurations(pconfig_map);
+
+    // see if it returns the expected planning context
+    auto pc = pcm.getPlanningContext(planning_scene_, request, error_code, node_handle_, false);
+
+    EXPECT_NE(pc->getOMPLSimpleSetup(), nullptr);
+
+    // TODO(jeroendm) As the joint_model_group_ has not IK solver initialized, we still get a joint model state space
+    // here, it would be nice if we could load an IK solver for the robot to test the PoseModelStateSpace.
+    auto ss = dynamic_cast<ompl_interface::JointModelStateSpace*>(pc->getOMPLStateSpace().get());
+    EXPECT_NE(ss, nullptr);
+
+    planning_interface::MotionPlanDetailedResponse res;
+    bool success = pc->solve(res);
+    EXPECT_TRUE(success);
+  }
+
+  // /***************************************************************************
+  //  * END Test implementation
+  //  * ************************************************************************/
+
+protected:
+  void SetUp() override
+  {
+    // create all the fixed input necessary for all planning context managers
+    constraint_sampler_manager_ = std::make_shared<constraint_samplers::ConstraintSamplerManager>();
+    planning_scene_ = std::make_shared<planning_scene::PlanningScene>(robot_model_);
+  }
+
+  void TearDown() override
+  {
+  }
+
+  /** Create a planning request to plan from a given start state to a joint space goal. **/
+  planning_interface::MotionPlanRequest createRequest(const std::vector<double>& start,
+                                                      const std::vector<double>& goal) const
+  {
+    planning_interface::MotionPlanRequest request;
+    request.group_name = group_name_;
+    request.allowed_planning_time = 5.0;
+
+    // fill out start state in request
+    robot_state::RobotState start_state(robot_model_);
+    start_state.setToDefaultValues();
+    start_state.setJointGroupPositions(joint_model_group_, start);
+    moveit::core::robotStateToRobotStateMsg(start_state, request.start_state);
+
+    // fill out goal state in request
+    robot_state::RobotState goal_state(robot_model_);
+    goal_state.setToDefaultValues();
+    goal_state.setJointGroupPositions(joint_model_group_, goal);
+    moveit_msgs::Constraints joint_goal =
+        kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group_, 0.001);
+    request.goal_constraints.push_back(joint_goal);
+
+    return request;
+  }
+
+  /** \brief Helper function to create a position constraint. **/
+  moveit_msgs::PositionConstraint createPositionConstraint(std::array<double, 3> position,
+                                                           std::array<double, 3> dimensions)
+  {
+    shape_msgs::SolidPrimitive box;
+    box.type = shape_msgs::SolidPrimitive::BOX;
+    box.dimensions.resize(3);
+    box.dimensions[shape_msgs::SolidPrimitive::BOX_X] = dimensions[0];
+    box.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = dimensions[1];
+    box.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = dimensions[2];
+
+    geometry_msgs::Pose box_pose;
+    box_pose.position.x = position[0];
+    box_pose.position.y = position[1];
+    box_pose.position.z = position[2];
+    box_pose.orientation.w = 1.0;
+
+    moveit_msgs::PositionConstraint pc;
+    pc.header.frame_id = base_link_name_;
+    pc.link_name = ee_link_name_;
+    pc.constraint_region.primitives.push_back(box);
+    pc.constraint_region.primitive_poses.push_back(box_pose);
+
+    return pc;
+  }
+
+  /** \brief Helper function to create a orientation constraint. **/
+  moveit_msgs::OrientationConstraint createOrientationConstraint(const geometry_msgs::Quaternion& nominal_orientation)
+  {
+    moveit_msgs::OrientationConstraint oc;
+    oc.header.frame_id = base_link_name_;
+    oc.link_name = ee_link_name_;
+    oc.orientation = nominal_orientation;
+    oc.absolute_x_axis_tolerance = 0.3;
+    oc.absolute_y_axis_tolerance = 0.3;
+    oc.absolute_z_axis_tolerance = 0.3;
+
+    return oc;
+  }
+
+  ompl_interface::ModelBasedStateSpacePtr state_space_;
+  ompl_interface::ModelBasedPlanningContextSpecification planning_context_spec_;
+  ompl_interface::ModelBasedPlanningContextPtr planning_context_;
+  planning_scene::PlanningScenePtr planning_scene_;
+
+  constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
+
+  /** Ideally we add an IK plugin to the joint_model_group_ to test the PoseModel state space, using the pluginlib to
+   * load the default KDL plugin? **/
+  // std::shared_ptr<kinematics::KinematicsBase> ik_plugin_;
+
+  /** we need a node handle to call getPlanningRequest, but it is never used, as we disable the
+   * 'use_constraints_approximation' option. **/
+  ros::NodeHandle node_handle_;
+};
+
+/***************************************************************************
+ * Run all tests on the Panda robot
+ * ************************************************************************/
+class PandaTestPlanningContext : public TestPlanningContext
+{
+protected:
+  PandaTestPlanningContext() : TestPlanningContext("panda", "panda_arm")
+  {
+  }
+};
+
+TEST_F(PandaTestPlanningContext, testSimpleRequest)
+{
+  // use the panda "ready" state from the srdf config as start state
+  // we know this state should be within limits and self-collision free
+  testSimpleRequest({ 0, -0.785, 0, -2.356, 0, 1.571, 0.785 }, { 0, -0.785, 0, -2.356, 0, 1.571, 0.685 });
+}
+
+TEST_F(PandaTestPlanningContext, testPathConstraints)
+{
+  testPathConstraints({ 0, -0.785, 0, -2.356, 0, 1.571, 0.785 }, { 0, -0.785, 0, -2.356, 0, 1.571, 0.685 });
+}
+
+/***************************************************************************
+ * Run all tests on the Fanuc robot
+ * ************************************************************************/
+class FanucTestPlanningContext : public TestPlanningContext
+{
+protected:
+  FanucTestPlanningContext() : TestPlanningContext("fanuc", "manipulator")
+  {
+  }
+};
+
+TEST_F(FanucTestPlanningContext, testSimpleRequest)
+{
+  testSimpleRequest({ 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0.1 });
+}
+
+TEST_F(FanucTestPlanningContext, testPathConstraints)
+{
+  testPathConstraints({ 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0.1 });
+}
+
+/***************************************************************************
+ * MAIN
+ * ************************************************************************/
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "planning_context_manager_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.test
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.test
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+    <test pkg="moveit_planners_ompl" type="test_planning_context_manager" test-name="test_planning_context_manager" />
+</launch>

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -26,7 +26,11 @@
   <depend version_gte="1.11.2">pluginlib</depend>
 
   <test_depend>moveit_resources_pr2_description</test_depend>
+  <test_depend>moveit_resources_fanuc_description</test_depend>
+  <test_depend>moveit_resources_panda_description</test_depend>
   <test_depend>rosunit</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>eigen_conversions</test_depend>
 
   <export>
     <moveit_core plugin="${prefix}/ompl_interface_plugin_description.xml"/>


### PR DESCRIPTION
### Description

(This pull request could use some extra work, but early feedback would be really valuable.)

This test goes through the main steps in solving a planning problem with the interface;

1. Create a `PlanningContextManager`.
2. Call it's `getPlanningContext` with a specific request to get a `ModelBasedPlanningContext`.
3. Call the `solve` method on the planning context.

The main intent is to check if the `ModelBasedPlanningContext` has the correct type of `ModelBasedStateSpace` assigned for planning. (For a detailed explanation of this process, see [here](https://github.com/JeroenDM/moveit/pull/2#issue-449635219).)
Calling the `solve` method is just the cherry on top of the cake.

The `load_test_robot_class.h` is exactly the same as in #2247, so I assume that change will not be part of this pull request once rebased.

### TODO / issues
**Loading a (dummy) IK solver for a planning group**
The selection of the state space depends on the availability of an IK solver. I found an example of how to load a solver in a test class in [test_constrained_sampler.cpp](https://github.com/ros-planning/moveit/blob/576c39c3d82744917123cab39dda99ba6e272a6d/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp), which basically adds a complete implementation of an IK solver (`KinematicsBase` class) to the test directory.

**rostest dependency**
Ideally, this test could be completely ROS independent if I had a way to create a "dummy" `ros::NodeHandle` without actually starting a roscore. The only method that needs this ROS handle is [loadConstraintApproximations](https://github.com/ros-planning/moveit/blob/576c39c3d82744917123cab39dda99ba6e272a6d/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp#L862), which I'm not testing here.

### Why are these useful?
I'm currently using this test in the context of #2092, where they are extremely helpful.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
