### PR TITLE
package.xml:  Add `moveit_resources` dependency

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -35,6 +35,7 @@
   <depend>liburdfdom-dev</depend>
   <depend>liburdfdom-headers-dev</depend>
   <depend>moveit_msgs</depend>
+  <depend>moveit_resources</depend>
   <depend>octomap</depend>
   <depend>octomap_msgs</depend>
   <depend>random_numbers</depend>


### PR DESCRIPTION
Various `CMakeLists.txt` files in subdirs try to
`find_package(moveit_resources REQUIRED)`, but this fails when the
`moveit_resources` package hasn't yet been built.

    Errors << moveit_core:cmake [...]/logs/moveit_core/build.cmake.000.log
    CMake Error at [...]/src/moveit/moveit_core/robot_model/CMakeLists.txt:21 (find_package):
      By not providing "Findmoveit_resources.cmake" in CMAKE_MODULE_PATH this
      project has asked CMake to find a package configuration file provided by
      "moveit_resources", but CMake did not find one.

      Could not find a package configuration file provided by "moveit_resources"
      with any of the following names:

        moveit_resourcesConfig.cmake
        moveit_resources-config.cmake

      Add the installation prefix of "moveit_resources" to CMAKE_PREFIX_PATH or
      set "moveit_resources_DIR" to a directory containing one of the above
      files.  If "moveit_resources" provides a separate development package or
      SDK, be sure it has been installed.

    Failed << moveit_core:cmake                                    [ Exited with code 1 ]

-----
This change affects only packaging, and as such the following checklist is all N/A, except for the last:

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
