### PR TITLE
Param /use_gui is not longer supported

### DIFF
--- a/moveit_planners/chomp/chomp_interface/test/rrbot_move_group.launch
+++ b/moveit_planners/chomp/chomp_interface/test/rrbot_move_group.launch
@@ -1,6 +1,6 @@
 <launch>
 
-   <arg name="use_gui" default="false" />
+  <arg name="use_gui" default="false" />
 
   <!-- The name of the parameter under which the URDF is loaded -->
   <arg name="robot_description" default="robot_description"/>

--- a/moveit_planners/chomp/chomp_interface/test/rrbot_move_group.launch
+++ b/moveit_planners/chomp/chomp_interface/test/rrbot_move_group.launch
@@ -17,8 +17,10 @@
   </group>
 
   <!-- We do not have a robot connected, so publish fake joint states -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="$(arg use_gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">
+    <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
+  </node>
+  <node name="joint_state_publisher" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg use_gui)">
     <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
   </node>
 

--- a/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
+++ b/moveit_ros/move_group/test/test_cancel_before_plan_execution.test
@@ -6,7 +6,6 @@
 
 	<!-- We do not have a robot connected, so publish fake joint states -->
 	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-		<param name="use_gui" value="false"/>
 		<rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
 	</node>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -31,8 +31,10 @@
   [VIRTUAL_JOINT_BROADCASTER]
 
   <!-- We do not have a robot connected, so publish fake joint states -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="$(arg use_gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">
+    <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
+  </node>
+  <node name="joint_state_publisher" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg use_gui)">
     <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
   </node>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -40,8 +40,12 @@
   [VIRTUAL_JOINT_BROADCASTER]
 
   <!-- We do not have a robot connected, so publish fake joint states -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="$(arg use_gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">
+    <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
+    <rosparam param="source_list">[/joint_states]</rosparam>
+  </node>
+  <node name="joint_state_publisher" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg use_gui)">
+    <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
     <rosparam param="source_list">[/joint_states]</rosparam>
   </node>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -23,6 +23,7 @@
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
### Description

`/use_gui` is deprecated in Noetic and displays a deprecation warning in Melodic.
Is the MoveIt demo sometimes used with `use_gui:=true`? Otherwise we could just drop the option for a lighter launchfile.
