### PR TITLE
Refactor velocity limit enforcement and add a unit test

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -113,10 +113,10 @@ private:
   void suddenHalt(trajectory_msgs::JointTrajectory& joint_trajectory);
 
   /** \brief  Scale the delta theta to match joint velocity/acceleration limits */
-  void enforceSRDFAccelVelLimits(Eigen::ArrayXd& delta_theta);
+  void enforceVelLimits(Eigen::ArrayXd& delta_theta);
 
   /** \brief Avoid overshooting joint limits */
-  bool enforceSRDFPositionLimits();
+  bool enforcePositionLimits();
 
   /** \brief Possibly calculate a velocity scaling factor, due to proximity of
    * singularity and direction of motion

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -726,13 +726,11 @@ void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
   // Apply the velocity scaling to all joints
   if (velocity_limit_scaling_factor < 1)
   {
-    joint_delta_index = 0;
-    for (auto joint : joint_model_group_->getActiveJointModels())
+    for (joint_delta_index = 0; joint_delta_index < joint_model_group_->getActiveJointModels().size();
+         ++joint_delta_index)
     {
       delta_theta(joint_delta_index) = velocity_limit_scaling_factor * delta_theta(joint_delta_index);
       velocity(joint_delta_index) = velocity_limit_scaling_factor * velocity(joint_delta_index);
-
-      ++joint_delta_index;
     }
   }
 }

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -685,7 +685,7 @@ void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
 
   std::size_t joint_delta_index = 0;
   // Track the smallest velocity scaling factor required, across all joints
-  double min_relative_velocity_all_joints = 1;
+  double velocity_limit_scaling_factor = 1;
 
   for (auto joint : joint_model_group_->getActiveJointModels())
   {
@@ -712,25 +712,25 @@ void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
       // Apply velocity bounds
       if (clip_velocity)
       {
-        const double relative_change =
+        const double scaling_factor =
             fabs(velocity_limit * parameters_.publish_period) / fabs(delta_theta(joint_delta_index));
 
         // Store the scaling factor if it's the smallest yet
-        if (relative_change < min_relative_velocity_all_joints)
-          min_relative_velocity_all_joints = relative_change;
+        if (scaling_factor < velocity_limit_scaling_factor)
+          velocity_limit_scaling_factor = scaling_factor;
       }
     }
     ++joint_delta_index;
   }
 
   // Apply the velocity scaling to all joints
-  if (min_relative_velocity_all_joints < 1)
+  if (velocity_limit_scaling_factor < 1)
   {
     joint_delta_index = 0;
     for (auto joint : joint_model_group_->getActiveJointModels())
     {
-      delta_theta(joint_delta_index) = min_relative_velocity_all_joints * delta_theta(joint_delta_index);
-      velocity(joint_delta_index) = min_relative_velocity_all_joints * velocity(joint_delta_index);
+      delta_theta(joint_delta_index) = velocity_limit_scaling_factor * delta_theta(joint_delta_index);
+      velocity(joint_delta_index) = velocity_limit_scaling_factor * velocity(joint_delta_index);
 
       ++joint_delta_index;
     }

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -681,7 +681,6 @@ double ServoCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& co
 void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
 {
   Eigen::ArrayXd velocity = delta_theta / parameters_.publish_period;
-  const Eigen::ArrayXd acceleration = (velocity - prev_joint_velocity_) / parameters_.publish_period;
 
   std::size_t joint_delta_index = 0;
   // Track the smallest velocity scaling factor required, across all joints

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -5,7 +5,7 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 
 ## Properties of incoming commands
 robot_link_command_frame:  panda_link0  # commands must be given in the frame of a robot link. Usually either the base or end effector
-command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
+command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
   linear:  0.003  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
@@ -137,7 +137,7 @@ TEST_F(ServoFixture, SendTwistStampedTest)
   }
 
   EXPECT_GT(received_count, num_commands - 20);
-  EXPECT_GT(received_count, 0);
+  EXPECT_GT(received_count, (unsigned)0);
   EXPECT_LT(received_count, num_commands + 20);
   servo_->stop();
 }
@@ -206,8 +206,8 @@ TEST_F(ServoFixture, JointVelocityEnforcementTest)
         if (received_count > 1)
         {
           // Need a sequence of two commands to calculate a velocity
-          EXPECT_GT(joint_command_from_servo.points.size(), 0);
-          EXPECT_GT(prev_joint_command_from_servo.points.size(), 0);
+          EXPECT_GT(joint_command_from_servo.points.size(), (unsigned)0);
+          EXPECT_GT(prev_joint_command_from_servo.points.size(), (unsigned)0);
           EXPECT_EQ(prev_joint_command_from_servo.points.size(), joint_command_from_servo.points.size());
           // No velocities larger than the largest allowable Panda velocity
           for (size_t joint_index = 0; joint_index < joint_command_from_servo.points[0].positions.size(); ++joint_index)

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
@@ -236,7 +236,7 @@ TEST_F(ServoFixture, JointVelocityEnforcementTest)
     msg->header.stamp = ros::Time::now();
     msg->header.frame_id = "panda_link0";
     msg->twist.linear.x = 10.0;
-    msg->twist.angular.y = 10.0;
+    msg->twist.angular.y = 5 * LARGEST_ALLOWABLE_PANDA_VEL;
 
     // Send the message
     twist_stamped_pub.publish(msg);


### PR DESCRIPTION
The way I was doing acceleration & velocity limit enforcement before had some flaws. It was only applied to one joint at a time, so it could affect the direction of motion of the robot. It was causing some serious direction swings.

This simplifies the whole limit checking, only enforcing velocity limits.

Also renamed the functions from  enforceSRDFAccelVelLimits -> enforceVelLimits. I think this function name was misleading because limits actually get stored in joint_limits.yaml or the URDF, not the SRDF.