### PR TITLE
MP display: add units to joints frame

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -383,8 +383,20 @@ void ProgressBarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   {
     QVariant joint_type = index.data(JointTypeRole);
     double value = index.data().toDouble();
-    bool is_revolute = joint_type.isValid() && joint_type.toInt() == moveit::core::JointModel::REVOLUTE;
-    style_option.text = option.locale.toString(is_revolute ? value * 180 / M_PI : value, 'f', is_revolute ? 0 : 3);
+    if (joint_type.isValid())
+    {
+      switch (joint_type.toInt())
+      {
+        case moveit::core::JointModel::REVOLUTE:
+          style_option.text = option.locale.toString(value * 180 / M_PI, 'f', 0).append("°");
+          break;
+        case moveit::core::JointModel::PRISMATIC:
+          style_option.text = option.locale.toString(value, 'f', 3).append("m");
+          break;
+        default:
+          break;
+      }
+    }
 
     QVariant vbounds = index.data(VariableBoundsRole);
     if (vbounds.isValid())


### PR DESCRIPTION
I still strictly prefer radian here, but this at least states units explicitly.

![degrees](https://user-images.githubusercontent.com/680358/90529378-f2402480-e173-11ea-8ad2-281b2bff4ce7.png)

Fixes #2263 .