### PR TITLE
attach cylinder function added for melodic-devel

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -143,6 +143,19 @@ class PlanningSceneInterface(object):
             aco.touch_links = [link]
         self.__submit(aco, attach=True)
 
+    def attach_cylinder(self, link, name, pose=None, height=1, radius=1, touch_links=[]):
+        aco = AttachedCollisionObject()
+        if pose is not None:
+            aco.object = self.__make_cylinder(name, pose, height, radius)
+        else:
+            aco.object = self.__make_existing(name)
+        aco.link_name = link
+        if len(touch_links) > 0:
+            aco.touch_links = touch_links
+        else:
+            aco.touch_links = [link]
+        self.__submit(aco, attach=True)
+
     def remove_world_object(self, name=None):
         """
         Remove an object from planning scene, or all if no name is provided


### PR DESCRIPTION
### Description

Added `attach_cylinder` function to `moveit_commander/planning_scene_interface.py`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
