### PR TITLE
Added GILReleaser to pick & place methods

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -262,6 +262,7 @@ public:
     convertListToPose(pose, msg.pose);
     msg.header.frame_id = getPoseReferenceFrame();
     msg.header.stamp = ros::Time::now();
+    GILReleaser gr;
     return place(object_name, msg, plan_only) == MoveItErrorCode::SUCCESS;
   }
 
@@ -271,6 +272,7 @@ public:
     std::vector<geometry_msgs::PoseStamped> poses(l);
     for (int i = 0; i < l; ++i)
       py_bindings_tools::deserializeMsg(py_bindings_tools::ByteString(poses_list[i]), poses[i]);
+    GILReleaser gr;
     return place(object_name, poses, plan_only) == MoveItErrorCode::SUCCESS;
   }
 
@@ -279,6 +281,7 @@ public:
   {
     std::vector<moveit_msgs::PlaceLocation> locations(1);
     py_bindings_tools::deserializeMsg(location_str, locations[0]);
+    GILReleaser gr;
     return place(object_name, std::move(locations), plan_only) == MoveItErrorCode::SUCCESS;
   }
 
@@ -288,11 +291,13 @@ public:
     std::vector<moveit_msgs::PlaceLocation> locations(l);
     for (int i = 0; i < l; ++i)
       py_bindings_tools::deserializeMsg(py_bindings_tools::ByteString(location_list[i]), locations[i]);
+    GILReleaser gr;
     return place(object_name, std::move(locations), plan_only) == MoveItErrorCode::SUCCESS;
   }
 
   bool placeAnywhere(const std::string& object_name, bool plan_only = false)
   {
+    GILReleaser gr;
     return place(object_name, plan_only) == MoveItErrorCode::SUCCESS;
   }
 
@@ -494,6 +499,7 @@ public:
   {
     moveit_msgs::Grasp grasp;
     py_bindings_tools::deserializeMsg(grasp_str, grasp);
+    GILReleaser gr;
     return pick(object, grasp, plan_only).val;
   }
 
@@ -503,6 +509,7 @@ public:
     std::vector<moveit_msgs::Grasp> grasps(l);
     for (int i = 0; i < l; ++i)
       py_bindings_tools::deserializeMsg(py_bindings_tools::ByteString(grasp_list[i]), grasps[i]);
+    GILReleaser gr;
     return pick(object, std::move(grasps), plan_only).val;
   }
 


### PR DESCRIPTION
### Description
Added the [GILReleaser Pattern](https://github.com/ros-planning/moveit/blob/master/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp#L436) to the pick and place operations to prevent thread blocking when those methods were called in python.

This should be merged after #2231 (as it includes the releaser in the methods added there).

Tested in melodic, it would be good to have it ported there too. 

@v4hn and @gleichdick may be good candidates for review.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
