### PR TITLE
Melodic backports in ompl interface (cleanup)

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
@@ -59,7 +59,7 @@ public:
 private:
   bool sampleUsingConstraintSampler(const ompl::base::GoalLazySamples* gls, ompl::base::State* new_goal);
   bool stateValidityCallback(ompl::base::State* new_goal, robot_state::RobotState const* state,
-                             const robot_model::JointModelGroup*, const double*, bool verbose = false) const;
+                             const robot_model::JointModelGroup* jmg, const double* jpos, bool verbose = false) const;
   bool checkStateValidity(ompl::base::State* new_goal, const robot_state::RobotState& state, bool verbose = false) const;
 
   const ModelBasedPlanningContext* planning_context_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
@@ -71,12 +71,6 @@ public:
   void setVerbose(bool flag);
 
 protected:
-  bool isValidWithoutCache(const ompl::base::State* state, bool verbose) const;
-  bool isValidWithoutCache(const ompl::base::State* state, double& dist, bool verbose) const;
-
-  bool isValidWithCache(const ompl::base::State* state, bool verbose) const;
-  bool isValidWithCache(const ompl::base::State* state, double& dist, bool verbose) const;
-
   const ModelBasedPlanningContext* planning_context_;
   std::string group_name_;
   TSStateStorage tss_;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -273,7 +273,7 @@ public:
   */
   bool solve(double timeout, unsigned int count);
 
-  /* @brief Benchmark the planning problem. Return true on succesful saving of benchmark results
+  /* @brief Benchmark the planning problem. Return true on successful saving of benchmark results
      @param timeout The time to spend on solving
      @param count The number of runs to average in the computation of the benchmark
      @param filename The name of the file to which the benchmark results are to be saved (automatic names can be

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -247,16 +247,6 @@ public:
     spec_.constraints_library_ = constraints_library;
   }
 
-  bool useStateValidityCache() const
-  {
-    return use_state_validity_cache_;
-  }
-
-  void useStateValidityCache(bool flag)
-  {
-    use_state_validity_cache_ = flag;
-  }
-
   bool simplifySolutions() const
   {
     return simplify_solutions_;
@@ -381,8 +371,6 @@ protected:
   /// the minimum number of points to include on the solution path (interpolation is used to reach this number, if
   /// needed)
   unsigned int minimum_waypoint_count_;
-
-  bool use_state_validity_cache_;
 
   bool simplify_solutions_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -305,6 +305,10 @@ public:
 
   void convertPath(const og::PathGeometric& pg, robot_trajectory::RobotTrajectory& traj) const;
 
+  /** \brief Configure ompl_simple_setup_ and optionally the constraints_library_.
+   *
+   * ompl_simple_setup_ gets a start state and state validity checker.
+   * */
   virtual void configure();
 
 protected:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -87,7 +87,7 @@ public:
       IS_GOAL_STATE = 16
     };
 
-    StateType() : ompl::base::State(), values(NULL), tag(-1), flags(0), distance(0.0)
+    StateType() : ompl::base::State(), values(nullptr), tag(-1), flags(0), distance(0.0)
     {
     }
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -56,7 +56,7 @@ public:
       POSE_COMPUTED = 512
     };
 
-    StateType() : ModelBasedStateSpace::StateType(), poses(NULL)
+    StateType() : ModelBasedStateSpace::StateType(), poses(nullptr)
     {
       flags |= JOINTS_COMPUTED;
     }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -142,6 +142,15 @@ public:
 
   ModelBasedPlanningContextPtr getPlanningContext(const std::string& config, const std::string& factory_type = "") const;
 
+  /** \brief Returns a planning context to OMPLInterface, which in turn passes it to OMPLPlannerManager.
+   *
+   * This function checks the input and reads planner specific configurations.
+   * Then it creates the planning context with PlanningContextManager::createPlanningContext.
+   * Finally, it puts the context into a state appropriate for planning.
+   * This last step involves setting the start, goal, and state validity checker using the method
+   * ModelBasedPlanningContext::configure.
+   *
+   * */
   ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                   const planning_interface::MotionPlanRequest& req,
                                                   moveit_msgs::MoveItErrorCodes& error_code) const;

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -45,6 +45,8 @@
 
 namespace ompl_interface
 {
+constexpr char LOGNAME[] = "constraints_library";
+
 namespace
 {
 template <typename T>
@@ -273,12 +275,11 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
   std::ifstream fin((path + "/manifest").c_str());
   if (!fin.good())
   {
-    ROS_WARN_NAMED("constraints_library", "Manifest not found in folder '%s'. Not loading constraint approximations.",
-                   path.c_str());
+    ROS_WARN_NAMED(LOGNAME, "Manifest not found in folder '%s'. Not loading constraint approximations.", path.c_str());
     return;
   }
 
-  ROS_INFO_NAMED("constraints_library", "Loading constrained space approximations from '%s'...", path.c_str());
+  ROS_INFO_NAMED(LOGNAME, "Loading constrained space approximations from '%s'...", path.c_str());
 
   while (fin.good() && !fin.eof())
   {
@@ -301,7 +302,7 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
     if (fin.eof())
       break;
     fin >> filename;
-    ROS_INFO_NAMED("constraints_library", "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
+    ROS_INFO_NAMED(LOGNAME, "Loading constraint approximation of type '%s' for group '%s' from '%s'...",
                    state_space_parameterization.c_str(), group.c_str(), filename.c_str());
     const ModelBasedPlanningContextPtr& pc = context_manager_.getPlanningContext(group, state_space_parameterization);
     if (pc)
@@ -314,24 +315,24 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
                                                                  msg, filename, ompl::base::StateStoragePtr(cass),
                                                                  milestones));
       if (constraint_approximations_.find(cap->getName()) != constraint_approximations_.end())
-        ROS_WARN_NAMED("constraints_library", "Overwriting constraint approximation named '%s'", cap->getName().c_str());
+        ROS_WARN_NAMED(LOGNAME, "Overwriting constraint approximation named '%s'", cap->getName().c_str());
       constraint_approximations_[cap->getName()] = cap;
       std::size_t sum = 0;
       for (std::size_t i = 0; i < cass->size(); ++i)
         sum += cass->getMetadata(i).first.size();
-      ROS_INFO_NAMED("constraints_library",
+      ROS_INFO_NAMED(LOGNAME,
                      "Loaded %lu states (%lu milestones) and %lu connections (%0.1lf per state) "
                      "for constraint named '%s'%s",
                      cass->size(), cap->getMilestoneCount(), sum, (double)sum / (double)cap->getMilestoneCount(),
                      msg.name.c_str(), explicit_motions ? ". Explicit motions included." : "");
     }
   }
-  ROS_INFO_NAMED("constraints_library", "Done loading constrained space approximations.");
+  ROS_INFO_NAMED(LOGNAME, "Done loading constrained space approximations.");
 }
 
 void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std::string& path)
 {
-  ROS_INFO_NAMED("constraints_library", "Saving %u constrained space approximations to '%s'",
+  ROS_INFO_NAMED(LOGNAME, "Saving %u constrained space approximations to '%s'",
                  (unsigned int)constraint_approximations_.size(), path.c_str());
   try
   {
@@ -358,7 +359,7 @@ void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std:
         it->second->getStateStorage()->store((path + "/" + it->second->getFilename()).c_str());
     }
   else
-    ROS_ERROR_NAMED("constraints_library", "Unable to save constraint approximation to '%s'", path.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unable to save constraint approximation to '%s'", path.c_str());
   fout.close();
 }
 
@@ -417,8 +418,7 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(const moveit_msgs
 
     ros::WallTime start = ros::WallTime::now();
     ompl::base::StateStoragePtr ss = constructConstraintApproximation(pc, constr_sampling, constr_hard, options, res);
-    ROS_INFO_NAMED("constraints_library", "Spent %lf seconds constructing the database",
-                   (ros::WallTime::now() - start).toSec());
+    ROS_INFO_NAMED(LOGNAME, "Spent %lf seconds constructing the database", (ros::WallTime::now() - start).toSec());
     if (ss)
     {
       ConstraintApproximationPtr ca(new ConstraintApproximation(
@@ -427,13 +427,12 @@ ompl_interface::ConstraintsLibrary::addConstraintApproximation(const moveit_msgs
               ".ompldb",
           ss, res.milestones));
       if (constraint_approximations_.find(ca->getName()) != constraint_approximations_.end())
-        ROS_WARN_NAMED("constraints_library", "Overwriting constraint approximation named '%s'", ca->getName().c_str());
+        ROS_WARN_NAMED(LOGNAME, "Overwriting constraint approximation named '%s'", ca->getName().c_str());
       constraint_approximations_[ca->getName()] = ca;
       res.approx = ca;
     }
     else
-      ROS_ERROR_NAMED("constraints_library", "Unable to construct constraint approximation for group '%s'",
-                      group.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "Unable to construct constraint approximation for group '%s'", group.c_str());
   }
   return res;
 }
@@ -487,19 +486,19 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     if (done != done_now)
     {
       done = done_now;
-      ROS_INFO_NAMED("constraints_library", "%d%% complete (kept %0.1lf%% sampled states)", done,
+      ROS_INFO_NAMED(LOGNAME, "%d%% complete (kept %0.1lf%% sampled states)", done,
                      100.0 * (double)sstor->size() / (double)attempts);
     }
 
     if (!slow_warn && attempts > 10 && attempts > sstor->size() * 100)
     {
       slow_warn = true;
-      ROS_WARN_NAMED("constraints_library", "Computation of valid state database is very slow...");
+      ROS_WARN_NAMED(LOGNAME, "Computation of valid state database is very slow...");
     }
 
     if (attempts > options.samples && sstor->size() == 0)
     {
-      ROS_ERROR_NAMED("constraints_library", "Unable to generate any samples");
+      ROS_ERROR_NAMED(LOGNAME, "Unable to generate any samples");
       break;
     }
 
@@ -516,19 +515,17 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
   }
 
   result.state_sampling_time = ompl::time::seconds(ompl::time::now() - start);
-  ROS_INFO_NAMED("constraints_library", "Generated %u states in %lf seconds", (unsigned int)sstor->size(),
-                 result.state_sampling_time);
+  ROS_INFO_NAMED(LOGNAME, "Generated %u states in %lf seconds", (unsigned int)sstor->size(), result.state_sampling_time);
   if (csmp)
   {
     result.sampling_success_rate = csmp->getConstrainedSamplingRate();
-    ROS_INFO_NAMED("constraints_library", "Constrained sampling rate: %lf", result.sampling_success_rate);
+    ROS_INFO_NAMED(LOGNAME, "Constrained sampling rate: %lf", result.sampling_success_rate);
   }
 
   result.milestones = sstor->size();
   if (options.edges_per_sample > 0)
   {
-    ROS_INFO_NAMED("constraints_library", "Computing graph connections (max %u edges per sample) ...",
-                   options.edges_per_sample);
+    ROS_INFO_NAMED(LOGNAME, "Computing graph connections (max %u edges per sample) ...", options.edges_per_sample);
 
     // construct connexions
     const ob::StateSpacePtr& space = pcontext->getOMPLSimpleSetup()->getStateSpace();
@@ -546,7 +543,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
       if (done != done_now)
       {
         done = done_now;
-        ROS_INFO_NAMED("constraints_library", "%d%% complete", done);
+        ROS_INFO_NAMED(LOGNAME, "%d%% complete", done);
       }
       if (cass->getMetadata(j).first.size() >= options.edges_per_sample)
         continue;
@@ -602,7 +599,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     }
 
     result.state_connection_time = ompl::time::seconds(ompl::time::now() - start);
-    ROS_INFO_NAMED("constraints_library", "Computed possible connexions in %lf seconds. Added %d connexions",
+    ROS_INFO_NAMED(LOGNAME, "Computed possible connexions in %lf seconds. Added %d connexions",
                    result.state_connection_time, good);
     pcontext->getOMPLSimpleSetup()->getSpaceInformation()->freeStates(int_states);
 
@@ -611,6 +608,6 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
 
   // TODO(davetcoleman): this function did not originally return a value, causing compiler warnings in ROS Melodic
   // Update with more intelligent logic as needed
-  ROS_ERROR_NAMED("constraints_library", "No StateStoragePtr found - implement better solution here.");
+  ROS_ERROR_NAMED(LOGNAME, "No StateStoragePtr found - implement better solution here.");
   return sstor;
 }

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -310,7 +310,7 @@ void ompl_interface::ConstraintsLibrary::loadConstraintApproximations(const std:
       moveit_msgs::Constraints msg;
       hexToMsg(serialization, msg);
       auto* cass = new ConstraintApproximationStateStorage(pc->getOMPLSimpleSetup()->getStateSpace());
-      cass->load((path + "/" + filename).c_str());
+      cass->load((std::string{ path }.append("/").append(filename)).c_str());
       ConstraintApproximationPtr cap(new ConstraintApproximation(group, state_space_parameterization, explicit_motions,
                                                                  msg, filename, ompl::base::StateStoragePtr(cass),
                                                                  milestones));
@@ -370,7 +370,8 @@ void ompl_interface::ConstraintsLibrary::clearConstraintApproximations()
 
 void ompl_interface::ConstraintsLibrary::printConstraintApproximations(std::ostream& out) const
 {
-  for (const std::pair<std::string, ConstraintApproximationPtr>& constraint_approximation : constraint_approximations_)
+  for (const std::pair<const std::string, ConstraintApproximationPtr>& constraint_approximation :
+       constraint_approximations_)
   {
     out << constraint_approximation.second->getGroup() << std::endl;
     out << constraint_approximation.second->getStateSpaceParameterization() << std::endl;

--- a/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp
@@ -528,7 +528,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
   {
     ROS_INFO_NAMED(LOGNAME, "Computing graph connections (max %u edges per sample) ...", options.edges_per_sample);
 
-    // construct connexions
+    // construct connections
     const ob::StateSpacePtr& space = pcontext->getOMPLSimpleSetup()->getStateSpace();
     unsigned int milestones = sstor->size();
     std::vector<ob::State*> int_states(options.max_explicit_points, nullptr);
@@ -600,7 +600,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     }
 
     result.state_connection_time = ompl::time::seconds(ompl::time::now() - start);
-    ROS_INFO_NAMED(LOGNAME, "Computed possible connexions in %lf seconds. Added %d connexions",
+    ROS_INFO_NAMED(LOGNAME, "Computed possible connections in %lf seconds. Added %d connections",
                    result.state_connection_time, good);
     pcontext->getOMPLSimpleSetup()->getSpaceInformation()->freeStates(int_states);
 

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -41,6 +41,11 @@
 
 #include <utility>
 
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "constrained_goal_sampler";
+}  // namespace ompl_interface
+
 ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedPlanningContext* pc,
                                                                kinematic_constraints::KinematicConstraintSetPtr ks,
                                                                constraint_samplers::ConstraintSamplerPtr cs)
@@ -58,7 +63,7 @@ ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedP
 {
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
-  ROS_DEBUG_NAMED("constrained_goal_sampler", "Constructed a ConstrainedGoalSampler instance at address %p", this);
+  ROS_DEBUG_NAMED(LOGNAME, "Constructed a ConstrainedGoalSampler instance at address %p", this);
   startSampling();
 }
 
@@ -138,9 +143,9 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
           if (!warned_invalid_samples_ && invalid_sampled_constraints_ >= (attempts_so_far * 8) / 10)
           {
             warned_invalid_samples_ = true;
-            ROS_WARN_NAMED("constrained_goal_sampler", "More than 80%% of the sampled goal states "
-                                                       "fail to satisfy the constraints imposed on the goal sampler. "
-                                                       "Is the constrained sampler working correctly?");
+            ROS_WARN_NAMED(LOGNAME, "More than 80%% of the sampled goal states "
+                                    "fail to satisfy the constraints imposed on the goal sampler. "
+                                    "Is the constrained sampler working correctly?");
           }
         }
       }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -40,6 +40,11 @@
 
 #include <utility>
 
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "constrained_valid_state_sampler";
+}  // namespace ompl_interface
+
 ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBasedPlanningContext* pc,
                                                                  kinematic_constraints::KinematicConstraintSetPtr ks,
                                                                  constraint_samplers::ConstraintSamplerPtr cs)
@@ -52,8 +57,7 @@ ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBase
   if (!constraint_sampler_)
     default_sampler_ = si_->allocStateSampler();
   inv_dim_ = si_->getStateSpace()->getDimension() > 0 ? 1.0 / (double)si_->getStateSpace()->getDimension() : 1.0;
-  ROS_DEBUG_NAMED("constrained_valid_state_sampler", "Constructed a ValidConstrainedSampler instance at address %p",
-                  this);
+  ROS_DEBUG_NAMED(LOGNAME, "Constructed a ValidConstrainedSampler instance at address %p", this);
 }
 
 bool ompl_interface::ValidConstrainedSampler::project(ompl::base::State* state)

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -70,117 +70,6 @@ void ompl_interface::StateValidityChecker::setVerbose(bool flag)
 
 bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, bool verbose) const
 {
-  //  moveit::Profiler::ScopedBlock sblock("isValid");
-  return planning_context_->useStateValidityCache() ? isValidWithCache(state, verbose) :
-                                                      isValidWithoutCache(state, verbose);
-}
-
-bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, double& dist, bool verbose) const
-{
-  //  moveit::Profiler::ScopedBlock sblock("isValid");
-  return planning_context_->useStateValidityCache() ? isValidWithCache(state, dist, verbose) :
-                                                      isValidWithoutCache(state, dist, verbose);
-}
-
-double ompl_interface::StateValidityChecker::cost(const ompl::base::State* state) const
-{
-  double cost = 0.0;
-
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  // Calculates cost from a summation of distance to obstacles times the size of the obstacle
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(collision_request_with_cost_, res, *robot_state);
-
-  for (const collision_detection::CostSource& cost_source : res.cost_sources)
-    cost += cost_source.cost * cost_source.getVolume();
-
-  return cost;
-}
-
-double ompl_interface::StateValidityChecker::clearance(const ompl::base::State* state) const
-{
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(collision_request_with_distance_, res, *robot_state);
-  return res.collision ? 0.0 : (res.distance < 0.0 ? std::numeric_limits<double>::infinity() : res.distance);
-}
-
-bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base::State* state, bool verbose) const
-{
-  // check bounds
-  if (!si_->satisfiesBounds(state))
-  {
-    if (verbose)
-      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
-    return false;
-  }
-
-  // convert ompl state to MoveIt! robot state
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  // check path constraints
-  const kinematic_constraints::KinematicConstraintSetPtr& kset = planning_context_->getPathConstraints();
-  if (kset && !kset->decide(*robot_state, verbose).satisfied)
-    return false;
-
-  // check feasibility
-  if (!planning_context_->getPlanningScene()->isStateFeasible(*robot_state, verbose))
-    return false;
-
-  // check collision avoidance
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(
-      verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *robot_state);
-  return !res.collision;
-}
-
-bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base::State* state, double& dist,
-                                                               bool verbose) const
-{
-  if (!si_->satisfiesBounds(state))
-  {
-    if (verbose)
-      ROS_INFO_NAMED("state_validity_checker", "State outside bounds");
-    return false;
-  }
-
-  robot_state::RobotState* robot_state = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
-
-  // check path constraints
-  const kinematic_constraints::KinematicConstraintSetPtr& kset = planning_context_->getPathConstraints();
-  if (kset)
-  {
-    kinematic_constraints::ConstraintEvaluationResult cer = kset->decide(*robot_state, verbose);
-    if (!cer.satisfied)
-    {
-      dist = cer.distance;
-      return false;
-    }
-  }
-
-  // check feasibility
-  if (!planning_context_->getPlanningScene()->isStateFeasible(*robot_state, verbose))
-  {
-    dist = 0.0;
-    return false;
-  }
-
-  // check collision avoidance
-  collision_detection::CollisionResult res;
-  planning_context_->getPlanningScene()->checkCollision(
-      verbose ? collision_request_with_distance_verbose_ : collision_request_with_distance_, res, *robot_state);
-  dist = res.distance;
-  return !res.collision;
-}
-
-bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State* state, bool verbose) const
-{
   if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown())
     return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();
 
@@ -225,8 +114,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   return !res.collision;
 }
 
-bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State* state, double& dist,
-                                                            bool verbose) const
+bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, double& dist, bool verbose) const
 {
   if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown() &&
       state->as<ModelBasedStateSpace::StateType>()->isGoalDistanceKnown())
@@ -272,4 +160,31 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
       verbose ? collision_request_with_distance_verbose_ : collision_request_with_distance_, res, *robot_state);
   dist = res.distance;
   return !res.collision;
+}
+
+double ompl_interface::StateValidityChecker::cost(const ompl::base::State* state) const
+{
+  double cost = 0.0;
+
+  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
+
+  // Calculates cost from a summation of distance to obstacles times the size of the obstacle
+  collision_detection::CollisionResult res;
+  planning_context_->getPlanningScene()->checkCollision(collision_request_with_cost_, res, *robot_state);
+
+  for (const collision_detection::CostSource& cost_source : res.cost_sources)
+    cost += cost_source.cost * cost_source.getVolume();
+
+  return cost;
+}
+
+double ompl_interface::StateValidityChecker::clearance(const ompl::base::State* state) const
+{
+  robot_state::RobotState* robot_state = tss_.getStateStorage();
+  planning_context_->getOMPLStateSpace()->copyToRobotState(*robot_state, state);
+
+  collision_detection::CollisionResult res;
+  planning_context_->getPlanningScene()->checkCollision(collision_request_with_distance_, res, *robot_state);
+  return res.collision ? 0.0 : (res.distance < 0.0 ? std::numeric_limits<double>::infinity() : res.distance);
 }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -59,6 +59,11 @@
 #include "ompl/base/objectives/StateCostIntegralObjective.h"
 #include "ompl/base/objectives/MaximizeMinClearanceObjective.h"
 
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "model_based_planning_context";
+}  // namespace ompl_interface
+
 ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::string& name,
                                                                      const ModelBasedPlanningContextSpecification& spec)
   : planning_interface::PlanningContext(name, spec.state_space_->getJointModelGroup()->getName())
@@ -91,7 +96,7 @@ void ompl_interface::ModelBasedPlanningContext::setProjectionEvaluator(const std
 {
   if (!spec_.state_space_)
   {
-    ROS_ERROR_NAMED("model_based_planning_context", "No state space is configured yet");
+    ROS_ERROR_NAMED(LOGNAME, "No state space is configured yet");
     return;
   }
   ob::ProjectionEvaluatorPtr pe = getProjectionEvaluator(peval);
@@ -108,7 +113,7 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
     if (getRobotModel()->hasLinkModel(link_name))
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorLinkPose(this, link_name));
     else
-      ROS_ERROR_NAMED("model_based_planning_context",
+      ROS_ERROR_NAMED(LOGNAME,
                       "Attempted to set projection evaluator with respect to position of link '%s', "
                       "but that link is not known to the kinematic model.",
                       link_name.c_str());
@@ -133,24 +138,21 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
             j.push_back(idx + q);
         }
         else
-          ROS_WARN_NAMED("model_based_planning_context", "%s: Ignoring joint '%s' in projection since it has 0 DOF",
-                         name_.c_str(), v.c_str());
+          ROS_WARN_NAMED(LOGNAME, "%s: Ignoring joint '%s' in projection since it has 0 DOF", name_.c_str(), v.c_str());
       }
       else
-        ROS_ERROR_NAMED("model_based_planning_context",
+        ROS_ERROR_NAMED(LOGNAME,
                         "%s: Attempted to set projection evaluator with respect to value of joint "
                         "'%s', but that joint is not known to the group '%s'.",
                         name_.c_str(), v.c_str(), getGroupName().c_str());
     }
     if (j.empty())
-      ROS_ERROR_NAMED("model_based_planning_context", "%s: No valid joints specified for joint projection",
-                      name_.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "%s: No valid joints specified for joint projection", name_.c_str());
     else
       return ob::ProjectionEvaluatorPtr(new ProjectionEvaluatorJointValue(this, j));
   }
   else
-    ROS_ERROR_NAMED("model_based_planning_context",
-                    "Unable to allocate projection evaluator based on description: '%s'", peval.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unable to allocate projection evaluator based on description: '%s'", peval.c_str());
   return ob::ProjectionEvaluatorPtr();
 }
 
@@ -159,13 +161,11 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 {
   if (spec_.state_space_.get() != ss)
   {
-    ROS_ERROR_NAMED("model_based_planning_context",
-                    "%s: Attempted to allocate a state sampler for an unknown state space", name_.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "%s: Attempted to allocate a state sampler for an unknown state space", name_.c_str());
     return ompl::base::StateSamplerPtr();
   }
 
-  ROS_DEBUG_NAMED("model_based_planning_context",
-                  "%s: Allocating a new state sampler (attempts to use path constraints)", name_.c_str());
+  ROS_DEBUG_NAMED(LOGNAME, "%s: Allocating a new state sampler (attempts to use path constraints)", name_.c_str());
 
   if (path_constraints_)
   {
@@ -181,7 +181,7 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
           ompl::base::StateSamplerPtr res = c_ssa(ss);
           if (res)
           {
-            ROS_INFO_NAMED("model_based_planning_context",
+            ROS_INFO_NAMED(LOGNAME,
                            "%s: Using precomputed state sampler (approximated constraint space) for constraint '%s'",
                            name_.c_str(), path_constraints_msg_.name.c_str());
             return res;
@@ -197,12 +197,11 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 
     if (cs)
     {
-      ROS_INFO_NAMED("model_based_planning_context", "%s: Allocating specialized state sampler for state space",
-                     name_.c_str());
+      ROS_INFO_NAMED(LOGNAME, "%s: Allocating specialized state sampler for state space", name_.c_str());
       return ob::StateSamplerPtr(new ConstrainedSampler(this, cs));
     }
   }
-  ROS_DEBUG_NAMED("model_based_planning_context", "%s: Allocating default state sampler for state space", name_.c_str());
+  ROS_DEBUG_NAMED(LOGNAME, "%s: Allocating default state sampler for state space", name_.c_str());
   return ss->allocDefaultStateSampler();
 }
 
@@ -221,7 +220,7 @@ void ompl_interface::ModelBasedPlanningContext::configure()
     if (ca)
     {
       getOMPLStateSpace()->setInterpolationFunction(ca->getInterpolationFunction());
-      ROS_INFO_NAMED("model_based_planning_context", "Using precomputed interpolation states");
+      ROS_INFO_NAMED(LOGNAME, "Using precomputed interpolation states");
     }
   }
 
@@ -279,8 +278,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     optimizer = "PathLengthOptimizationObjective";
-    ROS_DEBUG_NAMED("model_based_planning_context", "No optimization objective specified, defaulting to %s",
-                    optimizer.c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "No optimization objective specified, defaulting to %s", optimizer.c_str());
   }
   else
   {
@@ -336,8 +334,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   if (it == cfg.end())
   {
     if (name_ != getGroupName())
-      ROS_WARN_NAMED("model_based_planning_context", "%s: Attribute 'type' not specified in planner configuration",
-                     name_.c_str());
+      ROS_WARN_NAMED(LOGNAME, "%s: Attribute 'type' not specified in planner configuration", name_.c_str());
   }
   else
   {
@@ -345,7 +342,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     cfg.erase(it);
     ompl_simple_setup_->setPlannerAllocator(std::bind(spec_.planner_selector_(type), std::placeholders::_1,
                                                       name_ != getGroupName() ? name_ : "", std::cref(spec_)));
-    ROS_INFO_NAMED("model_based_planning_context",
+    ROS_INFO_NAMED(LOGNAME,
                    "Planner configuration '%s' will use planner '%s'. "
                    "Additional configuration parameters will be set when the planner is constructed.",
                    name_.c_str(), type.c_str());
@@ -363,9 +360,9 @@ void ompl_interface::ModelBasedPlanningContext::setPlanningVolume(const moveit_m
   if (wparams.min_corner.x == wparams.max_corner.x && wparams.min_corner.x == 0.0 &&
       wparams.min_corner.y == wparams.max_corner.y && wparams.min_corner.y == 0.0 &&
       wparams.min_corner.z == wparams.max_corner.z && wparams.min_corner.z == 0.0)
-    ROS_WARN_NAMED("model_based_planning_context", "It looks like the planning volume was not specified.");
+    ROS_WARN_NAMED(LOGNAME, "It looks like the planning volume was not specified.");
 
-  ROS_DEBUG_NAMED("model_based_planning_context",
+  ROS_DEBUG_NAMED(LOGNAME,
                   "%s: Setting planning volume (affects SE2 & SE3 joints only) to x = [%f, %f], y = "
                   "[%f, %f], z = [%f, %f]",
                   name_.c_str(), wparams.min_corner.x, wparams.max_corner.x, wparams.min_corner.y, wparams.max_corner.y,
@@ -455,7 +452,7 @@ ompl::base::GoalPtr ompl_interface::ModelBasedPlanningContext::constructGoal()
   if (!goals.empty())
     return goals.size() == 1 ? goals[0] : ompl::base::GoalPtr(new GoalSampleableRegionMux(goals));
   else
-    ROS_ERROR_NAMED("model_based_planning_context", "Unable to construct goal representation");
+    ROS_ERROR_NAMED(LOGNAME, "Unable to construct goal representation");
 
   return ob::GoalPtr();
 }
@@ -507,8 +504,7 @@ bool ompl_interface::ModelBasedPlanningContext::setGoalConstraints(
 
   if (goal_constraints_.empty())
   {
-    ROS_WARN_NAMED("model_based_planning_context", "%s: No goal constraints specified. There is no problem to solve.",
-                   name_.c_str());
+    ROS_WARN_NAMED(LOGNAME, "%s: No goal constraints specified. There is no problem to solve.", name_.c_str());
     if (error)
       error->val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
@@ -573,10 +569,10 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
   stopSampling();
   int v = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getValidMotionCount();
   int iv = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getInvalidMotionCount();
-  ROS_DEBUG_NAMED("model_based_planning_context", "There were %d valid motions and %d invalid motions.", v, iv);
+  ROS_DEBUG_NAMED(LOGNAME, "There were %d valid motions and %d invalid motions.", v, iv);
 
   if (ompl_simple_setup_->getProblemDefinition()->hasApproximateSolution())
-    ROS_WARN_NAMED("model_based_planning_context", "Computed solution is approximate");
+    ROS_WARN_NAMED(LOGNAME, "Computed solution is approximate");
 }
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)
@@ -594,8 +590,8 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
       interpolateSolution();
 
     // fill the response
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Returning successful solution with %lu states",
-                    getName().c_str(), getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Returning successful solution with %lu states", getName().c_str(),
+                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
 
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(getRobotModel(), getGroupName()));
     getSolutionPath(*res.trajectory_);
@@ -604,7 +600,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
   }
   else
   {
-    ROS_INFO_NAMED("model_based_planning_context", "Unable to solve the planning problem");
+    ROS_INFO_NAMED(LOGNAME, "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -647,13 +643,13 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
     }
 
     // fill the response
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Returning successful solution with %lu states",
-                    getName().c_str(), getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Returning successful solution with %lu states", getName().c_str(),
+                    getOMPLSimpleSetup()->getSolutionPath().getStateCount());
     return true;
   }
   else
   {
-    ROS_INFO_NAMED("model_based_planning_context", "Unable to solve the planning problem");
+    ROS_INFO_NAMED(LOGNAME, "Unable to solve the planning problem");
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
@@ -668,7 +664,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   bool result = false;
   if (count <= 1)
   {
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Solving the planning problem once...", name_.c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Solving the planning problem once...", name_.c_str());
     ob::PlannerTerminationCondition ptc =
         ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start));
     registerTerminationCondition(ptc);
@@ -678,8 +674,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   }
   else
   {
-    ROS_DEBUG_NAMED("model_based_planning_context", "%s: Solving the planning problem %u times...", name_.c_str(),
-                    count);
+    ROS_DEBUG_NAMED(LOGNAME, "%s: Solving the planning problem %u times...", name_.c_str(), count);
     ompl_parallel_plan_.clearHybridizationPaths();
     if (count <= max_planning_threads_)
     {

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -81,7 +81,6 @@ ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::
   , max_planning_threads_(0)
   , max_solution_segment_length_(0.0)
   , minimum_waypoint_count_(0)
-  , use_state_validity_cache_(true)
   , simplify_solutions_(true)
   , interpolate_(true)
   , hybridize_(true)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -236,10 +236,14 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     std::map<std::string, std::string> specific_group_params;
     for (const std::string& k : KNOWN_GROUP_PARAMS)
     {
-      if (nh_.hasParam(group_name + "/" + k))
+      std::string param_name{ group_name };
+      param_name += "/";
+      param_name += k;
+
+      if (nh_.hasParam(param_name))
       {
         std::string value;
-        if (nh_.getParam(group_name + "/" + k, value))
+        if (nh_.getParam(param_name, value))
         {
           if (!value.empty())
             specific_group_params[k] = value;
@@ -247,7 +251,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         double value_d;
-        if (nh_.getParam(group_name + "/" + k, value_d))
+        if (nh_.getParam(param_name, value_d))
         {
           // convert to string using no locale
           specific_group_params[k] = moveit::core::toString(value_d);
@@ -255,14 +259,14 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
         }
 
         int value_i;
-        if (nh_.getParam(group_name + "/" + k, value_i))
+        if (nh_.getParam(param_name, value_i))
         {
           specific_group_params[k] = std::to_string(value_i);
           continue;
         }
 
         bool value_b;
-        if (nh_.getParam(group_name + "/" + k, value_b))
+        if (nh_.getParam(param_name, value_b))
         {
           specific_group_params[k] = std::to_string(value_b);
           continue;

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,6 +42,11 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "ompl_interface";
+}  // namespace ompl_interface
+
 ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
                                              const ros::NodeHandle& nh)
   : nh_(nh)
@@ -52,7 +57,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
 {
-  ROS_INFO("Initializing OMPL interface using ROS parameters");
+  ROS_INFO_NAMED(LOGNAME, "Initializing OMPL interface using ROS parameters");
   loadPlannerConfigurations();
   loadConstraintApproximations();
   loadConstraintSamplers();
@@ -69,7 +74,7 @@ ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstP
   , use_constraints_approximations_(true)
   , simplify_solutions_(true)
 {
-  ROS_INFO("Initializing OMPL interface using specified configuration");
+  ROS_INFO_NAMED(LOGNAME, "Initializing OMPL interface using specified configuration");
   setPlannerConfigurations(pconfig);
   loadConstraintApproximations();
   loadConstraintSamplers();
@@ -137,7 +142,7 @@ void ompl_interface::OMPLInterface::loadConstraintApproximations(const std::stri
   constraints_library_->loadConstraintApproximations(path);
   std::stringstream ss;
   constraints_library_->printConstraintApproximations(ss);
-  ROS_INFO_STREAM(ss.str());
+  ROS_INFO_STREAM_NAMED(LOGNAME, ss.str());
 }
 
 void ompl_interface::OMPLInterface::saveConstraintApproximations(const std::string& path)
@@ -153,7 +158,7 @@ bool ompl_interface::OMPLInterface::saveConstraintApproximations()
     saveConstraintApproximations(cpath);
     return true;
   }
-  ROS_WARN("ROS param 'constraint_approximations' not found. Unable to save constraint approximations");
+  ROS_WARN_NAMED(LOGNAME, "ROS param 'constraint_approximations' not found. Unable to save constraint approximations");
   return false;
 }
 
@@ -182,14 +187,14 @@ bool ompl_interface::OMPLInterface::loadPlannerConfiguration(
   XmlRpc::XmlRpcValue xml_config;
   if (!nh_.getParam("planner_configs/" + planner_id, xml_config))
   {
-    ROS_ERROR("Could not find the planner configuration '%s' on the param server", planner_id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Could not find the planner configuration '%s' on the param server", planner_id.c_str());
     return false;
   }
 
   if (xml_config.getType() != XmlRpc::XmlRpcValue::TypeStruct)
   {
-    ROS_ERROR("A planning configuration should be of type XmlRpc Struct type (for configuration '%s')",
-              planner_id.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "A planning configuration should be of type XmlRpc Struct type (for configuration '%s')",
+                    planner_id.c_str());
     return false;
   }
 
@@ -290,9 +295,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     {
       if (config_names.getType() != XmlRpc::XmlRpcValue::TypeArray)
       {
-        ROS_ERROR("The planner_configs argument of a group configuration "
-                  "should be an array of strings (for group '%s')",
-                  group_name.c_str());
+        ROS_ERROR_NAMED(LOGNAME,
+                        "The planner_configs argument of a group configuration "
+                        "should be an array of strings (for group '%s')",
+                        group_name.c_str());
         continue;
       }
 
@@ -300,7 +306,8 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
       {
         if (config_names[j].getType() != XmlRpc::XmlRpcValue::TypeString)
         {
-          ROS_ERROR("Planner configuration names must be of type string (for group '%s')", group_name.c_str());
+          ROS_ERROR_NAMED(LOGNAME, "Planner configuration names must be of type string (for group '%s')",
+                          group_name.c_str());
           continue;
         }
 
@@ -315,10 +322,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
 
   for (const std::pair<std::string, planning_interface::PlannerConfigurationSettings>& config : pconfig)
   {
-    ROS_DEBUG_STREAM_NAMED("parameters", "Parameters for configuration '" << config.first << "'");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Parameters for configuration '" << config.first << "'");
 
     for (const std::pair<std::string, std::string>& parameters : config.second.config)
-      ROS_DEBUG_STREAM_NAMED("parameters", " - " << parameters.first << " = " << parameters.second);
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, " - " << parameters.first << " = " << parameters.second);
   }
 
   setPlannerConfigurations(pconfig);
@@ -326,5 +333,5 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
 
 void ompl_interface::OMPLInterface::printStatus()
 {
-  ROS_INFO("OMPL ROS interface is running.");
+  ROS_INFO_NAMED(LOGNAME, "OMPL ROS interface is running.");
 }

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -324,11 +324,11 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     }
   }
 
-  for (const std::pair<std::string, planning_interface::PlannerConfigurationSettings>& config : pconfig)
+  for (const std::pair<const std::string, planning_interface::PlannerConfigurationSettings>& config : pconfig)
   {
     ROS_DEBUG_STREAM_NAMED(LOGNAME, "Parameters for configuration '" << config.first << "'");
 
-    for (const std::pair<std::string, std::string>& parameters : config.second.config)
+    for (const std::pair<const std::string, std::string>& parameters : config.second.config)
       ROS_DEBUG_STREAM_NAMED(LOGNAME, " - " << parameters.first << " = " << parameters.second);
   }
 

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner.cpp
@@ -48,6 +48,7 @@ static const std::string PLANNER_SERVICE_NAME =
     "plan_kinematic_path";  // name of the advertised service (within the ~ namespace)
 static const std::string ROBOT_DESCRIPTION =
     "robot_description";  // name of the robot description (a param name, so it can be changed externally)
+static const std::string LOGNAME = "ompl_planner";  // name to indicate that log statements come from this file
 
 class OMPLPlannerService
 {
@@ -65,7 +66,7 @@ public:
 
   bool computePlan(moveit_msgs::GetMotionPlan::Request& req, moveit_msgs::GetMotionPlan::Response& res)
   {
-    ROS_INFO("Received new planning request...");
+    ROS_INFO_NAMED(LOGNAME, "Received new planning request...");
     if (debug_)
       pub_request_.publish(req.motion_plan_request);
     planning_interface::MotionPlanResponse response;
@@ -74,7 +75,7 @@ public:
         ompl_interface_.getPlanningContext(psm_.getPlanningScene(), req.motion_plan_request);
     if (!context)
     {
-      ROS_ERROR_STREAM_NAMED("computePlan", "No planning context found");
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "No planning context found");
       return false;
     }
     context->clear();
@@ -86,7 +87,7 @@ public:
       if (result)
         displaySolution(res.motion_plan_response);
       std::stringstream ss;
-      ROS_INFO("%s", ss.str().c_str());
+      ROS_INFO_NAMED(LOGNAME, "%s", ss.str().c_str());
     }
     return result;
   }
@@ -103,9 +104,9 @@ public:
   void status()
   {
     ompl_interface_.printStatus();
-    ROS_INFO("Responding to planning and bechmark requests");
+    ROS_INFO_NAMED(LOGNAME, "Responding to planning and bechmark requests");
     if (debug_)
-      ROS_INFO("Publishing debug information");
+      ROS_INFO_NAMED(LOGNAME, "Publishing debug information");
   }
 
 private:
@@ -147,7 +148,7 @@ int main(int argc, char** argv)
     ros::waitForShutdown();
   }
   else
-    ROS_ERROR("Planning scene not configured");
+    ROS_ERROR_NAMED(LOGNAME, "Planning scene not configured");
 
   return 0;
 }

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -56,6 +56,8 @@ namespace ompl_interface
 {
 using namespace moveit_planners_ompl;
 
+constexpr char LOGNAME[] = "ompl_planner_manager";
+
 #define OMPL_ROS_LOG(ros_log_level)                                                                                    \
   {                                                                                                                    \
     ROSCONSOLE_DEFINE_LOCATION(true, ros_log_level, ROSCONSOLE_NAME_PREFIX ".ompl");                                   \
@@ -265,13 +267,13 @@ private:
     {
       pub_markers_.shutdown();
       planner_data_link_name_.clear();
-      ROS_INFO("Not displaying OMPL exploration data structures.");
+      ROS_INFO_NAMED(LOGNAME, "Not displaying OMPL exploration data structures.");
     }
     else if (!config.link_for_exploration_tree.empty() && planner_data_link_name_.empty())
     {
       pub_markers_ = nh_.advertise<visualization_msgs::MarkerArray>("ompl_planner_data_marker_array", 5);
       planner_data_link_name_ = config.link_for_exploration_tree;
-      ROS_INFO("Displaying OMPL exploration data structures for %s", planner_data_link_name_.c_str());
+      ROS_INFO_NAMED(LOGNAME, "Displaying OMPL exploration data structures for %s", planner_data_link_name_.c_str());
     }
 
     ompl_interface_->simplifySolutions(config.simplify_solutions);

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -133,7 +133,7 @@ public:
     const planning_interface::PlannerConfigurationMap& pconfig = ompl_interface_->getPlannerConfigurations();
     algs.clear();
     algs.reserve(pconfig.size());
-    for (const std::pair<std::string, planning_interface::PlannerConfigurationSettings>& config : pconfig)
+    for (const std::pair<const std::string, planning_interface::PlannerConfigurationSettings>& config : pconfig)
       algs.push_back(config.first);
   }
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -37,6 +37,11 @@
 #include <moveit/ompl_interface/parameterization/model_based_state_space.h>
 #include <utility>
 
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "model_based_state_space";
+}  // namespace ompl_interface
+
 ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceSpecification spec)
   : ompl::base::StateSpace(), spec_(std::move(spec))
 {
@@ -49,8 +54,7 @@ ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceS
   // make sure we have bounds for every joint stored within the spec (use default bounds if not specified)
   if (!spec_.joint_bounds_.empty() && spec_.joint_bounds_.size() != joint_model_vector_.size())
   {
-    ROS_ERROR_NAMED("model_based_state_space",
-                    "Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
+    ROS_ERROR_NAMED(LOGNAME, "Joint group '%s' has incorrect bounds specified. Using the default bounds instead.",
                     spec_.joint_model_group_->getName().c_str());
     spec_.joint_bounds_.clear();
   }
@@ -86,7 +90,7 @@ double ompl_interface::ModelBasedStateSpace::getTagSnapToSegment() const
 void ompl_interface::ModelBasedStateSpace::setTagSnapToSegment(double snap)
 {
   if (snap < 0.0 || snap > 1.0)
-    ROS_WARN_NAMED("model_based_state_space",
+    ROS_WARN_NAMED(LOGNAME,
                    "Snap to segment for tags is a ratio. It's value must be between 0.0 and 1.0. "
                    "Value remains as previously set (%lf)",
                    tag_snap_to_segment_);

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -40,6 +40,11 @@
 
 #include <utility>
 
+namespace ompl_interface
+{
+constexpr char LOGNAME[] = "pose_model_state_space";
+}  // namespace ompl_interface
+
 const std::string ompl_interface::PoseModelStateSpace::PARAMETERIZATION_TYPE = "PoseModel";
 
 ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSpaceSpecification& spec)
@@ -56,8 +61,7 @@ ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSp
       poses_.emplace_back(it.first, it.second);
   }
   if (poses_.empty())
-    ROS_ERROR_NAMED("pose_model_state_space", "No kinematics solvers specified. Unable to construct a "
-                                              "PoseModelStateSpace");
+    ROS_ERROR_NAMED(LOGNAME, "No kinematics solvers specified. Unable to construct a PoseModelStateSpace");
   else
     std::sort(poses_.begin(), poses_.end());
   setName(getName() + "_" + PARAMETERIZATION_TYPE);

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -282,28 +282,8 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     // Choose the correct simple setup type to load
     context_spec.ompl_simple_setup_.reset(new ompl::geometric::SimpleSetup(context_spec.state_space_));
 
-    bool state_validity_cache = true;
-    if (config.config.find("subspaces") != config.config.end())
-    {
-      context_spec.config_.erase("subspaces");
-      // if the planner operates at subspace level the cache may be unsafe
-      state_validity_cache = false;
-      boost::char_separator<char> sep(" ");
-      boost::tokenizer<boost::char_separator<char> > tok(config.config.at("subspaces"), sep);
-      for (boost::tokenizer<boost::char_separator<char> >::iterator beg = tok.begin(); beg != tok.end(); ++beg)
-      {
-        const ompl_interface::ModelBasedStateSpaceFactoryPtr& sub_fact = factory_selector(*beg);
-        if (sub_fact)
-        {
-          ModelBasedStateSpaceSpecification sub_space_spec(robot_model_, *beg);
-          context_spec.subspaces_.push_back(sub_fact->getNewStateSpace(sub_space_spec));
-        }
-      }
-    }
-
     ROS_DEBUG_NAMED(LOGNAME, "Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
-    context->useStateValidityCache(state_validity_cache);
     {
       std::unique_lock<std::mutex> slock(cached_contexts_->lock_);
       cached_contexts_->contexts_[std::make_pair(config.name, factory->getType())].push_back(context);

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -74,6 +74,8 @@ using namespace std::placeholders;
 
 namespace ompl_interface
 {
+constexpr char LOGNAME[] = "planning_context_manager";
+
 struct PlanningContextManager::CachedContexts
 {
   std::map<std::pair<std::string, std::string>, std::vector<ModelBasedPlanningContextPtr> > contexts_;
@@ -125,7 +127,7 @@ ompl_interface::PlanningContextManager::plannerSelector(const std::string& plann
     return it->second;
   else
   {
-    ROS_ERROR_NAMED("planning_context_manager", "Unknown planner: '%s'", planner.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Unknown planner: '%s'", planner.c_str());
     return ConfiguredPlannerAllocator();
   }
 }
@@ -238,7 +240,7 @@ ompl_interface::PlanningContextManager::getPlanningContext(const std::string& co
   }
   else
   {
-    ROS_ERROR_NAMED("planning_context_manager", "Planning configuration '%s' was not found", config.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Planning configuration '%s' was not found", config.c_str());
     return ModelBasedPlanningContextPtr();
   }
 }
@@ -260,7 +262,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       for (const ModelBasedPlanningContextPtr& cached_context : cached_contexts->second)
         if (cached_context.unique())
         {
-          ROS_DEBUG_NAMED("planning_context_manager", "Reusing cached planning context");
+          ROS_DEBUG_NAMED(LOGNAME, "Reusing cached planning context");
           context = cached_context;
           break;
         }
@@ -299,7 +301,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       }
     }
 
-    ROS_DEBUG_NAMED("planning_context_manager", "Creating new planning context");
+    ROS_DEBUG_NAMED(LOGNAME, "Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
     context->useStateValidityCache(state_validity_cache);
     {
@@ -330,7 +332,7 @@ ompl_interface::PlanningContextManager::getStateSpaceFactory1(const std::string&
     return f->second;
   else
   {
-    ROS_ERROR_NAMED("planning_context_manager", "Factory of type '%s' was not found", factory_type.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Factory of type '%s' was not found", factory_type.c_str());
     static const ModelBasedStateSpaceFactoryPtr EMPTY;
     return EMPTY;
   }
@@ -356,14 +358,14 @@ ompl_interface::PlanningContextManager::getStateSpaceFactory2(const std::string&
 
   if (best == state_space_factories_.end())
   {
-    ROS_ERROR_NAMED("planning_context_manager", "There are no known state spaces that can represent the given planning "
-                                                "problem");
+    ROS_ERROR_NAMED(LOGNAME, "There are no known state spaces that can represent the given planning "
+                             "problem");
     static const ModelBasedStateSpaceFactoryPtr EMPTY;
     return EMPTY;
   }
   else
   {
-    ROS_DEBUG_NAMED("planning_context_manager", "Using '%s' parameterization for solving problem", best->first.c_str());
+    ROS_DEBUG_NAMED(LOGNAME, "Using '%s' parameterization for solving problem", best->first.c_str());
     return best->second;
   }
 }
@@ -375,7 +377,7 @@ ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene:
 {
   if (req.group_name.empty())
   {
-    ROS_ERROR_NAMED("planning_context_manager", "No group specified to plan for");
+    ROS_ERROR_NAMED(LOGNAME, "No group specified to plan for");
     error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
     return ModelBasedPlanningContextPtr();
   }
@@ -384,7 +386,7 @@ ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene:
 
   if (!planning_scene)
   {
-    ROS_ERROR_NAMED("planning_context_manager", "No planning scene supplied as input");
+    ROS_ERROR_NAMED(LOGNAME, "No planning scene supplied as input");
     return ModelBasedPlanningContextPtr();
   }
 
@@ -396,7 +398,7 @@ ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene:
                                    req.group_name + "[" + req.planner_id + "]" :
                                    req.planner_id);
     if (pc == planner_configs_.end())
-      ROS_WARN_NAMED("planning_context_manager",
+      ROS_WARN_NAMED(LOGNAME,
                      "Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
                      req.group_name.c_str(), req.planner_id.c_str());
   }
@@ -406,8 +408,7 @@ ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene:
     pc = planner_configs_.find(req.group_name);
     if (pc == planner_configs_.end())
     {
-      ROS_ERROR_NAMED("planning_context_manager", "Cannot find planning configuration for group '%s'",
-                      req.group_name.c_str());
+      ROS_ERROR_NAMED(LOGNAME, "Cannot find planning configuration for group '%s'", req.group_name.c_str());
       return ModelBasedPlanningContextPtr();
     }
   }
@@ -451,12 +452,12 @@ ompl_interface::PlanningContextManager::getPlanningContext(const planning_scene:
     try
     {
       context->configure();
-      ROS_DEBUG_NAMED("planning_context_manager", "%s: New planning context is set.", context->getName().c_str());
+      ROS_DEBUG_NAMED(LOGNAME, "%s: New planning context is set.", context->getName().c_str());
       error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
     }
     catch (ompl::Exception& ex)
     {
-      ROS_ERROR_NAMED("planning_context_manager", "OMPL encountered an error: %s", ex.what());
+      ROS_ERROR_NAMED(LOGNAME, "OMPL encountered an error: %s", ex.what());
       context.reset();
     }
   }


### PR DESCRIPTION
### Description

I manually backported the commits mentioned in #2252:

- #2211: Add named logging with LOGNAME to OMPL interface
- #2214: Remove dead code from ompl interface (related to subspaces)
- #2226: Add documentation to ompl interface
- #2227: OMPL interface: fix / ignore clang-tidy warnings

There was not always a clear one-to-one mapping, so some minor things are different.

- Add named logging to a script that is removed in the latest version: 0c0d8aa
- Fixed another clang-tidy warning: `performance-implicit-conversion-in-loop` in [constraint_library.cpp](https://github.com/ros-planning/moveit/blob/8b5782cce98e93b9efa33a3269d11c0c84c2f536/moveit_planners/ompl/ompl_interface/src/constraints_library.cpp#L373).
- Correct some spelling errors, while I was going through it anyway: 8b5782c
