### PR TITLE
Cleanup: Add a utility to print collision pairs

### DIFF
--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MOVEIT_LIB_NAME moveit_collision_detection)
 
 add_library(${MOVEIT_LIB_NAME}
   src/allvalid/collision_env_allvalid.cpp
+  src/collision_common.cpp
   src/collision_matrix.cpp
   src/collision_octomap_filter.cpp
   src/collision_tools.cpp

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -144,12 +144,7 @@ struct CostSource
 /** \brief Representation of a collision checking result */
 struct CollisionResult
 {
-  CollisionResult()
-    : collision(false)
-    , distance(std::numeric_limits<double>::max())
-    , contact_count(0)
-    , collision_log_period(5)
-    , collision_log_name("collision_common")
+  CollisionResult() : collision(false), distance(std::numeric_limits<double>::max()), contact_count(0)
   {
   }
   typedef std::map<std::pair<std::string, std::string>, std::vector<Contact> > ContactMap;
@@ -166,25 +161,8 @@ struct CollisionResult
     cost_sources.clear();
   }
 
-  /** \brief Throttled warning of the first collision pair, if any. Other collisions are logged at the DEBUG level */
-  void print()
-  {
-    if (!contacts.empty())
-    {
-      ROS_WARN_STREAM_THROTTLE_NAMED(collision_log_period, collision_log_name,
-                                     "Objects in collision (printing first collision pair of "
-                                         << contacts.size() << "): " << contacts.begin()->first.first << ", "
-                                         << contacts.begin()->first.second);
-
-      // Log all collisions at the debug level
-      ROS_DEBUG_STREAM_THROTTLE_NAMED(collision_log_period, collision_log_name, "Objects in collision:");
-      for (auto contact : contacts)
-      {
-        ROS_DEBUG_STREAM_THROTTLE_NAMED(collision_log_period, collision_log_name,
-                                        "\t" << contact.first.first << ", " << contact.first.second);
-      }
-    }
-  }
+  /** \brief Throttled warning printing the first collision pair, if any. All collisions are logged at DEBUG level */
+  void print() const;
 
   /** \brief True if collision was found, false otherwise */
   bool collision;
@@ -200,12 +178,6 @@ struct CollisionResult
 
   /** \brief These are the individual cost sources when costs are computed */
   std::set<CostSource> cost_sources;
-
-  /** \brief Period for logging collisions */
-  double collision_log_period;
-
-  /** Log name, for printed messages */
-  std::string collision_log_name;
 };
 
 /** \brief Representation of a collision checking request */

--- a/moveit_core/collision_detection/src/collision_common.cpp
+++ b/moveit_core/collision_detection/src/collision_common.cpp
@@ -1,0 +1,61 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit/collision_detection/collision_common.h>
+
+static const char LOGNAME[] = "collision_common";
+constexpr size_t LOG_THROTTLE_PERIOD = 5;
+
+namespace collision_detection
+{
+void CollisionResult::print() const
+{
+  if (!contacts.empty())
+  {
+    ROS_WARN_STREAM_THROTTLE_NAMED(LOG_THROTTLE_PERIOD, LOGNAME,
+                                   "Objects in collision (printing 1st of "
+                                       << contacts.size() << " pairs): " << contacts.begin()->first.first << ", "
+                                       << contacts.begin()->first.second);
+
+    // Log all collisions at the debug level
+    ROS_DEBUG_STREAM_THROTTLE_NAMED(LOG_THROTTLE_PERIOD, LOGNAME, "Objects in collision:");
+    for (const auto& contact : contacts)
+    {
+      ROS_DEBUG_STREAM_THROTTLE_NAMED(LOG_THROTTLE_PERIOD, LOGNAME,
+                                      "\t" << contact.first.first << ", " << contact.first.second);
+    }
+  }
+}
+
+}  // namespace collision_detection


### PR DESCRIPTION
I think @tylerjw merged #2275 too early (without having approvals from two maintainers). This PR realizes some changes required in my opinion (see below).