### PR TITLE
[maint] Remove patch status from codecov

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -7,7 +7,4 @@ coverage:
       default:
         target: auto
         threshold: 5%
-    patch:
-      default:
-        target: auto
-        threshold: 5%
+    patch: off


### PR DESCRIPTION
### Description

This disables the "patch" status reporting from codecov.  I believe this is what is causing this:

https://github.com/ros-planning/moveit/pull/2305#issuecomment-690861772

Patch status documentation is here: https://docs.codecov.io/docs/commit-status#patch-status
Here is the documentation for disabling a status: https://docs.codecov.io/docs/commit-status#disabling-a-status
