### PR TITLE
[fix] Servo heap-buffer-overflow bug

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -806,8 +806,6 @@ void ServoCalcs::suddenHalt(trajectory_msgs::JointTrajectory& joint_trajectory)
   point.velocities.resize(num_joints_);
 
   // Assert the following loop is safe to execute
-  assert(point.positions.size() >= num_joints_);
-  assert(point.velocities.size() >= num_joints_);
   assert(original_joint_state_.position.size() >= num_joints_);
 
   // Set the positions and velocities vectors


### PR DESCRIPTION
### Description

This was fun to track down.  The short story here is that when `suddenHalt` is called sometimes there is a point in the `points` array so the code inside the if statement doesn't get run.  Then the code below uses the `operator[]` and writes past the end of heap memory allocations that are not large enough.

What made this fun is this was corrupting memory so that later the program would crash sometimes with an error about deallocating memory that was already deallocated and the stack trace was inside ompl.  In the end what helped me find this was building with address sanitizer.

```bash
catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer -fsanitize=address" -DCMAKE_C_FLAGS="-fno-omit-frame-pointer -fsanitize=address" -DCMAKE_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=address" -- --no-install
```

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
