### PR TITLE
Clean up Rviz Motion Planning plugin, add tooltips

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1335,8 +1335,6 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
       frame_->ui_->velocity_scaling_factor->setValue(d);
     if (config.mapGetFloat("Acceleration_Scaling_Factor", &d))
       frame_->ui_->acceleration_scaling_factor->setValue(d);
-    if (config.mapGetFloat("MoveIt_Goal_Tolerance", &d))
-      frame_->ui_->goal_tolerance->setValue(d);
 
     bool b;
     if (config.mapGetBool("MoveIt_Allow_Replanning", &b))
@@ -1394,8 +1392,6 @@ void MotionPlanningDisplay::save(rviz::Config config) const
   {
     config.mapSetValue("MoveIt_Warehouse_Host", frame_->ui_->database_host->text());
     config.mapSetValue("MoveIt_Warehouse_Port", frame_->ui_->database_port->value());
-
-    config.mapSetValue("MoveIt_Goal_Tolerance", frame_->ui_->goal_tolerance->value());
 
     // "Options" Section
     config.mapSetValue("MoveIt_Planning_Time", frame_->ui_->planning_time->value());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -163,8 +163,6 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->database_host, SIGNAL(textChanged(QString)), this, SIGNAL(configChanged()));
   connect(ui_->database_port, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
 
-  connect(ui_->goal_tolerance, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
-
   connect(ui_->planning_time, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
   connect(ui_->planning_attempts, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
   connect(ui_->velocity_scaling_factor, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>507</width>
-    <height>389</height>
+    <height>380</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,7 +26,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="context">
       <attribute name="title">
@@ -526,7 +526,7 @@
            <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
-             <height>41</height>
+             <height>32</height>
             </size>
            </property>
           </spacer>
@@ -586,7 +586,7 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_10">
             <property name="spacing">
-             <number>2</number>
+             <number>1</number>
             </property>
             <property name="bottomMargin">
              <number>4</number>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -797,9 +797,9 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>If checked, the IK solver tried to avoid collisions when searching for the state set via the interactive marker.
+               <string>If checked, the IK solver tries to avoid collisions when searching for a start/end state set via the interactive marker.
 
-This is usually achieved by random seeing, which can flip the robot configuration (e.g. elbow up/down). Note that motion planning is always collision-aware, regardless of this checkbox.</string>
+This is usually achieved by random seeding, which can flip the robot configuration (e.g. elbow up/down). Note that motion planning is always collision-aware, regardless of this checkbox.</string>
               </property>
               <property name="text">
                <string>Collision-aware IK</string>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -26,7 +26,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="context">
       <attribute name="title">
@@ -96,6 +96,9 @@
             </item>
             <item>
              <widget class="moveit_rviz_plugin::MotionPlanningParamWidget" name="planner_param_treeview">
+              <property name="autoScroll">
+               <bool>false</bool>
+              </property>
               <property name="indentation">
                <number>0</number>
               </property>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -417,7 +417,7 @@
                  <bool>false</bool>
                 </property>
                 <property name="toolTip">
-                 <string>Send a stop() command to the move_group.</string>
+                 <string>Stop execution by sending a stop command to the move_group.</string>
                 </property>
                 <property name="text">
                  <string>&amp;Stop</string>
@@ -549,7 +549,7 @@
             <item>
              <widget class="QComboBox" name="path_constraints_combo_box">
               <property name="toolTip">
-               <string>Set path constraints from the database. </string>
+               <string>Select path constraints from the database. </string>
               </property>
              </widget>
             </item>
@@ -610,7 +610,7 @@
               <item>
                <widget class="QLabel" name="label_9">
                 <property name="toolTip">
-                 <string>The maximum amount of time the planner is allowed to take. This is the total amount, not the amount of time per planning attempt.</string>
+                 <string>Total time allowed for planning.  Planning stops if time or number of attempts is exceeded, or goal is reached.</string>
                 </property>
                 <property name="text">
                  <string>Planning Time (s):</string>
@@ -652,7 +652,7 @@
               <item>
                <widget class="QLabel" name="label_10">
                 <property name="toolTip">
-                 <string>Maximum allowed number of planning attempts.</string>
+                 <string>Allowed number of planning attempts. Planning stops if time or number of attempts is exceeded, or goal is reached.</string>
                 </property>
                 <property name="text">
                  <string>Planning Attempts:</string>
@@ -691,7 +691,7 @@
               <item>
                <widget class="QLabel" name="label_11">
                 <property name="toolTip">
-                 <string>Velocity scaling (applied to each joint)</string>
+                 <string>Factor (between 0 and 1) that scales maximum joint velocities</string>
                 </property>
                 <property name="text">
                  <string>Velocity Scaling:</string>
@@ -727,7 +727,7 @@
               <item>
                <widget class="QLabel" name="label_20">
                 <property name="toolTip">
-                 <string>Acceleration scaling (applied to each joint)</string>
+                 <string>Factor (between 0 and 1) that scales maximum joint accelerations</string>
                 </property>
                 <property name="text">
                  <string>Accel. Scaling:</string>
@@ -770,7 +770,9 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Check this to generate a linear path in Cartesian (3D) space</string>
+               <string>Check this to generate a linear path in Cartesian (3D) space.
+
+ This does not plan around obstacles. </string>
               </property>
               <property name="text">
                <string>Use Cartesian Path</string>
@@ -795,10 +797,12 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>If checked, a new IK solution is calculated whenever the robot state is in collision. This setting only affects the state set via the interactive marker. Planning is always aware of collisions.</string>
+               <string>If checked, the IK solver tried to avoid collisions when searching for the state set via the interactive marker.
+
+This is usually achieved by random seeing, which can flip the robot configuration (e.g. elbow up/down). Note that motion planning is always collision-aware, regardless of this checkbox.</string>
               </property>
               <property name="text">
-               <string>Reset IK on collision</string>
+               <string>Collision-aware IK</string>
               </property>
               <property name="checked">
                <bool>false</bool>
@@ -820,10 +824,35 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Allow approximate IK solutions</string>
+               <string>Allow approximate IK solutions, which deviate from the target pose. Useful when an exact solution cannot be found, e.g. for underactuated arms or when trying to reach an unreachable target.</string>
               </property>
               <property name="text">
                <string>Approx IK Solutions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="allow_external_program">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Allow controlling the interactive marker through ROS topics (under /rviz/moveit/marker/ ) published other nodes.</string>
+              </property>
+              <property name="text">
+               <string>External Comm.</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -842,7 +871,10 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Allows the robot to replan if the plan to be executed collides with the environment.</string>
+               <string>EXPERIMENTAL: Trigger replanning if new collisions are detected during plan execution. Only works for the &quot;Plan &amp; Execute&quot; button. </string>
+              </property>
+              <property name="autoFillBackground">
+               <bool>false</bool>
               </property>
               <property name="text">
                <string>Replanning</string>
@@ -867,35 +899,10 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Allows the robot to reposition its sensor to look around. A sensor needs to be set up and the planning algorithm has to support this, otherwise it has no effect.</string>
+               <string>EXPERIMENTAL: Allows the robot to reposition its sensor to look around to resolve apparent collisions. A sensor needs to be set up and the new measurements have to affect the collision scene, otherwise it has no effect. See tutorial.</string>
               </property>
               <property name="text">
                <string>Sensor Positioning</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="allow_external_program">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>30</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Allow communication with an external program that sends an interactive marker position to control the robot.</string>
-              </property>
-              <property name="text">
-               <string>External Comm.</string>
               </property>
               <property name="checked">
                <bool>false</bool>
@@ -2166,7 +2173,6 @@
   <tabstop>acceleration_scaling_factor</tabstop>
   <tabstop>allow_replanning</tabstop>
   <tabstop>allow_looking</tabstop>
-  <tabstop>allow_external_program</tabstop>
   <tabstop>path_constraints_combo_box</tabstop>
   <tabstop>goal_tolerance</tabstop>
   <tabstop>place_button</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -523,7 +523,7 @@
            <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
-             <height>6</height>
+             <height>41</height>
             </size>
            </property>
           </spacer>
@@ -552,20 +552,6 @@
                <string>Select path constraints from the database. </string>
               </property>
              </widget>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_11">
-              <item>
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>Goal Tolerance:</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QDoubleSpinBox" name="goal_tolerance"/>
-              </item>
-             </layout>
             </item>
            </layout>
           </widget>
@@ -2174,7 +2160,6 @@ This is usually achieved by random seeding, which can flip the robot configurati
   <tabstop>allow_replanning</tabstop>
   <tabstop>allow_looking</tabstop>
   <tabstop>path_constraints_combo_box</tabstop>
-  <tabstop>goal_tolerance</tabstop>
   <tabstop>place_button</tabstop>
   <tabstop>roi_center_x</tabstop>
   <tabstop>roi_center_y</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -2160,21 +2160,35 @@ This is usually achieved by random seeding, which can flip the robot configurati
   <tabstop>database_port</tabstop>
   <tabstop>reset_db_button</tabstop>
   <tabstop>database_connect_button</tabstop>
+  <tabstop>wcenter_x</tabstop>
+  <tabstop>wcenter_y</tabstop>
+  <tabstop>wcenter_z</tabstop>
+  <tabstop>wsize_x</tabstop>
+  <tabstop>wsize_y</tabstop>
+  <tabstop>wsize_z</tabstop>
   <tabstop>plan_button</tabstop>
   <tabstop>execute_button</tabstop>
   <tabstop>plan_and_execute_button</tabstop>
   <tabstop>stop_button</tabstop>
+  <tabstop>clear_octomap_button</tabstop>
   <tabstop>planning_group_combo_box</tabstop>
   <tabstop>start_state_combo_box</tabstop>
   <tabstop>goal_state_combo_box</tabstop>
-  <tabstop>clear_octomap_button</tabstop>
+  <tabstop>path_constraints_combo_box</tabstop>
   <tabstop>planning_time</tabstop>
   <tabstop>planning_attempts</tabstop>
   <tabstop>velocity_scaling_factor</tabstop>
   <tabstop>acceleration_scaling_factor</tabstop>
+  <tabstop>use_cartesian_path</tabstop>
+  <tabstop>collision_aware_ik</tabstop>
+  <tabstop>approximate_ik</tabstop>
+  <tabstop>allow_external_program</tabstop>
   <tabstop>allow_replanning</tabstop>
   <tabstop>allow_looking</tabstop>
-  <tabstop>path_constraints_combo_box</tabstop>
+  <tabstop>detected_objects_list</tabstop>
+  <tabstop>detect_objects_button</tabstop>
+  <tabstop>support_surfaces_list</tabstop>
+  <tabstop>pick_button</tabstop>
   <tabstop>place_button</tabstop>
   <tabstop>roi_center_x</tabstop>
   <tabstop>roi_center_y</tabstop>
@@ -2183,6 +2197,13 @@ This is usually achieved by random seeding, which can flip the robot configurati
   <tabstop>roi_size_y</tabstop>
   <tabstop>roi_size_z</tabstop>
   <tabstop>collision_objects_list</tabstop>
+  <tabstop>shape_size_x_spin_box</tabstop>
+  <tabstop>shape_size_z_spin_box</tabstop>
+  <tabstop>shape_size_y_spin_box</tabstop>
+  <tabstop>shapes_combo_box</tabstop>
+  <tabstop>add_object_button</tabstop>
+  <tabstop>remove_object_button</tabstop>
+  <tabstop>clear_scene_button</tabstop>
   <tabstop>object_x</tabstop>
   <tabstop>object_y</tabstop>
   <tabstop>object_z</tabstop>
@@ -2210,16 +2231,6 @@ This is usually achieved by random seeding, which can flip the robot configurati
   <tabstop>save_goal_state_button</tabstop>
   <tabstop>status_text</tabstop>
   <tabstop>tabWidget</tabstop>
-  <tabstop>wcenter_x</tabstop>
-  <tabstop>wcenter_y</tabstop>
-  <tabstop>wcenter_z</tabstop>
-  <tabstop>wsize_x</tabstop>
-  <tabstop>wsize_y</tabstop>
-  <tabstop>wsize_z</tabstop>
-  <tabstop>pick_button</tabstop>
-  <tabstop>support_surfaces_list</tabstop>
-  <tabstop>detected_objects_list</tabstop>
-  <tabstop>detect_objects_button</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -521,7 +521,7 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
+            <enum>QSizePolicy::Expanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -558,19 +558,6 @@
             </item>
            </layout>
           </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </item>
@@ -757,6 +744,19 @@
              </layout>
             </item>
             <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QCheckBox" name="use_cartesian_path">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -912,19 +912,6 @@ This is usually achieved by random seeding, which can flip the robot configurati
             </item>
            </layout>
           </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </item>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>532</width>
+    <width>507</width>
     <height>389</height>
    </rect>
   </property>
@@ -26,7 +26,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="context">
       <attribute name="title">
@@ -157,6 +157,12 @@
           </item>
           <item>
            <widget class="QPushButton" name="reset_db_button">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="styleSheet">
              <string notr="true">color:red</string>
             </property>
@@ -401,7 +407,7 @@
               <item>
                <widget class="QPushButton" name="plan_and_execute_button">
                 <property name="text">
-                 <string>Plan and E&amp;xecute</string>
+                 <string>Plan &amp;&amp; E&amp;xecute</string>
                 </property>
                </widget>
               </item>
@@ -409,6 +415,9 @@
                <widget class="QPushButton" name="stop_button">
                 <property name="enabled">
                  <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Send a stop() command to the move_group.</string>
                 </property>
                 <property name="text">
                  <string>&amp;Stop</string>
@@ -538,7 +547,11 @@
              <number>6</number>
             </property>
             <item>
-             <widget class="QComboBox" name="path_constraints_combo_box"/>
+             <widget class="QComboBox" name="path_constraints_combo_box">
+              <property name="toolTip">
+               <string>Set path constraints from the database. </string>
+              </property>
+             </widget>
             </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_11">
@@ -596,6 +609,9 @@
               </property>
               <item>
                <widget class="QLabel" name="label_9">
+                <property name="toolTip">
+                 <string>The maximum amount of time the planner is allowed to take. This is the total amount, not the amount of time per planning attempt.</string>
+                </property>
                 <property name="text">
                  <string>Planning Time (s):</string>
                 </property>
@@ -608,6 +624,15 @@
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>40</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="decimals">
+                 <number>1</number>
                 </property>
                 <property name="maximum">
                  <double>300.000000000000000</double>
@@ -626,6 +651,9 @@
               </property>
               <item>
                <widget class="QLabel" name="label_10">
+                <property name="toolTip">
+                 <string>Maximum allowed number of planning attempts.</string>
+                </property>
                 <property name="text">
                  <string>Planning Attempts:</string>
                 </property>
@@ -638,6 +666,12 @@
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>40</width>
+                  <height>0</height>
+                 </size>
                 </property>
                 <property name="maximum">
                  <number>1000</number>
@@ -656,6 +690,9 @@
               </property>
               <item>
                <widget class="QLabel" name="label_11">
+                <property name="toolTip">
+                 <string>Velocity scaling (applied to each joint)</string>
+                </property>
                 <property name="text">
                  <string>Velocity Scaling:</string>
                 </property>
@@ -663,11 +700,17 @@
               </item>
               <item>
                <widget class="QDoubleSpinBox" name="velocity_scaling_factor">
+                <property name="minimumSize">
+                 <size>
+                  <width>40</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="maximum">
                  <double>1.000000000000000</double>
                 </property>
                 <property name="singleStep">
-                 <double>0.010000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="value">
                  <double>1.000000000000000</double>
@@ -683,18 +726,27 @@
               </property>
               <item>
                <widget class="QLabel" name="label_20">
+                <property name="toolTip">
+                 <string>Acceleration scaling (applied to each joint)</string>
+                </property>
                 <property name="text">
-                 <string>Acceleration Scaling:</string>
+                 <string>Accel. Scaling:</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QDoubleSpinBox" name="acceleration_scaling_factor">
+                <property name="minimumSize">
+                 <size>
+                  <width>40</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="maximum">
                  <double>1.000000000000000</double>
                 </property>
                 <property name="singleStep">
-                 <double>0.010000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="value">
                  <double>1.000000000000000</double>
@@ -704,37 +756,22 @@
              </layout>
             </item>
             <item>
-             <widget class="QCheckBox" name="allow_replanning">
-              <property name="text">
-               <string>Allow Replanning</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="allow_looking">
-              <property name="text">
-               <string>Allow Sensor Positioning</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="allow_external_program">
-              <property name="text">
-               <string>Allow External Comm.</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
              <widget class="QCheckBox" name="use_cartesian_path">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Check this to generate a linear path in Cartesian (3D) space</string>
+              </property>
               <property name="text">
                <string>Use Cartesian Path</string>
               </property>
@@ -745,18 +782,123 @@
             </item>
             <item>
              <widget class="QCheckBox" name="collision_aware_ik">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>If checked, a new IK solution is calculated whenever the robot state is in collision. This setting only affects the state set via the interactive marker. Planning is always aware of collisions.</string>
+              </property>
               <property name="text">
-               <string>Use Collision-Aware IK</string>
+               <string>Reset IK on collision</string>
               </property>
               <property name="checked">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QCheckBox" name="approximate_ik">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Allow approximate IK solutions</string>
+              </property>
               <property name="text">
-               <string>Allow Approx IK Solutions</string>
+               <string>Approx IK Solutions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="allow_replanning">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Allows the robot to replan if the plan to be executed collides with the environment.</string>
+              </property>
+              <property name="text">
+               <string>Replanning</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="allow_looking">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Allows the robot to reposition its sensor to look around. A sensor needs to be set up and the planning algorithm has to support this, otherwise it has no effect.</string>
+              </property>
+              <property name="text">
+               <string>Sensor Positioning</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="allow_external_program">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Allow communication with an external program that sends an interactive marker position to control the robot.</string>
+              </property>
+              <property name="text">
+               <string>External Comm.</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -857,6 +999,18 @@
          <layout class="QGridLayout" name="gridLayout_14">
           <item row="0" column="2">
            <widget class="QDoubleSpinBox" name="roi_center_y">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="minimum">
              <double>-99.000000000000000</double>
             </property>
@@ -867,6 +1021,18 @@
           </item>
           <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="roi_size_x">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
@@ -877,6 +1043,18 @@
           </item>
           <item row="1" column="3">
            <widget class="QDoubleSpinBox" name="roi_size_z">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
@@ -887,6 +1065,18 @@
           </item>
           <item row="1" column="2">
            <widget class="QDoubleSpinBox" name="roi_size_y">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
@@ -904,6 +1094,18 @@
           </item>
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="roi_center_x">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="minimum">
              <double>-99.000000000000000</double>
             </property>
@@ -921,6 +1123,18 @@
           </item>
           <item row="0" column="3">
            <widget class="QDoubleSpinBox" name="roi_center_z">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="minimum">
              <double>-99.000000000000000</double>
             </property>
@@ -1009,6 +1223,18 @@
              <layout class="QHBoxLayout" name="horizontalLayout_16">
               <item>
                <widget class="QDoubleSpinBox" name="shape_size_x_spin_box">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="toolTip">
                  <string>x dimension</string>
                 </property>
@@ -1022,6 +1248,18 @@
               </item>
               <item>
                <widget class="QDoubleSpinBox" name="shape_size_z_spin_box">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="toolTip">
                  <string>y dimension</string>
                 </property>
@@ -1035,6 +1273,18 @@
               </item>
               <item>
                <widget class="QDoubleSpinBox" name="shape_size_y_spin_box">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="toolTip">
                  <string>z dimension</string>
                 </property>
@@ -1051,7 +1301,14 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_13">
               <item>
-               <widget class="QComboBox" name="shapes_combo_box"/>
+               <widget class="QComboBox" name="shapes_combo_box">
+                <property name="minimumSize">
+                 <size>
+                  <width>30</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </widget>
               </item>
               <item>
                <widget class="QToolButton" name="add_object_button">
@@ -1124,8 +1381,11 @@
         <layout class="QVBoxLayout" name="verticalLayout_20">
          <item>
           <widget class="QGroupBox" name="pose_scale_group_box">
+           <property name="toolTip">
+            <string>Change the pose and scale of the selected object</string>
+           </property>
            <property name="title">
-            <string>Change pose and scale of selected object</string>
+            <string>Change object pose/scale</string>
            </property>
            <layout class="QGridLayout" name="gridLayout">
             <property name="leftMargin">
@@ -1159,6 +1419,12 @@
             </item>
             <item row="1" column="1">
              <widget class="QDoubleSpinBox" name="object_x">
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <double>-999.990000000000009</double>
               </property>
@@ -1172,6 +1438,12 @@
             </item>
             <item row="2" column="3">
              <widget class="QDoubleSpinBox" name="object_rz">
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <double>-3.140000000000000</double>
               </property>
@@ -1185,6 +1457,12 @@
             </item>
             <item row="2" column="1">
              <widget class="QDoubleSpinBox" name="object_rx">
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <double>-3.140000000000000</double>
               </property>
@@ -1198,6 +1476,12 @@
             </item>
             <item row="2" column="2">
              <widget class="QDoubleSpinBox" name="object_ry">
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <double>-3.140000000000000</double>
               </property>
@@ -1211,6 +1495,12 @@
             </item>
             <item row="1" column="2">
              <widget class="QDoubleSpinBox" name="object_y">
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <double>-999.990000000000009</double>
               </property>
@@ -1242,7 +1532,7 @@
                <widget class="QSlider" name="scene_scale">
                 <property name="minimumSize">
                  <size>
-                  <width>160</width>
+                  <width>40</width>
                   <height>0</height>
                  </size>
                 </property>
@@ -1280,6 +1570,12 @@
             </item>
             <item row="1" column="3">
              <widget class="QDoubleSpinBox" name="object_z">
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <double>-999.990000000000009</double>
               </property>
@@ -1296,8 +1592,11 @@
          </item>
          <item>
           <widget class="QGroupBox" name="groupBox_5">
+           <property name="toolTip">
+            <string>Describes the selected object's pose, geometry and subframes.</string>
+           </property>
            <property name="title">
-            <string>Status of selected object</string>
+            <string>Object status</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_12">
             <property name="leftMargin">
@@ -1328,6 +1627,9 @@
               </property>
               <property name="textFormat">
                <enum>Qt::AutoText</enum>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
               </property>
               <property name="WordWrap" stdset="0">
                <bool>true</bool>
@@ -1371,10 +1673,16 @@
             <item>
              <widget class="QPushButton" name="publish_current_scene_button">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>40</width>
+                <height>0</height>
+               </size>
               </property>
               <property name="text">
                <string>&amp;Publish</string>
@@ -1396,6 +1704,18 @@
             </item>
             <item>
              <widget class="QPushButton" name="export_scene_geometry_text_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>40</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="toolTip">
                <string>Export scene geometry to a .scene file (only geometry information is preserved)</string>
               </property>
@@ -1406,6 +1726,18 @@
             </item>
             <item>
              <widget class="QPushButton" name="import_scene_geometry_text_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>40</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="toolTip">
                <string>Import scene geometry from a .scene file (only geometry information is preserved)</string>
               </property>
@@ -1835,8 +2167,6 @@
   <tabstop>allow_replanning</tabstop>
   <tabstop>allow_looking</tabstop>
   <tabstop>allow_external_program</tabstop>
-  <tabstop>collision_aware_ik</tabstop>
-  <tabstop>approximate_ik</tabstop>
   <tabstop>path_constraints_combo_box</tabstop>
   <tabstop>goal_tolerance</tabstop>
   <tabstop>place_button</tabstop>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -617,6 +617,9 @@
                   <height>0</height>
                  </size>
                 </property>
+                <property name="toolTip">
+                 <string>Total time allowed for planning.  Planning stops if time or number of attempts is exceeded, or goal is reached.</string>
+                </property>
                 <property name="decimals">
                  <number>1</number>
                 </property>
@@ -659,6 +662,9 @@
                   <height>0</height>
                  </size>
                 </property>
+                <property name="toolTip">
+                 <string>Allowed number of planning attempts. Planning stops if time or number of attempts is exceeded, or goal is reached.</string>
+                </property>
                 <property name="maximum">
                  <number>1000</number>
                 </property>
@@ -677,7 +683,7 @@
               <item>
                <widget class="QLabel" name="label_11">
                 <property name="toolTip">
-                 <string>Factor (between 0 and 1) that scales maximum joint velocities</string>
+                 <string>Factor (between 0 and 1) to scale down maximum joint velocities</string>
                 </property>
                 <property name="text">
                  <string>Velocity Scaling:</string>
@@ -691,6 +697,9 @@
                   <width>40</width>
                   <height>0</height>
                  </size>
+                </property>
+                <property name="toolTip">
+                 <string>Factor (between 0 and 1) to scale down maximum joint velocities</string>
                 </property>
                 <property name="maximum">
                  <double>1.000000000000000</double>
@@ -713,7 +722,7 @@
               <item>
                <widget class="QLabel" name="label_20">
                 <property name="toolTip">
-                 <string>Factor (between 0 and 1) that scales maximum joint accelerations</string>
+                 <string>Factor (between 0 and 1) to scale down maximum joint accelerations</string>
                 </property>
                 <property name="text">
                  <string>Accel. Scaling:</string>
@@ -727,6 +736,9 @@
                   <width>40</width>
                   <height>0</height>
                  </size>
+                </property>
+                <property name="toolTip">
+                 <string>Factor (between 0 and 1) to scale down maximum joint accelerations</string>
                 </property>
                 <property name="maximum">
                  <double>1.000000000000000</double>
@@ -832,7 +844,7 @@ This is usually achieved by random seeding, which can flip the robot configurati
                </size>
               </property>
               <property name="toolTip">
-               <string>Allow controlling the interactive marker through ROS topics (under /rviz/moveit/marker/ ) published other nodes.</string>
+               <string>Allow other nodes to control start and end poses as well as planning and execution, using ROS topics (/rviz/moveit/ ).</string>
               </property>
               <property name="text">
                <string>External Comm.</string>


### PR DESCRIPTION
### Description

I had a go at making the plugin smaller. This version isn't perfect either, but what is? Here are the before and after images:

**Before:**
![Screenshot from 2020-09-13 14-19-51](https://user-images.githubusercontent.com/4535737/93011196-2241e280-f5cf-11ea-8dbb-7ce387b4b243.png) ![Screenshot from 2020-09-13 14-20-03](https://user-images.githubusercontent.com/4535737/93011200-25d56980-f5cf-11ea-856e-b03a137d3df8.png)

**After:**
![Screenshot from 2020-09-13 14-21-00](https://user-images.githubusercontent.com/4535737/93011204-2a018700-f5cf-11ea-8490-aa7b1ddf0562.png) ![Screenshot from 2020-09-13 14-24-09](https://user-images.githubusercontent.com/4535737/93011207-2cfc7780-f5cf-11ea-80ef-6a9f2f35010e.png)

Changes:  
- Added tooltips
- Reduced the minimum size of entry fields so they can partially hide numbers if required (users will resize the panel when they need to change the values). This should only affect the layout when the user resizes to _under_ the previous minimum size. The previous sizes should look the same as before.
- Reordered and renamed options in the Planning tab. Some of these had confused me when I started out. Most of these are just suggestions and up for discussion though. I just took the liberty while I was at it.

Notes:  
- I don't know if `allowReplanning` and `allowLooking` have any effect. I have a feeling that this is stub functionality added by Ioan, but that was never fully implemented. Because it seems like no one uses these checkboxes (and they are not mentioned in the tutorials afaik) I moved them down.
- There is a progress bar at the bottom that appears during planning, but not execution. It doesn't seem very useful. If it can't work during execution (I haven't looked into it), it might be better to remove it.
- I would actually like to turn off `Use Collision-Aware IK` by default. The robot looks like it freaks out whenever you move it into a collision, and you always lose your IK configuration. Opinions?
- [Qt SizePolicy documentation](https://doc.qt.io/archives/qt-4.8/qsizepolicy.html#Policy-enum) 

This should be cherry-picked to Kinetic and Melodic if possible.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers