### PR TITLE
planning context is already loaded in move_group.launch

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -11,6 +11,9 @@
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
 
+  <!-- By default, we will load or override the robot_description -->
+  <arg name="load_robot_description" default="true"/>
+
   <!--
   By default, hide joint_state_publisher's GUI
 
@@ -21,11 +24,6 @@
   -->
   <arg name="use_gui" default="false" />
   <arg name="use_rviz" default="true" />
-
-  <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
-  </include>
 
   <!-- If needed, broadcast static tf for robot root -->
   [VIRTUAL_JOINT_BROADCASTER]
@@ -46,6 +44,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -8,6 +8,9 @@
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
 
+  <!-- By default, we won't load or override the robot_description -->
+  <arg name="load_robot_description" default="false"/>
+
   <!--
   By default, hide joint_state_publisher's GUI
 
@@ -31,11 +34,6 @@
     <arg name="urdf_path" value="$(arg urdf_path)"/>
   </include>
 
-  <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
-    <arg name="load_robot_description" value="false"/>
-  </include>
-
   <!-- If needed, broadcast static tf for robot root -->
   [VIRTUAL_JOINT_BROADCASTER]
 
@@ -54,6 +52,7 @@
     <arg name="fake_execution" value="false"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
   </include>  
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->


### PR DESCRIPTION
It looks that the `planning_context.launch` is included twice when running `demo*.launch` (in `move_group.launch` and `demo*.launch`. Here's a simplification proposal.