### PR TITLE
Add comment to MOVEIT_CLASS_FORWARD

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -47,7 +47,7 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);
+MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);  // Defines AllowedCollisionMatrixPtr, ConstPtr, WeakPtr... etc
 
 /** \brief The types of bodies that are considered for collision */
 namespace BodyTypes

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -41,7 +41,7 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(CollisionDetectorAllocator);
+MOVEIT_CLASS_FORWARD(CollisionDetectorAllocator);  // Defines CollisionDetectorAllocatorPtr, ConstPtr, WeakPtr... etc
 
 /** \brief An allocator for a compatible CollisionWorld/CollisionRobot pair. */
 class CollisionDetectorAllocator

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -45,7 +45,7 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(CollisionEnv);
+MOVEIT_CLASS_FORWARD(CollisionEnv);  // Defines CollisionEnvPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Provides the interface to the individual collision checking libraries. */
 class CollisionEnv

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -71,7 +71,7 @@ enum Type
  * CONDITIONAL) */
 typedef boost::function<bool(collision_detection::Contact&)> DecideContactFn;
 
-MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);
+MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);  // Defines AllowedCollisionMatrixPtr, ConstPtr, WeakPtr... etc
 
 /** @class AllowedCollisionMatrix
  *  @brief Definition of a structure for the allowed collision matrix. All elements in the collision world are referred

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
@@ -40,7 +40,7 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(CollisionPlugin);
+MOVEIT_CLASS_FORWARD(CollisionPlugin);  // Defines CollisionPluginPtr, ConstPtr, WeakPtr... etc
 
 /**
  * @brief Plugin API for loading a custom collision detection robot/world.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -48,12 +48,12 @@
 
 namespace shapes
 {
-MOVEIT_CLASS_FORWARD(Shape);
+MOVEIT_CLASS_FORWARD(Shape);  // Defines ShapePtr, ConstPtr, WeakPtr... etc
 }
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(World);
+MOVEIT_CLASS_FORWARD(World);  // Defines WorldPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Maintain a representation of the environment */
 class World

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -41,7 +41,7 @@
 
 namespace collision_detection
 {
-MOVEIT_CLASS_FORWARD(WorldDiff);
+MOVEIT_CLASS_FORWARD(WorldDiff);  // Defines WorldDiffPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Maintain a diff list of changes that have happened to a World. */
 class WorldDiff

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -109,7 +109,7 @@ struct GradientInfo
 };
 
 MOVEIT_CLASS_FORWARD(PosedDistanceField)
-MOVEIT_CLASS_FORWARD(BodyDecomposition);
+MOVEIT_CLASS_FORWARD(BodyDecomposition);  // Defines BodyDecompositionPtr, ConstPtr, WeakPtr... etc
 MOVEIT_CLASS_FORWARD(PosedBodySphereDecomposition)
 MOVEIT_CLASS_FORWARD(PosedBodyPointDecomposition)
 MOVEIT_CLASS_FORWARD(PosedBodySphereDecompositionVector)

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -53,7 +53,7 @@ static const double DEFAULT_RESOLUTION = .02;
 static const double DEFAULT_COLLISION_TOLERANCE = 0.0;
 static const double DEFAULT_MAX_PROPOGATION_DISTANCE = .25;
 
-MOVEIT_CLASS_FORWARD(CollisionEnvDistanceField);
+MOVEIT_CLASS_FORWARD(CollisionEnvDistanceField);  // Defines CollisionEnvDistanceFieldPtr, ConstPtr, WeakPtr... etc
 
 class CollisionEnvDistanceField : public CollisionEnv
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -50,7 +50,7 @@
  */
 namespace constraint_samplers
 {
-MOVEIT_CLASS_FORWARD(ConstraintSampler);
+MOVEIT_CLASS_FORWARD(ConstraintSampler);  // Defines ConstraintSamplerPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief ConstraintSampler is an abstract base class that allows the

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
@@ -41,7 +41,7 @@
 
 namespace constraint_samplers
 {
-MOVEIT_CLASS_FORWARD(ConstraintSamplerAllocator);
+MOVEIT_CLASS_FORWARD(ConstraintSamplerAllocator);  // Defines ConstraintSamplerAllocatorPtr, ConstPtr, WeakPtr... etc
 
 class ConstraintSamplerAllocator
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -41,7 +41,7 @@
 
 namespace constraint_samplers
 {
-MOVEIT_CLASS_FORWARD(ConstraintSamplerManager);
+MOVEIT_CLASS_FORWARD(ConstraintSamplerManager);  // Defines ConstraintSamplerManagerPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief This class assists in the generation of a ConstraintSampler for a

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -42,7 +42,7 @@
 
 namespace constraint_samplers
 {
-MOVEIT_CLASS_FORWARD(JointConstraintSampler);
+MOVEIT_CLASS_FORWARD(JointConstraintSampler);  // Defines JointConstraintSamplerPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief JointConstraintSampler is a class that allows the sampling
@@ -279,7 +279,7 @@ struct IKSamplingPose
       orientation_constraint_; /**< \brief Holds the orientation constraint for sampling */
 };
 
-MOVEIT_CLASS_FORWARD(IKConstraintSampler);
+MOVEIT_CLASS_FORWARD(IKConstraintSampler);  // Defines IKConstraintSamplerPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief A class that allows the sampling of IK constraints.

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -98,7 +98,7 @@ private:
   Value status_;
 };
 
-MOVEIT_CLASS_FORWARD(MoveItControllerHandle);
+MOVEIT_CLASS_FORWARD(MoveItControllerHandle);  // Defines MoveItControllerHandlePtr, ConstPtr, WeakPtr... etc
 
 /** \brief MoveIt sends commands to a controller via a handle that satisfies this interface. */
 class MoveItControllerHandle
@@ -146,7 +146,7 @@ protected:
   std::string name_;
 };
 
-MOVEIT_CLASS_FORWARD(MoveItControllerManager);
+MOVEIT_CLASS_FORWARD(MoveItControllerManager);  // Defines MoveItControllerManagerPtr, ConstPtr, WeakPtr... etc
 
 /** @brief MoveIt does not enforce how controllers are implemented.
     To make your controllers usable by MoveIt, this interface needs to be implemented.

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -47,7 +47,7 @@
 
 namespace shapes
 {
-MOVEIT_CLASS_FORWARD(Shape);
+MOVEIT_CLASS_FORWARD(Shape);  // Defines ShapePtr, ConstPtr, WeakPtr... etc
 }
 namespace octomap
 {
@@ -71,7 +71,7 @@ enum PlaneVisualizationType
   YZ_PLANE
 };
 
-MOVEIT_CLASS_FORWARD(DistanceField);
+MOVEIT_CLASS_FORWARD(DistanceField);  // Defines DistanceFieldPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief DistanceField is an abstract base class for computing

--- a/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
+++ b/moveit_core/dynamics_solver/include/moveit/dynamics_solver/dynamics_solver.h
@@ -49,7 +49,7 @@
 /** \brief This namespace includes the dynamics_solver library */
 namespace dynamics_solver
 {
-MOVEIT_CLASS_FORWARD(DynamicsSolver);
+MOVEIT_CLASS_FORWARD(DynamicsSolver);  // Defines DynamicsSolverPtr, ConstPtr, WeakPtr... etc
 
 /**
  * This solver currently computes the required torques given a

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -71,7 +71,7 @@ struct ConstraintEvaluationResult
   double distance; /**< \brief The distance evaluation from the constraint or constraints */
 };
 
-MOVEIT_CLASS_FORWARD(KinematicConstraint);
+MOVEIT_CLASS_FORWARD(KinematicConstraint);  // Defines KinematicConstraintPtr, ConstPtr, WeakPtr... etc
 
 /// \brief Base class for representing a kinematic constraint
 class KinematicConstraint
@@ -178,7 +178,7 @@ protected:
                                 distance computed by the decide() function  */
 };
 
-MOVEIT_CLASS_FORWARD(JointConstraint);
+MOVEIT_CLASS_FORWARD(JointConstraint);  // Defines JointConstraintPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief Class for handling single DOF joint constraints.
@@ -331,7 +331,7 @@ protected:
   double joint_position_, joint_tolerance_above_, joint_tolerance_below_; /**< \brief Position and tolerance values*/
 };
 
-MOVEIT_CLASS_FORWARD(OrientationConstraint);
+MOVEIT_CLASS_FORWARD(OrientationConstraint);  // Defines OrientationConstraintPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief Class for constraints on the orientation of a link
@@ -490,7 +490,7 @@ protected:
       absolute_z_axis_tolerance_; /**< \brief Storage for the tolerances */
 };
 
-MOVEIT_CLASS_FORWARD(PositionConstraint);
+MOVEIT_CLASS_FORWARD(PositionConstraint);  // Defines PositionConstraintPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief Class for constraints on the XYZ position of a link
@@ -652,7 +652,7 @@ protected:
   const moveit::core::LinkModel* link_model_; /**< \brief The link model constraint subject */
 };
 
-MOVEIT_CLASS_FORWARD(VisibilityConstraint);
+MOVEIT_CLASS_FORWARD(VisibilityConstraint);  // Defines VisibilityConstraintPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief Class for constraints on the visibility relationship between
@@ -852,7 +852,7 @@ protected:
   double max_range_angle_;           /**< \brief Storage for the max range angle */
 };
 
-MOVEIT_CLASS_FORWARD(KinematicConstraintSet);
+MOVEIT_CLASS_FORWARD(KinematicConstraintSet);  // Defines KinematicConstraintSetPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief A class that contains many different constraints, and can

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -135,7 +135,7 @@ struct KinematicsResult
                                        of solutions explored. */
 };
 
-MOVEIT_CLASS_FORWARD(KinematicsBase);
+MOVEIT_CLASS_FORWARD(KinematicsBase);  // Defines KinematicsBasePtr, ConstPtr, WeakPtr... etc
 
 /**
  * @class KinematicsBase

--- a/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
+++ b/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
@@ -41,7 +41,7 @@
 /** @brief Namespace for kinematics metrics */
 namespace kinematics_metrics
 {
-MOVEIT_CLASS_FORWARD(KinematicsMetrics);
+MOVEIT_CLASS_FORWARD(KinematicsMetrics);  // Defines KinematicsMetricsPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief Compute different kinds of metrics for kinematics evaluation. Currently includes

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -44,7 +44,7 @@
 
 namespace planning_scene
 {
-MOVEIT_CLASS_FORWARD(PlanningScene);
+MOVEIT_CLASS_FORWARD(PlanningScene);  // Defines PlanningScenePtr, ConstPtr, WeakPtr... etc
 }
 
 /** \brief This namespace includes the base class for MoveIt planners */
@@ -73,7 +73,7 @@ struct PlannerConfigurationSettings
 /** \brief Map from PlannerConfigurationSettings.name to PlannerConfigurationSettings */
 typedef std::map<std::string, PlannerConfigurationSettings> PlannerConfigurationMap;
 
-MOVEIT_CLASS_FORWARD(PlanningContext);
+MOVEIT_CLASS_FORWARD(PlanningContext);  // Defines PlanningContextPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Representation of a particular planning context -- the planning scene and the request are known,
     solution is not yet computed. */
@@ -144,7 +144,7 @@ protected:
   MotionPlanRequest request_;
 };
 
-MOVEIT_CLASS_FORWARD(PlannerManager);
+MOVEIT_CLASS_FORWARD(PlannerManager);  // Defines PlannerManagerPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Base class for a MoveIt planner */
 class PlannerManager

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -44,7 +44,7 @@
 /** \brief Generic interface to adapting motion planning requests */
 namespace planning_request_adapter
 {
-MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);
+MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);  // Defines PlanningRequestAdapterPtr, ConstPtr, WeakPtr... etc
 
 class PlanningRequestAdapter
 {

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -59,7 +59,7 @@
 /** \brief This namespace includes the central class for representing planning contexts */
 namespace planning_scene
 {
-MOVEIT_CLASS_FORWARD(PlanningScene);
+MOVEIT_CLASS_FORWARD(PlanningScene);  // Defines PlanningScenePtr, ConstPtr, WeakPtr... etc
 
 /** \brief This is the function signature for additional feasibility checks to be imposed on states (in addition to
    respecting constraints and collision avoidance).

--- a/moveit_core/robot_model/include/moveit/robot_model/link_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/link_model.h
@@ -47,7 +47,7 @@
 
 namespace shapes
 {
-MOVEIT_CLASS_FORWARD(Shape);
+MOVEIT_CLASS_FORWARD(Shape);  // Defines ShapePtr, ConstPtr, WeakPtr... etc
 }
 
 namespace moveit

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -59,7 +59,7 @@ namespace moveit
 /** \brief Core components of MoveIt */
 namespace core
 {
-MOVEIT_CLASS_FORWARD(RobotModel);
+MOVEIT_CLASS_FORWARD(RobotModel);  // Defines RobotModelPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Definition of a kinematic model. This class is not thread
     safe, however multiple instances can be created */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -59,7 +59,7 @@ namespace moveit
 {
 namespace core
 {
-MOVEIT_CLASS_FORWARD(RobotState);
+MOVEIT_CLASS_FORWARD(RobotState);  // Defines RobotStatePtr, ConstPtr, WeakPtr... etc
 
 /** \brief Signature for functions that can verify that if the group \e joint_group in \e robot_state is set to \e
    joint_group_variable_values

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -44,7 +44,7 @@
 
 namespace robot_trajectory
 {
-MOVEIT_CLASS_FORWARD(RobotTrajectory);
+MOVEIT_CLASS_FORWARD(RobotTrajectory);  // Defines RobotTrajectoryPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Maintain a sequence of waypoints and the time durations
     between these waypoints */

--- a/moveit_core/sensor_manager/include/moveit/sensor_manager/sensor_manager.h
+++ b/moveit_core/sensor_manager/include/moveit/sensor_manager/sensor_manager.h
@@ -70,7 +70,7 @@ struct SensorInfo
   double y_angle;
 };
 
-MOVEIT_CLASS_FORWARD(MoveItSensorManager);
+MOVEIT_CLASS_FORWARD(MoveItSensorManager);  // Defines MoveItSensorManagerPtr, ConstPtr, WeakPtr... etc
 
 class MoveItSensorManager
 {

--- a/moveit_core/transforms/include/moveit/transforms/transforms.h
+++ b/moveit_core/transforms/include/moveit/transforms/transforms.h
@@ -45,7 +45,7 @@ namespace moveit
 {
 namespace core
 {
-MOVEIT_CLASS_FORWARD(Transforms);
+MOVEIT_CLASS_FORWARD(Transforms);  // Defines TransformsPtr, ConstPtr, WeakPtr... etc
 
 /// @brief Map frame names to the transformation matrix that can transform objects from the frame name to the planning
 /// frame

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
@@ -42,7 +42,7 @@
 
 namespace chomp_interface
 {
-MOVEIT_CLASS_FORWARD(CHOMPInterface);
+MOVEIT_CLASS_FORWARD(CHOMPInterface);  // Defines CHOMPInterfacePtr, ConstPtr, WeakPtr... etc
 
 class CHOMPInterface : public chomp::ChompPlanner
 {

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -41,7 +41,7 @@
 
 namespace chomp_interface
 {
-MOVEIT_CLASS_FORWARD(CHOMPPlanningContext);
+MOVEIT_CLASS_FORWARD(CHOMPPlanningContext);  // Defines CHOMPPlanningContextPtr, ConstPtr, WeakPtr... etc
 
 class CHOMPPlanningContext : public planning_interface::PlanningContext
 {

--- a/moveit_planners/ompl/ompl_interface/cfg/cpp/ompl_interface_ros/OMPLDynamicReconfigureConfig.h
+++ b/moveit_planners/ompl/ompl_interface/cfg/cpp/ompl_interface_ros/OMPLDynamicReconfigureConfig.h
@@ -62,7 +62,7 @@ class OMPLDynamicReconfigureConfigStatics;
 class OMPLDynamicReconfigureConfig
 {
 public:
-  MOVEIT_CLASS_FORWARD(AbstractParamDescription);
+  MOVEIT_CLASS_FORWARD(AbstractParamDescription);  // Defines AbstractParamDescriptionPtr, ConstPtr, WeakPtr... etc
   class AbstractParamDescription : public dynamic_reconfigure::ParamDescription
   {
   public:
@@ -141,7 +141,7 @@ public:
     }
   };
 
-  MOVEIT_CLASS_FORWARD(AbstractGroupDescription);
+  MOVEIT_CLASS_FORWARD(AbstractGroupDescription);  // Defines AbstractGroupDescriptionPtr, ConstPtr, WeakPtr... etc
   class AbstractGroupDescription : public dynamic_reconfigure::Group
   {
   public:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_valid_state_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_valid_state_sampler.h
@@ -45,7 +45,7 @@ namespace ompl_interface
 {
 class ModelBasedPlanningContext;
 
-MOVEIT_CLASS_FORWARD(ValidStateSampler);
+MOVEIT_CLASS_FORWARD(ValidStateSampler);  // Defines ValidStateSamplerPtr, ConstPtr, WeakPtr... etc
 
 /** @class ValidConstrainedSampler
  *  This class defines a sampler that tries to find a valid sample that satisfies the specified constraints */

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraints_library.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraints_library.h
@@ -155,7 +155,7 @@ struct ConstraintApproximationConstructionResults
   double sampling_success_rate;
 };
 
-MOVEIT_CLASS_FORWARD(ConstraintsLibrary);
+MOVEIT_CLASS_FORWARD(ConstraintsLibrary);  // Defines ConstraintsLibraryPtr, ConstPtr, WeakPtr... etc
 
 class ConstraintsLibrary
 {

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -52,8 +52,8 @@ namespace ob = ompl::base;
 namespace og = ompl::geometric;
 namespace ot = ompl::tools;
 
-MOVEIT_CLASS_FORWARD(ModelBasedPlanningContext);
-MOVEIT_CLASS_FORWARD(ConstraintsLibrary);
+MOVEIT_CLASS_FORWARD(ModelBasedPlanningContext);  // Defines ModelBasedPlanningContextPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(ConstraintsLibrary);         // Defines ConstraintsLibraryPtr, ConstPtr, WeakPtr... etc
 
 struct ModelBasedPlanningContextSpecification;
 typedef std::function<ob::PlannerPtr(const ompl::base::SpaceInformationPtr& si, const std::string& name,

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space_factory.h
@@ -42,7 +42,7 @@
 
 namespace ompl_interface
 {
-MOVEIT_CLASS_FORWARD(ModelBasedStateSpaceFactory);
+MOVEIT_CLASS_FORWARD(ModelBasedStateSpaceFactory);  // Defines ModelBasedStateSpaceFactoryPtr, ConstPtr, WeakPtr... etc
 
 class ModelBasedStateSpaceFactory
 {

--- a/moveit_planners/trajopt/include/trajopt_interface/problem_description.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/problem_description.h
@@ -38,19 +38,19 @@ where j indexes over DOF, and \f$c_j\f$ are the coeffs.
 */
 
 struct TermInfo;
-MOVEIT_CLASS_FORWARD(TermInfo);
+MOVEIT_CLASS_FORWARD(TermInfo);  // Defines TermInfoPtr, ConstPtr, WeakPtr... etc
 
 class TrajOptProblem;
-MOVEIT_CLASS_FORWARD(TrajOptProblem);
+MOVEIT_CLASS_FORWARD(TrajOptProblem);  // Defines TrajOptProblemPtr, ConstPtr, WeakPtr... etc
 
 struct JointPoseTermInfo;
-MOVEIT_CLASS_FORWARD(JointPoseTermInfo);
+MOVEIT_CLASS_FORWARD(JointPoseTermInfo);  // Defines JointPoseTermInfoPtr, ConstPtr, WeakPtr... etc
 
 struct CartPoseTermInfo;
-MOVEIT_CLASS_FORWARD(CartPoseTermInfo);
+MOVEIT_CLASS_FORWARD(CartPoseTermInfo);  // Defines CartPoseTermInfoPtr, ConstPtr, WeakPtr... etc
 
 struct JointVelTermInfo;
-MOVEIT_CLASS_FORWARD(JointVelTermInfo);
+MOVEIT_CLASS_FORWARD(JointVelTermInfo);  // Defines JointVelTermInfoPtr, ConstPtr, WeakPtr... etc
 
 struct ProblemInfo;
 TrajOptProblemPtr ConstructProblem(const ProblemInfo&);

--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_interface.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_interface.h
@@ -42,7 +42,7 @@
 
 namespace trajopt_interface
 {
-MOVEIT_CLASS_FORWARD(TrajOptInterface);
+MOVEIT_CLASS_FORWARD(TrajOptInterface);  // Defines TrajOptInterfacePtr, ConstPtr, WeakPtr... etc
 
 class TrajOptInterface
 {

--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
@@ -7,7 +7,7 @@
 
 namespace trajopt_interface
 {
-MOVEIT_CLASS_FORWARD(TrajOptPlanningContext);
+MOVEIT_CLASS_FORWARD(TrajOptPlanningContext);  // Defines TrajOptPlanningContextPtr, ConstPtr, WeakPtr... etc
 
 class TrajOptPlanningContext : public planning_interface::PlanningContext
 {

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -46,7 +46,7 @@
 
 namespace moveit_fake_controller_manager
 {
-MOVEIT_CLASS_FORWARD(BaseFakeController);
+MOVEIT_CLASS_FORWARD(BaseFakeController);  // Defines BaseFakeControllerPtr, ConstPtr, WeakPtr... etc
 
 // common base class to all fake controllers in this package
 class BaseFakeController : public moveit_controller_manager::MoveItControllerHandle

--- a/moveit_plugins/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
+++ b/moveit_plugins/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
@@ -41,7 +41,7 @@
 
 namespace moveit_ros_control_interface
 {
-MOVEIT_CLASS_FORWARD(ControllerHandleAllocator);
+MOVEIT_CLASS_FORWARD(ControllerHandleAllocator);  // Defines ControllerHandleAllocatorPtr, ConstPtr, WeakPtr... etc
 
 /**
  * Base class for MoveItControllerHandle allocators

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -73,7 +73,7 @@ bool checkTimeout(ros::Time& t, double timeout, bool force = false)
   return false;
 }
 
-MOVEIT_CLASS_FORWARD(MoveItControllerManager);
+MOVEIT_CLASS_FORWARD(MoveItControllerManager);  // Defines MoveItControllerManagerPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief moveit_controller_manager::MoveItControllerManager sub class that interfaces one ros_control

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -61,7 +61,8 @@ public:
   }
 };
 
-MOVEIT_CLASS_FORWARD(ActionBasedControllerHandleBase);
+MOVEIT_CLASS_FORWARD(
+    ActionBasedControllerHandleBase);  // Defines ActionBasedControllerHandleBasePtr, ConstPtr, WeakPtr... etc
 
 /*
  * This is a simple base class, which handles all of the action creation/etc

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_stage.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_stage.h
@@ -42,7 +42,7 @@
 
 namespace pick_place
 {
-MOVEIT_CLASS_FORWARD(ManipulationStage);
+MOVEIT_CLASS_FORWARD(ManipulationStage);  // Defines ManipulationStagePtr, ConstPtr, WeakPtr... etc
 
 class ManipulationStage
 {

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/pick_place.h
@@ -48,7 +48,7 @@
 
 namespace pick_place
 {
-MOVEIT_CLASS_FORWARD(PickPlace);
+MOVEIT_CLASS_FORWARD(PickPlace);  // Defines PickPlacePtr, ConstPtr, WeakPtr... etc
 
 class PickPlacePlanBase
 {
@@ -92,7 +92,7 @@ protected:
   moveit_msgs::MoveItErrorCodes error_code_;
 };
 
-MOVEIT_CLASS_FORWARD(PickPlan);
+MOVEIT_CLASS_FORWARD(PickPlan);  // Defines PickPlanPtr, ConstPtr, WeakPtr... etc
 
 class PickPlan : public PickPlacePlanBase
 {
@@ -101,7 +101,7 @@ public:
   bool plan(const planning_scene::PlanningSceneConstPtr& planning_scene, const moveit_msgs::PickupGoal& goal);
 };
 
-MOVEIT_CLASS_FORWARD(PlacePlan);
+MOVEIT_CLASS_FORWARD(PlacePlan);  // Defines PlacePlanPtr, ConstPtr, WeakPtr... etc
 
 class PlacePlan : public PickPlacePlanBase
 {

--- a/moveit_ros/move_group/include/moveit/move_group/move_group_capability.h
+++ b/moveit_ros/move_group/include/moveit/move_group/move_group_capability.h
@@ -52,7 +52,7 @@ enum MoveGroupState
   LOOK
 };
 
-MOVEIT_CLASS_FORWARD(MoveGroupCapability);
+MOVEIT_CLASS_FORWARD(MoveGroupCapability);  // Defines MoveGroupCapabilityPtr, ConstPtr, WeakPtr... etc
 
 class MoveGroupCapability
 {

--- a/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
+++ b/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
@@ -40,23 +40,23 @@
 
 namespace planning_scene_monitor
 {
-MOVEIT_CLASS_FORWARD(PlanningSceneMonitor);
+MOVEIT_CLASS_FORWARD(PlanningSceneMonitor);  // Defines PlanningSceneMonitorPtr, ConstPtr, WeakPtr... etc
 }
 
 namespace planning_pipeline
 {
-MOVEIT_CLASS_FORWARD(PlanningPipeline);
+MOVEIT_CLASS_FORWARD(PlanningPipeline);  // Defines PlanningPipelinePtr, ConstPtr, WeakPtr... etc
 }
 
 namespace plan_execution
 {
-MOVEIT_CLASS_FORWARD(PlanExecution);
-MOVEIT_CLASS_FORWARD(PlanWithSensing);
+MOVEIT_CLASS_FORWARD(PlanExecution);    // Defines PlanExecutionPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(PlanWithSensing);  // Defines PlanWithSensingPtr, ConstPtr, WeakPtr... etc
 }  // namespace plan_execution
 
 namespace trajectory_execution_manager
 {
-MOVEIT_CLASS_FORWARD(TrajectoryExecutionManager);
+MOVEIT_CLASS_FORWARD(TrajectoryExecutionManager);  // Defines TrajectoryExecutionManagerPtr, ConstPtr, WeakPtr... etc
 }
 
 namespace move_group

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -53,7 +53,7 @@ typedef boost::function<bool(const std::string& target_frame, const ros::Time& t
 
 class OccupancyMapMonitor;
 
-MOVEIT_CLASS_FORWARD(OccupancyMapUpdater);
+MOVEIT_CLASS_FORWARD(OccupancyMapUpdater);  // Defines OccupancyMapUpdaterPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Base class for classes which update the occupancy map.
  */

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/filter_job.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/filter_job.h
@@ -43,7 +43,7 @@
 
 namespace mesh_filter
 {
-MOVEIT_CLASS_FORWARD(Job);
+MOVEIT_CLASS_FORWARD(Job);  // Defines JobPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief This class is used to execute functions within the thread that holds the OpenGL context.

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
@@ -48,7 +48,7 @@
 
 namespace mesh_filter
 {
-MOVEIT_CLASS_FORWARD(GLRenderer);
+MOVEIT_CLASS_FORWARD(GLRenderer);  // Defines GLRendererPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Abstracts the OpenGL frame buffer objects, and provides an interface to render meshes, and retrieve the color
  * and depth ap from opengl.

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.h
@@ -53,8 +53,8 @@ class Mesh;
 
 namespace mesh_filter
 {
-MOVEIT_CLASS_FORWARD(Job);
-MOVEIT_CLASS_FORWARD(GLMesh);
+MOVEIT_CLASS_FORWARD(Job);     // Defines JobPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(GLMesh);  // Defines GLMeshPtr, ConstPtr, WeakPtr... etc
 
 typedef unsigned int MeshHandle;
 typedef uint32_t LabelType;

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/sensor_model.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/sensor_model.h
@@ -51,7 +51,7 @@ class GLRenderer;
 class SensorModel
 {
 public:
-  MOVEIT_CLASS_FORWARD(Parameters);
+  MOVEIT_CLASS_FORWARD(Parameters);  // Defines ParametersPtr, ConstPtr, WeakPtr... etc
 
   /**
    * \brief Abstract Interface defining Sensor Parameters.

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -120,7 +120,7 @@ private:
    */
   void updateTransforms();
 
-  MOVEIT_CLASS_FORWARD(TransformContext);
+  MOVEIT_CLASS_FORWARD(TransformContext);  // Defines TransformContextPtr, ConstPtr, WeakPtr... etc
 
   /**
    * \brief Context Object for registered frames

--- a/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
+++ b/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
@@ -46,14 +46,14 @@
 
 namespace shapes
 {
-MOVEIT_CLASS_FORWARD(Shape);
+MOVEIT_CLASS_FORWARD(Shape);  // Defines ShapePtr, ConstPtr, WeakPtr... etc
 }
 
 namespace moveit
 {
 namespace semantic_world
 {
-MOVEIT_CLASS_FORWARD(SemanticWorld);
+MOVEIT_CLASS_FORWARD(SemanticWorld);  // Defines SemanticWorldPtr, ConstPtr, WeakPtr... etc
 
 /**
  * @brief A (simple) semantic world representation for pick and place and other tasks.

--- a/moveit_ros/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
+++ b/moveit_ros/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
@@ -62,7 +62,7 @@ public:
   bool activate(const std::string& name, const planning_scene::PlanningScenePtr& scene, bool exclusive);
 
 private:
-  MOVEIT_CLASS_FORWARD(CollisionPluginLoaderImpl);
+  MOVEIT_CLASS_FORWARD(CollisionPluginLoaderImpl);  // Defines CollisionPluginLoaderImplPtr, ConstPtr, WeakPtr... etc
   CollisionPluginLoaderImplPtr loader_;
 };
 

--- a/moveit_ros/planning/constraint_sampler_manager_loader/include/moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/include/moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h
@@ -41,7 +41,8 @@
 
 namespace constraint_sampler_manager_loader
 {
-MOVEIT_CLASS_FORWARD(ConstraintSamplerManagerLoader);
+MOVEIT_CLASS_FORWARD(
+    ConstraintSamplerManagerLoader);  // Defines ConstraintSamplerManagerLoaderPtr, ConstPtr, WeakPtr... etc
 
 class ConstraintSamplerManagerLoader
 {

--- a/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -43,7 +43,7 @@
 
 namespace kinematics_plugin_loader
 {
-MOVEIT_CLASS_FORWARD(KinematicsPluginLoader);
+MOVEIT_CLASS_FORWARD(KinematicsPluginLoader);  // Defines KinematicsPluginLoaderPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Helper class for loading kinematics solvers */
 class KinematicsPluginLoader
@@ -103,7 +103,7 @@ private:
   std::string robot_description_;
   double default_search_resolution_;
 
-  MOVEIT_CLASS_FORWARD(KinematicsLoaderImpl);
+  MOVEIT_CLASS_FORWARD(KinematicsLoaderImpl);  // Defines KinematicsLoaderImplPtr, ConstPtr, WeakPtr... etc
   KinematicsLoaderImplPtr loader_;
 
   std::vector<std::string> groups_;

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -47,7 +47,7 @@
 /** \brief This namespace includes functionality specific to the execution and monitoring of motion plans */
 namespace plan_execution
 {
-MOVEIT_CLASS_FORWARD(PlanExecution);
+MOVEIT_CLASS_FORWARD(PlanExecution);  // Defines PlanExecutionPtr, ConstPtr, WeakPtr... etc
 
 class PlanExecution
 {

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_with_sensing.h
@@ -48,7 +48,7 @@
 
 namespace plan_execution
 {
-MOVEIT_CLASS_FORWARD(PlanWithSensing);
+MOVEIT_CLASS_FORWARD(PlanWithSensing);  // Defines PlanWithSensingPtr, ConstPtr, WeakPtr... etc
 
 class PlanWithSensing
 {

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -194,5 +194,5 @@ private:
   ros::Publisher contacts_publisher_;
 };
 
-MOVEIT_CLASS_FORWARD(PlanningPipeline);
+MOVEIT_CLASS_FORWARD(PlanningPipeline);  // Defines PlanningPipelinePtr, ConstPtr, WeakPtr... etc
 }  // namespace planning_pipeline

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -210,5 +210,5 @@ private:
   std::shared_ptr<TFConnection> tf_connection_;
 };
 
-MOVEIT_CLASS_FORWARD(CurrentStateMonitor);
+MOVEIT_CLASS_FORWARD(CurrentStateMonitor);  // Defines CurrentStateMonitorPtr, ConstPtr, WeakPtr... etc
 }  // namespace planning_scene_monitor

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -53,7 +53,7 @@
 
 namespace planning_scene_monitor
 {
-MOVEIT_CLASS_FORWARD(PlanningSceneMonitor);
+MOVEIT_CLASS_FORWARD(PlanningSceneMonitor);  // Defines PlanningSceneMonitorPtr, ConstPtr, WeakPtr... etc
 
 /**
  * @brief PlanningSceneMonitor

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -47,7 +47,7 @@ namespace planning_scene_monitor
 typedef boost::function<void(const moveit::core::RobotStateConstPtr& state, const ros::Time& stamp)>
     TrajectoryStateAddedCallback;
 
-MOVEIT_CLASS_FORWARD(TrajectoryMonitor);
+MOVEIT_CLASS_FORWARD(TrajectoryMonitor);  // Defines TrajectoryMonitorPtr, ConstPtr, WeakPtr... etc
 
 /** @class TrajectoryMonitor
     @brief Monitors the joint_states topic and tf to record the trajectory of the robot. */

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -42,7 +42,7 @@
 
 namespace rdf_loader
 {
-MOVEIT_CLASS_FORWARD(RDFLoader);
+MOVEIT_CLASS_FORWARD(RDFLoader);  // Defines RDFLoaderPtr, ConstPtr, WeakPtr... etc
 
 /** @class RDFLoader
  *  @brief Default constructor

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -43,7 +43,7 @@
 
 namespace robot_model_loader
 {
-MOVEIT_CLASS_FORWARD(RobotModelLoader);
+MOVEIT_CLASS_FORWARD(RobotModelLoader);  // Defines RobotModelLoaderPtr, ConstPtr, WeakPtr... etc
 
 /** @class RobotModelLoader */
 class RobotModelLoader

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -51,7 +51,7 @@
 
 namespace trajectory_execution_manager
 {
-MOVEIT_CLASS_FORWARD(TrajectoryExecutionManager);
+MOVEIT_CLASS_FORWARD(TrajectoryExecutionManager);  // Defines TrajectoryExecutionManagerPtr, ConstPtr, WeakPtr... etc
 
 // Two modes:
 // Managed controllers

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -89,7 +89,7 @@ public:
   }
 };
 
-MOVEIT_CLASS_FORWARD(MoveGroupInterface);
+MOVEIT_CLASS_FORWARD(MoveGroupInterface);  // Defines MoveGroupInterfacePtr, ConstPtr, WeakPtr... etc
 
 /** \class MoveGroupInterface move_group_interface.h moveit/planning_interface/move_group_interface.h
 

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -50,7 +50,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-MOVEIT_CLASS_FORWARD(MoveItCpp);
+MOVEIT_CLASS_FORWARD(MoveItCpp);  // Defines MoveItCppPtr, ConstPtr, WeakPtr... etc
 
 class MoveItCpp
 {

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -49,7 +49,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-MOVEIT_CLASS_FORWARD(PlanningComponent);
+MOVEIT_CLASS_FORWARD(PlanningComponent);  // Defines PlanningComponentPtr, ConstPtr, WeakPtr... etc
 
 class PlanningComponent
 {

--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -47,7 +47,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-MOVEIT_CLASS_FORWARD(PlanningSceneInterface);
+MOVEIT_CLASS_FORWARD(PlanningSceneInterface);  // Defines PlanningSceneInterfacePtr, ConstPtr, WeakPtr... etc
 
 class PlanningSceneInterface
 {

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -46,9 +46,9 @@
 
 namespace robot_interaction
 {
-MOVEIT_CLASS_FORWARD(InteractionHandler);
-MOVEIT_CLASS_FORWARD(RobotInteraction);
-MOVEIT_CLASS_FORWARD(KinematicOptionsMap);
+MOVEIT_CLASS_FORWARD(InteractionHandler);   // Defines InteractionHandlerPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(RobotInteraction);     // Defines RobotInteractionPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(KinematicOptionsMap);  // Defines KinematicOptionsMapPtr, ConstPtr, WeakPtr... etc
 
 struct EndEffectorInteraction;
 struct JointInteraction;

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -44,7 +44,7 @@
 
 namespace robot_interaction
 {
-MOVEIT_CLASS_FORWARD(LockedRobotState);
+MOVEIT_CLASS_FORWARD(LockedRobotState);  // Defines LockedRobotStatePtr, ConstPtr, WeakPtr... etc
 
 /// Maintain a RobotState in a multithreaded environment.
 //

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -57,9 +57,9 @@ class InteractiveMarkerServer;
 
 namespace robot_interaction
 {
-MOVEIT_CLASS_FORWARD(InteractionHandler);
-MOVEIT_CLASS_FORWARD(KinematicOptionsMap);
-MOVEIT_CLASS_FORWARD(RobotInteraction);
+MOVEIT_CLASS_FORWARD(InteractionHandler);   // Defines InteractionHandlerPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(KinematicOptionsMap);  // Defines KinematicOptionsMapPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(RobotInteraction);     // Defines RobotInteractionPtr, ConstPtr, WeakPtr... etc
 
 // Manage interactive markers for controlling a robot state.
 //

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -77,9 +77,9 @@ class MotionPlanningUI;
 
 namespace moveit_warehouse
 {
-MOVEIT_CLASS_FORWARD(PlanningSceneStorage);
-MOVEIT_CLASS_FORWARD(ConstraintsStorage);
-MOVEIT_CLASS_FORWARD(RobotStateStorage);
+MOVEIT_CLASS_FORWARD(PlanningSceneStorage);  // Defines PlanningSceneStoragePtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(ConstraintsStorage);    // Defines ConstraintsStoragePtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(RobotStateStorage);     // Defines RobotStateStoragePtr, ConstPtr, WeakPtr... etc
 }  // namespace moveit_warehouse
 
 namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
@@ -47,7 +47,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-MOVEIT_CLASS_FORWARD(MoveGroupInterface);
+MOVEIT_CLASS_FORWARD(MoveGroupInterface);  // Defines MoveGroupInterfacePtr, ConstPtr, WeakPtr... etc
 }
 }  // namespace moveit
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
@@ -54,9 +54,9 @@ class DisplayContext;
 
 namespace moveit_rviz_plugin
 {
-MOVEIT_CLASS_FORWARD(RobotStateVisualization);
-MOVEIT_CLASS_FORWARD(RenderShapes);
-MOVEIT_CLASS_FORWARD(PlanningSceneRender);
+MOVEIT_CLASS_FORWARD(RobotStateVisualization);  // Defines RobotStateVisualizationPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(RenderShapes);             // Defines RenderShapesPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(PlanningSceneRender);      // Defines PlanningSceneRenderPtr, ConstPtr, WeakPtr... etc
 
 class PlanningSceneRender
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
@@ -56,8 +56,8 @@ class Shape;
 
 namespace moveit_rviz_plugin
 {
-MOVEIT_CLASS_FORWARD(OcTreeRender);
-MOVEIT_CLASS_FORWARD(RenderShapes);
+MOVEIT_CLASS_FORWARD(OcTreeRender);  // Defines OcTreeRenderPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(RenderShapes);  // Defines RenderShapesPtr, ConstPtr, WeakPtr... etc
 
 class RenderShapes
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -47,8 +47,8 @@ DIAGNOSTIC_POP
 
 namespace moveit_rviz_plugin
 {
-MOVEIT_CLASS_FORWARD(RenderShapes);
-MOVEIT_CLASS_FORWARD(RobotStateVisualization);
+MOVEIT_CLASS_FORWARD(RenderShapes);             // Defines RenderShapesPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(RobotStateVisualization);  // Defines RobotStateVisualizationPtr, ConstPtr, WeakPtr... etc
 
 /** \brief Update the links of an rviz::Robot using a moveit::core::RobotState */
 class RobotStateVisualization

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -68,7 +68,7 @@ class MovableText;
 
 namespace moveit_rviz_plugin
 {
-MOVEIT_CLASS_FORWARD(TrajectoryVisualization);
+MOVEIT_CLASS_FORWARD(TrajectoryVisualization);  // Defines TrajectoryVisualizationPtr, ConstPtr, WeakPtr... etc
 
 class TrajectoryVisualization : public QObject
 {

--- a/moveit_ros/warehouse/warehouse/include/moveit/warehouse/constraints_storage.h
+++ b/moveit_ros/warehouse/warehouse/include/moveit/warehouse/constraints_storage.h
@@ -45,7 +45,7 @@ namespace moveit_warehouse
 typedef warehouse_ros::MessageWithMetadata<moveit_msgs::Constraints>::ConstPtr ConstraintsWithMetadata;
 typedef warehouse_ros::MessageCollection<moveit_msgs::Constraints>::Ptr ConstraintsCollection;
 
-MOVEIT_CLASS_FORWARD(ConstraintsStorage);
+MOVEIT_CLASS_FORWARD(ConstraintsStorage);  // Defines ConstraintsStoragePtr, ConstPtr, WeakPtr... etc
 
 class ConstraintsStorage : public MoveItMessageStorage
 {

--- a/moveit_ros/warehouse/warehouse/include/moveit/warehouse/planning_scene_storage.h
+++ b/moveit_ros/warehouse/warehouse/include/moveit/warehouse/planning_scene_storage.h
@@ -52,7 +52,7 @@ typedef warehouse_ros::MessageCollection<moveit_msgs::PlanningScene>::Ptr Planni
 typedef warehouse_ros::MessageCollection<moveit_msgs::MotionPlanRequest>::Ptr MotionPlanRequestCollection;
 typedef warehouse_ros::MessageCollection<moveit_msgs::RobotTrajectory>::Ptr RobotTrajectoryCollection;
 
-MOVEIT_CLASS_FORWARD(PlanningSceneStorage);
+MOVEIT_CLASS_FORWARD(PlanningSceneStorage);  // Defines PlanningSceneStoragePtr, ConstPtr, WeakPtr... etc
 
 class PlanningSceneStorage : public MoveItMessageStorage
 {

--- a/moveit_ros/warehouse/warehouse/include/moveit/warehouse/state_storage.h
+++ b/moveit_ros/warehouse/warehouse/include/moveit/warehouse/state_storage.h
@@ -45,7 +45,7 @@ namespace moveit_warehouse
 typedef warehouse_ros::MessageWithMetadata<moveit_msgs::RobotState>::ConstPtr RobotStateWithMetadata;
 typedef warehouse_ros::MessageCollection<moveit_msgs::RobotState>::Ptr RobotStateCollection;
 
-MOVEIT_CLASS_FORWARD(RobotStateStorage);
+MOVEIT_CLASS_FORWARD(RobotStateStorage);  // Defines RobotStateStoragePtr, ConstPtr, WeakPtr... etc
 
 class RobotStateStorage : public MoveItMessageStorage
 {

--- a/moveit_ros/warehouse/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
+++ b/moveit_ros/warehouse/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
@@ -46,7 +46,7 @@ typedef warehouse_ros::MessageWithMetadata<moveit_msgs::TrajectoryConstraints>::
     TrajectoryConstraintsWithMetadata;
 typedef warehouse_ros::MessageCollection<moveit_msgs::TrajectoryConstraints>::Ptr TrajectoryConstraintsCollection;
 
-MOVEIT_CLASS_FORWARD(TrajectoryConstraintsStorage);
+MOVEIT_CLASS_FORWARD(TrajectoryConstraintsStorage);  // Defines TrajectoryConstraintsStoragePtr, ConstPtr, WeakPtr... etc
 
 class TrajectoryConstraintsStorage : public MoveItMessageStorage
 {

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/compute_default_collisions.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/compute_default_collisions.h
@@ -40,7 +40,7 @@
 #include <moveit/macros/class_forward.h>
 namespace planning_scene
 {
-MOVEIT_CLASS_FORWARD(PlanningScene);
+MOVEIT_CLASS_FORWARD(PlanningScene);  // Defines PlanningScenePtr, ConstPtr, WeakPtr... etc
 }
 
 namespace moveit_setup_assistant

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -174,7 +174,7 @@ private:
   std::string comment_;  // comment briefly describing what this parameter does
 };
 
-MOVEIT_CLASS_FORWARD(MoveItConfigData);
+MOVEIT_CLASS_FORWARD(MoveItConfigData);  // Defines MoveItConfigDataPtr, ConstPtr, WeakPtr... etc
 
 /** \brief This class is shared with all widgets and contains the common configuration data
     needed for generating each robot's MoveIt configuration package.


### PR DESCRIPTION
### Description

This adds a comment to every call of `MOVEIT_CLASS_FORWARD`, making it easier to discover for new users, and allowing e.g. `RobotModelPtr` to be found through text search. I think the name of the macro could be more expressive, and I would prefer if all the definitions could be found by text, but this change should be helpful already.

This question came up on the Discord/[ROS Answers](https://answers.ros.org/question/361537/where-is-the-definition-of-the-ptr-naming-standard/), and @tylerjw and I both remember having trouble figuring this out ourselves.

The regex if you want to change wording: `find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs sed -i -E 's/(MOVEIT_CLASS_FORWARD)\(([A-Za-z]+)\);/\1(\2);  \/\/ Defines \2Ptr, ConstPtr, WeakPtr... etc/g' $1`

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers