### PR TITLE
[Kinetic] Let the max number of contacts be the amount of world objects + link models with geometry

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -11,7 +11,7 @@
 - git:
     local-name: moveit_resources
     uri: https://github.com/ros-planning/moveit_resources.git
-    version: master
+    version: 0.6.5
 - git:
     local-name: moveit_visual_tools
     uri: https://github.com/ros-planning/moveit_visual_tools.git

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -66,8 +66,8 @@ bool move_group::MoveGroupStateValidationService::computeService(moveit_msgs::Ge
   creq.group_name = req.group_name;
   creq.cost = true;
   creq.contacts = true;
-  creq.max_contacts = ls->getWorld()->size();
-  creq.max_cost_sources = creq.max_contacts + ls->getRobotModel()->getLinkModelsWithCollisionGeometry().size();
+  creq.max_contacts = ls->getWorld()->size() + ls->getRobotModel()->getLinkModelsWithCollisionGeometry().size();
+  creq.max_cost_sources = creq.max_contacts;
   creq.max_contacts *= creq.max_contacts;
   collision_detection::CollisionResult cres;
 

--- a/moveit_ros/move_group/test/test_check_state_validity_in_empty_scene.py
+++ b/moveit_ros/move_group/test/test_check_state_validity_in_empty_scene.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import sys
+import rospy
+import unittest
+from actionlib import SimpleActionClient
+import moveit_commander
+from moveit_msgs.msg import Constraints
+from moveit_msgs.srv import GetStateValidity
+
+
+class TestCheckStateValidityInEmptyScene(unittest.TestCase):
+
+    def setUp(self):
+        moveit_commander.roscpp_initialize(sys.argv)
+        self.robot_commander = moveit_commander.RobotCommander()
+        self.group_name = self.robot_commander.get_group_names()[0]
+        self.group_commander = moveit_commander.MoveGroupCommander(self.group_name)
+
+        self._check_state_validity = rospy.ServiceProxy('/check_state_validity', GetStateValidity)
+
+    def test_check_collision_free_state_validity_in_empty_scene(self):
+        current_robot_state = self.robot_commander.get_current_state()
+
+        validity_report = self._check_state_validity(current_robot_state, self.group_name, Constraints())
+        self.assertListEqual(validity_report.contacts, [], "In the default_robot_state, the robot should not collide with itself")
+
+
+    def test_check_colliding_state_validity_in_empty_scene(self):
+        current_robot_state = self.robot_commander.get_current_state()
+
+        current_robot_state.joint_state.position = list(current_robot_state.joint_state.position)
+        current_robot_state.joint_state.position[2] = -2  # Known to be in collision for a Fanuc M-10iA
+
+        validity_report = self._check_state_validity(current_robot_state, self.group_name, Constraints())
+
+        self.assertNotEqual(len(validity_report.contacts), 0, "When the robot collides with itself, it should have some contacts (with itself)")
+
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node('check_state_validity_in_empty_scene')
+    rostest.rosrun('moveit_ros_move_group', 'test_check_state_validity_in_empty_scene', TestCheckStateValidityInEmptyScene)

--- a/moveit_ros/move_group/test/test_check_state_validity_in_empty_scene.test
+++ b/moveit_ros/move_group/test/test_check_state_validity_in_empty_scene.test
@@ -1,0 +1,24 @@
+<launch>
+	<!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+		<arg name="load_robot_description" value="true"/>
+	</include>
+
+	<!-- We do not have a robot connected, so publish fake joint states -->
+	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+		<param name="use_gui" value="false"/>
+		<rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
+	</node>
+
+	<!-- Given the published joint states, publish tf for the robot links -->
+	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+	<!-- Run the main MoveIt! executable without trajectory execution (we do not have controllers configured by default) -->
+	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/move_group.launch">
+		<arg name="allow_trajectory_execution" value="true"/>
+		<arg name="fake_execution" value="true"/>
+		<arg name="info" value="true"/>
+	</include>
+
+	<test test-name="check_state_validity_in_empty_scene" pkg="moveit_ros_move_group" type="test_check_state_validity_in_empty_scene.py"/>
+</launch>


### PR DESCRIPTION
### Description

Fix for https://github.com/ros-planning/moveit/issues/1673, where 
> MoveIt 'check_state_validity' service does not return the contact points of the collision if there is no extra collision object added to the panning scene.

The maximum number of contacts was set to the total number of world objects, but in case there is an empty world (number of world objects == 0) and the `RobotState`-to-check has a self collision, the number of contacts would still be 0. 
This is incorrect, the max number of contacts should be number of world objects) + number of robot links

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) :arrow_right: not applicable
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes :arrow_right: not applicable
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI :arrow_right: not applicable
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers :arrow_right: I don't feel qualified to do so, all PRs have better reviews than I can give