### PR TITLE
Fix Clear Octomap button, disable when no octomap is published

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -531,6 +531,8 @@ void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningS
 
 void PlanningSceneMonitor::clearOctomap()
 {
+  if (scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS))
+    triggerSceneUpdateEvent(UPDATE_SCENE);
   if (octomap_monitor_)
   {
     octomap_monitor_->getOcTreePtr()->lockWrite();

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -531,8 +531,8 @@ void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningS
 
 void PlanningSceneMonitor::clearOctomap()
 {
-  scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS);
-  triggerSceneUpdateEvent(UPDATE_SCENE);
+  if (scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS))
+    triggerSceneUpdateEvent(UPDATE_SCENE);
   if (octomap_monitor_)
   {
     octomap_monitor_->getOcTreePtr()->lockWrite();

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -531,8 +531,8 @@ void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningS
 
 void PlanningSceneMonitor::clearOctomap()
 {
-  if (scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS))
-    triggerSceneUpdateEvent(UPDATE_SCENE);
+  scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS);
+  triggerSceneUpdateEvent(UPDATE_SCENE);
   if (octomap_monitor_)
   {
     octomap_monitor_->getOcTreePtr()->lockWrite();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -431,12 +431,7 @@ void MotionPlanningFrame::changePlanningGroup()
 void MotionPlanningFrame::sceneUpdate(planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type)
 {
   if (update_type & planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY)
-  {
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
-    // Enable Clear Octomap button only if octomap exists in the world
-    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
-    ui_->clear_octomap_button->setEnabled(ps->getWorld()->hasObject(ps->OCTOMAP_NS));
-  }
 }
 
 void MotionPlanningFrame::addSceneObject()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -431,7 +431,12 @@ void MotionPlanningFrame::changePlanningGroup()
 void MotionPlanningFrame::sceneUpdate(planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type)
 {
   if (update_type & planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY)
+  {
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
+    // Enable Clear Octomap button only if octomap exists in the world
+    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+    ui_->clear_octomap_button->setEnabled(ps->getWorld()->hasObject(ps->OCTOMAP_NS));
+  }
 }
 
 void MotionPlanningFrame::addSceneObject()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -921,6 +921,7 @@ void MotionPlanningFrame::populateCollisionObjectsList()
 {
   ui_->collision_objects_list->setUpdatesEnabled(false);
   bool old_state = ui_->collision_objects_list->blockSignals(true);
+  bool octomap_in_scene = false;
 
   {
     QList<QListWidgetItem*> sel = ui_->collision_objects_list->selectedItems();
@@ -938,7 +939,10 @@ void MotionPlanningFrame::populateCollisionObjectsList()
       for (std::size_t i = 0; i < collision_object_names.size(); ++i)
       {
         if (collision_object_names[i] == planning_scene::PlanningScene::OCTOMAP_NS)
+        {
+          octomap_in_scene = true;
           continue;
+        }
 
         QListWidgetItem* item =
             new QListWidgetItem(QString::fromStdString(collision_object_names[i]), ui_->collision_objects_list, (int)i);
@@ -970,6 +974,7 @@ void MotionPlanningFrame::populateCollisionObjectsList()
     }
   }
 
+  ui_->clear_octomap_button->setEnabled(octomap_in_scene);
   ui_->collision_objects_list->blockSignals(old_state);
   ui_->collision_objects_list->setUpdatesEnabled(true);
   selectedCollisionObjectChanged();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -110,6 +110,7 @@ void MotionPlanningFrame::onClearOctomapClicked()
 {
   std_srvs::Empty srv;
   clear_octomap_service_client_.call(srv);
+  ui_->clear_octomap_button->setEnabled(false);
 }
 
 bool MotionPlanningFrame::computeCartesianPlan()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -445,6 +445,9 @@
               </item>
               <item>
                <widget class="QPushButton" name="clear_octomap_button">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
                 <property name="text">
                  <string>Clear octomap</string>
                 </property>


### PR DESCRIPTION
### Description

As discussed in #2310, the Clear Octomap button shouldn't be active when there is no octomap to clear. This PR disables the button by default and enables it when an octomap is in the planning scene. 

You can test this with `roslaunch moveit_tutorials detect_and_add_cylinder_collision_object_demo.launch` which publishes an octomap every 10 seconds, ~although the octomap doesn't actually seem to be cleared when pushing the button~.

![Screenshot 2020-09-22 01:44:45](https://user-images.githubusercontent.com/4535737/93796053-3c399000-fc75-11ea-88d1-8c65a69980a7.png)

**edit:** I think I fixed part of the problem that caused the octomap not to be cleared. There's still something quirky, though.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
