### PR TITLE
fix some more python3 issues

### DIFF
--- a/moveit_commander/CMakeLists.txt
+++ b/moveit_commander/CMakeLists.txt
@@ -7,7 +7,8 @@ catkin_python_setup()
 
 catkin_package()
 
-install(PROGRAMS bin/${PROJECT_NAME}_cmdline.py
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(
+  PROGRAMS bin/${PROJECT_NAME}_cmdline.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 add_subdirectory(test)

--- a/moveit_kinematics/ikfast_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/CMakeLists.txt
@@ -7,6 +7,12 @@ set(MOVEIT_LIB_NAME moveit_ikfast_kinematics_plugin)
 install(
   PROGRAMS
     scripts/auto_create_ikfast_moveit_plugin.sh
+  DESTINATION
+    ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+catkin_install_python(
+  PROGRAMS
     scripts/create_ikfast_moveit_plugin.py
     scripts/round_collada_numbers.py
   DESTINATION

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -30,8 +30,12 @@
   <depend condition="$ROS_DISTRO != noetic">orocos_kdl</depend>
   <depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</depend>
 
-  <exec_depend>python-lxml</exec_depend>
-  <exec_depend>liburdfdom-tools</exec_depend> <!-- provides check_urdf required by ikfast scripts -->
+  <!-- some requirements of ikfast scripts -->
+  <exec_depend>liburdfdom-tools</exec_depend> <!-- provides check_urdf -->
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-lxml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-lxml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>moveit_ros_planning</test_depend>

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -62,7 +62,8 @@ install(
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
-install(PROGRAMS scripts/moveit_benchmark_statistics.py
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(
+  PROGRAMS scripts/moveit_benchmark_statistics.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY examples/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/examples)

--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # ********************************************************************
 # Software License Agreement (BSD License)
 #


### PR DESCRIPTION
Fixes #2322:
* `ikfast` was missing some python dependencies
* [python scripts should be installed via `catkin_install_python()`](http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs)