### PR TITLE
Export symbols for windows

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Enable warnings
   add_compile_options(-Wall -Wextra

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -4,6 +4,9 @@ add_library(${MOVEIT_LIB_NAME}
   src/collision_common.cpp
   src/collision_env_fcl.cpp
 )
+include(GenerateExportHeader)
+generate_export_header(${MOVEIT_LIB_NAME} EXPORT_MACRO_NAME moveit_collision_detection_fcl_EXPORT)
+
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
@@ -11,8 +14,10 @@ add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 add_library(collision_detector_fcl_plugin src/collision_detector_fcl_plugin_loader.cpp)
 set_target_properties(collision_detector_fcl_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(collision_detector_fcl_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME})
+target_link_libraries(collision_detector_fcl_plugin ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} moveit_planning_scene)
+add_dependencies(collision_detector_fcl_plugin moveit_planning_scene)
 
+target_include_directories(${MOVEIT_LIB_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 install(TARGETS ${MOVEIT_LIB_NAME} collision_detector_fcl_plugin
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_allocator_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_allocator_fcl.h
@@ -38,6 +38,7 @@
 
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_detection_fcl/collision_env_fcl.h>
+#include "moveit_collision_detection_fcl_export.h"
 
 namespace collision_detection
 {
@@ -46,6 +47,6 @@ class CollisionDetectorAllocatorFCL
   : public CollisionDetectorAllocatorTemplate<CollisionEnvFCL, CollisionDetectorAllocatorFCL>
 {
 public:
-  static const std::string NAME;  // defined in collision_env_fcl.cpp
+  static moveit_collision_detection_fcl_EXPORT const std::string NAME;  // defined in collision_env_fcl.cpp
 };
 }  // namespace collision_detection

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}
   ${LIBOCTOMAP_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${MOVEIT_LIB_NAME} moveit_collision_detection_fcl)
 
 install(TARGETS ${MOVEIT_LIB_NAME}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
### Description

We are currently building ROS packages with conda (see https://medium.com/@wolfv/ros-on-conda-forge-dca6827ac4b6 and https://github.com/RoboStack/ros-noetic). While moveit builds fine on Linux using conda, it failed on Windows. There are some conda specific patches, however the PR here addresses an issue which I think goes beyond conda. In particular, a static variable wasn't exported properly.

This PR adds some cmake magic to properly export this variable, and adds the required dependencies to find it.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
