### PR TITLE
Fix clang-tidy warning

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -61,7 +61,7 @@ namespace
 QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subframes)
 {
   QString status_text = "\nIt has the subframes '";
-  for (auto subframe : subframes)
+  for (const auto& subframe : subframes)
   {
     status_text += QString::fromStdString(subframe.first) + "', '";
   }


### PR DESCRIPTION
Somehow this issue wasn't detected by clang-tidy before...