### PR TITLE
MSA: Fix disappearing robot on change of reference frame

### DIFF
--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -187,6 +187,7 @@ void SetupAssistantWidget::virtualJointReferenceFrameChanged()
   {
     rviz_manager_->setFixedFrame(QString::fromStdString(config_data_->getRobotModel()->getModelFrame()));
     robot_state_display_->reset();
+    robot_state_display_->setVisible(true);
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -436,6 +436,7 @@ void VirtualJointsWidget::deleteSelected()
   // Reload main screen table
   loadDataTable();
   config_data_->changes |= MoveItConfigData::VIRTUAL_JOINTS;
+  Q_EMIT referenceFrameChanged();
 }
 
 // ******************************************************************************************


### PR DESCRIPTION
This fixes https://github.com/ros-planning/moveit_tutorials/issues/533.

- set visibility of robot-state-display to true after reset()
- correctly update reference frame also on deletion of virtual joint

This needs to be backported to Melodic as well!