### PR TITLE
Fix some clang-tidy issues on Travis

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -303,7 +303,7 @@ struct DistanceRequest
 };
 
 /** \brief Generic representation of the distance information for a pair of objects */
-struct DistanceResultsData
+struct DistanceResultsData  // NOLINT(readability-identifier-naming) - suppress spurious clang-tidy warning
 {
   DistanceResultsData()
   {

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -67,7 +67,7 @@ enum Type
 }  // namespace BodyTypes
 
 /** \brief The types of bodies that are considered for collision */
-typedef BodyTypes::Type BodyType;
+using BodyType = BodyTypes::Type;
 
 /** \brief Definition of a contact point */
 struct Contact
@@ -147,7 +147,7 @@ struct CollisionResult
   CollisionResult() : collision(false), distance(std::numeric_limits<double>::max()), contact_count(0)
   {
   }
-  typedef std::map<std::pair<std::string, std::string>, std::vector<Contact> > ContactMap;
+  using ContactMap = std::map<std::pair<std::string, std::string>, std::vector<Contact> >;
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -240,7 +240,7 @@ enum DistanceRequestType
   ALL       ///< Find all the contacts for a given pair
 };
 }
-typedef DistanceRequestTypes::DistanceRequestType DistanceRequestType;
+using DistanceRequestType = DistanceRequestTypes::DistanceRequestType;
 
 /** \brief Representation of a distance-reporting request */
 struct DistanceRequest
@@ -356,7 +356,7 @@ struct DistanceResultsData
 };
 
 /** \brief Mapping between the names of the collision objects and the DistanceResultData. */
-typedef std::map<const std::pair<std::string, std::string>, std::vector<DistanceResultsData> > DistanceMap;
+using DistanceMap = std::map<const std::pair<std::string, std::string>, std::vector<DistanceRequest> >;
 
 /** \brief Result of a distance request. */
 struct DistanceResult

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -356,7 +356,7 @@ struct DistanceResultsData  // NOLINT(readability-identifier-naming) - suppress 
 };
 
 /** \brief Mapping between the names of the collision objects and the DistanceResultData. */
-using DistanceMap = std::map<const std::pair<std::string, std::string>, std::vector<DistanceRequest> >;
+using DistanceMap = std::map<const std::pair<std::string, std::string>, std::vector<DistanceResultsData> >;
 
 /** \brief Result of a distance request. */
 struct DistanceResult

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -248,8 +248,8 @@ public:
     return world_const_;
   }
 
-  typedef World::ObjectPtr ObjectPtr;
-  typedef World::ObjectConstPtr ObjectConstPtr;
+  using ObjectPtr = World::ObjectPtr;
+  using ObjectConstPtr = World::ObjectConstPtr;
 
   /** @brief The kinematic model corresponding to this collision model*/
   const moveit::core::RobotModelConstPtr& getRobotModel() const

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -69,7 +69,7 @@ enum Type
 
 /** \brief Signature of predicate that decides whether a contact is allowed or not (when AllowedCollision::Type is
  * CONDITIONAL) */
-typedef boost::function<bool(collision_detection::Contact&)> DecideContactFn;
+using DecideContactFn = boost::function<bool(collision_detection::Contact&)>;
 
 MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);  // Defines AllowedCollisionMatrixPtr, ConstPtr, WeakPtr... etc
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -119,7 +119,7 @@ public:
   ObjectConstPtr getObject(const std::string& object_id) const;
 
   /** iterator over the objects in the world. */
-  typedef std::map<std::string, ObjectPtr>::const_iterator const_iterator;
+  using const_iterator = std::map<std::string, ObjectPtr>::const_iterator;
   /** iterator pointing to first change */
   const_iterator begin() const
   {
@@ -254,7 +254,7 @@ public:
     friend class World;
   };
 
-  typedef boost::function<void(const ObjectConstPtr&, Action)> ObserverCallbackFn;
+  using ObserverCallbackFn = boost::function<void(const ObjectConstPtr&, Action)>;
 
   /** \brief register a callback function for notification of changes.
    * \e callback will be called right after any change occurs to any Object.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -76,7 +76,7 @@ public:
     return changes_;
   }
 
-  typedef std::map<std::string, World::Action>::const_iterator const_iterator;
+  using const_iterator = std::map<std::string, World::Action>::const_iterator;
   /** iterator pointing to first change */
   const_iterator begin() const
   {

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -493,8 +493,6 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     ROS_DEBUG_NAMED("collision_detection.fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
                     cd2->getID().c_str());
 
-  fcl::DistanceResultd fcl_result;
-  DistanceResultsData dist_result;
   double dist_threshold = cdata->req->distance_threshold;
 
   const std::pair<std::string, std::string>& pc = cd1->getID() < cd2->getID() ?
@@ -523,6 +521,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     }
   }
 
+  fcl::DistanceResultd fcl_result;
   fcl_result.min_distance = dist_threshold;
   // fcl::distance segfaults when given an octree with a null root pointer (using FCL 0.6.1)
   if ((o1->getObjectType() == fcl::OT_OCTREE &&
@@ -539,6 +538,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   // one and add the new distance information.
   if (d < dist_threshold)
   {
+    DistanceResultsData dist_result;
     dist_result.distance = fcl_result.min_distance;
 #if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
     dist_result.nearest_points[0] = fcl_result.nearest_points[0];

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -76,7 +76,7 @@ enum DiscretizationMethod
                            The unused redundant joints will be fixed at their current value. */
 };
 }  // namespace DiscretizationMethods
-typedef DiscretizationMethods::DiscretizationMethod DiscretizationMethod;
+using DiscretizationMethod = DiscretizationMethods::DiscretizationMethod;
 
 /*
  * @enum KinematicErrors
@@ -98,7 +98,7 @@ enum KinematicError
 
 };
 }  // namespace KinematicErrors
-typedef KinematicErrors::KinematicError KinematicError;
+using KinematicError = KinematicErrors::KinematicError;
 
 /**
  * @struct KinematicsQueryOptions
@@ -148,9 +148,8 @@ public:
   static const double DEFAULT_TIMEOUT;               /* = 1.0 */
 
   /** @brief Signature for a callback to validate an IK solution. Typically used for collision checking. */
-  typedef boost::function<void(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_solution,
-                               moveit_msgs::MoveItErrorCodes& error_code)>
-      IKCallbackFn;
+  using IKCallbackFn =
+      boost::function<void(const geometry_msgs::Pose&, const std::vector<double>&, moveit_msgs::MoveItErrorCodes&)>;
 
   /**
    * @brief Given a desired pose of the end-effector, compute the joint angles to reach it

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -49,10 +49,9 @@ MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);  // Defines PlanningRequestAdapter
 class PlanningRequestAdapter
 {
 public:
-  typedef boost::function<bool(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                               const planning_interface::MotionPlanRequest& req,
-                               planning_interface::MotionPlanResponse& res)>
-      PlannerFn;
+  using PlannerFn =
+      boost::function<bool(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
+                           planning_interface::MotionPlanResponse&)>;
 
   PlanningRequestAdapter()
   {

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -72,13 +72,14 @@ typedef boost::function<bool(const moveit::core::RobotState&, bool)> StateFeasib
     The order of the arguments matters: the notion of feasibility is to be checked for motion segments that start at the
    first state and end at the second state. The third argument indicates
     whether the check should be verbose or not. */
-typedef boost::function<bool(const moveit::core::RobotState&, const moveit::core::RobotState&, bool)> MotionFeasibilityFn;
+using MotionFeasibilityFn =
+    boost::function<bool(const moveit::core::RobotState&, const moveit::core::RobotState&, bool)>;
 
 /** \brief A map from object names (e.g., attached bodies, collision objects) to their colors */
-typedef std::map<std::string, std_msgs::ColorRGBA> ObjectColorMap;
+using ObjectColorMap = std::map<std::string, std_msgs::ColorRGBA>;
 
 /** \brief A map from object names (e.g., attached bodies, collision objects) to their types */
-typedef std::map<std::string, object_recognition_msgs::ObjectType> ObjectTypeMap;
+using ObjectTypeMap = std::map<std::string, object_recognition_msgs::ObjectType>;
 
 /** \brief This class maintains the representation of the
     environment as seen by a planning instance. The environment
@@ -1000,8 +1001,8 @@ private:
   };
   friend struct CollisionDetector;
 
-  typedef std::map<std::string, CollisionDetectorPtr>::iterator CollisionDetectorIterator;
-  typedef std::map<std::string, CollisionDetectorPtr>::const_iterator CollisionDetectorConstIterator;
+  using CollisionDetectorIterator = std::map<std::string, CollisionDetectorPtr>::iterator;
+  using CollisionDetectorConstIterator = std::map<std::string, CollisionDetectorPtr>::const_iterator;
 
   void allocateCollisionDetectors();
   void allocateCollisionDetectors(CollisionDetector& detector);

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -84,13 +84,13 @@ class JointModel;
 typedef std::map<std::string, int> VariableIndexMap;
 
 /** \brief Data type for holding mappings from variable names to their bounds */
-typedef std::map<std::string, VariableBounds> VariableBoundsMap;
+using VariableBoundsMap = std::map<std::string, VariableBounds>;
 
 /** \brief Map of names to instances for JointModel */
-typedef std::map<std::string, JointModel*> JointModelMap;
+using JointModelMap = std::map<std::string, JointModel*>;
 
 /** \brief Map of names to const instances for JointModel */
-typedef std::map<std::string, const JointModel*> JointModelMapConst;
+using JointModelMapConst = std::map<std::string, const JointModel*>;
 
 /** \brief A joint from the robot. Models the transform that
     this joint applies in the kinematic chain. A joint
@@ -119,7 +119,7 @@ public:
   };
 
   /** \brief The datatype for the joint bounds */
-  typedef std::vector<VariableBounds> Bounds;
+  using Bounds = std::vector<VariableBounds>;
 
   /** \brief Construct a joint named \e name */
   JointModel(const std::string& name);

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -55,15 +55,15 @@ class JointModelGroup;
 typedef boost::function<kinematics::KinematicsBasePtr(const JointModelGroup*)> SolverAllocatorFn;
 
 /** \brief Map from group instances to allocator functions & bijections */
-typedef std::map<const JointModelGroup*, SolverAllocatorFn> SolverAllocatorMapFn;
+using SolverAllocatorMapFn = std::map<const JointModelGroup*, SolverAllocatorFn>;
 
 /** \brief Map of names to instances for JointModelGroup */
-typedef std::map<std::string, JointModelGroup*> JointModelGroupMap;
+using JointModelGroupMap = std::map<std::string, JointModelGroup*>;
 
 /** \brief Map of names to const instances for JointModelGroup */
-typedef std::map<std::string, const JointModelGroup*> JointModelGroupMapConst;
+using JointModelGroupMapConst = std::map<std::string, const JointModelGroup*>;
 
-typedef std::vector<const JointModel::Bounds*> JointBoundsVector;
+using JointBoundsVector = std::vector<const JointModel::Bounds*>;
 
 class JointModelGroup
 {
@@ -102,7 +102,7 @@ public:
   };
 
   /// Map from group instances to allocator functions & bijections
-  typedef std::map<const JointModelGroup*, KinematicsSolver> KinematicsSolverMap;
+  using KinematicsSolverMap = std::map<const JointModelGroup*, KinematicsSolver>;
 
   JointModelGroup(const std::string& name, const srdf::Model::Group& config,
                   const std::vector<const JointModel*>& joint_vector, const RobotModel* parent_model);

--- a/moveit_core/robot_model/include/moveit/robot_model/link_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/link_model.h
@@ -61,12 +61,11 @@ class LinkModel;
 typedef std::map<std::string, LinkModel*> LinkModelMap;
 
 /** \brief Map of names to const instances for LinkModel */
-typedef std::map<std::string, const LinkModel*> LinkModelMapConst;
+using LinkModelMapConst = std::map<std::string, const LinkModel*>;
 
 /** \brief Map from link model instances to Eigen transforms */
-typedef std::map<const LinkModel*, Eigen::Isometry3d, std::less<const LinkModel*>,
-                 Eigen::aligned_allocator<std::pair<const LinkModel* const, Eigen::Isometry3d> > >
-    LinkTransformMap;
+using LinkTransformMap = std::map<const LinkModel*, Eigen::Isometry3d, std::less<const LinkModel*>,
+                                  Eigen::aligned_allocator<std::pair<const LinkModel* const, Eigen::Isometry3d> > >;
 
 /** \brief A link from the robot. Contains the constant transform applied to the link and its geometry */
 class LinkModel

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -71,7 +71,7 @@ class IterativeSplineParameterization
 {
 public:
   IterativeSplineParameterization(bool add_points = true);
-  ~IterativeSplineParameterization();
+  ~IterativeSplineParameterization() = default;
 
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
                          const double max_acceleration_scaling_factor = 1.0) const;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
@@ -46,7 +46,7 @@ class IterativeParabolicTimeParameterization
 {
 public:
   IterativeParabolicTimeParameterization(unsigned int max_iterations = 100, double max_time_change_per_it = .01);
-  ~IterativeParabolicTimeParameterization();
+  ~IterativeParabolicTimeParameterization() = default;
 
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
                          const double max_acceleration_scaling_factor = 1.0) const;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -76,8 +76,6 @@ IterativeSplineParameterization::IterativeSplineParameterization(bool add_points
 {
 }
 
-IterativeSplineParameterization::~IterativeSplineParameterization() = default;
-
 bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                                                         const double max_velocity_scaling_factor,
                                                         const double max_acceleration_scaling_factor) const

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -50,8 +50,6 @@ IterativeParabolicTimeParameterization::IterativeParabolicTimeParameterization(u
 {
 }
 
-IterativeParabolicTimeParameterization::~IterativeParabolicTimeParameterization() = default;
-
 namespace
 {
 void printPoint(const trajectory_msgs::JointTrajectoryPoint& point, std::size_t i)

--- a/moveit_core/transforms/include/moveit/transforms/transforms.h
+++ b/moveit_core/transforms/include/moveit/transforms/transforms.h
@@ -49,9 +49,8 @@ MOVEIT_CLASS_FORWARD(Transforms);  // Defines TransformsPtr, ConstPtr, WeakPtr..
 
 /// @brief Map frame names to the transformation matrix that can transform objects from the frame name to the planning
 /// frame
-typedef std::map<std::string, Eigen::Isometry3d, std::less<std::string>,
-                 Eigen::aligned_allocator<std::pair<const std::string, Eigen::Isometry3d> > >
-    FixedTransformsMap;
+using FixedTransformsMap = std::map<std::string, Eigen::Isometry3d, std::less<std::string>,
+                                    Eigen::aligned_allocator<std::pair<const std::string, Eigen::Isometry3d> > >;
 
 /** @brief Provides an implementation of a snapshot of a transform tree that can be easily queried for
     transforming different quantities. Transforms are maintained as a list of transforms to a particular frame.

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -87,8 +87,8 @@ public:
     tree_mutex_.unlock();
   }
 
-  typedef boost::shared_lock<boost::shared_mutex> ReadLock;
-  typedef boost::unique_lock<boost::shared_mutex> WriteLock;
+  using ReadLock = boost::shared_lock<boost::shared_mutex>;
+  using WriteLock = boost::unique_lock<boost::shared_mutex>;
 
   ReadLock reading()
   {
@@ -117,6 +117,6 @@ private:
   boost::function<void()> update_callback_;
 };
 
-typedef std::shared_ptr<OccMapTree> OccMapTreePtr;
-typedef std::shared_ptr<const OccMapTree> OccMapTreeConstPtr;
+using OccMapTreePtr = std::shared_ptr<OccMapTree>;
+using OccMapTreeConstPtr = std::shared_ptr<const OccMapTree>;
 }  // namespace occupancy_map_monitor

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -44,12 +44,10 @@
 
 namespace occupancy_map_monitor
 {
-typedef unsigned int ShapeHandle;
-typedef std::map<ShapeHandle, Eigen::Isometry3d, std::less<ShapeHandle>,
-                 Eigen::aligned_allocator<std::pair<const ShapeHandle, Eigen::Isometry3d> > >
-    ShapeTransformCache;
-typedef boost::function<bool(const std::string& target_frame, const ros::Time& target_time, ShapeTransformCache& cache)>
-    TransformCacheProvider;
+using ShapeHandle = unsigned int;
+using ShapeTransformCache = std::map<ShapeHandle, Eigen::Isometry3d, std::less<ShapeHandle>,
+                                     Eigen::aligned_allocator<std::pair<const ShapeHandle, Eigen::Isometry3d> > >;
+using TransformCacheProvider = boost::function<bool(const std::string&, const ros::Time&, ShapeTransformCache&)>;
 
 class OccupancyMapMonitor;
 

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h
@@ -85,5 +85,5 @@ struct ExecutableMotionPlan
 };
 
 /// The signature of a function that can compute a motion plan
-typedef boost::function<bool(ExecutableMotionPlan& plan)> ExecutableMotionPlanComputationFn;
+using ExecutableMotionPlanComputationFn = boost::function<bool(ExecutableMotionPlan&)>;
 }  // namespace plan_execution

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -46,13 +46,13 @@
 
 namespace planning_scene_monitor
 {
-typedef boost::function<void(const sensor_msgs::JointStateConstPtr& joint_state)> JointStateUpdateCallback;
+using JointStateUpdateCallback = boost::function<void(const sensor_msgs::JointStateConstPtr&)>;
 
 /** @class CurrentStateMonitor
     @brief Monitors the joint_states topic and tf to maintain the current state of the robot. */
 class CurrentStateMonitor
 {
-  typedef boost::signals2::connection TFConnection;
+  using TFConnection = boost::signals2::connection;
 
 public:
   /**

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -519,11 +519,10 @@ protected:
   typedef std::map<const moveit::core::LinkModel*,
                    std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > >
       LinkShapeHandles;
-  typedef std::map<const moveit::core::AttachedBody*,
-                   std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > >
-      AttachedBodyShapeHandles;
-  typedef std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, const Eigen::Isometry3d*> > >
-      CollisionBodyShapeHandles;
+  using AttachedBodyShapeHandles = std::map<const moveit::core::AttachedBody*,
+                                            std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t> > >;
+  using CollisionBodyShapeHandles =
+      std::map<std::string, std::vector<std::pair<occupancy_map_monitor::ShapeHandle, const Eigen::Isometry3d*> > >;
 
   LinkShapeHandles link_shape_handles_;
   AttachedBodyShapeHandles attached_body_shape_handles_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -44,8 +44,7 @@
 
 namespace planning_scene_monitor
 {
-typedef boost::function<void(const moveit::core::RobotStateConstPtr& state, const ros::Time& stamp)>
-    TrajectoryStateAddedCallback;
+using TrajectoryStateAddedCallback = boost::function<void(const moveit::core::RobotStateConstPtr&, const ros::Time&)>;
 
 MOVEIT_CLASS_FORWARD(TrajectoryMonitor);  // Defines TrajectoryMonitorPtr, ConstPtr, WeakPtr... etc
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -67,7 +67,7 @@ public:
 
   /// Definition of the function signature that is called when the execution of a pushed trajectory completes
   /// successfully.
-  typedef boost::function<void(std::size_t)> PathSegmentCompleteCallback;
+  using PathSegmentCompleteCallback = boost::function<void(std::size_t)>;
 
   /// Data structure that represents information necessary to execute a trajectory
   struct TrajectoryExecutionContext


### PR DESCRIPTION
Having switched to Noetic (and clang-tidy-10?) on Travis, we get some new clang-tidy issues reported:
https://travis-ci.com/github/ros-planning/moveit/jobs/393573194

Interestingly, locally I got even more issues!? There is also one "fix" applied that is nonsense:
```diff
-struct DistanceResultsData
+struct i0
```