### PR TITLE
MSA: fix pose definitions

### DIFF
--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -339,12 +339,12 @@ void RobotPosesWidget::previewClicked(int row, int /*column*/, int /*previous_ro
 // ******************************************************************************************
 void RobotPosesWidget::showPose(srdf::Model::GroupState* pose)
 {
-  // Set pose joint values by adding them to the local joint state map
+  // Set the joints based on the SRDF pose
+  moveit::core::RobotState& robot_state = config_data_->getPlanningScene()->getCurrentStateNonConst();
   for (std::map<std::string, std::vector<double> >::const_iterator value_it = pose->joint_values_.begin();
        value_it != pose->joint_values_.end(); ++value_it)
   {
-    // Only copy the first joint value // TODO: add capability for multi-DOF joints?
-    joint_state_map_[value_it->first] = value_it->second[0];
+    robot_state.setJointPositions(value_it->first, value_it->second);
   }
 
   // Update the joints
@@ -362,25 +362,8 @@ void RobotPosesWidget::showPose(srdf::Model::GroupState* pose)
 // ******************************************************************************************
 void RobotPosesWidget::showDefaultPose()
 {
-  // Get list of all joints for the robot
-  std::vector<const moveit::core::JointModel*> joint_models = config_data_->getRobotModel()->getJointModels();
-
-  // Iterate through the joints
-  for (std::vector<const moveit::core::JointModel*>::const_iterator joint_it = joint_models.begin();
-       joint_it < joint_models.end(); ++joint_it)
-  {
-    // Check that this joint only represents 1 variable.
-    if ((*joint_it)->getVariableCount() == 1)
-    {
-      double init_value;
-
-      // get the first joint value in its vector
-      (*joint_it)->getVariableDefaultPositions(&init_value);
-
-      // Change joint's value in joint_state_map to the default
-      joint_state_map_[(*joint_it)->getName()] = init_value;
-    }
-  }
+  moveit::core::RobotState& robot_state = config_data_->getPlanningScene()->getCurrentStateNonConst();
+  robot_state.setToDefaultValues();
 
   // Update the joints
   publishJoints();
@@ -441,16 +424,7 @@ void RobotPosesWidget::edit(int row)
   }
   group_name_field_->setCurrentIndex(index);
 
-  // Set pose joint values by adding them to the local joint state map
-  for (std::map<std::string, std::vector<double> >::const_iterator value_it = pose->joint_values_.begin();
-       value_it != pose->joint_values_.end(); ++value_it)
-  {
-    // Only copy the first joint value // TODO: add capability for multi-DOF joints?
-    joint_state_map_[value_it->first] = value_it->second[0];
-  }
-
-  // Update robot model in rviz
-  publishJoints();
+  showPose(pose);
 
   // Switch to screen - do this before setCurrentIndex
   stacked_layout_->setCurrentIndex(1);
@@ -517,30 +491,18 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
   // Get list of associated joints
   const moveit::core::JointModelGroup* joint_model_group =
       config_data_->getRobotModel()->getJointModelGroup(group_name);
-  joint_models_ = joint_model_group->getJointModels();
+  const auto& robot_state = config_data_->getPlanningScene()->getCurrentState();
 
   // Iterate through the joints
   int num_joints = 0;
-  for (const moveit::core::JointModel* joint_model : joint_models_)
+  for (const moveit::core::JointModel* joint_model : joint_model_group->getJointModels())
   {
     if (joint_model->getVariableCount() != 1 ||  // only consider 1-variable joints
         joint_model->isPassive() ||              // ignore passive
         joint_model->getMimic())                 // and mimic joints
       continue;
 
-    double init_value;
-
-    // Decide what this joint's initial value is
-    if (joint_state_map_.find(joint_model->getName()) == joint_state_map_.end())
-    {
-      // The joint state map does not yet have an entry for this joint
-      // Get the first joint value in its vector
-      joint_model->getVariableDefaultPositions(&init_value);
-    }
-    else  // There is already a value in the map
-    {
-      init_value = joint_state_map_[joint_model->getName()];
-    }
+    double init_value = robot_state.getVariablePosition(joint_model->getVariableNames()[0]);
 
     // For each joint in group add slider
     SliderWidget* sw = new SliderWidget(this, joint_model, init_value);
@@ -683,19 +645,22 @@ void RobotPosesWidget::doneEditing()
   // Clear the old values
   searched_data->joint_values_.clear();
 
-  // Iterate through the current group's joints and add to SRDF
-  for (std::vector<const moveit::core::JointModel*>::const_iterator joint_it = joint_models_.begin();
-       joint_it < joint_models_.end(); ++joint_it)
+  const moveit::core::JointModelGroup* joint_model_group = config_data_->getRobotModel()->getJointModelGroup(group);
+  const auto& robot_state = config_data_->getPlanningScene()->getCurrentState();
+
+  // Iterate through the current group's joints and add them to SRDF
+  for (const moveit::core::JointModel* jm : joint_model_group->getJointModels())
   {
     // Check that this joint only represents 1 variable.
-    if ((*joint_it)->getVariableCount() == 1)
+    if (jm->getVariableCount() == 1 && !jm->isPassive() && !jm->getMimic())
     {
       // Create vector for new joint values
-      std::vector<double> joint_value;
-      joint_value.push_back(joint_state_map_[(*joint_it)->getName()]);
+      std::vector<double> joint_values(jm->getVariableCount());
+      const double* const first_variable = robot_state.getVariablePositions() + jm->getFirstVariableIndex();
+      std::copy(first_variable, first_variable + joint_values.size(), joint_values.begin());
 
       // Add joint vector to SRDF
-      searched_data->joint_values_[(*joint_it)->getName()] = joint_value;
+      searched_data->joint_values_[jm->getName()] = std::move(joint_values);
     }
   }
 
@@ -794,24 +759,21 @@ void RobotPosesWidget::focusGiven()
 // ******************************************************************************************
 void RobotPosesWidget::updateRobotModel(const std::string& name, double value)
 {
-  // Save the new value
-  joint_state_map_[name] = value;
+  moveit::core::RobotState& robot_state = config_data_->getPlanningScene()->getCurrentStateNonConst();
+  robot_state.setVariablePosition(name, value);
 
   // Update the robot model/rviz
   publishJoints();
 }
 
 // ******************************************************************************************
-// Publish the joint values in the joint_state_map_ to Rviz
+// Publish the current RobotState to Rviz
 // ******************************************************************************************
 void RobotPosesWidget::publishJoints()
 {
-  // Set the joints based on the map
-  moveit::core::RobotState& robot_state = config_data_->getPlanningScene()->getCurrentStateNonConst();
-  robot_state.setVariablePositions(joint_state_map_);
-  // Prevent dirty collision body transforms
+  // Update link + collision transforms
+  auto& robot_state = config_data_->getPlanningScene()->getCurrentStateNonConst();
   robot_state.update();
-
   // Create a planning scene message
   moveit_msgs::DisplayRobotState msg;
   moveit::core::robotStateToRobotStateMsg(robot_state, msg.state);

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.h
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.h
@@ -152,12 +152,6 @@ private:
   /// Pointer to currently edited group state
   srdf::Model::GroupState* current_edit_pose_;
 
-  /// All the joint slider values that have thus far been seen. May contain more than just the current joints' values
-  std::map<std::string, double> joint_state_map_;
-
-  /// The joints currently in the selected planning group
-  std::vector<const moveit::core::JointModel*> joint_models_;
-
   /// Remember the publisher for quick publishing later
   ros::Publisher pub_robot_state_;
 

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -255,29 +255,6 @@ void VirtualJointsWidget::editDoubleClicked(int /*row*/, int /*column*/)
 // ******************************************************************************************
 void VirtualJointsWidget::previewClicked(int /*row*/, int /*column*/)
 {
-  // TODO: highlight the virtual joint?
-
-  /*  // Get list of all selected items
-  QList<QTableWidgetItem*> selected = data_table_->selectedItems();
-
-  // Check that an element was selected
-  if( !selected.size() )
-    return;
-
-  // Find the selected in datastructure
-  srdf::Model::GroupState *vjoint = findVjointByName( selected[0]->text().toStdString() );
-
-  // Set vjoint joint values by adding them to the local joint state map
-  for( std::map<std::string, std::vector<double> >::const_iterator value_it = vjoint->joint_values_.begin();
-       value_it != vjoint->joint_values_.end(); ++value_it )
-  {
-    // Only copy the first joint value
-    joint_state_map_[ value_it->first ] = value_it->second[0];
-  }
-
-  // Update the joints
-  publishJoints();
-  */
 }
 
 // ******************************************************************************************


### PR DESCRIPTION
Fix #2344 and other issues:
- The joint values of the initial robot pose (shown in rviz window after loading) were not taking into account for saving poses.
- mimic joints were written to SRDF (with wrong values), overriding auto-updates of mimic joints (causing #2344)
- Cleaning up code to use a RobotState for robot poses (instead of a separate joint_states_map_)