### PR TITLE
Change servo namespacing logic

### DIFF
--- a/moveit_ros/moveit_servo/config/ur_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/ur_simulated_config.yaml
@@ -46,10 +46,10 @@ hard_stop_singularity_threshold: 30 # Stop when the condition number hits this
 joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
 
 ## Topic names
-cartesian_command_in_topic: servo_server/delta_twist_cmds  # Topic for incoming Cartesian twist commands
-joint_command_in_topic: servo_server/delta_joint_cmds # Topic for incoming joint angle commands
-joint_topic:  joint_states
-status_topic: servo_server/status # Publish status to this topic
+cartesian_command_in_topic: delta_twist_cmds  # Topic for incoming Cartesian twist commands
+joint_command_in_topic: delta_joint_cmds # Topic for incoming joint angle commands
+joint_topic: joint_states
+status_topic: status # Publish status to this topic
 command_out_topic: joint_group_position_controller/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body

--- a/moveit_ros/moveit_servo/config/ur_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/ur_simulated_config.yaml
@@ -50,7 +50,7 @@ cartesian_command_in_topic: delta_twist_cmds  # Topic for incoming Cartesian twi
 joint_command_in_topic: delta_joint_cmds # Topic for incoming joint angle commands
 joint_topic: joint_states
 status_topic: status # Publish status to this topic
-command_out_topic: joint_group_position_controller/command # Publish outgoing commands here
+command_out_topic: /joint_group_position_controller/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -85,8 +85,7 @@ class PoseTracking
 {
 public:
   /** \brief Constructor. Loads ROS parameters under the given namespace. */
-  PoseTracking(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-               const std::string& parameter_ns = "");
+  PoseTracking(const ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   PoseTrackingStatusCode moveToPose(const Eigen::Vector3d& positional_tolerance, const double angular_tolerance,
                                     const double target_pose_timeout);
@@ -183,9 +182,6 @@ private:
 
   // Flag that a different thread has requested a stop.
   std::atomic<bool> stop_requested_;
-
-  // Read parameters from this namespace
-  std::string parameter_ns_;
 
   double angular_error_;
 };

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -53,8 +53,7 @@ namespace moveit_servo
 class Servo
 {
 public:
-  Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-        const std::string& parameter_ns = "");
+  Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   ~Servo();
 
@@ -112,9 +111,6 @@ private:
   std::shared_ptr<JointStateSubscriber> joint_state_subscriber_;
   std::unique_ptr<ServoCalcs> servo_calcs_;
   std::unique_ptr<CollisionCheck> collision_checker_;
-
-  // Read parameters from this namespace
-  std::string parameter_ns_;
 };
 
 // ServoPtr using alias

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -66,7 +66,7 @@ class ServoCalcs
 public:
   ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
              const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-             const std::shared_ptr<JointStateSubscriber>& joint_state_subscriber, std::string& ros_namespace);
+             const std::shared_ptr<JointStateSubscriber>& joint_state_subscriber);
 
   ~ServoCalcs()
   {

--- a/moveit_ros/moveit_servo/launch/cpp_interface_example.launch
+++ b/moveit_ros/moveit_servo/launch/cpp_interface_example.launch
@@ -2,8 +2,8 @@
   <!-- Launch an example that sends commands via C++ API. -->
 
   <node name="servo_server" pkg="moveit_servo" type="cpp_interface_example" output="screen" >
-    <param name="parameter_ns" type="string" value="servo_server" />
-    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
+    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
+    <rosparam ns="optional_parameter_namespace" command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
   </node>
 
 </launch>

--- a/moveit_ros/moveit_servo/launch/spacenav_cpp.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_cpp.launch
@@ -13,8 +13,8 @@
   <node name="spacenav_to_twist" pkg="moveit_servo" type="spacenav_to_twist" output="screen" />
 
   <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
-    <param name="parameter_ns" type="string" value="servo_server" />
-    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
+    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
+    <rosparam ns="optional_parameter_namespace" command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
   </node>
 
 </launch>

--- a/moveit_ros/moveit_servo/launch/spacenav_teleop_tools.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_teleop_tools.launch
@@ -10,8 +10,8 @@
 
   <!-- This node does the servoing calculations -->
   <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
-    <param name="parameter_ns" type="string" value="servo_server" />
-    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
+    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
+    <rosparam ns="optional_parameter_namespace" command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
   </node>
 
   <!-- teleop_tools translates a joystick command into a twist message -->

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -75,7 +75,7 @@ CollisionCheck::CollisionCheck(ros::NodeHandle& nh, const moveit_servo::ServoPar
   safety_factor_ = parameters_.collision_distance_safety_factor;
 
   // Internal namespace
-  ros::NodeHandle internal_nh("~internal");
+  ros::NodeHandle internal_nh(nh_, "internal");
   collision_velocity_scale_pub_ = internal_nh.advertise<std_msgs::Float64>("collision_velocity_scale", ROS_QUEUE_SIZE);
   worst_case_stop_time_sub_ =
       internal_nh.subscribe("worst_case_stop_time", ROS_QUEUE_SIZE, &CollisionCheck::worstCaseStopTimeCB, this);

--- a/moveit_ros/moveit_servo/src/cpp_interface_example/cpp_interface_example.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_example/cpp_interface_example.cpp
@@ -75,7 +75,7 @@ private:
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, LOGNAME);
-  ros::NodeHandle nh;
+  ros::NodeHandle nh("~");
   ros::AsyncSpinner spinner(8);
   spinner.start();
 

--- a/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_example.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_example.cpp
@@ -79,7 +79,7 @@ private:
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, LOGNAME);
-  ros::NodeHandle nh;
+  ros::NodeHandle nh("~");
   ros::AsyncSpinner spinner(8);
   spinner.start();
 
@@ -100,14 +100,14 @@ int main(int argc, char** argv)
   planning_scene_monitor->startStateMonitor();
 
   // Create the pose tracker
-  moveit_servo::PoseTracking tracker(planning_scene_monitor, "servo_server");
+  moveit_servo::PoseTracking tracker(nh, planning_scene_monitor);
 
   // Make a publisher for sending pose commands
   ros::Publisher target_pose_pub =
-      nh.advertise<geometry_msgs::PoseStamped>("/servo_server/target_pose", 1 /* queue */, true /* latch */);
+      nh.advertise<geometry_msgs::PoseStamped>("target_pose", 1 /* queue */, true /* latch */);
 
   // Subscribe to servo status (and log it when it changes)
-  StatusMonitor status_monitor(nh, "servo_server/status");
+  StatusMonitor status_monitor(nh, "status");
 
   Eigen::Vector3d lin_tol{ 0.01, 0.01, 0.01 };
   double rot_tol = 0.1;

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -43,13 +43,13 @@ constexpr double ROS_STARTUP_WAIT = 10;    // sec
 
 namespace moveit_servo
 {
-PoseTracking::PoseTracking(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-                           const std::string& parameter_ns)
-  : planning_scene_monitor_(planning_scene_monitor)
+PoseTracking::PoseTracking(const ros::NodeHandle& nh,
+                           const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+  : nh_(nh)
+  , planning_scene_monitor_(planning_scene_monitor)
   , loop_rate_(DEFAULT_LOOP_RATE)
   , transform_listener_(transform_buffer_)
   , stop_requested_(false)
-  , parameter_ns_(parameter_ns)
   , angular_error_(0)
 {
   readROSParams();
@@ -64,13 +64,12 @@ PoseTracking::PoseTracking(const planning_scene_monitor::PlanningSceneMonitorPtr
   initializePID(angular_pid_config_, cartesian_orientation_pids_);
 
   // Use the C++ interface that Servo provides
-  servo_ = std::make_unique<moveit_servo::Servo>(nh_, planning_scene_monitor_, parameter_ns_);
+  servo_ = std::make_unique<moveit_servo::Servo>(nh_, planning_scene_monitor_);
   servo_->start();
 
   // Connect to Servo ROS interfaces
-  std::string target_pose_topic = "/" + parameter_ns_ + "/target_pose";
   target_pose_sub_ =
-      nh_.subscribe<geometry_msgs::PoseStamped>(target_pose_topic, 1, &PoseTracking::targetPoseCallback, this);
+      nh_.subscribe<geometry_msgs::PoseStamped>("target_pose", 1, &PoseTracking::targetPoseCallback, this);
 
   // Publish outgoing twist commands to the Servo object
   twist_stamped_pub_ =
@@ -145,30 +144,27 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 
 void PoseTracking::readROSParams()
 {
-  std::size_t error = 0;
+  // Optional parameter sub-namespace specified in the launch file. All other parameters will be read from this namespace.
+  std::string parameter_ns;
+  ros::param::get("~parameter_ns", parameter_ns);
 
-  // Check for parameter namespace from launch file. All other parameters will be read from this namespace.
-  std::string yaml_namespace;
-  if (ros::param::get("~parameter_ns", yaml_namespace))
-  {
-    if (!parameter_ns_.empty())
-      ROS_WARN_STREAM_NAMED(LOGNAME,
-                            "A parameter namespace was specified in the launch file AND in the constructor argument.");
-
-    parameter_ns_ = yaml_namespace;
-  }
+  // If parameters have been loaded into sub-namespace within the node namespace, append the parameter namespace
+  // to load the parameters correctly.
+  ros::NodeHandle nh = parameter_ns.empty() ? nh_ : ros::NodeHandle(nh_, parameter_ns);
 
   // Wait for ROS parameters to load
   ros::Time begin = ros::Time::now();
-  while (ros::ok() && !ros::param::has(parameter_ns_ + "/planning_frame") &&
-         ((ros::Time::now() - begin).toSec() < ROS_STARTUP_WAIT))
+  while (ros::ok() && !nh.hasParam("planning_frame") && ((ros::Time::now() - begin).toSec() < ROS_STARTUP_WAIT))
   {
-    ROS_WARN_STREAM_NAMED(LOGNAME, "Waiting for parameter: " << parameter_ns_ + "/planning_frame");
+    ROS_WARN_STREAM_NAMED(LOGNAME, "Waiting for parameter: "
+                                       << "planning_frame");
     ros::Duration(0.1).sleep();
   }
 
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/planning_frame", planning_frame_);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/move_group_name", move_group_name_);
+  std::size_t error = 0;
+
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "planning_frame", planning_frame_);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "move_group_name", move_group_name_);
   if (!planning_scene_monitor_->getRobotModel()->hasJointModelGroup(move_group_name_))
   {
     ++error;
@@ -176,7 +172,7 @@ void PoseTracking::readROSParams()
   }
 
   double publish_period;
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/publish_period", publish_period);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_period", publish_period);
   loop_rate_ = ros::Rate(1 / publish_period);
 
   x_pid_config_.dt = publish_period;
@@ -185,25 +181,25 @@ void PoseTracking::readROSParams()
   angular_pid_config_.dt = publish_period;
 
   double windup_limit;
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/windup_limit", windup_limit);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "windup_limit", windup_limit);
   x_pid_config_.windup_limit = windup_limit;
   y_pid_config_.windup_limit = windup_limit;
   z_pid_config_.windup_limit = windup_limit;
   angular_pid_config_.windup_limit = windup_limit;
 
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/x_proportional_gain", x_pid_config_.k_p);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/y_proportional_gain", y_pid_config_.k_p);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/z_proportional_gain", z_pid_config_.k_p);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/x_integral_gain", x_pid_config_.k_i);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/y_integral_gain", y_pid_config_.k_i);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/z_integral_gain", z_pid_config_.k_i);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/x_derivative_gain", x_pid_config_.k_d);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/y_derivative_gain", y_pid_config_.k_d);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/z_derivative_gain", z_pid_config_.k_d);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "x_proportional_gain", x_pid_config_.k_p);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "y_proportional_gain", y_pid_config_.k_p);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "z_proportional_gain", z_pid_config_.k_p);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "x_integral_gain", x_pid_config_.k_i);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "y_integral_gain", y_pid_config_.k_i);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "z_integral_gain", z_pid_config_.k_i);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "x_derivative_gain", x_pid_config_.k_d);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "y_derivative_gain", y_pid_config_.k_d);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "z_derivative_gain", z_pid_config_.k_d);
 
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/angular_proportional_gain", angular_pid_config_.k_p);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/angular_integral_gain", angular_pid_config_.k_i);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/angular_derivative_gain", angular_pid_config_.k_d);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "angular_proportional_gain", angular_pid_config_.k_p);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "angular_integral_gain", angular_pid_config_.k_i);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "angular_derivative_gain", angular_pid_config_.k_d);
 
   rosparam_shortcuts::shutdownIfError(ros::this_node::getName(), error);
 }

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -52,14 +52,8 @@ Servo::Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMon
   if (!readParameters())
     exit(EXIT_FAILURE);
 
-  // By default joint topic name is relative to the node parent namespace. E.g. if the joint topic specified in the
-  // configuration files is "joint_states" and the node is launched in namespace "bar", which exists within
-  // namespace "foo", then the subscribed topic would be "/foo/bar/joint_states".
-  //
-  // Fully custom joint name topics can be used by using absolute topic names in config files. For example,
-  // joint topic parameter can be explicitly set to "/baz/my_joint_state_topic".
-  // **Note!** Make sure your planning scene monitor subscribes to correct joint states topic when using absolute
-  // joint state topic name *or* custom relative joint state topic name (for example, "my_joint_states").
+  // By default, joint topic name is relative to the node parent namespace. Fully custom joint name topics can be
+  // set by using absolute topic names in config files. For example, "/foo/my_joint_state_topic".
   ros::NodeHandle nh_parent_ns = ros::NodeHandle("");
   joint_state_subscriber_ = std::make_shared<JointStateSubscriber>(nh_parent_ns, parameters_.joint_topic);
 

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -76,67 +76,64 @@ bool Servo::readParameters()
 {
   std::size_t error = 0;
 
-  // Check for parameter namespace from launch file. All other parameters will be read from this namespace.
-  std::string yaml_namespace;
-  if (ros::param::get("~parameter_ns", yaml_namespace))
-  {
-    if (!parameter_ns_.empty())
-      ROS_WARN_STREAM_NAMED(LOGNAME,
-                            "A parameter namespace was specified in the launch file AND in the constructor argument.");
+  // Optional parameter sub-namespace specified in the launch file. All other parameters will be read from this namespace.
+  std::string parameter_ns;
+  ros::param::get("~parameter_ns", parameter_ns);
 
-    parameter_ns_ = yaml_namespace;
-  }
+  // If parameters have been loaded into sub-namespace within the node namespace, append the parameter namespace
+  // to load the parameters correctly.
+  ros::NodeHandle nh = parameter_ns.empty() ? nh_ : ros::NodeHandle(nh_, parameter_ns);
 
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/publish_period", parameters_.publish_period);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/collision_check_rate", parameters_.collision_check_rate);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/num_outgoing_halt_msgs_to_publish",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_period", parameters_.publish_period);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "collision_check_rate", parameters_.collision_check_rate);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "num_outgoing_halt_msgs_to_publish",
                                     parameters_.num_outgoing_halt_msgs_to_publish);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/scale/linear", parameters_.linear_scale);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/scale/rotational", parameters_.rotational_scale);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/scale/joint", parameters_.joint_scale);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "scale/linear", parameters_.linear_scale);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "scale/rotational", parameters_.rotational_scale);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "scale/joint", parameters_.joint_scale);
   error +=
-      !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/low_pass_filter_coeff", parameters_.low_pass_filter_coeff);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/joint_topic", parameters_.joint_topic);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/command_in_type", parameters_.command_in_type);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/cartesian_command_in_topic",
+      !rosparam_shortcuts::get(LOGNAME, nh, "low_pass_filter_coeff", parameters_.low_pass_filter_coeff);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_topic", parameters_.joint_topic);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "command_in_type", parameters_.command_in_type);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "cartesian_command_in_topic",
                                     parameters_.cartesian_command_in_topic);
   error +=
-      !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/joint_command_in_topic", parameters_.joint_command_in_topic);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/robot_link_command_frame",
+      !rosparam_shortcuts::get(LOGNAME, nh, "joint_command_in_topic", parameters_.joint_command_in_topic);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "robot_link_command_frame",
                                     parameters_.robot_link_command_frame);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/incoming_command_timeout",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "incoming_command_timeout",
                                     parameters_.incoming_command_timeout);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/lower_singularity_threshold",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "lower_singularity_threshold",
                                     parameters_.lower_singularity_threshold);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/hard_stop_singularity_threshold",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "hard_stop_singularity_threshold",
                                     parameters_.hard_stop_singularity_threshold);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/move_group_name", parameters_.move_group_name);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/planning_frame", parameters_.planning_frame);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/ee_frame_name", parameters_.ee_frame_name);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/use_gazebo", parameters_.use_gazebo);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/joint_limit_margin", parameters_.joint_limit_margin);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/command_out_topic", parameters_.command_out_topic);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/command_out_type", parameters_.command_out_type);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/publish_joint_positions",
-                                    parameters_.publish_joint_positions);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/publish_joint_velocities",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "move_group_name", parameters_.move_group_name);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "planning_frame", parameters_.planning_frame);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "use_gazebo", parameters_.use_gazebo);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_limit_margin", parameters_.joint_limit_margin);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "command_out_topic", parameters_.command_out_topic);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "command_out_type", parameters_.command_out_type);
+  error +=
+      !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_positions", parameters_.publish_joint_positions);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_velocities",
                                     parameters_.publish_joint_velocities);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/publish_joint_accelerations",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_accelerations",
                                     parameters_.publish_joint_accelerations);
 
   // Parameters for collision checking
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/check_collisions", parameters_.check_collisions);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/collision_check_type", parameters_.collision_check_type);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "check_collisions", parameters_.check_collisions);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "collision_check_type", parameters_.collision_check_type);
   bool have_self_collision_proximity_threshold = rosparam_shortcuts::get(
-      "", nh_, parameter_ns_ + "/self_collision_proximity_threshold", parameters_.self_collision_proximity_threshold);
+      LOGNAME, nh, "self_collision_proximity_threshold", parameters_.self_collision_proximity_threshold);
   bool have_scene_collision_proximity_threshold = rosparam_shortcuts::get(
-      "", nh_, parameter_ns_ + "/scene_collision_proximity_threshold", parameters_.scene_collision_proximity_threshold);
+      LOGNAME, nh, "scene_collision_proximity_threshold", parameters_.scene_collision_proximity_threshold);
+  
   double collision_proximity_threshold;
   // 'collision_proximity_threshold' parameter was removed, replaced with separate self- and scene-collision proximity
   // thresholds
   // TODO(JStech): remove this deprecation warning in ROS Noetic; simplify error case handling
-  if (nh_.hasParam(parameter_ns_ + "/collision_proximity_threshold") &&
-      rosparam_shortcuts::get("", nh_, parameter_ns_ + "/collision_proximity_threshold", collision_proximity_threshold))
+  if (nh_.hasParam("collision_proximity_threshold") &&
+      rosparam_shortcuts::get(LOGNAME, nh, "collision_proximity_threshold", collision_proximity_threshold))
   {
     ROS_WARN_NAMED(LOGNAME, "'collision_proximity_threshold' parameter is deprecated, and has been replaced by separate"
                             "'self_collision_proximity_threshold' and 'scene_collision_proximity_threshold' "
@@ -154,22 +151,22 @@ bool Servo::readParameters()
   }
   error += !have_self_collision_proximity_threshold;
   error += !have_scene_collision_proximity_threshold;
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/collision_distance_safety_factor",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "collision_distance_safety_factor",
                                     parameters_.collision_distance_safety_factor);
-  error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/min_allowable_collision_distance",
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "min_allowable_collision_distance",
                                     parameters_.min_allowable_collision_distance);
 
   // This parameter name was changed recently.
   // Try retrieving from the correct name. If it fails, then try the deprecated name.
   // TODO(andyz): remove this deprecation warning in ROS Noetic
-  if (!rosparam_shortcuts::get("", nh_, parameter_ns_ + "/status_topic", parameters_.status_topic))
+  if (!rosparam_shortcuts::get(LOGNAME, nh, "status_topic", parameters_.status_topic))
   {
     ROS_WARN_NAMED(LOGNAME, "'status_topic' parameter is missing. Recently renamed from 'warning_topic'. Please update "
                             "the servoing yaml file.");
-    error += !rosparam_shortcuts::get("", nh_, parameter_ns_ + "/warning_topic", parameters_.status_topic);
+    error += !rosparam_shortcuts::get(LOGNAME, nh, "warning_topic", parameters_.status_topic);
   }
 
-  rosparam_shortcuts::shutdownIfError(parameter_ns_, error);
+  rosparam_shortcuts::shutdownIfError(LOGNAME, error);
 
   // Input checking
   if (parameters_.publish_period <= 0.)

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -104,6 +104,7 @@ bool Servo::readParameters()
                                     parameters_.hard_stop_singularity_threshold);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "move_group_name", parameters_.move_group_name);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "planning_frame", parameters_.planning_frame);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "ee_frame_name", parameters_.ee_frame_name);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "use_gazebo", parameters_.use_gazebo);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_limit_margin", parameters_.joint_limit_margin);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "command_out_topic", parameters_.command_out_topic);

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -91,20 +91,15 @@ bool Servo::readParameters()
   error += !rosparam_shortcuts::get(LOGNAME, nh, "scale/linear", parameters_.linear_scale);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "scale/rotational", parameters_.rotational_scale);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "scale/joint", parameters_.joint_scale);
-  error +=
-      !rosparam_shortcuts::get(LOGNAME, nh, "low_pass_filter_coeff", parameters_.low_pass_filter_coeff);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "low_pass_filter_coeff", parameters_.low_pass_filter_coeff);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_topic", parameters_.joint_topic);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "command_in_type", parameters_.command_in_type);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "cartesian_command_in_topic",
-                                    parameters_.cartesian_command_in_topic);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "cartesian_command_in_topic", parameters_.cartesian_command_in_topic);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_command_in_topic", parameters_.joint_command_in_topic);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "robot_link_command_frame", parameters_.robot_link_command_frame);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "incoming_command_timeout", parameters_.incoming_command_timeout);
   error +=
-      !rosparam_shortcuts::get(LOGNAME, nh, "joint_command_in_topic", parameters_.joint_command_in_topic);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "robot_link_command_frame",
-                                    parameters_.robot_link_command_frame);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "incoming_command_timeout",
-                                    parameters_.incoming_command_timeout);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "lower_singularity_threshold",
-                                    parameters_.lower_singularity_threshold);
+      !rosparam_shortcuts::get(LOGNAME, nh, "lower_singularity_threshold", parameters_.lower_singularity_threshold);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "hard_stop_singularity_threshold",
                                     parameters_.hard_stop_singularity_threshold);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "move_group_name", parameters_.move_group_name);
@@ -113,12 +108,10 @@ bool Servo::readParameters()
   error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_limit_margin", parameters_.joint_limit_margin);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "command_out_topic", parameters_.command_out_topic);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "command_out_type", parameters_.command_out_type);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_positions", parameters_.publish_joint_positions);
+  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_velocities", parameters_.publish_joint_velocities);
   error +=
-      !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_positions", parameters_.publish_joint_positions);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_velocities",
-                                    parameters_.publish_joint_velocities);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_accelerations",
-                                    parameters_.publish_joint_accelerations);
+      !rosparam_shortcuts::get(LOGNAME, nh, "publish_joint_accelerations", parameters_.publish_joint_accelerations);
 
   // Parameters for collision checking
   error += !rosparam_shortcuts::get(LOGNAME, nh, "check_collisions", parameters_.check_collisions);

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -45,9 +45,8 @@ static const std::string LOGNAME = "servo_node";
 
 namespace moveit_servo
 {
-Servo::Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-             const std::string& parameter_ns)
-  : nh_(nh), planning_scene_monitor_(planning_scene_monitor), parameter_ns_(parameter_ns)
+Servo::Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+  : nh_(nh), planning_scene_monitor_(planning_scene_monitor)
 {
   // Read ROS parameters, typically from YAML file
   if (!readParameters())
@@ -64,8 +63,7 @@ Servo::Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMon
   ros::NodeHandle nh_parent_ns = ros::NodeHandle("");
   joint_state_subscriber_ = std::make_shared<JointStateSubscriber>(nh_parent_ns, parameters_.joint_topic);
 
-  servo_calcs_ =
-      std::make_unique<ServoCalcs>(nh_, parameters_, planning_scene_monitor_, joint_state_subscriber_, parameter_ns_);
+  servo_calcs_ = std::make_unique<ServoCalcs>(nh_, parameters_, planning_scene_monitor_, joint_state_subscriber_);
 
   collision_checker_ =
       std::make_unique<CollisionCheck>(nh_, parameters_, planning_scene_monitor_, joint_state_subscriber_);
@@ -121,7 +119,7 @@ bool Servo::readParameters()
       LOGNAME, nh, "self_collision_proximity_threshold", parameters_.self_collision_proximity_threshold);
   bool have_scene_collision_proximity_threshold = rosparam_shortcuts::get(
       LOGNAME, nh, "scene_collision_proximity_threshold", parameters_.scene_collision_proximity_threshold);
-  
+
   double collision_proximity_threshold;
   // 'collision_proximity_threshold' parameter was removed, replaced with separate self- and scene-collision proximity
   // thresholds

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -53,7 +53,16 @@ Servo::Servo(ros::NodeHandle& nh, const planning_scene_monitor::PlanningSceneMon
   if (!readParameters())
     exit(EXIT_FAILURE);
 
-  joint_state_subscriber_ = std::make_shared<JointStateSubscriber>(nh_, parameters_.joint_topic);
+  // By default joint topic name is relative to the node parent namespace. E.g. if the joint topic specified in the
+  // configuration files is "joint_states" and the node is launched in namespace "bar", which exists within
+  // namespace "foo", then the subscribed topic would be "/foo/bar/joint_states".
+  //
+  // Fully custom joint name topics can be used by using absolute topic names in config files. For example,
+  // joint topic parameter can be explicitly set to "/baz/my_joint_state_topic".
+  // **Note!** Make sure your planning scene monitor subscribes to correct joint states topic when using absolute
+  // joint state topic name *or* custom relative joint state topic name (for example, "my_joint_states").
+  ros::NodeHandle nh_parent_ns = ros::NodeHandle("");
+  joint_state_subscriber_ = std::make_shared<JointStateSubscriber>(nh_parent_ns, parameters_.joint_topic);
 
   servo_calcs_ =
       std::make_unique<ServoCalcs>(nh_, parameters_, planning_scene_monitor_, joint_state_subscriber_, parameter_ns_);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -114,15 +114,18 @@ ServoCalcs::ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
 
   // ROS Server for allowing drift in some dimensions
   drift_dimensions_server_ =
-      nh_.advertiseService(ros_namespace + "/change_drift_dimensions", &ServoCalcs::changeDriftDimensions, this);
+      nh_.advertiseService(ros::names::append(nh_.getNamespace(), "change_drift_dimensions"),
+                           &ServoCalcs::changeDriftDimensions, this);
 
   // ROS Server for changing the control dimensions
   control_dimensions_server_ =
-      nh_.advertiseService(ros_namespace + "/change_control_dimensions", &ServoCalcs::changeControlDimensions, this);
+      nh_.advertiseService(ros::names::append(nh_.getNamespace(), "change_control_dimensions"),
+                           &ServoCalcs::changeControlDimensions, this);
 
   // ROS Server to reset the status, e.g. so the arm can move again after a collision
   reset_servo_status_ =
-      nh_.advertiseService(ros_namespace + "/reset_servo_status", &ServoCalcs::resetServoStatus, this);
+      nh_.advertiseService(ros::names::append(nh_.getNamespace(), "reset_servo_status"),
+                           &ServoCalcs::resetServoStatus, this);
 
   // Publish and Subscribe to internal namespace topics
   ros::NodeHandle internal_nh("~internal");

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -125,7 +125,7 @@ ServoCalcs::ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
                                              &ServoCalcs::resetServoStatus, this);
 
   // Publish and Subscribe to internal namespace topics
-  ros::NodeHandle internal_nh("~internal");
+  ros::NodeHandle internal_nh(nh_, "internal");
   collision_velocity_scale_sub_ =
       internal_nh.subscribe("collision_velocity_scale", ROS_QUEUE_SIZE, &ServoCalcs::collisionVelocityScaleCB, this);
   worst_case_stop_time_pub_ = internal_nh.advertise<std_msgs::Float64>("worst_case_stop_time", ROS_QUEUE_SIZE);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -113,19 +113,16 @@ ServoCalcs::ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
   joint_cmd_sub_ = nh_.subscribe(parameters_.joint_command_in_topic, ROS_QUEUE_SIZE, &ServoCalcs::jointCmdCB, this);
 
   // ROS Server for allowing drift in some dimensions
-  drift_dimensions_server_ =
-      nh_.advertiseService(ros::names::append(nh_.getNamespace(), "change_drift_dimensions"),
-                           &ServoCalcs::changeDriftDimensions, this);
+  drift_dimensions_server_ = nh_.advertiseService(ros::names::append(nh_.getNamespace(), "change_drift_dimensions"),
+                                                  &ServoCalcs::changeDriftDimensions, this);
 
   // ROS Server for changing the control dimensions
-  control_dimensions_server_ =
-      nh_.advertiseService(ros::names::append(nh_.getNamespace(), "change_control_dimensions"),
-                           &ServoCalcs::changeControlDimensions, this);
+  control_dimensions_server_ = nh_.advertiseService(ros::names::append(nh_.getNamespace(), "change_control_dimensions"),
+                                                    &ServoCalcs::changeControlDimensions, this);
 
   // ROS Server to reset the status, e.g. so the arm can move again after a collision
-  reset_servo_status_ =
-      nh_.advertiseService(ros::names::append(nh_.getNamespace(), "reset_servo_status"),
-                           &ServoCalcs::resetServoStatus, this);
+  reset_servo_status_ = nh_.advertiseService(ros::names::append(nh_.getNamespace(), "reset_servo_status"),
+                                             &ServoCalcs::resetServoStatus, this);
 
   // Publish and Subscribe to internal namespace topics
   ros::NodeHandle internal_nh("~internal");

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -86,7 +86,7 @@ geometry_msgs::TransformStamped convertIsometryToTransform(const Eigen::Isometry
 // Constructor for the class that handles servoing calculations
 ServoCalcs::ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
                        const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-                       const std::shared_ptr<JointStateSubscriber>& joint_state_subscriber, std::string& ros_namespace)
+                       const std::shared_ptr<JointStateSubscriber>& joint_state_subscriber)
   : nh_(nh)
   , parameters_(parameters)
   , planning_scene_monitor_(planning_scene_monitor)

--- a/moveit_ros/moveit_servo/src/servo_server.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
   ros::AsyncSpinner spinner(ROS_THREADS);
   spinner.start();
 
-  ros::NodeHandle nh;
+  ros::NodeHandle nh("~");
 
   // Load the planning scene monitor
   auto planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -78,10 +78,9 @@ public:
         planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
         false /* skip octomap monitor */);
 
-    tracker_ = std::make_shared<moveit_servo::PoseTracking>(planning_scene_monitor_, "");
+    tracker_ = std::make_shared<moveit_servo::PoseTracking>(nh_, planning_scene_monitor_);
 
-    target_pose_pub_ =
-        nh_.advertise<geometry_msgs::PoseStamped>("/pose_tracking_test/target_pose", 1 /* queue */, true /* latch */);
+    target_pose_pub_ = nh_.advertise<geometry_msgs::PoseStamped>("target_pose", 1 /* queue */, true /* latch */);
 
     // Tolerance for pose seeking
     translation_tolerance_ << TRANSLATION_TOLERANCE, TRANSLATION_TOLERANCE, TRANSLATION_TOLERANCE;
@@ -91,7 +90,7 @@ public:
   }
 
 protected:
-  ros::NodeHandle nh_;
+  ros::NodeHandle nh_{ "~" };
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   Eigen::Vector3d translation_tolerance_;
   moveit_servo::PoseTrackingPtr tracker_;

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.test
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.test
@@ -17,7 +17,7 @@
 
   <test pkg="moveit_servo" type="pose_tracking_test" test-name="pose_tracking_test" time-limit="60
     " args="">
-    <param name="parameter_ns" type="string" value="pose_tracking_test" />
+    <param name="parameter_ns" type="string" value="" />
     <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings.yaml"/>
     <rosparam command="load" file="$(find moveit_servo)/config/pose_tracking_settings.yaml"/>
   </test>

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
@@ -89,7 +89,7 @@ public:
   }
 
 protected:
-  ros::NodeHandle nh_;
+  ros::NodeHandle nh_{ "~" };
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   moveit_servo::ServoPtr servo_;
 };  // class ServoFixture

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.test
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.test
@@ -12,7 +12,7 @@
   </node>
 
   <test pkg="moveit_servo" type="servo_cpp_interface_test" test-name="servo_cpp_interface_test" time-limit="60" args="">
-    <param name="parameter_ns" type="string" value="servo_cpp_interface_test" />
-    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings.yaml"/>
+    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
+    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings.yaml" ns="optional_parameter_namespace"/>
   </test>
 </launch>


### PR DESCRIPTION
The namespacing logic seemed odd when running multiple servo servers within their own namespaces. This PR attempts to fix/change the namespacing logic within Servo to make it more intuitive. I listed before/after comparisons below to better illustrate the changes made in this PR.

**Before**

- Service namespaces were a bit surprising for the services Servo advertises. Namespacing the node that made use of Servo into namespace `foo` resulted to service topics like this: `/foo/foo/<nodeName>/change_drift_dimensions` when I would have expected simple `/foo/<nodeName>/change_drift_dimensions`.
- User was forced to load parameters into separate parameter namespace **that matched the node name**. This was a bit confusing since the node namespace is where the parameters are loaded by default.
- The topic names that Servo subscribed to had, by default, in the example files the name of the Servo server node (for example `servo_server/delta_twist_cmds`). And to be more precise, the topic names had to match the node name. I think it it better to keep relative topic names in config files without the requirement to use node name as part of them. This way user doesn't have to change config file topic names if the node name is changed in the launch file.
- Joint states subscriber subscribed to topic relative to the node handle namespace. Normally this is OK but if you wanted to place all the topics into the node namespace by initializing Servo using `ros::NodeHandle nh("~")` the joint states subscriber would start listening to `/<nodeName>/joint_states` topic which, I would argue, is rarely what one wants. And if more complex namespacing was used, there was no easy way (that I know of) to drop the `<nodeName>` part out of the full topic name just by modifying the topic name in the config file.

**After**

- The service namespacing problem is solved by always advertising the services in the namespace of the node.
- I made parameter namespacing optional since it is nice to be able to sometimes stash the Servo specific parameter under a sub-namespace within the node namespace. So user can now leave the parameters into node namespace for example like this `/servo_server/<parameters>` or use sub-namespace `/servo_server/my_own_servo_param_namespace/<parameters>`
- The topic names in the Servo config file do not need to know about the node name that calls Servo. One can still use absolute names such as`/foo/bar/servo/delta_twist_cmds` just like before. Only the implicit requirement of specifying the calling node name as part of the topic names is removed, that is, `delta_twist_cmds` will now suffice for as value for `cartesian_command_in_topic` parameter.
- Joint states subscriber listens always to the node parent namespace + topic name specified in the configuration file. For nodes running in global namespace the topic will default to `/joint_states`, for more complex namespaces the subscribed topic might be, for example, `/foo/bar/baz/joint_states`. Note that user is still able to specify absolute topic names in config file just like before.

In addition to the changes described in before/after examples, the servo server and cpp example files as well as the launch and config files have been modified to work with the changes in this PR.

