### PR TITLE
Explicitly use version 0.6.5 of moveit_resources, the last version th…

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -11,7 +11,7 @@
 - git:
     local-name: moveit_resources
     uri: https://github.com/ros-planning/moveit_resources.git
-    version: master
+    version: 0.6.5
 - git:
     local-name: moveit_visual_tools
     uri: https://github.com/ros-planning/moveit_visual_tools.git


### PR DESCRIPTION
…at supports kinetic

Isolate this change from #2319 . I guess we will not spend much more work on the kinetic branch, so hardcoding the resources version makes sense to me.

Newer versions of moveit_resources make it a metapackage and the tests in kinetic-devel are not set up for that; they refer to subdirectories of moveit_resources
instead of eg. moveit_resources_fanuc_moveit_config which only exists from version 0.7.0 onwards