### PR TITLE
Depend on ros-noetic-fcl (0.6) in Noetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
     - ROS_DISTRO=noetic
-    - ROS_REPO=ros
+    - ROS_REPO=ros-testing
     - UPSTREAM_WORKSPACE=moveit.rosinstall
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
     - WARNINGS_OK=false

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -26,7 +26,8 @@
   <depend>bullet</depend>
   <depend>eigen_stl_containers</depend>
   <depend>eigen_conversions</depend>
-  <depend>libfcl-dev</depend>
+  <depend condition="$ROS_DISTRO != noetic">libfcl-dev</depend>
+  <depend condition="$ROS_DISTRO == noetic">fcl</depend>
   <depend version_gte="0.5.2">geometric_shapes</depend>
   <depend>geometry_msgs</depend>
   <depend>kdl_parser</depend>


### PR DESCRIPTION
After [having fcl 0.6 released](https://github.com/ros/rosdistro/pull/26706) into the ROS repos (additionally to fcl 0.5 in the standard Ubuntu/Debian repos) we can switch to this newer version of fcl now.
Probably, Travis will need to be switched to ros-testing (because it's not synced yet).