### PR TITLE
Convert tabs to spaces, fix over-indentation

### DIFF
--- a/moveit_setup_assistant/launch/setup_assistant.launch
+++ b/moveit_setup_assistant/launch/setup_assistant.launch
@@ -8,7 +8,7 @@
 
   <!-- Run -->
   <node pkg="moveit_setup_assistant" type="moveit_setup_assistant" name="moveit_setup_assistant"
-	launch-prefix="$(arg launch_prefix)"
+        launch-prefix="$(arg launch_prefix)"
         output="screen"  required="true" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -26,7 +26,7 @@
   <arg name="use_rviz" default="true" />
 
   <!-- If needed, broadcast static tf for robot root -->
-  [VIRTUAL_JOINT_BROADCASTER]
+[VIRTUAL_JOINT_BROADCASTER]
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/edit_configuration_package.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/edit_configuration_package.launch
@@ -8,8 +8,8 @@
 
   <!-- Run -->
   <node pkg="moveit_setup_assistant" type="moveit_setup_assistant" name="moveit_setup_assistant"
-	args="--config_pkg=[GENERATED_PACKAGE_NAME]"
-	launch-prefix="$(arg launch_prefix)"
+        args="--config_pkg=[GENERATED_PACKAGE_NAME]"
+        launch-prefix="$(arg launch_prefix)"
         output="screen" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -4,7 +4,7 @@
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix"
-	   value="gdb -x $(find [GENERATED_PACKAGE_NAME])/launch/gdb_settings.gdb --ex run --args" />
+           value="gdb -x $(find [GENERATED_PACKAGE_NAME])/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
   <arg name="info" default="$(arg debug)" />

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_rviz.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_rviz.launch
@@ -9,7 +9,7 @@
   <arg unless="$(eval rviz_config=='')" name="command_args" value="-d $(arg rviz_config)" />
 
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
-	args="$(arg command_args)" output="screen">
+        args="$(arg command_args)" output="screen">
   </node>
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
@@ -6,10 +6,10 @@
   <!-- The request adapters (plugins) used when planning with TrajOpt.
        ORDER MATTERS -->
   <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
-				       default_planner_request_adapters/FixWorkspaceBounds
-				       default_planner_request_adapters/FixStartStateBounds
-				       default_planner_request_adapters/FixStartStateCollision
-				       default_planner_request_adapters/FixStartStatePathConstraints" />
+                                       default_planner_request_adapters/FixWorkspaceBounds
+                                       default_planner_request_adapters/FixStartStateBounds
+                                       default_planner_request_adapters/FixStartStateCollision
+                                       default_planner_request_adapters/FixStartStatePathConstraints" />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
 


### PR DESCRIPTION
### Description
 * Convert tabs to spaces
 * Fix issue with overindentation of `VIRTUAL_JOINT_BROADCASTER`

The generated `demo.launch` is currently
```
  <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
  <include file="$(find stretch_moveit_config)/launch/planning_context.launch">
    <arg name="load_robot_description" value="true"/>
  </include>

  <!-- If needed, broadcast static tf for robot root -->
    <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 map base_link" />
```

This is because the template is indented and the line added [here](https://github.com/ros-planning/moveit/blob/73416fb9fb1b242f5c6af05a628d076425c6ea25/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp#L1097) are both indented. Since there could be multiple broadcasters, each requiring indentation, it made sense to remove it from the template. 


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
