### PR TITLE
Fix servo trajectory point timestamping

### DIFF
--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -132,11 +132,8 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
       return PoseTrackingStatusCode::STOP_REQUESTED;
     }
 
-    // Compute servo command from PID controller output
-    auto msg = calculateTwistCommand();
-
-    // Send command to the Servo object, for execution
-    twist_stamped_pub_.publish(*msg);
+    // Compute servo command from PID controller output and send it to the Servo object, for execution
+    twist_stamped_pub_.publish(calculateTwistCommand());
   }
 
   doPostMotionReset();

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -169,6 +169,9 @@ void ServoCalcs::start()
   // We will update last_sent_command_ every time we start servo
   auto initial_joint_trajectory = moveit::util::make_shared_from_pool<trajectory_msgs::JointTrajectory>();
 
+  // When a joint_trajectory_controller receives a new command, a stamp of 0 indicates "begin immediately"
+  // See http://wiki.ros.org/joint_trajectory_controller#Trajectory_replacement
+  initial_joint_trajectory->header.stamp = ros::Time(0);
   initial_joint_trajectory->header.frame_id = parameters_.planning_frame;
   initial_joint_trajectory->joint_names = internal_joint_state_.name;
   trajectory_msgs::JointTrajectoryPoint point;
@@ -360,6 +363,9 @@ void ServoCalcs::run(const ros::TimerEvent& timer_event)
     // (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
     if (parameters_.command_out_type == "trajectory_msgs/JointTrajectory")
     {
+      // When a joint_trajectory_controller receives a new command, a stamp of 0 indicates "begin immediately"
+      // See http://wiki.ros.org/joint_trajectory_controller#Trajectory_replacement
+      joint_trajectory->header.stamp = ros::Time(0);
       outgoing_cmd_pub_.publish(joint_trajectory);
     }
     else if (parameters_.command_out_type == "std_msgs/Float64MultiArray")
@@ -592,6 +598,9 @@ void ServoCalcs::calculateJointVelocities(sensor_msgs::JointState& joint_state, 
 void ServoCalcs::composeJointTrajMessage(const sensor_msgs::JointState& joint_state,
                                          trajectory_msgs::JointTrajectory& joint_trajectory) const
 {
+  // When a joint_trajectory_controller receives a new command, a stamp of 0 indicates "begin immediately"
+  // See http://wiki.ros.org/joint_trajectory_controller#Trajectory_replacement
+  joint_trajectory.header.stamp = ros::Time(0);
   joint_trajectory.header.frame_id = parameters_.planning_frame;
   joint_trajectory.joint_names = joint_state.name;
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -808,6 +808,8 @@ void ServoCalcs::suddenHalt(trajectory_msgs::JointTrajectory& joint_trajectory)
   joint_trajectory.points.clear();
   joint_trajectory.points.emplace_back();
   trajectory_msgs::JointTrajectoryPoint& point = joint_trajectory.points.front();
+  point.time_from_start.fromNSec(1);
+
   point.positions.resize(num_joints_);
   point.velocities.resize(num_joints_);
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -170,7 +170,6 @@ void ServoCalcs::start()
   auto initial_joint_trajectory = moveit::util::make_shared_from_pool<trajectory_msgs::JointTrajectory>();
 
   initial_joint_trajectory->header.frame_id = parameters_.planning_frame;
-  initial_joint_trajectory->header.stamp = ros::Time::now();
   initial_joint_trajectory->joint_names = internal_joint_state_.name;
   trajectory_msgs::JointTrajectoryPoint point;
   point.time_from_start = ros::Duration(parameters_.publish_period);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -816,6 +816,11 @@ void ServoCalcs::suddenHalt(trajectory_msgs::JointTrajectory& joint_trajectory)
   joint_trajectory.points.clear();
   joint_trajectory.points.emplace_back();
   trajectory_msgs::JointTrajectoryPoint& point = joint_trajectory.points.front();
+
+  // When sending out trajectory_msgs/JointTrajectory type messages, the "trajectory" is just a single point.
+  // That point cannot have the same timestamp as the start of trajectory execution since that would mean the
+  // arm has to reach the first trajectory point the moment execution begins. To prevent errors about points
+  // being 0 seconds in the past, the smallest supported timestep is added as time from start to the trajectory point.
   point.time_from_start.fromNSec(1);
 
   point.positions.resize(num_joints_);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -361,7 +361,6 @@ void ServoCalcs::run(const ros::TimerEvent& timer_event)
     // (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
     if (parameters_.command_out_type == "trajectory_msgs/JointTrajectory")
     {
-      joint_trajectory->header.stamp = ros::Time::now();
       outgoing_cmd_pub_.publish(joint_trajectory);
     }
     else if (parameters_.command_out_type == "std_msgs/Float64MultiArray")
@@ -595,7 +594,6 @@ void ServoCalcs::composeJointTrajMessage(const sensor_msgs::JointState& joint_st
                                          trajectory_msgs::JointTrajectory& joint_trajectory) const
 {
   joint_trajectory.header.frame_id = parameters_.planning_frame;
-  joint_trajectory.header.stamp = ros::Time::now();
   joint_trajectory.joint_names = joint_state.name;
 
   trajectory_msgs::JointTrajectoryPoint point;


### PR DESCRIPTION
This PR removes trajectory point timestamping which causes warnings about trajectory points being dropped due to having old timestamps:
```
ros.joint_trajectory_controller: Dropping all 1 trajectory point(s), as they occur before the current time.
Last point is 0.000064s in the past.
```
By removing explicit timestamping, the stamps will default to 0, meaning the trajectory execution defaults to _start now_. For more details, see section 2.3: [http://wiki.ros.org/joint_trajectory_controller](http://wiki.ros.org/joint_trajectory_controller) 

Small time from start is added to the trajectory point generated in `suddenHalt` to prevent warnings about trajectory point being 0.0000 seconds in the past (not sure if this should be considered as a bug or not, but it is clearly a corner case).

Finally, there is a tiny optimization added to the way twist command is passed to publisher from `calculateTwistCommand` function. It is not strictly related but felt too small for its own PR.