### PR TITLE
Order PlaceLocations by quality during planning

### DIFF
--- a/moveit_ros/manipulation/pick_place/src/pick.cpp
+++ b/moveit_ros/manipulation/pick_place/src/pick.cpp
@@ -173,7 +173,8 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
   for (std::size_t i = 0; i < goal.possible_grasps.size(); ++i)
     grasp_order[i] = i;
   OrderGraspQuality oq(goal.possible_grasps);
-  std::sort(grasp_order.begin(), grasp_order.end(), oq);
+  // using stable_sort to preserve order of grasps with equal quality
+  std::stable_sort(grasp_order.begin(), grasp_order.end(), oq);
 
   // feed the available grasps to the stages we set up
   for (std::size_t i = 0; i < goal.possible_grasps.size(); ++i)

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -51,6 +51,20 @@ PlacePlan::PlacePlan(const PickPlaceConstPtr& pick_place) : PickPlacePlanBase(pi
 
 namespace
 {
+struct OrderPlaceLocationQuality
+{
+  OrderPlaceLocationQuality(const std::vector<moveit_msgs::PlaceLocation>& places) : places_(places)
+  {
+  }
+
+  bool operator()(const std::size_t a, const std::size_t b) const
+  {
+    return places_[a].quality > places_[b].quality;
+  }
+
+  const std::vector<moveit_msgs::PlaceLocation>& places_;
+};
+
 bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
                                 const moveit::core::AttachedBody* attached_body, geometry_msgs::PoseStamped& place_pose)
 {
@@ -304,11 +318,18 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
 
   pipeline_.start();
 
+  // order the place locations by quality
+  std::vector<std::size_t> places_order(goal.place_locations.size());
+  for (std::size_t i = 0; i < goal.place_locations.size(); ++i)
+    places_order[i] = i;
+  OrderPlaceLocationQuality oq(goal.place_locations);
+  std::sort(places_order.begin(), places_order.end(), oq);
+
   // add possible place locations
   for (std::size_t i = 0; i < goal.place_locations.size(); ++i)
   {
     ManipulationPlanPtr p(new ManipulationPlan(const_plan_data));
-    const moveit_msgs::PlaceLocation& pl = goal.place_locations[i];
+    const moveit_msgs::PlaceLocation& pl = goal.place_locations[places_order[i]];
 
     if (goal.place_eef)
       p->goal_pose_ = pl.place_pose;
@@ -325,7 +346,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
     p->approach_ = pl.pre_place_approach;
     p->retreat_ = pl.post_place_retreat;
     p->retreat_posture_ = pl.post_place_posture;
-    p->id_ = i;
+    p->id_ = places_order[i];
     if (p->retreat_posture_.joint_names.empty())
       p->retreat_posture_ = attached_body->getDetachPosture();
     pipeline_.push(p);

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -59,7 +59,9 @@ struct OrderPlaceLocationQuality
 
   bool operator()(const std::size_t a, const std::size_t b) const
   {
-    return places_[a].quality > places_[b].quality;
+    if (places_[a].quality > places_[b].quality) return true;
+    if (places_[a].quality == places_[b].quality) return a > b;
+    return false;
   }
 
   const std::vector<moveit_msgs::PlaceLocation>& places_;

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -319,17 +319,17 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   pipeline_.start();
 
   // order the place locations by quality
-  std::vector<std::size_t> places_order(goal.place_locations.size());
+  std::vector<std::size_t> place_locations_order(goal.place_locations.size());
   for (std::size_t i = 0; i < goal.place_locations.size(); ++i)
-    places_order[i] = i;
+    place_locations_order[i] = i;
   OrderPlaceLocationQuality oq(goal.place_locations);
-  std::sort(places_order.begin(), places_order.end(), oq);
+  std::sort(place_locations_order.begin(), place_locations_order.end(), oq);
 
   // add possible place locations
   for (std::size_t i = 0; i < goal.place_locations.size(); ++i)
   {
     ManipulationPlanPtr p(new ManipulationPlan(const_plan_data));
-    const moveit_msgs::PlaceLocation& pl = goal.place_locations[places_order[i]];
+    const moveit_msgs::PlaceLocation& pl = goal.place_locations[place_locations_order[i]];
 
     if (goal.place_eef)
       p->goal_pose_ = pl.place_pose;
@@ -346,7 +346,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
     p->approach_ = pl.pre_place_approach;
     p->retreat_ = pl.post_place_retreat;
     p->retreat_posture_ = pl.post_place_posture;
-    p->id_ = places_order[i];
+    p->id_ = place_locations_order[i];
     if (p->retreat_posture_.joint_names.empty())
       p->retreat_posture_ = attached_body->getDetachPosture();
     pipeline_.push(p);

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -59,9 +59,7 @@ struct OrderPlaceLocationQuality
 
   bool operator()(const std::size_t a, const std::size_t b) const
   {
-    if (places_[a].quality > places_[b].quality) return true;
-    if (places_[a].quality == places_[b].quality) return a > b;
-    return false;
+    return places_[a].quality > places_[b].quality;
   }
 
   const std::vector<moveit_msgs::PlaceLocation>& places_;
@@ -325,7 +323,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
   for (std::size_t i = 0; i < goal.place_locations.size(); ++i)
     place_locations_order[i] = i;
   OrderPlaceLocationQuality oq(goal.place_locations);
-  std::sort(place_locations_order.begin(), place_locations_order.end(), oq);
+  // using stable_sort to preserve order of place locations with equal quality
+  std::stable_sort(place_locations_order.begin(), place_locations_order.end(), oq);
 
   // add possible place locations
   for (std::size_t i = 0; i < goal.place_locations.size(); ++i)


### PR DESCRIPTION
### Description

The quality field was added by https://github.com/ros-planning/moveit_msgs/commit/cdb9e4aa964269f1a159a8f35c7b634365e86038.
The changes are adapted from pick.cpp, where the Grasps are also ordered by quality.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
