### PR TITLE
Fix QObject::connect: Cannot queue arguments of type 'QVector<int>'

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -112,9 +112,6 @@ public:
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 
-Q_SIGNALS:
-  void changeSceneName(const QString& name);
-
 private Q_SLOTS:
 
   // ******************************************************************************************

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -112,6 +112,9 @@ public:
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 
+Q_SIGNALS:
+  void changeSceneName(const QString& name);
+
 private Q_SLOTS:
 
   // ******************************************************************************************
@@ -130,6 +133,7 @@ private Q_SLOTS:
   void changedSceneDisplayTime();
   void changedOctreeRenderMode();
   void changedOctreeColorMode();
+  void setSceneName(const QString& name);
 
 protected Q_SLOTS:
   virtual void changedAttachedBodyColor();

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -90,6 +90,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   scene_name_property_ = new rviz::StringProperty("Scene Name", "(noname)", "Shows the name of the planning scene",
                                                   scene_category_, SLOT(changedSceneName()), this);
   scene_name_property_->setShouldBeSaved(false);
+  connect(this, &PlanningSceneDisplay::changeSceneName, this, &PlanningSceneDisplay::setSceneName);
   scene_enabled_property_ =
       new rviz::BoolProperty("Show Scene Geometry", true, "Indicates whether planning scenes should be displayed",
                              scene_category_, SLOT(changedSceneEnabled()), this);

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -583,12 +583,15 @@ void PlanningSceneDisplay::sceneMonitorReceivedUpdate(
 void PlanningSceneDisplay::onSceneMonitorReceivedUpdate(
     planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType /*update_type*/)
 {
-  bool old_state = scene_name_property_->blockSignals(true);
   getPlanningSceneRW()->getCurrentStateNonConst().update();
-  scene_name_property_->setStdString(getPlanningSceneRO()->getName());
-  scene_name_property_->blockSignals(old_state);
-
+  Q_EMIT changeSceneName(QString::fromStdString(getPlanningSceneRO()->getName()));
   planning_scene_needs_render_ = true;
+}
+
+void PlanningSceneDisplay::setSceneName(const QString& name)
+{
+  QSignalBlocker block(scene_name_property_);
+  scene_name_property_->setString(name);
 }
 
 void PlanningSceneDisplay::onEnable()

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -90,7 +90,6 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   scene_name_property_ = new rviz::StringProperty("Scene Name", "(noname)", "Shows the name of the planning scene",
                                                   scene_category_, SLOT(changedSceneName()), this);
   scene_name_property_->setShouldBeSaved(false);
-  connect(this, &PlanningSceneDisplay::changeSceneName, this, &PlanningSceneDisplay::setSceneName);
   scene_enabled_property_ =
       new rviz::BoolProperty("Show Scene Geometry", true, "Indicates whether planning scenes should be displayed",
                              scene_category_, SLOT(changedSceneEnabled()), this);
@@ -585,13 +584,13 @@ void PlanningSceneDisplay::onSceneMonitorReceivedUpdate(
     planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType /*update_type*/)
 {
   getPlanningSceneRW()->getCurrentStateNonConst().update();
-  Q_EMIT changeSceneName(QString::fromStdString(getPlanningSceneRO()->getName()));
+  QMetaObject::invokeMethod(this, "setSceneName", Qt::QueuedConnection,
+                            Q_ARG(QString, QString::fromStdString(getPlanningSceneRO()->getName())));
   planning_scene_needs_render_ = true;
 }
 
 void PlanningSceneDisplay::setSceneName(const QString& name)
 {
-  QSignalBlocker block(scene_name_property_);
   scene_name_property_->setString(name);
 }
 


### PR DESCRIPTION
Fix annoying Qt warning about unregistered `QVector<int>`. The reason was that the planning scene name was changed from a non-GUI thread, causing a `dataChanged()` signal emitted from this thread, which then needs to be queued for processing in the main event loop.
I fixed that by emitting a signal from the thread to change the name. Thus, a `QString` event is queued, which doesn't pose an issue.