### PR TITLE
Fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - [Overview of MoveIt](https://moveit.ros.org)
 - [Installation Instructions](https://moveit.ros.org/install/)
-- [Documentation](https://moveit.ros.org/documentation/)
+- [Documentation](https://moveit.ros.org/documentation/source-code-api/)
 - [Get Involved](https://moveit.ros.org/about/get_involved/)
 
 ## Branches Policy


### PR DESCRIPTION
### Description

FIxed the Documentation link in the README.

The previous link pointed to "https://moveit.ros.org/documentation/" which is not a page in the moveit.ros.org domain. A better fix may be to create a documentation index page on that domain. For now, this change points the link to the "souce-code-api" section of the documentation. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
