### PR TITLE
Fix pose tracking race condition

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -170,6 +170,7 @@ private:
   Eigen::Isometry3d command_frame_transform_;
   ros::Time command_frame_transform_stamp_;
   geometry_msgs::PoseStamped target_pose_;
+  std::mutex target_pose_mtx_;
 
   // Subscribe to target pose
   ros::Subscriber target_pose_sub_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -114,7 +114,6 @@ public:
    */
   bool getCommandFrameTransform(geometry_msgs::TransformStamped& transform);
 
-
   /** \brief Re-initialize the target pose to an empty message. Can be used to reset motion between waypoints. */
   void resetTargetPose();
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -114,6 +114,10 @@ public:
    */
   bool getCommandFrameTransform(geometry_msgs::TransformStamped& transform);
 
+
+  /** \brief Re-initialize the target pose to an empty message. Can be used to reset motion between waypoints. */
+  void resetTargetPose();
+
   // moveit_servo::Servo instance. Public so we can access member functions like setPaused()
   std::unique_ptr<moveit_servo::Servo> servo_;
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -170,7 +170,7 @@ private:
   Eigen::Isometry3d command_frame_transform_;
   ros::Time command_frame_transform_stamp_;
   geometry_msgs::PoseStamped target_pose_;
-  std::mutex target_pose_mtx_;
+  mutable std::mutex target_pose_mtx_;
 
   // Subscribe to target pose
   ros::Subscriber target_pose_sub_;

--- a/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_example.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_example.cpp
@@ -127,6 +127,10 @@ int main(int argc, char** argv)
   // Modify it a little bit
   target_pose.pose.position.x += 0.1;
 
+  // resetTargetPose() can be used to clear the target pose and wait for a new one, e.g. when moving between multiple
+  // waypoints
+  tracker.resetTargetPose();
+
   // Publish target pose
   target_pose.header.stamp = ros::Time::now();
   target_pose_pub.publish(target_pose);

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -79,9 +79,6 @@ PoseTracking::PoseTracking(const ros::NodeHandle& nh,
 PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positional_tolerance,
                                                 const double angular_tolerance, const double target_pose_timeout)
 {
-  // Roll back the target pose timestamp to ensure we wait for a new target pose message
-  target_pose_.header.stamp = ros::Time::now() - ros::Duration(2 * target_pose_timeout);
-
   // Wait a bit for a target pose message to arrive.
   // The target pose may get updated by new messages as the robot moves (in a callback function).
   ros::Time start_time = ros::Time::now();
@@ -247,7 +244,6 @@ void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& 
     }
     tf2::doTransform(target_pose_, target_pose_, target_to_planning_frame);
   }
-  target_pose_.header.stamp = ros::Time::now();
 }
 
 geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -271,7 +271,7 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
 
     // Orientation algorithm:
     // - Find the orientation error as a quaternion: q_error = q_desired * q_current ^ -1
-    // - Use the quaternion PID controllers to calculate a quaternion rate, q_error_dot
+    // - Use the angle-axis PID controller to calculate an angular rate
     // - Convert to angular velocity for the TwistStamped message
     q_desired = Eigen::Quaterniond(target_pose_.pose.orientation.w, target_pose_.pose.orientation.x,
                                    target_pose_.pose.orientation.y, target_pose_.pose.orientation.z);
@@ -347,6 +347,13 @@ void PoseTracking::getPIDErrors(double& x_error, double& y_error, double& z_erro
   cartesian_position_pids_.at(1).getCurrentPIDErrors(&y_error, &dummy1, &dummy2);
   cartesian_position_pids_.at(2).getCurrentPIDErrors(&z_error, &dummy1, &dummy2);
   cartesian_orientation_pids_.at(0).getCurrentPIDErrors(&orientation_error, &dummy1, &dummy2);
+}
+
+void PoseTracking::resetTargetPose()
+{
+  std::lock_guard<std::mutex> lock(target_pose_mtx_);
+  target_pose_ = geometry_msgs::PoseStamped();
+  target_pose_.header.stamp = ros::Time(0);
 }
 
 bool PoseTracking::getCommandFrameTransform(geometry_msgs::TransformStamped& transform)

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -222,7 +222,7 @@ bool PoseTracking::satisfiesPoseTolerance(const Eigen::Vector3d& positional_tole
   double z_error = target_pose_.pose.position.z - command_frame_transform_.translation()(2);
 
   return ((std::abs(x_error) < positional_tolerance(0)) && (std::abs(y_error) < positional_tolerance(1)) &&
-         (std::abs(z_error) < positional_tolerance(2)) && (std::abs(angular_error_) < angular_tolerance));
+          (std::abs(z_error) < positional_tolerance(2)) && (std::abs(angular_error_) < angular_tolerance));
 }
 
 void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& msg)

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -144,7 +144,7 @@ TEST_F(PoseTrackingFixture, OutgoingMsgTest)
 
   // resetTargetPose() can be used to clear the target pose and wait for a new one, e.g. when moving between multiple
   // waypoints
-  tracker_->resetTargetPose()
+  tracker_->resetTargetPose();
 
   tracker_->moveToPose(translation_tolerance_, ROTATION_TOLERANCE, 1 /* target pose timeout */);
 

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -141,6 +141,11 @@ TEST_F(PoseTrackingFixture, OutgoingMsgTest)
   });
 
   ros::Duration(ROS_PUB_SUB_DELAY).sleep();
+
+  // resetTargetPose() can be used to clear the target pose and wait for a new one, e.g. when moving between multiple
+  // waypoints
+  tracker_->resetTargetPose()
+
   tracker_->moveToPose(translation_tolerance_, ROTATION_TOLERANCE, 1 /* target pose timeout */);
 
   target_pub_thread.join();


### PR DESCRIPTION
This PR fixes issues where `target_pose` timestamp rewriting caused surprising and unwanted behaviour. This PR also fixes possible data races on the variable where it's value can be written in the subscriber callback function while it is simultaneously being read in another function.

- Timestamp rewriting was removed from the subscriber callback function to prevent outdated target poses being used in `moveToPose` function.
- Another instance of timestamp rewriting was removed from the `moveToPose` function itself to prevent situations where sending just one target pose message would occasionally result in situation where target pose would be sent with a reasonable timestamp, callback function would then process and store it, and finally moveToPose would be called which would rewrite the timestamp and then wait until failure for a target pose with a correct timestamp. 

In addition, access to class member variable `target_pose_` was protected with a mutex to prevent data races on it.

