### PR TITLE
WIP: Introduce interactive marker offset

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -74,6 +74,8 @@ class FloatProperty;
 class RosTopicProperty;
 class EditableEnumProperty;
 class ColorProperty;
+class VectorProperty;
+class QuaternionProperty;
 class MovableText;
 }  // namespace rviz
 
@@ -171,6 +173,7 @@ private Q_SLOTS:
   void changedQueryStartState();
   void changedQueryGoalState();
   void changedQueryMarkerScale();
+  void changedQueryMarkerOffset();
   void changedQueryStartColor();
   void changedQueryGoalColor();
   void changedQueryStartAlpha();
@@ -295,6 +298,9 @@ protected:
   rviz::BoolProperty* query_start_state_property_;
   rviz::BoolProperty* query_goal_state_property_;
   rviz::FloatProperty* query_marker_scale_property_;
+  rviz::Property* query_marker_offset_category_;
+  rviz::VectorProperty*  query_marker_offset_position_property_;
+  rviz::QuaternionProperty* query_marker_offset_orientation_property_;
   rviz::ColorProperty* query_start_color_property_;
   rviz::ColorProperty* query_goal_color_property_;
   rviz::FloatProperty* query_start_alpha_property_;


### PR DESCRIPTION
### Description

This patch introduces a new interactive marker offset property for the RViz plugin.

In the process I found a bug in the InteractionHandler, which applied the marker offset incorrectly.

This PR is work in progress, I still need to make screenshots and update the docs if applicable.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
