### PR TITLE
FixStartStateBounds: Copy attached bodies when adapting the start state

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -181,7 +181,7 @@ public:
     if (change_req)
     {
       planning_interface::MotionPlanRequest req2 = req;
-      moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state, false);
+      moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
       solved = planner(planning_scene, req2, res);
     }
     else


### PR DESCRIPTION
This fixes https://github.com/ros-planning/moveit_task_constructor/issues/211, where an attached object was "lost" during planning. Turned out that the `FixStartStateBounds` adapter, while creating a new _non-diff_ `start_state`, did not copy all the attached objects, which are part of the RobotState as well. Thus with new joints, also attached objects were overridden.
Interestingly this bug was undetected over all the years...