### PR TITLE
New orientation constraint parameterization

### DIFF
--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -475,9 +475,28 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
     double angle_z =
         2.0 * (random_number_generator_.uniform01() - 0.5) *
         (sampling_pose_.orientation_constraint_->getZAxisTolerance() - std::numeric_limits<double>::epsilon());
-    Eigen::Isometry3d diff(Eigen::AngleAxisd(angle_x, Eigen::Vector3d::UnitX()) *
-                           Eigen::AngleAxisd(angle_y, Eigen::Vector3d::UnitY()) *
-                           Eigen::AngleAxisd(angle_z, Eigen::Vector3d::UnitZ()));
+
+    Eigen::Isometry3d diff;  // (jeroendm) is this second constructor a significant performance penalty?
+    if (sampling_pose_.orientation_constraint_->getParameterization() ==
+        moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES)
+    {
+      diff = Eigen::Isometry3d(Eigen::AngleAxisd(angle_x, Eigen::Vector3d::UnitX()) *
+                               Eigen::AngleAxisd(angle_y, Eigen::Vector3d::UnitY()) *
+                               Eigen::AngleAxisd(angle_z, Eigen::Vector3d::UnitZ()));
+    }
+    else if (sampling_pose_.orientation_constraint_->getParameterization() ==
+             moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
+    {
+      Eigen::Vector3d rotation_vector(angle_x, angle_y, angle_z);
+      diff = Eigen::Isometry3d(Eigen::AngleAxisd(rotation_vector.norm(), rotation_vector.normalized()));
+    }
+    else
+    {
+      /* The parameterization type should be validated in configure, so this should never happen. */
+      ROS_ERROR_STREAM_NAMED("default_constraint_samplers",
+                             "The parameterization type for the orientation constraints is invalid.");
+    }
+
     // diff is isometry by construction
     // getDesiredRotationMatrix() returns a valid rotation matrix by contract
     // reqr has thus to be a valid isometry

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -476,15 +476,15 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
         2.0 * (random_number_generator_.uniform01() - 0.5) *
         (sampling_pose_.orientation_constraint_->getZAxisTolerance() - std::numeric_limits<double>::epsilon());
 
-    Eigen::Isometry3d diff;  // (jeroendm) is this second constructor a significant performance penalty?
-    if (sampling_pose_.orientation_constraint_->getParameterization() ==
+    Eigen::Isometry3d diff;
+    if (sampling_pose_.orientation_constraint_->getParameterizationType() ==
         moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES)
     {
       diff = Eigen::Isometry3d(Eigen::AngleAxisd(angle_x, Eigen::Vector3d::UnitX()) *
                                Eigen::AngleAxisd(angle_y, Eigen::Vector3d::UnitY()) *
                                Eigen::AngleAxisd(angle_z, Eigen::Vector3d::UnitZ()));
     }
-    else if (sampling_pose_.orientation_constraint_->getParameterization() ==
+    else if (sampling_pose_.orientation_constraint_->getParameterizationType() ==
              moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
     {
       Eigen::Vector3d rotation_vector(angle_x, angle_y, angle_z);

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -338,6 +338,7 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSampler)
   ocm.absolute_y_axis_tolerance = 0.01;
   ocm.absolute_z_axis_tolerance = 0.01;
   ocm.weight = 1.0;
+  ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
 
   EXPECT_TRUE(oc.configure(ocm, tf));
 
@@ -348,6 +349,18 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSampler)
   EXPECT_TRUE(oc.configure(ocm, tf));
 
   constraint_samplers::IKConstraintSampler iks(ps_, "right_arm");
+  EXPECT_TRUE(iks.configure(constraint_samplers::IKSamplingPose(oc)));
+  for (int t = 0; t < 100; ++t)
+  {
+    ks.update();
+    EXPECT_TRUE(iks.sample(ks, ks_const, 100));
+    EXPECT_TRUE(oc.decide(ks).satisfied);
+  }
+
+  // test another parameterization for orientation constraints
+  ocm.parameterization = moveit_msgs::OrientationConstraint::ROTATION_VECTOR;
+  EXPECT_TRUE(oc.configure(ocm, tf));
+
   EXPECT_TRUE(iks.configure(constraint_samplers::IKSamplingPose(oc)));
   for (int t = 0; t < 100; ++t)
   {

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -479,6 +479,13 @@ public:
   }
 
 protected:
+  /** Describes the three parameter representation of an orientation matrix to apply constraint tolerance around x, y and x axis. **/
+  enum class Parameterization
+  {
+    EULER_ANGLES,
+    ANGLE_AXIS
+  };
+
   const moveit::core::LinkModel* link_model_;   /**< \brief The target link model */
   Eigen::Matrix3d desired_rotation_matrix_;     /**< \brief The desired rotation matrix in the tf frame. Guaranteed to
                                                  * be valid rotation matrix. */
@@ -486,6 +493,7 @@ protected:
                                                  * efficiency. Guaranteed to be valid rotation matrix. */
   std::string desired_rotation_frame_id_;       /**< \brief The target frame of the transform tree */
   bool mobile_frame_;                           /**< \brief Whether or not the header frame is mobile or fixed */
+  Parameterization parameterization_;           /**< \brief Parameterization type for orientation tolerance. */
   double absolute_x_axis_tolerance_, absolute_y_axis_tolerance_,
       absolute_z_axis_tolerance_; /**< \brief Storage for the tolerances */
 };

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -491,7 +491,7 @@ protected:
                                                  * efficiency. Guaranteed to be valid rotation matrix. */
   std::string desired_rotation_frame_id_;       /**< \brief The target frame of the transform tree */
   bool mobile_frame_;                           /**< \brief Whether or not the header frame is mobile or fixed */
-  int parameterization_;           /**< \brief Parameterization type for orientation tolerance. */
+  int parameterization_;                        /**< \brief Parameterization type for orientation tolerance. */
   double absolute_x_axis_tolerance_, absolute_y_axis_tolerance_,
       absolute_z_axis_tolerance_; /**< \brief Storage for the tolerances */
 };

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -478,14 +478,12 @@ public:
     return absolute_z_axis_tolerance_;
   }
 
-protected:
-  /** Describes the three parameter representation of an orientation matrix to apply constraint tolerance around x, y and x axis. **/
-  enum class Parameterization
+  int getParameterization() const
   {
-    EULER_ANGLES,
-    ANGLE_AXIS
-  };
+    return parameterization_;
+  }
 
+protected:
   const moveit::core::LinkModel* link_model_;   /**< \brief The target link model */
   Eigen::Matrix3d desired_rotation_matrix_;     /**< \brief The desired rotation matrix in the tf frame. Guaranteed to
                                                  * be valid rotation matrix. */
@@ -493,7 +491,7 @@ protected:
                                                  * efficiency. Guaranteed to be valid rotation matrix. */
   std::string desired_rotation_frame_id_;       /**< \brief The target frame of the transform tree */
   bool mobile_frame_;                           /**< \brief Whether or not the header frame is mobile or fixed */
-  Parameterization parameterization_;           /**< \brief Parameterization type for orientation tolerance. */
+  int parameterization_;           /**< \brief Parameterization type for orientation tolerance. */
   double absolute_x_axis_tolerance_, absolute_y_axis_tolerance_,
       absolute_z_axis_tolerance_; /**< \brief Storage for the tolerances */
 };

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -339,9 +339,9 @@ MOVEIT_CLASS_FORWARD(OrientationConstraint);  // Defines OrientationConstraintPt
  * This class expresses an orientation constraint on a particular
  * link.  The constraint is specified in terms of a quaternion, with
  * tolerances on X,Y, and Z axes.  The rotation difference is computed
- * based on the XYZ Euler angle formulation (intrinsic rotations).  The header on the
- * quaternion can be specified in terms of either a fixed frame or a
- * mobile frame.  The type value will return ORIENTATION_CONSTRAINT.
+ * based on the XYZ Euler angle formulation (intrinsic rotations) or as a rotation vector. This depends on the
+ * `Parameterization` type.  The header on the  quaternion can be specified in terms of either a fixed frame or a mobile
+ * frame.  The type value will return ORIENTATION_CONSTRAINT.
  *
  */
 class OrientationConstraint : public KinematicConstraint

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -478,9 +478,9 @@ public:
     return absolute_z_axis_tolerance_;
   }
 
-  int getParameterization() const
+  int getParameterizationType() const
   {
-    return parameterization_;
+    return parameterization_type_;
   }
 
 protected:
@@ -491,7 +491,7 @@ protected:
                                                  * efficiency. Guaranteed to be valid rotation matrix. */
   std::string desired_rotation_frame_id_;       /**< \brief The target frame of the transform tree */
   bool mobile_frame_;                           /**< \brief Whether or not the header frame is mobile or fixed */
-  int parameterization_;                        /**< \brief Parameterization type for orientation tolerance. */
+  int parameterization_type_;                   /**< \brief Parameterization type for orientation tolerance. */
   double absolute_x_axis_tolerance_, absolute_y_axis_tolerance_,
       absolute_z_axis_tolerance_; /**< \brief Storage for the tolerances */
 };

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -340,7 +340,7 @@ MOVEIT_CLASS_FORWARD(OrientationConstraint);  // Defines OrientationConstraintPt
  * link.  The constraint is specified in terms of a quaternion, with
  * tolerances on X,Y, and Z axes.  The rotation difference is computed
  * based on the XYZ Euler angle formulation (intrinsic rotations) or as a rotation vector. This depends on the
- * `Parameterization` type.  The header on the  quaternion can be specified in terms of either a fixed frame or a mobile
+ * `Parameterization` type. The header on the quaternion can be specified in terms of either a fixed or a mobile
  * frame.  The type value will return ORIENTATION_CONSTRAINT.
  *
  */

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -603,7 +603,25 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
     constraint_weight_ = 1.0;
   }
   else
+  {
     constraint_weight_ = oc.weight;
+  }
+
+  if (oc.parameterization == 0)
+  {
+    // default case
+    parameterization_ = Parameterization::EULER_ANGLES;
+  }
+  else if (oc.parameterization == 1)
+  {
+    parameterization_ = Parameterization::ANGLE_AXIS;
+  }
+  else
+  {
+    ROS_WARN_NAMED("kinematic_constraints",
+                   "Unkown parameterization for orientation constraint tolerance, using default (EULER_ANGLES).");
+  }
+
   absolute_x_axis_tolerance_ = fabs(oc.absolute_x_axis_tolerance);
   if (absolute_x_axis_tolerance_ < std::numeric_limits<double>::epsilon())
     ROS_WARN_NAMED("kinematic_constraints", "Near-zero value for absolute_x_axis_tolerance");

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -673,41 +673,58 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
   if (!link_model_)
     return ConstraintEvaluationResult(true, 0.0);
 
-  std::tuple<Eigen::Vector3d, bool> euler_angles_error;
+  Eigen::Vector3d xyz;
+  Eigen::Isometry3d diff;
   if (mobile_frame_)
   {
     // getFrameTransform() returns a valid isometry by contract
     Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).linear() * desired_rotation_matrix_;
     // getGlobalLinkTransform() returns a valid isometry by contract
-    Eigen::Isometry3d diff(tmp.transpose() * state.getGlobalLinkTransform(link_model_).linear());  // valid isometry
-    euler_angles_error = CalcEulerAngles(diff.linear());
+    diff = Eigen::Isometry3d(tmp.transpose() * state.getGlobalLinkTransform(link_model_).linear());  // valid isometry
   }
   else
   {
     // diff is valid isometry by construction
-    Eigen::Isometry3d diff(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).linear());
-    euler_angles_error = CalcEulerAngles(diff.linear());
+    diff = Eigen::Isometry3d(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).linear());
   }
 
-  // Converting from a rotation matrix to an intrinsic XYZ euler angles have 2 singularities:
-  // pitch ~= pi/2 ==> roll + yaw = theta
-  // pitch ~= -pi/2 ==> roll - yaw = theta
-  // in those cases CalcEulerAngles will set roll (xyz(0)) to theta and yaw (xyz(2)) to zero, so for us to be able to
-  // capture yaw tolerance violation we do the following, if theta violate the absolute yaw tolerance we think of it as
-  // pure yaw rotation and set roll to zero
-  auto& xyz = std::get<Eigen::Vector3d>(euler_angles_error);
-  if (!std::get<bool>(euler_angles_error))
+  // TODO(jeroendm) do this variable need to be outside the scope of the if statement below?
+  // look into what std::get does.
+  std::tuple<Eigen::Vector3d, bool> euler_angles_error;
+  if (parameterization_ == Parameterization::EULER_ANGLES)
   {
-    if (normalizeAbsoluteAngle(xyz(0)) > absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon())
+    euler_angles_error = CalcEulerAngles(diff.linear());
+    // Converting from a rotation matrix to an intrinsic XYZ euler angles have 2 singularities:
+    // pitch ~= pi/2 ==> roll + yaw = theta
+    // pitch ~= -pi/2 ==> roll - yaw = theta
+    // in those cases CalcEulerAngles will set roll (xyz(0)) to theta and yaw (xyz(2)) to zero, so for us to be able to
+    // capture yaw tolerance violation we do the following, if theta violate the absolute yaw tolerance we think of it
+    // as pure yaw rotation and set roll to zero
+    auto& xyz = std::get<Eigen::Vector3d>(euler_angles_error);
+    if (!std::get<bool>(euler_angles_error))
     {
-      xyz(2) = xyz(0);
-      xyz(0) = 0;
+      if (normalizeAbsoluteAngle(xyz(0)) > absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon())
+      {
+        xyz(2) = xyz(0);
+        xyz(0) = 0;
+      }
     }
+    // Account for angle wrapping
+    xyz = xyz.unaryExpr(&normalizeAbsoluteAngle);
   }
-  // Account for angle wrapping
-  xyz = xyz.unaryExpr(&normalizeAbsoluteAngle);
+  else if (parameterization_ == Parameterization::ANGLE_AXIS)
+  {
+    Eigen::AngleAxisd aa(diff.linear());
+    xyz = aa.axis() * aa.angle();
+    xyz(0) = fabs(xyz(0));
+    xyz(1) = fabs(xyz(1));
+    xyz(2) = fabs(xyz(2));
+  }
+  else
+  {
+    // Is it possible for parameterization_ to have an unkown type?
+  }
 
-  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(1) < absolute_y_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(0) < absolute_x_axis_tolerance_ + std::numeric_limits<double>::epsilon();

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -609,7 +609,6 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
 
   if (oc.parameterization == 0)
   {
-    // default case
     parameterization_ = Parameterization::EULER_ANGLES;
   }
   else if (oc.parameterization == 1)
@@ -620,6 +619,7 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
   {
     ROS_WARN_NAMED("kinematic_constraints",
                    "Unkown parameterization for orientation constraint tolerance, using default (EULER_ANGLES).");
+    parameterization_ = Parameterization::EULER_ANGLES;
   }
 
   absolute_x_axis_tolerance_ = fabs(oc.absolute_x_axis_tolerance);

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -607,19 +607,14 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
     constraint_weight_ = oc.weight;
   }
 
-  if (oc.parameterization == 0)
-  {
-    parameterization_ = Parameterization::EULER_ANGLES;
-  }
-  else if (oc.parameterization == 1)
-  {
-    parameterization_ = Parameterization::ANGLE_AXIS;
-  }
-  else
+  parameterization_ = oc.parameterization;
+  // validate the parameterization, set to default value if invalid
+  if (parameterization_ != moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES &&
+      parameterization_ != moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
   {
     ROS_WARN_NAMED("kinematic_constraints",
-                   "Unkown parameterization for orientation constraint tolerance, using default (EULER_ANGLES).");
-    parameterization_ = Parameterization::EULER_ANGLES;
+                   "Unkown parameterization for orientation constraint tolerance, using default (XYZ_EULER_ANGLES).");
+    parameterization_ = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
   }
 
   absolute_x_axis_tolerance_ = fabs(oc.absolute_x_axis_tolerance);
@@ -691,7 +686,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
   // TODO(jeroendm) do this variable need to be outside the scope of the if statement below?
   // look into what std::get does.
   std::tuple<Eigen::Vector3d, bool> euler_angles_error;
-  if (parameterization_ == Parameterization::EULER_ANGLES)
+  if (parameterization_ == moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES)
   {
     euler_angles_error = CalcEulerAngles(diff.linear());
     // Converting from a rotation matrix to an intrinsic XYZ euler angles have 2 singularities:
@@ -712,7 +707,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
     // Account for angle wrapping
     xyz = xyz.unaryExpr(&normalizeAbsoluteAngle);
   }
-  else if (parameterization_ == Parameterization::ANGLE_AXIS)
+  else if (parameterization_ == moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
   {
     Eigen::AngleAxisd aa(diff.linear());
     xyz = aa.axis() * aa.angle();

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -717,7 +717,9 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
   }
   else
   {
-    // Is it possible for parameterization_ to have an unkown type?
+    /* The parameterization type should be validated in configure, so this should never happen. */
+    ROS_ERROR_STREAM_NAMED("kinematic_constraints",
+                           "The parameterization type for the orientation constraints is invalid.");
   }
 
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -695,7 +695,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
     // in those cases CalcEulerAngles will set roll (xyz(0)) to theta and yaw (xyz(2)) to zero, so for us to be able to
     // capture yaw tolerance violation we do the following, if theta violate the absolute yaw tolerance we think of it
     // as pure yaw rotation and set roll to zero
-    auto& xyz = std::get<Eigen::Vector3d>(euler_angles_error);
+    xyz = std::get<Eigen::Vector3d>(euler_angles_error);
     if (!std::get<bool>(euler_angles_error))
     {
       if (normalizeAbsoluteAngle(xyz(0)) > absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon())

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -607,14 +607,14 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
     constraint_weight_ = oc.weight;
   }
 
-  parameterization_ = oc.parameterization;
+  parameterization_type_ = oc.parameterization;
   // validate the parameterization, set to default value if invalid
-  if (parameterization_ != moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES &&
-      parameterization_ != moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
+  if (parameterization_type_ != moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES &&
+      parameterization_type_ != moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
   {
     ROS_WARN_NAMED("kinematic_constraints",
                    "Unknown parameterization for orientation constraint tolerance, using default (XYZ_EULER_ANGLES).");
-    parameterization_ = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
+    parameterization_type_ = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
   }
 
   absolute_x_axis_tolerance_ = fabs(oc.absolute_x_axis_tolerance);
@@ -685,7 +685,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
 
   // TODO(jeroendm) do this variable need to be outside the scope of the if statement below?
   std::tuple<Eigen::Vector3d, bool> euler_angles_error;
-  if (parameterization_ == moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES)
+  if (parameterization_type_ == moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES)
   {
     euler_angles_error = CalcEulerAngles(diff.linear());
     // Converting from a rotation matrix to intrinsic XYZ Euler angles has 2 singularities:
@@ -706,7 +706,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
     // Account for angle wrapping
     xyz = xyz.unaryExpr(&normalizeAbsoluteAngle);
   }
-  else if (parameterization_ == moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
+  else if (parameterization_type_ == moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
   {
     Eigen::AngleAxisd aa(diff.linear());
     xyz = aa.axis() * aa.angle();

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -613,7 +613,7 @@ bool OrientationConstraint::configure(const moveit_msgs::OrientationConstraint& 
       parameterization_ != moveit_msgs::OrientationConstraint::ROTATION_VECTOR)
   {
     ROS_WARN_NAMED("kinematic_constraints",
-                   "Unkown parameterization for orientation constraint tolerance, using default (XYZ_EULER_ANGLES).");
+                   "Unknown parameterization for orientation constraint tolerance, using default (XYZ_EULER_ANGLES).");
     parameterization_ = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
   }
 

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -684,17 +684,16 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
   }
 
   // TODO(jeroendm) do this variable need to be outside the scope of the if statement below?
-  // look into what std::get does.
   std::tuple<Eigen::Vector3d, bool> euler_angles_error;
   if (parameterization_ == moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES)
   {
     euler_angles_error = CalcEulerAngles(diff.linear());
-    // Converting from a rotation matrix to an intrinsic XYZ euler angles have 2 singularities:
+    // Converting from a rotation matrix to intrinsic XYZ Euler angles has 2 singularities:
     // pitch ~= pi/2 ==> roll + yaw = theta
     // pitch ~= -pi/2 ==> roll - yaw = theta
     // in those cases CalcEulerAngles will set roll (xyz(0)) to theta and yaw (xyz(2)) to zero, so for us to be able to
-    // capture yaw tolerance violation we do the following, if theta violate the absolute yaw tolerance we think of it
-    // as pure yaw rotation and set roll to zero
+    // capture yaw tolerance violations we do the following: If theta violates the absolute yaw tolerance we think of it
+    // as a pure yaw rotation and set roll to zero.
     xyz = std::get<Eigen::Vector3d>(euler_angles_error);
     if (!std::get<bool>(euler_angles_error))
     {

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -5,6 +5,7 @@
 
 #include <urdf_parser/urdf_parser.h>
 #include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <moveit/utils/robot_model_test_utils.h>
 #include <boost/math/constants/constants.hpp>
 
@@ -45,7 +46,31 @@ class LoadPlanningModelsPr2 : public testing::Test
 protected:
   void SetUp() override
   {
-    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
+    //robot_model_ = moveit::core::loadTestingRobotModel("pr2");
+
+    tf2::Quaternion q1, q2, q3;
+    q1.setRPY(M_PI_2, -M_PI_2, 0.0);
+    // q1 = tf2::Quaternion::getIdentity();
+
+    q2.setRPY(0.0, M_PI_2, 0.0);
+    // q2.setRPY(0.0, 0.0, M_PI_2);
+    // q2 = tf2::Quaternion::getIdentity();
+
+    // q3.setRPY(0.0, M_PI_2, 0.0);
+    q3.setRPY(0.0, 0.0, -M_PI_2);
+    // q3 = tf2::Quaternion::getIdentity();
+
+    geometry_msgs::Pose p1, p2, p3;
+    tf2::convert(q1, p1.orientation);
+    tf2::convert(q2, p2.orientation);
+    tf2::convert(q3, p3.orientation);
+
+    moveit::core::RobotModelBuilder robot("robot_wrist", "base_link");
+    robot.addChain("base_link->a->b->c", "revolute", {p1, p2, p3});
+    // robot.addChain("c->tool", "fixed", {p1});
+    robot.addGroupChain("base_link", "c", "wrist");
+    ASSERT_TRUE(robot.isValid());
+    robot_wrist_model_ = robot.build();
   }
 
   void TearDown() override
@@ -53,7 +78,8 @@ protected:
   }
 
 protected:
-  moveit::core::RobotModelPtr robot_model_;
+  //moveit::core::RobotModelPtr robot_model_;
+  moveit::core::RobotModelPtr robot_wrist_model_;
 };
 
 TEST_F(SphericalRobot, Test1)
@@ -258,30 +284,94 @@ TEST_F(SphericalRobot, Test5)
 
 TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)
 {
-  moveit::core::RobotState robot_state(robot_model_);
+   moveit::core::RobotState robot_state(robot_wrist_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
-  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_wrist_model_->getModelFrame());
 
-  kinematic_constraints::OrientationConstraint oc(robot_model_);
+  kinematic_constraints::OrientationConstraint oc(robot_wrist_model_);
 
   moveit_msgs::OrientationConstraint ocm;
 
-  ocm.link_name = "r_wrist_roll_link";
-  ocm.header.frame_id = robot_model_->getModelFrame();
-  ocm.orientation.x = 0.0;
-  ocm.orientation.y = 0.0;
-  ocm.orientation.z = 0.0;
-  ocm.orientation.w = 1.0;
-  ocm.absolute_x_axis_tolerance = 0.1;
-  ocm.absolute_y_axis_tolerance = 0.1;
-  ocm.absolute_z_axis_tolerance = 0.1;
+  // center the orientation constraints around the current orientation of the link
+  geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("c"));
+  ocm.orientation = p.orientation;
+
+  ocm.link_name = "c";
+  ocm.header.frame_id = robot_wrist_model_->getModelFrame();
+  // ocm.orientation.x = 0.0;
+  // ocm.orientation.y = 0.0;
+  // ocm.orientation.z = 0.0;
+  // ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.5;
+  ocm.absolute_y_axis_tolerance = 0.5;
+  ocm.absolute_z_axis_tolerance = 0.5;
   // ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
   ocm.parameterization = 3;
   ocm.weight = 1.0;
 
   EXPECT_TRUE(oc.configure(ocm, tf));
+
+  // Constraints should be satisfied based on how we created them
+  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+
+  // move a joint and check the constraints again
+  std::map<std::string, double> jvals;
+  jvals["base_link-a-joint"] = 0.0;
+  jvals["a-b-joint"] = 0.5;
+  jvals["b-c-joint"] = 0.5;
+  robot_state.setVariablePositions(jvals);
+  robot_state.update();
+
+  EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
+
+  //oc.decide()
+
 }
+
+// TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)
+// {
+//   moveit::core::RobotState robot_state(robot_model_);
+//   robot_state.setToDefaultValues();
+//   robot_state.update();
+//   moveit::core::Transforms tf(robot_model_->getModelFrame());
+
+//   kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+//   moveit_msgs::OrientationConstraint ocm;
+
+//   // center the orientation constraints around the current orientation of the link
+//   geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("r_wrist_roll_link"));
+//   ocm.orientation = p.orientation;
+
+//   ocm.link_name = "r_wrist_roll_link";
+//   ocm.header.frame_id = robot_model_->getModelFrame();
+//   // ocm.orientation.x = 0.0;
+//   // ocm.orientation.y = 0.0;
+//   // ocm.orientation.z = 0.0;
+//   // ocm.orientation.w = 1.0;
+//   ocm.absolute_x_axis_tolerance = 0.5;
+//   ocm.absolute_y_axis_tolerance = 0.5;
+//   ocm.absolute_z_axis_tolerance = 0.5;
+//   // ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
+//   ocm.parameterization = 3;
+//   ocm.weight = 1.0;
+
+//   EXPECT_TRUE(oc.configure(ocm, tf));
+
+//   // Constraints should be satisfied based on how we created them
+//   EXPECT_TRUE(oc.decide(robot_state).satisfied);
+
+//   // move a joint and check the constraints again
+//   std::map<std::string, double> jvals;
+//   jvals["r_wrist_flex_joint"] = 1.0;
+//   robot_state.setVariablePositions(jvals);
+//   robot_state.update();
+
+//   EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
+
+//   //oc.decide()
+// }
 
 int main(int argc, char** argv)
 {

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -1,3 +1,40 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, KU Leuven
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of KU Leuven nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jeroen De Maeyer */
+
+
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <gtest/gtest.h>
 
@@ -334,9 +371,11 @@ TEST_F(LoadRobotModel, TestDefaultParameterization)
   // set to non-existing parameterization on purpose
   ocm.parameterization = 99;
 
-  // configuring should still work
+  // configuring the constraints should still work
   kinematic_constraints::OrientationConstraint oc(robot_model_);
   EXPECT_TRUE(oc.configure(ocm, tf));
+
+  // check if the expected default parameterization was set
   EXPECT_EQ(oc.getParameterization(), moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES);
 }
 

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -37,8 +37,6 @@
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <gtest/gtest.h>
 
-#include <fstream>
-
 #include <urdf_parser/urdf_parser.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -1,5 +1,8 @@
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <gtest/gtest.h>
+
+#include <fstream>
+
 #include <urdf_parser/urdf_parser.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/utils/robot_model_test_utils.h>
@@ -27,6 +30,22 @@ protected:
     jvals["roll-pitch-joint"] = pitch;
     jvals["pitch-yaw-joint"] = yaw;
     return jvals;
+  }
+
+  void TearDown() override
+  {
+  }
+
+protected:
+  moveit::core::RobotModelPtr robot_model_;
+};
+
+class LoadPlanningModelsPr2 : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    robot_model_ = moveit::core::loadTestingRobotModel("pr2");
   }
 
   void TearDown() override
@@ -235,6 +254,33 @@ TEST_F(SphericalRobot, Test5)
 
   EXPECT_TRUE(oc.configure(ocm, tf));
   EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+}
+
+TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)
+{
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "r_wrist_roll_link";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.1;
+  ocm.absolute_y_axis_tolerance = 0.1;
+  ocm.absolute_z_axis_tolerance = 0.1;
+  // ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
+  ocm.parameterization = 3;
+  ocm.weight = 1.0;
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -373,7 +373,7 @@ TEST_F(FloatingJointRobot, TestDefaultParameterization)
   EXPECT_TRUE(oc.configure(ocm, tf));
 
   // check if the expected default parameterization was set
-  EXPECT_EQ(oc.getParameterization(), moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES);
+  EXPECT_EQ(oc.getParameterizationType(), moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES);
 }
 
 TEST_F(FloatingJointRobot, OrientationConstraintsParameterization)

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -46,31 +46,11 @@ class LoadPlanningModelsPr2 : public testing::Test
 protected:
   void SetUp() override
   {
-    //robot_model_ = moveit::core::loadTestingRobotModel("pr2");
-
-    tf2::Quaternion q1, q2, q3;
-    q1.setRPY(M_PI_2, -M_PI_2, 0.0);
-    // q1 = tf2::Quaternion::getIdentity();
-
-    q2.setRPY(0.0, M_PI_2, 0.0);
-    // q2.setRPY(0.0, 0.0, M_PI_2);
-    // q2 = tf2::Quaternion::getIdentity();
-
-    // q3.setRPY(0.0, M_PI_2, 0.0);
-    q3.setRPY(0.0, 0.0, -M_PI_2);
-    // q3 = tf2::Quaternion::getIdentity();
-
-    geometry_msgs::Pose p1, p2, p3;
-    tf2::convert(q1, p1.orientation);
-    tf2::convert(q2, p2.orientation);
-    tf2::convert(q3, p3.orientation);
-
-    moveit::core::RobotModelBuilder robot("robot_wrist", "base_link");
-    robot.addChain("base_link->a->b->c", "revolute", {p1, p2, p3});
-    // robot.addChain("c->tool", "fixed", {p1});
-    robot.addGroupChain("base_link", "c", "wrist");
+    moveit::core::RobotModelBuilder robot("floating_robot", "base_link");
+    robot.addChain("base_link->ee", "floating");
+    robot.addGroupChain("base_link", "ee", "group1");
     ASSERT_TRUE(robot.isValid());
-    robot_wrist_model_ = robot.build();
+    robot_model_ = robot.build();
   }
 
   void TearDown() override
@@ -78,9 +58,22 @@ protected:
   }
 
 protected:
-  //moveit::core::RobotModelPtr robot_model_;
-  moveit::core::RobotModelPtr robot_wrist_model_;
+  moveit::core::RobotModelPtr robot_model_;
+  // moveit::core::RobotModelPtr robot_wrist_model_;
 };
+
+inline Eigen::Quaterniond xyz_intrinsix_to_quat(double rx, double ry, double rz)
+{
+  return Eigen::AngleAxisd(rx, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(ry, Eigen::Vector3d::UnitY()) *
+         Eigen::AngleAxisd(rz, Eigen::Vector3d::UnitZ());
+}
+
+inline Eigen::Quaterniond rotation_vector_to_quat(double rx, double ry, double rz)
+{
+  Eigen::Vector3d v{ rx, ry, rz };
+  Eigen::Matrix3d m{ Eigen::AngleAxisd(v.norm(), v.normalized()) };
+  return Eigen::Quaterniond{ m };
+}
 
 TEST_F(SphericalRobot, Test1)
 {
@@ -284,49 +277,46 @@ TEST_F(SphericalRobot, Test5)
 
 TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)
 {
-   moveit::core::RobotState robot_state(robot_wrist_model_);
+  moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
   robot_state.update();
-  moveit::core::Transforms tf(robot_wrist_model_->getModelFrame());
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
-  kinematic_constraints::OrientationConstraint oc(robot_wrist_model_);
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
 
   moveit_msgs::OrientationConstraint ocm;
 
   // center the orientation constraints around the current orientation of the link
-  geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("c"));
+  geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("ee"));
   ocm.orientation = p.orientation;
 
-  ocm.link_name = "c";
-  ocm.header.frame_id = robot_wrist_model_->getModelFrame();
-  // ocm.orientation.x = 0.0;
-  // ocm.orientation.y = 0.0;
-  // ocm.orientation.z = 0.0;
-  // ocm.orientation.w = 1.0;
+  ocm.link_name = "ee";
+  ocm.header.frame_id = robot_model_->getModelFrame();
   ocm.absolute_x_axis_tolerance = 0.5;
   ocm.absolute_y_axis_tolerance = 0.5;
   ocm.absolute_z_axis_tolerance = 0.5;
   // ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
-  ocm.parameterization = 3;
+  ocm.parameterization = moveit_msgs::OrientationConstraint::ROTATION_VECTOR;
+  // ocm.parameterization = 3;
   ocm.weight = 1.0;
 
   EXPECT_TRUE(oc.configure(ocm, tf));
 
-  // Constraints should be satisfied based on how we created them
+  // Constraints should be satisfied because we created them around the current orientation
   EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
 
-  // move a joint and check the constraints again
-  std::map<std::string, double> jvals;
-  jvals["base_link-a-joint"] = 0.0;
-  jvals["a-b-joint"] = 0.5;
-  jvals["b-c-joint"] = 0.5;
-  robot_state.setVariablePositions(jvals);
+  // change the orientation of the end-effector to some fixed values
+  // and check the constraints again
+  // Eigen::Quaterniond quat = xyz_intrinsix_to_quat(0.1, 0.2, 0.3);
+  Eigen::Quaterniond quat = rotation_vector_to_quat(0.1, 0.2, 0.3);
+  Eigen::VectorXd joint_values(7);
+  joint_values << 0.0, 0.0, 0.0, quat.x(), quat.y(), quat.z(), quat.w();
+  robot_state.setJointGroupPositions("group1", joint_values);
   robot_state.update();
 
   EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
 
-  //oc.decide()
-
+  // oc.decide()
 }
 
 // TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -75,7 +75,7 @@ protected:
   moveit::core::RobotModelPtr robot_model_;
 };
 
-class LoadRobotModel : public testing::Test
+class FloatingJointRobot : public testing::Test
 {
 protected:
   /** A robot model with a single floating joint will be created. **/
@@ -139,7 +139,7 @@ inline Eigen::Quaterniond rotation_vector_to_quat(double rx, double ry, double r
   return Eigen::Quaterniond{ m };
 }
 
-/** Helper function to set the orientation of the robot end-effector**/
+/** Helper function to set the orientation of the robot end-effector for the FloatingJointRobot. **/
 void setRobotEndEffectorOrientation(moveit::core::RobotState& robot_state, const Eigen::Quaterniond& quat)
 {
   Eigen::VectorXd joint_values(7);
@@ -348,7 +348,7 @@ TEST_F(SphericalRobot, Test5)
   EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
 }
 
-TEST_F(LoadRobotModel, TestDefaultParameterization)
+TEST_F(FloatingJointRobot, TestDefaultParameterization)
 {
   // Simple test that checks whether the configuration defaults to the expected parameterization
   // if we put an invalid type in the message.
@@ -376,7 +376,7 @@ TEST_F(LoadRobotModel, TestDefaultParameterization)
   EXPECT_EQ(oc.getParameterization(), moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES);
 }
 
-TEST_F(LoadRobotModel, OrientationConstraintsParameterization)
+TEST_F(FloatingJointRobot, OrientationConstraintsParameterization)
 {
   // load and initialize robot model
   moveit::core::RobotState robot_state(robot_model_);

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -34,7 +34,6 @@
 
 /* Author: Jeroen De Maeyer */
 
-
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <gtest/gtest.h>
 

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -41,38 +41,77 @@ protected:
   moveit::core::RobotModelPtr robot_model_;
 };
 
-class LoadPlanningModelsPr2 : public testing::Test
+class LoadRobotModel : public testing::Test
 {
 protected:
+  /** A robot model with a single floating joint will be created. **/
+  moveit::core::RobotModelPtr robot_model_;
+
+  /** Test data
+   *
+   * The test data represents valid orientations for an absolute tolerance of 0.5 around x, y and z.
+   *
+   * The first matrix contains valid orientations for xyx_euler_angles error, but invalid for rotation_vector.
+   * The second matrix is the other way around.
+   *
+   * The rows contain a quaternion in the order x, y, z and w.
+   * */
+  Eigen::Matrix<double, 8, 4> valid_euler_data_;
+  Eigen::Matrix<double, 8, 4> valid_rotvec_data_;
+
   void SetUp() override
   {
+    // create robot
     moveit::core::RobotModelBuilder robot("floating_robot", "base_link");
     robot.addChain("base_link->ee", "floating");
     robot.addGroupChain("base_link", "ee", "group1");
+
     ASSERT_TRUE(robot.isValid());
     robot_model_ = robot.build();
+
+    // hardcoded test data created with an external python script
+    valid_euler_data_ << -0.1712092272140422, -0.2853625129991958, -0.1712092272140422, 0.9273311367620117,
+        -0.28536251299919585, -0.17120922721404216, 0.28536251299919585, 0.8987902273981057, 0.28536251299919585,
+        -0.17120922721404216, -0.28536251299919585, 0.8987902273981057, 0.1712092272140422, -0.2853625129991958,
+        0.1712092272140422, 0.9273311367620117, -0.28536251299919585, 0.17120922721404216, -0.28536251299919585,
+        0.8987902273981057, -0.1712092272140422, 0.2853625129991958, 0.1712092272140422, 0.9273311367620117,
+        0.1712092272140422, 0.2853625129991958, -0.1712092272140422, 0.9273311367620117, 0.28536251299919585,
+        0.17120922721404216, 0.28536251299919585, 0.8987902273981057;
+    valid_rotvec_data_ << -0.23771285949073287, -0.23771285949073287, -0.23771285949073287, 0.911305541132181,
+        -0.2401272988734743, -0.2401272988734743, 0.0, 0.9405731022474852, -0.23771285949073287, -0.23771285949073287,
+        0.23771285949073287, 0.911305541132181, 0.0, -0.24012729887347428, -0.24012729887347428, 0.9405731022474851,
+        0.0, -0.24012729887347428, 0.24012729887347428, 0.9405731022474851, 0.23771285949073287, -0.23771285949073287,
+        -0.23771285949073287, 0.911305541132181, 0.2401272988734743, -0.2401272988734743, 0.0, 0.9405731022474852,
+        0.23771285949073287, -0.23771285949073287, 0.23771285949073287, 0.911305541132181;
   }
 
   void TearDown() override
   {
   }
-
-protected:
-  moveit::core::RobotModelPtr robot_model_;
-  // moveit::core::RobotModelPtr robot_wrist_model_;
 };
 
+/** Helper function to create a quaternion from Euler angles. **/
 inline Eigen::Quaterniond xyz_intrinsix_to_quat(double rx, double ry, double rz)
 {
   return Eigen::AngleAxisd(rx, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(ry, Eigen::Vector3d::UnitY()) *
          Eigen::AngleAxisd(rz, Eigen::Vector3d::UnitZ());
 }
 
+/** Helper function to create a quaternion from a rotation vector. **/
 inline Eigen::Quaterniond rotation_vector_to_quat(double rx, double ry, double rz)
 {
   Eigen::Vector3d v{ rx, ry, rz };
   Eigen::Matrix3d m{ Eigen::AngleAxisd(v.norm(), v.normalized()) };
   return Eigen::Quaterniond{ m };
+}
+
+/** Helper function to set the orientation of the robot end-effector**/
+void setRobotEndEffectorOrientation(moveit::core::RobotState& robot_state, const Eigen::Quaterniond& quat)
+{
+  Eigen::VectorXd joint_values(7);
+  joint_values << 0.0, 0.0, 0.0, quat.x(), quat.y(), quat.z(), quat.w();
+  robot_state.setJointGroupPositions("group1", joint_values);
+  robot_state.update();
 }
 
 TEST_F(SphericalRobot, Test1)
@@ -275,93 +314,129 @@ TEST_F(SphericalRobot, Test5)
   EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
 }
 
-TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)
+TEST_F(LoadRobotModel, TestDefaultParameterization)
 {
-  moveit::core::RobotState robot_state(robot_model_);
-  robot_state.setToDefaultValues();
-  robot_state.update();
+  // Simple test that checks whether the configuration defaults to the expected parameterization
+  // if we put an invalid type in the message.
   moveit::core::Transforms tf(robot_model_->getModelFrame());
 
-  kinematic_constraints::OrientationConstraint oc(robot_model_);
-
   moveit_msgs::OrientationConstraint ocm;
-
-  // center the orientation constraints around the current orientation of the link
-  geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("ee"));
-  ocm.orientation = p.orientation;
-
   ocm.link_name = "ee";
   ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
   ocm.absolute_x_axis_tolerance = 0.5;
   ocm.absolute_y_axis_tolerance = 0.5;
   ocm.absolute_z_axis_tolerance = 0.5;
-  // ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
-  ocm.parameterization = moveit_msgs::OrientationConstraint::ROTATION_VECTOR;
-  // ocm.parameterization = 3;
   ocm.weight = 1.0;
 
+  // set to non-existing parameterization on purpose
+  ocm.parameterization = 99;
+
+  // configuring should still work
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
   EXPECT_TRUE(oc.configure(ocm, tf));
-
-  // Constraints should be satisfied because we created them around the current orientation
-  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
-
-  // change the orientation of the end-effector to some fixed values
-  // and check the constraints again
-  // Eigen::Quaterniond quat = xyz_intrinsix_to_quat(0.1, 0.2, 0.3);
-  Eigen::Quaterniond quat = rotation_vector_to_quat(0.1, 0.2, 0.3);
-  Eigen::VectorXd joint_values(7);
-  joint_values << 0.0, 0.0, 0.0, quat.x(), quat.y(), quat.z(), quat.w();
-  robot_state.setJointGroupPositions("group1", joint_values);
-  robot_state.update();
-
-  EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
-
-  // oc.decide()
+  EXPECT_EQ(oc.getParameterization(), moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES);
 }
 
-// TEST_F(LoadPlanningModelsPr2, OrientationConstraintsParameterization)
-// {
-//   moveit::core::RobotState robot_state(robot_model_);
-//   robot_state.setToDefaultValues();
-//   robot_state.update();
-//   moveit::core::Transforms tf(robot_model_->getModelFrame());
+TEST_F(LoadRobotModel, OrientationConstraintsParameterization)
+{
+  // load and initialize robot model
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  robot_state.update();
 
-//   kinematic_constraints::OrientationConstraint oc(robot_model_);
+  // center the orientation constraints around the current orientation of the link
+  geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("ee"));
 
-//   moveit_msgs::OrientationConstraint ocm;
+  // we also need the name of the base link
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
 
-//   // center the orientation constraints around the current orientation of the link
-//   geometry_msgs::Pose p = tf2::toMsg(robot_state.getGlobalLinkTransform("r_wrist_roll_link"));
-//   ocm.orientation = p.orientation;
+  // create message to configure orientation constraints
+  moveit_msgs::OrientationConstraint ocm;
+  ocm.link_name = "ee";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation = p.orientation;
+  ocm.absolute_x_axis_tolerance = 0.5;
+  ocm.absolute_y_axis_tolerance = 0.5;
+  ocm.absolute_z_axis_tolerance = 0.5;
+  ocm.weight = 1.0;
 
-//   ocm.link_name = "r_wrist_roll_link";
-//   ocm.header.frame_id = robot_model_->getModelFrame();
-//   // ocm.orientation.x = 0.0;
-//   // ocm.orientation.y = 0.0;
-//   // ocm.orientation.z = 0.0;
-//   // ocm.orientation.w = 1.0;
-//   ocm.absolute_x_axis_tolerance = 0.5;
-//   ocm.absolute_y_axis_tolerance = 0.5;
-//   ocm.absolute_z_axis_tolerance = 0.5;
-//   // ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
-//   ocm.parameterization = 3;
-//   ocm.weight = 1.0;
+  // create orientation constraints with the xyz_euler_angle parameterization
+  kinematic_constraints::OrientationConstraint oc_euler(robot_model_);
+  ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
+  EXPECT_TRUE(oc_euler.configure(ocm, tf));
 
-//   EXPECT_TRUE(oc.configure(ocm, tf));
+  // create orientation constraints with the rotation_vector parameterization
+  kinematic_constraints::OrientationConstraint oc_rotvec(robot_model_);
+  ocm.parameterization = moveit_msgs::OrientationConstraint::ROTATION_VECTOR;
+  EXPECT_TRUE(oc_rotvec.configure(ocm, tf));
 
-//   // Constraints should be satisfied based on how we created them
-//   EXPECT_TRUE(oc.decide(robot_state).satisfied);
+  // Constraints should be satisfied for current state because we created them around the current orientation
+  EXPECT_TRUE(oc_euler.decide(robot_state, true).satisfied);
+  EXPECT_TRUE(oc_rotvec.decide(robot_state, true).satisfied);
 
-//   // move a joint and check the constraints again
-//   std::map<std::string, double> jvals;
-//   jvals["r_wrist_flex_joint"] = 1.0;
-//   robot_state.setVariablePositions(jvals);
-//   robot_state.update();
+  // some trivial test cases
+  setRobotEndEffectorOrientation(robot_state, xyz_intrinsix_to_quat(0.1, 0.2, -0.3));
+  EXPECT_TRUE(oc_euler.decide(robot_state).satisfied);
 
-//   EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
+  setRobotEndEffectorOrientation(robot_state, xyz_intrinsix_to_quat(0.1, 0.2, -0.6));
+  EXPECT_FALSE(oc_euler.decide(robot_state).satisfied);
 
-//   //oc.decide()
-// }
+  setRobotEndEffectorOrientation(robot_state, rotation_vector_to_quat(0.1, 0.2, -0.3));
+  EXPECT_TRUE(oc_rotvec.decide(robot_state).satisfied);
+
+  setRobotEndEffectorOrientation(robot_state, rotation_vector_to_quat(0.1, 0.2, -0.6));
+  EXPECT_FALSE(oc_rotvec.decide(robot_state).satisfied);
+
+  // more extensive testing using the test data hardcoded at the top of this file
+  Eigen::VectorXd joint_values(7);
+  joint_values << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0;
+  for (Eigen::Index i_row{ 0 }; i_row < valid_euler_data_.rows(); ++i_row)
+  {
+    joint_values[3] = valid_euler_data_(i_row, 0);
+    joint_values[4] = valid_euler_data_(i_row, 1);
+    joint_values[5] = valid_euler_data_(i_row, 2);
+    joint_values[6] = valid_euler_data_(i_row, 3);
+    robot_state.setJointGroupPositions("group1", joint_values);
+    robot_state.update();
+    EXPECT_TRUE(oc_euler.decide(robot_state).satisfied);
+    EXPECT_FALSE(oc_rotvec.decide(robot_state).satisfied);
+
+    joint_values[3] = valid_rotvec_data_(i_row, 0);
+    joint_values[4] = valid_rotvec_data_(i_row, 1);
+    joint_values[5] = valid_rotvec_data_(i_row, 2);
+    joint_values[6] = valid_rotvec_data_(i_row, 3);
+    robot_state.setJointGroupPositions("group1", joint_values);
+    robot_state.update();
+    EXPECT_FALSE(oc_euler.decide(robot_state).satisfied);
+    EXPECT_TRUE(oc_rotvec.decide(robot_state).satisfied);
+  }
+
+  // and now some simple test cases where whe change the nominal orientation of the constraints,
+  // instead of changing the orientation of the robot
+  robot_state.setToDefaultValues();
+  robot_state.update();
+
+  ocm.parameterization = moveit_msgs::OrientationConstraint::XYZ_EULER_ANGLES;
+  ocm.orientation = tf2::toMsg(xyz_intrinsix_to_quat(0.1, 0.2, -0.3));
+  EXPECT_TRUE(oc_euler.configure(ocm, tf));
+  EXPECT_TRUE(oc_euler.decide(robot_state).satisfied);
+
+  ocm.orientation = tf2::toMsg(xyz_intrinsix_to_quat(0.1, 0.2, -0.6));
+  EXPECT_TRUE(oc_euler.configure(ocm, tf));
+  EXPECT_FALSE(oc_euler.decide(robot_state).satisfied);
+
+  ocm.parameterization = moveit_msgs::OrientationConstraint::ROTATION_VECTOR;
+  ocm.orientation = tf2::toMsg(rotation_vector_to_quat(0.1, 0.2, -0.3));
+  EXPECT_TRUE(oc_rotvec.configure(ocm, tf));
+  EXPECT_TRUE(oc_rotvec.decide(robot_state).satisfied);
+
+  ocm.orientation = tf2::toMsg(rotation_vector_to_quat(0.1, 0.2, -0.6));
+  EXPECT_TRUE(oc_rotvec.configure(ocm, tf));
+  EXPECT_FALSE(oc_rotvec.decide(robot_state).satisfied);
+}
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Depends on [this moveit_msgs PR](https://github.com/ros-planning/moveit_msgs/pull/96)!

### Description
MoveIt represents the error for orientation constraints as intrinsic XYZ Euler angles. This PR adds a second option that uses a rotation vector (rotation axis multiplied with the rotation angle). For more info on the math, see section "Rotation vector" on [this Wikipedia page](https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation).

This new parameterization is not only a requirement for the new OMPL constrained planner (#2273), but it is also useful when we support path constraints with Trajopt. The same parameterization is used [there](https://github.com/ros-industrial-consortium/trajopt_ros/blob/a393abb99b221c97603ae40fcbd0f172f94a7fcc/trajopt/include/trajopt/utils.hpp#L161).

### Implementation considerations / questions
I originally used an `enum class` for the `parameterization_` member. But then I changed it to a simple `int` flag so I can read it directly from the `OrientationConstraint` message like this:
```C++
 parameterization_ = oc.parameterization;
  // validate the parameterization, set to default value when invalid
...
```
I'm not sure what the best approach is here.

### TODO's (oops, sorry, I discovered something was missing after creating this PR)

- [x] Implement a default constraint sampler [here](https://github.com/ros-planning/moveit/blob/9f9e69c54529e1aa156851abb6aae7047b20780d/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp#L466).


Also, maybe I need to make sure the angle is in a specific interval before multiplying it with the axis. In the [trajopt_ros implementation](https://github.com/ros-industrial-consortium/trajopt_ros/blob/a393abb99b221c97603ae40fcbd0f172f94a7fcc/trajopt/include/trajopt/utils.hpp#L161) they do something along these lines. But I'm not yet sure this is necessary. (I would probably need to dig into the Eigen implementation to find this out.)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
