### PR TITLE
PlanExecution: Reset preempt_requested_ when entering executeAndMonitor()

### DIFF
--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -133,7 +133,7 @@ public:
 
       In case there is no \e planning_scene or \e planning_scene_monitor set in the \e plan they will be set at the
       start of the method. They are then used to monitor the execution. */
-  moveit_msgs::MoveItErrorCodes executeAndMonitor(ExecutableMotionPlan& plan);
+  moveit_msgs::MoveItErrorCodes executeAndMonitor(ExecutableMotionPlan& plan, bool reset_preempted = true);
 
   void stop();
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -305,6 +305,8 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
 
 moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan)
 {
+  preempt_requested_ = false;
+
   if (!plan.planning_scene_monitor_)
     plan.planning_scene_monitor_ = planning_scene_monitor_;
   if (!plan.planning_scene_)

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -220,8 +220,8 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
       if (preempt_requested_)
         break;
 
-      // execute the trajectory, and monitor its executionm
-      plan.error_code_ = executeAndMonitor(plan);
+      // execute the trajectory, and monitor its execution
+      plan.error_code_ = executeAndMonitor(plan, false);
     }
 
     // if we are done, then we exit the loop
@@ -303,9 +303,10 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
   return true;
 }
 
-moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan)
+moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan, bool reset_preempted)
 {
-  preempt_requested_ = false;
+  if (reset_preempted)
+    preempt_requested_ = false;
 
   if (!plan.planning_scene_monitor_)
     plan.planning_scene_monitor_ = planning_scene_monitor_;

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -303,7 +303,8 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
   return true;
 }
 
-moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan, bool reset_preempted)
+moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan,
+                                                                               bool reset_preempted)
 {
   if (reset_preempted)
     preempt_requested_ = false;


### PR DESCRIPTION
So far, `executeAndMonitor()` was only called via `planAndExecuteHelper()`, which was resetting the `preempt_requested_` flag:
https://github.com/ros-planning/moveit/blob/f85db808303cb7787320dc48162eabdc07593fdc/moveit_ros/planning/plan_execution/src/plan_execution.cpp#L164

However, this should also work if the function is called directly.
Fixes https://github.com/ros-planning/moveit_task_constructor/issues/217.
