### PR TITLE
Fix empty sequence in moveit_setup_assistant

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -566,16 +566,16 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     emitter << YAML::EndSeq;
   else
   {
-    // Add empty list for valid yaml
-    emitter << YAML::BeginSeq;
-    emitter << YAML::EndSeq;
-
     // Add commented lines to show how the feature can be used
     if (default_group_name.empty())
       default_group_name = "group";
     emitter << YAML::Newline;
     emitter << YAML::Comment(" - group: " + default_group_name) << YAML::Newline;
     emitter << YAML::Comment("   pose: home") << YAML::Newline;
+
+    // Add empty list for valid yaml
+    emitter << YAML::BeginSeq;
+    emitter << YAML::EndSeq;
   }
 
   emitter << YAML::EndMap;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -566,6 +566,10 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     emitter << YAML::EndSeq;
   else
   {
+    // Add empty list for valid yaml
+    emitter << YAML::BeginSeq;
+    emitter << YAML::EndSeq;
+
     // Add commented lines to show how the feature can be used
     if (default_group_name.empty())
       default_group_name = "group";


### PR DESCRIPTION
### Description
There's a bug right now in the generation of fake_controllers.yaml such that if no poses are found, it will output invalid yaml. 

```
initial:  # Define initial robot poses.
#  - group: right_arm
#    pose: home
```
(and then the end of the file)

This results in a cryptic error like
```
load_parameters: unable to set parameters (last param was [/controller_list=[SNIP]]): cannot marshal None unless allow_none is enabled
```

With this PR, it now generates
```
initial:  # Define initial robot poses.
  []
#  - group: group
#    pose: home
```


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
