### PR TITLE
Changed processing_thread_ spin to use std::make_unique instead of new

### DIFF
--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -46,7 +46,7 @@ BackgroundProcessing::BackgroundProcessing()
   // spin a thread that will process user events
   run_processing_thread_ = true;
   processing_ = false;
-  processing_thread_.reset(new boost::thread(boost::bind(&BackgroundProcessing::processingThread, this)));
+  processing_thread_ = std::make_unique<boost::thread>(boost::bind(&BackgroundProcessing::processingThread, this));
 }
 
 BackgroundProcessing::~BackgroundProcessing()


### PR DESCRIPTION
### Description
Updated `moveit_core/background_processing/src/background_processing.cpp` to use `std::make_unique` instead of `new` when spinning a background processing thread as mentioned in #2383 and #1411 .
