### PR TITLE
Fix OrientationConstraint::decide

### DIFF
--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -620,9 +620,9 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
     xyz = diff.linear().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   }
 
-  xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::pi<double>() - fabs(xyz(0)));
-  xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::pi<double>() - fabs(xyz(1)));
-  xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::pi<double>() - fabs(xyz(2)));
+  xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::two_pi<double>() - fabs(xyz(0)));
+  xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::two_pi<double>() - fabs(xyz(1)));
+  xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::two_pi<double>() - fabs(xyz(2)));
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(1) < absolute_y_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(0) < absolute_x_axis_tolerance_ + std::numeric_limits<double>::epsilon();

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -620,6 +620,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
     xyz = diff.linear().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   }
 
+  // Account for angle wrapping
   xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::two_pi<double>() - fabs(xyz(0)));
   xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::two_pi<double>() - fabs(xyz(1)));
   xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::two_pi<double>() - fabs(xyz(2)));

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -654,6 +654,7 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
   robot_state.update();
   EXPECT_FALSE(oc.decide(robot_state).satisfied);
 
+  // rotation by pi does not wrap to zero
   jvals["r_wrist_roll_joint"] = boost::math::constants::pi<double>();
   robot_state.setVariablePositions(jvals);
   robot_state.update();

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -40,6 +40,7 @@
 #include <fstream>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/utils/robot_model_test_utils.h>
+#include <boost/math/constants/constants.hpp>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -649,6 +650,11 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
   EXPECT_TRUE(oc.decide(robot_state).satisfied);
 
   jvals["r_wrist_roll_joint"] = .11;
+  robot_state.setVariablePositions(jvals);
+  robot_state.update();
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+  
+  jvals["r_wrist_roll_joint"] = boost::math::constants::pi<double>();
   robot_state.setVariablePositions(jvals);
   robot_state.update();
   EXPECT_FALSE(oc.decide(robot_state).satisfied);

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -653,7 +653,7 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
   robot_state.setVariablePositions(jvals);
   robot_state.update();
   EXPECT_FALSE(oc.decide(robot_state).satisfied);
-  
+
   jvals["r_wrist_roll_joint"] = boost::math::constants::pi<double>();
   robot_state.setVariablePositions(jvals);
   robot_state.update();


### PR DESCRIPTION
### Description

The implementation of OrientationConstraint::decide does not handle the case where the relative orientation of the target and current link poses are represented by Euler angles which were all +/- pi or zero.  For example, if a link's target pose is rotated 180 degrees about the X axis relative to the current pose, the decide() function returns a value indicating that the current pose satisfies the target pose constraint.

This PR corrects the behavior of decide() and adds a test case that fails without this change.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [N/A] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [N/A] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [X] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [N/A] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
