### PR TITLE
WIP: Use Bullet for Servo collision detection

### DIFF
--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -130,7 +130,7 @@ void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, C
     manager_->setCollisionObjectsTransform(link, state.getCollisionBodyTransform(link, 0));
   }
 
-  manager_->contactTest(res, req, acm, false);
+  manager_->contactTest(res, req, acm, true);
 
   for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : cows)
   {

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -130,7 +130,7 @@ void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, C
     manager_->setCollisionObjectsTransform(link, state.getCollisionBodyTransform(link, 0));
   }
 
-  manager_->contactTest(res, req, acm, true);
+  manager_->contactTest(res, req, acm, false);
 
   for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : cows)
   {

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -39,6 +39,8 @@
 #pragma once
 
 #include <moveit/collision_detection/collision_common.h>
+#include <moveit/collision_detection_bullet/collision_detector_allocator_bullet.h>
+#include <moveit/collision_detection_bullet/collision_env_bullet.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <sensor_msgs/JointState.h>
@@ -123,6 +125,8 @@ private:
   // collision request
   collision_detection::CollisionRequest collision_request_;
   collision_detection::CollisionResult collision_result_;
+  std::shared_ptr<collision_detection::CollisionDetectorAllocatorBullet> collision_det_allocation_;
+  collision_detection::CollisionEnvPtr collision_env_;
 
   // ROS
   ros::Timer timer_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -96,9 +96,13 @@ private:
 
   // Pointer to the collision environment that was passed to the constructor
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
-  // Maintain this local copy of the planning scene, to reduce locking of planning_scene_monitor_
-  // Also, we want to use Bullet collision checking, not the default FCL
+  // Maintain this local copy of the planning scene, to reduce locking of planning_scene_monitor_.
+  // Also, we want to use Bullet collision checking for speed, not the default FCL.
+  // This is used for self-collision checking
   std::unique_ptr<planning_scene::PlanningScene> local_planning_scene_;
+  // A separate collision environment, for Bullet collision detection with the world
+  std::shared_ptr<collision_detection::CollisionDetectorAllocatorBullet> collision_det_allocation_;
+  collision_detection::CollisionEnvPtr collision_env_;
 
   // Robot state and collision matrix from planning scene
   std::shared_ptr<moveit::core::RobotState> current_state_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -94,8 +94,11 @@ private:
   // Parameters from yaml
   const ServoParameters& parameters_;
 
-  // Pointer to the collision environment
+  // Pointer to the collision environment that was passed to the constructor
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+  // Maintain this local copy of the planning scene, to reduce locking of planning_scene_monitor_
+  // Also, we want to use Bullet collision checking, not the default FCL
+  std::unique_ptr<planning_scene::PlanningScene> local_planning_scene_;
 
   // Robot state and collision matrix from planning scene
   std::shared_ptr<moveit::core::RobotState> current_state_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -39,8 +39,8 @@
 #pragma once
 
 #include <moveit/collision_detection/collision_common.h>
-#include <moveit/collision_detection_bullet/collision_detector_allocator_bullet.h>
-#include <moveit/collision_detection_bullet/collision_env_bullet.h>
+#include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
+#include <moveit/collision_detection_fcl/collision_env_fcl.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <sensor_msgs/JointState.h>
@@ -125,7 +125,7 @@ private:
   // collision request
   collision_detection::CollisionRequest collision_request_;
   collision_detection::CollisionResult collision_result_;
-  std::shared_ptr<collision_detection::CollisionDetectorAllocatorBullet> collision_det_allocation_;
+  std::shared_ptr<collision_detection::CollisionDetectorAllocatorFCL> collision_det_allocation_;
   collision_detection::CollisionEnvPtr collision_env_;
 
   // ROS

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -125,8 +125,6 @@ private:
   // collision request
   collision_detection::CollisionRequest collision_request_;
   collision_detection::CollisionResult collision_result_;
-  std::shared_ptr<collision_detection::CollisionDetectorAllocatorBullet> collision_det_allocation_;
-  collision_detection::CollisionEnvPtr collision_env_;
 
   // ROS
   ros::Timer timer_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -39,8 +39,8 @@
 #pragma once
 
 #include <moveit/collision_detection/collision_common.h>
-#include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
-#include <moveit/collision_detection_fcl/collision_env_fcl.h>
+#include <moveit/collision_detection_bullet/collision_detector_allocator_bullet.h>
+#include <moveit/collision_detection_bullet/collision_env_bullet.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <sensor_msgs/JointState.h>
@@ -125,7 +125,7 @@ private:
   // collision request
   collision_detection::CollisionRequest collision_request_;
   collision_detection::CollisionResult collision_result_;
-  std::shared_ptr<collision_detection::CollisionDetectorAllocatorFCL> collision_det_allocation_;
+  std::shared_ptr<collision_detection::CollisionDetectorAllocatorBullet> collision_det_allocation_;
   collision_detection::CollisionEnvPtr collision_env_;
 
   // ROS

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -85,9 +85,12 @@ CollisionCheck::CollisionCheck(ros::NodeHandle& nh, const moveit_servo::ServoPar
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
   acm_ = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
 
+  // Maintain this local copy of the planning scene, to reduce locking of planning_scene_monitor_
+  local_planning_scene_ = std::make_unique<planning_scene::PlanningScene>(
+    getLockedPlanningSceneRO()->getRobotModel()
+    );
   // Use Bullet collision detection, for speed
-  planning_scene_monitor::LockedPlanningSceneRW(planning_scene_monitor_)->
-    setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create());
+  local_planning_scene_->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create());
 }
 
 planning_scene_monitor::LockedPlanningSceneRO CollisionCheck::getLockedPlanningSceneRO() const
@@ -117,30 +120,29 @@ void CollisionCheck::run(const ros::TimerEvent& timer_event)
 
   // Update to the latest current state
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
-  current_state_->updateCollisionBodyTransforms();
+  current_state_->update();
   collision_detected_ = false;
 
   using namespace std::chrono;
   high_resolution_clock::time_point t1 = high_resolution_clock::now();
 
   collision_result_.clear();
-  getLockedPlanningSceneRO()->getCollisionEnv()->checkRobotCollision(collision_request_, collision_result_,
-                                                                     *current_state_);
+  local_planning_scene_->getCollisionEnv()->checkRobotCollision(collision_request_, collision_result_, *current_state_);
   scene_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
   collision_result_.print();
 
   collision_result_.clear();
   // Self-collisions and scene collisions are checked separately so different thresholds can be used
-  getLockedPlanningSceneRO()->getCollisionEnvUnpadded()->checkSelfCollision(collision_request_, collision_result_,
-                                                                            *current_state_, acm_);
+  local_planning_scene_->checkSelfCollision(collision_request_, collision_result_, *current_state_, acm_);
   self_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
   collision_result_.print();
+  ROS_ERROR_STREAM_THROTTLE(0.05, self_collision_distance_);
 
   high_resolution_clock::time_point t2 = high_resolution_clock::now();
   duration<double> time_span = duration_cast<duration<double>>(t2 - t1);
-  ROS_ERROR_STREAM_THROTTLE(0.05, time_span.count());
+//  ROS_ERROR_STREAM_THROTTLE(0.05, time_span.count());
 
   velocity_scale_ = 1;
   // If we're definitely in collision, stop immediately

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -82,7 +82,7 @@ CollisionCheck::CollisionCheck(ros::NodeHandle& nh, const moveit_servo::ServoPar
   acm_ = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
 
   // Set up Bullet collision detection
-  collision_det_allocation_ = std::make_shared<collision_detection::CollisionDetectorAllocatorBullet>();
+  collision_det_allocation_ = std::make_shared<collision_detection::CollisionDetectorAllocatorFCL>();
   const collision_detection::WorldPtr& world =
       planning_scene_monitor::LockedPlanningSceneRW(planning_scene_monitor_)->getWorldNonConst();
   collision_env_ = collision_det_allocation_->allocateEnv(world, getLockedPlanningSceneRO()->getRobotModel());

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -82,7 +82,7 @@ CollisionCheck::CollisionCheck(ros::NodeHandle& nh, const moveit_servo::ServoPar
   acm_ = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
 
   // Set up Bullet collision detection
-  collision_det_allocation_ = std::make_shared<collision_detection::CollisionDetectorAllocatorFCL>();
+  collision_det_allocation_ = std::make_shared<collision_detection::CollisionDetectorAllocatorBullet>();
   const collision_detection::WorldPtr& world =
       planning_scene_monitor::LockedPlanningSceneRW(planning_scene_monitor_)->getWorldNonConst();
   collision_env_ = collision_det_allocation_->allocateEnv(world, getLockedPlanningSceneRO()->getRobotModel());

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -126,11 +126,12 @@ void CollisionCheck::run(const ros::TimerEvent& timer_event)
   using namespace std::chrono;
   high_resolution_clock::time_point t1 = high_resolution_clock::now();
 
-  collision_result_.clear();
-  local_planning_scene_->getCollisionEnv()->checkRobotCollision(collision_request_, collision_result_, *current_state_);
-  scene_collision_distance_ = collision_result_.distance;
-  collision_detected_ |= collision_result_.collision;
-  collision_result_.print();
+  // collision_result_.clear();
+  // local_planning_scene_->getCollisionEnv()->checkRobotCollision(collision_request_, collision_result_, *current_state_, acm_);
+  // scene_collision_distance_ = collision_result_.distance;
+  // collision_detected_ |= collision_result_.collision;
+  // collision_result_.print();
+  scene_collision_distance_ = 1000;
 
   collision_result_.clear();
   // Self-collisions and scene collisions are checked separately so different thresholds can be used

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -80,6 +80,12 @@ CollisionCheck::CollisionCheck(ros::NodeHandle& nh, const moveit_servo::ServoPar
 
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
   acm_ = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
+
+  // Set up Bullet collision detection
+  collision_det_allocation_ = std::make_shared<collision_detection::CollisionDetectorAllocatorBullet>();
+  const collision_detection::WorldPtr& world =
+      planning_scene_monitor::LockedPlanningSceneRW(planning_scene_monitor_)->getWorldNonConst();
+  collision_env_ = collision_det_allocation_->allocateEnv(world, getLockedPlanningSceneRO()->getRobotModel());
 }
 
 planning_scene_monitor::LockedPlanningSceneRO CollisionCheck::getLockedPlanningSceneRO() const
@@ -112,18 +118,15 @@ void CollisionCheck::run(const ros::TimerEvent& timer_event)
   current_state_->updateCollisionBodyTransforms();
   collision_detected_ = false;
 
-  // Do a timer-safe distance-based collision detection
   collision_result_.clear();
-  getLockedPlanningSceneRO()->getCollisionEnv()->checkRobotCollision(collision_request_, collision_result_,
-                                                                     *current_state_);
+  collision_env_->checkRobotCollision(collision_request_, collision_result_, *current_state_, acm_);
   scene_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
   collision_result_.print();
 
   collision_result_.clear();
   // Self-collisions and scene collisions are checked separately so different thresholds can be used
-  getLockedPlanningSceneRO()->getCollisionEnvUnpadded()->checkSelfCollision(collision_request_, collision_result_,
-                                                                            *current_state_, acm_);
+  collision_env_->checkSelfCollision(collision_request_, collision_result_, *current_state_, acm_);
   self_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
   collision_result_.print();


### PR DESCRIPTION
This switches from FCL collision detection to Bullet collision detection. It's nice for a couple reasons:

- It doesn't lock the planning scene. No `getLockedPlanningSceneRO()`
- It runs faster. I dropped a high resolution timer around collision_check.cpp, Lines 115-129. Here are the results:

Bullet:  cycle time varied from 0.9-2.7 ms
FCL:    cycle time varied from 15-69 ms

Wow!
