### PR TITLE
Prevent moveit_servo transforms between fixed frames from causing timeout

### DIFF
--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -240,7 +240,7 @@ void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& 
       tf2::doTransform(target_pose_, target_pose_, target_to_planning_frame);
 
       // Prevent doTransform from copying a stamp of 0, which will cause the haveRecentTargetPose check to fail servo motions
-      target_pose_.header.stamp = msg->header.stamp;
+      target_pose_.header.stamp = ros::Time::now();
     }
     catch (const tf2::TransformException& ex)
     {

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -238,6 +238,9 @@ void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& 
       geometry_msgs::TransformStamped target_to_planning_frame = transform_buffer_.lookupTransform(
           planning_frame_, target_pose_.header.frame_id, ros::Time(0), ros::Duration(0.1));
       tf2::doTransform(target_pose_, target_pose_, target_to_planning_frame);
+
+      // Prevent doTransform from copying a stamp of 0, which will cause the haveRecentTargetPose check to fail servo motions
+      target_pose_.header.stamp = msg->header.stamp;
     }
     catch (const tf2::TransformException& ex)
     {


### PR DESCRIPTION
### Description

Currently, if target_pose must be transformed to be in planning_frame (in `targetPoseCallback` function), and a URDF transform from the current frame to planning_frame is available, then TransformStamped time returned by lookupTransform will be 0. 0 is then copied into target_pose_'s stamp by doTransform. This will result in the timestamp checking in `haveRecentTargetPose` to cause `moveToPose` to always abort because it doesn't think it has received a target_pose recently. 

Two examples of when users could experience this behavior:
- They publish `target_pose` in world frame, but `planning_frame` is configured to be `base_link` (and world to base_link is defined in the URDF)
- They are running in a noise-less simulation, and in this simulation have the object they are servoing to as part of the URDF

Solution:
I don't think we can assume that a TransformStamped timestamp of 0 will always means that it was a URDF defined transform. So instead of checking for that, I am simply copying back the target_pose's original timestamp back if a transform has to be applied. I think this is fine as the purpose of the timestamp checking in `haveRecentTargetPose` is to see if the pose was received recently, rather than how recent the transform is. The TransformException catch will still flag failures to get any transform in the provided time window.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
