### PR TITLE
Make a plugin for differential IK solvers

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -62,6 +62,21 @@ include_directories(SYSTEM
 ## Library to process realtime twist or joint commands ##
 #########################################################
 
+# Base plugin for local IK solvers. Inherit from this class to create your own IK solver
+add_library(ik_solver_base
+  src/ik_solver_base.cpp
+)
+
+# This library provides IK solutions. You can replace it with a plugin of your own
+# It inherits from ik_solver_base
+add_library(inverse_jacobian_ik
+  src/inverse_jacobian_ik_plugin.cpp
+)
+target_link_libraries(inverse_jacobian_ik
+  ${catkin_LIBRARIES}
+  ik_solver_base
+)
+
 # This library provides an interface for sending realtime twist or joint commands to a robot
 add_library(${SERVO_LIB_NAME}
   # These files are used to produce differential motion
@@ -141,6 +156,7 @@ target_link_libraries(spacenav_to_twist ${catkin_LIBRARIES})
 
 install(
   TARGETS
+    ik_solver_base
     ${SERVO_LIB_NAME}
     pose_tracking
     pose_tracking_example

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -58,9 +58,9 @@ include_directories(SYSTEM
   ${Boost_INCLUDE_DIR}
 )
 
-#########################################################
-## Library to process realtime twist or joint commands ##
-#########################################################
+##################################
+## Incremental IK solver plugin ##
+##################################
 
 # Base plugin for local IK solvers. Inherit from this class to create your own IK solver
 add_library(ik_solver_base
@@ -76,6 +76,10 @@ target_link_libraries(inverse_jacobian_ik
   ${catkin_LIBRARIES}
   ik_solver_base
 )
+
+#########################################################
+## Library to process realtime twist or joint commands ##
+#########################################################
 
 # This library provides an interface for sending realtime twist or joint commands to a robot
 add_library(${SERVO_LIB_NAME}

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -157,6 +157,7 @@ target_link_libraries(spacenav_to_twist ${catkin_LIBRARIES})
 install(
   TARGETS
     ik_solver_base
+    inverse_jacobian_ik
     ${SERVO_LIB_NAME}
     pose_tracking
     pose_tracking_example

--- a/moveit_ros/moveit_servo/config/inverse_jacobian_ik_plugin.xml
+++ b/moveit_ros/moveit_servo/config/inverse_jacobian_ik_plugin.xml
@@ -1,0 +1,7 @@
+<library path="lib/libInverseJacobianIKPlugin">
+  <class type="moveit_servo::InverseJacobianIKPlugin" base_class_type="moveit_servo::IKSolverBase">
+  <description>
+    This is a local IK solver plugin
+  </description>
+  </class>
+</library>

--- a/moveit_ros/moveit_servo/config/inverse_jacobian_ik_plugin.xml
+++ b/moveit_ros/moveit_servo/config/inverse_jacobian_ik_plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/libInverseJacobianIKPlugin">
+<library path="lib/libinverse_jacobian_ik">
   <class type="moveit_servo::InverseJacobianIKPlugin" base_class_type="moveit_servo::IKSolverBase">
   <description>
     This is a local IK solver plugin

--- a/moveit_ros/moveit_servo/config/ur_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/ur_simulated_config.yaml
@@ -41,9 +41,6 @@ incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a ne
 # Important because ROS may drop some messages and we need the robot to halt reliably.
 num_outgoing_halt_msgs_to_publish: 4
 
-## Configure handling of singularities and joint limits
-lower_singularity_threshold:  17  # Start decelerating when the condition number hits this (close to singularity)
-hard_stop_singularity_threshold: 30 # Stop when the condition number hits this
 joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
 
 ## Topic names
@@ -66,3 +63,7 @@ scene_collision_proximity_threshold: 0.05 # Start decelerating when a scene coll
 # Parameters for "stop_distance"-type collision checking
 collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]
+
+# These parameters are specific to the inverse jacobian IK plugin. They may not be needed for other IK solver plugins
+lower_singularity_threshold:  17  # Start decelerating when the condition number hits this (close to singularity)
+hard_stop_singularity_threshold: 30 # Stop when the condition number hits this

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -42,6 +42,7 @@
 
 #include <geometry_msgs/TwistStamped.h>
 #include <moveit/robot_state/robot_state.h>
+#include <moveit_servo/status_codes.h>
 #include <trajectory_msgs/JointTrajectory.h>
 
 namespace moveit_servo
@@ -53,14 +54,19 @@ class IKSolverBase
 public:
 
   /**
-   * From a twist command and the current robot state, compute a new JointTrajectory message with an incremental change
-   * in joint values.
+   * From a Cartesian delta command and the current robot state, compute a new JointTrajectory message with an
+   * incremental change in joint values.
+   * The idea is to add new function signatures here as different IK solvers are added.
    * @param current_state current state of the robot from MoveIt
-   * @param twist_cmd a vector with 6 elements (x-dot, y-dot, z-dot, roll-dot, pitch-dot, yaw-dot)
+   * @param delta_x a vector with 6 elements (delta-x, delta-y, delta-z, delta-roll, delta-pitch, delta-yaw)
    * @return true if calculations were successful
    */
-  virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, const Eigen::VectorXd& twist_cmd,
-                               trajectory_msgs::JointTrajectory& joint_trajectory)
+  virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, Eigen::VectorXd& delta_x,
+                               const moveit::core::JointModelGroup* joint_model_group,
+                               const std::array<bool, 6>& drift_dimensions,
+                               double loop_period, double& velocity_scaling_for_singularity,
+                               Eigen::ArrayXd& delta_theta,
+                               StatusCode& status)
   {
     return true;
   }

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -34,16 +34,14 @@
 /*
    Author: Andy Zelenak
    Desc: A plugin providing an IK solution.
-   The plugin can be any IK method that takes a current RobotState and TwistStamped command
-   and outputs an incremental trajectory_msgs::JointTrajectory
+   The plugin can be any IK method that takes a current RobotState and Cartesian delta command
+   and outputs an incremental delta_theta
 */
 
 #pragma once
 
-#include <geometry_msgs/TwistStamped.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_servo/status_codes.h>
-#include <trajectory_msgs/JointTrajectory.h>
 
 namespace moveit_servo
 {
@@ -52,7 +50,9 @@ namespace moveit_servo
 class IKSolverBase
 {
 public:
-  virtual void initialize(ros::NodeHandle& nh){}
+  virtual bool initialize(ros::NodeHandle& nh)
+  {
+  }
 
   /**
    * From a Cartesian delta command and the current robot state, compute a new JointTrajectory message with an
@@ -60,18 +60,19 @@ public:
    * The idea is to add new function signatures here as different IK solvers are added.
    * @param current_state current state of the robot from MoveIt
    * @param delta_x a vector with 6 elements (delta-x, delta-y, delta-z, delta-roll, delta-pitch, delta-yaw)
+   * @param joint_mmodel_group the MoveIt joint model group of interest
+   * @param loop_period control rate, as specified in config file
+   * @param velocity_scaling_for_singularity a double between 0 and 1; decelerate if near singularity
+   * @param delta_theta return the change in each joint
+   * @param status an enumerated status code
    * @return true if calculations were successful
    */
-  virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, Eigen::VectorXd& delta_x,
-                               const moveit::core::JointModelGroup* joint_model_group,
-                               double loop_period, double& velocity_scaling_for_singularity,
-                               Eigen::ArrayXd& delta_theta,
-                               StatusCode& status)
+  virtual bool doDifferentialIK(const moveit::core::RobotStatePtr& current_state, Eigen::VectorXd& delta_x,
+                                const moveit::core::JointModelGroup* joint_model_group, const double loop_period,
+                                double& velocity_scaling_for_singularity, Eigen::ArrayXd& delta_theta,
+                                StatusCode& status)
   {
     return true;
   }
-
-protected:
-  IKSolverBase(){}
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -38,10 +38,16 @@
 
 #pragma once
 
+#include <iostream>
+
 namespace moveit_servo
 {
 class IKSolverBase
 {
-
+public:
+  void testPrint()
+  {
+    std::cout << "Hello World!" << std::endl;
+  }
 };
 }

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -46,10 +46,20 @@
 
 namespace moveit_servo
 {
+// Base class for incremental IK solvers.
+// If your IK solver requires something different, please raise a Github issue or notify a maintainer.
 class IKSolverBase
 {
 public:
-  virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, geometry_msgs::TwistStamped& cmd,
+
+  /**
+   * From a twist command and the current robot state, compute a new JointTrajectory message with an incremental change
+   * in joint values.
+   * @param current_state current state of the robot from MoveIt
+   * @param twist_cmd a vector with 6 elements (x-dot, y-dot, z-dot, roll-dot, pitch-dot, yaw-dot)
+   * @return true if calculations were successful
+   */
+  virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, const Eigen::VectorXd& twist_cmd,
                                trajectory_msgs::JointTrajectory& joint_trajectory)
   {
     return true;

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -1,0 +1,47 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+   Author: Andy Zelenak
+   Desc: A plugin providing an IK solution
+*/
+
+#pragma once
+
+namespace moveit_servo
+{
+class IKSolverBase
+{
+
+};
+}

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -33,21 +33,26 @@
  *********************************************************************/
 /*
    Author: Andy Zelenak
-   Desc: A plugin providing an IK solution
+   Desc: A plugin providing an IK solution.
+   The plugin can be any IK method that takes a current RobotState and TwistStamped command
+   and outputs an incremental trajectory_msgs::JointTrajectory
 */
 
 #pragma once
 
-#include <iostream>
+#include <geometry_msgs/TwistStamped.h>
+#include <moveit/robot_state/robot_state.h>
+#include <trajectory_msgs/JointTrajectory.h>
 
 namespace moveit_servo
 {
 class IKSolverBase
 {
 public:
-  void testPrint()
+  virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, geometry_msgs::TwistStamped& cmd,
+                               trajectory_msgs::JointTrajectory& joint_trajectory)
   {
-    std::cout << "Hello World!" << std::endl;
+    return true;
   }
 };
-}
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/ik_solver_base.h
@@ -52,6 +52,7 @@ namespace moveit_servo
 class IKSolverBase
 {
 public:
+  virtual void initialize(ros::NodeHandle& nh){}
 
   /**
    * From a Cartesian delta command and the current robot state, compute a new JointTrajectory message with an
@@ -63,12 +64,14 @@ public:
    */
   virtual bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, Eigen::VectorXd& delta_x,
                                const moveit::core::JointModelGroup* joint_model_group,
-                               const std::array<bool, 6>& drift_dimensions,
                                double loop_period, double& velocity_scaling_for_singularity,
                                Eigen::ArrayXd& delta_theta,
                                StatusCode& status)
   {
     return true;
   }
+
+protected:
+  IKSolverBase(){}
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
@@ -44,6 +44,7 @@ namespace moveit_servo
 {
 class InverseJacobianIKPlugin : public IKSolverBase
 {
-
+  bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, geometry_msgs::TwistStamped& cmd,
+                       trajectory_msgs::JointTrajectory& joint_trajectory);
 };
-}
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
@@ -42,9 +42,10 @@
 
 namespace moveit_servo
 {
+// Inherit from a generic base class
 class InverseJacobianIKPlugin : public IKSolverBase
 {
-  bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, geometry_msgs::TwistStamped& cmd,
+  bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, const Eigen::VectorXd& twist_cmd,
                        trajectory_msgs::JointTrajectory& joint_trajectory);
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
@@ -1,0 +1,49 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+   Author: Andy Zelenak
+   Desc: A plugin providing an IK solution
+*/
+
+#pragma once
+
+#include "moveit_servo/ik_solver_base.h"
+
+namespace moveit_servo
+{
+class InverseJacobianIKPlugin : public IKSolverBase
+{
+
+};
+}

--- a/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/inverse_jacobian_ik_plugin.h
@@ -48,13 +48,12 @@ namespace moveit_servo
 class InverseJacobianIKPlugin : public IKSolverBase
 {
 public:
-  void initialize(ros::NodeHandle& nh) override;
+  bool initialize(ros::NodeHandle& nh) override;
 
-  bool doIncrementalIK(const moveit::core::RobotStatePtr& current_state, Eigen::VectorXd& twist_cmd,
-                       const moveit::core::JointModelGroup* joint_model_group,
-                       double loop_period, double& velocity_scaling_for_singularity,
-                       Eigen::ArrayXd& delta_theta,
-                       StatusCode& status) override;
+  bool doDifferentialIK(const moveit::core::RobotStatePtr& current_state, Eigen::VectorXd& twist_cmd,
+                        const moveit::core::JointModelGroup* joint_model_group, const double loop_period,
+                        double& velocity_scaling_for_singularity, Eigen::ArrayXd& delta_theta,
+                        StatusCode& status) override;
 
   /**
    * Remove the Jacobian row and the delta-x element of one Cartesian dimension, to take advantage of task redundancy
@@ -76,8 +75,7 @@ public:
                                              const moveit::core::JointModelGroup* joint_model_group,
                                              const Eigen::VectorXd& commanded_velocity,
                                              const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
-                                             const Eigen::MatrixXd& pseudo_inverse,
-                                             StatusCode& status);
+                                             const Eigen::MatrixXd& pseudo_inverse, StatusCode& status);
 
 private:
   /**
@@ -94,5 +92,7 @@ private:
   ros::ServiceServer drift_dimensions_server_;
   // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
   std::array<bool, 6> drift_dimensions_ = { { false, false, false, false, false, false } };
+  double lower_singularity_threshold_;
+  double hard_stop_singularity_threshold_;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -63,6 +63,10 @@
 #include <moveit_servo/status_codes.h>
 #include <moveit_servo/low_pass_filter.h>
 
+// IK plugin
+#include <moveit_servo/ik_solver_base.h>
+#include <pluginlib/class_loader.h>
+
 namespace moveit_servo
 {
 class ServoCalcs
@@ -219,6 +223,8 @@ private:
   bool resetServoStatus(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
 
   ros::NodeHandle nh_;
+
+  boost::shared_ptr<moveit_servo::IKSolverBase> ik_plugin_;
 
   // Parameters from yaml
   ServoParameters& parameters_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -144,18 +144,8 @@ private:
    */
   void suddenHalt(trajectory_msgs::JointTrajectory& joint_trajectory);
 
-  /** \brief  Scale the delta theta to match joint velocity/acceleration limits */
-  void enforceVelLimits(Eigen::ArrayXd& delta_theta);
-
   /** \brief Avoid overshooting joint limits */
   bool enforcePositionLimits();
-
-  /** \brief Possibly calculate a velocity scaling factor, due to proximity of
-   * singularity and direction of motion
-   */
-  double velocityScalingFactorForSingularity(const Eigen::VectorXd& commanded_velocity,
-                                             const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
-                                             const Eigen::MatrixXd& pseudo_inverse);
 
   /**
    * Slow motion down if close to singularity or collision.
@@ -186,15 +176,6 @@ private:
    * Satisfy Gazebo by stuffing multiple messages into one.
    */
   void insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTrajectory& joint_trajectory, int count) const;
-
-  /**
-   * Remove the Jacobian row and the delta-x element of one Cartesian dimension, to take advantage of task redundancy
-   *
-   * @param matrix The Jacobian matrix.
-   * @param delta_x Vector of Cartesian delta commands, should be the same size as matrix.rows()
-   * @param row_to_remove Dimension that will be allowed to drift, e.g. row_to_remove = 2 allows z-translation drift.
-   */
-  void removeDimension(Eigen::MatrixXd& matrix, Eigen::VectorXd& delta_x, unsigned int row_to_remove);
 
   /* \brief Callback for joint subsription */
   void jointStateCB(const sensor_msgs::JointStateConstPtr& msg);

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -49,7 +49,6 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
-#include <moveit_msgs/ChangeDriftDimensions.h>
 #include <moveit_msgs/ChangeControlDimensions.h>
 #include <sensor_msgs/JointState.h>
 #include <std_msgs/Float64.h>
@@ -185,17 +184,6 @@ private:
   void jointCmdCB(const control_msgs::JointJogConstPtr& msg);
   void collisionVelocityScaleCB(const std_msgs::Float64ConstPtr& msg);
 
-  /**
-   * Allow drift in certain dimensions. For example, may allow the wrist to rotate freely.
-   * This can help avoid singularities.
-   *
-   * @param request the service request
-   * @param response the service response
-   * @return true if the adjustment was made
-   */
-  bool changeDriftDimensions(moveit_msgs::ChangeDriftDimensions::Request& req,
-                             moveit_msgs::ChangeDriftDimensions::Response& res);
-
   /** \brief Service callback for changing servoing dimensions (e.g. ignore rotation about X) */
   bool changeControlDimensions(moveit_msgs::ChangeControlDimensions::Request& req,
                                moveit_msgs::ChangeControlDimensions::Response& res);
@@ -256,7 +244,6 @@ private:
   ros::Publisher status_pub_;
   ros::Publisher worst_case_stop_time_pub_;
   ros::Publisher outgoing_cmd_pub_;
-  ros::ServiceServer drift_dimensions_server_;
   ros::ServiceServer control_dimensions_server_;
   ros::ServiceServer reset_servo_status_;
 
@@ -279,9 +266,6 @@ private:
   const int gazebo_redundant_message_count_ = 30;
 
   uint num_joints_;
-
-  // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
-  std::array<bool, 6> drift_dimensions_ = { { false, false, false, false, false, false } };
 
   // The dimesions to control. In the command frame. [x, y, z, roll, pitch, yaw]
   std::array<bool, 6> control_dimensions_ = { { true, true, true, true, true, true } };

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -60,8 +60,6 @@ struct ServoParameters
   double linear_scale;
   double rotational_scale;
   double joint_scale;
-  double lower_singularity_threshold;
-  double hard_stop_singularity_threshold;
   double low_pass_filter_coeff;
   double publish_period;
   double incoming_command_timeout;

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -39,6 +39,7 @@
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
 
   <export>
+    <moveit_servo plugin="config/inverse_jacobian_ik_plugin.xml"/>
   </export>
 
 </package>

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -39,7 +39,7 @@
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
 
   <export>
-    <moveit_servo plugin="config/inverse_jacobian_ik_plugin.xml"/>
+    <moveit_servo plugin="${prefix}/config/inverse_jacobian_ik_plugin.xml"/>
   </export>
 
 </package>

--- a/moveit_ros/moveit_servo/src/ik_solver_base.cpp
+++ b/moveit_ros/moveit_servo/src/ik_solver_base.cpp
@@ -1,0 +1,39 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "moveit_servo/ik_solver_base.h"
+
+namespace moveit_servo
+{
+}

--- a/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
+++ b/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
@@ -38,9 +38,12 @@
 namespace moveit_servo
 {
 bool InverseJacobianIKPlugin::doIncrementalIK(const moveit::core::RobotStatePtr& current_state,
-                                              geometry_msgs::TwistStamped& cmd,
+                                              const Eigen::VectorXd& twist_cmd,
                                               trajectory_msgs::JointTrajectory& joint_trajectory)
 {
+  // Convert from cartesian commands to joint commands
+//  Eigen::MatrixXd jacobian = current_state->getJacobian(joint_model_group.get());
+
   return true;
 }
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
+++ b/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
@@ -1,0 +1,43 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "moveit_servo/inverse_jacobian_ik_plugin.h"
+#include "pluginlib/class_list_macros.h"
+
+namespace moveit_servo
+{
+}
+
+// Declare availability as a ROS plugin
+PLUGINLIB_EXPORT_CLASS(moveit_servo::InverseJacobianIKPlugin, moveit_servo::IKSolverBase)

--- a/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
+++ b/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
@@ -35,16 +35,190 @@
 #include "moveit_servo/inverse_jacobian_ik_plugin.h"
 #include "pluginlib/class_list_macros.h"
 
+static const std::string LOGNAME = "inverse_jacobian_ik_plugin";
+constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30;  // Seconds to throttle logs inside loops
+
 namespace moveit_servo
 {
 bool InverseJacobianIKPlugin::doIncrementalIK(const moveit::core::RobotStatePtr& current_state,
-                                              const Eigen::VectorXd& twist_cmd,
-                                              trajectory_msgs::JointTrajectory& joint_trajectory)
+                                              Eigen::VectorXd& delta_x,
+                                              const moveit::core::JointModelGroup* joint_model_group,
+                                              const std::array<bool, 6>& drift_dimensions,
+                                              double loop_period, double& velocity_scaling_for_singularity, 
+                                              Eigen::ArrayXd& delta_theta,
+                                              StatusCode& status)
 {
   // Convert from cartesian commands to joint commands
-//  Eigen::MatrixXd jacobian = current_state->getJacobian(joint_model_group.get());
+  Eigen::MatrixXd jacobian = current_state->getJacobian(joint_model_group);
+
+  // May allow some dimensions to drift, based on drift_dimensions
+  // i.e. take advantage of task redundancy.
+  // Remove the Jacobian rows corresponding to True in the vector drift_dimensions
+  // Work backwards through the 6-vector so indices don't get out of order
+  for (auto dimension = jacobian.rows() - 1; dimension >= 0; --dimension)
+  {
+    if (drift_dimensions[dimension] && jacobian.rows() > 1)
+    {
+      removeDimension(jacobian, delta_x, dimension);
+    }
+  }
+
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd =
+      Eigen::JacobiSVD<Eigen::MatrixXd>(jacobian, Eigen::ComputeThinU | Eigen::ComputeThinV);
+  Eigen::MatrixXd matrix_s = svd.singularValues().asDiagonal();
+  Eigen::MatrixXd pseudo_inverse = svd.matrixV() * matrix_s.inverse() * svd.matrixU().transpose();
+
+  delta_theta = pseudo_inverse * delta_x;
+
+  enforceVelLimits(delta_theta, loop_period, joint_model_group);
+
+  velocity_scaling_for_singularity = velocityScalingFactorForSingularity(current_state, joint_model_group, delta_x,
+                                                                         svd, pseudo_inverse, status);
 
   return true;
+}
+
+void InverseJacobianIKPlugin::removeDimension(Eigen::MatrixXd& jacobian, Eigen::VectorXd& delta_x, unsigned int row_to_remove)
+{
+  unsigned int num_rows = jacobian.rows() - 1;
+  unsigned int num_cols = jacobian.cols();
+
+  if (row_to_remove < num_rows)
+  {
+    jacobian.block(row_to_remove, 0, num_rows - row_to_remove, num_cols) =
+        jacobian.block(row_to_remove + 1, 0, num_rows - row_to_remove, num_cols);
+    delta_x.segment(row_to_remove, num_rows - row_to_remove) =
+        delta_x.segment(row_to_remove + 1, num_rows - row_to_remove);
+  }
+  jacobian.conservativeResize(num_rows, num_cols);
+  delta_x.conservativeResize(num_rows);
+}
+
+void InverseJacobianIKPlugin::enforceVelLimits(Eigen::ArrayXd& delta_theta, double loop_period,
+                                               const moveit::core::JointModelGroup* joint_model_group)
+{
+  Eigen::ArrayXd velocity = delta_theta / loop_period;
+
+  std::size_t joint_delta_index = 0;
+  // Track the smallest velocity scaling factor required, across all joints
+  double velocity_limit_scaling_factor = 1;
+
+  for (auto joint : joint_model_group->getActiveJointModels())
+  {
+    // Some joints do not have bounds defined
+    const auto bounds = joint->getVariableBounds(joint->getName());
+
+    if (bounds.velocity_bounded_)
+    {
+      velocity(joint_delta_index) = delta_theta(joint_delta_index) / loop_period;
+
+      bool clip_velocity = false;
+      double velocity_limit = 0.0;
+      if (velocity(joint_delta_index) < bounds.min_velocity_)
+      {
+        clip_velocity = true;
+        velocity_limit = bounds.min_velocity_;
+      }
+      else if (velocity(joint_delta_index) > bounds.max_velocity_)
+      {
+        clip_velocity = true;
+        velocity_limit = bounds.max_velocity_;
+      }
+
+      // Apply velocity bounds
+      if (clip_velocity)
+      {
+        const double scaling_factor =
+            fabs(velocity_limit * loop_period) / fabs(delta_theta(joint_delta_index));
+
+        // Store the scaling factor if it's the smallest yet
+        if (scaling_factor < velocity_limit_scaling_factor)
+          velocity_limit_scaling_factor = scaling_factor;
+      }
+    }
+    ++joint_delta_index;
+  }
+
+  // Apply the velocity scaling to all joints
+  if (velocity_limit_scaling_factor < 1)
+  {
+    for (joint_delta_index = 0; joint_delta_index < joint_model_group->getActiveJointModels().size();
+         ++joint_delta_index)
+    {
+      delta_theta(joint_delta_index) = velocity_limit_scaling_factor * delta_theta(joint_delta_index);
+      velocity(joint_delta_index) = velocity_limit_scaling_factor * velocity(joint_delta_index);
+    }
+  }
+}
+
+// Possibly calculate a velocity scaling factor, due to proximity of singularity and direction of motion
+double InverseJacobianIKPlugin::velocityScalingFactorForSingularity(const moveit::core::RobotStatePtr& current_state,
+                                                       const moveit::core::JointModelGroup* joint_model_group,
+                                                       const Eigen::VectorXd& commanded_velocity,
+                                                       const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
+                                                       const Eigen::MatrixXd& pseudo_inverse,
+                                                       StatusCode& status)
+{
+  double velocity_scale = 1;
+  std::size_t num_dimensions = commanded_velocity.size();
+
+  // Find the direction away from nearest singularity.
+  // The last column of U from the SVD of the Jacobian points directly toward or away from the singularity.
+  // The sign can flip at any time, so we have to do some extra checking.
+  // Look ahead to see if the Jacobian's condition will decrease.
+  Eigen::VectorXd vector_toward_singularity = svd.matrixU().col(num_dimensions - 1);
+
+  double ini_condition = svd.singularValues()(0) / svd.singularValues()(svd.singularValues().size() - 1);
+
+  // This singular vector tends to flip direction unpredictably. See R. Bro,
+  // "Resolving the Sign Ambiguity in the Singular Value Decomposition".
+  // Look ahead to see if the Jacobian's condition will decrease in this
+  // direction. Start with a scaled version of the singular vector
+  Eigen::VectorXd delta_x(num_dimensions);
+  double scale = 100;
+  delta_x = vector_toward_singularity / scale;
+
+  // Calculate a small change in joints
+  Eigen::VectorXd new_theta;
+  current_state->copyJointGroupPositions(joint_model_group, new_theta);
+  new_theta += pseudo_inverse * delta_x;
+  current_state->setJointGroupPositions(joint_model_group, new_theta);
+  Eigen::MatrixXd new_jacobian = current_state->getJacobian(joint_model_group);
+
+  Eigen::JacobiSVD<Eigen::MatrixXd> new_svd(new_jacobian);
+  double new_condition = new_svd.singularValues()(0) / new_svd.singularValues()(new_svd.singularValues().size() - 1);
+  // If new_condition < ini_condition, the singular vector does point towards a
+  // singularity. Otherwise, flip its direction.
+  if (ini_condition >= new_condition)
+  {
+    vector_toward_singularity *= -1;
+  }
+
+  // If this dot product is positive, we're moving toward singularity ==> decelerate
+  double dot = vector_toward_singularity.dot(commanded_velocity);
+  if (dot > 0)
+  {
+    // Ramp velocity down linearly when the Jacobian condition is between lower_singularity_threshold and
+    // hard_stop_singularity_threshold, and we're moving towards the singularity
+    if ((ini_condition > 20 /*parameters_.lower_singularity_threshold*/) &&
+        (ini_condition < 50 /*parameters_.hard_stop_singularity_threshold*/))
+    {
+      velocity_scale = 1. - (ini_condition - 20 /*parameters_.lower_singularity_threshold*/) /
+                                (50-20 /*parameters_.hard_stop_singularity_threshold - parameters_.lower_singularity_threshold*/);
+      status = StatusCode::DECELERATE_FOR_SINGULARITY;
+      ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME, SERVO_STATUS_CODE_MAP.at(status));
+    }
+
+    // Very close to singularity, so halt.
+    else if (ini_condition > 50 /*parameters_.hard_stop_singularity_threshold*/)
+    {
+      velocity_scale = 0;
+      status = StatusCode::HALT_FOR_SINGULARITY;
+      ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME, SERVO_STATUS_CODE_MAP.at(status));
+    }
+  }
+
+  return velocity_scale;
 }
 }  // namespace moveit_servo
 

--- a/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
+++ b/moveit_ros/moveit_servo/src/inverse_jacobian_ik_plugin.cpp
@@ -37,7 +37,13 @@
 
 namespace moveit_servo
 {
+bool InverseJacobianIKPlugin::doIncrementalIK(const moveit::core::RobotStatePtr& current_state,
+                                              geometry_msgs::TwistStamped& cmd,
+                                              trajectory_msgs::JointTrajectory& joint_trajectory)
+{
+  return true;
 }
+}  // namespace moveit_servo
 
 // Declare availability as a ROS plugin
 PLUGINLIB_EXPORT_CLASS(moveit_servo::InverseJacobianIKPlugin, moveit_servo::IKSolverBase)

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -108,10 +108,6 @@ bool Servo::readParameters()
   error += !rosparam_shortcuts::get(LOGNAME, nh, "joint_command_in_topic", parameters_.joint_command_in_topic);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "robot_link_command_frame", parameters_.robot_link_command_frame);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "incoming_command_timeout", parameters_.incoming_command_timeout);
-  error +=
-      !rosparam_shortcuts::get(LOGNAME, nh, "lower_singularity_threshold", parameters_.lower_singularity_threshold);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "hard_stop_singularity_threshold",
-                                    parameters_.hard_stop_singularity_threshold);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "move_group_name", parameters_.move_group_name);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "planning_frame", parameters_.planning_frame);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "ee_frame_name", parameters_.ee_frame_name);
@@ -194,20 +190,6 @@ bool Servo::readParameters()
   {
     ROS_WARN_NAMED(LOGNAME,
                    "Parameter 'num_outgoing_halt_msgs_to_publish' should be greater than zero. Check yaml file.");
-    return false;
-  }
-  if (parameters_.hard_stop_singularity_threshold < parameters_.lower_singularity_threshold)
-  {
-    ROS_WARN_NAMED(LOGNAME, "Parameter 'hard_stop_singularity_threshold' "
-                            "should be greater than 'lower_singularity_threshold.' "
-                            "Check yaml file.");
-    return false;
-  }
-  if ((parameters_.hard_stop_singularity_threshold < 0.) || (parameters_.lower_singularity_threshold < 0.))
-  {
-    ROS_WARN_NAMED(LOGNAME, "Parameters 'hard_stop_singularity_threshold' "
-                            "and 'lower_singularity_threshold' should be "
-                            "greater than zero. Check yaml file.");
     return false;
   }
   if (parameters_.low_pass_filter_coeff < 0.)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -118,9 +118,9 @@ ServoCalcs::ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
     // TODO: read plugin name from yaml
     ik_plugin_ = ik_plugin_loader.createInstance("moveit_servo::InverseJacobianIKPlugin");
   }
-  catch(pluginlib::PluginlibException& ex)
+  catch (pluginlib::PluginlibException& ex)
   {
-    //handle the class failing to load
+    // handle the class failing to load
     ROS_ERROR_NAMED(LOGNAME, "The IK solver plugin failed to load. Error: %s", ex.what());
     std::exit(EXIT_FAILURE);
   }
@@ -350,6 +350,7 @@ void ServoCalcs::calculateSingleIteration()
   // Only run commands if not stale and nonzero
   if (have_nonzero_twist_stamped_ && !twist_command_is_stale_)
   {
+    ik_plugin_->doIncrementalIK(current_state_, twist_stamped_cmd_, *joint_trajectory);
     if (!cartesianServoCalcs(twist_stamped_cmd_, *joint_trajectory))
     {
       resetLowPassFilters(original_joint_state_);
@@ -448,8 +449,6 @@ void ServoCalcs::calculateSingleIteration()
 bool ServoCalcs::cartesianServoCalcs(geometry_msgs::TwistStamped& cmd,
                                      trajectory_msgs::JointTrajectory& joint_trajectory)
 {
-  ik_plugin_->testPrint();
-
   // Check for nan's in the incoming command
   if (std::isnan(cmd.twist.linear.x) || std::isnan(cmd.twist.linear.y) || std::isnan(cmd.twist.linear.z) ||
       std::isnan(cmd.twist.angular.x) || std::isnan(cmd.twist.angular.y) || std::isnan(cmd.twist.angular.z))

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -525,39 +525,21 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::TwistStamped& cmd,
 
   Eigen::VectorXd delta_x = scaleCartesianCommand(cmd);
 
-  if (!ik_plugin_->doIncrementalIK(current_state_, delta_x, joint_trajectory))
+  double velocity_scaling_for_singularity = 1;
+
+  // For now, only one solver type is available.
+  // May need to add a different solver type later (add a yaml file and a switch-case to select it)
+  if (!ik_plugin_->doIncrementalIK(current_state_, delta_x, joint_model_group_, drift_dimensions_,
+                                   parameters_.publish_period, velocity_scaling_for_singularity, delta_theta_,
+                                   status_))
   {
     ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME,
                                    "IK calculation failed.");
     return false;
   }
 
-  // Convert from cartesian commands to joint commands
-  Eigen::MatrixXd jacobian = current_state_->getJacobian(joint_model_group_);
-
-  // May allow some dimensions to drift, based on drift_dimensions
-  // i.e. take advantage of task redundancy.
-  // Remove the Jacobian rows corresponding to True in the vector drift_dimensions
-  // Work backwards through the 6-vector so indices don't get out of order
-  for (auto dimension = jacobian.rows() - 1; dimension >= 0; --dimension)
-  {
-    if (drift_dimensions_[dimension] && jacobian.rows() > 1)
-    {
-      removeDimension(jacobian, delta_x, dimension);
-    }
-  }
-
-  Eigen::JacobiSVD<Eigen::MatrixXd> svd =
-      Eigen::JacobiSVD<Eigen::MatrixXd>(jacobian, Eigen::ComputeThinU | Eigen::ComputeThinV);
-  Eigen::MatrixXd matrix_s = svd.singularValues().asDiagonal();
-  Eigen::MatrixXd pseudo_inverse = svd.matrixV() * matrix_s.inverse() * svd.matrixU().transpose();
-
-  delta_theta_ = pseudo_inverse * delta_x;
-
-  enforceVelLimits(delta_theta_);
-
   // If close to a collision or a singularity, decelerate
-  applyVelocityScaling(delta_theta_, velocityScalingFactorForSingularity(delta_x, svd, pseudo_inverse));
+  applyVelocityScaling(delta_theta_, velocity_scaling_for_singularity);
 
   prev_joint_velocity_ = delta_theta_ / parameters_.publish_period;
 
@@ -579,8 +561,6 @@ bool ServoCalcs::jointServoCalcs(const control_msgs::JointJog& cmd, trajectory_m
 
   // Apply user-defined scaling
   delta_theta_ = scaleJointCommand(cmd);
-
-  enforceVelLimits(delta_theta_);
 
   // If close to a collision, decelerate
   applyVelocityScaling(delta_theta_, 1.0 /* scaling for singularities -- ignore for joint motions */);
@@ -708,129 +688,6 @@ void ServoCalcs::applyVelocityScaling(Eigen::ArrayXd& delta_theta, double singul
   {
     ROS_WARN_STREAM_THROTTLE_NAMED(3, LOGNAME, "Halting for collision!");
     delta_theta_.setZero();
-  }
-}
-
-// Possibly calculate a velocity scaling factor, due to proximity of singularity and direction of motion
-double ServoCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& commanded_velocity,
-                                                       const Eigen::JacobiSVD<Eigen::MatrixXd>& svd,
-                                                       const Eigen::MatrixXd& pseudo_inverse)
-{
-  double velocity_scale = 1;
-  std::size_t num_dimensions = commanded_velocity.size();
-
-  // Find the direction away from nearest singularity.
-  // The last column of U from the SVD of the Jacobian points directly toward or away from the singularity.
-  // The sign can flip at any time, so we have to do some extra checking.
-  // Look ahead to see if the Jacobian's condition will decrease.
-  Eigen::VectorXd vector_toward_singularity = svd.matrixU().col(num_dimensions - 1);
-
-  double ini_condition = svd.singularValues()(0) / svd.singularValues()(svd.singularValues().size() - 1);
-
-  // This singular vector tends to flip direction unpredictably. See R. Bro,
-  // "Resolving the Sign Ambiguity in the Singular Value Decomposition".
-  // Look ahead to see if the Jacobian's condition will decrease in this
-  // direction. Start with a scaled version of the singular vector
-  Eigen::VectorXd delta_x(num_dimensions);
-  double scale = 100;
-  delta_x = vector_toward_singularity / scale;
-
-  // Calculate a small change in joints
-  Eigen::VectorXd new_theta;
-  current_state_->copyJointGroupPositions(joint_model_group_, new_theta);
-  new_theta += pseudo_inverse * delta_x;
-  current_state_->setJointGroupPositions(joint_model_group_, new_theta);
-  Eigen::MatrixXd new_jacobian = current_state_->getJacobian(joint_model_group_);
-
-  Eigen::JacobiSVD<Eigen::MatrixXd> new_svd(new_jacobian);
-  double new_condition = new_svd.singularValues()(0) / new_svd.singularValues()(new_svd.singularValues().size() - 1);
-  // If new_condition < ini_condition, the singular vector does point towards a
-  // singularity. Otherwise, flip its direction.
-  if (ini_condition >= new_condition)
-  {
-    vector_toward_singularity *= -1;
-  }
-
-  // If this dot product is positive, we're moving toward singularity ==> decelerate
-  double dot = vector_toward_singularity.dot(commanded_velocity);
-  if (dot > 0)
-  {
-    // Ramp velocity down linearly when the Jacobian condition is between lower_singularity_threshold and
-    // hard_stop_singularity_threshold, and we're moving towards the singularity
-    if ((ini_condition > parameters_.lower_singularity_threshold) &&
-        (ini_condition < parameters_.hard_stop_singularity_threshold))
-    {
-      velocity_scale = 1. - (ini_condition - parameters_.lower_singularity_threshold) /
-                                (parameters_.hard_stop_singularity_threshold - parameters_.lower_singularity_threshold);
-      status_ = StatusCode::DECELERATE_FOR_SINGULARITY;
-      ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME, SERVO_STATUS_CODE_MAP.at(status_));
-    }
-
-    // Very close to singularity, so halt.
-    else if (ini_condition > parameters_.hard_stop_singularity_threshold)
-    {
-      velocity_scale = 0;
-      status_ = StatusCode::HALT_FOR_SINGULARITY;
-      ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME, SERVO_STATUS_CODE_MAP.at(status_));
-    }
-  }
-
-  return velocity_scale;
-}
-
-void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
-{
-  Eigen::ArrayXd velocity = delta_theta / parameters_.publish_period;
-
-  std::size_t joint_delta_index = 0;
-  // Track the smallest velocity scaling factor required, across all joints
-  double velocity_limit_scaling_factor = 1;
-
-  for (auto joint : joint_model_group_->getActiveJointModels())
-  {
-    // Some joints do not have bounds defined
-    const auto bounds = joint->getVariableBounds(joint->getName());
-
-    if (bounds.velocity_bounded_)
-    {
-      velocity(joint_delta_index) = delta_theta(joint_delta_index) / parameters_.publish_period;
-
-      bool clip_velocity = false;
-      double velocity_limit = 0.0;
-      if (velocity(joint_delta_index) < bounds.min_velocity_)
-      {
-        clip_velocity = true;
-        velocity_limit = bounds.min_velocity_;
-      }
-      else if (velocity(joint_delta_index) > bounds.max_velocity_)
-      {
-        clip_velocity = true;
-        velocity_limit = bounds.max_velocity_;
-      }
-
-      // Apply velocity bounds
-      if (clip_velocity)
-      {
-        const double scaling_factor =
-            fabs(velocity_limit * parameters_.publish_period) / fabs(delta_theta(joint_delta_index));
-
-        // Store the scaling factor if it's the smallest yet
-        if (scaling_factor < velocity_limit_scaling_factor)
-          velocity_limit_scaling_factor = scaling_factor;
-      }
-    }
-    ++joint_delta_index;
-  }
-
-  // Apply the velocity scaling to all joints
-  if (velocity_limit_scaling_factor < 1)
-  {
-    for (joint_delta_index = 0; joint_delta_index < joint_model_group_->getActiveJointModels().size();
-         ++joint_delta_index)
-    {
-      delta_theta(joint_delta_index) = velocity_limit_scaling_factor * delta_theta(joint_delta_index);
-      velocity(joint_delta_index) = velocity_limit_scaling_factor * velocity(joint_delta_index);
-    }
   }
 }
 
@@ -1047,22 +904,6 @@ bool ServoCalcs::addJointIncrements(sensor_msgs::JointState& output, const Eigen
   }
 
   return true;
-}
-
-void ServoCalcs::removeDimension(Eigen::MatrixXd& jacobian, Eigen::VectorXd& delta_x, unsigned int row_to_remove)
-{
-  unsigned int num_rows = jacobian.rows() - 1;
-  unsigned int num_cols = jacobian.cols();
-
-  if (row_to_remove < num_rows)
-  {
-    jacobian.block(row_to_remove, 0, num_rows - row_to_remove, num_cols) =
-        jacobian.block(row_to_remove + 1, 0, num_rows - row_to_remove, num_cols);
-    delta_x.segment(row_to_remove, num_rows - row_to_remove) =
-        delta_x.segment(row_to_remove + 1, num_rows - row_to_remove);
-  }
-  jacobian.conservativeResize(num_rows, num_cols);
-  delta_x.conservativeResize(num_rows);
 }
 
 bool ServoCalcs::getCommandFrameTransform(Eigen::Isometry3d& transform)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -448,6 +448,8 @@ void ServoCalcs::calculateSingleIteration()
 bool ServoCalcs::cartesianServoCalcs(geometry_msgs::TwistStamped& cmd,
                                      trajectory_msgs::JointTrajectory& joint_trajectory)
 {
+  ik_plugin_->testPrint();
+
   // Check for nan's in the incoming command
   if (std::isnan(cmd.twist.linear.x) || std::isnan(cmd.twist.linear.y) || std::isnan(cmd.twist.linear.z) ||
       std::isnan(cmd.twist.angular.x) || std::isnan(cmd.twist.angular.y) || std::isnan(cmd.twist.angular.z))

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -41,9 +41,6 @@ incoming_command_timeout:  1  # Stop servoing if X seconds elapse without a new 
 # Important because ROS may drop some messages and we need the robot to halt reliably.
 num_outgoing_halt_msgs_to_publish: 1
 
-## Configure handling of singularities and joint limits
-lower_singularity_threshold:  30  # Start decelerating when the condition number hits this (close to singularity)
-hard_stop_singularity_threshold: 45 # Stop when the condition number hits this
 joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
 
 ## Topic names
@@ -66,3 +63,7 @@ scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision 
 # Parameters for "stop_distance"-type collision checking
 collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]
+
+# These parameters are specific to the inverse jacobian IK plugin. They may not be needed for other IK solver plugins
+lower_singularity_threshold:  30  # Start decelerating when the condition number hits this (close to singularity)
+hard_stop_singularity_threshold: 45 # Stop when the condition number hits this


### PR DESCRIPTION
This converts Servo's differential inverse Jacobian IK solver into a plugin. This should make it interchangeable with other differential IK solvers.

No API/ABI changes. If this didn't work, the existing tests would catch it.

@sjahr 