### PR TITLE
Readd missing TrajectoryConstraints functions for MoveitCommander

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -497,14 +497,14 @@ class MoveGroupCommander(object):
         self._g.clear_path_constraints()
 
     def get_trajectory_constraints(self):
-        """ Get the actual trajectory constraints in form of a moveit_msgs.msgs.Constraints """
-        c = Constraints()
+        """ Get the actual trajectory constraints in form of a moveit_msgs.msgs.TrajectoryConstraints """
+        c = TrajectoryConstraints()
         c_str = self._g.get_trajectory_constraints()
         conversions.msg_from_string(c, c_str)
         return c
 
     def set_trajectory_constraints(self, value):
-        """ Specify the trajectory constraints to be used """
+        """ Specify the trajectory constraints to be used (setting from database is not implemented yet)"""
         if value is None:
             self.clear_trajectory_constraints()
         else:
@@ -512,7 +512,7 @@ class MoveGroupCommander(object):
                 self._g.set_trajectory_constraints_from_msg(
                     conversions.msg_to_string(value)
                 )
-            elif not self._g.set_trajectory_constraints(value):
+            else:
                 raise MoveItCommanderException(
                     "Unable to set trajectory constraints " + value
                 )

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -549,6 +549,19 @@ public:
     return py_bindings_tools::serializeMsg(constraints_msg);
   }
 
+  void setTrajectoryConstraintsFromMsg(const py_bindings_tools::ByteString& constraints_str)
+  {
+    moveit_msgs::TrajectoryConstraints constraints_msg;
+    py_bindings_tools::deserializeMsg(constraints_str, constraints_msg);
+    setTrajectoryConstraints(constraints_msg);
+  }
+
+  py_bindings_tools::ByteString getTrajectoryConstraintsPython()
+  {
+    moveit_msgs::TrajectoryConstraints constraints_msg(getTrajectoryConstraints());
+    return py_bindings_tools::serializeMsg(constraints_msg);
+  }
+
   py_bindings_tools::ByteString retimeTrajectory(const py_bindings_tools::ByteString& ref_state_str,
                                                  const py_bindings_tools::ByteString& traj_str,
                                                  double velocity_scaling_factor, double acceleration_scaling_factor,
@@ -757,6 +770,12 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("set_path_constraints_from_msg", &MoveGroupInterfaceWrapper::setPathConstraintsFromMsg);
   move_group_interface_class.def("get_path_constraints", &MoveGroupInterfaceWrapper::getPathConstraintsPython);
   move_group_interface_class.def("clear_path_constraints", &MoveGroupInterfaceWrapper::clearPathConstraints);
+
+  move_group_interface_class.def("set_trajectory_constraints_from_msg",
+                                 &MoveGroupInterfaceWrapper::setTrajectoryConstraintsFromMsg);
+  move_group_interface_class.def("get_trajectory_constraints",
+                                 &MoveGroupInterfaceWrapper::getTrajectoryConstraintsPython);
+  move_group_interface_class.def("clear_trajectory_constraints", &MoveGroupInterfaceWrapper::clearTrajectoryConstraints);
   move_group_interface_class.def("get_known_constraints", &MoveGroupInterfaceWrapper::getKnownConstraintsList);
   move_group_interface_class.def("set_constraints_database", &MoveGroupInterfaceWrapper::setConstraintsDatabase);
   move_group_interface_class.def("set_workspace", &MoveGroupInterfaceWrapper::setWorkspace);


### PR DESCRIPTION
### Description

fix #2373 

Does not look like this message is used other than in very specific applications, but currently the python wrapper uses functions that do not exist, which seems like it is still worth fixing.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
