### PR TITLE
Add support for master-source docker container running clang-tidy commands from the instructions

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -24,7 +24,11 @@ RUN \
 
 ENV PYTHONIOENCODING UTF-8
 RUN cd .. && \
-    catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
     # Status rate is limited so that just enough info is shown to keep Docker from timing out,
     # but not too much such that the Docker log gets too long (another form of timeout)
     catkin build --limit-status-rate 0.001 --no-notify
+
+# Environment variable used in instructions on moveit.ros.org website for running clang-tidy
+ENV CATKIN_WS /root/ws_moveit
+


### PR DESCRIPTION
### Description

Going through pull request tutorial. 

