### PR TITLE
Fix orientation constraints failing on satisfied configurations

### DIFF
--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -20,4 +20,7 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_constraints test/test_constraints.cpp)
   target_link_libraries(test_constraints moveit_test_utils ${MOVEIT_LIB_NAME})
+
+  catkin_add_gtest(test_orientation_constraints test/test_orientation_constraints.cpp)
+  target_link_libraries(test_orientation_constraints moveit_test_utils ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -66,11 +66,6 @@ static double normalizeAbsoluteAngle(const double angle)
   return std::min(2 * M_PI - normalized_angle, normalized_angle);
 }
 
-static Eigen::Vector3d normalizeAbsoluteAngles(const Eigen::Vector3d& angles)
-{
-  return angles.unaryExpr(&normalizeAbsoluteAngle);
-}
-
 /**
  * This's copied from
  * https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/src/EulerAngles/EulerSystem.h#L187
@@ -692,7 +687,7 @@ ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::Rob
     }
   }
   // Account for angle wrapping
-  xyz = normalizeAbsoluteAngles(xyz);
+  xyz = xyz.unaryExpr(&normalizeAbsoluteAngle);
 
   // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -58,7 +58,7 @@ static double normalizeAngle(double angle)
   return v;
 }
 
-// Normalizes an angles to an absolute angle.
+// Normalizes an angle to the interval [-pi, +pi] and then take the absolute value
 // The returned values will be in the following range [0, +pi]
 static double normalizeAbsoluteAngle(const double angle)
 {

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -58,6 +58,63 @@ static double normalizeAngle(double angle)
   return v;
 }
 
+// Normalizes an angles to an absolute angle.
+// The returned values will be in the following range [0, +pi]
+static double normalizeAbsoluteAngle(const double angle)
+{
+  const double normalized_angle = std::fmod(std::abs(angle), 2 * M_PI);
+  return std::min(2 * M_PI - normalized_angle, normalized_angle);
+}
+
+static Eigen::Vector3d normalizeAbsoluteAngles(const Eigen::Vector3d& angles)
+{
+  return angles.unaryExpr(&normalizeAbsoluteAngle);
+}
+
+/**
+ * This's copied from
+ * https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/src/EulerAngles/EulerSystem.h#L187
+ * Return the intrinsic Roll-Pitch-Yaw euler angles given the input rotation matrix and boolean indicating whether the
+ * there's a singularity in the input rotation matrix (true: the input rotation matrix don't have a singularity, false:
+ * the input rotation matrix have a singularity) The returned angles are in the ranges [-pi:pi]x[-pi/2:pi/2]x[-pi:pi]
+ */
+template <typename Derived>
+std::tuple<Eigen::Matrix<typename Eigen::MatrixBase<Derived>::Scalar, 3, 1>, bool>
+CalcEulerAngles(const Eigen::MatrixBase<Derived>& R)
+{
+  using std::atan2;
+  using std::sqrt;
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived, 3, 3)
+  using Index = EIGEN_DEFAULT_DENSE_INDEX_TYPE;
+  using Scalar = typename Eigen::MatrixBase<Derived>::Scalar;
+  const Index i = 0;
+  const Index j = 1;
+  const Index k = 2;
+  Eigen::Matrix<Scalar, 3, 1> res;
+  const Scalar Rsum = sqrt((R(i, i) * R(i, i) + R(i, j) * R(i, j) + R(j, k) * R(j, k) + R(k, k) * R(k, k)) / 2);
+  res[1] = atan2(R(i, k), Rsum);
+  // There is a singularity when cos(beta) == 0
+  if (Rsum > 4 * Eigen::NumTraits<Scalar>::epsilon())
+  {  // cos(beta) != 0
+    res[0] = atan2(-R(j, k), R(k, k));
+    res[2] = atan2(-R(i, j), R(i, i));
+    return { res, true };
+  }
+  else if (R(i, k) > 0)
+  {                                         // cos(beta) == 0 and sin(beta) == 1
+    const Scalar spos = R(j, i) + R(k, j);  // 2*sin(alpha + gamma)
+    const Scalar cpos = R(j, j) - R(k, i);  // 2*cos(alpha + gamma)
+    res[0] = atan2(spos, cpos);
+    res[2] = 0;
+    return { res, false };
+  }                                       // cos(beta) == 0 and sin(beta) == -1
+  const Scalar sneg = R(k, j) - R(j, i);  // 2*sin(alpha + gamma)
+  const Scalar cneg = R(j, j) + R(k, i);  // 2*cos(alpha + gamma)
+  res[0] = atan2(sneg, cneg);
+  res[2] = 0;
+  return { res, false };
+}
+
 KinematicConstraint::KinematicConstraint(const moveit::core::RobotModelConstPtr& model)
   : type_(UNKNOWN_CONSTRAINT), robot_model_(model), constraint_weight_(std::numeric_limits<double>::epsilon())
 {
@@ -598,76 +655,40 @@ bool OrientationConstraint::enabled() const
   return link_model_;
 }
 
-/**
- * TODO(JafarAbdi): This's copied from
- * https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/src/EulerAngles/EulerSystem.h#L187
- * Return the intrinsic Roll-Pitch-Yaw euler angles given the input rotation matrix
- * The returned angles are in the ranges [-pi:pi]x[-pi/2:pi/2]x[-pi:pi]
- */
-template <typename Derived>
-Eigen::Matrix<typename Eigen::MatrixBase<Derived>::Scalar, 3, 1> CalcEulerAngles(const Eigen::MatrixBase<Derived>& R)
-{
-  using std::atan2;
-  using std::sqrt;
-  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived, 3, 3)
-  using Index = EIGEN_DEFAULT_DENSE_INDEX_TYPE;
-  using Scalar = typename Eigen::MatrixBase<Derived>::Scalar;
-  const Index i = 0;
-  const Index j = 1;
-  const Index k = 2;
-  Eigen::Matrix<Scalar, 3, 1> res;
-  const Scalar Rsum = sqrt((R(i, i) * R(i, i) + R(i, j) * R(i, j) + R(j, k) * R(j, k) + R(k, k) * R(k, k)) / 2);
-  res[1] = atan2(R(i, k), Rsum);
-  // There is a singularity when cos(beta) == 0
-  if (Rsum > 4 * Eigen::NumTraits<Scalar>::epsilon())
-  {  // cos(beta) != 0
-    res[0] = atan2(-R(j, k), R(k, k));
-    res[2] = atan2(-R(i, j), R(i, i));
-  }
-  else if (R(i, k) > 0)
-  {                                         // cos(beta) == 0 and sin(beta) == 1
-    const Scalar spos = R(j, i) + R(k, j);  // 2*sin(alpha + gamma)
-    const Scalar cpos = R(j, j) - R(k, i);  // 2*cos(alpha + gamma)
-    res[0] = atan2(spos, cpos);
-    res[2] = 0;
-  }
-  else
-  {                                         // cos(beta) == 0 and sin(beta) == -1
-    const Scalar sneg = R(k, j) - R(j, i);  // 2*sin(alpha + gamma)
-    const Scalar cneg = R(j, j) + R(k, i);  // 2*cos(alpha + gamma)
-    res[0] = atan2(sneg, cneg);
-    res[2] = 0;
-  }
-  return res;
-}
-
 ConstraintEvaluationResult OrientationConstraint::decide(const moveit::core::RobotState& state, bool verbose) const
 {
   if (!link_model_)
     return ConstraintEvaluationResult(true, 0.0);
 
-  Eigen::Vector3d xyz;
+  std::tuple<Eigen::Vector3d, bool> euler_angles_error;
   if (mobile_frame_)
   {
-    // getFrameTransform() returns a valid isometry by contract
-    const Eigen::Vector3d desired_rpy =
-        CalcEulerAngles(state.getFrameTransform(desired_rotation_frame_id_).linear() * desired_rotation_matrix_);
-    // getGlobalLinkTransform() returns a valid isometry by contract
-    const Eigen::Vector3d current_rpy =
-        CalcEulerAngles(state.getGlobalLinkTransform(link_model_).linear());  // valid isometry
-    xyz = current_rpy - desired_rpy;
+    Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).linear() * desired_rotation_matrix_;
+    Eigen::Isometry3d diff(tmp.transpose() * state.getGlobalLinkTransform(link_model_).linear());  // valid isometry
+    euler_angles_error = CalcEulerAngles(diff.rotation());
   }
   else
   {
-    const Eigen::Vector3d desired_rpy = CalcEulerAngles(desired_rotation_matrix_);
-    const Eigen::Vector3d current_rpy = CalcEulerAngles(state.getGlobalLinkTransform(link_model_).linear());
-    xyz = current_rpy - desired_rpy;
+    Eigen::Isometry3d diff(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).linear());
+    euler_angles_error = CalcEulerAngles(diff.rotation());
   }
-  // Account for angle wrapping
-  xyz = xyz.unaryExpr([](const double angle) {
-    const double normalized_angle = std::fmod(std::abs(angle), boost::math::constants::two_pi<double>());
-    return std::min(boost::math::constants::two_pi<double>() - normalized_angle, normalized_angle);
-  });
+
+  // Converting from a rotation matrix to an intrinsic XYZ euler angles have 2 singularities:
+  // pitch ~= pi/2 ==> roll + yaw = theta
+  // pitch ~= -pi/2 ==> roll - yaw = theta
+  // in those cases CalcEulerAngles will set roll (xyz(0)) to theta and yaw (xyz(2)) to zero, so for us to be able to
+  // capture yaw tolerance violation we do the following, if theta violate the absolute yaw tolerance we think of it as
+  // pure yaw rotation and set roll to zero
+  auto& xyz = std::get<Eigen::Vector3d>(euler_angles_error);
+  if (!std::get<bool>(euler_angles_error))
+  {
+    if (normalizeAbsoluteAngle(xyz(0)) > absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon())
+    {
+      xyz(2) = xyz(0);
+      xyz(0) = 0;
+    }
+  }
+  xyz = normalizeAbsoluteAngles(xyz);
 
   // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -61,7 +61,7 @@ TEST_F(SphericalRobot, Test1)
   robot_state.update();
 
   EXPECT_TRUE(oc.configure(ocm, tf));
-  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+  EXPECT_TRUE(oc.decide(robot_state).satisfied);
 }
 
 TEST_F(SphericalRobot, Test2)
@@ -84,18 +84,130 @@ TEST_F(SphericalRobot, Test2)
 
   moveit::core::RobotState robot_state(robot_model_);
   // Singularity: roll + yaw = theta
+  // These violate either absolute_x_axis_tolerance or absolute_z_axis_tolerance
   robot_state.setVariablePositions(getJointValues(0.15, boost::math::constants::half_pi<double>(), 0.15));
   robot_state.update();
-
   EXPECT_TRUE(oc.configure(ocm, tf));
-  EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.21, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
 
   // Singularity: roll - yaw = theta
+  // This's identical to -pi/2 pitch rotation
   robot_state.setVariablePositions(getJointValues(0.15, -boost::math::constants::half_pi<double>(), 0.15));
   robot_state.update();
 
   EXPECT_TRUE(oc.configure(ocm, tf));
-  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+  EXPECT_TRUE(oc.decide(robot_state).satisfied);
+}
+
+TEST_F(SphericalRobot, Test3)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.2;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.3;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // Singularity: roll + yaw = theta
+
+  // These tests violate absolute_x_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  ocm.absolute_x_axis_tolerance = 0.3;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.2;
+
+  // These tests violate absolute_z_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+}
+
+TEST_F(SphericalRobot, Test4)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.2;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.3;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // Singularity: roll + yaw = theta
+
+  // These tests violate absolute_x_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, -boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, -boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  ocm.absolute_x_axis_tolerance = 0.3;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.2;
+
+  // These tests violate absolute_z_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, -boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, -boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.5, -boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -1,0 +1,105 @@
+#include <moveit/kinematic_constraints/kinematic_constraint.h>
+#include <gtest/gtest.h>
+#include <urdf_parser/urdf_parser.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <boost/math/constants/constants.hpp>
+
+class SphericalRobot : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    moveit::core::RobotModelBuilder builder("robot", "base_link");
+    geometry_msgs::Pose origin;
+    origin.orientation.w = 1;
+    builder.addChain("base_link->roll", "revolute", { origin }, urdf::Vector3(1, 0, 0));
+    builder.addChain("roll->pitch", "revolute", { origin }, urdf::Vector3(0, 1, 0));
+    builder.addChain("pitch->yaw", "revolute", { origin }, urdf::Vector3(0, 0, 1));
+    ASSERT_TRUE(builder.isValid());
+    robot_model_ = builder.build();
+  }
+
+  std::map<std::string, double> getJointValues(const double roll, const double pitch, const double yaw)
+  {
+    std::map<std::string, double> jvals;
+    jvals["base_link-roll-joint"] = roll;
+    jvals["roll-pitch-joint"] = pitch;
+    jvals["pitch-yaw-joint"] = yaw;
+    return jvals;
+  }
+
+  void TearDown() override
+  {
+  }
+
+protected:
+  moveit::core::RobotModelPtr robot_model_;
+};
+
+TEST_F(SphericalRobot, Test1)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.8;
+  ocm.absolute_y_axis_tolerance = 0.8;
+  ocm.absolute_z_axis_tolerance = 3.15;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // This's identical to a -1.57rad rotation around Z-axis
+  robot_state.setVariablePositions(getJointValues(3.140208, 3.141588, 1.570821));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+}
+
+TEST_F(SphericalRobot, Test2)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.2;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.2;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // Singularity: roll + yaw = theta
+  robot_state.setVariablePositions(getJointValues(0.15, boost::math::constants::half_pi<double>(), 0.15));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state, true).satisfied);
+
+  // Singularity: roll - yaw = theta
+  robot_state.setVariablePositions(getJointValues(0.15, -boost::math::constants::half_pi<double>(), 0.15));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -210,6 +210,33 @@ TEST_F(SphericalRobot, Test4)
   EXPECT_FALSE(oc.decide(robot_state).satisfied);
 }
 
+// Both the current and the desired orientations are in singularities
+TEST_F(SphericalRobot, Test5)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  tf2::convert(Eigen::Quaterniond(robot_state.getGlobalLinkTransform(ocm.link_name).linear()), ocm.orientation);
+  ocm.absolute_x_axis_tolerance = 0.0;
+  ocm.absolute_y_axis_tolerance = 0.0;
+  ocm.absolute_z_axis_tolerance = 1.0;
+  ocm.weight = 1.0;
+
+  robot_state.setVariablePositions(getJointValues(0.2, boost::math::constants::half_pi<double>(), 0.3));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -104,7 +104,8 @@ public:
    * \param[in] joint_axis The joint axis specified in the joint frame defaults to (1,0,0)
    */
   void addChain(const std::string& section, const std::string& type,
-                const std::vector<geometry_msgs::Pose>& joint_origins = {}, urdf::Vector3 joint_axis = urdf::Vector3(1.0, 0.0, 0.0));
+                const std::vector<geometry_msgs::Pose>& joint_origins = {},
+                urdf::Vector3 joint_axis = urdf::Vector3(1.0, 0.0, 0.0));
 
   /** \brief Adds a collision mesh to a specific link.
    *  \param[in] link_name The name of the link to which the mesh will be added. Must already be in the builder

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -101,9 +101,10 @@ public:
    * the joints will be given this type. To add multiple types of joints, call this method multiple times
    * \param[in] joint_origins The "parent to joint" origins for the joints connecting the links. If not used, all
    * origins will default to the identity transform
+   * \param[in] joint_axis The joint axis specified in the joint frame defaults to (1,0,0)
    */
   void addChain(const std::string& section, const std::string& type,
-                const std::vector<geometry_msgs::Pose>& joint_origins = {});
+                const std::vector<geometry_msgs::Pose>& joint_origins = {}, urdf::Vector3 joint_axis = urdf::Vector3(1.0, 0.0, 0.0));
 
   /** \brief Adds a collision mesh to a specific link.
    *  \param[in] link_name The name of the link to which the mesh will be added. Must already be in the builder

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -110,7 +110,7 @@ RobotModelBuilder::RobotModelBuilder(const std::string& name, const std::string&
 }
 
 void RobotModelBuilder::addChain(const std::string& section, const std::string& type,
-                                 const std::vector<geometry_msgs::Pose>& joint_origins)
+                                 const std::vector<geometry_msgs::Pose>& joint_origins, urdf::Vector3 joint_axis)
 {
   std::vector<std::string> link_names;
   boost::split_regex(link_names, section, boost::regex("->"));
@@ -182,7 +182,7 @@ void RobotModelBuilder::addChain(const std::string& section, const std::string& 
       return;
     }
 
-    joint->axis = urdf::Vector3(1.0, 0.0, 0.0);
+    joint->axis = joint_axis;
     if (joint->type == urdf::Joint::REVOLUTE || joint->type == urdf::Joint::PRISMATIC)
     {
       urdf::JointLimitsSharedPtr limits(new urdf::JointLimits);


### PR DESCRIPTION
### Description

After applying the following fix https://github.com/ros-planning/moveit/pull/2414 a pipeline I’m working on isn’t working anymore (with a bunch of errors about constraints not statisfied one of them is `ros.moveit_planners_ompl.constrained_goal_sampler: More than 80% of the sampled goal states fail to satisfy the constraints imposed on the goal sampler. Is the constrained sampler working correctly?`)

The reason is, right now we're calculating the error rotation matrix and call eulerAngles from Eigen to find the angles’ errors which return them in the following ranges `[0:pi]x[-pi:pi]x[-pi:pi]` ([link](https://eigen.tuxfamily.org/dox/group__Geometry__Module.html#ga17994d2e81b723295f5bc3b1f862ed3b))

The issues are
1- As shown in the first test, despite the error is 1.57rad around Z-axis, eulerAngles will return x=3.139981, y=3.139841, z=1.570810 causing the constraint to fail
2- Another example in the second test `0.15, -pi/2, 0.15` eulerAngles will return `3.05343, -1.5708, 3.05343` which again will cause the constraint to fail ([link](https://gcc.godbolt.org/z/4fvd5z))
3- This function isn’t stable around the identity rotation [link#1](https://github.com/stack-of-tasks/pinocchio/pull/1158#issuecomment-615105106) and [link#2](https://gcc.godbolt.org/z/Ycboa8)

~Even if we use the function from `unsupported/Eigen` it will cause similar problems but in different orientations for example if the error rotation matrix correspond to pure rotation about Y with angles bigger than pi/2 the returned roll/yaw angles will cause a satisfied constraint to fails again~

~To fix this I used the Euler angles of the desired and the current orientations to find the angles’ errors~

To fix this I did copy the implementation from [unsupported/Eigen/EulerSystem.h](https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/src/EulerAngles/EulerSystem.h#L187) since it’s not released yet which will return the angles in the following ranges `[-pi:pi]x[-pi/2:pi/2]x[-pi:pi]` and handled the singularities differently when we compare the error with the tolerances

~TODO: I need to add more tests before merging this~

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
