### PR TITLE
[feature] Simulation launchfile for panda spacenav servo teleop

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -1,0 +1,68 @@
+###############################################
+# Modify all parameters related to servoing here
+###############################################
+use_gazebo: false # Whether the robot is started in a Gazebo simulation environment
+
+## Properties of incoming commands
+command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
+scale:
+  # Scale parameters are only used if command_in_type=="unitless"
+  linear:  0.003  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.006 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  joint: 0.01
+low_pass_filter_coeff: 2.  # Larger --> trust the filtered data more, trust the measurements less.
+
+## Properties of outgoing commands
+low_latency_mode: false  # Set this to true to tie the output rate to the input rate
+publish_period: 0.01  # 1/Nominal publish rate [seconds]
+
+# What type of topic does your robot driver expect?
+# Currently supported are std_msgs/Float64MultiArray (for ros_control JointGroupVelocityController or JointGroupPositionController)
+# or trajectory_msgs/JointTrajectory (for Universal Robots and other non-ros_control robots)
+command_out_type: trajectory_msgs/JointTrajectory
+
+# What to publish? Can save some bandwidth as most robots only require positions or velocities
+publish_joint_positions: true
+publish_joint_velocities: false
+publish_joint_accelerations: false
+
+## MoveIt properties
+move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
+planning_frame: panda_link0  # The MoveIt planning frame. Often 'panda_link0' or 'world'
+
+## Other frames
+ee_frame_name: panda_link7  # The name of the end effector link, used to return the EE pose
+robot_link_command_frame:  panda_link0  # commands must be given in the frame of a robot link. Usually either the base or end effector
+
+## Stopping behaviour
+incoming_command_timeout:  1  # Stop servoing if X seconds elapse without a new command
+# If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
+# Important because ROS may drop some messages and we need the robot to halt reliably.
+num_outgoing_halt_msgs_to_publish: 1
+
+## Configure handling of singularities and joint limits
+lower_singularity_threshold:  30  # Start decelerating when the condition number hits this (close to singularity)
+hard_stop_singularity_threshold: 45 # Stop when the condition number hits this
+joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
+
+## Topic names
+cartesian_command_in_topic: servo_server/delta_twist_cmds  # Topic for incoming Cartesian twist commands
+joint_command_in_topic: servo_server/delta_joint_cmds # Topic for incoming joint angle commands
+joint_topic:  joint_states
+status_topic: servo_server/status # Publish status to this topic
+command_out_topic: servo_server/command # Publish outgoing commands here
+
+## Collision checking for the entire robot body
+check_collisions: true # Check collisions?
+collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+# Two collision check algorithms are available:
+# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
+# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
+collision_check_type: stop_distance
+# Parameters for "threshold_distance"-type collision checking
+self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
+scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
+# Parameters for "stop_distance"-type collision checking
+collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
+min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_ros/moveit_servo/launch/spacenav_teleop_panda_simulation.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_teleop_panda_simulation.launch
@@ -1,0 +1,34 @@
+<launch>
+  <!-- This file launches moveit_servo to control a panda in rviz with a spacenav.
+  -->
+
+  <!-- Load URDF, SRDF -->
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch" >
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Initial joint positions -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam command="load" file="$(find moveit_servo)/test/config/initial_position.yaml" />
+    <param name="publish_frequency" type="double" value="50.0"/>
+  </node>
+
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="tool_state_publisher">
+    <param name="publish_frequency" type="double" value="50.0"/>
+  </node>
+
+  <node name="$(anon rviz)" pkg="rviz" type="rviz" respawn="false" output="screen" args="-d $(find panda_moveit_config)/launch/moveit.rviz">
+    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
+  </node>
+
+  <node name="spacenav_node" pkg="spacenav_node" type="spacenav_node" />
+
+  <node name="spacenav_to_twist" pkg="moveit_servo" type="spacenav_to_twist" output="screen" />
+
+  <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
+    <param name="parameter_ns" type="string" value="servo_parameter_ns" />
+    <param name="provide_planning_scene_service" type="bool" value="true" />
+    <rosparam ns="servo_parameter_ns" command="load" file="$(find moveit_servo)/config/panda_simulated_config.yaml" />
+  </node>
+
+</launch>


### PR DESCRIPTION
### Description

This change makes it easy to launch spacenav teleop of a panda in rviz using servo.  I wrote this because I wanted an easy button for debugging an issue I discovered with parameters and wanted to be able to launch servo and verify it was working as intended and all parameters were loaded correctly.

This does add a parameter to the servo_server node for enabling providing a planning scene service (which is needed for rviz).  The way I did it will cause a warning for people who haven't set this parameter to tell them about a new default value that was set (false).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
