### PR TITLE
[WIP] Switch to Bullet collision detection in Servo.

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -39,6 +39,8 @@
 #pragma once
 
 #include <moveit/collision_detection/collision_common.h>
+#include <moveit/collision_detection_bullet/collision_detector_allocator_bullet.h>
+#include <moveit/collision_detection_bullet/collision_env_bullet.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <sensor_msgs/JointState.h>
@@ -92,7 +94,7 @@ private:
   // Parameters from yaml
   const ServoParameters& parameters_;
 
-  // Pointer to the collision environment
+  // Pointer to the collision environment that was passed to the constructor
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
   // Robot state and collision matrix from planning scene
@@ -123,6 +125,8 @@ private:
   // collision request
   collision_detection::CollisionRequest collision_request_;
   collision_detection::CollisionResult collision_result_;
+  std::shared_ptr<collision_detection::CollisionDetectorAllocatorBullet> collision_det_allocation_;
+  collision_detection::CollisionEnvPtr collision_env_;
 
   // ROS
   ros::Timer timer_;

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -122,12 +122,14 @@ void CollisionCheck::run(const ros::TimerEvent& timer_event)
   collision_env_->checkRobotCollision(collision_request_, collision_result_, *current_state_, acm_);
   scene_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
+  collision_result_.print();
 
   collision_result_.clear();
   // Self-collisions and scene collisions are checked separately so different thresholds can be used
   collision_env_->checkSelfCollision(collision_request_, collision_result_, *current_state_, acm_);
   self_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
+  collision_result_.print();
 
   velocity_scale_ = 1;
   // If we're definitely in collision, stop immediately


### PR DESCRIPTION
This is a follow-up to PR #2415  (closed accidentally). It uses Bullet collision detection instead of FCL.

It's been tested pretty heavily on two different setups now, so I feel confident in the changes.

Bullet runs much faster than FCL. Here are some run times for one collision checking cycle:

Bullet:  0.2-0.5ms
Previous implementation with FCL: 15-69ms
