### PR TITLE
Fix scaling factor parameter names

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -126,9 +126,9 @@ public:
     goal_orientation_tolerance_ = 1e-3;  // ~0.1 deg
     allowed_planning_time_ = 5.0;
     num_planning_attempts_ = 1;
-    node_handle_.param<double>("robot_description_planning/joint_limits/default_velocity_scaling_factor",
+    node_handle_.param<double>("robot_description_planning/default_velocity_scaling_factor",
                                max_velocity_scaling_factor_, 0.1);
-    node_handle_.param<double>("robot_description_planning/joint_limits/default_acceleration_scaling_factor",
+    node_handle_.param<double>("robot_description_planning/default_acceleration_scaling_factor",
                                max_acceleration_scaling_factor_, 0.1);
     initializing_constraints_ = false;
 


### PR DESCRIPTION
### Description

Fix #2451.

Remove the `joint_limits` prefix from parameters `default_velocity_scaling_factor` and `default_acceleration_scaling_factor` that `move_group_interface`  node gets.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
