### PR TITLE
Upgrade cmake_minimum_required to 3.1

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1.3)
 project(pilz_industrial_motion_planner)
 
 ## Add support for C++11, supported in ROS Kinetic and newer
@@ -339,7 +339,7 @@ if(CATKIN_ENABLE_TESTING)
     test/unittest_velocity_profile_atrap.cpp
     src/velocity_profile_atrap.cpp
   )
-  target_link_libraries(unittest_velocity_profile_atrap 
+  target_link_libraries(unittest_velocity_profile_atrap
     ${catkin_LIBRARIES}
   )
 
@@ -502,7 +502,7 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gmock(unittest_get_solver_tip_frame
     test/unittest_get_solver_tip_frame.cpp
   )
-  target_link_libraries(unittest_get_solver_tip_frame 
+  target_link_libraries(unittest_get_solver_tip_frame
     ${catkin_LIBRARIES}
   )
 

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1.3)
 project(pilz_industrial_motion_planner_testutils)
 
 ## Add support for C++11, supported in ROS Kinetic and newer


### PR DESCRIPTION
to suppressing CMP0048 warning in Noetic.
@jschleicher
