### PR TITLE
RobotModelBuilder: Allow adding end effectors

### DIFF
--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -164,6 +164,9 @@ public:
    */
   void addGroup(const std::vector<std::string>& links, const std::vector<std::string>& joints, const std::string& name);
 
+  void addEndEffector(const std::string& name, const std::string& parent_link, const std::string& parent_group = "",
+                      const std::string& component_group = "");
+
   /** \} */
 
   /** \brief Returns true if the building process so far has been valid. */

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -342,6 +342,17 @@ void RobotModelBuilder::addGroup(const std::vector<std::string>& links, const st
   srdf_writer_->groups_.push_back(new_group);
 }
 
+void RobotModelBuilder::addEndEffector(const std::string& name, const std::string& parent_link,
+                                       const std::string& parent_group, const std::string& component_group)
+{
+  srdf::Model::EndEffector eef;
+  eef.name_ = name;
+  eef.parent_link_ = parent_link;
+  eef.parent_group_ = parent_group;
+  eef.component_group_ = component_group;
+  srdf_writer_->end_effectors_.push_back(eef);
+}
+
 bool RobotModelBuilder::isValid()
 {
   return is_valid_;


### PR DESCRIPTION
`RobotModelBuilder` used in unit tests to quickly assemble a `RobotModel`, was missing a feature to add end effectors.