### PR TITLE
Provide a function to set the position of active joints in a JointModelGroup

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -411,6 +411,13 @@ public:
     return variable_count_;
   }
 
+  /** \brief Get the number of variables that describe the active joints in this joint group. This excludes variables
+      necessary for mimic joints. */
+  unsigned int getActiveVariableCount() const
+  {
+    return active_variable_count_;
+  }
+
   /** \brief Set the names of the subgroups for this group */
   void setSubgroupNames(const std::vector<std::string>& subgroups);
 
@@ -693,6 +700,9 @@ protected:
 
   /** \brief The number of variables necessary to describe this group of joints */
   unsigned int variable_count_;
+
+  /** \brief The number of variables necessary to describe the active joints in this group of joints */
+  unsigned int active_variable_count_;
 
   /** \brief True if the state of this group is contiguous within the full robot state; this also means that
       the index values in variable_index_list_ are consecutive integers */

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -105,6 +105,7 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
   , name_(group_name)
   , common_root_(nullptr)
   , variable_count_(0)
+  , active_variable_count_(0)
   , is_contiguous_index_list_(true)
   , is_chain_(false)
   , is_single_dof_(true)
@@ -133,6 +134,7 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
         active_joint_model_name_vector_.push_back(joint_model->getName());
         active_joint_model_start_index_.push_back(variable_count_);
         active_joint_models_bounds_.push_back(&joint_model->getVariableBounds());
+        active_variable_count_ += vc;
       }
       else
         mimic_joints_.push_back(joint_model);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -614,7 +614,8 @@ public:
   void setJointGroupPositions(const std::string& joint_group_name, const std::vector<double>& gstate)
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
-    if (jmg) {
+    if (jmg)
+    {
       assert(gstate.size() == jmg->getVariableCount());
       setJointGroupPositions(jmg, &gstate[0]);
     }
@@ -637,7 +638,8 @@ public:
   void setJointGroupPositions(const std::string& joint_group_name, const Eigen::VectorXd& values)
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
-    if (jmg) {
+    if (jmg)
+    {
       assert(values.size() == jmg->getVariableCount());
       setJointGroupPositions(jmg, values);
     }
@@ -651,6 +653,37 @@ public:
    * in the order found in the group (excluding values of mimic joints), set those
    * as the new values that correspond to the group */
   void setJointGroupActivePositions(const JointModelGroup* group, const std::vector<double>& gstate);
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const std::string& joint_group_name, const std::vector<double>& gstate)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+    {
+      assert(gstate.size() == jmg->getVariableCount());
+      setJointGroupActivePositions(jmg, gstate);
+    }
+  }
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const JointModelGroup* group, const Eigen::VectorXd& values);
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const std::string& joint_group_name, const Eigen::VectorXd& values)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+    {
+      assert(values.size() == jmg->getVariableCount());
+      setJointGroupActivePositions(jmg, values);
+    }
+  }
 
   /** \brief For a given group, copy the position values of the variables that make up the group into another location,
    * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -647,6 +647,11 @@ public:
    *   of mimic joints), set those as the new values that correspond to the group */
   void setJointGroupPositions(const JointModelGroup* group, const Eigen::VectorXd& values);
 
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const JointModelGroup* group, const std::vector<double>& gstate);
+
   /** \brief For a given group, copy the position values of the variables that make up the group into another location,
    * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the
    * RobotState itself, so we copy instead of returning a pointer.*/

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -662,7 +662,7 @@ public:
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
     if (jmg)
     {
-      assert(gstate.size() == jmg->getVariableCount());
+      assert(gstate.size() == jmg->getActiveVariableCount());
       setJointGroupActivePositions(jmg, gstate);
     }
   }
@@ -680,7 +680,7 @@ public:
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
     if (jmg)
     {
-      assert(values.size() == jmg->getVariableCount());
+      assert(values.size() == jmg->getActiveVariableCount());
       setJointGroupActivePositions(jmg, values);
     }
   }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -614,14 +614,17 @@ public:
   void setJointGroupPositions(const std::string& joint_group_name, const std::vector<double>& gstate)
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
-    if (jmg)
+    if (jmg) {
+      assert(gstate.size() == jmg->getVariableCount());
       setJointGroupPositions(jmg, &gstate[0]);
+    }
   }
 
   /** \brief Given positions for the variables that make up a group, in the order found in the group (including values
    *   of mimic joints), set those as the new values that correspond to the group */
   void setJointGroupPositions(const JointModelGroup* group, const std::vector<double>& gstate)
   {
+    assert(gstate.size() == group->getVariableCount());
     setJointGroupPositions(group, &gstate[0]);
   }
 
@@ -634,8 +637,10 @@ public:
   void setJointGroupPositions(const std::string& joint_group_name, const Eigen::VectorXd& values)
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
-    if (jmg)
+    if (jmg) {
+      assert(values.size() == jmg->getVariableCount());
       setJointGroupPositions(jmg, values);
+    }
   }
 
   /** \brief Given positions for the variables that make up a group, in the order found in the group (including values

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -515,10 +515,24 @@ void RobotState::setJointGroupActivePositions(const JointModelGroup* group, cons
 {
   assert(gstate.size() == group->getActiveVariableCount());
   std::size_t i = 0;
-  for (const JointModel* jm : group->getActiveJointModels()) {
+  for (const JointModel* jm : group->getActiveJointModels())
+  {
     setJointPositions(jm, &gstate[i]);
     i += jm->getVariableCount();
   }
+  updateMimicJoints(group);
+}
+
+void RobotState::setJointGroupActivePositions(const JointModelGroup* group, const Eigen::VectorXd& values)
+{
+  assert(values.size() == group->getActiveVariableCount());
+  std::size_t i = 0;
+  for (const JointModel* jm : group->getActiveJointModels())
+  {
+    setJointPositions(jm, &values(i));
+    i += jm->getVariableCount();
+  }
+  updateMimicJoints(group);
 }
 
 void RobotState::copyJointGroupPositions(const JointModelGroup* group, double* gstate) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -511,6 +511,16 @@ void RobotState::setJointGroupPositions(const JointModelGroup* group, const Eige
   updateMimicJoints(group);
 }
 
+void RobotState::setJointGroupActivePositions(const JointModelGroup* group, const std::vector<double>& gstate)
+{
+  assert(gstate.size() == group->getActiveVariableCount());
+  std::size_t i = 0;
+  for (const JointModel* jm : group->getActiveJointModels()) {
+    setJointPositions(jm, &gstate[i]);
+    i += jm->getVariableCount();
+  }
+}
+
 void RobotState::copyJointGroupPositions(const JointModelGroup* group, double* gstate) const
 {
   const std::vector<int>& il = group->getVariableIndexList();


### PR DESCRIPTION
### Description

this fixes #2442 and provides an less error prone alternative for https://github.com/ros-planning/moveit_visual_tools/pull/83

The general problem is that while usually you only concern yourself with the values of active joints when storing positions in a vector, the function `setJointGroupPositions` actually expects a vector/array containing the variables for *all* joints (including mimic joints). Ignoring this will lead to reading out-of-bounds memory at least and to a mismatch at worst (yes, there where physical crashes ...). Also the code might crash.

@felixvd suggested fixing `setJointGroupPositions` to actually work with only the variables of active joints. I have no objections except this being quite hidden and incompatible if anybody actually uses these functions correctly (I found 12 places in Mikado where we did not ...)

The second commit contains a proof of concept for adding another function with the intended behavior, this would preserve compatibility.

I'm open for either way, let the discussions begin!

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

---
Has been rebased to master, please squash merge as I failed to properly clang-format the first commit anyway