### PR TITLE
Added ability to change resample_dt, path_tol etc from parameter server.

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -47,17 +47,56 @@ using namespace trajectory_processing;
 class AddTimeOptimalParameterization : public planning_request_adapter::PlanningRequestAdapter
 {
 public:
+  double path_tolerance = 0.1;
+  double resample_dt = 0.1;
+  double min_angle_change = 0.001;
+
   AddTimeOptimalParameterization() : planning_request_adapter::PlanningRequestAdapter()
   {
   }
 
-  void initialize(const ros::NodeHandle& /*nh*/) override
+  void initialize(const ros::NodeHandle& nh) override
   {
+
+    
+    double path_tolerance_override;
+    if (!nh.getParam("/path_tolerance", path_tolerance_override))
+    {
+        ROS_INFO("No param found for path_tolerance");
+    }
+    else
+    {
+        path_tolerance = path_tolerance_override;
+        ROS_INFO("Overriding path_tolerance parameters: %f", path_tolerance);
+    }
+     
+     double resample_override;
+    if (!nh.getParam("/resample_dt", resample_override))
+    {
+        ROS_INFO("No param found for resample_dt");
+    }
+    else
+    {
+        resample_dt = resample_override;
+        ROS_INFO("Overriding resample_dt parameters: %f", resample_dt);
+    }
+    
+    double min_angle_change_override;
+    if (!nh.getParam("/min_angle_change", min_angle_change_override))
+    {
+        ROS_INFO("No param found for min_angle_change");
+    }
+    else
+    {
+        min_angle_change = min_angle_change_override;
+        ROS_INFO("Overriding min_angle_change parameters: %f", min_angle_change);
+    }
+    
   }
 
   std::string getDescription() const override
   {
-    return "Add Time Optimal Parameterization";
+    return "Add Time Optimal Parameterization2";
   }
 
   bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
@@ -68,7 +107,8 @@ public:
     if (result && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
-      TimeOptimalTrajectoryGeneration totg;
+      TimeOptimalTrajectoryGeneration totg(path_tolerance, resample_dt, min_angle_change);
+      //TimeOptimalTrajectoryGeneration totg;
       if (!totg.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                   req.max_acceleration_scaling_factor))
       {


### PR DESCRIPTION
### Description

Hey all. I'm a bit of a noob. This is maybe second ever pull request so I'm not even sure if I'm doing it correctly. I just wanted to add the ability to change the Time Optimal Parameterization variables 'path_tolerance', 'resample_dt', and 'min_angle_change'. My approach may be naive here but it worked for my purposes. The only change is to add_time_optimal_parameterization.cpp'

This is a very simple change. Of course, I have no idea how to set up tests etc.

Best,
Drew Hamilton

### Checklist
- [ x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
