### PR TITLE
Fix doxygen documentation for setToIKSolverFrame

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -900,14 +900,6 @@ public:
    *  @{
    */
 
-  /**
-   * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
-   * @param pose - the input to change
-   * @param solver - a kin solver whose base frame is important to us
-   * @return true if no error
-   */
-  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
-
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
@@ -1752,10 +1744,18 @@ private:
   /**
    * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
    * @param pose - the input to change
+   * @param solver - a kin solver whose base frame is important to us
+   * @return true if no error
+   */
+  inline bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
+
+  /**
+   * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
+   * @param pose - the input to change
    * @param ik_frame - the name of frame of reference of base of ik solver
    * @return true if no error
    */
-  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
+  inline bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
 
   void markDirtyJointTransforms(const JointModel* joint)
   {

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -901,20 +901,12 @@ public:
    */
 
   /**
-   * \brief Transform the frame of reference of the pose to that same frame as the IK solver expects
+   * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
    * @param pose - the input to change
    * @param solver - a kin solver whose base frame is important to us
    * @return true if no error
    */
   bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
-
-  /**
-   * \brief Transform the frame of reference of the pose to that same frame as the IK solver expects
-   * @param pose - the input to change
-   * @param ik_frame - the previous frame of reference of the pose
-   * @return true if no error
-   */
-  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -1756,6 +1748,14 @@ private:
   void allocMemory();
   void initTransforms();
   void copyFrom(const RobotState& other);
+
+  /**
+   * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
+   * @param pose - the input to change
+   * @param ik_frame - the name of frame of reference of base of ik solver
+   * @return true if no error
+   */
+  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
 
   void markDirtyJointTransforms(const JointModel* joint)
   {

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -901,7 +901,7 @@ public:
    */
 
   /**
-   * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
+   * \brief Transform the frame of reference of the pose to that same frame as the IK solver expects
    * @param pose - the input to change
    * @param solver - a kin solver whose base frame is important to us
    * @return true if no error
@@ -909,7 +909,7 @@ public:
   bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
 
   /**
-   * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
+   * \brief Transform the frame of reference of the pose to that same frame as the IK solver expects
    * @param pose - the input to change
    * @param ik_frame - the previous frame of reference of the pose
    * @return true if no error

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -911,7 +911,7 @@ public:
   /**
    * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
    * @param pose - the input to change
-   * @param ik_frame - the name of frame of reference of base of ik solver
+   * @param ik_frame - the previous frame of reference of the pose
    * @return true if no error
    */
   bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1755,7 +1755,7 @@ private:
    * @param ik_frame - the name of frame of reference of base of ik solver
    * @return true if no error
    */
-  inline bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
+  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
 
   void markDirtyJointTransforms(const JointModel* joint)
   {


### PR DESCRIPTION
I think the documentation [here](http://docs.ros.org/en/melodic/api/moveit_core/html/classmoveit_1_1core_1_1RobotState.html#a34d8fc133b4a21527ea0875fdb423e25) on setToIKSolverFrame() must be wrong. Here's what it says:

```
bool moveit::core::RobotState::setToIKSolverFrame ( Eigen::Isometry3d& pose, const std::string& ik_frame)

pose - the input to change
ik_frame - the name of frame of reference of base of ik solver
```

If that were correct, how would we know what the original frame of `pose` is? I think it should say:

```
bool moveit::core::RobotState::setToIKSolverFrame | ( Eigen::Isometry3d& pose, const std::string& ik_frame)

pose - the input to change
ik_frame - the **previous** frame of reference of the pose
```


Fixes #2460 
