### PR TITLE
[Servo] Fix initial angle error is always 0

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -39,13 +39,13 @@
 #pragma once
 
 #include <atomic>
+#include <boost/optional.hpp>
 #include <control_toolbox/pid.h>
 #include <moveit_servo/make_shared_from_pool.h>
 #include <moveit_servo/servo.h>
 #include <rosparam_shortcuts/rosparam_shortcuts.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
-#include <boost/optional.hpp>
 
 // Conventions:
 // Calculations are done in the planning_frame_ unless otherwise noted.

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -50,7 +50,7 @@ PoseTracking::PoseTracking(const ros::NodeHandle& nh,
   , loop_rate_(DEFAULT_LOOP_RATE)
   , transform_listener_(transform_buffer_)
   , stop_requested_(false)
-  , angular_error_(0)
+  , angular_error_(3.5)
 {
   readROSParams();
 


### PR DESCRIPTION
### Description

I was trying to use Servo's Pose Tracking feature to point a camera in a specific orientation when I discovered this tiny problem: the angle error is only calculated when the Twist command is being calculated. So during the first check to see if the desired pose has been reached, the angle error is always 0 (from initialization, regardless of what the actual state of the robot is). The result is that if the position errors start within tolerance but the angular error does not, Pose Tracking will return success before sending any commands to Servo.

You can replicate this by running the pose tracking example with 2 modifications:

1. Set the position tolerances large e.g. `Eigen::Vector3d lin_tol{ 1.0, 1.0, 1.0 };`
2. Give an orientation change in the goal pose e.g. by setting the goal orientation to a random quaternion

Even though the orientation needs to be corrected (but position is OK), a success will be returned first iteration and no motion will happen.

To fix this I simply initialized the angular error to 3.5 (above pi) so it always fails the first tolerances check. I've tested this on hardware.

I am open to a better fix, maybe calculating the angle error during the tolerances check or when a new pose target is started.