### PR TITLE
Catch exceptions during RobotModel loading and display them in rviz

### DIFF
--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -375,20 +375,27 @@ void RobotStateDisplay::loadRobotModel()
 
   if (rdf_loader_->getURDF())
   {
-    const srdf::ModelSharedPtr& srdf =
-        rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
-    robot_model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
-    robot_->load(*robot_model_->getURDF());
-    robot_state_.reset(new moveit::core::RobotState(robot_model_));
-    robot_state_->setToDefaultValues();
-    bool old_state = root_link_name_property_->blockSignals(true);
-    root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());
-    root_link_name_property_->blockSignals(old_state);
-    update_state_ = true;
-    setStatus(rviz::StatusProperty::Ok, "RobotModel", "Loaded successfully");
+    try
+    {
+      const srdf::ModelSharedPtr& srdf =
+          rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
+      robot_model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
+      robot_->load(*robot_model_->getURDF());
+      robot_state_.reset(new moveit::core::RobotState(robot_model_));
+      robot_state_->setToDefaultValues();
+      bool old_state = root_link_name_property_->blockSignals(true);
+      root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());
+      root_link_name_property_->blockSignals(old_state);
+      update_state_ = true;
+      setStatus(rviz::StatusProperty::Ok, "RobotModel", "Loaded successfully");
 
-    changedEnableVisualVisible();
-    changedEnableCollisionVisible();
+      changedEnableVisualVisible();
+      changedEnableCollisionVisible();
+    }
+    catch (std::exception& e)
+    {
+      setStatus(rviz::StatusProperty::Error, "RobotModel", QString("Loading failed: %1").arg(e.what()));
+    }
   }
   else
     setStatus(rviz::StatusProperty::Error, "RobotModel", "Loading failed");

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -64,22 +64,29 @@ void TrajectoryDisplay::onInitialize()
 
 void TrajectoryDisplay::loadRobotModel()
 {
-  rdf_loader_.reset(new rdf_loader::RDFLoader(robot_description_property_->getStdString()));
-
-  if (!rdf_loader_->getURDF())
+  try
   {
-    this->setStatus(rviz::StatusProperty::Error, "Robot Model",
-                    "Failed to load from parameter " + robot_description_property_->getString());
-    return;
+    rdf_loader_.reset(new rdf_loader::RDFLoader(robot_description_property_->getStdString()));
+
+    if (!rdf_loader_->getURDF())
+    {
+      this->setStatus(rviz::StatusProperty::Error, "Robot Model",
+                      "Failed to load from parameter " + robot_description_property_->getString());
+      return;
+    }
+    this->setStatus(rviz::StatusProperty::Ok, "Robot Model", "Successfully loaded");
+
+    const srdf::ModelSharedPtr& srdf =
+        rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
+    robot_model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
+
+    // Send to child class
+    trajectory_visual_->onRobotModelLoaded(robot_model_);
   }
-  this->setStatus(rviz::StatusProperty::Ok, "Robot Model", "Successfully loaded");
-
-  const srdf::ModelSharedPtr& srdf =
-      rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
-  robot_model_.reset(new moveit::core::RobotModel(rdf_loader_->getURDF(), srdf));
-
-  // Send to child class
-  trajectory_visual_->onRobotModelLoaded(robot_model_);
+  catch (std::exception& e)
+  {
+    setStatus(rviz::StatusProperty::Error, "RobotModel", QString("Loading failed: %1").arg(e.what()));
+  }
 }
 
 void TrajectoryDisplay::reset()


### PR DESCRIPTION
### Description

This fixes #2238 : 
> Somewhat recently (https://github.com/ros-planning/geometric_shapes/commit/07a5254b698ecc89e511dc5b3182ecb6c7d2258e) a check was introduced whether `Shapes` have negative lengths. This crashes whoever displays that URDF (`RobotStateDisplay`)

![grafik](https://user-images.githubusercontent.com/372442/103141538-dd613800-46f5-11eb-9504-3834ef15481f.png)
You can see the error message from the exception and also that negative dimensions are not checked in the code path for `rviz::Robot` and Ogre actually handles them quite fine (in contrast to fcl so it's good that we do have those checks).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)