### PR TITLE
WIP: standalone clang tidy script

### DIFF
--- a/tools/clang_tidy.sh
+++ b/tools/clang_tidy.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Software License Agreement - BSD 3-Clause License
+#
+# Author:  Robert Haschke and Tyler Weaver
+#
+# Adapted from script in moveit_ci
+# https://github.com/ros-planning/moveit_ci/blob/master/check_clang_tidy.sh
+#
+# Intended to be run from workspace directory.  Takes one argument, the base
+# git tag or branch to compare against for finding file changes.  Leaving
+# that argument unchanged defaults it to master.
+
+WS_DIR=$PWD
+REPO_DIR="${WS_DIR}/src/moveit"
+TOOLS_DIR="${REPO_DIR}/tools"
+BASE_BRANCH=${1:-master}
+
+# source utility functions
+source ${TOOLS_DIR}/util.sh
+
+_run_clang_tidy_fix() {
+    SOURCE_PKGS=$(catkin_topological_order $REPO_DIR --only-names 2> /dev/null)
+    PKG_PATHS=()
+    for pkg in ${SOURCE_PKGS[@]} ; do
+        echo -e "- $(colorize BLUE Processing $pkg)"
+        file="$WS_DIR/build/$pkg/compile_commands.json";
+        build_dir=$(dirname "$file")
+        if [ -r "$file" ]; then
+
+            modified_files=()
+            src_dir=$(grep "^CMAKE_HOME_DIRECTORY:INTERNAL=" "${build_dir}/CMakeCache.txt")
+            _collect_modified_files modified_files "\.cpp$" $(realpath "${src_dir#*=}") $BASE_BRANCH
+
+            if [ ${#modified_files[@]} -eq 0 ]; then
+                echo "No modified .cpp files"
+            else
+                PKG_PATHS+=("${file}")
+                cmd="clang-tidy-6.0 \
+                    -fix -header-filter=\"${REPO_DIR}/.*\" -p ${build_dir} \
+                    ${modified_files[@]:-}"
+                echo $cmd
+                $cmd 2> /dev/null
+            fi
+        else
+            echo $(colorize YELLOW "$file not found, skipping")
+        fi
+    done
+
+    pushd $REPO_DIR > /dev/null
+    # if there are workspace changes, print broken pkg to file descriptor 3
+    _have_fixes && 1>&3 ezcho $pkg || true
+    popd > /dev/null
+}
+
+# Make sure no changes have occured in repo
+pushd $REPO_DIR > /dev/null
+if ! git diff-index --quiet HEAD --; then
+    # changes
+    read -p "You have uncommitted changes, are you sure you want to continue? (y/n)" resp
+
+    if [[ "$resp" != "y" ]]; then
+        exit -1
+    fi
+fi
+popd > /dev/null
+
+# run the test
+echo -e $(colorize BLUE "Running clang-tidy test on files changed \
+    since branch \`$BASE_BRANCH\` in \`$REPO_DIR\`")
+3>/tmp/clang-tidy.tainted _run_clang_tidy_fix
+result=$?
+test $result -ne 0 && exit $result
+
+# Read content of /tmp/clang-tidy.tainted into variable TAINTED_PKGS
+TAINTED_PKGS=$(< /tmp/clang-tidy.tainted)
+
+if [ -z "$TAINTED_PKGS" ] ; then
+  echo -e $(colorize GREEN "Passed clang-tidy check")
+else
+  echo -e "$(colorize RED \"clang-tidy check failed for the following packages:\")\\n$(_colorize YELLOW $(colorize THIN $TAINTED_PKGS))"
+  exit 2
+fi

--- a/tools/util.sh
+++ b/tools/util.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Software License Agreement - BSD 3-Clause License
+#
+# Author:  Robert Haschke
+#
+# Adapted from script in moveit_ci
+# https://github.com/ros-planning/moveit_ci/blob/master/util.sh
+
+export ANSI_RED="\033[31m"
+export ANSI_GREEN="\033[32m"
+export ANSI_YELLOW="\033[33m"
+export ANSI_BLUE="\033[34m"
+
+export ANSI_THIN="\033[22m"
+export ANSI_BOLD="\033[1m"
+
+export ANSI_RESET="\033[0m"
+export ANSI_CLEAR="\033[0K"
+
+# usage: echo -e $(colorize RED Some ${fancy} text.)
+function colorize() {
+   local color reset
+   while true ; do
+      case "${1:-}" in
+         RED|GREEN|YELLOW|BLUE)
+            color="ANSI_$1"; eval "color=\$$color"; reset="${ANSI_RESET}" ;;
+         THIN)
+            color="${color:-}${ANSI_THIN}" ;;
+         BOLD)
+            color="${color:-}${ANSI_BOLD}"; reset="${reset:-${ANSI_THIN}}" ;;
+         *) break ;;
+      esac
+      shift
+   done
+   echo -e "${color:-}$@${reset:-}"
+}
+
+_have_fixes() {
+    if ! git diff --quiet . ; then  # check for changes in current dir
+        echo -e $(colorize RED "\\nThe following issues were detected:")
+        git --no-pager diff .
+        return 0
+  fi
+  return 1
+}
+
+function _collect_modified_files() {
+  local -n __modified_files=$1     # -n to modify argument by reference
+  local filter=$2
+  local src_dir=${3:-$PWD}
+  local base=${4:-$BASE_BRANCH}
+
+  # Find top-level git folder of src_dir
+  local prefix_dir=$(cd "$src_dir"; git rev-parse --show-toplevel)
+  # Strip git folder from src_dir to keep relative path from git root to source files as stip_prefix
+  strip_prefix="${src_dir#$prefix_dir/}"
+
+  pushd $prefix_dir > /dev/null
+  while IFS='' read -r line ; do
+    # Add modified or added files to array - only using the relative path from src_dir, i.e. removing strip_prefix
+    __modified_files+=("${prefix_dir}/${line}")
+  done < <(git diff --name-only --diff-filter=MA "$base"..HEAD "$src_dir" | grep "$filter")
+  popd > /dev/null
+}


### PR DESCRIPTION
### Description

This is a standalone adaption of the script in moveit_ci for running clang-tidy against a specific branch testing packages with changed source files since that branch.  One feature this does not support yet is running clang-tidy against the full repo.  However, that is much simpler (can be done with a one-liner) and there are instructions on how to do that on our website.

It might be nice to write this in python or maybe even extend ament_clang_tidy to support the feature of only testing packages that have changed.  I started down that path and then realized that there was no simple way to use ament in a ros1 environment.

To test this simply run it from the workspace directory after building with compile commands exported.

The goal of this script is an easy way for people to locally test and fix clang-tidy issues with their changes using the same script used by CI to test their changes.