### PR TITLE
Refactor Servo velocity bounds enforcement

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -175,23 +175,23 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
   )
 
-#  # servo_cpp_interface
-#  add_rostest_gtest(servo_cpp_interface_test
-#    test/servo_cpp_interface_test.test
-#    test/servo_cpp_interface_test.cpp
-#  )
-#  target_link_libraries(servo_cpp_interface_test
-#    ${SERVO_LIB_NAME}
-#    ${catkin_LIBRARIES}
-#  )
-#
-#  # pose_tracking
-#  add_rostest_gtest(pose_tracking_test
-#    test/pose_tracking_test.test
-#    test/pose_tracking_test.cpp
-#  )
-#  target_link_libraries(pose_tracking_test
-#    pose_tracking
-#    ${catkin_LIBRARIES}
-#  )
+  # servo_cpp_interface
+  add_rostest_gtest(servo_cpp_interface_test
+    test/servo_cpp_interface_test.test
+    test/servo_cpp_interface_test.cpp
+  )
+  target_link_libraries(servo_cpp_interface_test
+    ${SERVO_LIB_NAME}
+    ${catkin_LIBRARIES}
+  )
+
+  # pose_tracking
+  add_rostest_gtest(pose_tracking_test
+    test/pose_tracking_test.test
+    test/pose_tracking_test.cpp
+  )
+  target_link_libraries(pose_tracking_test
+    pose_tracking
+    ${catkin_LIBRARIES}
+  )
 endif()

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -165,33 +165,33 @@ install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
-  # servo_cpp_interface
-  add_rostest_gtest(servo_cpp_interface_test
-    test/servo_cpp_interface_test.test
-    test/servo_cpp_interface_test.cpp
+  # basic functionality
+  add_rostest_gtest(basic_servo_tests
+    test/basic_servo_tests.test
+    test/basic_servo_tests.cpp
   )
-  target_link_libraries(servo_cpp_interface_test
+  target_link_libraries(basic_servo_tests
     ${SERVO_LIB_NAME}
     ${catkin_LIBRARIES}
   )
 
-  # low_latency
-  add_rostest_gtest(servo_low_latency_test
-    test/servo_low_latency_test.test
-    test/servo_low_latency_test.cpp
-  )
-  target_link_libraries(servo_low_latency_test
-    ${SERVO_LIB_NAME}
-    ${catkin_LIBRARIES}
-  )
-
-  # pose_tracking
-  add_rostest_gtest(pose_tracking_test
-    test/pose_tracking_test.test
-    test/pose_tracking_test.cpp
-  )
-  target_link_libraries(pose_tracking_test
-    pose_tracking
-    ${catkin_LIBRARIES}
-  )
+#  # servo_cpp_interface
+#  add_rostest_gtest(servo_cpp_interface_test
+#    test/servo_cpp_interface_test.test
+#    test/servo_cpp_interface_test.cpp
+#  )
+#  target_link_libraries(servo_cpp_interface_test
+#    ${SERVO_LIB_NAME}
+#    ${catkin_LIBRARIES}
+#  )
+#
+#  # pose_tracking
+#  add_rostest_gtest(pose_tracking_test
+#    test/pose_tracking_test.test
+#    test/pose_tracking_test.cpp
+#  )
+#  target_link_libraries(pose_tracking_test
+#    pose_tracking
+#    ${catkin_LIBRARIES}
+#  )
 endif()

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -38,11 +38,16 @@
 
 #pragma once
 
+// System
 #include <memory>
 
+// MoveIt
 #include <moveit_servo/collision_check.h>
 #include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/servo_calcs.h>
+
+// testing
+#include <gtest/gtest.h>
 
 namespace moveit_servo
 {
@@ -92,6 +97,9 @@ public:
   {
     servo_calcs_->changeRobotLinkCommandFrame(new_command_frame);
   }
+
+  // Give test access to private/protected methods
+  friend class ServoFixture;
 
 private:
   bool readParameters();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -104,6 +104,9 @@ public:
    */
   void changeRobotLinkCommandFrame(const std::string& new_command_frame);
 
+  // Give test access to private/protected methods
+  friend class ServoFixture;
+
 private:
   /** \brief Run the main calculation loop */
   void mainCalcLoop();

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -758,58 +758,23 @@ double ServoCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& co
 
 void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
 {
+  // Convert to joint angle velocities for checking and applying joint specific velocity limits.
   Eigen::ArrayXd velocity = delta_theta / parameters_.publish_period;
 
   std::size_t joint_delta_index = 0;
-  // Track the smallest velocity scaling factor required, across all joints
-  double velocity_limit_scaling_factor = 1;
-
-  for (auto joint : joint_model_group_->getActiveJointModels())
+  for (const moveit::core::JointModel* joint : joint_model_group_->getActiveJointModels())
   {
-    // Some joints do not have bounds defined
-    const auto bounds = joint->getVariableBounds(joint->getName());
-
+    const auto& bounds = joint->getVariableBounds(joint->getName());
     if (bounds.velocity_bounded_)
     {
-      velocity(joint_delta_index) = delta_theta(joint_delta_index) / parameters_.publish_period;
-
-      bool clip_velocity = false;
-      double velocity_limit = 0.0;
-      if (velocity(joint_delta_index) < bounds.min_velocity_)
-      {
-        clip_velocity = true;
-        velocity_limit = bounds.min_velocity_;
-      }
-      else if (velocity(joint_delta_index) > bounds.max_velocity_)
-      {
-        clip_velocity = true;
-        velocity_limit = bounds.max_velocity_;
-      }
-
-      // Apply velocity bounds
-      if (clip_velocity)
-      {
-        const double scaling_factor =
-            fabs(velocity_limit * parameters_.publish_period) / fabs(delta_theta(joint_delta_index));
-
-        // Store the scaling factor if it's the smallest yet
-        if (scaling_factor < velocity_limit_scaling_factor)
-          velocity_limit_scaling_factor = scaling_factor;
-      }
-    }
-    ++joint_delta_index;
-  }
-
-  // Apply the velocity scaling to all joints
-  if (velocity_limit_scaling_factor < 1)
-  {
-    for (joint_delta_index = 0; joint_delta_index < joint_model_group_->getActiveJointModels().size();
-         ++joint_delta_index)
-    {
-      delta_theta(joint_delta_index) = velocity_limit_scaling_factor * delta_theta(joint_delta_index);
-      velocity(joint_delta_index) = velocity_limit_scaling_factor * velocity(joint_delta_index);
+      velocity(joint_delta_index) =
+          std::min(std::max(velocity(joint_delta_index), bounds.min_velocity_), bounds.max_velocity_);
+      ++joint_delta_index;
     }
   }
+
+  // Convert back to joint angle increments.
+  delta_theta = velocity * parameters_.publish_period;
 }
 
 bool ServoCalcs::enforcePositionLimits()

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -771,8 +771,8 @@ void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
       const auto unbounded_velocity = velocity(joint_delta_index);
       velocity(joint_delta_index) = std::min(std::max(unbounded_velocity, bounds.min_velocity_), bounds.max_velocity_);
       velocity_scaling_factor = std::min(velocity_scaling_factor, unbounded_velocity / velocity(joint_delta_index));
-      ++joint_delta_index;
     }
+    ++joint_delta_index;
   }
 
   // Convert back to joint angle increments.

--- a/moveit_ros/moveit_servo/test/basic_servo_tests.cpp
+++ b/moveit_ros/moveit_servo/test/basic_servo_tests.cpp
@@ -198,9 +198,10 @@ TEST_F(ServoFixture, EnforceVelLimitsTest)
   // From Panda arm MoveIt joint_limits.yaml. The largest velocity limits for a joint.
   const double panda_max_joint_vel = 2.610;  // rad/s
   const double velocity_scaling_factor = panda_max_joint_vel / (orig_delta_theta.maxCoeff() / publish_period);
+  const double tolerance = 5e-3;
   for (int i = 0; i < 7; ++i)
   {
-    EXPECT_DOUBLE_EQ(orig_delta_theta(i) * velocity_scaling_factor, delta_theta(i));
+    EXPECT_NEAR(orig_delta_theta(i) * velocity_scaling_factor, delta_theta(i), tolerance);
   }
 
   // Now, negative joint angle deltas. Some will result to velocities
@@ -218,7 +219,7 @@ TEST_F(ServoFixture, EnforceVelLimitsTest)
   enforceVelLimits(delta_theta);
   for (int i = 0; i < 7; ++i)
   {
-    EXPECT_DOUBLE_EQ(orig_delta_theta(i) * velocity_scaling_factor, delta_theta(i));
+    EXPECT_NEAR(orig_delta_theta(i) * velocity_scaling_factor, delta_theta(i), tolerance);
   }
 
   // Final test with joint angle deltas that will result in velocities
@@ -236,7 +237,7 @@ TEST_F(ServoFixture, EnforceVelLimitsTest)
   enforceVelLimits(delta_theta);
   for (int i = 0; i < 7; ++i)
   {
-    EXPECT_DOUBLE_EQ(orig_delta_theta(i), delta_theta(i));
+    EXPECT_NEAR(orig_delta_theta(i), delta_theta(i), tolerance);
   }
 }
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/test/basic_servo_tests.cpp
+++ b/moveit_ros/moveit_servo/test/basic_servo_tests.cpp
@@ -194,6 +194,16 @@ TEST_F(ServoFixture, EnforceVelLimitsTest)
   double panda_max_joint_vel = 2.8710;  // From Panda URDF. rad/s
   EXPECT_LT(delta_theta.maxCoeff() / publish_period, panda_max_joint_vel);
   EXPECT_GT(delta_theta.minCoeff() / publish_period, -panda_max_joint_vel);
+
+  // Now, negative velocities
+  delta_theta[0] = 0;  // rad
+  delta_theta[1] = -1;
+  delta_theta[2] = -2;
+  delta_theta[3] = -3;
+  delta_theta[4] = -4;
+  delta_theta[5] = -5;
+  EXPECT_LT(delta_theta.maxCoeff() / publish_period, panda_max_joint_vel);
+  EXPECT_GT(delta_theta.minCoeff() / publish_period, -panda_max_joint_vel);
 }
 }  // namespace moveit_servo
 

--- a/moveit_ros/moveit_servo/test/basic_servo_tests.test
+++ b/moveit_ros/moveit_servo/test/basic_servo_tests.test
@@ -11,7 +11,7 @@
     <param name="publish_frequency" type="double" value="50.0"/>
   </node>
 
-  <test pkg="moveit_servo" type="servo_low_latency_test" test-name="servo_low_latency_test" time-limit="60" args="">
+  <test pkg="moveit_servo" type="basic_servo_tests" test-name="basic_servo_tests" time-limit="60" args="">
     <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
     <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings_low_latency.yaml" ns="optional_parameter_namespace"/>
   </test>


### PR DESCRIPTION
The `enforceVelLimits` function struck me as bit odd so I figured I make this PR to start a conversation about what I think it is doing and I why I think it looks like it might not be correct.

Prior to my changes the function would calculate joint angle velocity for each joint based on the delta theta (joint angle change) and would determined the smallest scaling factor for the velocities based on the biggest out-of-bounds velocity value. So if one would have joint velocities of, say, `[1, 1, 1, 2, 3, 100]`, and each joint was bounded to `[-1, 1]` range, then the scaling factor would be `0.01` . That's at least how I interpreted it. This scaling factor was then applied to the delta thetas meaning if one joint received a command that would translate into very large velocity, the other joints would slow to a crawl.

I felt it would make more sense and be more correct to just apply the velocity limits as they are used elsewhere in MoveIt, that is, make them upper and lower bounds for the joint velocities by clamping the velocities to `[min_vel, max_vel]` range.

One thing I don't currently understand is how the delta thetas and joint bounds are matched together. Is it guaranteed that the bounds are in correct order with respect to the `delta_theta` vector and just applying them in order is enough?

 
