### PR TITLE
Fix RobotState::dropAccelerations/dropEffort to not drop velocities

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -257,12 +257,12 @@ void RobotState::dropVelocities()
 
 void RobotState::dropAccelerations()
 {
-  has_velocity_ = false;
+  has_acceleration_ = false;
 }
 
 void RobotState::dropEffort()
 {
-  has_velocity_ = false;
+  has_effort_ = false;
 }
 
 void RobotState::dropDynamics()


### PR DESCRIPTION
### Description

Fixed the drop*() methods to refer to the correct boolean variable. See also issue #2477 

resolves #2477 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
