### PR TITLE
Lock the Bullet collision environment, for thread safety

### DIFF
--- a/moveit_core/collision_detection_bullet/README.md
+++ b/moveit_core/collision_detection_bullet/README.md
@@ -5,4 +5,4 @@ To use Bullet as a collision checker you can manually switch to Bullet using the
 For speed comparisons to FCL please see (relative link to README of benchmark script will be added).
 
 ### Current Limitations
-The collision detection using Bullet is not thread safe as the internal collision managers are `mutable` members of the collision environment.
+Collision detection using Bullet is thread safe but parallelization does not improve performance.

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
@@ -39,6 +39,7 @@
 #include <moveit/collision_detection/collision_env.h>
 #include <moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h>
 #include <moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h>
+#include <mutex>
 
 namespace collision_detection
 {
@@ -113,12 +114,12 @@ protected:
   void addLinkAsCollisionObject(const urdf::LinkSharedPtr& link);
 
   /** \brief Handles self collision checks */
-  mutable collision_detection_bullet::BulletDiscreteBVHManagerPtr manager_{
+  collision_detection_bullet::BulletDiscreteBVHManagerPtr manager_{
     new collision_detection_bullet::BulletDiscreteBVHManager()
   };
 
   /** \brief Handles continuous robot world collision checks */
-  mutable collision_detection_bullet::BulletCastBVHManagerPtr manager_CCD_{
+  collision_detection_bullet::BulletCastBVHManagerPtr manager_CCD_{
     new collision_detection_bullet::BulletCastBVHManager()
   };
 
@@ -140,5 +141,8 @@ private:
   void notifyObjectChange(const ObjectConstPtr& obj, World::Action action);
 
   World::ObserverHandle observer_handle_;
+
+  // Lock the collision environment, for thread safety
+  mutable std::mutex collision_env_mutex_;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -110,6 +110,8 @@ void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, C
                                                   const moveit::core::RobotState& state,
                                                   const AllowedCollisionMatrix* acm) const
 {
+  std::lock_guard<std::mutex> guard(collision_env_mutex_);
+
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> cows;
   addAttachedOjects(state, cows);
 
@@ -171,6 +173,8 @@ void CollisionEnvBullet::checkRobotCollisionHelper(const CollisionRequest& req, 
                                                    const moveit::core::RobotState& state,
                                                    const AllowedCollisionMatrix* acm) const
 {
+  std::lock_guard<std::mutex> guard(collision_env_mutex_);
+
   if (req.distance)
   {
     manager_->setContactDistanceThreshold(MAX_DISTANCE_MARGIN);
@@ -200,6 +204,8 @@ void CollisionEnvBullet::checkRobotCollisionHelperCCD(const CollisionRequest& re
                                                       const moveit::core::RobotState& state2,
                                                       const AllowedCollisionMatrix* acm) const
 {
+  std::lock_guard<std::mutex> guard(collision_env_mutex_);
+
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
   addAttachedOjects(state1, attached_cows);
 
@@ -302,6 +308,7 @@ void CollisionEnvBullet::setWorld(const WorldPtr& world)
 
 void CollisionEnvBullet::notifyObjectChange(const ObjectConstPtr& obj, World::Action action)
 {
+  std::lock_guard<std::mutex> guard(collision_env_mutex_);
   if (action == World::DESTROY)
   {
     manager_->removeCollisionObject(obj->id_);


### PR DESCRIPTION
Lock the collision checking methods of Bullet, for thread safety.

The main problem was updating the scene with a callback while doing a collision check at the same time.

This PR locks all three possible types of collision check:  self-collision, environment collision, and continuous collision detection.