### PR TITLE
pilz planner: add string includes

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -38,6 +38,7 @@
 
 #include <map>
 #include <vector>
+#include <string>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_extension.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_extension.h
@@ -37,6 +37,7 @@
 
 #include <joint_limits_interface/joint_limits.h>
 #include <map>
+#include <string>
 
 namespace pilz_industrial_motion_planner
 {


### PR DESCRIPTION
On my (non-Ubuntu) system I get error messages about `std::string` being undefined in these two places.
Not sure why this does not happen to everyone, but maybe some upstream header changed its includes recently.