### PR TITLE
Adding a missing dependency declaration on joint_limits_interface

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -9,6 +9,7 @@ add_definitions(-Wno-unused-parameter)
 
 find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
+  joint_limits_interface
   kdl_conversions
   moveit_core
   moveit_msgs

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>eigen_conversions</depend>
+  <depend>joint_limits_interface</depend>
   <depend>kdl_conversions</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_msgs</depend>


### PR DESCRIPTION
Adding a missing dependency declaration on joint_limits_interface
