### PR TITLE
Update subframes test

### DIFF
--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -33,7 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Felix von Drigalski, Jacob Aas, Tyler Weaver */
+/* Author: Felix von Drigalski, Jacob Aas, Tyler Weaver, Boston Cleek */
 
 /* This integration test is based on the tutorial for using subframes
  * https://ros-planning.github.io/moveit_tutorials/doc/subframes/subframes_tutorial.html
@@ -59,7 +59,8 @@
 #include <eigen_conversions/eigen_msg.h>
 
 constexpr double EPSILON = 1e-2;
-constexpr double Z_OFFSET = 0.01;
+constexpr double Z_OFFSET = 0.05;
+constexpr double PLANNING_TIME_S = 30.0;
 
 // Function copied from tutorial
 // a small helper function to create our planning requests and move the robot.
@@ -73,7 +74,9 @@ bool moveToCartPose(const geometry_msgs::PoseStamped& pose, moveit::planning_int
 
   moveit::planning_interface::MoveGroupInterface::Plan myplan;
   if (group.plan(myplan) && group.execute(myplan))
+  {
     return true;
+  }
 
   ROS_WARN("Failed to perform motion.");
   return false;
@@ -150,7 +153,7 @@ TEST(TestPlanUsingSubframes, SubframesTests)
   auto planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface;
   moveit::planning_interface::MoveGroupInterface group("panda_arm");
-  group.setPlanningTime(10.0);
+  group.setPlanningTime(PLANNING_TIME_S);
 
   spawnCollisionObjects(planning_scene_interface);
   moveit_msgs::AttachedCollisionObject att_coll_object;


### PR DESCRIPTION
Sometime the SubframesTests will fail. Planning on this particular problem
takes ~10s and the allotted planning time for move_group was set to 10s.
The planning time has been increased to 30s and the target pose offset was
increased from 1cm to 5cm. This should make the planning problem easier to
solve and therefore more likely to pass the test.

The result from the test is bellow: @tylerjw 
![subframes](https://user-images.githubusercontent.com/36201047/104651021-50fec100-5674-11eb-91ea-c49f50becc4a.png)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"