### PR TITLE
Use kinematics solver timeout if not specified otherwise

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -61,18 +61,18 @@ namespace pilz_industrial_motion_planner
  * @param solution: solution of IK
  * @param check_self_collision: true to enable self collision checking after IK
  * computation
- * @param max_attempt: maximal attempts of IK
+ * @param timeout: timeout for IK, if not set the default solver timeout is used
  * @return true if succeed
  */
 bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
                    const std::string& link_name, const Eigen::Isometry3d& pose, const std::string& frame_id,
                    const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
-                   bool check_self_collision = true, const double timeout = 0.1);
+                   bool check_self_collision = true, const double timeout = 0.0);
 
 bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
                    const std::string& link_name, const geometry_msgs::Pose& pose, const std::string& frame_id,
                    const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
-                   bool check_self_collision = true, const double timeout = 0.1);
+                   bool check_self_collision = true, const double timeout = 0.0);
 
 /**
  * @brief compute the pose of a link at give robot state


### PR DESCRIPTION
### Description

This should fix #2459.

Setting the default timeout to zero prevents it from overriding the kinematics solver timeout in the call to `robot_state::setFromIK`. See https://github.com/ros-planning/moveit/blob/664ae01803abf5e0b4649063102357262de9e05c/moveit_core/robot_state/src/robot_state.cpp#L1747

This makes the default `0.5`. See https://github.com/ros-planning/moveit/blob/664ae01803abf5e0b4649063102357262de9e05c/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h#L73

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
