### PR TITLE
[ompl] Partially Thread safe model based state space type

### DIFF
--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -22,7 +22,12 @@ add_library(${MOVEIT_LIB_NAME}
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 IF(NOT MSVC)
+  # gcc requires libatomic
   target_link_libraries(${MOVEIT_LIB_NAME} "atomic")
+  IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
+    # enable compare_exchage_16 on x64
+    target_compile_options(${MOVEIT_LIB_NAME} PUBLIC "-mcx16")
+  ENDIF()
 ENDIF()
 
 find_package(OpenMP REQUIRED)

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
+IF(NOT MSVC)
+  target_link_libraries(${MOVEIT_LIB_NAME} "atomic")
+ENDIF()
+
 find_package(OpenMP REQUIRED)
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -131,7 +131,7 @@ public:
 
     void markValid(double d) const
     {
-      modify_cache([d](AtomicCache& desired) {
+      modifyCache([d](AtomicCache& desired) {
         desired.distance = d;
         desired.flags |= (VALIDITY_KNOWN | VALIDITY_TRUE | GOAL_DISTANCE_KNOWN);
       });
@@ -139,12 +139,12 @@ public:
 
     void markValid() const
     {
-      setflag(VALIDITY_KNOWN | VALIDITY_TRUE);
+      setFlag(VALIDITY_KNOWN | VALIDITY_TRUE);
     }
 
     void markInvalid(double d) const
     {
-      modify_cache([d](AtomicCache& desired) {
+      modifyCache([d](AtomicCache& desired) {
         desired.distance = d;
         desired.flags &= ~VALIDITY_TRUE;
         desired.flags |= (VALIDITY_KNOWN | GOAL_DISTANCE_KNOWN);
@@ -153,7 +153,7 @@ public:
 
     void markInvalid() const
     {
-      modify_cache([](AtomicCache& desired) {
+      modifyCache([](AtomicCache& desired) {
         desired.flags &= ~VALIDITY_TRUE;
         desired.flags |= VALIDITY_KNOWN;
       });
@@ -161,38 +161,38 @@ public:
 
     void clearKnownInformation()
     {
-      modify_cache([](AtomicCache& desired) { desired.flags = 0; });
+      modifyCache([](AtomicCache& desired) { desired.flags = 0; });
     }
 
     void markStartState()
     {
-      setflag(IS_START_STATE);
+      setFlag(IS_START_STATE);
     }
 
     void markGoalState()
     {
-      setflag(IS_GOAL_STATE);
+      setFlag(IS_GOAL_STATE);
     }
 
     int flags() const
     {
       return atomic_cache.load().flags;
     }
-    void setflag(int flag) const
+    void setFlag(int flag) const
     {
-      modify_cache([flag](AtomicCache& desired) { desired.flags |= ~flag; });
+      modifyCache([flag](AtomicCache& desired) { desired.flags |= ~flag; });
     }
     void clearflag(int flag) const
     {
-      modify_cache([flag](AtomicCache& desired) { desired.flags &= ~flag; });
+      modifyCache([flag](AtomicCache& desired) { desired.flags &= ~flag; });
     }
     int tag() const
     {
       return atomic_cache.load().tag;
     }
-    void settag(int tag)
+    void setTag(int tag)
     {
-      modify_cache([tag](AtomicCache& desired) { desired.tag = tag; });
+      modifyCache([tag](AtomicCache& desired) { desired.tag = tag; });
     }
     AtomicCache getCache() const
     {
@@ -217,7 +217,7 @@ public:
      *
      */
     template <class Func>
-    void modify_cache(Func func) const
+    void modifyCache(Func func) const
     {
       AtomicCache desired, expected = atomic_cache.load();
       do

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -180,7 +180,7 @@ public:
     }
     void setFlag(int flag) const
     {
-      modifyCache([flag](AtomicCache& desired) { desired.flags |= ~flag; });
+      modifyCache([flag](AtomicCache& desired) { desired.flags |= flag; });
     }
     void clearflag(int flag) const
     {
@@ -217,7 +217,7 @@ public:
      *
      */
     template <class Func>
-    void modifyCache(Func func) const
+    void modifyCache(Func&& func) const
     {
       AtomicCache desired, expected = atomic_cache.load();
       do

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -57,33 +57,33 @@ public:
 
     StateType() : ModelBasedStateSpace::StateType(), poses(nullptr)
     {
-      flags |= JOINTS_COMPUTED;
+      setflag(JOINTS_COMPUTED);
     }
 
     bool jointsComputed() const
     {
-      return flags & JOINTS_COMPUTED;
+      return flags() & JOINTS_COMPUTED;
     }
 
     bool poseComputed() const
     {
-      return flags & POSE_COMPUTED;
+      return flags() & POSE_COMPUTED;
     }
 
     void setJointsComputed(bool value)
     {
       if (value)
-        flags |= JOINTS_COMPUTED;
+        setflag(JOINTS_COMPUTED);
       else
-        flags &= ~JOINTS_COMPUTED;
+        clearflag(JOINTS_COMPUTED);
     }
 
     void setPoseComputed(bool value)
     {
       if (value)
-        flags |= POSE_COMPUTED;
+        setflag(POSE_COMPUTED);
       else
-        flags &= ~POSE_COMPUTED;
+        clearflag(POSE_COMPUTED);
     }
 
     ompl::base::SE3StateSpace::StateType** poses;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -57,7 +57,7 @@ public:
 
     StateType() : ModelBasedStateSpace::StateType(), poses(nullptr)
     {
-      setflag(JOINTS_COMPUTED);
+      setFlag(JOINTS_COMPUTED);
     }
 
     bool jointsComputed() const
@@ -73,7 +73,7 @@ public:
     void setJointsComputed(bool value)
     {
       if (value)
-        setflag(JOINTS_COMPUTED);
+        setFlag(JOINTS_COMPUTED);
       else
         clearflag(JOINTS_COMPUTED);
     }
@@ -81,7 +81,7 @@ public:
     void setPoseComputed(bool value)
     {
       if (value)
-        setflag(POSE_COMPUTED);
+        setFlag(POSE_COMPUTED);
       else
         clearflag(POSE_COMPUTED);
     }

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -100,7 +100,7 @@ public:
   void sampleUniformNear(ob::State* state, const ob::State* near, const double distance) override
   {
     int index = -1;
-    int tag = near->as<ModelBasedStateSpace::StateType>()->tag;
+    int tag = near->as<ModelBasedStateSpace::StateType>()->tag();
 
     if (tag >= 0)
     {
@@ -149,8 +149,8 @@ protected:
 bool interpolateUsingStoredStates(const ConstraintApproximationStateStorage* state_storage, const ob::State* from,
                                   const ob::State* to, const double t, ob::State* state)
 {
-  int tag_from = from->as<ModelBasedStateSpace::StateType>()->tag;
-  int tag_to = to->as<ModelBasedStateSpace::StateType>()->tag;
+  int tag_from = from->as<ModelBasedStateSpace::StateType>()->tag();
+  int tag_to = to->as<ModelBasedStateSpace::StateType>()->tag();
 
   if (tag_from < 0 || tag_to < 0)
     return false;

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -530,7 +530,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     {
       if (state_storage->size() < options.samples)
       {
-        temp->as<ModelBasedStateSpace::StateType>()->tag = state_storage->size();
+        temp->as<ModelBasedStateSpace::StateType>()->settag(state_storage->size());
         state_storage->addState(temp.get());
       }
     }
@@ -607,7 +607,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
             cass->getMetadata(i).second[j].first = state_storage->size();
             for (unsigned int k = 0; k < isteps; ++k)
             {
-              int_states[k]->as<ModelBasedStateSpace::StateType>()->tag = -1;
+              int_states[k]->as<ModelBasedStateSpace::StateType>()->settag(-1);
               state_storage->addState(int_states[k]);
             }
             cass->getMetadata(i).second[j].second = state_storage->size();

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -530,7 +530,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
     {
       if (state_storage->size() < options.samples)
       {
-        temp->as<ModelBasedStateSpace::StateType>()->settag(state_storage->size());
+        temp->as<ModelBasedStateSpace::StateType>()->setTag(state_storage->size());
         state_storage->addState(temp.get());
       }
     }
@@ -607,7 +607,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
             cass->getMetadata(i).second[j].first = state_storage->size();
             for (unsigned int k = 0; k < isteps; ++k)
             {
-              int_states[k]->as<ModelBasedStateSpace::StateType>()->settag(-1);
+              int_states[k]->as<ModelBasedStateSpace::StateType>()->setTag(-1);
               state_storage->addState(int_states[k]);
             }
             cass->getMetadata(i).second[j].second = state_storage->size();

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -76,14 +76,18 @@ void ompl_interface::StateValidityChecker::setVerbose(bool flag)
 bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, bool verbose) const
 {
   // Use cached validity if it is available
-  if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown())
-    return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();
+  {
+    const ModelBasedStateSpace::StateType::AtomicBits loaded_state =
+        state->as<ModelBasedStateSpace::StateType>()->atomic_bits.load();
+    if (loaded_state.isValidityKnown())
+      return loaded_state.isMarkedValid();
+  }
 
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
       ROS_INFO_NAMED(LOGNAME, "State outside bounds");
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
+    state->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
 
@@ -94,14 +98,14 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* stat
   const kinematic_constraints::KinematicConstraintSetPtr& kset = planning_context_->getPathConstraints();
   if (kset && !kset->decide(*robot_state, verbose).satisfied)
   {
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
+    state->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
 
   // check feasibility
   if (!planning_context_->getPlanningScene()->isStateFeasible(*robot_state, verbose))
   {
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
+    state->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
 
@@ -111,11 +115,11 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* stat
       verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *robot_state);
   if (!res.collision)
   {
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markValid();
+    state->as<ModelBasedStateSpace::StateType>()->markValid();
   }
   else
   {
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
+    state->as<ModelBasedStateSpace::StateType>()->markInvalid();
   }
   return !res.collision;
 }
@@ -123,18 +127,21 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* stat
 bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* state, double& dist, bool verbose) const
 {
   // Use cached validity and distance if they are available
-  if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown() &&
-      state->as<ModelBasedStateSpace::StateType>()->isGoalDistanceKnown())
   {
-    dist = state->as<ModelBasedStateSpace::StateType>()->distance;
-    return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();
+    const ModelBasedStateSpace::StateType::AtomicBits loaded_state =
+        state->as<ModelBasedStateSpace::StateType>()->atomic_bits.load();
+    if (loaded_state.isValidityKnown() && loaded_state.isGoalDistanceKnown())
+    {
+      dist = loaded_state.distance;
+      return loaded_state.isMarkedValid();
+    }
   }
 
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
       ROS_INFO_NAMED(LOGNAME, "State outside bounds");
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(0.0);
+    state->as<ModelBasedStateSpace::StateType>()->markInvalid(0.0);
     return false;
   }
 
@@ -149,7 +156,7 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* stat
     if (!cer.satisfied)
     {
       dist = cer.distance;
-      const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(dist);
+      state->as<ModelBasedStateSpace::StateType>()->markInvalid(dist);
       return false;
     }
   }

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -77,8 +77,8 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* stat
 {
   // Use cached validity if it is available
   {
-    const ModelBasedStateSpace::StateType::AtomicBits loaded_state =
-        state->as<ModelBasedStateSpace::StateType>()->atomic_bits.load();
+    const ModelBasedStateSpace::StateType::AtomicCache loaded_state =
+        state->as<ModelBasedStateSpace::StateType>()->getCache();
     if (loaded_state.isValidityKnown())
       return loaded_state.isMarkedValid();
   }
@@ -128,8 +128,8 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State* stat
 {
   // Use cached validity and distance if they are available
   {
-    const ModelBasedStateSpace::StateType::AtomicBits loaded_state =
-        state->as<ModelBasedStateSpace::StateType>()->atomic_bits.load();
+    const ModelBasedStateSpace::StateType::AtomicCache loaded_state =
+        state->as<ModelBasedStateSpace::StateType>()->getCache();
     if (loaded_state.isValidityKnown() && loaded_state.isGoalDistanceKnown())
     {
       dist = loaded_state.distance;

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -134,7 +134,7 @@ void ompl_interface::ModelBasedStateSpace::serialize(void* serialization, const 
 
 void ompl_interface::ModelBasedStateSpace::deserialize(ompl::base::State* state, const void* serialization) const
 {
-  state->as<StateType>()->settag(*reinterpret_cast<const int*>(serialization));
+  state->as<StateType>()->setTag(*reinterpret_cast<const int*>(serialization));
   memcpy(state->as<StateType>()->values, reinterpret_cast<const char*>(serialization) + sizeof(int), state_values_size_);
 }
 
@@ -210,11 +210,11 @@ void ompl_interface::ModelBasedStateSpace::interpolate(const ompl::base::State* 
     const auto from_tag = from->as<StateType>()->tag();
     const auto to_tag = to->as<StateType>()->tag();
     if (from_tag >= 0 && t < 1.0 - tag_snap_to_segment_)
-      state->as<StateType>()->settag(from_tag);
+      state->as<StateType>()->setTag(from_tag);
     else if (to_tag >= 0 && t > tag_snap_to_segment_)
-      state->as<StateType>()->settag(to_tag);
+      state->as<StateType>()->setTag(to_tag);
     else
-      state->as<StateType>()->settag(-1);
+      state->as<StateType>()->setTag(-1);
   }
 }
 

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -303,19 +303,20 @@ void ompl_interface::ModelBasedStateSpace::printState(const ompl::base::State* s
       out << state->as<StateType>()->values[idx + i] << " ";
     out << std::endl;
   }
+  const StateType::AtomicBits loaded_state = state->as<StateType>()->atomic_bits.load();
 
-  if (state->as<StateType>()->isStartState())
+  if (loaded_state.isStartState())
     out << "* start state" << std::endl;
-  if (state->as<StateType>()->isGoalState())
+  if (loaded_state.isGoalState())
     out << "* goal state" << std::endl;
-  if (state->as<StateType>()->isValidityKnown())
+  if (loaded_state.isValidityKnown())
   {
-    if (state->as<StateType>()->isMarkedValid())
+    if (loaded_state.isMarkedValid())
       out << "* valid state" << std::endl;
     else
       out << "* invalid state" << std::endl;
   }
-  out << "Tag: " << state->as<StateType>()->tag << std::endl;
+  out << "Tag: " << loaded_state.tag << std::endl;
 }
 
 void ompl_interface::ModelBasedStateSpace::copyToRobotState(moveit::core::RobotState& rstate,

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -118,7 +118,7 @@ void ompl_interface::ModelBasedStateSpace::copyState(ompl::base::State* destinat
                                                      const ompl::base::State* source) const
 {
   memcpy(destination->as<StateType>()->values, source->as<StateType>()->values, state_values_size_);
-  destination->as<StateType>()->atomic_bits.store(source->as<StateType>()->atomic_bits.load());
+  destination->as<StateType>()->setCache(source->as<StateType>()->getCache());
 }
 
 unsigned int ompl_interface::ModelBasedStateSpace::getSerializationLength() const
@@ -303,7 +303,7 @@ void ompl_interface::ModelBasedStateSpace::printState(const ompl::base::State* s
       out << state->as<StateType>()->values[idx + i] << " ";
     out << std::endl;
   }
-  const StateType::AtomicBits loaded_state = state->as<StateType>()->atomic_bits.load();
+  const StateType::AtomicCache loaded_state = state->as<StateType>()->getCache();
 
   if (loaded_state.isStartState())
     out << "* start state" << std::endl;


### PR DESCRIPTION
### Description

#2273 shows that the current implementation of the OMPL interface requires to modify const-qualified state objects,
by `const_cast`ing away the constness (which is UB). In this PR, some members of this state class are put into an atomic container (`AtomicCache`) which is declared as `mutable`. In this way, `const_cast` is no longer needed.

Note that the container 16 bytes big, clang requires x64 processors to have the `CMPXCHG16B` instruction (which is not the case for very old x64 processors). I've read that steam on Linux requires this instruction, and there were some discussions.
The container can't be smaller, as it has to contain at least the `flags` and the `distance` member (which are 12 bytes). If only the `flags` were atomic, data races could occur (Thread A reads flags and learns that the distance is valid, gets preempted, thread B changes the distance and the flag, gets preemted, now thread A reads the (now invalid) distance).
GCC wraps this instruction into libatomic and has a fallback.

The other members (e.g. `values` pointer) are not protected, as I expect them to be unmodified and thus not affected by potential data races.

Right now, all `load()` / `store()`s are using the default memory orders, which are safe defaults. To gain some performance, they can be adapted (e.g. to `std::memory_order_relaxed`), but I don't have enough experience to see all the side effects of altering them.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
