### PR TITLE
Fix logic in PlanningScene::clearDiffs() for multiple CollisionDetectors

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -774,8 +774,10 @@ public:
   void removeObjectType(const std::string& id);
   void getKnownObjectTypes(ObjectTypeMap& kc) const;
 
-  /** \brief Clear the diffs accumulated for this planning scene, with respect to the parent. This function is a no-op
-   * if there is no parent specified. */
+  /** \brief Clear the diffs accumulated for this planning scene, with respect to:
+   * the parent PlanningScene (if it exists)
+   * the parent CollisionDetector (if it exists)
+   * This function is a no-op if there is no parent planning scene. */
   void clearDiffs();
 
   /** \brief If there is a parent specified for this scene, then the diffs with respect to that parent are applied to a

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -389,17 +389,15 @@ void PlanningScene::clearDiffs()
 
     if (it.second->parent_)
     {
-      it.second->cenv_ = it.second->alloc_->allocateEnv(it.second->parent_->cenv_, world_);
-      it.second->cenv_const_ = it.second->cenv_;
-
       it.second->cenv_unpadded_ = it.second->alloc_->allocateEnv(it.second->parent_->cenv_unpadded_, world_);
       it.second->cenv_unpadded_const_ = it.second->cenv_unpadded_;
-    }
-    else
-    {
-      it.second->copyPadding(*parent_->active_collision_);
 
       it.second->cenv_ = it.second->alloc_->allocateEnv(it.second->parent_->cenv_, world_);
+      it.second->cenv_const_ = it.second->cenv_;
+    }
+    else  // This is the parent CollisionDetector
+    {
+      it.second->copyPadding(*parent_->active_collision_);
       it.second->cenv_const_ = it.second->cenv_;
     }
   }


### PR DESCRIPTION
Fix a bug for the case when `it.second->parent_` is null (i.e. if the current Collision Detector is the parent or the only one).

Provide better Doxygen comments for `clearDiffs()`

This seems like a pretty deep bug. I guess it wasn't found previously because nobody is using >1 collision detection algorithm.