### PR TITLE
Initialize the PlanningScene parent to nullptr

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -112,14 +112,14 @@ bool PlanningScene::isEmpty(const moveit_msgs::PlanningSceneWorld& msg)
 
 PlanningScene::PlanningScene(const moveit::core::RobotModelConstPtr& robot_model,
                              const collision_detection::WorldPtr& world)
-  : robot_model_(robot_model), world_(world), world_const_(world)
+  : parent_(nullptr), robot_model_(robot_model), world_(world), world_const_(world)
 {
   initialize();
 }
 
 PlanningScene::PlanningScene(const urdf::ModelInterfaceSharedPtr& urdf_model,
                              const srdf::ModelConstSharedPtr& srdf_model, const collision_detection::WorldPtr& world)
-  : world_(world), world_const_(world)
+  : parent_(nullptr), world_(world), world_const_(world)
 {
   if (!urdf_model)
     throw moveit::ConstructException("The URDF model cannot be NULL");


### PR DESCRIPTION
The `parent_` pointer was uninitialized. That can lead to some problems later in planning_scene.cpp when `parent_` is checked, e.g.:

```
void PlanningScene::clearDiffs()
{
  if (!parent_)
    return;
```