### PR TITLE
ensure thread safety in clear octomap

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -545,7 +545,7 @@ void PlanningSceneMonitor::clearOctomap()
     else
     {
       ROS_WARN_NAMED(LOGNAME, "Unable to clear octomap since no octomap monitor has been initialized");
-    }
+    }  // Lift the scoped lock before calling triggerSceneUpdateEvent to avoid deadlock
   }
 
   if (removed)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -531,18 +531,25 @@ void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningS
 
 void PlanningSceneMonitor::clearOctomap()
 {
-  if (scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS))
-    triggerSceneUpdateEvent(UPDATE_SCENE);
-  if (octomap_monitor_)
+  bool removed = false;
   {
-    octomap_monitor_->getOcTreePtr()->lockWrite();
-    octomap_monitor_->getOcTreePtr()->clear();
-    octomap_monitor_->getOcTreePtr()->unlockWrite();
+    boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
+    removed = scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS);
+
+    if (octomap_monitor_)
+    {
+      octomap_monitor_->getOcTreePtr()->lockWrite();
+      octomap_monitor_->getOcTreePtr()->clear();
+      octomap_monitor_->getOcTreePtr()->unlockWrite();
+    }
+    else
+    {
+      ROS_WARN_NAMED(LOGNAME, "Unable to clear octomap since no octomap monitor has been initialized");
+    }
   }
-  else
-  {
-    ROS_WARN_NAMED(LOGNAME, "Unable to clear octomap since no octomap monitor has been initialized");
-  }
+
+  if (removed)
+    triggerSceneUpdateEvent(UPDATE_GEOMETRY);
 }
 
 bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)


### PR DESCRIPTION
### Description
As commented in https://github.com/ros-planning/moveit/pull/2320#issuecomment-746096098 I recently encountered some crashes when clearOctomap is being called while some planners still run. Even though that is a weird thing to do, it still shouldn't crash.

Also #2320 uses `UPDATE_SCENE` which causes a full scene to be transmitted while `UPDATE_GEOMETRY` should be sufficient.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
