### PR TITLE
[Servo] Halt Servo command on Pose Tracking stop

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -92,10 +92,7 @@ public:
                                     const double target_pose_timeout);
 
   /** \brief A method for a different thread to stop motion and return early from control loop */
-  void stopMotion()
-  {
-    stop_requested_ = true;
-  }
+  void stopMotion();
 
   /** \brief Change PID parameters. Motion is stopped before the udpate */
   void updatePIDConfig(const double x_proportional_gain, const double x_integral_gain, const double x_derivative_gain,

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -317,6 +317,15 @@ void PoseTracking::doPostMotionReset()
   cartesian_position_pids_[1].reset();
   cartesian_position_pids_[2].reset();
   cartesian_orientation_pids_[0].reset();
+
+  // Send a 0 command to Servo to halt arm motion
+  auto msg = moveit::util::make_shared_from_pool<geometry_msgs::TwistStamped>();
+  {
+    std::lock_guard<std::mutex> lock(target_pose_mtx_);
+    msg->header.frame_id = target_pose_.header.frame_id;
+  }
+  msg->header.stamp = ros::Time::now();
+  twist_stamped_pub_.publish(msg);
 }
 
 void PoseTracking::updatePIDConfig(const double x_proportional_gain, const double x_integral_gain,

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -307,16 +307,9 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
   return msg;
 }
 
-void PoseTracking::doPostMotionReset()
+void PoseTracking::stopMotion()
 {
-  stop_requested_ = false;
-  angular_error_ = boost::none;
-
-  // Reset error integrals and previous errors of PID controllers
-  cartesian_position_pids_[0].reset();
-  cartesian_position_pids_[1].reset();
-  cartesian_position_pids_[2].reset();
-  cartesian_orientation_pids_[0].reset();
+  stop_requested_ = true;
 
   // Send a 0 command to Servo to halt arm motion
   auto msg = moveit::util::make_shared_from_pool<geometry_msgs::TwistStamped>();
@@ -326,6 +319,19 @@ void PoseTracking::doPostMotionReset()
   }
   msg->header.stamp = ros::Time::now();
   twist_stamped_pub_.publish(msg);
+}
+
+void PoseTracking::doPostMotionReset()
+{
+  stopMotion();
+  stop_requested_ = false;
+  angular_error_ = boost::none;
+
+  // Reset error integrals and previous errors of PID controllers
+  cartesian_position_pids_[0].reset();
+  cartesian_position_pids_[1].reset();
+  cartesian_position_pids_[2].reset();
+  cartesian_orientation_pids_[0].reset();
 }
 
 void PoseTracking::updatePIDConfig(const double x_proportional_gain, const double x_integral_gain,


### PR DESCRIPTION
### Description

Small change to make Pose Tracking publish a 0 twist message for Servo when it is stopping. Before this, if you were using a velocity controller and stopped Pose Tracking during a movement, the last published command to Servo would be nonzero and the manipulator would still move, see attached.

It might be worth exposing some kind of `halt()` function in Servo itself, which I can do here if needed. 

Haven't been able to replicate with the Servo demonstrations (position controllers), so attached videos on hardware. In the clip, I use Pose Tracking to point the left arm camera at the right gripper, but call `stopMotion()` and cancel the pose tracking before it gets there. In the first, the arm holds the last velocity command sent until I E-stop. In the second gif, a 0-twist command is sent to Servo during Pose Tracking stopping.

![pose_tracking_problem](https://user-images.githubusercontent.com/28165117/105876045-2aba1900-5fc4-11eb-9615-16993e90595a.gif)


![pose_tracking_fix](https://user-images.githubusercontent.com/28165117/105875383-5a1c5600-5fc3-11eb-8fd0-6d477e278da6.gif)
