### PR TITLE
Add debugging informative log statement for a common error

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1623,8 +1623,12 @@ void MoveGroupInterface::getJointValueTarget(std::vector<double>& group_variable
 
 bool MoveGroupInterface::setJointValueTarget(const std::vector<double>& joint_values)
 {
-  if (joint_values.size() != impl_->getJointModelGroup()->getVariableCount())
+  auto const n_group_joints =  impl_->getJointModelGroup()->getVariableCount();
+  if (joint_values.size() != n_group_joints)
+  {
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group has " << n_group_joints << " joints");
     return false;
+  }
   impl_->setTargetType(JOINT);
   impl_->getTargetRobotState().setJointGroupPositions(impl_->getJointModelGroup(), joint_values);
   return impl_->getTargetRobotState().satisfiesBounds(impl_->getJointModelGroup(), impl_->getGoalJointTolerance());

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1626,8 +1626,9 @@ bool MoveGroupInterface::setJointValueTarget(const std::vector<double>& joint_va
   auto const n_group_joints = impl_->getJointModelGroup()->getVariableCount();
   if (joint_values.size() != n_group_joints)
   {
-    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group has "
-                                                                            << n_group_joints << " joints");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group "
+                                                                            << impl_->getJointModelGroup()->getName()
+                                                                            << " has " << n_group_joints << " joints");
     return false;
   }
   impl_->setTargetType(JOINT);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1623,10 +1623,11 @@ void MoveGroupInterface::getJointValueTarget(std::vector<double>& group_variable
 
 bool MoveGroupInterface::setJointValueTarget(const std::vector<double>& joint_values)
 {
-  auto const n_group_joints =  impl_->getJointModelGroup()->getVariableCount();
+  auto const n_group_joints = impl_->getJointModelGroup()->getVariableCount();
   if (joint_values.size() != n_group_joints)
   {
-    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group has " << n_group_joints << " joints");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group has "
+                                                                            << n_group_joints << " joints");
     return false;
   }
   impl_->setTargetType(JOINT);


### PR DESCRIPTION
### Description

If the user calls setJointValueTarget with the wrong number of joint values, it just returns false without providing any information as to what went wrong. Personally when something in moveit goes wrong the first thing I do is turn on debug logging so this would help in that case.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
