### PR TITLE
Check wether endeffector parent group is empty or matches the current…

### DIFF
--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -284,7 +284,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   if (smap.first)
   {
     for (const srdf::Model::EndEffector& eef : eefs)
-      if ((jmg->hasLinkModel(eef.parent_link_) && ( jmg->getName().empty() || jmg->getName() == eef.parent_group_ ) ) &&
+      if ((jmg->hasLinkModel(eef.parent_link_) && (jmg->getName().empty() || jmg->getName() == eef.parent_group_)) &&
           jmg->canSetStateFromIK(eef.parent_link_))
       {
         // We found an end-effector whose parent is the group.

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -284,7 +284,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   if (smap.first)
   {
     for (const srdf::Model::EndEffector& eef : eefs)
-      if ((jmg->hasLinkModel(eef.parent_link_) || jmg->getName() == eef.parent_group_) &&
+      if ((jmg->hasLinkModel(eef.parent_link_) && ( jmg->getName().empty() || jmg->getName() == eef.parent_group_ ) ) &&
           jmg->canSetStateFromIK(eef.parent_link_))
       {
         // We found an end-effector whose parent is the group.


### PR DESCRIPTION
Hi,

this PR addresses my issue #2236 when using the RViz Motion Planning panel.

Without this change an endeffector control might be attached to the tip of the wrong kinematic chain if the parent link of the other chain's defined endeffector is part of the selected planning chain. This is the case if the selected chain is one link shorter, such that the tip of the selected chain the parent link of the tip of the other chain, or if the selected chain is longer and contains the parent link of the tip of the other chain.

With this change endeffectors in the srdf are only considered if their parent_group attribute matches the selected planning chain or if the optional parent_group attribute is left empty.

A similar problem exists in the RobotModel, which I will address in a later PR if this gets merged.

Regards,
Matthias