### PR TITLE
Servo: add missing include

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -42,6 +42,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <atomic>
 
 // ROS
 #include <control_msgs/JointJog.h>


### PR DESCRIPTION
The code uses `std::atomic<bool>` further below, but relies on other headers including it.
It's not always there though. Compiling failed for me on Lunar-Linux with ROS melodic.