### PR TITLE
It's not an error not to define a plugin

### DIFF
--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -181,7 +181,7 @@ void OccupancyMapMonitor::initialize()
     }
   }
   else
-    ROS_INFO_NAMED(LOGNAME, "No 3D sensor plugin defined for octomap updates");
+    ROS_INFO_NAMED(LOGNAME, "No 3D sensor plugin(s) defined for octomap updates");
 
   /* advertise a service for loading octomaps from disk */
   save_map_srv_ = nh_.advertiseService("save_map", &OccupancyMapMonitor::saveMapCallback, this);

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -181,7 +181,7 @@ void OccupancyMapMonitor::initialize()
     }
   }
   else
-    ROS_ERROR_NAMED(LOGNAME, "Failed to find 3D sensor plugin parameters for octomap generation");
+    ROS_INFO_NAMED(LOGNAME, "No 3D sensor plugin defined for octomap updates");
 
   /* advertise a service for loading octomaps from disk */
   save_map_srv_ = nh_.advertiseService("save_map", &OccupancyMapMonitor::saveMapCallback, this);


### PR DESCRIPTION
An info message is fine. But octomap plugins are explicitly optional,
so a setup that does not define a plugin (the default!) must not report errors.

This is basically a fixup for https://github.com/ros-planning/moveit/pull/1873