### PR TITLE
Check whether we can transform to the frame an object is defined in

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1694,6 +1694,12 @@ bool PlanningScene::processCollisionObjectMsg(const moveit_msgs::CollisionObject
     if (object.operation == moveit_msgs::CollisionObject::ADD && world_->hasObject(object.id))
       world_->removeObject(object.id);
 
+    if (!getTransforms().canTransform(object.header.frame_id))
+    {
+      ROS_ERROR_STREAM_NAMED("planning_scene", "Cannot transform to object's frame_id '" << object.header.frame_id << "'");
+      return false;
+    }
+
     const Eigen::Affine3d& t = getTransforms().getTransform(object.header.frame_id);
 
     for (std::size_t i = 0; i < object.primitives.size(); ++i)

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -167,6 +167,33 @@ TEST(PlanningScene, isStateValid)
   }
 }
 
+TEST(PlanningScene, AttachToNonExistent)
+{
+  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  urdf::ModelInterfaceSharedPtr urdf_model;
+  loadRobotModel(urdf_model);
+
+  planning_scene::PlanningScenePtr ps(new planning_scene::PlanningScene(urdf_model, srdf_model));
+
+  moveit_msgs::CollisionObject obj;
+  obj.operation = moveit_msgs::CollisionObject::ADD;
+  obj.id = "new_object";
+  obj.header.frame_id = "non_existant_frame";
+
+  obj.primitives.resize(1);
+  obj.primitives[0].type = shape_msgs::SolidPrimitive::BOX;
+  obj.primitives[0].dimensions.push_back(1.0);
+  obj.primitives[0].dimensions.push_back(1.0);
+  obj.primitives[0].dimensions.push_back(1.0);
+  obj.primitive_poses.resize(1);
+  obj.primitive_poses[0].position.x = 0;
+  obj.primitive_poses[0].position.y = 0;
+  obj.primitive_poses[0].position.z = 2.0;
+  obj.primitive_poses[0].orientation.w = 1.0;
+
+  EXPECT_FALSE(ps->processCollisionObjectMsg(obj));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit/issues/323. When adding a new object to the planning scene and MoveIt cannot (yet?) transform the frame_id a new `CollisionObject` is defined in, you'll get a message 
`[/move_group][ERROR] [...]: Unable to transform from frame 'non_existant_frame' to frame '/map'. Returning identity.`
and get the object inserted in the wrong place. Moreover, the service `ApplyPlanningScene` returns with `success = true` and afterwards the object's ID is also in the PlanningSceneInterface's known_objects. Lies! Deception!

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] ~~Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)~~ Not needed I think, this is the intended behavior
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
