### PR TITLE
Add utility functions to Python PSI

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -78,6 +78,12 @@ class PlanningSceneInterface(object):
             else:
                 self._pub_co.publish(collision_object)
 
+    def add_object(self, collision_object):
+        """
+        Add an object to the planning scene
+        """
+        self.__submit(collision_object, attach=False)
+
     def add_sphere(self, name, pose, radius=1):
         """
         Add a sphere to the planning scene
@@ -118,6 +124,12 @@ class PlanningSceneInterface(object):
         co.planes = [p]
         co.plane_poses = [pose.pose]
         self.__submit(co, attach=False)
+    
+    def attach_object(self, attached_collision_object):
+        """
+        Attach an object in the planning scene
+        """
+        self.__submit(attached_collision_object, attach=True)
 
     def attach_mesh(self, link, name, pose=None, filename='', size=(1, 1, 1), touch_links=[]):
         aco = AttachedCollisionObject()

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -235,6 +235,12 @@ class PlanningSceneInterface(object):
         """
         return self._psi.apply_collision_object(conversions.msg_to_string(collision_object_message))
     
+    def apply_planning_scene(self, planning_scene_message):
+        """
+        Applies the planning scene message.
+        """
+        return self._psi.apply_planning_scene(conversions.msg_to_string(planning_scene_message))
+
     @staticmethod
     def __make_existing(name):
         """

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -230,12 +230,6 @@ class PlanningSceneInterface(object):
             aobjs[key] = msg
         return aobjs
     
-    def apply_collision_object(self, collision_object_message):
-        """
-        Applies the collision object message to the scene.
-        """
-        return self._psi.apply_collision_object(conversions.msg_to_string(collision_object_message))
-    
     def apply_planning_scene(self, planning_scene_message):
         """
         Applies the planning scene message.

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -55,10 +55,13 @@ except:
 
 
 class PlanningSceneInterface(object):
-    """ Simple interface to making updates to a planning scene """
+    """ 
+    Python interface for a planning scene.
+    Uses both C++ wrapped methods and scene manipulation topics.
+    See wrap_python_planning_scene_interface.cpp for the wrapped methods.
+    """
 
     def __init__(self, ns='', synchronous=False, service_timeout=5.0):
-        """ Create a planning scene interface; it uses both C++ wrapped methods and scene manipulation topics. """
         self._psi = _moveit_planning_scene_interface.PlanningSceneInterface(ns)
 
         self._pub_co = rospy.Publisher(ns_join(ns, 'collision_object'), CollisionObject, queue_size=100)
@@ -225,7 +228,13 @@ class PlanningSceneInterface(object):
             conversions.msg_from_string(msg, ser_aobjs[key])
             aobjs[key] = msg
         return aobjs
-
+    
+    def apply_collision_object(self, collision_object_message):
+        """
+        Applies the collision object message to the scene.
+        """
+        return self._psi.apply_collision_object(conversions.msg_to_string(collision_object_message))
+    
     @staticmethod
     def __make_existing(name):
         """

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -56,8 +56,9 @@ except:
 
 class PlanningSceneInterface(object):
     """ 
-    Python interface for a planning scene.
-    Uses both C++ wrapped methods and scene manipulation topics.
+    Python interface for a C++ PlanningSceneInterface.
+    Uses both C++ wrapped methods and scene manipulation topics 
+    to manipulate the PlanningScene managed by the PlanningSceneMonitor.
     See wrap_python_planning_scene_interface.cpp for the wrapped methods.
     """
 

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -104,13 +104,6 @@ public:
     return py_bindings_tools::dictFromType(ser_aobjs);
   }
 
-  bool applyCollisionObjectPython(const py_bindings_tools::ByteString& msg_bytestring)
-  {
-    moveit_msgs::CollisionObject co_msg;
-    py_bindings_tools::deserializeMsg(msg_bytestring, co_msg);
-    return applyCollisionObject(co_msg);
-  }
-
   bool applyPlanningScenePython(const py_bindings_tools::ByteString& ps_str)
   {
     moveit_msgs::PlanningScene ps_msg;
@@ -130,7 +123,6 @@ static void wrap_planning_scene_interface()
   planning_scene_class.def("get_object_poses", &PlanningSceneInterfaceWrapper::getObjectPosesPython);
   planning_scene_class.def("get_objects", &PlanningSceneInterfaceWrapper::getObjectsPython);
   planning_scene_class.def("get_attached_objects", &PlanningSceneInterfaceWrapper::getAttachedObjectsPython);
-  planning_scene_class.def("apply_collision_object", &PlanningSceneInterfaceWrapper::applyCollisionObjectPython);
   planning_scene_class.def("apply_planning_scene", &PlanningSceneInterfaceWrapper::applyPlanningScenePython);
 }
 }  // namespace planning_interface

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -104,6 +104,13 @@ public:
     return py_bindings_tools::dictFromType(ser_aobjs);
   }
 
+  bool applyCollisionObjectPython(const py_bindings_tools::ByteString& msg_bytestring)
+  {
+    moveit_msgs::CollisionObject co_msg;
+    py_bindings_tools::deserializeMsg(msg_bytestring, co_msg);
+    return applyCollisionObject(co_msg);
+  }
+
   bool applyPlanningScenePython(const py_bindings_tools::ByteString& ps_str)
   {
     moveit_msgs::PlanningScene ps_msg;
@@ -123,6 +130,7 @@ static void wrap_planning_scene_interface()
   planning_scene_class.def("get_object_poses", &PlanningSceneInterfaceWrapper::getObjectPosesPython);
   planning_scene_class.def("get_objects", &PlanningSceneInterfaceWrapper::getObjectsPython);
   planning_scene_class.def("get_attached_objects", &PlanningSceneInterfaceWrapper::getAttachedObjectsPython);
+  planning_scene_class.def("apply_collision_object", &PlanningSceneInterfaceWrapper::applyCollisionObjectPython);
   planning_scene_class.def("apply_planning_scene", &PlanningSceneInterfaceWrapper::applyPlanningScenePython);
 }
 }  // namespace planning_interface


### PR DESCRIPTION
I found a few very basic functions that I had added in the past, but apparently forgot to push upstream. The `ApplyPlanningScene` function seems to have been implemented already in `wrap_python_planning_scene_interface.cpp` but not exposed in the Python class, so I added that as well.

The interface seems not very useful without these functions and I'd like to use them in a different project where we don't build MoveIt from source, so it would be great if these found their way into the binaries.

This should be ported back to Melodic, possibly even Kinetic.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)