### PR TITLE
add get_active_joint_names

### DIFF
--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -191,9 +191,9 @@ class RobotCommander(object):
 
     def get_active_joint_names(self, group=None):
         """
-        Get the names of all the movable joints that make up a group
-        If no group name is specified, all joints in the robot model are returned
-        Excludes mimic and fixed joints.
+        Get the names of all the movable joints that make up a group.
+        If no group name is specified, all joints in the robot model are returned.
+        Excludes fixed and mimic joints.
         """
         if group is not None:
             if self.has_group(group):
@@ -205,8 +205,9 @@ class RobotCommander(object):
 
     def get_joint_names(self, group=None):
         """
-        Get the names of all the movable joints that make up a group
-        If no group name is specified, all joints in the robot model are returned
+        Get the names of all the movable joints that make up a group.
+        If no group name is specified, all joints in the robot model are returned.
+        Includes fixed and mimic joints.
         """
         if group is not None:
             if self.has_group(group):

--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -189,12 +189,24 @@ class RobotCommander(object):
         """Get the name of the root link of the robot model """
         return self._r.get_robot_root_link()
 
+    def get_active_joint_names(self, group=None):
+        """
+        Get the names of all the movable joints that make up a group
+        If no group name is specified, all joints in the robot model are returned
+        Excludes mimic and fixed joints.
+        """
+        if group is not None:
+            if self.has_group(group):
+                return self._r.get_group_active_joint_names(group)
+            else:
+                raise MoveItCommanderException("There is no group named %s" % group)
+        else:
+            return self._r.get_active_joint_names()
+
     def get_joint_names(self, group=None):
         """
         Get the names of all the movable joints that make up a group
-        (mimic joints and fixed joints are excluded). If no group name is
-        specified, all joints in the robot model are returned, including
-        fixed and mimic joints.
+        If no group name is specified, all joints in the robot model are returned
         """
         if group is not None:
             if self.has_group(group):

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -163,6 +163,12 @@ public:
     return active_joint_model_vector_const_;
   }
 
+  /** \brief Get the array of active joint names, in the order they appear in the robot state. */
+  const std::vector<std::string>& getActiveJointModelNames() const
+  {
+    return active_joint_model_names_vector_;
+  }
+
   /** \brief Get the array of joints that are active (not fixed, not mimic) in this model */
   const std::vector<JointModel*>& getActiveJointModels()
   {
@@ -514,6 +520,9 @@ protected:
 
   /** \brief The vector of joints in the model, in the order they appear in the state vector */
   std::vector<JointModel*> active_joint_model_vector_;
+
+  /** \brief The vector of joint names that corresponds to active_joint_model_vector_ */
+  std::vector<std::string> active_joint_model_names_vector_;
 
   /** \brief The vector of joints in the model, in the order they appear in the state vector */
   std::vector<const JointModel*> active_joint_model_vector_const_;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -272,6 +272,7 @@ void RobotModel::buildJointInfo()
       {
         active_joint_model_start_index_.push_back(variable_count_);
         active_joint_model_vector_.push_back(joint_model_vector_[i]);
+        active_joint_model_names_vector_.push_back(joint_model_vector_[i]->getName());
         active_joint_model_vector_const_.push_back(joint_model_vector_[i]);
         active_joint_models_bounds_.push_back(&joint_model_vector_[i]->getVariableBounds());
       }

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -72,6 +72,20 @@ public:
     return robot_model_->getName().c_str();
   }
 
+  bp::list getActiveJointNames() const
+  {
+    return py_bindings_tools::listFromString(robot_model_->getActiveJointModelNames());
+  }
+
+  bp::list getGroupActiveJointNames(const std::string& group) const
+  {
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    if (jmg)
+      return py_bindings_tools::listFromString(jmg->getActiveJointModelNames());
+    else
+      return bp::list();
+  }
+
   bp::list getJointNames() const
   {
     return py_bindings_tools::listFromString(robot_model_->getJointModelNames());
@@ -381,6 +395,8 @@ static void wrap_robot_interface()
 
   robot_class.def("get_joint_names", &RobotInterfacePython::getJointNames);
   robot_class.def("get_group_joint_names", &RobotInterfacePython::getGroupJointNames);
+  robot_class.def("get_active_joint_names", &RobotInterfacePython::getActiveJointNames);
+  robot_class.def("get_group_active_joint_names", &RobotInterfacePython::getGroupActiveJointNames);
   robot_class.def("get_group_default_states", &RobotInterfacePython::getDefaultStateNames);
   robot_class.def("get_group_joint_tips", &RobotInterfacePython::getGroupJointTips);
   robot_class.def("get_group_names", &RobotInterfacePython::getGroupNames);


### PR DESCRIPTION
### Description

Creates new API in C++ and Python for getting active joint names, including the case where no group is specified.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
