### PR TITLE
Warn empty state, resolves #2517

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -145,6 +145,10 @@ void MoveGroupKinematicsService::computeIK(moveit_msgs::PositionIKRequest& req, 
 bool MoveGroupKinematicsService::computeIKService(moveit_msgs::GetPositionIK::Request& req,
                                                   moveit_msgs::GetPositionIK::Response& res)
 {
+  if (req.ik_request.robot_state.joint_state.position.empty())
+  {
+    ROS_WARN("Empty joint_state position in GetPositionIK::Request msgs. Starting from the current robot state");
+  }
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   // check if the planning scene needs to be kept locked; if so, call computeIK() in the scope of the lock


### PR DESCRIPTION
### Description
The PR tries to address #2517 

I added a warning upon calling [`computeIKService`](https://github.com/FabianSchuetze/moveit/blob/30a170f224c37fc1f28de1640b8da0b3afef6614/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp#L145) with a [`GetPositionIK::Request` message](http://docs.ros.org/en/hydro/api/moveit_msgs/html/msg/PositionIKRequest.html) without explicitly setting the robot state. The PR warns if the passed `joint state` is empty since this element seems to be the crucial ingredients to me. The error message mentioned in the [ROS-Answers question](https://answers.ros.org/question/371571/found-empty-jointstate-message/) is caused by the following check in [_robotStateMsgToRobotStateHelper](https://github.com/FabianSchuetze/moveit/blob/30a170f224c37fc1f28de1640b8da0b3afef6614/moveit_core/robot_state/src/conversions.cpp#L373):
```c++
  if (!rs.is_diff && rs.joint_state.name.empty() && rs.multi_dof_joint_state.joint_names.empty())
  {
    ROS_ERROR_NAMED(LOGNAME, "Found empty JointState message");
    return false;
  }
```

We could also duplicate this check in the service call, but I am not sure if this duplication is valuable. 

I might have misunderstood the issue and therefore implemented the wrong patch. I am grateful for any hints or suggestions for how to improve the PR! 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
