### PR TITLE
Fix missing isEmpty check in compute_ik service

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -75,7 +75,10 @@ void MoveGroupKinematicsService::computeIK(moveit_msgs::PositionIKRequest& req, 
   const moveit::core::JointModelGroup* jmg = rs.getJointModelGroup(req.group_name);
   if (jmg)
   {
-    moveit::core::robotStateMsgToRobotState(req.robot_state, rs);
+    if (!moveit::core::isEmpty(req.robot_state))
+    {
+      moveit::core::robotStateMsgToRobotState(req.robot_state, rs);
+    }
     const std::string& default_frame = context_->planning_scene_monitor_->getRobotModel()->getModelFrame();
 
     if (req.pose_stamped_vector.empty() || req.pose_stamped_vector.size() == 1)


### PR DESCRIPTION
Everything works as expected here, if you specify an empty RobotState it is a common pattern in MoveIt to use the current state instead.

The error message is a leftover artifact from #499.

Closes #2517.