### PR TITLE
increase travis time limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 
 env:
   global:
-    - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
+    - MOVEIT_CI_TRAVIS_TIMEOUT=125  # Some limit for execution time
     - ROS_DISTRO=noetic
     - ROS_REPO=ros-testing
     - UPSTREAM_WORKSPACE=moveit.rosinstall


### PR DESCRIPTION
master is currently still failing travis builds because of timeouts. If I got that correctly, picknick is paying for a travis plan, so the time limit of 90 minutes is no longer applicable?

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] ~Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)~
- [ ] ~Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes~
- [ ] ~Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)~
- [ ] ~Include a screenshot if changing a GUI~
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

