### PR TITLE
Fixed flood of errors on startup for `mesh_filter`

### DIFF
--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -58,9 +58,9 @@ public:
   /**
    * \brief Constructor
    * \author Suat Gedikli (gedikli@willowgarage.com)
-   * \param[in] interval_us update interval in micro seconds
+   * \param[in] update_rate update rate in Hz
    */
-  TransformProvider(unsigned long interval_us = 30000);
+  TransformProvider(double update_rate = 30.);
 
   /** \brief Destructor */
   ~TransformProvider();
@@ -78,7 +78,7 @@ public:
    * \brief registers a mesh with its handle
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \param[in] handle handle of the mesh
-   * \param[in] name frame_id_ of teh mesh
+   * \param[in] name frame_id_ of the mesh
    */
   void addHandle(mesh_filter::MeshHandle handle, const std::string& name);
 
@@ -102,13 +102,12 @@ public:
   void stop();
 
   /**
-   * \brief sets the update interval in micro seconds. This should be low enough to reduce the system load but high
-   * enough
-   * to get up-to-date transformations. For PSDK compatible devices this value should be around 30000 = 30ms
+   * \brief sets the update rate in Hz. This should be slow enough to reduce the system load but fast enough to get
+   * up-to-date transformations. For PSDK compatible devices this value should be around 30 Hz.
    * \author Suat Gedikli (gedikli@willowgarage.com)
-   * \param[in] usecs interval in micro seconds
+   * \param[in] update_rate update rate in Hz
    */
-  void setUpdateInterval(unsigned long usecs);
+  void setUpdateRate(double update_rate);
 
 private:
   /**
@@ -162,6 +161,6 @@ private:
   /** \flag to leave the update loop*/
   bool stop_;
 
-  /** \brief update interval in micro seconds*/
-  unsigned long interval_us_;
+  /** \brief update rate in Hz*/
+  ros::Rate update_rate_;
 };

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -68,9 +68,9 @@ void mesh_filter::DepthSelfFiltering::onInit()
   private_nh.param("shadow_threshold", shadow_threshold_, 0.3);
   private_nh.param("padding_scale", padding_scale_, 1.0);
   private_nh.param("padding_offset", padding_offset_, 0.005);
-  double tf_update_rate = 30;
+  double tf_update_rate = 30.;
   private_nh.param("tf_update_rate", tf_update_rate, 30.0);
-  transform_provider_.setUpdateInterval(long(1000000.0 / tf_update_rate));
+  transform_provider_.setUpdateRate(tf_update_rate);
 
   image_transport::SubscriberStatusCallback itssc = std::bind(&DepthSelfFiltering::connectCb, this);
   ros::SubscriberStatusCallback rssc = std::bind(&DepthSelfFiltering::connectCb, this);

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -39,7 +39,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_eigen/tf2_eigen.h>
 
-TransformProvider::TransformProvider(unsigned long interval_us) : stop_(true), interval_us_(interval_us)
+TransformProvider::TransformProvider(double update_rate) : stop_(true), update_rate_(update_rate)
 {
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
   tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
@@ -110,17 +110,24 @@ void TransformProvider::run()
   while (!stop_)
   {
     updateTransforms();
-    usleep(interval_us_);
+    update_rate_.sleep();
   }
 }
 
-void TransformProvider::setUpdateInterval(unsigned long usecs)
+void TransformProvider::setUpdateRate(double update_rate)
 {
-  interval_us_ = usecs;
+  update_rate_ = ros::Rate(update_rate);
 }
 
 void TransformProvider::updateTransforms()
 {
+  // Don't bother if frame_id_ is empty (true initially)
+  if (frame_id_.empty())
+  {
+    ROS_DEBUG_THROTTLE(2., "Not updating transforms because frame_id_ is empty.");
+    return;
+  }
+
   static tf2::Stamped<Eigen::Isometry3d> input_transform, output_transform;
   static moveit::core::RobotStatePtr robot_state;
   robot_state = psm_->getStateMonitor()->getCurrentState();

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -107,7 +107,7 @@ void TransformProvider::run()
   if (handle2context_.empty())
     throw std::runtime_error("TransformProvider is listening to empty list of frames!");
 
-  while (!stop_)
+  while (ros::ok() && !stop_)
   {
     updateTransforms();
     update_rate_.sleep();


### PR DESCRIPTION
### Description

The mesh filter was producing a flood of errors when it started, which stopped after a subscriber connected to its output. This prevents these errors, and instead produces a trickle of debug messages. I cleaned up a few little things, too, while I was at it.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
