### PR TITLE
PlanExecution: fix leftover state after preempt

### DIFF
--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -44,6 +44,8 @@
 #include <moveit/sensor_manager/sensor_manager.h>
 #include <pluginlib/class_loader.hpp>
 
+#include <atomic>
+
 /** \brief This namespace includes functionality specific to the execution and monitoring of motion plans */
 namespace plan_execution
 {
@@ -133,7 +135,7 @@ public:
 
       In case there is no \e planning_scene or \e planning_scene_monitor set in the \e plan they will be set at the
       start of the method. They are then used to monitor the execution. */
-  moveit_msgs::MoveItErrorCodes executeAndMonitor(ExecutableMotionPlan& plan);
+  moveit_msgs::MoveItErrorCodes executeAndMonitor(ExecutableMotionPlan& plan, bool reset_preempted = true);
 
   void stop();
 
@@ -154,7 +156,25 @@ private:
 
   unsigned int default_max_replan_attempts_;
 
-  bool preempt_requested_;
+  class
+  {
+  private:
+    std::atomic<bool> preemption_requested{ false };
+
+  public:
+    /** \brief check *and clear* the preemption flag
+
+        A true return value has to trigger full execution stop, as it consumes the request */
+    inline bool checkAndClear()
+    {
+      return preemption_requested.exchange(false);
+    }
+    inline void request()
+    {
+      preemption_requested.store(true);
+    }
+  } preempt_;
+
   bool new_scene_update_;
 
   bool execution_complete_;


### PR DESCRIPTION
Clearly differentiate between preemption signal and state.

Alternative to #2403.

Fixes https://github.com/ros-planning/moveit_task_constructor/issues/217