### PR TITLE
Planning scene nullptr check

### DIFF
--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -108,7 +108,10 @@ bool CollisionPluginLoader::activate(const std::string& name, const planning_sce
 void CollisionPluginLoader::setupScene(ros::NodeHandle& nh, const planning_scene::PlanningScenePtr& scene)
 {
   if (!scene)
+  {
+    ROS_WARN_NAMED("collision_detection", "Cannot setup scene, PlanningScenePtr is null.");
     return;
+  }
 
   std::string param_name;
   std::string collision_detector_name;

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -36,6 +36,7 @@
 #include <pluginlib/class_loader.hpp>
 #include <memory>
 
+static const std::string LOGNAME = "collision_detection";
 namespace collision_detection
 {
 class CollisionPluginLoader::CollisionPluginLoaderImpl
@@ -109,7 +110,7 @@ void CollisionPluginLoader::setupScene(ros::NodeHandle& nh, const planning_scene
 {
   if (!scene)
   {
-    ROS_WARN_NAMED("collision_detection", "Cannot setup scene, PlanningScenePtr is null.");
+    ROS_WARN_NAMED(LOGNAME, "Cannot setup scene, PlanningScenePtr is null.");
     return;
   }
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -190,15 +190,11 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
   {
     robot_model_ = rm_loader_->getModel();
     scene_ = scene;
-    collision_loader_.setupScene(nh_, scene_);
-    scene_const_ = scene_;
     if (!scene_)
     {
       try
       {
         scene_.reset(new planning_scene::PlanningScene(rm_loader_->getModel()));
-        collision_loader_.setupScene(nh_, scene_);
-        scene_const_ = scene_;
         configureCollisionMatrix(scene_);
         configureDefaultPadding();
 
@@ -220,11 +216,14 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
       {
         ROS_ERROR_NAMED(LOGNAME, "Configuration of planning scene failed");
         scene_.reset();
-        scene_const_ = scene_;
       }
     }
+    // scene_const_ is set regardless scene_ is null or not
+    scene_const_ = scene_;
     if (scene_)
     {
+      // The scene_ is loded on the collision loeader only if it was correctly instantiated
+      collision_loader_.setupScene(nh_, scene_);
       scene_->setAttachedBodyUpdateCallback(
           boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, _1, _2));
       scene_->setCollisionObjectUpdateCallback(

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -222,7 +222,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     scene_const_ = scene_;
     if (scene_)
     {
-      // The scene_ is loded on the collision loeader only if it was correctly instantiated
+      // The scene_ is loaded on the collision loader only if it was correctly instantiated
       collision_loader_.setupScene(nh_, scene_);
       scene_->setAttachedBodyUpdateCallback(
           boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, _1, _2));

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -218,7 +218,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
         scene_.reset();
       }
     }
-    // scene_const_ is set regardless scene_ is null or not
+    // scene_const_ is set regardless if scene_ is null or not
     scene_const_ = scene_;
     if (scene_)
     {


### PR DESCRIPTION
### Description

Issue description [here](https://github.com/ros-planning/moveit/issues/2405).

- Now the code in `planning_scene_monitor.cpp`, `PlanningSceneMonitor::initialize` is easier to read.
- Now `CollisionPluginLoader::setupScene` shows a message when its `PlanningScenePtr` argument is `nullptr`.


### Checklist
- [   ] `scene_const_` is assigned just once.
- [  ] `collision_loader_.setupScene` is called once
- [  ] Test the code.
