### PR TITLE
Shift catkin_lint to pre-commit checks

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,8 +13,19 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - name: Install clang-format-10
-      run: sudo apt-get install clang-format-10
-    - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install clang-format-10
+        run: sudo apt-get install clang-format-10
+      - name: Install catkin-lint
+        run: |
+          lsb_release -sc
+          sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+          sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+          sudo apt-get -q update
+          sudo apt-get -q install python3-rosdep
+          sudo rosdep init
+          rosdep update
+          sudo apt-get -q install catkin-lint
+          export ROS_DISTRO=noetic
+      - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -16,17 +16,17 @@ jobs:
     strategy:
       matrix:
         env:
-          - IMAGE: 'master-ci'
+          - IMAGE: master-ci
             CCOV: true
-          - IMAGE: 'master-ci-shadow-fixed'
+          - IMAGE: master-ci-shadow-fixed
             CATKIN_LINT: true
-          - IMAGE: 'melodic-ci'
+          - IMAGE: melodic-ci
             IKFAST_TEST: true
             CLANG_TIDY: true
     env:
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: moveit.rosinstall
-      AFTER_SETUP_UPSTREAM_WORKSPACE: 'vcs pull $BASEDIR/upstream_ws/src'
+      AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       BEFORE_TARGET_TEST_EMBED: ${{ matrix.env.IKFAST_TEST && 'set +u && source moveit_kinematics/test/test_ikfast_plugins.sh && set -u' || '' }}
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >
@@ -81,7 +81,7 @@ jobs:
             ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ccache-${{ env.CACHE_PREFIX }}
       - name: industrial_ci
-        uses: 'tylerjw/industrial_ci@clang-tidy-modified-filter'
+        uses: tylerjw/industrial_ci@clang-tidy-modified-filter
         env: ${{ matrix.env }}
       - name: upload test artifacts (on failure)
         uses: actions/upload-artifact@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,10 @@ repos:
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']
+      - id: catkin_lint
+        name: catkin_lint
+        description: Check package.xml and cmake files
+        entry: catkin_lint .
+        language: system
+        always_run: true
+        pass_filenames: false


### PR DESCRIPTION
Fixes #2566 (hopefully). Works locally. The key was, I think, `pass_filenames: false`.