### PR TITLE
Make setToIKSolverFrame accessible again

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1799,18 +1799,13 @@ public:
 
   std::string getStateTreeString(const std::string& prefix = "") const;
 
-private:
-  void allocMemory();
-  void initTransforms();
-  void copyFrom(const RobotState& other);
-
   /**
    * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
    * @param pose - the input to change
    * @param solver - a kin solver whose base frame is important to us
    * @return true if no error
    */
-  inline bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
+  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
 
   /**
    * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
@@ -1819,6 +1814,11 @@ private:
    * @return true if no error
    */
   bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
+
+private:
+  void allocMemory();
+  void initTransforms();
+  void copyFrom(const RobotState& other);
 
   void markDirtyJointTransforms(const JointModel* joint)
   {


### PR DESCRIPTION
This is public API because the solver's getPositionIK requires input poses
in the frame and the relevant transform is otherwise inaccessible.

Partially reverts #2461.

Supersedes #2575