### PR TITLE
Fix remove_attached_object API in Python PSI, add clear()

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -93,36 +93,26 @@ class PlanningSceneInterface(object):
                 self._pub_co.publish(collision_object)
 
     def add_object(self, collision_object):
-        """
-        Add an object to the planning scene
-        """
+        """ Add an object to the planning scene """
         self.__submit(collision_object, attach=False)
 
     def add_sphere(self, name, pose, radius=1):
-        """
-        Add a sphere to the planning scene
-        """
+        """ Add a sphere to the planning scene """
         co = self.__make_sphere(name, pose, radius)
         self.__submit(co, attach=False)
 
     def add_cylinder(self, name, pose, height, radius):
-        """
-        Add a cylinder to the planning scene
-        """
+        """ Add a cylinder to the planning scene """
         co = self.__make_cylinder(name, pose, height, radius)
         self.__submit(co, attach=False)
 
     def add_mesh(self, name, pose, filename, size=(1, 1, 1)):
-        """
-        Add a mesh to the planning scene
-        """
+        """ Add a mesh to the planning scene """
         co = self.__make_mesh(name, pose, filename, size)
         self.__submit(co, attach=False)
 
     def add_box(self, name, pose, size=(1, 1, 1)):
-        """
-        Add a box to the planning scene
-        """
+        """ Add a box to the planning scene """
         co = self.__make_box(name, pose, size)
         self.__submit(co, attach=False)
 
@@ -140,9 +130,7 @@ class PlanningSceneInterface(object):
         self.__submit(co, attach=False)
 
     def attach_object(self, attached_collision_object):
-        """
-        Attach an object in the planning scene
-        """
+        """ Attach an object in the planning scene """
         self.__submit(attached_collision_object, attach=True)
 
     def attach_mesh(
@@ -267,7 +255,7 @@ class PlanningSceneInterface(object):
     @staticmethod
     def __make_existing(name):
         """
-        Create an empty Collision Object, used when the object already exists
+        Create an empty Collision Object. Used when the object already exists
         """
         co = CollisionObject()
         co.id = name

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -172,6 +172,11 @@ class PlanningSceneInterface(object):
             aco.touch_links = [link]
         self.__submit(aco, attach=True)
 
+    def clear(self):
+        """ Remove all objects from the planning scene """
+        self.remove_attached_object()
+        self.remove_world_object()
+
     def remove_world_object(self, name=None):
         """
         Remove an object from planning scene, or all if no name is provided

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -182,13 +182,18 @@ class PlanningSceneInterface(object):
             co.id = name
         self.__submit(co, attach=False)
 
-    def remove_attached_object(self, link, name=None):
+    def remove_attached_object(self, link=None, name=None):
         """
-        Remove an attached object from planning scene, or all objects attached to this link if no name is provided
+        Remove an attached object from the robot, or all objects attached to the link if no name is provided,
+        or all attached objects in the scene if neither link nor name are provided.
+
+        Removed attached objects remain in the scene as world objects.
+        Call remove_world_object afterwards to remove them from the scene.
         """
         aco = AttachedCollisionObject()
         aco.object.operation = CollisionObject.REMOVE
-        aco.link_name = link
+        if link is not None:
+            aco.link_name = link
         if name is not None:
             aco.object.id = name
         self.__submit(aco, attach=True)


### PR DESCRIPTION
Setting the link name in `remove_attached_object` is not necessary. `planning_scene.cpp` treats the message as described.

I also added a `clear()` method because I could have used it today and saw that @mikeferguson also did in [moveit_python](http://docs.ros.org/en/api/moveit_python/html/classmoveit__python_1_1planning__scene__interface_1_1PlanningSceneInterface.html#aa36ea0b0171e79ddfea196aed4f9d8a4).