### PR TITLE
Velocity limit error

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -58,7 +58,17 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   // collect most strict joint limits for each group in robot model
   for (const auto& jmg : robot_model->getJointModelGroups())
   {
-    JointLimit most_strict_limit = joint_limits_.getCommonLimit(jmg->getActiveJointModelNames());
+
+    auto active_joints = jmg->getActiveJointModelNames();
+
+    // no active joints
+    if(active_joints.empty())
+    {
+      continue;
+    }
+
+    JointLimit most_strict_limit = joint_limits_.getCommonLimit(active_joints);
+
 
     if (!most_strict_limit.has_velocity_limits)
     {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -58,17 +58,15 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   // collect most strict joint limits for each group in robot model
   for (const auto& jmg : robot_model->getJointModelGroups())
   {
-
     auto active_joints = jmg->getActiveJointModelNames();
 
     // no active joints
-    if(active_joints.empty())
+    if (active_joints.empty())
     {
       continue;
     }
 
     JointLimit most_strict_limit = joint_limits_.getCommonLimit(active_joints);
-
 
     if (!most_strict_limit.has_velocity_limits)
     {


### PR DESCRIPTION
### Description

Integration of https://github.com/PilzDE/pilz_industrial_motion/pull/328: Do not check joint model groups which contain fixed joints only (e.g. an empty endeffector group). 


