### PR TITLE
Set rotation value of cartesian MaxEEFStep by default

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -75,10 +75,16 @@ struct JumpThreshold
 
 /** \brief Struct for containing max_step for computeCartesianPath
 
-    Setting translation to zero will disable checking for translations and the same goes for rotation */
+    Setting translation to zero will disable checking for translations. The same goes for rotation.
+    Initializing with only one value (translation) sets the rotation such that
+    1 cm of allowed translation = 2 degrees of allowed rotation. */
 struct MaxEEFStep
 {
-  MaxEEFStep(double translation = 0.0, double rotation = 0.0) : translation(translation), rotation(rotation)
+  MaxEEFStep(double translation, double rotation) : translation(translation), rotation(rotation)
+  {
+  }
+
+  MaxEEFStep(double translation) : translation(translation), rotation(3.5 * translation)  // 0.035 rad = 2 deg
   {
   }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -84,7 +84,7 @@ struct MaxEEFStep
   {
   }
 
-  MaxEEFStep(double translation) : translation(translation), rotation(3.5 * translation)  // 0.035 rad = 2 deg
+  MaxEEFStep(double step_size) : translation(step_size), rotation(3.5 * step_size)  // 0.035 rad = 2 deg
   {
   }
 


### PR DESCRIPTION
I was trying to plan a pure rotation today and noticed that `max_step` did not apply to the rotation anymore. If the motion is a pure rotation, `move_group.computeCartesianPath()` returns no intermediate points. It looks like this bug was introduced when we added `CartesianInterpolator`, which sets the rotation value of `MaxEEFStep` to zero by default.

This PR fixes the constructor of `MaxEEFStep` and sets the rotation to a reasonable value if it is not set. I chose a value of 1 cm = 2 deg, but I would be fine with 1 cm = 1 deg as well. 