### PR TITLE
document solution in ROS_ERROR on failed self-filtering

### DIFF
--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -74,7 +74,15 @@ bool OccupancyMapUpdater::updateTransformCache(const std::string& target_frame, 
 {
   transform_cache_.clear();
   if (transform_provider_callback_)
-    return transform_provider_callback_(target_frame, target_time, transform_cache_);
+  {
+    bool success = transform_provider_callback_(target_frame, target_time, transform_cache_);
+    if (!success)
+      ROS_ERROR_THROTTLE_NAMED(
+          1, LOGNAME,
+          "Transform cache was not updated. Self-filtering may fail. If transforms were not available yet, consider "
+          "setting robot_description_planning/shape_transform_cache_lookup_wait_time to wait longer for transforms");
+    return success;
+  }
   else
   {
     ROS_WARN_THROTTLE_NAMED(1, LOGNAME, "No callback provided for updating the transform cache for octomap updaters");

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -311,10 +311,7 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
   }
 
   if (!updateTransformCache(depth_msg->header.frame_id, depth_msg->header.stamp))
-  {
-    ROS_ERROR_THROTTLE_NAMED(1, LOGNAME, "Transform cache was not updated. Self-filtering may fail.");
     return;
-  }
 
   if (depth_msg->is_bigendian && !HOST_IS_BIG_ENDIAN)
     ROS_ERROR_THROTTLE_NAMED(1, LOGNAME, "endian problem: received image data does not match host");

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -214,10 +214,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   Eigen::Vector3d sensor_origin_eigen(sensor_origin_tf.getX(), sensor_origin_tf.getY(), sensor_origin_tf.getZ());
 
   if (!updateTransformCache(cloud_msg->header.frame_id, cloud_msg->header.stamp))
-  {
-    ROS_ERROR_THROTTLE_NAMED(1, LOGNAME, "Transform cache was not updated. Self-filtering may fail.");
     return;
-  }
 
   /* mask out points on the robot */
   shape_mask_->maskContainment(*cloud_msg, sensor_origin_eigen, 0.0, max_range_, mask_);


### PR DESCRIPTION
Also move the log command to the base class (which even uses the same logname...)

I just spend some time on https://github.com/ros-planning/moveit_tutorials/issues/192
and found a solution eventually, but this could have been a no-brainer with more information...