### PR TITLE
Melodic Backports

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -24,7 +24,11 @@ RUN \
 
 ENV PYTHONIOENCODING UTF-8
 RUN cd .. && \
-    catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
     # Status rate is limited so that just enough info is shown to keep Docker from timing out,
     # but not too much such that the Docker log gets too long (another form of timeout)
     catkin build --limit-status-rate 0.001 --no-notify
+
+# Environment variable used in instructions on moveit.ros.org website for running clang-tidy
+ENV CATKIN_WS /root/ws_moveit
+

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -31,4 +31,3 @@ RUN cd .. && \
 
 # Environment variable used in instructions on moveit.ros.org website for running clang-tidy
 ENV CATKIN_WS /root/ws_moveit
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Free up disk space"
         if: ${{ matrix.env.CCOV }}
         run: |
-          sudo apt-get -qq purge build-essential ghc*
+          sudo apt-get -qq purge build-essential "ghc*"
           sudo apt-get clean
           # cleanup docker images not used by us
           docker system prune -af
@@ -50,7 +50,7 @@ jobs:
           mkdir ${{ env.CCACHE_DIR }}
           sudo mount --bind ${{ env.CCACHE_DIR }} /mnt/ccache
           # free up a lot of stuff from /usr/local
-          sudo rm -rf /usr/local/*
+          sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
       - name: cache upstream_ws

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -5,49 +5,33 @@ name: pre-release
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - melodic-devel
 
 jobs:
   default:
-    env:
-      ROS_DISTRO: melodic
-      PRERELEASE: true
-      BASEDIR: ${{ github.workspace }}/.work
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CACHE_PREFIX: melodic-pre-release
+    strategy:
+      matrix:
+        distro: [melodic]
 
+    env:
+      ROS_DISTRO: ${{ matrix.distro }}
+      PRERELEASE: true
+      # https://github.com/ros-industrial/industrial_ci/issues/666
+      BUILDER: catkin_make_isolated
+      UPSTREAM_WORKSPACE: github:ros-planning/moveit_resources#melodic-devel
+      BASEDIR: ${{ github.workspace }}/.work
+
+    name: "${{ matrix.distro }}"
     runs-on: ubuntu-latest
     steps:
       - name: "Free up disk space"
         run: |
-          sudo apt-get -qq purge build-essential ghc*
+          sudo apt-get -qq purge build-essential "ghc*"
           sudo apt-get clean
           # cleanup docker images not used by us
           docker system prune -af
-          # shift ccache folder to /mnt on a separate disk
-          sudo mkdir /mnt/ccache
-          mkdir ${{ env.CCACHE_DIR }}
-          sudo mount --bind ${{ env.CCACHE_DIR }} /mnt/ccache
           # free up a lot of stuff from /usr/local
-          sudo rm -rf /usr/local/*
+          sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
-      - name: cache ccache
-        uses: pat-s/always-upload-cache@v2.1.3
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
-            ccache-${{ env.CACHE_PREFIX }}
       - name: industrial_ci
         uses: ros-industrial/industrial_ci@master
-      - name: upload test artifacts (on failure)
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: test-results
-          path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,53 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: pre-release
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - melodic-devel
+
+jobs:
+  default:
+    env:
+      ROS_DISTRO: melodic
+      PRERELEASE: true
+      BASEDIR: ${{ github.workspace }}/.work
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CACHE_PREFIX: melodic-pre-release
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Free up disk space"
+        run: |
+          sudo apt-get -qq purge build-essential ghc*
+          sudo apt-get clean
+          # cleanup docker images not used by us
+          docker system prune -af
+          # shift ccache folder to /mnt on a separate disk
+          sudo mkdir /mnt/ccache
+          mkdir ${{ env.CCACHE_DIR }}
+          sudo mount --bind ${{ env.CCACHE_DIR }} /mnt/ccache
+          # free up a lot of stuff from /usr/local
+          sudo rm -rf /usr/local/*
+          df -h
+      - uses: actions/checkout@v2
+      - name: cache ccache
+        uses: pat-s/always-upload-cache@v2.1.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
+            ccache-${{ env.CACHE_PREFIX }}
+      - name: industrial_ci
+        uses: ros-industrial/industrial_ci@master
+      - name: upload test artifacts (on failure)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-results
+          path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Currently we support ROS Indigo, Kinetic, and Melodic.
 
 ## Branches Policy
 
-We develop all new 1.0 features on ``master``. The ``*-devel`` branches correspond to
-released and stable versions of MoveIt for specific distributions of ROS.
-Bug fixes occationally get backported to these released versions of MoveIt.
-The next version of MoveIt 1.0 will be branched to ``noetic-devel`` around May 2020.
+- We develop latest features on ``master``.
+- The ``*-devel`` branches correspond to released and stable versions of MoveIt for specific distributions of ROS.
+- Bug fixes occasionally get backported to these released versions of MoveIt.
+- For MoveIt 2 development, see [moveit2](https://github.com/ros-planning/moveit2).
 
 For MoveIt 2.0 development, see [moveit2](https://github.com/ros-planning/moveit2).
 

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -57,7 +57,12 @@ except:
 
 
 class PlanningSceneInterface(object):
-    """ Simple interface to making updates to a planning scene """
+    """
+    Python interface for a C++ PlanningSceneInterface.
+    Uses both C++ wrapped methods and scene manipulation topics
+    to manipulate the PlanningScene managed by the PlanningSceneMonitor.
+    See wrap_python_planning_scene_interface.cpp for the wrapped methods.
+    """
 
     def __init__(self, ns="", synchronous=False, service_timeout=5.0):
         """ Create a planning scene interface; it uses both C++ wrapped methods and scene manipulation topics. """
@@ -87,6 +92,12 @@ class PlanningSceneInterface(object):
                 self._pub_aco.publish(collision_object)
             else:
                 self._pub_co.publish(collision_object)
+
+    def add_object(self, collision_object):
+        """
+        Add an object to the planning scene
+        """
+        self.__submit(collision_object, attach=False)
 
     def add_sphere(self, name, pose, radius=1):
         """
@@ -128,6 +139,12 @@ class PlanningSceneInterface(object):
         co.planes = [p]
         co.plane_poses = [pose.pose]
         self.__submit(co, attach=False)
+
+    def attach_object(self, attached_collision_object):
+        """
+        Attach an object in the planning scene
+        """
+        self.__submit(attached_collision_object, attach=True)
 
     def attach_mesh(
         self, link, name, pose=None, filename="", size=(1, 1, 1), touch_links=[]
@@ -229,6 +246,14 @@ class PlanningSceneInterface(object):
             conversions.msg_from_string(msg, ser_aobjs[key])
             aobjs[key] = msg
         return aobjs
+
+    def apply_planning_scene(self, planning_scene_message):
+        """
+        Applies the planning scene message.
+        """
+        return self._psi.apply_planning_scene(
+            conversions.msg_to_string(planning_scene_message)
+        )
 
     @staticmethod
     def __make_existing(name):

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -94,36 +94,26 @@ class PlanningSceneInterface(object):
                 self._pub_co.publish(collision_object)
 
     def add_object(self, collision_object):
-        """
-        Add an object to the planning scene
-        """
+        """ Add an object to the planning scene """
         self.__submit(collision_object, attach=False)
 
     def add_sphere(self, name, pose, radius=1):
-        """
-        Add a sphere to the planning scene
-        """
+        """ Add a sphere to the planning scene """
         co = self.__make_sphere(name, pose, radius)
         self.__submit(co, attach=False)
 
     def add_cylinder(self, name, pose, height, radius):
-        """
-        Add a cylinder to the planning scene
-        """
+        """ Add a cylinder to the planning scene """
         co = self.__make_cylinder(name, pose, height, radius)
         self.__submit(co, attach=False)
 
     def add_mesh(self, name, pose, filename, size=(1, 1, 1)):
-        """
-        Add a mesh to the planning scene
-        """
+        """ Add a mesh to the planning scene """
         co = self.__make_mesh(name, pose, filename, size)
         self.__submit(co, attach=False)
 
     def add_box(self, name, pose, size=(1, 1, 1)):
-        """
-        Add a box to the planning scene
-        """
+        """ Add a box to the planning scene """
         co = self.__make_box(name, pose, size)
         self.__submit(co, attach=False)
 
@@ -141,9 +131,7 @@ class PlanningSceneInterface(object):
         self.__submit(co, attach=False)
 
     def attach_object(self, attached_collision_object):
-        """
-        Attach an object in the planning scene
-        """
+        """ Attach an object in the planning scene """
         self.__submit(attached_collision_object, attach=True)
 
     def attach_mesh(
@@ -173,6 +161,11 @@ class PlanningSceneInterface(object):
             aco.touch_links = [link]
         self.__submit(aco, attach=True)
 
+    def clear(self):
+        """ Remove all objects from the planning scene """
+        self.remove_attached_object()
+        self.remove_world_object()
+
     def remove_world_object(self, name=None):
         """
         Remove an object from planning scene, or all if no name is provided
@@ -183,13 +176,18 @@ class PlanningSceneInterface(object):
             co.id = name
         self.__submit(co, attach=False)
 
-    def remove_attached_object(self, link, name=None):
+    def remove_attached_object(self, link=None, name=None):
         """
-        Remove an attached object from planning scene, or all objects attached to this link if no name is provided
+        Remove an attached object from the robot, or all objects attached to the link if no name is provided,
+        or all attached objects in the scene if neither link nor name are provided.
+
+        Removed attached objects remain in the scene as world objects.
+        Call remove_world_object afterwards to remove them from the scene.
         """
         aco = AttachedCollisionObject()
         aco.object.operation = CollisionObject.REMOVE
-        aco.link_name = link
+        if link is not None:
+            aco.link_name = link
         if name is not None:
             aco.object.id = name
         self.__submit(aco, attach=True)
@@ -258,7 +256,7 @@ class PlanningSceneInterface(object):
     @staticmethod
     def __make_existing(name):
         """
-        Create an empty Collision Object, used when the object already exists
+        Create an empty Collision Object. Used when the object already exists
         """
         co = CollisionObject()
         co.id = name

--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -194,12 +194,25 @@ class RobotCommander(object):
         """Get the name of the root link of the robot model """
         return self._r.get_robot_root_link()
 
+    def get_active_joint_names(self, group=None):
+        """
+        Get the names of all the movable joints that make up a group.
+        If no group name is specified, all joints in the robot model are returned.
+        Excludes fixed and mimic joints.
+        """
+        if group is not None:
+            if self.has_group(group):
+                return self._r.get_group_active_joint_names(group)
+            else:
+                raise MoveItCommanderException("There is no group named %s" % group)
+        else:
+            return self._r.get_active_joint_names()
+
     def get_joint_names(self, group=None):
         """
-        Get the names of all the movable joints that make up a group
-        (mimic joints and fixed joints are excluded). If no group name is
-        specified, all joints in the robot model are returned, including
-        fixed and mimic joints.
+        Get the names of all the movable joints that make up a group.
+        If no group name is specified, all joints in the robot model are returned.
+        Includes fixed and mimic joints.
         """
         if group is not None:
             if self.has_group(group):

--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -46,7 +46,7 @@ BackgroundProcessing::BackgroundProcessing()
   // spin a thread that will process user events
   run_processing_thread_ = true;
   processing_ = false;
-  processing_thread_.reset(new boost::thread(boost::bind(&BackgroundProcessing::processingThread, this)));
+  processing_thread_ = std::make_unique<boost::thread>(boost::bind(&BackgroundProcessing::processingThread, this));
 }
 
 BackgroundProcessing::~BackgroundProcessing()

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -1,0 +1,432 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Jens Petit
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Jens Petit */
+
+#include <moveit/collision_detection_bullet/collision_env_bullet.h>
+#include <moveit/collision_detection_bullet/collision_detector_allocator_bullet.h>
+#include <moveit/collision_detection_bullet/bullet_integration/ros_bullet_utils.h>
+#include <moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h>
+#include <boost/bind.hpp>
+#include <bullet/btBulletCollisionCommon.h>
+
+namespace collision_detection
+{
+const std::string CollisionDetectorAllocatorBullet::NAME("Bullet");
+const double MAX_DISTANCE_MARGIN = 99;
+constexpr char LOGNAME[] = "collision_detection.bullet";
+
+CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
+  : CollisionEnv(model, padding, scale)
+{
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, _1, _2));
+
+  for (const std::pair<const std::string, urdf::LinkSharedPtr>& link : robot_model_->getURDF()->links_)
+  {
+    addLinkAsCollisionObject(link.second);
+  }
+}
+
+CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world,
+                                       double padding, double scale)
+  : CollisionEnv(model, world, padding, scale)
+{
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, _1, _2));
+
+  for (const std::pair<const std::string, urdf::LinkSharedPtr>& link : robot_model_->getURDF()->links_)
+  {
+    addLinkAsCollisionObject(link.second);
+  }
+
+  getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
+}
+
+CollisionEnvBullet::CollisionEnvBullet(const CollisionEnvBullet& other, const WorldPtr& world)
+  : CollisionEnv(other, world)
+{
+  // TODO(j-petit): Verify this constructor
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, _1, _2));
+
+  for (const std::pair<const std::string, urdf::LinkSharedPtr>& link : other.robot_model_->getURDF()->links_)
+  {
+    addLinkAsCollisionObject(link.second);
+  }
+}
+
+CollisionEnvBullet::~CollisionEnvBullet()
+{
+  getWorld()->removeObserver(observer_handle_);
+}
+
+void CollisionEnvBullet::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                            const moveit::core::RobotState& state) const
+{
+  checkSelfCollisionHelper(req, res, state, nullptr);
+}
+
+void CollisionEnvBullet::checkSelfCollision(const CollisionRequest& req, CollisionResult& res,
+                                            const moveit::core::RobotState& state,
+                                            const AllowedCollisionMatrix& acm) const
+{
+  checkSelfCollisionHelper(req, res, state, &acm);
+}
+
+void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                  const moveit::core::RobotState& state,
+                                                  const AllowedCollisionMatrix* acm) const
+{
+  std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> cows;
+  addAttachedOjects(state, cows);
+
+  if (req.distance)
+  {
+    manager_->setContactDistanceThreshold(MAX_DISTANCE_MARGIN);
+  }
+
+  for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : cows)
+  {
+    manager_->addCollisionObject(cow);
+    manager_->setCollisionObjectsTransform(
+        cow->getName(), state.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0]);
+  }
+
+  // updating link positions with the current robot state
+  for (const std::string& link : active_)
+  {
+    manager_->setCollisionObjectsTransform(link, state.getCollisionBodyTransform(link, 0));
+  }
+
+  manager_->contactTest(res, req, acm, true);
+
+  for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : cows)
+  {
+    manager_->removeCollisionObject(cow->getName());
+  }
+}
+
+void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                             const moveit::core::RobotState& state) const
+{
+  checkRobotCollisionHelper(req, res, state, nullptr);
+}
+
+void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                             const moveit::core::RobotState& state,
+                                             const AllowedCollisionMatrix& acm) const
+{
+  checkRobotCollisionHelper(req, res, state, &acm);
+}
+
+void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                             const moveit::core::RobotState& state1,
+                                             const moveit::core::RobotState& state2) const
+{
+  checkRobotCollisionHelperCCD(req, res, state1, state2, nullptr);
+}
+
+void CollisionEnvBullet::checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
+                                             const moveit::core::RobotState& state1,
+                                             const moveit::core::RobotState& state2,
+                                             const AllowedCollisionMatrix& acm) const
+{
+  checkRobotCollisionHelperCCD(req, res, state1, state2, &acm);
+}
+
+void CollisionEnvBullet::checkRobotCollisionHelper(const CollisionRequest& req, CollisionResult& res,
+                                                   const moveit::core::RobotState& state,
+                                                   const AllowedCollisionMatrix* acm) const
+{
+  if (req.distance)
+  {
+    manager_->setContactDistanceThreshold(MAX_DISTANCE_MARGIN);
+  }
+
+  std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
+  addAttachedOjects(state, attached_cows);
+  updateTransformsFromState(state, manager_);
+
+  for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
+  {
+    manager_->addCollisionObject(cow);
+    manager_->setCollisionObjectsTransform(
+        cow->getName(), state.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0]);
+  }
+
+  manager_->contactTest(res, req, acm, false);
+
+  for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
+  {
+    manager_->removeCollisionObject(cow->getName());
+  }
+}
+
+void CollisionEnvBullet::checkRobotCollisionHelperCCD(const CollisionRequest& req, CollisionResult& res,
+                                                      const moveit::core::RobotState& state1,
+                                                      const moveit::core::RobotState& state2,
+                                                      const AllowedCollisionMatrix* acm) const
+{
+  std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
+  addAttachedOjects(state1, attached_cows);
+
+  for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
+  {
+    manager_CCD_->addCollisionObject(cow);
+    manager_CCD_->setCastCollisionObjectsTransform(
+        cow->getName(), state1.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0],
+        state2.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0]);
+  }
+
+  for (const std::string& link : active_)
+  {
+    manager_CCD_->setCastCollisionObjectsTransform(link, state1.getCollisionBodyTransform(link, 0),
+                                                   state2.getCollisionBodyTransform(link, 0));
+  }
+
+  manager_CCD_->contactTest(res, req, acm, false);
+
+  for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
+  {
+    manager_CCD_->removeCollisionObject(cow->getName());
+  }
+}
+
+void CollisionEnvBullet::distanceSelf(const DistanceRequest& req, DistanceResult& res,
+                                      const moveit::core::RobotState& state) const
+{
+  ROS_INFO_NAMED(LOGNAME, "distanceSelf is not implemented for Bullet.");
+}
+
+void CollisionEnvBullet::distanceRobot(const DistanceRequest& req, DistanceResult& res,
+                                       const moveit::core::RobotState& state) const
+{
+  ROS_INFO_NAMED(LOGNAME, "distanceRobot is not implemented for Bullet.");
+}
+
+void CollisionEnvBullet::addToManager(const World::Object* obj)
+{
+  std::vector<collision_detection_bullet::CollisionObjectType> collision_object_types;
+
+  for (const shapes::ShapeConstPtr& shape : obj->shapes_)
+  {
+    if (shape->type == shapes::MESH)
+      collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::CONVEX_HULL);
+    else
+      collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::USE_SHAPE_TYPE);
+  }
+
+  collision_detection_bullet::CollisionObjectWrapperPtr cow(new collision_detection_bullet::CollisionObjectWrapper(
+      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_, obj->shape_poses_, collision_object_types,
+      false));
+
+  manager_->addCollisionObject(cow);
+  manager_CCD_->addCollisionObject(cow->clone());
+}
+
+void CollisionEnvBullet::updateManagedObject(const std::string& id)
+{
+  if (getWorld()->hasObject(id))
+  {
+    auto it = getWorld()->find(id);
+    if (manager_->hasCollisionObject(id))
+    {
+      manager_->removeCollisionObject(id);
+      manager_CCD_->removeCollisionObject(id);
+      addToManager(it->second.get());
+    }
+    else
+    {
+      addToManager(it->second.get());
+    }
+  }
+  else
+  {
+    if (manager_->hasCollisionObject(id))
+    {
+      manager_->removeCollisionObject(id);
+      manager_CCD_->removeCollisionObject(id);
+    }
+  }
+}
+
+void CollisionEnvBullet::setWorld(const WorldPtr& world)
+{
+  if (world == getWorld())
+    return;
+
+  // turn off notifications about old world
+  getWorld()->removeObserver(observer_handle_);
+
+  CollisionEnv::setWorld(world);
+
+  // request notifications about changes to new world
+  observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, _1, _2));
+
+  // get notifications any objects already in the new world
+  getWorld()->notifyObserverAllObjects(observer_handle_, World::CREATE);
+}
+
+void CollisionEnvBullet::notifyObjectChange(const ObjectConstPtr& obj, World::Action action)
+{
+  if (action == World::DESTROY)
+  {
+    manager_->removeCollisionObject(obj->id_);
+    manager_CCD_->removeCollisionObject(obj->id_);
+  }
+  else
+  {
+    updateManagedObject(obj->id_);
+  }
+}
+
+void CollisionEnvBullet::addAttachedOjects(const moveit::core::RobotState& state,
+                                           std::vector<collision_detection_bullet::CollisionObjectWrapperPtr>& cows) const
+{
+  std::vector<const moveit::core::AttachedBody*> attached_bodies;
+  state.getAttachedBodies(attached_bodies);
+
+  for (const moveit::core::AttachedBody*& body : attached_bodies)
+  {
+    const EigenSTL::vector_Isometry3d& attached_body_transform = body->getGlobalCollisionBodyTransforms();
+
+    std::vector<collision_detection_bullet::CollisionObjectType> collision_object_types(
+        attached_body_transform.size(), collision_detection_bullet::CollisionObjectType::USE_SHAPE_TYPE);
+
+    try
+    {
+      collision_detection_bullet::CollisionObjectWrapperPtr cow(new collision_detection_bullet::CollisionObjectWrapper(
+          body->getName(), collision_detection::BodyType::ROBOT_ATTACHED, body->getShapes(), attached_body_transform,
+          collision_object_types, body->getTouchLinks()));
+      cows.push_back(cow);
+    }
+    catch (std::exception&)
+    {
+      ROS_ERROR_STREAM_NAMED("collision_detetction.bullet",
+                             "Not adding " << body->getName() << " due to bad arguments.");
+    }
+  }
+}
+
+void CollisionEnvBullet::updatedPaddingOrScaling(const std::vector<std::string>& links)
+{
+  for (const std::string& link : links)
+  {
+    if (robot_model_->getURDF()->links_.find(link) != robot_model_->getURDF()->links_.end())
+    {
+      addLinkAsCollisionObject(robot_model_->getURDF()->links_[link]);
+    }
+    else
+    {
+      ROS_ERROR_NAMED("collision_detection.bullet", "Updating padding or scaling for unknown link: '%s'", link.c_str());
+    }
+  }
+}
+
+void CollisionEnvBullet::updateTransformsFromState(
+    const moveit::core::RobotState& state, const collision_detection_bullet::BulletDiscreteBVHManagerPtr& manager) const
+{
+  // updating link positions with the current robot state
+  for (const std::string& link : active_)
+  {
+    // select the first of the transformations for each link (composed of multiple shapes...)
+    manager->setCollisionObjectsTransform(link, state.getCollisionBodyTransform(link, 0));
+  }
+}
+
+void CollisionEnvBullet::addLinkAsCollisionObject(const urdf::LinkSharedPtr& link)
+{
+  if (!link->collision_array.empty())
+  {
+    const std::vector<urdf::CollisionSharedPtr>& col_array =
+        link->collision_array.empty() ? std::vector<urdf::CollisionSharedPtr>(1, link->collision) :
+                                        link->collision_array;
+
+    std::vector<shapes::ShapeConstPtr> shapes;
+    collision_detection_bullet::AlignedVector<Eigen::Isometry3d> shape_poses;
+    std::vector<collision_detection_bullet::CollisionObjectType> collision_object_types;
+
+    for (const auto& i : col_array)
+    {
+      if (i && i->geometry)
+      {
+        shapes::ShapePtr shape = collision_detection_bullet::constructShape(i->geometry.get());
+
+        if (shape)
+        {
+          if (fabs(getLinkScale(link->name) - 1.0) >= std::numeric_limits<double>::epsilon() ||
+              fabs(getLinkPadding(link->name)) >= std::numeric_limits<double>::epsilon())
+          {
+            shape->scaleAndPadd(getLinkScale(link->name), getLinkPadding(link->name));
+          }
+
+          shapes.push_back(shape);
+          shape_poses.push_back(collision_detection_bullet::urdfPose2Eigen(i->origin));
+
+          if (shape->type == shapes::MESH)
+          {
+            collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::CONVEX_HULL);
+          }
+          else
+          {
+            collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::USE_SHAPE_TYPE);
+          }
+        }
+      }
+    }
+
+    if (manager_->hasCollisionObject(link->name))
+    {
+      manager_->removeCollisionObject(link->name);
+      manager_CCD_->removeCollisionObject(link->name);
+    }
+
+    try
+    {
+      collision_detection_bullet::CollisionObjectWrapperPtr cow(new collision_detection_bullet::CollisionObjectWrapper(
+          link->name, collision_detection::BodyType::ROBOT_LINK, shapes, shape_poses, collision_object_types, true));
+      manager_->addCollisionObject(cow);
+      manager_CCD_->addCollisionObject(cow->clone());
+      active_.push_back(cow->getName());
+    }
+    catch (std::exception&)
+    {
+      ROS_ERROR_STREAM_NAMED("collision_detetction.bullet", "Not adding " << link->name << " due to bad arguments.");
+    }
+  }
+}
+
+}  // end of namespace collision_detection

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -20,4 +20,7 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_constraints test/test_constraints.cpp)
   target_link_libraries(test_constraints moveit_test_utils ${MOVEIT_LIB_NAME})
+
+  catkin_add_gtest(test_orientation_constraints test/test_orientation_constraints.cpp)
+  target_link_libraries(test_orientation_constraints moveit_test_utils ${MOVEIT_LIB_NAME})
 endif()

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -615,9 +615,10 @@ ConstraintEvaluationResult OrientationConstraint::decide(const robot_state::Robo
         diff.rotation().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   }
 
-  xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::pi<double>() - fabs(xyz(0)));
-  xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::pi<double>() - fabs(xyz(1)));
-  xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::pi<double>() - fabs(xyz(2)));
+  // Account for angle wrapping
+  xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::two_pi<double>() - fabs(xyz(0)));
+  xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::two_pi<double>() - fabs(xyz(1)));
+  xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::two_pi<double>() - fabs(xyz(2)));
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(1) < absolute_y_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(0) < absolute_x_axis_tolerance_ + std::numeric_limits<double>::epsilon();

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -58,7 +58,59 @@ static double normalizeAngle(double angle)
   return v;
 }
 
-KinematicConstraint::KinematicConstraint(const robot_model::RobotModelConstPtr& model)
+// Normalizes an angle to the interval [-pi, +pi] and then take the absolute value
+// The returned values will be in the following range [0, +pi]
+static double normalizeAbsoluteAngle(const double angle)
+{
+  const double normalized_angle = std::fmod(std::abs(angle), 2 * M_PI);
+  return std::min(2 * M_PI - normalized_angle, normalized_angle);
+}
+
+/**
+ * This's copied from
+ * https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/src/EulerAngles/EulerSystem.h#L187
+ * Return the intrinsic Roll-Pitch-Yaw euler angles given the input rotation matrix and boolean indicating whether the
+ * there's a singularity in the input rotation matrix (true: the input rotation matrix don't have a singularity, false:
+ * the input rotation matrix have a singularity) The returned angles are in the ranges [-pi:pi]x[-pi/2:pi/2]x[-pi:pi]
+ */
+template <typename Derived>
+std::tuple<Eigen::Matrix<typename Eigen::MatrixBase<Derived>::Scalar, 3, 1>, bool>
+CalcEulerAngles(const Eigen::MatrixBase<Derived>& R)
+{
+  using std::atan2;
+  using std::sqrt;
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived, 3, 3)
+  using Index = EIGEN_DEFAULT_DENSE_INDEX_TYPE;
+  using Scalar = typename Eigen::MatrixBase<Derived>::Scalar;
+  const Index i = 0;
+  const Index j = 1;
+  const Index k = 2;
+  Eigen::Matrix<Scalar, 3, 1> res;
+  const Scalar rsum = sqrt((R(i, i) * R(i, i) + R(i, j) * R(i, j) + R(j, k) * R(j, k) + R(k, k) * R(k, k)) / 2);
+  res[1] = atan2(R(i, k), rsum);
+  // There is a singularity when cos(beta) == 0
+  if (rsum > 4 * Eigen::NumTraits<Scalar>::epsilon())
+  {  // cos(beta) != 0
+    res[0] = atan2(-R(j, k), R(k, k));
+    res[2] = atan2(-R(i, j), R(i, i));
+    return { res, true };
+  }
+  else if (R(i, k) > 0)
+  {                                         // cos(beta) == 0 and sin(beta) == 1
+    const Scalar spos = R(j, i) + R(k, j);  // 2*sin(alpha + gamma)
+    const Scalar cpos = R(j, j) - R(k, i);  // 2*cos(alpha + gamma)
+    res[0] = atan2(spos, cpos);
+    res[2] = 0;
+    return { res, false };
+  }                                       // cos(beta) == 0 and sin(beta) == -1
+  const Scalar sneg = R(k, j) - R(j, i);  // 2*sin(alpha + gamma)
+  const Scalar cneg = R(j, j) + R(k, i);  // 2*cos(alpha + gamma)
+  res[0] = atan2(sneg, cneg);
+  res[2] = 0;
+  return { res, false };
+}
+
+KinematicConstraint::KinematicConstraint(const moveit::core::RobotModelConstPtr& model)
   : type_(UNKNOWN_CONSTRAINT), robot_model_(model), constraint_weight_(std::numeric_limits<double>::epsilon())
 {
 }
@@ -600,25 +652,41 @@ ConstraintEvaluationResult OrientationConstraint::decide(const robot_state::Robo
   if (!link_model_)
     return ConstraintEvaluationResult(true, 0.0);
 
-  Eigen::Vector3d xyz;
+  std::tuple<Eigen::Vector3d, bool> euler_angles_error;
   if (mobile_frame_)
   {
-    Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).rotation() * desired_rotation_matrix_;
-    Eigen::Isometry3d diff(tmp.transpose() * state.getGlobalLinkTransform(link_model_).rotation());
-    xyz = diff.rotation().eulerAngles(0, 1, 2);
-    // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
+    // getFrameTransform() returns a valid isometry by contract
+    Eigen::Matrix3d tmp = state.getFrameTransform(desired_rotation_frame_id_).linear() * desired_rotation_matrix_;
+    // getGlobalLinkTransform() returns a valid isometry by contract
+    Eigen::Isometry3d diff(tmp.transpose() * state.getGlobalLinkTransform(link_model_).linear());  // valid isometry
+    euler_angles_error = CalcEulerAngles(diff.linear());
   }
   else
   {
-    Eigen::Isometry3d diff(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).rotation());
-    xyz =
-        diff.rotation().eulerAngles(0, 1, 2);  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
+    // diff is valid isometry by construction
+    Eigen::Isometry3d diff(desired_rotation_matrix_inv_ * state.getGlobalLinkTransform(link_model_).linear());
+    euler_angles_error = CalcEulerAngles(diff.linear());
   }
 
+  // Converting from a rotation matrix to an intrinsic XYZ euler angles have 2 singularities:
+  // pitch ~= pi/2 ==> roll + yaw = theta
+  // pitch ~= -pi/2 ==> roll - yaw = theta
+  // in those cases CalcEulerAngles will set roll (xyz(0)) to theta and yaw (xyz(2)) to zero, so for us to be able to
+  // capture yaw tolerance violation we do the following, if theta violate the absolute yaw tolerance we think of it as
+  // pure yaw rotation and set roll to zero
+  auto& xyz = std::get<Eigen::Vector3d>(euler_angles_error);
+  if (!std::get<bool>(euler_angles_error))
+  {
+    if (normalizeAbsoluteAngle(xyz(0)) > absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon())
+    {
+      xyz(2) = xyz(0);
+      xyz(0) = 0;
+    }
+  }
   // Account for angle wrapping
-  xyz(0) = std::min(fabs(xyz(0)), boost::math::constants::two_pi<double>() - fabs(xyz(0)));
-  xyz(1) = std::min(fabs(xyz(1)), boost::math::constants::two_pi<double>() - fabs(xyz(1)));
-  xyz(2) = std::min(fabs(xyz(2)), boost::math::constants::two_pi<double>() - fabs(xyz(2)));
+  xyz = xyz.unaryExpr(&normalizeAbsoluteAngle);
+
+  // 0,1,2 corresponds to XYZ, the convention used in sampling constraints
   bool result = xyz(2) < absolute_z_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(1) < absolute_y_axis_tolerance_ + std::numeric_limits<double>::epsilon() &&
                 xyz(0) < absolute_x_axis_tolerance_ + std::numeric_limits<double>::epsilon();

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -40,6 +40,7 @@
 #include <fstream>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/utils/robot_model_test_utils.h>
+#include <boost/math/constants/constants.hpp>
 
 class LoadPlanningModelsPr2 : public testing::Test
 {
@@ -649,6 +650,12 @@ TEST_F(LoadPlanningModelsPr2, OrientationConstraintsSimple)
   EXPECT_TRUE(oc.decide(robot_state).satisfied);
 
   jvals["r_wrist_roll_joint"] = .11;
+  robot_state.setVariablePositions(jvals);
+  robot_state.update();
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  // rotation by pi does not wrap to zero
+  jvals["r_wrist_roll_joint"] = boost::math::constants::pi<double>();
   robot_state.setVariablePositions(jvals);
   robot_state.update();
   EXPECT_FALSE(oc.decide(robot_state).satisfied);

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -1,0 +1,244 @@
+#include <moveit/kinematic_constraints/kinematic_constraint.h>
+#include <gtest/gtest.h>
+#include <urdf_parser/urdf_parser.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <boost/math/constants/constants.hpp>
+
+class SphericalRobot : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    moveit::core::RobotModelBuilder builder("robot", "base_link");
+    geometry_msgs::Pose origin;
+    origin.orientation.w = 1;
+    builder.addChain("base_link->roll", "revolute", { origin }, urdf::Vector3(1, 0, 0));
+    builder.addChain("roll->pitch", "revolute", { origin }, urdf::Vector3(0, 1, 0));
+    builder.addChain("pitch->yaw", "revolute", { origin }, urdf::Vector3(0, 0, 1));
+    ASSERT_TRUE(builder.isValid());
+    robot_model_ = builder.build();
+  }
+
+  std::map<std::string, double> getJointValues(const double roll, const double pitch, const double yaw)
+  {
+    std::map<std::string, double> jvals;
+    jvals["base_link-roll-joint"] = roll;
+    jvals["roll-pitch-joint"] = pitch;
+    jvals["pitch-yaw-joint"] = yaw;
+    return jvals;
+  }
+
+  void TearDown() override
+  {
+  }
+
+protected:
+  moveit::core::RobotModelPtr robot_model_;
+};
+
+TEST_F(SphericalRobot, Test1)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.8;
+  ocm.absolute_y_axis_tolerance = 0.8;
+  ocm.absolute_z_axis_tolerance = 3.15;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // This's identical to a -1.57rad rotation around Z-axis
+  robot_state.setVariablePositions(getJointValues(3.140208, 3.141588, 1.570821));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_TRUE(oc.decide(robot_state).satisfied);
+}
+
+TEST_F(SphericalRobot, Test2)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.2;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.2;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // Singularity: roll + yaw = theta
+  // These violate either absolute_x_axis_tolerance or absolute_z_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.15, boost::math::constants::half_pi<double>(), 0.15));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.21, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  // Singularity: roll - yaw = theta
+  // This's identical to -pi/2 pitch rotation
+  robot_state.setVariablePositions(getJointValues(0.15, -boost::math::constants::half_pi<double>(), 0.15));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_TRUE(oc.decide(robot_state).satisfied);
+}
+
+TEST_F(SphericalRobot, Test3)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.2;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.3;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // Singularity: roll + yaw = theta
+
+  // These tests violate absolute_x_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  ocm.absolute_x_axis_tolerance = 0.3;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.2;
+
+  // These tests violate absolute_z_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+}
+
+TEST_F(SphericalRobot, Test4)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  ocm.orientation.x = 0.0;
+  ocm.orientation.y = 0.0;
+  ocm.orientation.z = 0.0;
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.2;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.3;
+  ocm.weight = 1.0;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  // Singularity: roll + yaw = theta
+
+  // These tests violate absolute_x_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, -boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, -boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  ocm.absolute_x_axis_tolerance = 0.3;
+  ocm.absolute_y_axis_tolerance = 2.0;
+  ocm.absolute_z_axis_tolerance = 0.2;
+
+  // These tests violate absolute_z_axis_tolerance
+  robot_state.setVariablePositions(getJointValues(0.21, -boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.0, -boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+
+  robot_state.setVariablePositions(getJointValues(0.5, -boost::math::constants::half_pi<double>(), 0.21));
+  robot_state.update();
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_FALSE(oc.decide(robot_state).satisfied);
+}
+
+// Both the current and the desired orientations are in singularities
+TEST_F(SphericalRobot, Test5)
+{
+  kinematic_constraints::OrientationConstraint oc(robot_model_);
+
+  moveit::core::Transforms tf(robot_model_->getModelFrame());
+  moveit_msgs::OrientationConstraint ocm;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setVariablePositions(getJointValues(0.0, boost::math::constants::half_pi<double>(), 0.0));
+  robot_state.update();
+
+  ocm.link_name = "yaw";
+  ocm.header.frame_id = robot_model_->getModelFrame();
+  tf2::convert(Eigen::Quaterniond(robot_state.getGlobalLinkTransform(ocm.link_name).linear()), ocm.orientation);
+  ocm.absolute_x_axis_tolerance = 0.0;
+  ocm.absolute_y_axis_tolerance = 0.0;
+  ocm.absolute_z_axis_tolerance = 1.0;
+  ocm.weight = 1.0;
+
+  robot_state.setVariablePositions(getJointValues(0.2, boost::math::constants::half_pi<double>(), 0.3));
+  robot_state.update();
+
+  EXPECT_TRUE(oc.configure(ocm, tf));
+  EXPECT_TRUE(oc.decide(robot_state, true).satisfied);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -412,6 +412,13 @@ public:
     return variable_count_;
   }
 
+  /** \brief Get the number of variables that describe the active joints in this joint group. This excludes variables
+      necessary for mimic joints. */
+  unsigned int getActiveVariableCount() const
+  {
+    return active_variable_count_;
+  }
+
   /** \brief Set the names of the subgroups for this group */
   void setSubgroupNames(const std::vector<std::string>& subgroups);
 
@@ -694,6 +701,9 @@ protected:
 
   /** \brief The number of variables necessary to describe this group of joints */
   unsigned int variable_count_;
+
+  /** \brief The number of variables necessary to describe the active joints in this group of joints */
+  unsigned int active_variable_count_;
 
   /** \brief True if the state of this group is contiguous within the full robot state; this also means that
       the index values in variable_index_list_ are consecutive integers */

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -337,7 +337,17 @@ public:
   }
   double getMaximumExtent(const JointBoundsVector& active_joint_bounds) const;
 
+  /** \brief Return the sum of joint distances between two states. Only considers active joints. */
   double distance(const double* state1, const double* state2) const;
+
+  /**
+   * Interpolate between "from" state, to "to" state. Mimic joints are correctly updated.
+   *
+   * @param from interpolate from this state
+   * @param to to this state
+   * @param t a fraction in the range [0 1]. If 1, the result matches "to" state exactly.
+   * @param state holds the result
+   */
   void interpolate(const double* from, const double* to, double t, double* state) const;
 
   /** \name Access to joint groups

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -164,6 +164,12 @@ public:
     return active_joint_model_vector_const_;
   }
 
+  /** \brief Get the array of active joint names, in the order they appear in the robot state. */
+  const std::vector<std::string>& getActiveJointModelNames() const
+  {
+    return active_joint_model_names_vector_;
+  }
+
   /** \brief Get the array of joints that are active (not fixed, not mimic) in this model */
   const std::vector<JointModel*>& getActiveJointModels()
   {
@@ -513,6 +519,9 @@ protected:
 
   /** \brief The vector of joints in the model, in the order they appear in the state vector */
   std::vector<JointModel*> active_joint_model_vector_;
+
+  /** \brief The vector of joint names that corresponds to active_joint_model_vector_ */
+  std::vector<std::string> active_joint_model_names_vector_;
 
   /** \brief The vector of joints in the model, in the order they appear in the state vector */
   std::vector<const JointModel*> active_joint_model_vector_const_;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -105,6 +105,7 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
   , name_(group_name)
   , common_root_(nullptr)
   , variable_count_(0)
+  , active_variable_count_(0)
   , is_contiguous_index_list_(true)
   , is_chain_(false)
   , is_single_dof_(true)
@@ -133,6 +134,7 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
         active_joint_model_name_vector_.push_back(joint_model_vector_[i]->getName());
         active_joint_model_start_index_.push_back(variable_count_);
         active_joint_models_bounds_.push_back(&joint_model_vector_[i]->getVariableBounds());
+        active_variable_count_ += vc;
       }
       else
         mimic_joints_.push_back(joint_model_vector_[i]);

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -271,6 +271,7 @@ void RobotModel::buildJointInfo()
       {
         active_joint_model_start_index_.push_back(variable_count_);
         active_joint_model_vector_.push_back(joint_model_vector_[i]);
+        active_joint_model_names_vector_.push_back(joint_model_vector_[i]->getName());
         active_joint_model_vector_const_.push_back(joint_model_vector_[i]);
         active_joint_models_bounds_.push_back(&joint_model_vector_[i]->getVariableBounds());
       }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1521,32 +1521,52 @@ as the new values that correspond to the group */
    *  @{
    */
 
+  /** \brief Return the sum of joint distances to "other" state. Only considers active joints. */
   double distance(const RobotState& other) const
   {
     return robot_model_->distance(position_, other.getVariablePositions());
   }
 
+  /** \brief Return the sum of joint distances to "other" state. Only considers active joints. */
   double distance(const RobotState& other, const JointModelGroup* joint_group) const;
 
+  /** \brief Return the sum of joint distances to "other" state. Only considers active joints. */
   double distance(const RobotState& other, const JointModel* joint) const
   {
     const int idx = joint->getFirstVariableIndex();
     return joint->distance(position_ + idx, other.position_ + idx);
   }
 
-  /** \brief Interpolate from this state towards state \e to, at time \e t in [0,1].
-      The result is stored in \e state, mimic joints are correctly updated and flags are set
-      so that FK is recomputed when needed. */
+  /**
+   * Interpolate towards "to" state. Mimic joints are correctly updated and flags are set so that FK is recomputed
+   * when needed.
+   *
+   * @param to interpolate to this state
+   * @param t a fraction in the range [0 1]. If 1, the result matches "to" state exactly.
+   * @param state holds the result
+   */
   void interpolate(const RobotState& to, double t, RobotState& state) const;
 
-  /** \brief Interpolate from this state towards \e to, at time \e t in [0,1], but only for the joints in the
-      specified group. If mimic joints need to be updated, they are updated accordingly. Flags are set so that FK
-      computation is triggered when needed. */
+  /**
+   * Interpolate towards "to" state, but only for the joints in the specified group. Mimic joints are correctly updated
+   * and flags are set so that FK is recomputed when needed.
+   *
+   * @param to interpolate to this state
+   * @param t a fraction in the range [0 1]. If 1, the result matches "to" state exactly.
+   * @param state holds the result
+   * @param joint_group interpolate only for the joints in this group
+   */
   void interpolate(const RobotState& to, double t, RobotState& state, const JointModelGroup* joint_group) const;
 
-  /** \brief Update \e state by interpolating form this state towards \e to, at time \e t in [0,1] but only for
-      the joint \e joint. If there are joints that mimic this joint, they are updated. Flags are set so that
-      FK computation is triggered as needed. */
+  /**
+   * Interpolate towards "to" state, but only for a single joint. Mimic joints are correctly updated
+   * and flags are set so that FK is recomputed when needed.
+   *
+   * @param to interpolate to this state
+   * @param t a fraction in the range [0 1]. If 1, the result matches "to" state exactly.
+   * @param state holds the result
+   * @param joint interpolate only for this joint
+   */
   void interpolate(const RobotState& to, double t, RobotState& state, const JointModel* joint) const
   {
     const int idx = joint->getFirstVariableIndex();

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -951,22 +951,6 @@ as the new values that correspond to the group */
    *  @{
    */
 
-  /**
-   * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
-   * @param pose - the input to change
-   * @param solver - a kin solver whose base frame is important to us
-   * @return true if no error
-   */
-  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
-
-  /**
-   * \brief Convert the frame of reference of the pose to that same frame as the IK solver expects
-   * @param pose - the input to change
-   * @param ik_frame - the name of frame of reference of base of ik solver
-   * @return true if no error
-   */
-  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
-
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
       The pose is assumed to be in the reference frame of the kinematic model. Returns true on success.
@@ -1831,6 +1815,22 @@ private:
   void allocMemory();
   void initTransforms();
   void copyFrom(const RobotState& other);
+
+  /**
+   * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
+   * @param pose - the input to change
+   * @param solver - a kin solver whose base frame is important to us
+   * @return true if no error
+   */
+  inline bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
+
+  /**
+   * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
+   * @param pose - the input to change
+   * @param ik_frame - the name of frame of reference of base of ik solver
+   * @return true if no error
+   */
+  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
 
   void markDirtyJointTransforms(const JointModel* joint)
   {

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1831,18 +1831,13 @@ as the new values that correspond to the group */
 
   std::string getStateTreeString(const std::string& prefix = "") const;
 
-private:
-  void allocMemory();
-  void initTransforms();
-  void copyFrom(const RobotState& other);
-
   /**
    * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
    * @param pose - the input to change
    * @param solver - a kin solver whose base frame is important to us
    * @return true if no error
    */
-  inline bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
+  bool setToIKSolverFrame(Eigen::Isometry3d& pose, const kinematics::KinematicsBaseConstPtr& solver);
 
   /**
    * \brief Transform pose from the robot model's base frame to the reference frame of the IK solver
@@ -1851,6 +1846,11 @@ private:
    * @return true if no error
    */
   bool setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& ik_frame);
+
+private:
+  void allocMemory();
+  void initTransforms();
+  void copyFrom(const RobotState& other);
 
   void markDirtyJointTransforms(const JointModel* joint)
   {

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -656,7 +656,10 @@ as the new values that correspond to the group */
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
     if (jmg)
+    {
+      assert(gstate.size() == jmg->getVariableCount());
       setJointGroupPositions(jmg, &gstate[0]);
+    }
   }
 
   /** \brief Given positions for the variables that make up a group, in the order found in the group (including values
@@ -664,6 +667,7 @@ of mimic joints), set those
 as the new values that correspond to the group */
   void setJointGroupPositions(const JointModelGroup* group, const std::vector<double>& gstate)
   {
+    assert(gstate.size() == group->getVariableCount());
     setJointGroupPositions(group, &gstate[0]);
   }
 
@@ -679,13 +683,52 @@ as the new values that correspond to the group */
   {
     const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
     if (jmg)
+    {
+      assert(values.size() == jmg->getVariableCount());
       setJointGroupPositions(jmg, values);
+    }
   }
 
   /** \brief Given positions for the variables that make up a group, in the order found in the group (including values
 of mimic joints), set those
 as the new values that correspond to the group */
   void setJointGroupPositions(const JointModelGroup* group, const Eigen::VectorXd& values);
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const JointModelGroup* group, const std::vector<double>& gstate);
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const std::string& joint_group_name, const std::vector<double>& gstate)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+    {
+      assert(gstate.size() == jmg->getActiveVariableCount());
+      setJointGroupActivePositions(jmg, gstate);
+    }
+  }
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const JointModelGroup* group, const Eigen::VectorXd& values);
+
+  /** \brief Given positions for the variables of active joints that make up a group,
+   * in the order found in the group (excluding values of mimic joints), set those
+   * as the new values that correspond to the group */
+  void setJointGroupActivePositions(const std::string& joint_group_name, const Eigen::VectorXd& values)
+  {
+    const JointModelGroup* jmg = robot_model_->getJointModelGroup(joint_group_name);
+    if (jmg)
+    {
+      assert(values.size() == jmg->getActiveVariableCount());
+      setJointGroupActivePositions(jmg, values);
+    }
+  }
 
   /** \brief For a given group, copy the position values of the variables that make up the group into another location,
    * in the order that the variables are found in the group. This is not necessarily a contiguous block of memory in the

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -91,10 +91,16 @@ struct JumpThreshold
 
 /** \brief Struct for containing max_step for computeCartesianPath
 
-    Setting translation to zero will disable checking for translations and the same goes for rotation */
+    Setting translation to zero will disable checking for translations. The same goes for rotation.
+    Initializing with only one value (translation) sets the rotation such that
+    1 cm of allowed translation = 2 degrees of allowed rotation. */
 struct MaxEEFStep
 {
-  MaxEEFStep(double translation = 0.0, double rotation = 0.0) : translation(translation), rotation(rotation)
+  MaxEEFStep(double translation, double rotation) : translation(translation), rotation(rotation)
+  {
+  }
+
+  MaxEEFStep(double step_size) : translation(step_size), rotation(3.5 * step_size)  // 0.035 rad = 2 deg
   {
   }
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -519,6 +519,30 @@ void RobotState::setJointGroupPositions(const JointModelGroup* group, const Eige
   updateMimicJoints(group);
 }
 
+void RobotState::setJointGroupActivePositions(const JointModelGroup* group, const std::vector<double>& gstate)
+{
+  assert(gstate.size() == group->getActiveVariableCount());
+  std::size_t i = 0;
+  for (const JointModel* jm : group->getActiveJointModels())
+  {
+    setJointPositions(jm, &gstate[i]);
+    i += jm->getVariableCount();
+  }
+  updateMimicJoints(group);
+}
+
+void RobotState::setJointGroupActivePositions(const JointModelGroup* group, const Eigen::VectorXd& values)
+{
+  assert(values.size() == group->getActiveVariableCount());
+  std::size_t i = 0;
+  for (const JointModel* jm : group->getActiveJointModels())
+  {
+    setJointPositions(jm, &values(i));
+    i += jm->getVariableCount();
+  }
+  updateMimicJoints(group);
+}
+
 void RobotState::copyJointGroupPositions(const JointModelGroup* group, double* gstate) const
 {
   const std::vector<int>& il = group->getVariableIndexList();

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -261,12 +261,12 @@ void RobotState::dropVelocities()
 
 void RobotState::dropAccelerations()
 {
-  has_velocity_ = false;
+  has_acceleration_ = false;
 }
 
 void RobotState::dropEffort()
 {
-  has_velocity_ = false;
+  has_effort_ = false;
 }
 
 void RobotState::dropDynamics()

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/round_collada_numbers.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/round_collada_numbers.py
@@ -39,6 +39,8 @@
 # Author: Dave Coleman
 # Desc:   Rounds all the numbers to <decimal places> places
 
+from __future__ import print_function
+
 from lxml import etree
 import shlex
 import sys
@@ -78,7 +80,7 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     print("\nCollada Number Rounder")
-    print("Rounding numbers to", decimal_places, " decimal places\n")
+    print("Rounding numbers to", decimal_places, "decimal places\n")
 
     # Read string from file
     f = open(input_file, "r")

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -69,8 +69,13 @@ void CHOMPInterface::loadParams()
   nh_.param("collision_threshold", params_.collision_threshold_, 0.07);
   // nh_.param("random_jump_amount", params_.random_jump_amount_, 1.0);
   nh_.param("use_stochastic_descent", params_.use_stochastic_descent_, true);
-  nh_.param("trajectory_initialization_method", params_.trajectory_initialization_method_,
-            std::string("quintic-spline"));
+  {
+    params_.trajectory_initialization_method_ = "quintic-spline";
+    std::string method;
+    if (nh_.getParam("trajectory_initialization_method", method) && !params_.setTrajectoryInitializationMethod(method))
+      ROS_ERROR_STREAM("Attempted to set trajectory_initialization_method to invalid value '"
+                       << method << "'. Using default '" << params_.trajectory_initialization_method_ << "' instead.");
+  }
   nh_.param("enable_failure_recovery", params_.enable_failure_recovery_, false);
   nh_.param("max_recovery_attempts", params_.max_recovery_attempts_, 5);
 }

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -57,6 +57,12 @@ public:
    */
   void setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations);
 
+  /**
+   * sets a valid trajectory initialization method
+   * @return true if a valid method (one of VALID_INITIALIZATION_METHODS) was specified
+   */
+  bool setTrajectoryInitializationMethod(std::string method);
+
 public:
   double planning_time_limit_;  /// maximum time the optimizer can take to find a solution before terminating
   int max_iterations_;          /// maximum number of iterations that the planner can take to find a good solution while
@@ -90,7 +96,10 @@ public:
   double collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
   bool filter_mode_;
   // double random_jump_amount_;
+
+  static const std::vector<std::string> VALID_INITIALIZATION_METHODS;
   std::string trajectory_initialization_method_;  /// trajectory initialization method to be specified
+
   bool enable_failure_recovery_;  /// if set to true, CHOMP tries to vary certain parameters to try and find a path if
                                   /// an initial path is not found with the specified chomp parameters
   int max_recovery_attempts_;     /// this the maximum recovery attempts to find a collision free path after an initial

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -80,4 +80,18 @@ void ChompParameters::setRecoveryParams(double learning_rate, double ridge_facto
   this->planning_time_limit_ = planning_time_limit;
   this->max_iterations_ = max_iterations;
 }
+
+const std::vector<std::string> ChompParameters::VALID_INITIALIZATION_METHODS{ "quintic-spline", "linear", "cubic",
+                                                                              "fillTrajectory" };
+
+bool ChompParameters::setTrajectoryInitializationMethod(std::string method)
+{
+  if (std::find(VALID_INITIALIZATION_METHODS.cbegin(), VALID_INITIALIZATION_METHODS.cend(), method) !=
+      VALID_INITIALIZATION_METHODS.end())
+  {
+    this->trajectory_initialization_method_ = std::move(method);
+    return true;
+  }
+  return false;
+}
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -136,7 +136,10 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     }
   }
   else
+  {
     ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
+    return false;
+  }
 
   ROS_INFO_NAMED("chomp_planner", "CHOMP trajectory initialized using method: %s ",
                  (params.trajectory_initialization_method_).c_str());

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -149,7 +149,7 @@ public:
     // default
     params_.trajectory_initialization_method_ = std::string("fillTrajectory");
     std::string trajectory_initialization_method;
-    if (!nh.getParam("trajectory_initialization_method", trajectory_initialization_method))
+    if (!nh_.getParam("trajectory_initialization_method", trajectory_initialization_method))
     {
       ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using value: "
                       << params_.trajectory_initialization_method_);

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -146,11 +146,19 @@ public:
       ROS_INFO_STREAM(
           "Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_);
     }
-    if (!nh_.getParam("trajectory_initialization_method", params_.trajectory_initialization_method_))
+    // default
+    params_.trajectory_initialization_method_ = std::string("fillTrajectory");
+    std::string trajectory_initialization_method;
+    if (!nh.getParam("trajectory_initialization_method", trajectory_initialization_method))
     {
-      params_.trajectory_initialization_method_ = std::string("fillTrajectory");
-      ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using New value as: "
+      ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using value: "
                       << params_.trajectory_initialization_method_);
+    }
+    else if (!params_.setTrajectoryInitializationMethod(trajectory_initialization_method))
+    {
+      ROS_ERROR_STREAM("Param trajectory_initialization_method set to invalid value '"
+                       << trajectory_initialization_method << "'. Using '" << params_.trajectory_initialization_method_
+                       << "' instead.");
     }
   }
 

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -9,6 +9,7 @@ add_definitions(-Wno-unused-parameter)
 
 find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
+  joint_limits_interface
   kdl_conversions
   moveit_core
   moveit_msgs

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1.3)
 project(pilz_industrial_motion_planner)
 
 ## Add support for C++11, supported in ROS Kinetic and newer

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -38,6 +38,7 @@
 
 #include <map>
 #include <vector>
+#include <string>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_extension.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_extension.h
@@ -37,6 +37,7 @@
 
 #include <joint_limits_interface/joint_limits.h>
 #include <map>
+#include <string>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -61,18 +61,18 @@ namespace pilz_industrial_motion_planner
  * @param solution: solution of IK
  * @param check_self_collision: true to enable self collision checking after IK
  * computation
- * @param max_attempt: maximal attempts of IK
+ * @param timeout: timeout for IK, if not set the default solver timeout is used
  * @return true if succeed
  */
 bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
                    const std::string& link_name, const Eigen::Isometry3d& pose, const std::string& frame_id,
                    const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
-                   bool check_self_collision = true, const double timeout = 0.1);
+                   bool check_self_collision = true, const double timeout = 0.0);
 
 bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model, const std::string& group_name,
                    const std::string& link_name, const geometry_msgs::Pose& pose, const std::string& frame_id,
                    const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
-                   bool check_self_collision = true, const double timeout = 0.1);
+                   bool check_self_collision = true, const double timeout = 0.0);
 
 /**
  * @brief compute the pose of a link at give robot state

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>eigen_conversions</depend>
+  <depend>joint_limits_interface</depend>
   <depend>kdl_conversions</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_msgs</depend>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -60,7 +60,15 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   // collect most strict joint limits for each group in robot model
   for (const auto& jmg : robot_model->getJointModelGroups())
   {
-    JointLimit most_strict_limit = joint_limits_.getCommonLimit(jmg->getActiveJointModelNames());
+    auto active_joints = jmg->getActiveJointModelNames();
+
+    // no active joints
+    if (active_joints.empty())
+    {
+      continue;
+    }
+
+    JointLimit most_strict_limit = joint_limits_.getCommonLimit(active_joints);
 
     if (!most_strict_limit.has_velocity_limits)
     {

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1.3)
 project(pilz_industrial_motion_planner_testutils)
 
 ## Add support for C++11, supported in ROS Kinetic and newer

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -75,7 +75,10 @@ void MoveGroupKinematicsService::computeIK(moveit_msgs::PositionIKRequest& req, 
   const robot_state::JointModelGroup* jmg = rs.getJointModelGroup(req.group_name);
   if (jmg)
   {
-    robot_state::robotStateMsgToRobotState(req.robot_state, rs);
+    if (!planning_scene::PlanningScene::isEmpty(req.robot_state))
+    {
+      moveit::core::robotStateMsgToRobotState(req.robot_state, rs);
+    }
     const std::string& default_frame = context_->planning_scene_monitor_->getRobotModel()->getModelFrame();
 
     if (req.pose_stamped_vector.empty() || req.pose_stamped_vector.size() == 1)

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -165,22 +165,22 @@ install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
+  # basic functionality
+  add_rostest_gtest(basic_servo_tests
+    test/basic_servo_tests.test
+    test/basic_servo_tests.cpp
+  )
+  target_link_libraries(basic_servo_tests
+    ${SERVO_LIB_NAME}
+    ${catkin_LIBRARIES}
+  )
+
   # servo_cpp_interface
   add_rostest_gtest(servo_cpp_interface_test
     test/servo_cpp_interface_test.test
     test/servo_cpp_interface_test.cpp
   )
   target_link_libraries(servo_cpp_interface_test
-    ${SERVO_LIB_NAME}
-    ${catkin_LIBRARIES}
-  )
-
-  # low_latency
-  add_rostest_gtest(servo_low_latency_test
-    test/servo_low_latency_test.test
-    test/servo_low_latency_test.cpp
-  )
-  target_link_libraries(servo_low_latency_test
     ${SERVO_LIB_NAME}
     ${catkin_LIBRARIES}
   )

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -175,6 +175,16 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
   )
 
+  # low_latency
+  add_rostest_gtest(servo_low_latency_test
+    test/servo_low_latency_test.test
+    test/servo_low_latency_test.cpp
+  )
+  target_link_libraries(servo_low_latency_test
+    ${SERVO_LIB_NAME}
+    ${catkin_LIBRARIES}
+  )
+
   # pose_tracking
   add_rostest_gtest(pose_tracking_test
     test/pose_tracking_test.test

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -92,10 +92,7 @@ public:
                                     const double target_pose_timeout);
 
   /** \brief A method for a different thread to stop motion and return early from control loop */
-  void stopMotion()
-  {
-    stop_requested_ = true;
-  }
+  void stopMotion();
 
   /** \brief Change PID parameters. Motion is stopped before the udpate */
   void updatePIDConfig(const double x_proportional_gain, const double x_integral_gain, const double x_derivative_gain,

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <atomic>
+#include <boost/optional.hpp>
 #include <control_toolbox/pid.h>
 #include <moveit_servo/make_shared_from_pool.h>
 #include <moveit_servo/servo.h>
@@ -187,7 +188,7 @@ private:
   // Flag that a different thread has requested a stop.
   std::atomic<bool> stop_requested_;
 
-  double angular_error_;
+  boost::optional<double> angular_error_;
 };
 
 // using alias

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -114,6 +114,9 @@ public:
    */
   bool getCommandFrameTransform(geometry_msgs::TransformStamped& transform);
 
+  /** \brief Re-initialize the target pose to an empty message. Can be used to reset motion between waypoints. */
+  void resetTargetPose();
+
   // moveit_servo::Servo instance. Public so we can access member functions like setPaused()
   std::unique_ptr<moveit_servo::Servo> servo_;
 
@@ -170,6 +173,7 @@ private:
   Eigen::Isometry3d command_frame_transform_;
   ros::Time command_frame_transform_stamp_;
   geometry_msgs::PoseStamped target_pose_;
+  mutable std::mutex target_pose_mtx_;
 
   // Subscribe to target pose
   ros::Subscriber target_pose_sub_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -38,11 +38,16 @@
 
 #pragma once
 
+// System
 #include <memory>
 
+// MoveIt
 #include <moveit_servo/collision_check.h>
 #include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/servo_calcs.h>
+
+// testing
+#include <gtest/gtest.h>
 
 namespace moveit_servo
 {
@@ -92,6 +97,9 @@ public:
   {
     servo_calcs_->changeRobotLinkCommandFrame(new_command_frame);
   }
+
+  // Give test access to private/protected methods
+  friend class ServoFixture;
 
 private:
   bool readParameters();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -39,7 +39,9 @@
 #pragma once
 
 // C++
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 
 // ROS
 #include <control_msgs/JointJog.h>
@@ -69,10 +71,7 @@ public:
   ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
              const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
-  ~ServoCalcs()
-  {
-    timer_.stop();
-  }
+  ~ServoCalcs();
 
   /** \brief Start the timer where we do work and publish outputs */
   void start();
@@ -106,8 +105,14 @@ public:
   void changeRobotLinkCommandFrame(const std::string& new_command_frame);
 
 private:
-  /** \brief Timer method */
-  void run(const ros::TimerEvent& timer_event);
+  /** \brief Run the main calculation loop */
+  void mainCalcLoop();
+
+  /** \brief Do calculations for a single iteration. Publish one outgoing command */
+  void calculateSingleIteration();
+
+  /** \brief Stop the currently running thread */
+  void stop();
 
   /** \brief Do servoing calculations for Cartesian twist commands. */
   bool cartesianServoCalcs(geometry_msgs::TwistStamped& cmd, trajectory_msgs::JointTrajectory& joint_trajectory);
@@ -257,8 +262,6 @@ private:
   trajectory_msgs::JointTrajectoryConstPtr last_sent_command_;
 
   // ROS
-  ros::Timer timer_;
-  ros::Duration period_;
   ros::Subscriber joint_state_sub_;
   ros::Subscriber twist_stamped_sub_;
   ros::Subscriber joint_cmd_sub_;
@@ -269,6 +272,10 @@ private:
   ros::ServiceServer drift_dimensions_server_;
   ros::ServiceServer control_dimensions_server_;
   ros::ServiceServer reset_servo_status_;
+
+  // Main tracking / result publisher loop
+  std::thread thread_;
+  bool stop_requested_;
 
   // Status
   StatusCode status_ = StatusCode::NO_WARNING;
@@ -292,8 +299,8 @@ private:
   // The dimesions to control. In the command frame. [x, y, z, roll, pitch, yaw]
   std::array<bool, 6> control_dimensions_ = { { true, true, true, true, true, true } };
 
-  // latest_state_mutex_ is used to protect the state below it
-  mutable std::mutex latest_state_mutex_;
+  // input_mutex_ is used to protect the state below it
+  mutable std::mutex input_mutex_;
   Eigen::Isometry3d tf_moveit_to_robot_cmd_frame_;
   Eigen::Isometry3d tf_moveit_to_ee_frame_;
   geometry_msgs::TwistStampedConstPtr latest_twist_stamped_;
@@ -302,5 +309,9 @@ private:
   ros::Time latest_joint_command_stamp_ = ros::Time(0.);
   bool latest_nonzero_twist_stamped_ = false;
   bool latest_nonzero_joint_cmd_ = false;
+
+  // input condition variable used for low latency mode
+  std::condition_variable input_cv_;
+  bool new_input_cmd_ = false;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -42,6 +42,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <atomic>
 
 // ROS
 #include <control_msgs/JointJog.h>

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -104,6 +104,9 @@ public:
    */
   void changeRobotLinkCommandFrame(const std::string& new_command_frame);
 
+  // Give test access to private/protected methods
+  friend class ServoFixture;
+
 private:
   /** \brief Run the main calculation loop */
   void mainCalcLoop();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -279,7 +279,7 @@ private:
 
   // Status
   StatusCode status_ = StatusCode::NO_WARNING;
-  bool paused_ = false;
+  std::atomic<bool> paused_;
   bool twist_command_is_stale_ = false;
   bool joint_command_is_stale_ = false;
   bool ok_to_publish_ = false;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -71,6 +71,7 @@ struct ServoParameters
   bool publish_joint_positions;
   bool publish_joint_velocities;
   bool publish_joint_accelerations;
+  bool low_latency_mode;
   // Collision checking
   bool check_collisions;
   std::string collision_check_type;

--- a/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_example.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_example.cpp
@@ -127,6 +127,10 @@ int main(int argc, char** argv)
   // Modify it a little bit
   target_pose.pose.position.x += 0.1;
 
+  // resetTargetPose() can be used to clear the target pose and wait for a new one, e.g. when moving between multiple
+  // waypoints
+  tracker.resetTargetPose();
+
   // Publish target pose
   target_pose.header.stamp = ros::Time::now();
   target_pose_pub.publish(target_pose);

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -238,6 +238,9 @@ void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& 
       geometry_msgs::TransformStamped target_to_planning_frame = transform_buffer_.lookupTransform(
           planning_frame_, target_pose_.header.frame_id, ros::Time(0), ros::Duration(0.1));
       tf2::doTransform(target_pose_, target_pose_, target_to_planning_frame);
+
+      // Prevent doTransform from copying a stamp of 0, which will cause the haveRecentTargetPose check to fail servo motions
+      target_pose_.header.stamp = ros::Time::now();
     }
     catch (const tf2::TransformException& ex)
     {

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -128,6 +128,11 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 
     // Compute servo command from PID controller output and send it to the Servo object, for execution
     twist_stamped_pub_.publish(calculateTwistCommand());
+
+    if (!loop_rate_.sleep())
+    {
+      ROS_WARN_STREAM_THROTTLE_NAMED(1, LOGNAME, "Target control rate was missed");
+    }
   }
 
   doPostMotionReset();

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -309,8 +309,23 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
   return msg;
 }
 
+void PoseTracking::stopMotion()
+{
+  stop_requested_ = true;
+
+  // Send a 0 command to Servo to halt arm motion
+  auto msg = moveit::util::make_shared_from_pool<geometry_msgs::TwistStamped>();
+  {
+    std::lock_guard<std::mutex> lock(target_pose_mtx_);
+    msg->header.frame_id = target_pose_.header.frame_id;
+  }
+  msg->header.stamp = ros::Time::now();
+  twist_stamped_pub_.publish(msg);
+}
+
 void PoseTracking::doPostMotionReset()
 {
+  stopMotion();
   stop_requested_ = false;
   angular_error_ = boost::none;
 

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -79,6 +79,8 @@ PoseTracking::PoseTracking(const ros::NodeHandle& nh,
 PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positional_tolerance,
                                                 const double angular_tolerance, const double target_pose_timeout)
 {
+  // Reset stop requested flag before starting motions
+  stop_requested_ = false;
   // Wait a bit for a target pose message to arrive.
   // The target pose may get updated by new messages as the robot moves (in a callback function).
   const ros::Time start_time = ros::Time::now();

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -136,7 +136,7 @@ bool Servo::readParameters()
   // 'collision_proximity_threshold' parameter was removed, replaced with separate self- and scene-collision proximity
   // thresholds
   // TODO(JStech): remove this deprecation warning in ROS Noetic; simplify error case handling
-  if (nh_.hasParam("collision_proximity_threshold") &&
+  if (nh.hasParam("collision_proximity_threshold") &&
       rosparam_shortcuts::get(LOGNAME, nh, "collision_proximity_threshold", collision_proximity_threshold))
   {
     ROS_WARN_NAMED(LOGNAME, "'collision_proximity_threshold' parameter is deprecated, and has been replaced by separate"
@@ -168,6 +168,17 @@ bool Servo::readParameters()
     ROS_WARN_NAMED(LOGNAME, "'status_topic' parameter is missing. Recently renamed from 'warning_topic'. Please update "
                             "the servoing yaml file.");
     error += !rosparam_shortcuts::get(LOGNAME, nh, "warning_topic", parameters_.status_topic);
+  }
+
+  if (nh.hasParam("low_latency_mode"))
+  {
+    error += !rosparam_shortcuts::get(LOGNAME, nh, "low_latency_mode", parameters_.low_latency_mode);
+  }
+  else
+  {
+    ROS_WARN_NAMED(LOGNAME, "'low_latency_mode' is a new parameter that runs servo calc immediately after receiving "
+                            "input.  Setting to the default value of false.");
+    parameters_.low_latency_mode = false;
   }
 
   rosparam_shortcuts::shutdownIfError(LOGNAME, error);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -188,8 +188,7 @@ void ServoCalcs::start()
     // I do not know of a robot that takes acceleration commands.
     // However, some controllers check that this data is non-empty.
     // Send all zeros, for now.
-    std::vector<double> acceleration(num_joints_);
-    point.accelerations = acceleration;
+    point.accelerations.resize(num_joints_);
   }
   initial_joint_trajectory->points.push_back(point);
   last_sent_command_ = initial_joint_trajectory;
@@ -835,8 +834,10 @@ void ServoCalcs::suddenHalt(trajectory_msgs::JointTrajectory& joint_trajectory)
   // being 0 seconds in the past, the smallest supported timestep is added as time from start to the trajectory point.
   point.time_from_start.fromNSec(1);
 
-  point.positions.resize(num_joints_);
-  point.velocities.resize(num_joints_);
+  if (parameters_.publish_joint_positions)
+    point.positions.resize(num_joints_);
+  if (parameters_.publish_joint_velocities)
+    point.velocities.resize(num_joints_);
 
   // Assert the following loop is safe to execute
   assert(original_joint_state_.position.size() >= num_joints_);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -86,7 +86,11 @@ geometry_msgs::TransformStamped convertIsometryToTransform(const Eigen::Isometry
 // Constructor for the class that handles servoing calculations
 ServoCalcs::ServoCalcs(ros::NodeHandle& nh, ServoParameters& parameters,
                        const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
-  : nh_(nh), parameters_(parameters), planning_scene_monitor_(planning_scene_monitor), stop_requested_(true)
+  : nh_(nh)
+  , parameters_(parameters)
+  , planning_scene_monitor_(planning_scene_monitor)
+  , stop_requested_(true)
+  , paused_(false)
 {
   // MoveIt Setup
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -231,14 +231,10 @@ void ServoCalcs::mainCalcLoop()
     // lock the input state mutex
     std::unique_lock<std::mutex> input_lock(input_mutex_);
 
-    // low latency mode
+    // low latency mode -- begin calculations as soon as a new command is received.
     if (parameters_.low_latency_mode)
     {
       input_cv_.wait(input_lock, [this] { return (new_input_cmd_ || stop_requested_); });
-
-      // break out of the loop if stop was requested
-      if (stop_requested_)
-        break;
     }
 
     // reset new_input_cmd_ flag

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -758,58 +758,26 @@ double ServoCalcs::velocityScalingFactorForSingularity(const Eigen::VectorXd& co
 
 void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
 {
+  // Convert to joint angle velocities for checking and applying joint specific velocity limits.
   Eigen::ArrayXd velocity = delta_theta / parameters_.publish_period;
 
-  std::size_t joint_delta_index = 0;
-  // Track the smallest velocity scaling factor required, across all joints
-  double velocity_limit_scaling_factor = 1;
-
-  for (auto joint : joint_model_group_->getActiveJointModels())
+  std::size_t joint_delta_index{ 0 };
+  double velocity_scaling_factor{ 1.0 };
+  for (const moveit::core::JointModel* joint : joint_model_group_->getActiveJointModels())
   {
-    // Some joints do not have bounds defined
-    const auto bounds = joint->getVariableBounds(joint->getName());
-
-    if (bounds.velocity_bounded_)
+    const auto& bounds = joint->getVariableBounds(joint->getName());
+    if (bounds.velocity_bounded_ && velocity(joint_delta_index) != 0.0)
     {
-      velocity(joint_delta_index) = delta_theta(joint_delta_index) / parameters_.publish_period;
-
-      bool clip_velocity = false;
-      double velocity_limit = 0.0;
-      if (velocity(joint_delta_index) < bounds.min_velocity_)
-      {
-        clip_velocity = true;
-        velocity_limit = bounds.min_velocity_;
-      }
-      else if (velocity(joint_delta_index) > bounds.max_velocity_)
-      {
-        clip_velocity = true;
-        velocity_limit = bounds.max_velocity_;
-      }
-
-      // Apply velocity bounds
-      if (clip_velocity)
-      {
-        const double scaling_factor =
-            fabs(velocity_limit * parameters_.publish_period) / fabs(delta_theta(joint_delta_index));
-
-        // Store the scaling factor if it's the smallest yet
-        if (scaling_factor < velocity_limit_scaling_factor)
-          velocity_limit_scaling_factor = scaling_factor;
-      }
+      const double unbounded_velocity = velocity(joint_delta_index);
+      // Clamp each joint velocity to a joint specific [min_velocity, max_velocity] range.
+      const auto bounded_velocity = std::min(std::max(unbounded_velocity, bounds.min_velocity_), bounds.max_velocity_);
+      velocity_scaling_factor = std::min(velocity_scaling_factor, bounded_velocity / unbounded_velocity);
     }
     ++joint_delta_index;
   }
 
-  // Apply the velocity scaling to all joints
-  if (velocity_limit_scaling_factor < 1)
-  {
-    for (joint_delta_index = 0; joint_delta_index < joint_model_group_->getActiveJointModels().size();
-         ++joint_delta_index)
-    {
-      delta_theta(joint_delta_index) = velocity_limit_scaling_factor * delta_theta(joint_delta_index);
-      velocity(joint_delta_index) = velocity_limit_scaling_factor * velocity(joint_delta_index);
-    }
-  }
+  // Convert back to joint angle increments.
+  delta_theta = velocity_scaling_factor * velocity * parameters_.publish_period;
 }
 
 bool ServoCalcs::enforcePositionLimits()

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -182,13 +182,13 @@ void ServoCalcs::start()
   initial_joint_trajectory->points.push_back(point);
   last_sent_command_ = initial_joint_trajectory;
 
-  timer_ = nh_.createTimer(period_, &ServoCalcs::run, this);
-
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
   tf_moveit_to_ee_frame_ = current_state_->getGlobalLinkTransform(parameters_.planning_frame).inverse() *
                            current_state_->getGlobalLinkTransform(parameters_.ee_frame_name);
   tf_moveit_to_robot_cmd_frame_ = current_state_->getGlobalLinkTransform(parameters_.planning_frame).inverse() *
                                   current_state_->getGlobalLinkTransform(parameters_.robot_link_command_frame);
+
+  timer_ = nh_.createTimer(period_, &ServoCalcs::run, this);
 }
 
 void ServoCalcs::run(const ros::TimerEvent& timer_event)

--- a/moveit_ros/moveit_servo/test/basic_servo_tests.test
+++ b/moveit_ros/moveit_servo/test/basic_servo_tests.test
@@ -11,7 +11,7 @@
     <param name="publish_frequency" type="double" value="50.0"/>
   </node>
 
-  <test pkg="moveit_servo" type="servo_low_latency_test" test-name="servo_low_latency_test" time-limit="60" args="">
+  <test pkg="moveit_servo" type="basic_servo_tests" test-name="basic_servo_tests" time-limit="60" args="">
     <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
     <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings_low_latency.yaml" ns="optional_parameter_namespace"/>
   </test>

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -14,6 +14,7 @@ scale:
 low_pass_filter_coeff: 2.  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## Properties of outgoing commands
+low_latency_mode: false  # Set this to true to tie the output rate to the input rate
 publish_period: 0.01  # 1/Nominal publish rate [seconds]
 
 # What type of topic does your robot driver expect?

--- a/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
@@ -1,26 +1,26 @@
 ###############################################
 # Modify all parameters related to servoing here
 ###############################################
-use_gazebo: true # Whether the robot is started in a Gazebo simulation environment
+use_gazebo: false # Whether the robot is started in a Gazebo simulation environment
 
 ## Properties of incoming commands
 command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.6  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.3 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  linear:  0.003  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.006 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
 low_pass_filter_coeff: 2.  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## Properties of outgoing commands
-publish_period: 0.008  # 1/Nominal publish rate [seconds]
-low_latency_mode: false  # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)
+low_latency_mode: true  # Set this to true to tie the output rate to the input rate
+publish_period: 0.01  # 1/Nominal publish rate [seconds]
 
 # What type of topic does your robot driver expect?
 # Currently supported are std_msgs/Float64MultiArray (for ros_control JointGroupVelocityController or JointGroupPositionController)
 # or trajectory_msgs/JointTrajectory (for Universal Robots and other non-ros_control robots)
-command_out_type: std_msgs/Float64MultiArray
+command_out_type: trajectory_msgs/JointTrajectory
 
 # What to publish? Can save some bandwidth as most robots only require positions or velocities
 publish_joint_positions: true
@@ -28,41 +28,41 @@ publish_joint_velocities: false
 publish_joint_accelerations: false
 
 ## MoveIt properties
-move_group_name:  manipulator  # Often 'manipulator' or 'arm'
-planning_frame: world  # The MoveIt planning frame. Often 'base_link' or 'world'
+move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
+planning_frame: panda_link0  # The MoveIt planning frame. Often 'panda_link0' or 'world'
 
 ## Other frames
-ee_frame_name: ee_link  # The name of the end effector link, used to return the EE pose
-robot_link_command_frame:  world  # commands must be given in the frame of a robot link. Usually either the base or end effector
+ee_frame_name: panda_link7  # The name of the end effector link, used to return the EE pose
+robot_link_command_frame:  panda_link0  # commands must be given in the frame of a robot link. Usually either the base or end effector
 
 ## Stopping behaviour
-incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
+incoming_command_timeout:  1  # Stop servoing if X seconds elapse without a new command
 # If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
 # Important because ROS may drop some messages and we need the robot to halt reliably.
-num_outgoing_halt_msgs_to_publish: 4
+num_outgoing_halt_msgs_to_publish: 1
 
 ## Configure handling of singularities and joint limits
-lower_singularity_threshold:  17  # Start decelerating when the condition number hits this (close to singularity)
-hard_stop_singularity_threshold: 30 # Stop when the condition number hits this
+lower_singularity_threshold:  30  # Start decelerating when the condition number hits this (close to singularity)
+hard_stop_singularity_threshold: 45 # Stop when the condition number hits this
 joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
 
 ## Topic names
-cartesian_command_in_topic: delta_twist_cmds  # Topic for incoming Cartesian twist commands
-joint_command_in_topic: delta_joint_cmds # Topic for incoming joint angle commands
-joint_topic: joint_states
-status_topic: status # Publish status to this topic
-command_out_topic: /joint_group_position_controller/command # Publish outgoing commands here
+cartesian_command_in_topic: servo_server/delta_twist_cmds  # Topic for incoming Cartesian twist commands
+joint_command_in_topic: servo_server/delta_joint_cmds # Topic for incoming joint angle commands
+joint_topic:  joint_states
+status_topic: servo_server/status # Publish status to this topic
+command_out_topic: servo_server/command # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
-collision_check_rate: 50 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+collision_check_rate: 5 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 # Two collision check algorithms are available:
 # "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
 # "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
-collision_check_type: threshold_distance
+collision_check_type: stop_distance
 # Parameters for "threshold_distance"-type collision checking
-self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
-scene_collision_proximity_threshold: 0.05 # Start decelerating when a scene collision is this far [m]
+self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
+scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
 # Parameters for "stop_distance"-type collision checking
 collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -141,6 +141,11 @@ TEST_F(PoseTrackingFixture, OutgoingMsgTest)
   });
 
   ros::Duration(ROS_PUB_SUB_DELAY).sleep();
+
+  // resetTargetPose() can be used to clear the target pose and wait for a new one, e.g. when moving between multiple
+  // waypoints
+  tracker_->resetTargetPose();
+
   tracker_->moveToPose(translation_tolerance_, ROTATION_TOLERANCE, 1 /* target pose timeout */);
 
   target_pub_thread.join();

--- a/moveit_ros/moveit_servo/test/servo_low_latency_test.cpp
+++ b/moveit_ros/moveit_servo/test/servo_low_latency_test.cpp
@@ -1,0 +1,185 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Test for the low latency mode of servo
+*/
+
+// C++
+#include <string>
+
+// ROS
+#include <ros/ros.h>
+
+// Testing
+#include <gtest/gtest.h>
+
+// Servo
+#include <moveit_servo/make_shared_from_pool.h>
+#include <moveit_servo/servo.h>
+
+static const std::string LOGNAME = "servo_low_latency_test";
+
+namespace moveit_servo
+{
+class ServoFixture : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    // Wait for several key topics / parameters
+    ros::topic::waitForMessage<sensor_msgs::JointState>("/joint_states");
+    while (!nh_.hasParam("/robot_description") && ros::ok())
+    {
+      ros::Duration(0.1).sleep();
+    }
+
+    // Load the planning scene monitor
+    planning_scene_monitor_ = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
+    planning_scene_monitor_->startSceneMonitor();
+    planning_scene_monitor_->startStateMonitor();
+    planning_scene_monitor_->startWorldGeometryMonitor(
+        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC,
+        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
+        false /* skip octomap monitor */);
+
+    // Create moveit_servo
+    servo_ = std::make_shared<Servo>(nh_, planning_scene_monitor_);
+  }
+  void TearDown() override
+  {
+  }
+
+protected:
+  ros::NodeHandle nh_{ "~" };
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+  moveit_servo::ServoPtr servo_;
+};  // class ServoFixture
+
+TEST_F(ServoFixture, SendTwistStampedTest)
+{
+  servo_->start();
+
+  auto parameters = servo_->getParameters();
+
+  // count trajectory messages sent by servo
+  size_t received_count = 0;
+  boost::function<void(const trajectory_msgs::JointTrajectoryConstPtr&)> traj_callback =
+      [&received_count](const trajectory_msgs::JointTrajectoryConstPtr& /*msg*/) { ++received_count; };
+  auto traj_sub = nh_.subscribe(parameters.command_out_topic, 1, traj_callback);
+
+  // Create publisher to send servo commands
+  auto twist_stamped_pub = nh_.advertise<geometry_msgs::TwistStamped>(parameters.cartesian_command_in_topic, 1);
+
+  constexpr double test_duration = 1.0;
+  const double publish_period = parameters.publish_period;
+  const size_t num_commands = static_cast<size_t>(test_duration / publish_period);
+
+  // Set the rate differently from the publish period from the parameters to show that
+  // the number of outputs is set by the number of commands sent and not the rate they are sent.
+  ros::Rate publish_rate(2. / publish_period);
+
+  // Send a few Cartesian velocity commands
+  for (size_t i = 0; i < num_commands && ros::ok(); ++i)
+  {
+    auto msg = moveit::util::make_shared_from_pool<geometry_msgs::TwistStamped>();
+    msg->header.stamp = ros::Time::now();
+    msg->header.frame_id = "panda_link0";
+    msg->twist.angular.y = 1.0;
+
+    // Send the message
+    twist_stamped_pub.publish(msg);
+    publish_rate.sleep();
+  }
+
+  EXPECT_GT(received_count, num_commands - 20);
+  EXPECT_GT(received_count, (unsigned)0);
+  EXPECT_LT(received_count, num_commands + 20);
+  servo_->setPaused(true);
+}
+
+TEST_F(ServoFixture, SendJointServoTest)
+{
+  servo_->start();
+
+  auto parameters = servo_->getParameters();
+
+  // count trajectory messages sent by servo
+  size_t received_count = 0;
+  boost::function<void(const trajectory_msgs::JointTrajectoryConstPtr&)> traj_callback =
+      [&received_count](const trajectory_msgs::JointTrajectoryConstPtr& /*msg*/) { ++received_count; };
+  auto traj_sub = nh_.subscribe(parameters.command_out_topic, 1, traj_callback);
+
+  // Create publisher to send servo commands
+  auto joint_servo_pub = nh_.advertise<control_msgs::JointJog>(parameters.joint_command_in_topic, 1);
+
+  constexpr double test_duration = 1.0;
+  const double publish_period = parameters.publish_period;
+  const size_t num_commands = static_cast<size_t>(test_duration / publish_period);
+
+  // Set the rate differently from the publish period from the parameters to show that
+  // the number of outputs is set by the number of commands sent and not the rate they are sent.
+  ros::Rate publish_rate(2. / publish_period);
+
+  // Send a few joint velocity commands
+  for (size_t i = 0; i < num_commands && ros::ok(); ++i)
+  {
+    auto msg = moveit::util::make_shared_from_pool<control_msgs::JointJog>();
+    msg->header.stamp = ros::Time::now();
+    msg->header.frame_id = "panda_link3";
+    msg->velocities.push_back(0.1);
+
+    // Send the message
+    joint_servo_pub.publish(msg);
+    publish_rate.sleep();
+  }
+
+  EXPECT_GT(received_count, num_commands - 20);
+  EXPECT_GT(received_count, (unsigned)0);
+  EXPECT_LT(received_count, num_commands + 20);
+  servo_->setPaused(true);
+}
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, LOGNAME);
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::AsyncSpinner spinner(8);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/moveit_ros/moveit_servo/test/servo_low_latency_test.test
+++ b/moveit_ros/moveit_servo/test/servo_low_latency_test.test
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Load URDF, SRDF -->
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch" >
+    <arg name="load_robot_description" value="true"/>
+  </include>
+
+  <!-- Initial joint positions -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam command="load" file="$(find moveit_servo)/test/config/initial_position.yaml" />
+    <param name="publish_frequency" type="double" value="50.0"/>
+  </node>
+
+  <test pkg="moveit_servo" type="servo_low_latency_test" test-name="servo_low_latency_test" time-limit="60" args="">
+    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
+    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings_low_latency.yaml" ns="optional_parameter_namespace"/>
+  </test>
+</launch>

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -174,7 +174,9 @@ void OccupancyMapMonitor::initialize()
     }
   }
   else
-    ROS_ERROR("Failed to find 3D sensor plugin parameters for octomap generation");
+  {
+    ROS_INFO("No 3D sensor plugin(s) defined for octomap updates");
+  }
 
   /* advertise a service for loading octomaps from disk */
   save_map_srv_ = nh_.advertiseService("save_map", &OccupancyMapMonitor::saveMapCallback, this);

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -49,11 +49,27 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   moveit_msgs
   moveit_ros_occupancy_map_monitor
+  moveit_ros_planning
+  nodelet
 )
 
 find_package(Eigen3 REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(OpenCV)
+
+set(PACKAGE_LIBRARIES
+  moveit_lazy_free_space_updater
+  moveit_point_containment_filter
+  moveit_pointcloud_octomap_updater_core
+  moveit_semantic_world
+)
+
+if (WITH_OPENGL)
+  list(APPEND PACKAGE_LIBRARIES
+          moveit_mesh_filter
+          moveit_depth_self_filter
+          moveit_depth_image_octomap_updater)
+endif(WITH_OPENGL)
 
 catkin_package(
   INCLUDE_DIRS
@@ -63,15 +79,14 @@ catkin_package(
     semantic_world/include
     ${perception_GL_INCLUDE_DIRS}
   LIBRARIES
-    moveit_lazy_free_space_updater
-    moveit_point_containment_filter
-    moveit_pointcloud_octomap_updater_core
-    moveit_semantic_world
+    ${PACKAGE_LIBRARIES}
   CATKIN_DEPENDS
     image_transport
     moveit_core
     moveit_msgs
     moveit_ros_occupancy_map_monitor
+    moveit_ros_planning
+    nodelet
     object_recognition_msgs
     roscpp
     sensor_msgs
@@ -109,5 +124,6 @@ install(
   FILES
     pointcloud_octomap_updater_plugin_description.xml
     depth_image_octomap_updater_plugin_description.xml
+    moveit_depth_self_filter.xml
   DESTINATION
     ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -6,10 +6,18 @@ add_library(${MOVEIT_LIB_NAME}
   src/stereo_camera_model.cpp
   src/gl_renderer.cpp
   src/gl_mesh.cpp
-  )
+)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} GLUT::GLUT ${GLEW_LIBRARIES})
+
+add_library(moveit_depth_self_filter
+  src/depth_self_filter_nodelet.cpp
+  src/transform_provider.cpp
+)
+set_target_properties(moveit_depth_self_filter PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+
+target_link_libraries(moveit_depth_self_filter ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME})
 
 if (CATKIN_ENABLE_TESTING)
   #catkin_lint: ignore_once env_var
@@ -24,7 +32,7 @@ if (CATKIN_ENABLE_TESTING)
   endif()
 endif()
 
-install(TARGETS ${MOVEIT_LIB_NAME}
+install(TARGETS ${MOVEIT_LIB_NAME} moveit_depth_self_filter
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/depth_self_filter_nodelet.h
@@ -39,8 +39,6 @@
 
 #include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>
-#include <boost/thread.hpp>
-#include <boost/thread/condition_variable.hpp>
 #include <moveit/mesh_filter/transform_provider.h>
 #include <moveit/mesh_filter/mesh_filter.h>
 #include <moveit/mesh_filter/stereo_camera_model.h>
@@ -58,10 +56,10 @@ class DepthSelfFiltering : public nodelet::Nodelet
 {
 public:
   /** \brief Nodelet init callback*/
-  virtual void onInit();
+  void onInit() override;
 
 private:
-  ~DepthSelfFiltering();
+  ~DepthSelfFiltering() override;
 
   /**
    * \brief adding the meshes to a given mesh filter object.
@@ -104,7 +102,7 @@ private:
   image_transport::CameraPublisher pub_model_label_image_;
 
   /** \brief required to avoid listener registration before we are all set*/
-  boost::mutex connect_mutex_;
+  std::mutex connect_mutex_;
   int queue_size_;
   TransformProvider transform_provider_;
 

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
@@ -45,7 +45,9 @@
 #include <GL/gl.h>
 #endif
 #include <string>
-#include <boost/thread.hpp>
+#include <thread>
+#include <mutex>
+#include <map>
 
 namespace mesh_filter
 {
@@ -295,10 +297,10 @@ private:
   float cy_;
 
   /** \brief map from thread id to OpenGL context */
-  static std::map<boost::thread::id, std::pair<unsigned, GLuint> > context_;
+  static std::map<std::thread::id, std::pair<unsigned, GLuint> > context_;
 
   /* \brief lock for context map */
-  static boost::mutex context_lock_;
+  static std::mutex context_lock_;
 
   static bool glutInitialized_;
 };

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter.h
@@ -41,7 +41,6 @@
 #include <moveit/macros/declare_ptr.h>
 #include <moveit/mesh_filter/gl_renderer.h>
 #include <moveit/mesh_filter/mesh_filter_base.h>
-#include <boost/function.hpp>
 
 // forward declarations
 namespace shapes

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -38,8 +38,6 @@
 #define MOVEIT_MESH_FILTER_TRANSFORM_PROVIDER_
 
 #include <string>
-#include <boost/thread/thread.hpp>
-#include <boost/thread/mutex.hpp>
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/mesh_filter/mesh_filter_base.h>
@@ -127,8 +125,9 @@ private:
    * \brief Context Object for registered frames
    * \author Suat Gedikli (gedikli@willowgarage.com)
    */
-  struct TransformContext
+  class TransformContext
   {
+  public:
     TransformContext(const std::string& name) : frame_id_(name)
     {
       transformation_.matrix().setZero();
@@ -136,7 +135,7 @@ private:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     std::string frame_id_;
     Eigen::Isometry3d transformation_;
-    boost::mutex mutex_;
+    std::mutex mutex_;
   };
 
   /**
@@ -159,7 +158,7 @@ private:
   std::string frame_id_;
 
   /** \brief thread object*/
-  boost::thread thread_;
+  std::thread thread_;
 
   /** \flag to leave the update loop*/
   bool stop_;

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -59,9 +59,9 @@ public:
   /**
    * \brief Constructor
    * \author Suat Gedikli (gedikli@willowgarage.com)
-   * \param[in] interval_us update interval in micro seconds
+   * \param[in] update_rate update rate in Hz
    */
-  TransformProvider(unsigned long interval_us = 30000);
+  TransformProvider(double update_rate = 30.);
 
   /** \brief Destructor */
   ~TransformProvider();
@@ -79,7 +79,7 @@ public:
    * \brief registers a mesh with its handle
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \param[in] handle handle of the mesh
-   * \param[in] name frame_id_ of teh mesh
+   * \param[in] name frame_id_ of the mesh
    */
   void addHandle(mesh_filter::MeshHandle handle, const std::string& name);
 
@@ -103,13 +103,12 @@ public:
   void stop();
 
   /**
-   * \brief sets the update interval in micro seconds. This should be low enough to reduce the system load but high
-   * enough
-   * to get up-to-date transformations. For PSDK compatible devices this value should be around 30000 = 30ms
+   * \brief sets the update rate in Hz. This should be slow enough to reduce the system load but fast enough to get
+   * up-to-date transformations. For PSDK compatible devices this value should be around 30 Hz.
    * \author Suat Gedikli (gedikli@willowgarage.com)
-   * \param[in] usecs interval in micro seconds
+   * \param[in] update_rate update rate in Hz
    */
-  void setUpdateInterval(unsigned long usecs);
+  void setUpdateRate(double update_rate);
 
 private:
   /**
@@ -163,7 +162,7 @@ private:
   /** \flag to leave the update loop*/
   bool stop_;
 
-  /** \brief update interval in micro seconds*/
-  unsigned long interval_us_;
+  /** \brief update rate in Hz*/
+  ros::Rate update_rate_;
 };
 #endif

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -68,9 +68,9 @@ void mesh_filter::DepthSelfFiltering::onInit()
   private_nh.param("shadow_threshold", shadow_threshold_, 0.3);
   private_nh.param("padding_scale", padding_scale_, 1.0);
   private_nh.param("padding_offset", padding_offset_, 0.005);
-  double tf_update_rate = 30;
+  double tf_update_rate = 30.;
   private_nh.param("tf_update_rate", tf_update_rate, 30.0);
-  transform_provider_.setUpdateInterval(long(1000000.0 / tf_update_rate));
+  transform_provider_.setUpdateRate(tf_update_rate);
 
   image_transport::SubscriberStatusCallback itssc = std::bind(&DepthSelfFiltering::connectCb, this);
   ros::SubscriberStatusCallback rssc = std::bind(&DepthSelfFiltering::connectCb, this);

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter.cpp
@@ -52,7 +52,7 @@ using namespace std;
 using namespace Eigen;
 using shapes::Mesh;
 
-mesh_filter::MeshFilter::MeshFilter(const boost::function<bool(MeshFilter::MeshHandle, Isometry3d&)>& transform_callback)
+mesh_filter::MeshFilter::MeshFilter(const std::function<bool(MeshFilter::MeshHandle, Isometry3d&)>& transform_callback)
   : mesh_renderer_(640, 480, 0.3, 10)  // some default values for buffer sizes and clipping planes
   , depth_filter_(640, 480, 0.3, 10)
   , next_handle_(FirstLabel)  // 0 and 1 are reserved!
@@ -117,7 +117,7 @@ void mesh_filter::MeshFilter::setSize(unsigned width, unsigned height)
 }
 
 void mesh_filter::MeshFilter::setTransformCallback(
-    const boost::function<bool(mesh_filter::MeshFilter::MeshHandle, Isometry3d&)>& transform_callback)
+    const std::function<bool(mesh_filter::MeshFilter::MeshHandle, Isometry3d&)>& transform_callback)
 {
   transform_callback_ = transform_callback;
 }

--- a/moveit_ros/perception/mesh_filter/src/stereo_camera_model.cpp
+++ b/moveit_ros/perception/mesh_filter/src/stereo_camera_model.cpp
@@ -37,8 +37,6 @@
 #include <moveit/mesh_filter/stereo_camera_model.h>
 #include <moveit/mesh_filter/gl_renderer.h>
 
-using namespace std;
-
 mesh_filter::StereoCameraModel::Parameters::Parameters(unsigned width, unsigned height,
                                                        float near_clipping_plane_distance,
                                                        float far_clipping_plane_distance, float fx, float fy, float cx,
@@ -112,7 +110,7 @@ void mesh_filter::StereoCameraModel::Parameters::setFilterParameters(GLRenderer&
 const mesh_filter::StereoCameraModel::Parameters& mesh_filter::StereoCameraModel::REGISTERED_PSDK_PARAMS =
     mesh_filter::StereoCameraModel::Parameters(640, 480, 0.4, 10.0, 525, 525, 319.5, 239.5, 0.075, 0.125);
 
-const string mesh_filter::StereoCameraModel::RENDER_VERTEX_SHADER_SOURCE =
+const std::string mesh_filter::StereoCameraModel::RENDER_VERTEX_SHADER_SOURCE =
     "#version 120\n"
     "uniform vec3 padding_coefficients;"
     "void main()"
@@ -127,22 +125,23 @@ const string mesh_filter::StereoCameraModel::RENDER_VERTEX_SHADER_SOURCE =
     "  gl_Position.y = -gl_Position.y;"
     "}";
 
-const string mesh_filter::StereoCameraModel::RENDER_FRAGMENT_SHADER_SOURCE = "#version 120\n"
-                                                                             "void main()"
-                                                                             "{"
-                                                                             "  gl_FragColor = gl_Color;"
-                                                                             "}";
+const std::string mesh_filter::StereoCameraModel::RENDER_FRAGMENT_SHADER_SOURCE = "#version 120\n"
+                                                                                  "void main()"
+                                                                                  "{"
+                                                                                  "  gl_FragColor = gl_Color;"
+                                                                                  "}";
 
-const string mesh_filter::StereoCameraModel::FILTER_VERTEX_SHADER_SOURCE = "#version 120\n"
-                                                                           "void main ()"
-                                                                           "{"
-                                                                           "     gl_FrontColor = gl_Color;"
-                                                                           "     gl_TexCoord[0] = gl_MultiTexCoord0;"
-                                                                           "     gl_Position = gl_Vertex;"
-                                                                           "  gl_Position.w = 1.0;"
-                                                                           "}";
+const std::string mesh_filter::StereoCameraModel::FILTER_VERTEX_SHADER_SOURCE =
+    "#version 120\n"
+    "void main ()"
+    "{"
+    "     gl_FrontColor = gl_Color;"
+    "     gl_TexCoord[0] = gl_MultiTexCoord0;"
+    "     gl_Position = gl_Vertex;"
+    "  gl_Position.w = 1.0;"
+    "}";
 
-const string mesh_filter::StereoCameraModel::FILTER_FRAGMENT_SHADER_SOURCE =
+const std::string mesh_filter::StereoCameraModel::FILTER_FRAGMENT_SHADER_SOURCE =
     "#version 120\n"
     "uniform sampler2D sensor;"
     "uniform sampler2D depth;"

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -39,12 +39,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_eigen/tf2_eigen.h>
 
-using namespace std;
-using namespace boost;
-using namespace Eigen;
-using namespace tf;
-using namespace mesh_filter;
-
 TransformProvider::TransformProvider(unsigned long interval_us) : stop_(true), interval_us_(interval_us)
 {
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
@@ -61,7 +55,7 @@ TransformProvider::~TransformProvider()
 void TransformProvider::start()
 {
   stop_ = false;
-  thread_ = thread(&TransformProvider::run, this);
+  thread_ = std::thread(&TransformProvider::run, this);
 }
 
 void TransformProvider::stop()
@@ -70,49 +64,48 @@ void TransformProvider::stop()
   thread_.join();
 }
 
-void TransformProvider::addHandle(MeshHandle handle, const string& name)
+void TransformProvider::addHandle(mesh_filter::MeshHandle handle, const std::string& name)
 {
   if (!stop_)
-    throw runtime_error("Can not add handles if TransformProvider is running");
+    throw std::runtime_error("Can not add handles if TransformProvider is running");
 
   handle2context_[handle].reset(new TransformContext(name));
 }
 
-void TransformProvider::setFrame(const string& frame)
+void TransformProvider::setFrame(const std::string& frame)
 {
   if (frame_id_ != frame)
   {
     frame_id_ = frame;
-    for (map<MeshHandle, shared_ptr<TransformContext> >::iterator contextIt = handle2context_.begin();
-         contextIt != handle2context_.end(); ++contextIt)
+    for (auto& context_it : handle2context_)
     {
       // invalidate transformations
-      contextIt->second->mutex_.lock();
-      contextIt->second->transformation_.matrix().setZero();
-      contextIt->second->mutex_.unlock();
+      context_it.second->mutex_.lock();
+      context_it.second->transformation_.matrix().setZero();
+      context_it.second->mutex_.unlock();
     }
   }
 }
 
-bool TransformProvider::getTransform(MeshHandle handle, Isometry3d& transform) const
+bool TransformProvider::getTransform(mesh_filter::MeshHandle handle, Eigen::Isometry3d& transform) const
 {
-  map<MeshHandle, shared_ptr<TransformContext> >::const_iterator contextIt = handle2context_.find(handle);
+  auto context_it = handle2context_.find(handle);
 
-  if (contextIt == handle2context_.end())
+  if (context_it == handle2context_.end())
   {
     ROS_ERROR("Unable to find mesh with handle %d", handle);
     return false;
   }
-  contextIt->second->mutex_.lock();
-  transform = contextIt->second->transformation_;
-  contextIt->second->mutex_.unlock();
+  context_it->second->mutex_.lock();
+  transform = context_it->second->transformation_;
+  context_it->second->mutex_.unlock();
   return !(transform.matrix().isZero(0));
 }
 
 void TransformProvider::run()
 {
   if (handle2context_.empty())
-    throw runtime_error("TransformProvider is listening to empty list of frames!");
+    throw std::runtime_error("TransformProvider is listening to empty list of frames!");
 
   while (!stop_)
   {
@@ -128,45 +121,43 @@ void TransformProvider::setUpdateInterval(unsigned long usecs)
 
 void TransformProvider::updateTransforms()
 {
-  static tf2::Stamped<Isometry3d> input_transform, output_transform;
+  static tf2::Stamped<Eigen::Isometry3d> input_transform, output_transform;
   static robot_state::RobotStatePtr robot_state;
   robot_state = psm_->getStateMonitor()->getCurrentState();
   try
   {
     geometry_msgs::TransformStamped common_tf =
         tf_buffer_->lookupTransform(frame_id_, psm_->getPlanningScene()->getPlanningFrame(), ros::Time(0.0));
+    input_transform.stamp_ = common_tf.header.stamp;
   }
   catch (tf2::TransformException& ex)
   {
     ROS_ERROR("TF Problem: %s", ex.what());
     return;
   }
-  input_transform.stamp_ = common_tf.header.stamp;
   input_transform.frame_id_ = psm_->getPlanningScene()->getPlanningFrame();
 
-  for (map<MeshHandle, shared_ptr<TransformContext> >::const_iterator contextIt = handle2context_.begin();
-       contextIt != handle2context_.end(); ++contextIt)
+  for (auto& context_it : handle2context_)
   {
     try
     {
       // TODO: check logic here - which global collision body's transform should be used?
-      input_transform.setData(
-          robot_state->getAttachedBody(contextIt->second->frame_id_)->getGlobalCollisionBodyTransforms()[0]);
+      input_transform.setData(robot_state->getGlobalLinkTransform(context_it.second->frame_id_));
       tf_buffer_->transform(input_transform, output_transform, frame_id_);
     }
     catch (const tf2::TransformException& ex)
     {
-      handle2context_[contextIt->first]->mutex_.lock();
-      handle2context_[contextIt->first]->transformation_.matrix().setZero();
-      handle2context_[contextIt->first]->mutex_.unlock();
+      handle2context_[context_it.first]->mutex_.lock();
+      handle2context_[context_it.first]->transformation_.matrix().setZero();
+      handle2context_[context_it.first]->mutex_.unlock();
       continue;
     }
     catch (std::exception& ex)
     {
       ROS_ERROR("Caught %s while updating transforms", ex.what());
     }
-    handle2context_[contextIt->first]->mutex_.lock();
-    handle2context_[contextIt->first]->transformation_ = static_cast<Isometry3d>(output_transform);
-    handle2context_[contextIt->first]->mutex_.unlock();
+    handle2context_[context_it.first]->mutex_.lock();
+    handle2context_[context_it.first]->transformation_ = static_cast<Eigen::Isometry3d>(output_transform);
+    handle2context_[context_it.first]->mutex_.unlock();
   }
 }

--- a/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
+++ b/moveit_ros/perception/mesh_filter/src/transform_provider.cpp
@@ -39,7 +39,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_eigen/tf2_eigen.h>
 
-TransformProvider::TransformProvider(unsigned long interval_us) : stop_(true), interval_us_(interval_us)
+TransformProvider::TransformProvider(double update_rate) : stop_(true), update_rate_(update_rate)
 {
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>();
   tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
@@ -107,20 +107,27 @@ void TransformProvider::run()
   if (handle2context_.empty())
     throw std::runtime_error("TransformProvider is listening to empty list of frames!");
 
-  while (!stop_)
+  while (ros::ok() && !stop_)
   {
     updateTransforms();
-    usleep(interval_us_);
+    update_rate_.sleep();
   }
 }
 
-void TransformProvider::setUpdateInterval(unsigned long usecs)
+void TransformProvider::setUpdateRate(double update_rate)
 {
-  interval_us_ = usecs;
+  update_rate_ = ros::Rate(update_rate);
 }
 
 void TransformProvider::updateTransforms()
 {
+  // Don't bother if frame_id_ is empty (true initially)
+  if (frame_id_.empty())
+  {
+    ROS_DEBUG_THROTTLE(2., "Not updating transforms because frame_id_ is empty.");
+    return;
+  }
+
   static tf2::Stamped<Eigen::Isometry3d> input_transform, output_transform;
   static robot_state::RobotStatePtr robot_state;
   robot_state = psm_->getStateMonitor()->getCurrentState();

--- a/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
+++ b/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
@@ -43,7 +43,7 @@
 using namespace mesh_filter;
 using namespace Eigen;
 using namespace std;
-using namespace boost;
+using namespace std::placeholders;
 
 namespace mesh_filter_test
 {
@@ -118,7 +118,7 @@ MeshFilterTest<Type>::MeshFilterTest(unsigned width, unsigned height, double nea
   , shadow_(shadow)
   , epsilon_(epsilon)
   , sensor_parameters_(width, height, near_, far_, width >> 1, height >> 1, width >> 1, height >> 1, 0.1, 0.1)
-  , filter_(boost::bind(&MeshFilterTest<Type>::transformCallback, this, _1, _2), sensor_parameters_)
+  , filter_(std::bind(&MeshFilterTest<Type>::transformCallback, this, _1, _2), sensor_parameters_)
   , sensor_data_(width_ * height_)
   , distance_(0.0)
 {

--- a/moveit_ros/perception/moveit_depth_self_filter.xml
+++ b/moveit_ros/perception/moveit_depth_self_filter.xml
@@ -1,0 +1,7 @@
+<library path="lib/libmoveit_depth_self_filter">
+    <class name="mesh_filter/DepthSelfFiltering" type="mesh_filter::DepthSelfFiltering" base_class_type="nodelet::Nodelet">
+        <description>
+            Nodelet for filtering meshes from depth images. e.g. meshes of the robot or any attached object where a transformation can be provided for.
+        </description>
+    </class>
+</library>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -38,6 +38,8 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>moveit_ros_occupancy_map_monitor</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend>nodelet</depend>
 
   <build_depend>eigen</build_depend>
 
@@ -46,6 +48,7 @@
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>
     <moveit_ros_perception plugin="${prefix}/depth_image_octomap_updater_plugin_description.xml"/>
+    <nodelet plugin="${prefix}/moveit_depth_self_filter.xml"/>
   </export>
 
 </package>

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -219,7 +219,7 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
       if (preempt_requested_)
         break;
 
-      // execute the trajectory, and monitor its executionm
+      // execute the trajectory, and monitor its execution
       plan.error_code_ = executeAndMonitor(plan);
     }
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -82,7 +82,6 @@ plan_execution::PlanExecution::PlanExecution(
 
   default_max_replan_attempts_ = 5;
 
-  preempt_requested_ = false;
   new_scene_update_ = false;
 
   // we want to be notified when new information is available
@@ -99,7 +98,7 @@ plan_execution::PlanExecution::~PlanExecution()
 
 void plan_execution::PlanExecution::stop()
 {
-  preempt_requested_ = true;
+  preempt_.request();
 }
 
 std::string plan_execution::PlanExecution::getErrorCodeString(const moveit_msgs::MoveItErrorCodes& error_code)
@@ -160,7 +159,9 @@ void plan_execution::PlanExecution::planAndExecute(ExecutableMotionPlan& plan,
 void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& plan, const Options& opt)
 {
   // perform initial configuration steps & various checks
-  preempt_requested_ = false;
+  preempt_.checkAndClear();  // clear any previous preempt_ request
+
+  bool preempt_requested = false;
 
   // run the actual motion plan & execution
   unsigned int max_replan_attempts =
@@ -188,7 +189,8 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
             opt.plan_callback_(plan) :
             opt.repair_plan_callback_(plan, trajectory_execution_manager_->getCurrentExpectedTrajectoryIndex());
 
-    if (preempt_requested_)
+    preempt_requested = preempt_.checkAndClear();
+    if (preempt_requested)
       break;
 
     // if planning fails in a manner that is not recoverable, we exit the loop,
@@ -216,23 +218,23 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
       if (opt.before_execution_callback_)
         opt.before_execution_callback_();
 
-      if (preempt_requested_)
+      preempt_requested = preempt_.checkAndClear();
+      if (preempt_requested)
         break;
 
       // execute the trajectory, and monitor its execution
-      plan.error_code_ = executeAndMonitor(plan);
+      plan.error_code_ = executeAndMonitor(plan, false);
     }
 
-    // if we are done, then we exit the loop
-    if (plan.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
-      break;
+    if (plan.error_code_.val == moveit_msgs::MoveItErrorCodes::PREEMPTED)
+      preempt_requested = true;
 
-    // if execution failed in a manner that we do not consider recoverable, we exit the loop (with failure)
+    // if execution succeeded or failed in a manner that we do not consider recoverable, we exit the loop (with failure)
     if (plan.error_code_.val != moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE)
       break;
     else
     {
-      // othewrise, we wait (if needed)
+      // otherwise, we wait (if needed)
       if (opt.replan_delay_ > 0.0)
       {
         ROS_INFO_NAMED("plan_execution", "Waiting for a %lf seconds before attempting a new plan ...",
@@ -242,9 +244,14 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
         ROS_INFO_NAMED("plan_execution", "Done waiting");
       }
     }
-  } while (!preempt_requested_ && max_replan_attempts > replan_attempts);
 
-  if (preempt_requested_)
+    preempt_requested = preempt_.checkAndClear();
+    if (preempt_requested)
+      break;
+
+  } while (replan_attempts < max_replan_attempts);
+
+  if (preempt_requested)
   {
     ROS_DEBUG_NAMED("plan_execution", "PlanExecution was preempted");
     plan.error_code_.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
@@ -313,8 +320,12 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
   return true;
 }
 
-moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan)
+moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(ExecutableMotionPlan& plan,
+                                                                               bool reset_preempted)
 {
+  if (reset_preempted)
+    preempt_.checkAndClear();
+
   if (!plan.planning_scene_monitor_)
     plan.planning_scene_monitor_ = planning_scene_monitor_;
   if (!plan.planning_scene_)
@@ -409,7 +420,9 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
   // wait for path to be done, while checking that the path does not become invalid
   ros::Rate r(100);
   path_became_invalid_ = false;
-  while (node_handle_.ok() && !execution_complete_ && !preempt_requested_ && !path_became_invalid_)
+  bool preempt_requested = false;
+
+  while (node_handle_.ok() && !execution_complete_ && !path_became_invalid_)
   {
     r.sleep();
     // check the path if there was an environment update in the meantime
@@ -422,10 +435,14 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
         break;
       }
     }
+
+    preempt_requested = preempt_.checkAndClear();
+    if (preempt_requested)
+      break;
   }
 
   // stop execution if needed
-  if (preempt_requested_)
+  if (preempt_requested)
   {
     ROS_INFO_NAMED("plan_execution", "Stopping execution due to preempt request");
     trajectory_execution_manager_->stopExecution();
@@ -457,7 +474,7 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
     result.val = moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE;
   else
   {
-    if (preempt_requested_)
+    if (preempt_requested)
     {
       result.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
     }
@@ -505,7 +522,7 @@ void plan_execution::PlanExecution::successfulTrajectorySegmentExecution(const E
     {
       // execution of side-effect failed
       ROS_ERROR_NAMED("plan_execution", "Execution of path-completion side-effect failed. Preempting.");
-      preempt_requested_ = true;
+      preempt_.request();
       return;
     }
 

--- a/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
@@ -150,7 +150,7 @@ bool plan_execution::PlanWithSensing::computePlan(ExecutableMotionPlan& plan,
   unsigned int look_attempts = 0;
 
   // this flag is set to true when all conditions for looking around are met, and the command is sent.
-  // the intention is for the planning looop not to terminate when having just looked around
+  // the intention is for the planning loop not to terminate when having just looked around
   bool just_looked_around = false;
 
   // this flag indicates whether the last lookAt() operation failed. If this operation fails once, we assume that
@@ -212,7 +212,7 @@ bool plan_execution::PlanWithSensing::computePlan(ExecutableMotionPlan& plan,
 
       bool looked_at_result = lookAt(cost_sources, plan.planning_scene_->getPlanningFrame());
       if (looked_at_result)
-        ROS_INFO("Sensor was succesfully actuated. Attempting to recompute a motion plan.");
+        ROS_INFO("Sensor was successfully actuated. Attempting to recompute a motion plan.");
       else
       {
         if (look_around_failed)

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -178,7 +178,7 @@ public:
     if (change_req)
     {
       planning_interface::MotionPlanRequest req2 = req;
-      robot_state::robotStateToRobotStateMsg(start_state, req2.start_state, false);
+      moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
       solved = planner(planning_scene, req2, res);
     }
     else

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -536,18 +536,25 @@ void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningS
 
 void PlanningSceneMonitor::clearOctomap()
 {
-  if (scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS))
-    triggerSceneUpdateEvent(UPDATE_SCENE);
-  if (octomap_monitor_)
+  bool removed = false;
   {
-    octomap_monitor_->getOcTreePtr()->lockWrite();
-    octomap_monitor_->getOcTreePtr()->clear();
-    octomap_monitor_->getOcTreePtr()->unlockWrite();
+    boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
+    removed = scene_->getWorldNonConst()->removeObject(scene_->OCTOMAP_NS);
+
+    if (octomap_monitor_)
+    {
+      octomap_monitor_->getOcTreePtr()->lockWrite();
+      octomap_monitor_->getOcTreePtr()->clear();
+      octomap_monitor_->getOcTreePtr()->unlockWrite();
+    }
+    else
+    {
+      ROS_WARN_NAMED(LOGNAME, "Unable to clear octomap since no octomap monitor has been initialized");
+    }  // Lift the scoped lock before calling triggerSceneUpdateEvent to avoid deadlock
   }
-  else
-  {
-    ROS_WARN_NAMED(LOGNAME, "Unable to clear octomap since no octomap monitor has been initialized");
-  }
+
+  if (removed)
+    triggerSceneUpdateEvent(UPDATE_GEOMETRY);
 }
 
 bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -228,7 +228,15 @@ public:
   void setPlannerParams(const std::string& planner_id, const std::string& group,
                         const std::map<std::string, std::string>& params, bool bReplace = false);
 
-  /** \brief Get the default planner for a given group (or global default) */
+  std::string getDefaultPlanningPipelineId() const;
+
+  /** \brief Specify a planning pipeline to be used for further planning */
+  void setPlanningPipelineId(const std::string& pipeline_id);
+
+  /** \brief Get the current planning_pipeline_id */
+  const std::string& getPlanningPipelineId() const;
+
+  /** \brief Get the default planner of the current planning pipeline for the given group (or the pipeline's default) */
   std::string getDefaultPlannerId(const std::string& group = "") const;
 
   /** \brief Specify a planner to be used for further planning */

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1612,8 +1612,14 @@ bool moveit::planning_interface::MoveGroupInterface::setNamedTarget(const std::s
 
 bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const std::vector<double>& joint_values)
 {
-  if (joint_values.size() != impl_->getJointModelGroup()->getVariableCount())
+  auto const n_group_joints = impl_->getJointModelGroup()->getVariableCount();
+  if (joint_values.size() != n_group_joints)
+  {
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group "
+                                                                            << impl_->getJointModelGroup()->getName()
+                                                                            << " has " << n_group_joints << " joints");
     return false;
+  }
   impl_->setTargetType(JOINT);
   impl_->getJointStateTarget().setJointGroupPositions(impl_->getJointModelGroup(), joint_values);
   return impl_->getJointStateTarget().satisfiesBounds(impl_->getJointModelGroup(), impl_->getGoalJointTolerance());

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1615,9 +1615,9 @@ bool moveit::planning_interface::MoveGroupInterface::setJointValueTarget(const s
   auto const n_group_joints = impl_->getJointModelGroup()->getVariableCount();
   if (joint_values.size() != n_group_joints)
   {
-    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Provided joint value list has length " << joint_values.size() << " but group "
-                                                                            << impl_->getJointModelGroup()->getName()
-                                                                            << " has " << n_group_joints << " joints");
+    ROS_DEBUG_STREAM("Provided joint value list has length " << joint_values.size() << " but group "
+                                                             << impl_->getJointModelGroup()->getName() << " has "
+                                                             << n_group_joints << " joints");
     return false;
   }
   impl_->setTargetType(JOINT);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -124,8 +124,10 @@ public:
     goal_orientation_tolerance_ = 1e-3;  // ~0.1 deg
     allowed_planning_time_ = 5.0;
     num_planning_attempts_ = 1;
-    max_velocity_scaling_factor_ = 1.0;
-    max_acceleration_scaling_factor_ = 1.0;
+    node_handle_.param<double>("robot_description_planning/default_velocity_scaling_factor",
+                               max_velocity_scaling_factor_, 0.1);
+    node_handle_.param<double>("robot_description_planning/default_acceleration_scaling_factor",
+                               max_acceleration_scaling_factor_, 0.1);
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -72,6 +72,20 @@ public:
     return robot_model_->getName().c_str();
   }
 
+  bp::list getActiveJointNames() const
+  {
+    return py_bindings_tools::listFromString(robot_model_->getActiveJointModelNames());
+  }
+
+  bp::list getGroupActiveJointNames(const std::string& group) const
+  {
+    const moveit::core::JointModelGroup* jmg = robot_model_->getJointModelGroup(group);
+    if (jmg)
+      return py_bindings_tools::listFromString(jmg->getActiveJointModelNames());
+    else
+      return bp::list();
+  }
+
   bp::list getJointNames() const
   {
     return py_bindings_tools::listFromString(robot_model_->getJointModelNames());
@@ -380,6 +394,8 @@ static void wrap_robot_interface()
 
   robot_class.def("get_joint_names", &RobotInterfacePython::getJointNames);
   robot_class.def("get_group_joint_names", &RobotInterfacePython::getGroupJointNames);
+  robot_class.def("get_active_joint_names", &RobotInterfacePython::getActiveJointNames);
+  robot_class.def("get_group_active_joint_names", &RobotInterfacePython::getGroupActiveJointNames);
   robot_class.def("get_group_default_states", &RobotInterfacePython::getDefaultStateNames);
   robot_class.def("get_group_joint_tips", &RobotInterfacePython::getGroupJointTips);
   robot_class.def("get_group_names", &RobotInterfacePython::getGroupNames);

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -33,7 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Tyler Weaver */
+/* Author: Tyler Weaver, Boston Cleek */
 
 /* These integration tests are based on the tutorials for using move_group:
  * https://ros-planning.github.io/moveit_tutorials/doc/move_group_interface/move_group_interface_tutorial.html
@@ -150,16 +150,27 @@ protected:
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
 };
 
-TEST_F(MoveGroupTestFixture, MoveToPoseTest)
+TEST_F(MoveGroupTestFixture, PathConstraintCollisionTest)
 {
-  SCOPED_TRACE("MoveToPoseTest");
+  SCOPED_TRACE("PathConstraintCollisionTest");
 
+  ////////////////////////////////////////////////////////////////////
+  // set a custom start state
+  // this simplifies planning for the orientation constraint bellow
+  geometry_msgs::Pose start_pose;
+  start_pose.orientation.w = 1.0;
+  start_pose.position.x = 0.3;
+  start_pose.position.y = 0.0;
+  start_pose.position.z = 0.6;
+  planAndMoveToPose(start_pose);
+
+  ////////////////////////////////////////////////////////////////////
   // Test setting target pose with eigen and with geometry_msgs
   geometry_msgs::Pose target_pose;
   target_pose.orientation.w = 1.0;
-  target_pose.position.x = 0.28;
-  target_pose.position.y = -0.2;
-  target_pose.position.z = 0.5;
+  target_pose.position.x = 0.3;
+  target_pose.position.y = -0.3;
+  target_pose.position.z = 0.6;
 
   // convert to eigen
   Eigen::Isometry3d eigen_target_pose;
@@ -174,11 +185,108 @@ TEST_F(MoveGroupTestFixture, MoveToPoseTest)
   // expect that they are identical
   testEigenPose(eigen_target_pose, eigen_set_target_pose);
 
+  ////////////////////////////////////////////////////////////////////
+  // create an orientation constraint
+  moveit_msgs::OrientationConstraint ocm;
+  ocm.link_name = move_group_->getEndEffectorLink();
+  ocm.header.frame_id = move_group_->getPlanningFrame();
+  ocm.orientation.w = 1.0;
+  ocm.absolute_x_axis_tolerance = 0.1;
+  ocm.absolute_y_axis_tolerance = 0.1;
+  ocm.absolute_z_axis_tolerance = 0.1;
+  ocm.weight = 1.0;
+  moveit_msgs::Constraints test_constraints;
+  test_constraints.orientation_constraints.push_back(ocm);
+  move_group_->setPathConstraints(test_constraints);
+
+  ////////////////////////////////////////////////////////////////////
+  // Define a collision object ROS message.
+  moveit_msgs::CollisionObject collision_object;
+  collision_object.header.frame_id = move_group_->getPlanningFrame();
+
+  // The id of the object is used to identify it.
+  collision_object.id = "box1";
+
+  // Define a box to add to the world.
+  shape_msgs::SolidPrimitive primitive;
+  primitive.type = primitive.BOX;
+  primitive.dimensions.resize(3);
+  primitive.dimensions[0] = 0.1;
+  primitive.dimensions[1] = 1.0;
+  primitive.dimensions[2] = 1.0;
+
+  // Define a pose for the box (specified relative to frame_id)
+  geometry_msgs::Pose box_pose;
+  box_pose.orientation.w = 1.0;
+  box_pose.position.x = 0.5;
+  box_pose.position.y = 0.0;
+  box_pose.position.z = 0.5;
+
+  collision_object.primitives.push_back(primitive);
+  collision_object.primitive_poses.push_back(box_pose);
+  collision_object.operation = collision_object.ADD;
+
+  std::vector<moveit_msgs::CollisionObject> collision_objects;
+  collision_objects.push_back(collision_object);
+
+  // Now, let's add the collision object into the world
+  planning_scene_interface_.addCollisionObjects(collision_objects);
+
+  ////////////////////////////////////////////////////////////////////
   // plan and move
   planAndMove();
 
   // get the pose after the movement
   testPose(eigen_target_pose);
+
+  // clear path constraints
+  move_group_->clearPathConstraints();
+
+  // attach and detach collision object
+  EXPECT_TRUE(move_group_->attachObject(collision_object.id));
+  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(1));
+  EXPECT_TRUE(move_group_->detachObject(collision_object.id));
+  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(0));
+
+  // remove object from world
+  const std::vector<std::string> object_ids = { collision_object.id };
+  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(1));
+  planning_scene_interface_.removeCollisionObjects(object_ids);
+  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(0));
+}
+
+TEST_F(MoveGroupTestFixture, CartPathTest)
+{
+  SCOPED_TRACE("CartPathTest");
+
+  // Plan from current pose
+  const geometry_msgs::PoseStamped start_pose = move_group_->getCurrentPose();
+
+  std::vector<geometry_msgs::Pose> waypoints;
+  waypoints.push_back(start_pose.pose);
+
+  geometry_msgs::Pose target_waypoint = start_pose.pose;
+  target_waypoint.position.z -= 0.2;
+  waypoints.push_back(target_waypoint);  // down
+
+  target_waypoint.position.y -= 0.2;
+  waypoints.push_back(target_waypoint);  // right
+
+  target_waypoint.position.z += 0.2;
+  target_waypoint.position.y += 0.2;
+  target_waypoint.position.x -= 0.2;
+  waypoints.push_back(target_waypoint);  // up and left
+
+  moveit_msgs::RobotTrajectory trajectory;
+  const auto jump_threshold = 0.0;
+  const auto eef_step = 0.01;
+  move_group_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+
+  // Execute trajectory
+  EXPECT_EQ(move_group_->execute(trajectory), moveit::planning_interface::MoveItErrorCode::SUCCESS);
+
+  // get the pose after the movement
+  testPose(target_waypoint);
 }
 
 TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
@@ -200,154 +308,6 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
 
   // test that we moved to the expected joint positions
   testJointPositions(plan_joint_positions);
-}
-
-TEST_F(MoveGroupTestFixture, PathConstraintTest)
-{
-  SCOPED_TRACE("PathConstraintTest");
-
-  // set a custom start state
-  geometry_msgs::Pose start_pose;
-  start_pose.orientation.w = 1.0;
-  start_pose.position.x = 0.55;
-  start_pose.position.y = -0.05;
-  start_pose.position.z = 0.8;
-  planAndMoveToPose(start_pose);
-
-  // create an orientation constraint
-  moveit_msgs::OrientationConstraint ocm;
-  ocm.link_name = move_group_->getEndEffectorLink();
-  ocm.header.frame_id = move_group_->getPlanningFrame();
-  ocm.orientation.w = 1.0;
-  ocm.absolute_x_axis_tolerance = 0.1;
-  ocm.absolute_y_axis_tolerance = 0.1;
-  ocm.absolute_z_axis_tolerance = 0.1;
-  ocm.weight = 1.0;
-  moveit_msgs::Constraints test_constraints;
-  test_constraints.orientation_constraints.push_back(ocm);
-  move_group_->setPathConstraints(test_constraints);
-
-  // move to a custom target pose
-  geometry_msgs::Pose target_pose;
-  target_pose.orientation.w = 1.0;
-  target_pose.position.x = 0.28;
-  target_pose.position.y = -0.2;
-  target_pose.position.z = 0.5;
-  planAndMoveToPose(target_pose);
-
-  // clear path constraints
-  move_group_->clearPathConstraints();
-
-  // get the pose after the movement
-  testPose(target_pose);
-}
-
-TEST_F(MoveGroupTestFixture, CartPathTest)
-{
-  SCOPED_TRACE("CartPathTest");
-
-  // set a custom start state
-  geometry_msgs::Pose start_pose;
-  start_pose.orientation.w = 1.0;
-  start_pose.position.x = 0.55;
-  start_pose.position.y = -0.05;
-  start_pose.position.z = 0.8;
-  planAndMoveToPose(start_pose);
-
-  std::vector<geometry_msgs::Pose> waypoints;
-  waypoints.push_back(start_pose);
-
-  geometry_msgs::Pose target_waypoint = start_pose;
-  target_waypoint.position.z -= 0.2;
-  waypoints.push_back(target_waypoint);  // down
-
-  target_waypoint.position.y -= 0.2;
-  waypoints.push_back(target_waypoint);  // right
-
-  target_waypoint.position.z += 0.2;
-  target_waypoint.position.y += 0.2;
-  target_waypoint.position.x -= 0.2;
-  waypoints.push_back(target_waypoint);  // up and left
-
-  moveit_msgs::RobotTrajectory trajectory;
-  const double jump_threshold = 0.0;
-  const double eef_step = 0.01;
-  move_group_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
-
-  // Execute trajectory
-  EXPECT_EQ(move_group_->execute(trajectory), moveit::planning_interface::MoveItErrorCode::SUCCESS);
-
-  // get the pose after the movement
-  testPose(target_waypoint);
-}
-
-TEST_F(MoveGroupTestFixture, CollisionObjectsTest)
-{
-  SCOPED_TRACE("CollisionObjectsTest");
-
-  // set a custom start state
-  geometry_msgs::Pose start_pose;
-  start_pose.orientation.w = 1.0;
-  start_pose.position.x = 0.28;
-  start_pose.position.y = -0.2;
-  start_pose.position.z = 0.5;
-  planAndMoveToPose(start_pose);
-
-  // Define a collision object ROS message.
-  moveit_msgs::CollisionObject collision_object;
-  collision_object.header.frame_id = move_group_->getPlanningFrame();
-
-  // The id of the object is used to identify it.
-  collision_object.id = "box1";
-
-  // Define a box to add to the world.
-  shape_msgs::SolidPrimitive primitive;
-  primitive.type = primitive.BOX;
-  primitive.dimensions.resize(3);
-  primitive.dimensions[0] = 0.4;
-  primitive.dimensions[1] = 0.1;
-  primitive.dimensions[2] = 0.1;
-
-  // Define a pose for the box (specified relative to frame_id)
-  geometry_msgs::Pose box_pose;
-  box_pose.orientation.w = 1.0;
-  box_pose.position.x = 0.4;
-  box_pose.position.y = -0.2;
-  box_pose.position.z = 0.8;
-
-  collision_object.primitives.push_back(primitive);
-  collision_object.primitive_poses.push_back(box_pose);
-  collision_object.operation = collision_object.ADD;
-
-  std::vector<moveit_msgs::CollisionObject> collision_objects;
-  collision_objects.push_back(collision_object);
-
-  // Now, let's add the collision object into the world
-  planning_scene_interface_.addCollisionObjects(collision_objects);
-
-  // plan trajectory avoiding object
-  geometry_msgs::Pose target_pose;
-  target_pose.orientation.w = 0.0;
-  target_pose.position.x = 0.4;
-  target_pose.position.y = -0.4;
-  target_pose.position.z = 0.7;
-  planAndMoveToPose(target_pose);
-
-  // get the pose after the movement
-  testPose(target_pose);
-
-  // attach and detach collision object
-  EXPECT_TRUE(move_group_->attachObject(collision_object.id));
-  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(1));
-  EXPECT_TRUE(move_group_->detachObject(collision_object.id));
-  EXPECT_EQ(planning_scene_interface_.getAttachedObjects().size(), std::size_t(0));
-
-  // remove object from world
-  std::vector<std::string> object_ids;
-  object_ids.push_back(collision_object.id);
-  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(1));
-  planning_scene_interface_.removeCollisionObjects(object_ids);
-  EXPECT_EQ(planning_scene_interface_.getObjects().size(), std::size_t(0));
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -298,11 +298,14 @@ void MotionPlanningDisplay::reset()
   // Planned Path Display
   trajectory_visual_->reset();
 
+  bool enabled = this->isEnabled();
   frame_->disable();
-  frame_->enable();
-
-  query_robot_start_->setVisible(query_start_state_property_->getBool());
-  query_robot_goal_->setVisible(query_goal_state_property_->getBool());
+  if (enabled)
+  {
+    frame_->enable();
+    query_robot_start_->setVisible(query_start_state_property_->getBool());
+    query_robot_goal_->setVisible(query_goal_state_property_->getBool());
+  }
 }
 
 void MotionPlanningDisplay::setName(const QString& name)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -131,6 +131,7 @@ private Q_SLOTS:
   void changedSceneDisplayTime();
   void changedOctreeRenderMode();
   void changedOctreeColorMode();
+  void setSceneName(const QString& name);
 
 protected Q_SLOTS:
   virtual void changedAttachedBodyColor();

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -179,7 +179,6 @@ protected:
   virtual void onSceneMonitorReceivedUpdate(planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type);
 
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
-  bool model_is_loading_;
   boost::mutex robot_model_loading_lock_;
 
   moveit::tools::BackgroundProcessing background_process_;

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -647,9 +647,9 @@ void PlanningSceneDisplay::update(float wall_dt, float ros_dt)
 void PlanningSceneDisplay::updateInternal(float wall_dt, float ros_dt)
 {
   current_scene_time_ += wall_dt;
-  if ((current_scene_time_ > scene_display_time_property_->getFloat() && planning_scene_render_ &&
-       robot_state_needs_render_) ||
-      planning_scene_needs_render_)
+  if (planning_scene_render_ &&
+      ((current_scene_time_ > scene_display_time_property_->getFloat() && robot_state_needs_render_) ||
+       planning_scene_needs_render_))
   {
     renderPlanningScene();
     calculateOffsetPosition();

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -203,7 +203,6 @@ void PlanningSceneDisplay::onInitialize()
 
 void PlanningSceneDisplay::reset()
 {
-  planning_scene_render_.reset();
   if (planning_scene_robot_)
     planning_scene_robot_->clear();
   Display::reset();

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -64,7 +64,7 @@ namespace moveit_rviz_plugin
 // Base class contructor
 // ******************************************************************************************
 PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool show_scene_robot)
-  : Display(), model_is_loading_(false), planning_scene_needs_render_(true), current_scene_time_(0.0f)
+  : Display(), planning_scene_needs_render_(true), current_scene_time_(0.0f)
 {
   move_group_ns_property_ = new rviz::StringProperty("Move Group Namespace", "",
                                                      "The name of the ROS namespace in "
@@ -524,7 +524,6 @@ void PlanningSceneDisplay::loadRobotModel()
 {
   // wait for other robot loadRobotModel() calls to complete;
   boost::mutex::scoped_lock _(robot_model_loading_lock_);
-  model_is_loading_ = true;
 
   // we need to make sure the clearing of the robot model is in the main thread,
   // so that rendering operations do not have data removed from underneath,
@@ -545,8 +544,6 @@ void PlanningSceneDisplay::loadRobotModel()
   {
     addMainLoopJob([this]() { setStatus(rviz::StatusProperty::Error, "PlanningScene", "No Planning Scene Loaded"); });
   }
-
-  model_is_loading_ = false;
 }
 
 // This should always run in the main GUI thread!

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -583,12 +583,15 @@ void PlanningSceneDisplay::sceneMonitorReceivedUpdate(
 void PlanningSceneDisplay::onSceneMonitorReceivedUpdate(
     planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type)
 {
-  bool old_state = scene_name_property_->blockSignals(true);
   getPlanningSceneRW()->getCurrentStateNonConst().update();
-  scene_name_property_->setStdString(getPlanningSceneRO()->getName());
-  scene_name_property_->blockSignals(old_state);
-
+  QMetaObject::invokeMethod(this, "setSceneName", Qt::QueuedConnection,
+                            Q_ARG(QString, QString::fromStdString(getPlanningSceneRO()->getName())));
   planning_scene_needs_render_ = true;
+}
+
+void PlanningSceneDisplay::setSceneName(const QString& name)
+{
+  scene_name_property_->setString(name);
 }
 
 void PlanningSceneDisplay::onEnable()

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -539,12 +539,11 @@ void PlanningSceneDisplay::loadRobotModel()
     planning_scene_monitor_.swap(psm);
     planning_scene_monitor_->addUpdateCallback(boost::bind(&PlanningSceneDisplay::sceneMonitorReceivedUpdate, this, _1));
     addMainLoopJob(boost::bind(&PlanningSceneDisplay::onRobotModelLoaded, this));
-    setStatus(rviz::StatusProperty::Ok, "PlanningScene", "Planning Scene Loaded Successfully");
     waitForAllMainLoopJobs();
   }
   else
   {
-    setStatus(rviz::StatusProperty::Error, "PlanningScene", "No Planning Scene Loaded");
+    addMainLoopJob([this]() { setStatus(rviz::StatusProperty::Error, "PlanningScene", "No Planning Scene Loaded"); });
   }
 
   model_is_loading_ = false;
@@ -569,6 +568,8 @@ void PlanningSceneDisplay::onRobotModelLoaded()
   bool old_state = scene_name_property_->blockSignals(true);
   scene_name_property_->setStdString(ps->getName());
   scene_name_property_->blockSignals(old_state);
+
+  setStatus(rviz::StatusProperty::Ok, "PlanningScene", "Planning Scene Loaded Successfully");
 }
 
 void PlanningSceneDisplay::onNewPlanningSceneState()

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -206,9 +206,10 @@ void PlanningSceneDisplay::reset()
   planning_scene_render_.reset();
   if (planning_scene_robot_)
     planning_scene_robot_->clear();
-
-  addBackgroundJob(boost::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
   Display::reset();
+
+  if (isEnabled())
+    addBackgroundJob(boost::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
 
   if (planning_scene_robot_)
   {

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -366,20 +366,27 @@ void RobotStateDisplay::loadRobotModel()
 
   if (rdf_loader_->getURDF())
   {
-    const srdf::ModelSharedPtr& srdf =
-        rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
-    robot_model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
-    robot_->load(*robot_model_->getURDF());
-    robot_state_.reset(new robot_state::RobotState(robot_model_));
-    robot_state_->setToDefaultValues();
-    bool old_state = root_link_name_property_->blockSignals(true);
-    root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());
-    root_link_name_property_->blockSignals(old_state);
-    update_state_ = true;
-    setStatus(rviz::StatusProperty::Ok, "RobotModel", "Loaded successfully");
+    try
+    {
+      const srdf::ModelSharedPtr& srdf =
+          rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : srdf::ModelSharedPtr(new srdf::Model());
+      robot_model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+      robot_->load(*robot_model_->getURDF());
+      robot_state_.reset(new robot_state::RobotState(robot_model_));
+      robot_state_->setToDefaultValues();
+      bool old_state = root_link_name_property_->blockSignals(true);
+      root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());
+      root_link_name_property_->blockSignals(old_state);
+      update_state_ = true;
+      setStatus(rviz::StatusProperty::Ok, "RobotModel", "Loaded successfully");
 
-    changedEnableVisualVisible();
-    changedEnableCollisionVisible();
+      changedEnableVisualVisible();
+      changedEnableCollisionVisible();
+    }
+    catch (std::exception& e)
+    {
+      setStatus(rviz::StatusProperty::Error, "RobotModel", QString("Loading failed: %1").arg(e.what()));
+    }
   }
   else
     setStatus(rviz::StatusProperty::Error, "RobotModel", "Loading failed");

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -574,6 +574,10 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
     emitter << YAML::Newline;
     emitter << YAML::Comment(" - group: " + default_group_name) << YAML::Newline;
     emitter << YAML::Comment("   pose: home") << YAML::Newline;
+
+    // Add empty list for valid yaml
+    emitter << YAML::BeginSeq;
+    emitter << YAML::EndSeq;
   }
 
   emitter << YAML::EndMap;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1395,7 +1395,8 @@ bool MoveItConfigData::inputPlanningContextLaunch(const std::string& file_path)
   // find the kinematics section
   TiXmlHandle doc(&launch_document);
   TiXmlElement* kinematics_group = doc.FirstChild("launch").FirstChild("group").ToElement();
-  while (kinematics_group && kinematics_group->Attribute("ns") != std::string("$(arg robot_description)_kinematics"))
+  while (kinematics_group && kinematics_group->Attribute("ns") &&
+         kinematics_group->Attribute("ns") != std::string("$(arg robot_description)_kinematics"))
   {
     kinematics_group = kinematics_group->NextSiblingElement("group");
   }

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -14,6 +14,9 @@
   <!-- By default, we will load or override the robot_description -->
   <arg name="load_robot_description" default="true"/>
 
+  <!-- Set execution mode for fake execution controllers -->
+  <arg name="execution_type" default="interpolate" />
+
   <!--
   By default, hide joint_state_publisher's GUI
 
@@ -43,6 +46,7 @@
   <include file="$(find [GENERATED_PACKAGE_NAME])/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
+    <arg name="execution_type" value="$(arg execution_type)"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -22,9 +22,11 @@
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>rviz</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>xacro</run_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->


### PR DESCRIPTION
### Description


Here are the backports for Melodic with trivial fixups to api and namespacing.

+ d5dcc9d6618bd14eed7bebf48a619a37a5f3a6fb Fix pose tracking race condition (#2395)
+ 382aa5a8cdd39eace07536d39c497a4b21f0f653 Fix QObject::connect: Cannot queue arguments of type 'QVector<int>' (#2392)
+ c616ef9aa86b34c4b237ca7b1cdd66c19dfc6f20 Fix empty sequence in moveit_setup_assistant (#2406)
+ e8f1a4c8156fd1655f9fa6d8e0c57806b4c2ec8b Move timer initialization down to fix potential race condition
+ 7f647b0594ef50674d711d97ac8f73b06bf06298 Changed processing_thread_ spin to use std::make_unique instead of new (#2412)
+ a15af07ee83b909ca5ef0a14e764dc87d62a93f1 [feature] Low latency mode (#2401)
+ bd53490301b4c0076483e713af082e44dfcd4074 Fix OrientationConstraint::decide (#2414)
+ 712a73a485226e7f7b9344136058347a4e2019ff Prevent moveit_servo transforms between fixed frames from causing timeout (#2418)
+ ad8ce6621bd676ef93f02d96753400d32ee6b58b docker-source: support running clang-tidy (#2430)
+ 10d6380438b2a5a5798ef9e02daf173e7a67b82c Upgrade cmake_minimum_required to 3.1 (#2453)
+ 253a2177f23c2d5e2e3fa415c75f720c9d6a98a5 Fix validation of orientation constraints (#2434)
+ 97c0b28f5580eadaade3f752f66f8eb12b0f7063 Fix doxygen documentation for setToIKSolverFrame (#2461)
+ 798b32f6769d3bd5635cf50a4aa3ef2a269558d3 Add an important sleep in Servo pose tracking (#2463)
+ da926ac95154ea2699247fedf6e3690b15d8eef3 Missing RViz and moveit_simple_controller_manager dependencies in MSA template (#2455)
+ abb83f178075b4d5bb655df2dc9dd3e400e258ca Fix some typos in comments (#2466)
+ be0cbaff7546348b9c19bd46a98ee253341f2c97 Catch exceptions during RobotModel loading in rviz (#2468)
+ ac55f9e252fb24321c4066d71bca4f447b55d961 Python3 compatibility for ikfast's round_collada_numbers.py (#2473)
+ 475e5810911961ae51cdb5cab0961471f5d4aa1a [Servo] Fix initial angle error is always 0 (#2464)
+ cc5d5a4e21c513e1527e306c2adaa8386a4bcef8 Fix RobotState::dropAccelerations/dropEffort to not drop velocities (#2478)
+ 50e19608d8d27a86f1e69fd2cd8c8b7abc330fb0 pilz planner: add string includes (#2483)
+ 680db65c14b3f0ac84beccd55bfc548719b8af84 Clean up collision-related log statements (#2480)
+ 0983cf9ab0a289af975971cc7374bd9182938b88 Fix scaling factor parameter names (#2452)
+ e573a36c6009c200c70d805d546865d0d1974bc9 Improve robustness of move group interface test (#2484)
+ 960745c8d7aaf8cec9703b810576d22cd321c54d Use kinematics solver timeout if not specified otherwise (#2489)
+ e32288400e80a1999474be4f076febb6c289046e Do not break out of loop -- need to update low pass filters (#2496)
+ 0e5911316ed51a765fc6b08a35f48c35f275e026 Protect paused_ flag, for thread safety (#2494)
+ 74b3e30db2e8683ac17b339cc124675ae52a5114 Add missing dependency on joint_limits_interface (#2487)
+ 8878682c2a71faf822db638a8ce21cedc512e4d5 Refactor Servo velocity bounds enforcement (#2471)
+ e986f6d709356920068610e22a424948baf95452 Servo: add missing include (#2519)
+ 47551054600f3445a4a243716bc1be6e18b5ff40 It's not an error not to define a plugin (#2521)
+ 41771d072341f488e075b747c2b2cb38267d579d Update README.md (#2525)
+ 7461264c20d2a5e9ddb4d322b16934640f7b7c30 Update doxygen comments for distance() and interpolate() (#2528)
+ 34b235692c41dac80a28186dff5021f46356ba65 Add debugging log statement for a common error (#2509)
+ f6fd34bbab6da4a1c72b7a532444c0075eee7001 add get_active_joint_names (#2533)
+ d18173b598846260d4e067ff604c3f3b29366f57 Add utility functions to Python PSI (#2532)
+ 30a170f224c37fc1f28de1640b8da0b3afef6614 thread safety in clear octomap & only update geometry (#2500)
+ ae7d1ad1c5eb2bdd65511fe9a4e8574b0f77241d Sanitize CHOMP initialization method parameter (#2540)
+ dd421646a6457e6ad90ee82c70ad0f45c5fffdbd Enable mesh filter (#2448)
+ 55b5878c0ece7b908d2209e85a4d64f966c2804b stop_requested_ flag clearing fix (#2537)
+ f4ebdd4a28e54ee6b3de61324446ea6bdda4b374 Fixed flood of errors on startup for `mesh_filter` (#2550)
+ 06b52899fb3526b6001ecf87324d77bc82d84dbe [Servo] Halt Servo command on Pose Tracking stop (#2501)
+ cd91cd10e01cd547f929ac93a8754ac174c1df6b Fix segfault in MSA (#2564)
+ d9b93ce646a5ff5aaa8cf9a4ceec926f0f1f1b85 Make setToIKSolverFrame accessible again (#2580)
+ 888c1ed5d90c1cbb23480c1df008440799b0c073 Keep MotionPlanningFrame hidden on Display::reset()
+ 393cee729a29c589fd6f78de1fe96025faaf9b53 Call renderPlanningScene() only if planning_scene_render_ is valid
+ 991335e01fd24a01d2bb1c8b15ae3cd1abadc6a0 Fix deadlock in PlanningSceneDisplay
+ 9de3111c65718db16efc5b5dcd72a9b20e256bda GHA: Add pre-release job
+ 550d386440d18465d759a34f983c7e7677c8729e Avoid joint jump when SuddenHalt() is called in velocity mode (#2594)
+ 3a61f184b82d01c75333292ca3e12ecd2765ecde Let users override fake execution type from demo.launch (#2602)
+ 58e1302648f69c70ecb4e729887152001bfc1121 Add clear() to Python PSI, allow empty call to remove_attached_object (#2609)
+ 224129a34c3ff8f7c584cb468999673822d3e383 Velocity limit error (#2610)
+ 824706ba8b6ad7e27c3acc3d1d9882d612973617 Call setStatus from main GUI thread only
+ d1fbbccf0ff77584920e48db2e63076359a397c7 Remove unused model_is_loading_
+ b598820b637658071ae370ff6f24ba2a7aadcbc9 Remove redundant planning_scene_render_.reset(); 
+ b13270be50ae7b43673cc5370bfe52a165c467e8 fix docstring in MGI API (#2626)

These patches are backported after resolving minor conflicts:

+ 59a372484f8f928152eec71bad636c58087d0f15 Provide a function to set the position of active joints in a JointModelGroup (#2456)
+ 8faed13a4dd27fd9181d0e606fe7ff64b27dae65 Fix missing isEmpty check in compute_ik service (#2544)
+ a3a4d8f97e3c0d2110dcd55883490cc58fcb92b1 Set rotation value of cartesian MaxEEFStep by default (#2614)
+ 9f9e69c54529e1aa156851abb6aae7047b20780d FixStartStateBounds: Copy attached bodies when adapting the start state (#2398)


These changes will not be backported for one reason or another or are already backported.

+ 225cb77cbd9d50e93c42d9e3ad6aa4490c6b30ed Add test to ompl interface for StateValidityChecker (#2247)
+ a461efe7dbef01328e3d72c1c83e66dce050eb2c Fix broken documentation link in README (#2393)
+ f85db808303cb7787320dc48162eabdc07593fdc [meta] first-timers-only issue template (#2385)
+ 0247ed0027ca9d7f1a7f066e62c80c9ce5dbbb5e [maint] Changelogs in pilz planner (#2408)
+ f56e17508c5f24f96c840a07243101f38f26096f Add Stargazer chart to README (#2417)
+ eca2deb1b80cbeb3eceaf00090ad853cc12851f2 Updated First Timers Only Issue Template (#2419)
+ bdd4bde4938c7bdac3a57a791cf738146c8834e0 Delete CollisionRequest min_cost_density
+ a9c8f939382193bc250788c62dd57c6627b25a2b Suppress warnings "mesh_use_embedded_materials is ignored"
+ 664ae01803abf5e0b4649063102357262de9e05c Improve robustness of subframes test (#2488)
+ 6512d987b8379519146193267906ee957586c4e8 resolved typo in first-timers-only.md (#2443)
+ ea5080167be92f1ed4441b560f9d94d542b06f4c Fix logic, improve function comment for clearDiffs() (#2497)
+ b7711c134a8a1e173c9bf956f68ad8bbe27796c4 Replaced eigen+kdl conversions with tf2_eigen + tf2_kdl (#2472)
+ a3023013b8df3d17b711e09124eb82e5e3982d58 increase time limit (#2545)
+ eb3bf6fdb6ece5324e3d1a81fd5d2b2197804710 Move moveit_cpp to moveit_ros_planning
+ 5f486dd74adb867443393ee3afd36fa476b6c57c Allow selecting planning pipeline in RViz MotionPlanningDisplay
+ 8df40df56ad58a6358834129b09b3a8b2c35a02c Run multiple planning pipelines with MoveGroup using MoveItCpp
+ db9cecc8955a0c8b6867517835820d87219d1e21 Update MSA launch templates for multi-pipeline support
+ 50614c640b96f550abd235f72bb6b84f88d4eca3 PlanExecution: Correctly handle preempt-requested flag (#2554)
+ 3b9977d18e4e838d103d71fd9b84534874981477 Migrate from Travis to GitHub Actions
+ b618bac5c84055f2354267ea2a0317cc9b1a547e Fix formatting errors
+ a8326da6cc420000b399e78f4048bf5df2abefca Update README for GitHub Actions
+ 3361b2d1b6b2feabc2d3e93c75653f5a00e87fa4 Python bindings for moveit_core (#2547)
+ f0e850af900b0ec438c00f8f6afabf17b6379107 Shift catkin_lint to pre-commit checks (#2569)
+ b1a17dcb7245ae1fd2312f5239a724d297d43b9a Add Readme line on how to ping someone (#2555)
+ 412a6f2c83c83446bb04232e1c0e8accf467c9c8 1.1.2
+ 90e70a59aa05ba8fe7413ed8b8dddba7bea06c71 Improve job naming
+ ae770f7446ab7406f813a47cfe70ee032c1d9f38  Lock the Bullet collision environment, for thread safety (#2598)
+ cf218879dbc23aadf88dd56b8abe7970b7d61030 Add Pilz industrial motion planner (#1893)
+ 460c152ab9f713f2606e345fd0f6abc07cd2c13e Order PlaceLocations by quality during planning (#2378)
- 09afa50b40ac8cb8644ba1a627bb7643137959d3 Update collision-related comments (#2382) (#2388)
- 7e1ccecde9b956c358d9d40630b13635171ec70d RobotModelBuilder: Allow adding end effectors (#2454)
- 5d2549fe5018bca5fa5cf22f90ecdc7b8b3f7762 RobotModelBuilder: Add parameter to specify the joint rotation axis

After this the `review-for-backports` tag can be moved to b13270be50ae7b43673cc5370bfe52a165c467e8

This also adds the pre-release test for melodic so we can run it here.