### PR TITLE
add python docs theme as a dependency

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>moveit_core</name>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
   <description>Core libraries used by MoveIt</description>
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>moveit_core</name>
-  <version>1.1.3</version>
+  <version>1.1.2</version>
   <description>Core libraries used by MoveIt</description>
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
@@ -31,17 +31,17 @@
   <depend>geometry_msgs</depend>
   <depend>kdl_parser</depend>
   <depend>libconsole-bridge-dev</depend>
+  <depend>urdf</depend>
   <depend>liburdfdom-dev</depend>
   <depend>liburdfdom-headers-dev</depend>
   <depend>moveit_msgs</depend>
   <depend>octomap</depend>
   <depend>octomap_msgs</depend>
   <depend>pybind11_catkin</depend>
-  <depend>python3-sphinx-rtd-theme</depend>
   <depend>random_numbers</depend>
-  <depend>rosconsole</depend>
   <depend>roslib</depend>
   <depend>rostime</depend>
+  <depend>rosconsole</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>
   <depend>srdfdom</depend>
@@ -49,9 +49,10 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>trajectory_msgs</depend>
-  <depend>urdf</depend>
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
+
+  <doc_depend>python3-sphinx-rtd-theme</doc_depend>
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>moveit_resources_pr2_description</test_depend>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -38,10 +38,11 @@
   <depend>octomap</depend>
   <depend>octomap_msgs</depend>
   <depend>pybind11_catkin</depend>
+  <depend>python3-sphinx-rtd-theme</depend>
   <depend>random_numbers</depend>
+  <depend>rosconsole</depend>
   <depend>roslib</depend>
   <depend>rostime</depend>
-  <depend>rosconsole</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>
   <depend>srdfdom</depend>
@@ -51,6 +52,7 @@
   <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
+
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>moveit_resources_pr2_description</test_depend>

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -31,7 +31,6 @@
   <depend>geometry_msgs</depend>
   <depend>kdl_parser</depend>
   <depend>libconsole-bridge-dev</depend>
-  <depend>urdf</depend>
   <depend>liburdfdom-dev</depend>
   <depend>liburdfdom-headers-dev</depend>
   <depend>moveit_msgs</depend>
@@ -50,9 +49,9 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>trajectory_msgs</depend>
+  <depend>urdf</depend>
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
-
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>moveit_resources_pr2_description</test_depend>


### PR DESCRIPTION
### Description

In https://github.com/ros-planning/moveit/pull/2547 we use the RTD theme for python, but didn't add it as a dependency, which is causing [the docs job](https://build.ros.org/view/Ndoc/job/Ndoc__moveit__ubuntu_focal_amd64/15/consoleFull#console-section-24) to not generate python docs

rosdep does not look at `doc_depend` which might cause problems. I'm not sure how to trigger a build farm job to test this, but if that's a problem we can change it to a normal `depend`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
