### PR TITLE
Install sympy0.7.1 from git as it is no long available from pypi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,15 +19,16 @@ jobs:
           - IMAGE: master-ci
             CCOV: true
           - IMAGE: master-ci-shadow-fixed
-            CATKIN_LINT: true
-          - IMAGE: melodic-ci
             IKFAST_TEST: true
+            CATKIN_LINT: true
             CLANG_TIDY: true
+          - IMAGE: melodic-ci
+            CATKIN_LINT: true
     env:
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: moveit.rosinstall
+      # Pull any updates to the upstream workspace (since after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
-      BEFORE_TARGET_TEST_EMBED: ${{ matrix.env.IKFAST_TEST && 'set +u && source moveit_kinematics/test/test_ikfast_plugins.sh && set -u' || '' }}
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'RelWithDebInfo' || 'Release'}}
@@ -80,6 +81,10 @@ jobs:
           restore-keys: |
             ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ccache-${{ env.CACHE_PREFIX }}
+      - name: generate ikfast packages
+        if: ${{ matrix.env.IKFAST_TEST }}
+        run: |
+          bash moveit_kinematics/test/test_ikfast_plugins.sh
       - name: industrial_ci
         uses: tylerjw/industrial_ci@clang-tidy-modified-filter
         env: ${{ matrix.env }}

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
@@ -97,7 +97,7 @@ RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E
     apt-get install -y --no-install-recommends python-pip build-essential liblapack-dev ros-indigo-collada-urdf && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 # enforce a specific version of sympy, which is known to work with OpenRave
-RUN pip install sympy==0.7.1
+RUN pip install git+https://github.com/sympy/sympy.git@sympy-0.7.1
 EOF
    # When running in quiet mode, save stdout as 3, then redirect stdout to /dev/null
    test "$QUIET" == "1" && STDOUT=3 && exec 3>&1 1>/dev/null

--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
 # Script to test ikfast plugin creation and functionality
-# This script is intended to run as a BEFORE_DOCKER_SCRIPT from Travis.
-# Particularly we assume that the travis_* utility functions are available.
 
 # We will create ikfast plugins for fanuc and panda from moveit_resources
 # using the script auto_create_ikfast_moveit_plugin.sh
+
+set -e # fail script on error
 
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 2
 
 if [ "$ROS_DISTRO" == "noetic" ]; then
 	sudo update-alternatives --set python /usr/bin/python3
-	travis_run sudo apt-get -qq install python3-lxml python3-yaml
+	sudo apt-get -qq install python3-lxml python3-yaml
 else
 	sudo update-alternatives --set python /usr/bin/python2
-	travis_run sudo apt-get -qq install python-lxml python-yaml
+	sudo apt-get -qq install python-lxml python-yaml
 fi
 
 # Clone moveit_resources for URDFs. They are not available before running docker.
-travis_run git clone -q --depth=1 https://github.com/ros-planning/moveit_resources /tmp/resources
+git clone -q --depth=1 https://github.com/ros-planning/moveit_resources /tmp/resources
 fanuc=/tmp/resources/fanuc_description/urdf/fanuc.urdf
 panda=/tmp/resources/panda_description/urdf/panda.urdf
 
@@ -27,10 +27,10 @@ panda=/tmp/resources/panda_description/urdf/panda.urdf
 test ${QUIET:-1} -eq 0 && QUIET="" || QUIET="--quiet"
 
 # Create ikfast plugins for Fanuc and Panda
-travis_run moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
+moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
 	$QUIET --name fanuc --pkg $PWD/fanuc_ikfast_plugin $fanuc manipulator base_link tool0
 
-travis_run moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
+moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
 	$QUIET --name panda --pkg $PWD/panda_ikfast_plugin $panda panda_arm panda_link0 panda_link8
 
 echo "Done."


### PR DESCRIPTION
### Description
auto_create_ikfast_moveit_plugin.sh fails due to sympy0.7.1 dependency not available from pip any more.  Fixed by installing directly from github

Please explain the changes you made, including a reference to the related issue if applicable
https://github.com/ros-planning/moveit/issues/2649

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
