### PR TITLE
Use private NodeHandle instead of child for PlanningPipeline topics

### DIFF
--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -67,25 +67,26 @@ public:
    * this topic (visualization_msgs::MarkerArray) */
   static const std::string MOTION_CONTACTS_TOPIC;
 
-  /** \brief Given a robot model (\e model), a node handle (\e nh), initialize the planning pipeline.
+  /** \brief Given a robot model (\e model), a node handle (\e pipeline_nh), initialize the planning pipeline.
       \param model The robot model for which this pipeline is initialized.
-      \param nh The ROS node handle that should be used for reading parameters needed for configuration
+      \param pipeline_nh The ROS node handle that should be used for reading parameters needed for configuration
       \param planning_plugin_param_name The name of the ROS parameter under which the name of the planning plugin is
      specified
       \param adapter_plugins_param_name The name of the ROS parameter under which the names of the request adapter
      plugins are specified (plugin names separated by space; order matters)
   */
-  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& nh = ros::NodeHandle("~"),
+  PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
+                   const ros::NodeHandle& pipeline_nh = ros::NodeHandle("~"),
                    const std::string& planning_plugin_param_name = "planning_plugin",
                    const std::string& adapter_plugins_param_name = "request_adapters");
 
-  /** \brief Given a robot model (\e model), a node handle (\e nh), initialize the planning pipeline.
+  /** \brief Given a robot model (\e model), a node handle (\e pipeline_nh), initialize the planning pipeline.
       \param model The robot model for which this pipeline is initialized.
-      \param nh The ROS node handle that should be used for reading parameters needed for configuration
+      \param pipeline_nh The ROS node handle that should be used for reading parameters needed for configuration
       \param planning_plugin_name The name of the planning plugin to load
       \param adapter_plugins_names The names of the planning request adapter plugins to load
   */
-  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& nh,
+  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& pipeline_nh,
                    const std::string& planning_plugin_name, const std::vector<std::string>& adapter_plugin_names);
 
   /** \brief Pass a flag telling the pipeline whether or not to publish the computed motion plans on DISPLAY_PATH_TOPIC.
@@ -168,7 +169,11 @@ public:
 private:
   void configure();
 
-  ros::NodeHandle nh_;
+  // The NodeHandle to initialize the PlanningPipeline (parameters plugins) with
+  ros::NodeHandle pipeline_nh_;
+  // The private node handle of the node this PlanningPipeline was initialized from.
+  // It's used for plugin-agnostic display and info topics.
+  ros::NodeHandle private_nh_;
 
   /// Flag indicating whether motion plans should be published as a moveit_msgs::DisplayTrajectory
   bool display_computed_motion_plans_;

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -49,17 +49,17 @@ const std::string planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC
 const std::string planning_pipeline::PlanningPipeline::MOTION_CONTACTS_TOPIC = "display_contacts";
 
 planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
-                                                      const ros::NodeHandle& nh,
+                                                      const ros::NodeHandle& pipeline_nh,
                                                       const std::string& planner_plugin_param_name,
                                                       const std::string& adapter_plugins_param_name)
-  : nh_(nh), robot_model_(model)
+  : pipeline_nh_(pipeline_nh), private_nh_("~"), robot_model_(model)
 {
   std::string planner;
-  if (nh_.getParam(planner_plugin_param_name, planner))
+  if (pipeline_nh_.getParam(planner_plugin_param_name, planner))
     planner_plugin_name_ = planner;
 
   std::string adapters;
-  if (nh_.getParam(adapter_plugins_param_name, adapters))
+  if (pipeline_nh_.getParam(adapter_plugins_param_name, adapters))
   {
     boost::char_separator<char> sep(" ");
     boost::tokenizer<boost::char_separator<char> > tok(adapters, sep);
@@ -71,9 +71,14 @@ planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotM
 }
 
 planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
-                                                      const ros::NodeHandle& nh, const std::string& planner_plugin_name,
+                                                      const ros::NodeHandle& pipeline_nh,
+                                                      const std::string& planner_plugin_name,
                                                       const std::vector<std::string>& adapter_plugin_names)
-  : nh_(nh), planner_plugin_name_(planner_plugin_name), adapter_plugin_names_(adapter_plugin_names), robot_model_(model)
+  : pipeline_nh_(pipeline_nh)
+  , planner_plugin_name_(planner_plugin_name)
+  , adapter_plugin_names_(adapter_plugin_names)
+  , private_nh_("~")
+  , robot_model_(model)
 {
   configure();
 }
@@ -114,7 +119,7 @@ void planning_pipeline::PlanningPipeline::configure()
   try
   {
     planner_instance_ = planner_plugin_loader_->createUniqueInstance(planner_plugin_name_);
-    if (!planner_instance_->initialize(robot_model_, nh_.getNamespace()))
+    if (!planner_instance_->initialize(robot_model_, pipeline_nh_.getNamespace()))
       throw std::runtime_error("Unable to initialize planning plugin");
     ROS_INFO_STREAM("Using planning interface '" << planner_instance_->getDescription() << "'");
   }
@@ -154,7 +159,7 @@ void planning_pipeline::PlanningPipeline::configure()
         }
         if (ad)
         {
-          ad->initialize(nh_);
+          ad->initialize(pipeline_nh_);
           ads.push_back(std::move(ad));
         }
       }
@@ -177,7 +182,7 @@ void planning_pipeline::PlanningPipeline::displayComputedMotionPlans(bool flag)
   if (display_computed_motion_plans_ && !flag)
     display_path_publisher_.shutdown();
   else if (!display_computed_motion_plans_ && flag)
-    display_path_publisher_ = nh_.advertise<moveit_msgs::DisplayTrajectory>(DISPLAY_PATH_TOPIC, 10, true);
+    display_path_publisher_ = private_nh_.advertise<moveit_msgs::DisplayTrajectory>(DISPLAY_PATH_TOPIC, 10, true);
   display_computed_motion_plans_ = flag;
 }
 
@@ -186,7 +191,8 @@ void planning_pipeline::PlanningPipeline::publishReceivedRequests(bool flag)
   if (publish_received_requests_ && !flag)
     received_request_publisher_.shutdown();
   else if (!publish_received_requests_ && flag)
-    received_request_publisher_ = nh_.advertise<moveit_msgs::MotionPlanRequest>(MOTION_PLAN_REQUEST_TOPIC, 10, true);
+    received_request_publisher_ =
+        private_nh_.advertise<moveit_msgs::MotionPlanRequest>(MOTION_PLAN_REQUEST_TOPIC, 10, true);
   publish_received_requests_ = flag;
 }
 
@@ -195,7 +201,7 @@ void planning_pipeline::PlanningPipeline::checkSolutionPaths(bool flag)
   if (check_solution_paths_ && !flag)
     contacts_publisher_.shutdown();
   else if (!check_solution_paths_ && flag)
-    contacts_publisher_ = nh_.advertise<visualization_msgs::MarkerArray>(MOTION_CONTACTS_TOPIC, 100, true);
+    contacts_publisher_ = private_nh_.advertise<visualization_msgs::MarkerArray>(MOTION_CONTACTS_TOPIC, 100, true);
   check_solution_paths_ = flag;
 }
 
@@ -291,7 +297,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
             ROS_ERROR_STREAM("Computed path is not valid. Invalid states at index locations: [ "
                              << ss.str() << "] out of " << state_count
                              << ". Explanations follow in command line. Contacts are published on "
-                             << nh_.resolveName(MOTION_CONTACTS_TOPIC));
+                             << private_nh_.resolveName(MOTION_CONTACTS_TOPIC));
 
             // call validity checks in verbose mode for the problematic states
             visualization_msgs::MarkerArray arr;


### PR DESCRIPTION
Fixes #2578.

#2127 introduced a child NodeHandle for initializing the PlanningPipeline. Since the display topics were generated from that one, the MotionPlanning panel wasn't able to receive any display markers from the "move_group" namespace anymore. By advertising the topics from a private NodeHandle (`"~"`) all markers and display messages are again published from the node's namespace, which in case of MoveGroup is "move_group". -> All fine!
