### PR TITLE
Allow selecting planning pipeline in MotionSequenceAction

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -44,6 +44,7 @@ from moveit_msgs.msg import (
     MoveItErrorCodes,
     TrajectoryConstraints,
     PlannerInterfaceDescription,
+    MotionPlanRequest,
 )
 from sensor_msgs.msg import JointState
 import rospy
@@ -636,6 +637,11 @@ class MoveGroupCommander(object):
             planning_time,
             error_code,
         )
+
+    def construct_motion_plan_request(self):
+        """ Returns a MotionPlanRequest filled with the current goals of the move_group_interface"""
+        mpr = MotionPlanRequest()
+        return mpr.deserialize(self._g.construct_motion_plan_request())
 
     def compute_cartesian_path(
         self,

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -259,7 +259,7 @@ bool MoveGroupSequenceAction::planUsingSequenceManager(const moveit_msgs::Motion
     plan.error_code_.val = ex.getErrorCode();
     return false;
   }
-  // LCOV_EXCL_START // Keep moveit up even if lower parts throw
+  // LCOV_EXCL_START // Keep MoveIt up even if lower parts throw
   catch (const std::exception& ex)
   {
     ROS_ERROR_STREAM("Planning pipeline threw an exception: " << ex.what());

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -241,7 +241,17 @@ bool MoveGroupSequenceAction::planUsingSequenceManager(const moveit_msgs::Motion
   RobotTrajCont traj_vec;
   try
   {
-    traj_vec = command_list_manager_->solve(plan.planning_scene_, context_->planning_pipeline_, req);
+    // Select planning_pipeline to handle request
+    // All motions in the SequenceRequest need to use the same planning pipeline (but can use different planners)
+    const planning_pipeline::PlanningPipelinePtr planning_pipeline =
+        resolvePlanningPipeline(req.items[0].req.pipeline_id);
+    if (!planning_pipeline)
+    {
+      ROS_ERROR_STREAM("Could not load planning pipeline " << req.items[0].req.pipeline_id);
+      return false;
+    }
+
+    traj_vec = command_list_manager_->solve(plan.planning_scene_, planning_pipeline, req);
   }
   catch (const MoveItErrorCodeException& ex)
   {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -185,7 +185,7 @@ void TrajectoryGenerator::checkGoalConstraints(
   if (goal_constraints.size() != 1)
   {
     std::ostringstream os;
-    os << "Exaclty one goal constraint required, but " << goal_constraints.size() << " goal constraints given";
+    os << "Exactly one goal constraint required, but " << goal_constraints.size() << " goal constraints given";
     throw NotExactlyOneGoalConstraintGiven(os.str());
   }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -481,6 +481,13 @@ public:
                           plan.planning_time_);
   }
 
+  py_bindings_tools::ByteString constructMotionPlanRequestPython()
+  {
+    moveit_msgs::MotionPlanRequest request;
+    constructMotionPlanRequest(request);
+    return py_bindings_tools::serializeMsg(request);
+  }
+
   bp::tuple computeCartesianPathPython(const bp::list& waypoints, double eef_step, double jump_threshold,
                                        bool avoid_collisions)
   {
@@ -765,6 +772,8 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("get_planning_pipeline_id", &MoveGroupInterfaceWrapper::getPlanningPipelineIdCStr);
   move_group_interface_class.def("set_num_planning_attempts", &MoveGroupInterfaceWrapper::setNumPlanningAttempts);
   move_group_interface_class.def("plan", &MoveGroupInterfaceWrapper::planPython);
+  move_group_interface_class.def("construct_motion_plan_request",
+                                 &MoveGroupInterfaceWrapper::constructMotionPlanRequestPython);
   move_group_interface_class.def("compute_cartesian_path", &MoveGroupInterfaceWrapper::computeCartesianPathPython);
   move_group_interface_class.def("compute_cartesian_path",
                                  &MoveGroupInterfaceWrapper::computeCartesianPathConstrainedPython);


### PR DESCRIPTION
I was trying out the `MotionPlanSequenceAction` today, and noticed that the planning pipeline cannot be switched from the initially loaded one. That makes it impossible to use e.g. LIN motions if OMPL is the default pipeline.

This PR uses the changes introduced in #2127 to allow switching the pipeline. The limitation is that only a single pipeline can be used per MotionSequence, but realistically no one will use this except for chaining `pilz` motions together, so I don't think this is a problem. I also don't think spending development time on it is worth it.

The PR also exposes the `constructMotionPlanRequest` function in the Python `MoveGroupInterface`, because defining a `MotionPlanSequenceRequest` without it is not feasible (unless you use a package like [the one linked in the tutorial](https://ros-planning.github.io/moveit_tutorials/doc/pilz_industrial_motion_planner/pilz_industrial_motion_planner.html#sequence-of-multiple-segments), but our intern could not get it to run, so we abandoned the idea).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers