### PR TITLE
declare conflict after moving headers

### DIFF
--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -40,6 +40,11 @@
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>rostest</test_depend>
 
+  <!-- we moved moveit_cpp from planning_interface in this version,
+       so files conflict. replace provides a migration path for deb/rpm -->
+  <conflict version_lt="1.1.2">moveit_ros_planning_interface</conflict>
+  <replace version_lt="1.1.2">moveit_ros_planning_interface</replace>
+
   <export>
     <moveit_core plugin="${prefix}/planning_request_adapters_plugin_description.xml"/>
   </export>


### PR DESCRIPTION
... that install to the same location.

Following the suggestion from https://github.com/ros-planning/moveit/issues/2648#issuecomment-836647351

Fixup for eb3bf6fdb6ece5324e3d1a81fd5d2b2197804710

Fixes #2648.


### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"