### PR TITLE
Fixup for #2596

### DIFF
--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -37,7 +37,7 @@
 #include <ros/ros.h>
 #include <moveit_msgs/SaveMap.h>
 #include <moveit_msgs/LoadMap.h>
-#include <moveit/occupancy_map_monitor/occupancy_map.h>
+#include <moveit/collision_detection/occupancy_map.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <XmlRpcException.h>
 


### PR DESCRIPTION
I forgot changing one include in #2596 which apparently does not bother the moveit-ci but does bother our internal ci

the relevant include is redundant as it's also included by `occupancy_map_monitor.h`, maybe that was the reason for MoveIt-CI being contempt

the include in the header could most likely be replaced by a forward decl, not sure if that would be worth the effort?