### PR TITLE
Refine CSM::haveCompleteState

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,7 @@ API changes in MoveIt releases
 - `RobotTrajectory` provides a copy constructor that allows a shallow (default) and deep copy of waypoints
 - Replace the redundant namespaces `robot_state::` and `robot_model::` with the actual namespace `moveit::core::`. The additional namespaces will disappear in the future (ROS2).
 - Moved the library `moveit_cpp` to `moveit_ros_planning`. The classes are now in namespace `moveit_cpp`, access via `moveit::planning_interface` is deprecated.
+- The joint states of `passive` joints must be published in ROS and the CurrentStateMonitor will now wait for them as well. Their semantics dictate that they cannot be actively controlled, but they must be known to use the full robot state in collision checks. (https://github.com/ros-planning/moveit/pull/2663)
 
 ## ROS Melodic
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -100,6 +100,13 @@ public:
   bool haveCompleteState() const;
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
+   *  @param oldest_allowed_update_time All joint information must be from this time or more current
+   *  @return False if we have no joint state information for one of the joints or if our state
+   *  information is more than \e age old*/
+  bool haveCompleteState(const ros::Time& oldest_allowed_update_time) const;
+
+  /** @brief Query whether we have joint state information for all DOFs in the kinematic model
+   *  @param age Joint information must be at most this old
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old
    */
@@ -112,10 +119,16 @@ public:
   bool haveCompleteState(std::vector<std::string>& missing_joints) const;
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
-   *  @param age The max allowed age of the joint state information
+   *  @param oldest_allowed_update_time All joint information must be from this time or more current
    *  @param missing_joints Returns the list of joints that are missing
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old*/
+  bool haveCompleteState(const ros::Time& oldest_allowed_update_time, std::vector<std::string>& missing_joints) const;
+
+  /** @brief Query whether we have joint state information for all DOFs in the kinematic model
+   *  @return False if we have no joint state information for one of the joints or if our state
+   *  information is more than \e age old
+   */
   bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const;
 
   /** @brief Get the current state

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -113,10 +113,10 @@ public:
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param age The max allowed age of the joint state information
-   *  @param missing_states Returns the list of joints that are missing
+   *  @param missing_joints Returns the list of joints that are missing
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old*/
-  bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_states) const;
+  bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const;
 
   /** @brief Get the current state
    *  @return Returns the current state */

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -188,6 +188,9 @@ public:
   }
 
 private:
+  bool haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
+                               std::vector<std::string>* missing_joints) const;
+
   void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
   void tfCallback();
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -97,39 +97,58 @@ public:
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @return False if we have no joint state information for one or more of the joints
    */
-  bool haveCompleteState() const;
+  inline bool haveCompleteState() const
+  {
+    return haveCompleteStateHelper(ros::Time(0), nullptr);
+  }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param oldest_allowed_update_time All joint information must be from this time or more current
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old*/
-  bool haveCompleteState(const ros::Time& oldest_allowed_update_time) const;
+  inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time) const
+  {
+    return haveCompleteStateHelper(oldest_allowed_update_time, nullptr);
+  }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param age Joint information must be at most this old
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old
    */
-  bool haveCompleteState(const ros::Duration& age) const;
+  inline bool haveCompleteState(const ros::Duration& age) const
+  {
+    return haveCompleteStateHelper(ros::Time::now() - age, nullptr);
+  }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param missing_joints Returns the list of joints that are missing
    *  @return False if we have no joint state information for one or more of the joints
    */
-  bool haveCompleteState(std::vector<std::string>& missing_joints) const;
+  inline bool haveCompleteState(std::vector<std::string>& missing_joints) const
+  {
+    return haveCompleteStateHelper(ros::Time(0), &missing_joints);
+  }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param oldest_allowed_update_time All joint information must be from this time or more current
    *  @param missing_joints Returns the list of joints that are missing
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old*/
-  bool haveCompleteState(const ros::Time& oldest_allowed_update_time, std::vector<std::string>& missing_joints) const;
+  inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time,
+                                std::vector<std::string>& missing_joints) const
+  {
+    return haveCompleteStateHelper(oldest_allowed_update_time, &missing_joints);
+  }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old
    */
-  bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const;
+  inline bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const
+  {
+    return haveCompleteStateHelper(ros::Time::now() - age, &missing_joints);
+  }
 
   /** @brief Get the current state
    *  @return Returns the current state */

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -194,9 +194,20 @@ bool CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_jo
   return haveCompleteStateHelper(ros::Time(0), &missing_joints);
 }
 
+bool CurrentStateMonitor::haveCompleteState(const ros::Time& oldest_allowed_update_time) const
+{
+  return haveCompleteStateHelper(oldest_allowed_update_time, nullptr);
+}
+
 bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age) const
 {
   return haveCompleteStateHelper(ros::Time::now() - age, nullptr);
+}
+
+bool CurrentStateMonitor::haveCompleteState(const ros::Time& oldest_allowed_update_time,
+                                            std::vector<std::string>& missing_joints) const
+{
+  return haveCompleteStateHelper(oldest_allowed_update_time, &missing_joints);
 }
 
 bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const
@@ -204,7 +215,7 @@ bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vecto
   return haveCompleteStateHelper(ros::Time::now() - age, &missing_joints);
 }
 
-bool CurrentStateMonitor::haveCompleteStateHelper(const ros::Time& min_update_time,
+bool CurrentStateMonitor::haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
                                                   std::vector<std::string>* missing_joints) const
 {
   const std::vector<const moveit::core::JointModel*>& active_joints = robot_model_->getActiveJointModels();
@@ -216,10 +227,10 @@ bool CurrentStateMonitor::haveCompleteStateHelper(const ros::Time& min_update_ti
     {
       ROS_DEBUG_NAMED(LOGNAME, "Joint '%s' has never been updated", joint->getName().c_str());
     }
-    else if (it->second < min_update_time)
+    else if (it->second < oldest_allowed_update_time)
     {
       ROS_DEBUG_NAMED(LOGNAME, "Joint '%s' was last updated %0.3lf seconds before requested time",
-                      joint->getName().c_str(), (min_update_time - it->second).toSec());
+                      joint->getName().c_str(), (oldest_allowed_update_time - it->second).toSec());
     }
     else
       continue;

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -184,37 +184,6 @@ std::string CurrentStateMonitor::getMonitoredTopic() const
     return "";
 }
 
-bool CurrentStateMonitor::haveCompleteState() const
-{
-  return haveCompleteStateHelper(ros::Time(0), nullptr);
-}
-
-bool CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_joints) const
-{
-  return haveCompleteStateHelper(ros::Time(0), &missing_joints);
-}
-
-bool CurrentStateMonitor::haveCompleteState(const ros::Time& oldest_allowed_update_time) const
-{
-  return haveCompleteStateHelper(oldest_allowed_update_time, nullptr);
-}
-
-bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age) const
-{
-  return haveCompleteStateHelper(ros::Time::now() - age, nullptr);
-}
-
-bool CurrentStateMonitor::haveCompleteState(const ros::Time& oldest_allowed_update_time,
-                                            std::vector<std::string>& missing_joints) const
-{
-  return haveCompleteStateHelper(oldest_allowed_update_time, &missing_joints);
-}
-
-bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const
-{
-  return haveCompleteStateHelper(ros::Time::now() - age, &missing_joints);
-}
-
 bool CurrentStateMonitor::haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
                                                   std::vector<std::string>* missing_joints) const
 {

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -41,15 +41,16 @@
 
 #include <limits>
 
-planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
-                                                                 const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
+namespace planning_scene_monitor
+{
+CurrentStateMonitor::CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
+                                         const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)
   : CurrentStateMonitor(robot_model, tf_buffer, ros::NodeHandle())
 {
 }
 
-planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
-                                                                 const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                                                 const ros::NodeHandle& nh)
+CurrentStateMonitor::CurrentStateMonitor(const moveit::core::RobotModelConstPtr& robot_model,
+                                         const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const ros::NodeHandle& nh)
   : nh_(nh)
   , tf_buffer_(tf_buffer)
   , robot_model_(robot_model)
@@ -61,33 +62,32 @@ planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const moveit::c
   robot_state_.setToDefaultValues();
 }
 
-planning_scene_monitor::CurrentStateMonitor::~CurrentStateMonitor()
+CurrentStateMonitor::~CurrentStateMonitor()
 {
   stopStateMonitor();
 }
 
-moveit::core::RobotStatePtr planning_scene_monitor::CurrentStateMonitor::getCurrentState() const
+moveit::core::RobotStatePtr CurrentStateMonitor::getCurrentState() const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
   moveit::core::RobotState* result = new moveit::core::RobotState(robot_state_);
   return moveit::core::RobotStatePtr(result);
 }
 
-ros::Time planning_scene_monitor::CurrentStateMonitor::getCurrentStateTime() const
+ros::Time CurrentStateMonitor::getCurrentStateTime() const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
   return current_state_time_;
 }
 
-std::pair<moveit::core::RobotStatePtr, ros::Time>
-planning_scene_monitor::CurrentStateMonitor::getCurrentStateAndTime() const
+std::pair<moveit::core::RobotStatePtr, ros::Time> CurrentStateMonitor::getCurrentStateAndTime() const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
   moveit::core::RobotState* result = new moveit::core::RobotState(robot_state_);
   return std::make_pair(moveit::core::RobotStatePtr(result), current_state_time_);
 }
 
-std::map<std::string, double> planning_scene_monitor::CurrentStateMonitor::getCurrentStateValues() const
+std::map<std::string, double> CurrentStateMonitor::getCurrentStateValues() const
 {
   std::map<std::string, double> m;
   boost::mutex::scoped_lock slock(state_update_lock_);
@@ -98,7 +98,7 @@ std::map<std::string, double> planning_scene_monitor::CurrentStateMonitor::getCu
   return m;
 }
 
-void planning_scene_monitor::CurrentStateMonitor::setToCurrentState(moveit::core::RobotState& upd) const
+void CurrentStateMonitor::setToCurrentState(moveit::core::RobotState& upd) const
 {
   boost::mutex::scoped_lock slock(state_update_lock_);
   const double* pos = robot_state_.getVariablePositions();
@@ -123,18 +123,18 @@ void planning_scene_monitor::CurrentStateMonitor::setToCurrentState(moveit::core
   }
 }
 
-void planning_scene_monitor::CurrentStateMonitor::addUpdateCallback(const JointStateUpdateCallback& fn)
+void CurrentStateMonitor::addUpdateCallback(const JointStateUpdateCallback& fn)
 {
   if (fn)
     update_callbacks_.push_back(fn);
 }
 
-void planning_scene_monitor::CurrentStateMonitor::clearUpdateCallbacks()
+void CurrentStateMonitor::clearUpdateCallbacks()
 {
   update_callbacks_.clear();
 }
 
-void planning_scene_monitor::CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topic)
+void CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topic)
 {
   if (!state_monitor_started_ && robot_model_)
   {
@@ -154,12 +154,12 @@ void planning_scene_monitor::CurrentStateMonitor::startStateMonitor(const std::s
   }
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::isActive() const
+bool CurrentStateMonitor::isActive() const
 {
   return state_monitor_started_;
 }
 
-void planning_scene_monitor::CurrentStateMonitor::stopStateMonitor()
+void CurrentStateMonitor::stopStateMonitor()
 {
   if (state_monitor_started_)
   {
@@ -174,7 +174,7 @@ void planning_scene_monitor::CurrentStateMonitor::stopStateMonitor()
   }
 }
 
-std::string planning_scene_monitor::CurrentStateMonitor::getMonitoredTopic() const
+std::string CurrentStateMonitor::getMonitoredTopic() const
 {
   if (joint_state_subscriber_)
     return joint_state_subscriber_.getTopic();
@@ -182,7 +182,7 @@ std::string planning_scene_monitor::CurrentStateMonitor::getMonitoredTopic() con
     return "";
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState() const
+bool CurrentStateMonitor::haveCompleteState() const
 {
   bool result = true;
   const std::vector<const moveit::core::JointModel*>& joints = robot_model_->getActiveJointModels();
@@ -199,7 +199,7 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState() const
   return result;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_states) const
+bool CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_states) const
 {
   bool result = true;
   const std::vector<const moveit::core::JointModel*>& joints = robot_model_->getActiveJointModels();
@@ -214,7 +214,7 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(std::vector<
   return result;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::Duration& age) const
+bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age) const
 {
   bool result = true;
   const std::vector<const moveit::core::JointModel*>& joints = robot_model_->getActiveJointModels();
@@ -241,8 +241,7 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::D
   return result;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::Duration& age,
-                                                                    std::vector<std::string>& missing_states) const
+bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_states) const
 {
   bool result = true;
   const std::vector<const moveit::core::JointModel*>& joints = robot_model_->getActiveJointModels();
@@ -271,7 +270,7 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const ros::D
   return result;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros::Time t, double wait_time) const
+bool CurrentStateMonitor::waitForCurrentState(const ros::Time t, double wait_time) const
 {
   ros::WallTime start = ros::WallTime::now();
   ros::WallDuration elapsed(0, 0);
@@ -293,7 +292,7 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const ros:
   return true;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(double wait_time) const
+bool CurrentStateMonitor::waitForCompleteState(double wait_time) const
 {
   double slept_time = 0.0;
   double sleep_step_s = std::min(0.05, wait_time / 10.0);
@@ -306,7 +305,7 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(double wa
   return haveCompleteState();
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(const std::string& group, double wait_time) const
+bool CurrentStateMonitor::waitForCompleteState(const std::string& group, double wait_time) const
 {
   if (waitForCompleteState(wait_time))
     return true;
@@ -333,7 +332,7 @@ bool planning_scene_monitor::CurrentStateMonitor::waitForCompleteState(const std
   return ok;
 }
 
-void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state)
+void CurrentStateMonitor::jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state)
 {
   if (joint_state->name.size() != joint_state->position.size())
   {
@@ -411,7 +410,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
   state_update_condition_.notify_all();
 }
 
-void planning_scene_monitor::CurrentStateMonitor::tfCallback()
+void CurrentStateMonitor::tfCallback()
 {
   // read multi-dof joint states from TF, if needed
   const std::vector<const moveit::core::JointModel*>& multi_dof_joints = robot_model_->getMultiDOFJointModels();
@@ -481,3 +480,5 @@ void planning_scene_monitor::CurrentStateMonitor::tfCallback()
     state_update_condition_.notify_all();
   }
 }
+
+}  // namespace planning_scene_monitor

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -199,7 +199,7 @@ bool CurrentStateMonitor::haveCompleteState() const
   return result;
 }
 
-bool CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_states) const
+bool CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_joints) const
 {
   bool result = true;
   const std::vector<const moveit::core::JointModel*>& joints = robot_model_->getActiveJointModels();
@@ -208,7 +208,7 @@ bool CurrentStateMonitor::haveCompleteState(std::vector<std::string>& missing_st
     if (joint_time_.find(joint) == joint_time_.end())
       if (!joint->isPassive() && !joint->getMimic())
       {
-        missing_states.push_back(joint->getName());
+        missing_joints.push_back(joint->getName());
         result = false;
       }
   return result;
@@ -241,7 +241,7 @@ bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age) const
   return result;
 }
 
-bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_states) const
+bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const
 {
   bool result = true;
   const std::vector<const moveit::core::JointModel*>& joints = robot_model_->getActiveJointModels();
@@ -256,14 +256,14 @@ bool CurrentStateMonitor::haveCompleteState(const ros::Duration& age, std::vecto
     if (it == joint_time_.end())
     {
       ROS_DEBUG("Joint '%s' has never been updated", joint->getName().c_str());
-      missing_states.push_back(joint->getName());
+      missing_joints.push_back(joint->getName());
       result = false;
     }
     else if (it->second < old)
     {
       ROS_DEBUG("Joint '%s' was last updated %0.3lf seconds ago (older than the allowed %0.3lf seconds)",
                 joint->getName().c_str(), (now - it->second).toSec(), age.toSec());
-      missing_states.push_back(joint->getName());
+      missing_joints.push_back(joint->getName());
       result = false;
     }
   }


### PR DESCRIPTION
I looked at these methods in the context of #2661 and was shocked they were in such a bad state.

Unifying the different overloads, I slightly changed the semantics of the method (for the better of course :cat: ).
The details are explained in fbecdeb .