### PR TITLE
add warning if interpolation parameter is out of range [0, 1]

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -61,7 +61,7 @@ namespace core
 {
 MOVEIT_CLASS_FORWARD(RobotModel);  // Defines RobotModelPtr, ConstPtr, WeakPtr... etc
 
-static inline void checkInterpolationParamBounds(const char LOGNAME[], const double& t)
+static inline void checkInterpolationParamBounds(const char LOGNAME[], double t)
 {
   if (std::isnan(t) || std::isinf(t))
   {

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -61,6 +61,15 @@ namespace core
 {
 MOVEIT_CLASS_FORWARD(RobotModel);  // Defines RobotModelPtr, ConstPtr, WeakPtr... etc
 
+static inline void checkInterpolationParamBounds(const char LOGNAME[], const double& t)
+{
+  if (std::isnan(t) || std::isinf(t))
+  {
+    throw Exception("Interpolation parameter is NaN or inf.");
+  }
+  ROS_WARN_STREAM_COND_NAMED(t < 0. || t > 1., LOGNAME, "Interpolation parameter is not in the range [0, 1]: " << t);
+}
+
 /** \brief Definition of a kinematic model. This class is not thread
     safe, however multiple instances can be created */
 class RobotModel

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -49,7 +49,10 @@ namespace moveit
 {
 namespace core
 {
-const std::string LOGNAME = "robot_model";
+namespace
+{
+constexpr char LOGNAME[] = "robot_model";
+}  // namespace
 
 RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model, const srdf::ModelConstSharedPtr& srdf_model)
 {
@@ -1290,8 +1293,7 @@ double RobotModel::distance(const double* state1, const double* state2) const
 
 void RobotModel::interpolate(const double* from, const double* to, double t, double* state) const
 {
-  ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
-                             "Interpolation parameter is not in the range [0, 1]: " << t);
+  moveit::core::checkInterpolationParamBounds(LOGNAME, t);
   // we interpolate values only for active joint models (non-mimic)
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
     active_joint_model_vector_[i]->interpolate(from + active_joint_model_start_index_[i],

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1290,6 +1290,8 @@ double RobotModel::distance(const double* state1, const double* state2) const
 
 void RobotModel::interpolate(const double* from, const double* to, double t, double* state) const
 {
+  ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
+                             "Interpolation paramter is not in the range [0, 1]: " << t);
   // we interpolate values only for active joint models (non-mimic)
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
     active_joint_model_vector_[i]->interpolate(from + active_joint_model_start_index_[i],

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1291,7 +1291,7 @@ double RobotModel::distance(const double* state1, const double* state2) const
 void RobotModel::interpolate(const double* from, const double* to, double t, double* state) const
 {
   ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
-                             "Interpolation paramter is not in the range [0, 1]: " << t);
+                             "Interpolation parameter is not in the range [0, 1]: " << t);
   // we interpolate values only for active joint models (non-mimic)
   for (std::size_t i = 0; i < active_joint_model_vector_.size(); ++i)
     active_joint_model_vector_[i]->interpolate(from + active_joint_model_start_index_[i],

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -902,6 +902,8 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
+  ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
+                             "Interpolation paramter is not in the range [0, 1]: " << t);
   robot_model_->interpolate(getVariablePositions(), to.getVariablePositions(), t, state.getVariablePositions());
 
   memset(state.dirty_joint_transforms_, 1, state.robot_model_->getJointModelCount() * sizeof(unsigned char));
@@ -910,6 +912,8 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state) 
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state, const JointModelGroup* joint_group) const
 {
+  ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
+                             "Interpolation paramter is not in the range [0, 1]: " << t);
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
   for (const JointModel* joint : jm)
   {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -903,7 +903,7 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
   ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
-                             "Interpolation paramter is not in the range [0, 1]: " << t);
+                             "Interpolation parameter is not in the range [0, 1]: " << t);
   robot_model_->interpolate(getVariablePositions(), to.getVariablePositions(), t, state.getVariablePositions());
 
   memset(state.dirty_joint_transforms_, 1, state.robot_model_->getJointModelCount() * sizeof(unsigned char));
@@ -913,7 +913,7 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state) 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state, const JointModelGroup* joint_group) const
 {
   ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
-                             "Interpolation paramter is not in the range [0, 1]: " << t);
+                             "Interpolation parameter is not in the range [0, 1]: " << t);
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
   for (const JointModel* joint : jm)
   {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -51,7 +51,10 @@ namespace moveit
 {
 namespace core
 {
-const std::string LOGNAME = "robot_state";
+namespace
+{
+constexpr char LOGNAME[] = "robot_state";
+}  // namespace
 
 RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)
@@ -902,8 +905,7 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
-  ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
-                             "Interpolation parameter is not in the range [0, 1]: " << t);
+  moveit::core::checkInterpolationParamBounds(LOGNAME, t);
   robot_model_->interpolate(getVariablePositions(), to.getVariablePositions(), t, state.getVariablePositions());
 
   memset(state.dirty_joint_transforms_, 1, state.robot_model_->getJointModelCount() * sizeof(unsigned char));
@@ -912,8 +914,7 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state) 
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state, const JointModelGroup* joint_group) const
 {
-  ROS_WARN_STREAM_COND_NAMED(std::isnan(t) || t < 0. || t > 1., LOGNAME,
-                             "Interpolation parameter is not in the range [0, 1]: " << t);
+  moveit::core::checkInterpolationParamBounds(LOGNAME, t);
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
   for (const JointModel* joint : jm)
   {


### PR DESCRIPTION
### Description

Added warnings if the interpolation parameter `t` is outside the range [0, 1] or NaN. Would have helped in debugging something recently.

Maybe it would be good to also clamp the value to [0, 1] (and make a NaN a 0 or something)?

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
