### PR TITLE
Add OCTOMAP_LIBRARIES and OCTOMAP_INCLUDE_DIRS to CMakeLists

### DIFF
--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -34,6 +34,7 @@ catkin_package(
     include
   LIBRARIES
     ${MOVEIT_LIB_NAME}
+    ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     moveit_core
     moveit_msgs
@@ -49,6 +50,7 @@ include_directories(SYSTEM
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
                     ${EIGEN3_INCLUDE_DIRS}
+                    ${OCTOMAP_INCLUDE_DIRS}
                     ${X11_INCLUDE_DIR}
                     )
 

--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -34,7 +34,6 @@ catkin_package(
     include
   LIBRARIES
     ${MOVEIT_LIB_NAME}
-    ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     moveit_core
     moveit_msgs


### PR DESCRIPTION
### Description

Hi there,

I had a linking issue regarding the moveit_ros/occupancy_map_monitor package and found a corresponding issue (https://github.com/ros-planning/moveit/issues/2560 ) without PR. Since it seemed to be an easy fix I decided to go for it. In the issue an undefined reference to octomath from the octomap package is described. I did elaborate in a comment on that issue and did provide some CMake snippets in order to support my PR. Sadly I am failing to reproduce the issue in a minimal example, but since another person reported the bug I thought it might still be helpful.

Since this linking issue does not pop up during the CI build and not during a manual source build of neither the melodic nor the noetic version of the entire moveit package, I was confused at first. However the CMake entries that I am proposing are defined in the moveit_core package, which is a direct dependency of the occupancy_map_monitor package, and might therefore be available to cmake. However when using the occupancy_map_monitor library in a custom package the linking issue appears, which suggests that the targets dependencies and include directories are not properly exported. Hence I added the missing entries in a similar fashion to what is found in the moveit_core [CMakeLists](https://github.com/ros-planning/moveit/blob/master/moveit_core/CMakeLists.txt) (L155 and L189).

Same [PR](https://github.com/ros-planning/moveit/pull/2670) for melodic-devel branch.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
