### PR TITLE
collision_detection_fcl: Report link_names in correct order

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -62,7 +62,7 @@ void checkFCLCapabilities(const DistanceRequest& req)
     //   https://github.com/flexible-collision-library/fcl/pull/288
     ROS_ERROR_THROTTLE_NAMED(2.0, LOGNAME,
                              "You requested a distance check with enable_nearest_points=true, "
-                             "but the FCL version MoveIt! was compiled against (%d.%d.%d) "
+                             "but the FCL version MoveIt was compiled against (%d.%d.%d) "
                              "is known to return bogus nearest points. Please update your FCL "
                              "to at least 0.6.0.",
                              FCL_MAJOR_VERSION, FCL_MINOR_VERSION, FCL_PATCH_VERSION);

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection_panda.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection_panda.cpp
@@ -40,8 +40,17 @@
 INSTANTIATE_TYPED_TEST_CASE_P(FCLCollisionCheckPanda, CollisionDetectorPandaTest,
                               collision_detection::CollisionDetectorAllocatorFCL);
 
+// FCL < 0.6 incorrectly reports distance results in the object coordinate frame.
+// See: https://github.com/flexible-collision-library/fcl/issues/171
+//  and https://github.com/flexible-collision-library/fcl/pull/288.
+// So only execute the full distance test suite on FCL >= 0.6.
+#if MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0)
+INSTANTIATE_TYPED_TEST_CASE_P(FCLDistanceCheckPanda, DistanceFullPandaTest,
+                              collision_detection::CollisionDetectorAllocatorFCL);
+#else
 INSTANTIATE_TYPED_TEST_CASE_P(FCLDistanceCheckPanda, DistanceCheckPandaTest,
                               collision_detection::CollisionDetectorAllocatorFCL);
+#endif
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
### Description

For distance queries, FCL may report results in different order than what was requested (e.g. `fcl::distance(o1, o2, ...)` might give an `fcl::DistanceResult` with `o2, o1`. The MoveIt wrapper does not check if this is the case, and thus may report nearest_points in order `o2,o1` with `link_name` in order `o1,o2`.

This PR fixes this issue by explicitly using the collision objects referenced in the `fcl::DistanceResult` object. It also adds a unit test which demonstrates the issue.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
    I feel this is not applicable, since this is a pure bugfix.
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
    I think the risk that somebody depends on the current broken behavior is quite low.
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)