### PR TITLE
Revert "Lock the octomap/octree while collision checking (#2596)"

### DIFF
--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -42,7 +42,7 @@
 #include <boost/function.hpp>
 #include <memory>
 
-namespace collision_detection
+namespace occupancy_map_monitor
 {
 typedef octomap::OcTreeNode OccMapNode;
 
@@ -86,7 +86,7 @@ public:
   using ReadLock = boost::shared_lock<boost::shared_mutex>;
   using WriteLock = boost::unique_lock<boost::shared_mutex>;
 
-  ReadLock reading() const
+  ReadLock reading()
   {
     return ReadLock(tree_mutex_);
   }
@@ -109,10 +109,10 @@ public:
   }
 
 private:
-  mutable boost::shared_mutex tree_mutex_;
+  boost::shared_mutex tree_mutex_;
   boost::function<void()> update_callback_;
 };
 
 using OccMapTreePtr = std::shared_ptr<OccMapTree>;
 using OccMapTreeConstPtr = std::shared_ptr<const OccMapTree>;
-}  // namespace collision_detection
+}  // namespace occupancy_map_monitor

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -44,7 +44,7 @@
 
 #include <moveit_msgs/SaveMap.h>
 #include <moveit_msgs/LoadMap.h>
-#include <moveit/collision_detection/occupancy_map.h>
+#include <moveit/occupancy_map_monitor/occupancy_map.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
 
 #include <boost/thread/mutex.hpp>
@@ -71,14 +71,14 @@ public:
 
   /** @brief Get a pointer to the underlying octree for this monitor. Lock the tree before reading or writing using this
    *  pointer. The value of this pointer stays the same throughout the existance of the monitor instance. */
-  const collision_detection::OccMapTreePtr& getOcTreePtr()
+  const OccMapTreePtr& getOcTreePtr()
   {
     return tree_;
   }
 
   /** @brief Get a const pointer to the underlying octree for this monitor. Lock the
    *  tree before reading this pointer */
-  const collision_detection::OccMapTreeConstPtr& getOcTreePtr() const
+  const OccMapTreeConstPtr& getOcTreePtr() const
   {
     return tree_const_;
   }
@@ -140,8 +140,8 @@ private:
   double map_resolution_;
   boost::mutex parameters_lock_;
 
-  collision_detection::OccMapTreePtr tree_;
-  collision_detection::OccMapTreeConstPtr tree_const_;
+  OccMapTreePtr tree_;
+  OccMapTreeConstPtr tree_const_;
 
   std::unique_ptr<pluginlib::ClassLoader<OccupancyMapUpdater> > updater_plugin_loader_;
   std::vector<OccupancyMapUpdaterPtr> map_updaters_;

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -37,7 +37,7 @@
 #pragma once
 
 #include <moveit/macros/class_forward.h>
-#include <moveit/collision_detection/occupancy_map.h>
+#include <moveit/occupancy_map_monitor/occupancy_map.h>
 #include <geometric_shapes/shapes.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -98,7 +98,7 @@ public:
 protected:
   OccupancyMapMonitor* monitor_;
   std::string type_;
-  collision_detection::OccMapTreePtr tree_;
+  OccMapTreePtr tree_;
   TransformCacheProvider transform_provider_callback_;
   ShapeTransformCache transform_cache_;
   bool debug_info_;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -99,7 +99,7 @@ void OccupancyMapMonitor::initialize()
                                                      << "\" specified but no TF instance (buffer) specified. "
                                                         "No transforms will be applied to received data.");
 
-  tree_.reset(new collision_detection::OccMapTree(map_resolution_));
+  tree_.reset(new OccMapTree(map_resolution_));
   tree_const_ = tree_;
 
   XmlRpc::XmlRpcValue sensor_list;

--- a/moveit_ros/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
+++ b/moveit_ros/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include <moveit/collision_detection/occupancy_map.h>
+#include <moveit/occupancy_map_monitor/occupancy_map.h>
 #include <boost/thread.hpp>
 #include <deque>
 #include <unordered_map>
@@ -46,7 +46,7 @@ namespace occupancy_map_monitor
 class LazyFreeSpaceUpdater
 {
 public:
-  LazyFreeSpaceUpdater(const collision_detection::OccMapTreePtr& tree, unsigned int max_batch_size = 10);
+  LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned int max_batch_size = 10);
   ~LazyFreeSpaceUpdater();
 
   void pushLazyUpdate(octomap::KeySet* occupied_cells, octomap::KeySet* model_cells,
@@ -67,7 +67,7 @@ private:
   void lazyUpdateThread();
   void processThread();
 
-  collision_detection::OccMapTreePtr tree_;
+  OccMapTreePtr tree_;
   bool running_;
   std::size_t max_batch_size_;
   double max_sensor_delta_;

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -41,7 +41,7 @@ namespace occupancy_map_monitor
 {
 static const std::string LOGNAME = "lazy_free_space_updater";
 
-LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const collision_detection::OccMapTreePtr& tree, unsigned int max_batch_size)
+LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned int max_batch_size)
   : tree_(tree)
   , running_(true)
   , max_batch_size_(max_batch_size)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -338,7 +338,7 @@ void PlanningSceneMonitor::scenePublishingThread()
   {
     moveit_msgs::PlanningScene msg;
     {
-      collision_detection::OccMapTree::ReadLock lock;
+      occupancy_map_monitor::OccMapTree::ReadLock lock;
       if (octomap_monitor_)
         lock = octomap_monitor_->getOcTreePtr()->reading();
       scene_->getPlanningSceneMsg(msg);
@@ -365,7 +365,7 @@ void PlanningSceneMonitor::scenePublishingThread()
             is_full = true;
           else
           {
-            collision_detection::OccMapTree::ReadLock lock;
+            occupancy_map_monitor::OccMapTree::ReadLock lock;
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
@@ -395,7 +395,7 @@ void PlanningSceneMonitor::scenePublishingThread()
           }
           if (is_full)
           {
-            collision_detection::OccMapTree::ReadLock lock;
+            occupancy_map_monitor::OccMapTree::ReadLock lock;
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneMsg(msg);


### PR DESCRIPTION
This reverts commit 0935d681b0141108e9695db30107184996963be7.

It introduced a deadlock in the standard MoveGroup planning pipeline.
Octomap is already locked in `PlanningSceneMonitor::lockSceneRead()` [before planning in the capability](https://github.com/ros-planning/moveit/blob/master/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp#L222).
So the recursive locking calls (even in a different thread because OMPL spawns [a separate goal sampling thread](https://github.com/ros-planning/moveit/blob/master/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp#L90)) can result in a deadlock if a writer lock is requested in the meanwhile.

@simonschmeisser To solve the issue you describe in  #2596, you will have to lock the `PlanningSceneMonitor` that maintains the `octomap_monitor_`. The only potential alternative I see is to deep-copy the octomap in `decoupleParent()` if you use that method.
According to its documentation, this should actually always happen, but it's not implemented there.
If you rely on collision-checking of a diff scene without locking the parent scene, you are definitely in undefined-behavior land.

Fixes #2666 .

Sorry for the inconvenience and the delay in addressing this urgent issue.
@rhaschke I believe we need another fixup release after this commit. Sorry for the trouble...