### PR TITLE
Split upstream and downstream workspaces

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -12,36 +12,29 @@ WORKDIR /root/ws_moveit
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 RUN \
-    mkdir src && \
-    cd src && \
-    #
-    # Download moveit source, so that we can get necessary dependencies
-    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/.github/workflows/upstream.rosinstall && \
-    git clone --depth 1 --branch ${ROS_DISTRO}-devel https://github/ros-planning/moveit && \
-    #
     # Update apt package list as previous containers clear the cache
     apt-get -qq update && \
     apt-get -qq dist-upgrade && \
     #
     # Install some base dependencies
-    apt-get -qq install -y \
-        # Some source builds require a package.xml be downloaded via wget from an external location
-        wget \
-        # Required for rosdep command
-        sudo \
+    apt-get -qq install --no-install-recommends -y \
+        # Some basic requirements
+        wget git sudo \
         # Preferred build tools
         python-catkin-tools \
         clang clang-format-10 clang-tidy clang-tools \
         ccache && \
     #
-    # Download all dependencies of MoveIt!
-    rosdep update && \
-    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # Download MoveIt source, so that we can fetch all necessary dependencies
+    wstool init --shallow src https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/.github/workflows/upstream.rosinstall && \
+    git clone --depth 1 --branch ${ROS_DISTRO}-devel https://github.com/ros-planning/moveit src/moveit && \
     #
+    # Download all dependencies of MoveIt
+    rosdep update && \
+    DEBIAN_FRONTEND=noninteractive \
+    rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     # Remove the source code from this container
-    # TODO: in the future we may want to keep this here for further optimization of later containers
-    cd .. && \
-    rm -rf src/ && \
+    rm -rf src && \
     #
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -16,7 +16,8 @@ RUN \
     cd src && \
     #
     # Download moveit source, so that we can get necessary dependencies
-    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/.github/workflows/upstream.rosinstall && \
+    git clone --depth 1 --branch ${ROS_DISTRO}-devel https://github/ros-planning/moveit && \
     #
     # Update apt package list as previous containers clear the cache
     apt-get -qq update && \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR $ROS_UNDERLAY/../src
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 RUN \
     # Download moveit source so that we can get necessary dependencies
-    wstool init . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/moveit.rosinstall && \
+    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/.github/workflows/upstream.rosinstall && \
+    git clone --depth 1 --branch ${ROS_DISTRO}-devel https://github/ros-planning/moveit && \
     #
     # Update apt package list as cache is cleared in previous container
     # Usually upgrading involves a few packages only (if container builds became out-of-sync)

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR $ROS_UNDERLAY/../src
 RUN \
     # Download moveit source so that we can get necessary dependencies
     wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit/${ROS_DISTRO}-devel/.github/workflows/upstream.rosinstall && \
-    git clone --depth 1 --branch ${ROS_DISTRO}-devel https://github/ros-planning/moveit && \
+    git clone --depth 1 --branch ${ROS_DISTRO}-devel https://github.com/ros-planning/moveit && \
     #
     # Update apt package list as cache is cleared in previous container
     # Usually upgrading involves a few packages only (if container builds became out-of-sync)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
           key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
           restore-keys: ${{ env.CACHE_PREFIX }}
         env:
-          CACHE_PREFIX: target_ws-${{ matrix.env.CCOV && '-ccov' || '' }}-${{ matrix.env.IMAGE }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
+          CACHE_PREFIX: target_ws${{ matrix.env.CCOV && '-ccov' || '' }}-${{ matrix.env.IMAGE }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
         uses: pat-s/always-upload-cache@v2.1.3
         with:
@@ -92,7 +92,7 @@ jobs:
             ${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ${{ env.CACHE_PREFIX }}
         env:
-          CACHE_PREFIX: ccache-${{ matrix.env.IMAGE }}-${{ matrix.env.CCOV && '-ccov' || '' }}
+          CACHE_PREFIX: ccache-${{ matrix.env.IMAGE }}${{ matrix.env.CCOV && '-ccov' || '' }}
 
       - name: generate ikfast packages
         if: ${{ matrix.env.IKFAST_TEST }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   default:
     strategy:
+      fail-fast: false
       matrix:
         env:
           - IMAGE: melodic-ci
@@ -23,14 +24,18 @@ jobs:
             CLANG_TIDY: true
     env:
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
+      UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall
       TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#melodic-devel
+      DOWNSTREAM_WORKSPACE: .github/workflows/downstream.rosinstall
+      # Pull any updates to the upstream workspace (after restoring it from cache)
+      AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
+      AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'RelWithDebInfo' || 'Release'}}
         ${{ matrix.env.CCOV && '-DCMAKE_CXX_FLAGS="--coverage" --no-warn-unused-cli' || '' }}
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       BASEDIR: ${{ github.workspace }}/.work
-      CACHE_PREFIX: "${{ matrix.env.IMAGE }}${{ matrix.env.CCOV && '-ccov' || '' }}"
       CLANG_TIDY_BASE_REF: "${{ github.base_ref || github.ref }}"
 
     name: "${{ matrix.env.IMAGE }}${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && ' + clang-tidy' || '' }}"
@@ -51,38 +56,52 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
-      - name: cache upstream_ws
+      - name: cache upstream workspace
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.BASEDIR }}/upstream_ws
-          key: upstream_ws-${{ env.CACHE_PREFIX }}-${{ github.run_id }}
-          restore-keys: |
-            upstream_ws-${{ env.CACHE_PREFIX }}
+          key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
+          restore-keys: ${{ env.CACHE_PREFIX }}
+        env:
+          CACHE_PREFIX: upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('.github/workflows/upstream.rosinstall') }}
+      - name: cache downstream workspace
+        uses: pat-s/always-upload-cache@v2.1.3
+        with:
+          path: ${{ env.BASEDIR }}/downstream_ws
+          key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
+          restore-keys: ${{ env.CACHE_PREFIX }}
+        env:
+          CACHE_PREFIX: downstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('.github/workflows/downstream.rosinstall') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
-      - name: cache target_ws
+      - name: cache target workspace
         if: ${{ ! matrix.env.CCOV }}
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.BASEDIR }}/target_ws
-          key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
-          restore-keys: |
-            target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
+          key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
+          restore-keys: ${{ env.CACHE_PREFIX }}
+        env:
+          CACHE_PREFIX: target_ws-${{ matrix.env.CCOV && '-ccov' || '' }}-${{ matrix.env.IMAGE }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
-            ccache-${{ env.CACHE_PREFIX }}
+            ${{ env.CACHE_PREFIX }}-${{ github.sha }}
+            ${{ env.CACHE_PREFIX }}
+        env:
+          CACHE_PREFIX: ccache-${{ matrix.env.IMAGE }}-${{ matrix.env.CCOV && '-ccov' || '' }}
+
       - name: generate ikfast packages
         if: ${{ matrix.env.IKFAST_TEST }}
         run: |
-          bash moveit_kinematics/test/test_ikfast_plugins.sh
+          moveit_kinematics/test/test_ikfast_plugins.sh
       - name: industrial_ci
         uses: ros-industrial/industrial_ci@master
         env: ${{ matrix.env }}
+
       - name: upload test artifacts (on failure)
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/downstream.rosinstall
+++ b/.github/workflows/downstream.rosinstall
@@ -1,0 +1,16 @@
+- git:
+    local-name: rviz_visual_tools
+    uri: https://github.com/PickNikRobotics/rviz_visual_tools
+    version: melodic-devel
+- git:
+    local-name: moveit_visual_tools
+    uri: https://github.com/ros-planning/moveit_visual_tools.git
+    version: melodic-devel
+- git:
+    local-name: moveit_tutorials
+    uri: https://github.com/ros-planning/moveit_tutorials.git
+    version: melodic-devel
+- git:
+    local-name: panda_moveit_config
+    uri: https://github.com/ros-planning/panda_moveit_config.git
+    version: melodic-devel

--- a/.github/workflows/upstream.rosinstall
+++ b/.github/workflows/upstream.rosinstall
@@ -1,0 +1,8 @@
+- git:
+    local-name: moveit_msgs
+    uri: https://github.com/ros-planning/moveit_msgs.git
+    version: melodic-devel
+- git:
+    local-name: geometric_shapes
+    uri: https://github.com/ros-planning/geometric_shapes.git
+    version: melodic-devel


### PR DESCRIPTION
Same as #2654. Plus: adapts Dockerfiles to not install moveit anymore (fixes #2689).