### PR TITLE
Make CI pedantic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           - IMAGE: melodic-ci
             CATKIN_LINT: true
     env:
-      CXXFLAGS: "-Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-deprecated-copy"
+      CXXFLAGS: "-Werror -Wall -Wextra -pedantic -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-deprecated-copy"
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall
       TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#master

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_bvh_manager.h
@@ -38,7 +38,7 @@
 
 namespace collision_detection_bullet
 {
-MOVEIT_CLASS_FORWARD(BulletBVHManager)
+MOVEIT_CLASS_FORWARD(BulletBVHManager);
 
 /** @brief A bounding volume hierarchy (BVH) implementation of a tesseract contact manager */
 class BulletBVHManager

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h
@@ -39,7 +39,7 @@
 
 namespace collision_detection_bullet
 {
-MOVEIT_CLASS_FORWARD(BulletCastBVHManager)
+MOVEIT_CLASS_FORWARD(BulletCastBVHManager);
 
 /** @brief A bounding volume hierarchy (BVH) implementation of a tesseract contact manager */
 class BulletCastBVHManager : public BulletBVHManager

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h
@@ -39,7 +39,7 @@
 
 namespace collision_detection_bullet
 {
-MOVEIT_CLASS_FORWARD(BulletDiscreteBVHManager)
+MOVEIT_CLASS_FORWARD(BulletDiscreteBVHManager);
 
 /** @brief A bounding volume hierarchy (BVH) implementaiton of a discrete bullet manager */
 class BulletDiscreteBVHManager : public BulletBVHManager

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
@@ -55,7 +55,7 @@ const btScalar BULLET_EPSILON = 1e-3f;                   // numerical precision 
 const btScalar BULLET_DEFAULT_CONTACT_DISTANCE = 0.00f;  // All pairs closer than this distance get reported
 const bool BULLET_COMPOUND_USE_DYNAMIC_AABB = true;
 
-MOVEIT_CLASS_FORWARD(CollisionObjectWrapper)
+MOVEIT_CLASS_FORWARD(CollisionObjectWrapper);
 
 /** \brief Allowed = true */
 inline bool acmCheck(const std::string& body_1, const std::string& body_2,

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_common_distance_field.h
@@ -44,8 +44,8 @@
 
 namespace collision_detection
 {
-MOVEIT_STRUCT_FORWARD(GroupStateRepresentation)
-MOVEIT_STRUCT_FORWARD(DistanceFieldCacheEntry)
+MOVEIT_STRUCT_FORWARD(GroupStateRepresentation);
+MOVEIT_STRUCT_FORWARD(DistanceFieldCacheEntry);
 
 /** collision volume representation for a particular pose and link group
  *

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -104,12 +104,12 @@ struct GradientInfo
   }
 };
 
-MOVEIT_CLASS_FORWARD(PosedDistanceField)
+MOVEIT_CLASS_FORWARD(PosedDistanceField);
 MOVEIT_CLASS_FORWARD(BodyDecomposition);  // Defines BodyDecompositionPtr, ConstPtr, WeakPtr... etc
-MOVEIT_CLASS_FORWARD(PosedBodySphereDecomposition)
-MOVEIT_CLASS_FORWARD(PosedBodyPointDecomposition)
-MOVEIT_CLASS_FORWARD(PosedBodySphereDecompositionVector)
-MOVEIT_CLASS_FORWARD(PosedBodyPointDecompositionVector)
+MOVEIT_CLASS_FORWARD(PosedBodySphereDecomposition);
+MOVEIT_CLASS_FORWARD(PosedBodyPointDecomposition);
+MOVEIT_CLASS_FORWARD(PosedBodySphereDecompositionVector);
+MOVEIT_CLASS_FORWARD(PosedBodyPointDecompositionVector);
 
 class PosedDistanceField : public distance_field::PropagationDistanceField
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -135,7 +135,7 @@ public:
   //                                 collision_detection::AllowedCollisionMatrix
   //                                 &acm) const;
 
-  MOVEIT_STRUCT_FORWARD(DistanceFieldCacheEntryWorld)
+  MOVEIT_STRUCT_FORWARD(DistanceFieldCacheEntryWorld);
   struct DistanceFieldCacheEntryWorld
   {
     std::map<std::string, std::vector<PosedBodyPointDecompositionPtr>> posed_body_point_decompositions_;

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -48,9 +48,9 @@ namespace moveit
 {
 namespace core
 {
-MOVEIT_CLASS_FORWARD(JointModelGroup)
-MOVEIT_CLASS_FORWARD(RobotState)
-MOVEIT_CLASS_FORWARD(RobotModel)
+MOVEIT_CLASS_FORWARD(JointModelGroup);
+MOVEIT_CLASS_FORWARD(RobotState);
+MOVEIT_CLASS_FORWARD(RobotModel);
 }  // namespace core
 }  // namespace moveit
 

--- a/moveit_core/macros/include/moveit/macros/class_forward.h
+++ b/moveit_core/macros/include/moveit/macros/class_forward.h
@@ -45,7 +45,7 @@
 
 #define MOVEIT_CLASS_FORWARD(C)                                                                                        \
   class C;                                                                                                             \
-  MOVEIT_DECLARE_PTR(C, C);
+  MOVEIT_DECLARE_PTR(C, C)
 
 /**
  * \def MOVEIT_STRUCT_FORWARD
@@ -54,4 +54,4 @@
  */
 #define MOVEIT_STRUCT_FORWARD(C)                                                                                       \
   struct C;                                                                                                            \
-  MOVEIT_DECLARE_PTR(C, C);
+  MOVEIT_DECLARE_PTR(C, C)

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -57,7 +57,7 @@
   typedef std::weak_ptr<Type> Name##WeakPtr;                                                                           \
   typedef std::weak_ptr<const Type> Name##ConstWeakPtr;                                                                \
   typedef std::unique_ptr<Type> Name##UniquePtr;                                                                       \
-  typedef std::unique_ptr<const Type> Name##ConstUniquePtr;
+  typedef std::unique_ptr<const Type> Name##ConstUniquePtr
 
 /**
  * \def MOVEIT_DELCARE_PTR_MEMBER
@@ -73,4 +73,4 @@
   typedef std::weak_ptr<Type> WeakPtr;                                                                                 \
   typedef std::weak_ptr<const Type> ConstWeakPtr;                                                                      \
   typedef std::unique_ptr<Type> UniquePtr;                                                                             \
-  typedef std::unique_ptr<const Type> ConstUniquePtr;
+  typedef std::unique_ptr<const Type> ConstUniquePtr

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraints_library.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraints_library.h
@@ -48,7 +48,7 @@ typedef std::pair<std::vector<std::size_t>, std::map<std::size_t, std::pair<std:
     ConstrainedStateMetadata;
 typedef ompl::base::StateStorageWithMetadata<ConstrainedStateMetadata> ConstraintApproximationStateStorage;
 
-MOVEIT_CLASS_FORWARD(ConstraintApproximation)
+MOVEIT_CLASS_FORWARD(ConstraintApproximation);
 
 class ConstraintApproximation
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -134,6 +134,6 @@ private:
   pilz_industrial_motion_planner::CartesianLimit cartesian_limit_;
 };
 
-MOVEIT_CLASS_FORWARD(CommandPlanner)
+MOVEIT_CLASS_FORWARD(CommandPlanner);
 
 }  // namespace pilz_industrial_motion_planner

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_circ.h
@@ -49,7 +49,7 @@
 
 namespace pilz_industrial_motion_planner
 {
-MOVEIT_CLASS_FORWARD(PlanningContext)
+MOVEIT_CLASS_FORWARD(PlanningContext);
 
 /**
  * @brief PlanningContext for obtaining CIRC trajectories

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_lin.h
@@ -47,7 +47,7 @@
 
 namespace pilz_industrial_motion_planner
 {
-MOVEIT_CLASS_FORWARD(PlanningContext)
+MOVEIT_CLASS_FORWARD(PlanningContext);
 
 /**
  * @brief PlanningContext for obtaining LIN trajectories

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_ptp.h
@@ -49,7 +49,7 @@
 
 namespace pilz_industrial_motion_planner
 {
-MOVEIT_CLASS_FORWARD(PlanningContext)
+MOVEIT_CLASS_FORWARD(PlanningContext);
 
 /**
  * @brief PlanningContext for obtaining PTP trajectories

--- a/moveit_ros/planning/constraint_sampler_manager_loader/include/moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/include/moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h
@@ -58,7 +58,7 @@ public:
 private:
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 
-  MOVEIT_CLASS_FORWARD(Helper)
+  MOVEIT_CLASS_FORWARD(Helper);
   HelperPtr impl_;
 };
 }  // namespace constraint_sampler_manager_loader

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
@@ -53,7 +53,7 @@ class MotionPlanningFrameJointsUI;
 }
 namespace robot_interaction
 {
-MOVEIT_CLASS_FORWARD(InteractionHandler)
+MOVEIT_CLASS_FORWARD(InteractionHandler);
 }
 namespace moveit_rviz_plugin
 {


### PR DESCRIPTION
We rely on C++14 and should enforce standard-compliance (not just warning-free builds).

Potential followup to #2687

Let's see if anything/what breaks.