### PR TITLE
Misspelled MoveIt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: misspelled-moveit
+        name: misspelled-moveit
+        description: MoveIt should be spelled exactly as MoveIt
+        language: pygrep
+        entry: Moveit\W|MoveIt!
+        exclude: .pre-commit-config.yaml
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -50,7 +50,7 @@
 namespace pilz_industrial_motion_planner
 {
 /**
- * @brief Moveit Plugin for Planning with Standart Robot Commands
+ * @brief MoveIt Plugin for Planning with Standard Robot Commands
  * This planner is dedicated to return a instance of PlanningContext that
  * corresponds to the requested motion command
  * set as planner_id in the MotionPlanRequest).

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_robots/frankaemika_panda/launch/moveit_planning_execution.launch
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_robots/frankaemika_panda/launch/moveit_planning_execution.launch
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 <!-- simulated environment for testing pilz_industrial_motion_planner with a panda robot -->
 
 <launch>
-  <!-- The planning and execution components of MoveIt! configured to run -->
+  <!-- The planning and execution components of MoveIt configured to run -->
   <!-- using the ROS-Industrial interface. -->
 
   <!-- Choose planning pipeline -->

--- a/moveit_ros/moveit_servo/README.md
+++ b/moveit_ros/moveit_servo/README.md
@@ -1,4 +1,4 @@
-## Moveit Servo
+## MoveIt Servo
 
 #### Quick Start Guide for UR5 example
 

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -62,7 +62,7 @@ PerceptionWidget::PerceptionWidget(QWidget* parent, const MoveItConfigDataPtr& c
 
   HeaderWidget* header =
       new HeaderWidget("Setup 3D Perception Sensors",
-                       "Configure your 3D sensors to work with Moveit "
+                       "Configure your 3D sensors to work with MoveIt "
                        "Please see <a "
                        "href='http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/perception_pipeline/"
                        "perception_pipeline_tutorial.html'>Perception Documentation</a> "


### PR DESCRIPTION
Absurdly this check exists for some of the auxiliary repositories,
but was not present in this the main repository yet.

Slightly modified because we use a number of `MoveitCommander` style
class names that should not be touched.
