### PR TITLE
Fix setup assistant template (execution_type, moveit_resources_prbt_moveit_config)

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -58,7 +58,7 @@
     </include>
 
     <!-- Pilz Industrial Motion-->
-    <include ns="pilz_industrial_motion_planner" file="$(find moveit_resources_prbt_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="pilz_industrial_motion_planner" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- this argument is not used here, only necessary so that this launch file has the same args as fake_moveit_controller_manager.launch -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="execution_type" default="unused" />
 
   <!-- loads moveit_controller_manager on the parameter server which is taken as argument
     if no argument is passed, moveit_simple_controller_manager will be set -->

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
@@ -1,5 +1,8 @@
 <launch>
 
+  <!-- this argument is not used here, only necessary so that this launch file has the same args as fake_moveit_controller_manager.launch -->
+  <arg name="execution_type" default="interpolate" />
+
   <!-- loads moveit_controller_manager on the parameter server which is taken as argument
     if no argument is passed, moveit_simple_controller_manager will be set -->
   <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />


### PR DESCRIPTION
* Fix package path for Pilz pipeline: Use the launch file from the generated package, not from moveit_resources_prbt_moveit_config

* Add missing execution_type arg. This is necessary to avoid the following error:

        RLException: unused args [execution_type] for include of [ [...]moveit_controller_manager.launch.xml]