### PR TITLE
Use thread_local var's in FCL distanceCallback()

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -494,9 +494,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
   double dist_threshold = cdata->req->distance_threshold;
 
-  thread_local std::pair<std::string, std::string> pc = std::make_pair(cd1->getID(), cd2->getID());
-  pc = cd1->getID() < cd2->getID() ? std::make_pair(cd1->getID(), cd2->getID()) :
-                                     std::make_pair(cd2->getID(), cd1->getID());
+  const std::pair<const std::string&, const std::string&> pc = cd1->getID() < cd2->getID() ?
+                                                                   std::make_pair(cd1->getID(), cd2->getID()) :
+                                                                   std::make_pair(cd2->getID(), cd1->getID());
 
   DistanceMap::iterator it = cdata->res->distances.find(pc);
 

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -551,8 +551,8 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     dist_result.nearest_points[0] = fcl_result.nearest_points[0];
     dist_result.nearest_points[1] = fcl_result.nearest_points[1];
 #else
-    dist_result.nearest_points[0] = Eigen::Vector3d(fcl_result.nearest_points[0].data.vs);
-    dist_result.nearest_points[1] = Eigen::Vector3d(fcl_result.nearest_points[1].data.vs);
+    dist_result.nearest_points[0] = Eigen::Map<const Eigen::Vector3d>(fcl_result.nearest_points[0].data.vs);
+    dist_result.nearest_points[1] = Eigen::Map<const Eigen::Vector3d>(fcl_result.nearest_points[1].data.vs);
 #endif
     dist_result.link_names[0] = res_cd1->getID();
     dist_result.link_names[1] = res_cd2->getID();
@@ -596,17 +596,16 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
         dist_result.nearest_points[0] = contact.pos;
         dist_result.nearest_points[1] = contact.pos;
 #else
-        dist_result.nearest_points[0] = Eigen::Vector3d(contact.pos.data.vs);
-        dist_result.nearest_points[1] = Eigen::Vector3d(contact.pos.data.vs);
+        dist_result.nearest_points[0] = Eigen::Map<const Eigen::Vector3d>(contact.pos.data.vs);
+        dist_result.nearest_points[1] = Eigen::Map<const Eigen::Vector3d>(contact.pos.data.vs);
 #endif
 
-        Eigen::Vector3d normal;
         if (cdata->req->enable_nearest_points)
         {
 #if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
-          normal = contact.normal;
+          Eigen::Vector3d normal = contact.normal;
 #else
-          normal = Eigen::Map<const Eigen::Vector3d>(contact.normal.data.vs);
+          Eigen::Vector3d normal = Eigen::Map<const Eigen::Vector3d>(contact.normal.data.vs);
 #endif
 
           // Check order of o1/o2 again, we might need to flip the normal

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -502,7 +502,13 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   thread_local DistanceMap::iterator it;
   it = cdata->res->distances.find(pc);
 
-  if (it != cdata->res->distances.end())
+  // GLOBAL search: for efficiency, distance_threshold starts at the smallest distance between any pairs found so far
+  if (cdata->req->type == DistanceRequestType::GLOBAL)
+  {
+    dist_threshold = cdata->res->minimum_distance.distance;
+  }
+  // Check if a distance between this pair has been found yet. Decrease threshold_distance if so, to narrow the search
+  else if (it != cdata->res->distances.end())
   {
     if (cdata->req->type == DistanceRequestType::LIMITED)
     {
@@ -511,10 +517,6 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       {
         return cdata->done;
       }
-    }
-    else if (cdata->req->type == DistanceRequestType::GLOBAL)
-    {
-      dist_threshold = cdata->res->minimum_distance.distance;
     }
     else if (cdata->req->type == DistanceRequestType::SINGLE)
     {

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -51,6 +51,8 @@
 #include <memory>
 #include <thread>
 
+#include <chrono>
+
 namespace collision_detection
 {
 bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)
@@ -410,6 +412,9 @@ struct FCLShapeCache
 
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist)
 {
+  using namespace std::chrono;
+  high_resolution_clock::time_point t1 = high_resolution_clock::now();
+
   thread_local DistanceData* cdata;
   cdata = reinterpret_cast<DistanceData*>(data);
 
@@ -672,6 +677,10 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       cdata->done = true;
     }
   }
+
+  high_resolution_clock::time_point t2 = high_resolution_clock::now();
+  auto duration(std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1));
+  ROS_ERROR_STREAM(duration.count());
 
   return cdata->done;
 }

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -51,8 +51,6 @@
 #include <memory>
 #include <thread>
 
-#include <chrono>
-
 namespace collision_detection
 {
 bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)
@@ -412,9 +410,6 @@ struct FCLShapeCache
 
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist)
 {
-  using namespace std::chrono;
-  high_resolution_clock::time_point t1 = high_resolution_clock::now();
-
   thread_local DistanceData* cdata;
   cdata = reinterpret_cast<DistanceData*>(data);
 
@@ -677,10 +672,6 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       cdata->done = true;
     }
   }
-
-  high_resolution_clock::time_point t2 = high_resolution_clock::now();
-  auto duration(std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1));
-  ROS_ERROR_STREAM(duration.count());
 
   return cdata->done;
 }

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -541,7 +541,6 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   if (distance < dist_threshold)
   {
     thread_local DistanceResultsData dist_result;
-    dist_result.clear();
     dist_result.distance = fcl_result.min_distance;
 
     // Careful here: Get the collision geometry data again, since FCL might

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -410,8 +410,7 @@ struct FCLShapeCache
 
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist)
 {
-  thread_local DistanceData* cdata;
-  cdata = reinterpret_cast<DistanceData*>(data);
+  DistanceData* cdata = reinterpret_cast<DistanceData*>(data);
 
   const CollisionGeometryData* cd1 = static_cast<const CollisionGeometryData*>(o1->collisionGeometry()->getUserData());
   const CollisionGeometryData* cd2 = static_cast<const CollisionGeometryData*>(o2->collisionGeometry()->getUserData());
@@ -441,14 +440,12 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   }
 
   // use the collision matrix (if any) to avoid certain distance checks
-  thread_local bool always_allow_collision;
-  always_allow_collision = false;
+  bool always_allow_collision = false;
   if (cdata->req->acm)
   {
-    AllowedCollision::Type type;
+    thread_local AllowedCollision::Type type;
 
-    thread_local bool found;
-    found = cdata->req->acm->getAllowedCollision(cd1->getID(), cd2->getID(), type);
+    bool found = cdata->req->acm->getAllowedCollision(cd1->getID(), cd2->getID(), type);
     if (found)
     {
       // if we have an entry in the collision matrix, we read it
@@ -497,8 +494,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     ROS_DEBUG_NAMED("collision_detection.fcl", "Actually checking collisions between %s and %s", cd1->getID().c_str(),
                     cd2->getID().c_str());
 
-  thread_local double dist_threshold;
-  dist_threshold = cdata->req->distance_threshold;
+  double dist_threshold = cdata->req->distance_threshold;
 
   thread_local std::pair<std::string, std::string> pc = std::make_pair(cd1->getID(), cd2->getID());
   pc = cd1->getID() < cd2->getID() ? std::make_pair(cd1->getID(), cd2->getID()) :
@@ -538,8 +534,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   {
     return false;
   }
-  thread_local double distance;
-  distance = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
+  double distance = fcl::distance(o1, o2, fcl::DistanceRequestd(cdata->req->enable_nearest_points), fcl_result);
 
   // Check if either object is already in the map. If not add it or if present
   // check to see if the new distance is closer. If closer remove the existing
@@ -585,10 +580,8 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       std::size_t contacts = fcl::collide(o1, o2, coll_req, coll_res);
       if (contacts > 0)
       {
-        thread_local double max_dist;
-        max_dist = 0;
-        thread_local int max_index;
-        max_index = 0;
+        double max_dist = 0;
+        int max_index = 0;
         for (std::size_t i = 0; i < contacts; ++i)
         {
           const fcl::Contactd& contact = coll_res.getContact(i);
@@ -610,13 +603,12 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
         dist_result.nearest_points[1] = Eigen::Vector3d(contact.pos.data.vs);
 #endif
 
+        thread_local Eigen::Vector3d normal;
         if (cdata->req->enable_nearest_points)
         {
 #if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
-          thread_local Eigen::Vector3d normal;
           normal = contact.normal;
 #else
-          thread_local Eigen::Vector3d normal;
           normal[0] = contact.normal.data.vs[0];
           normal[1] = contact.normal.data.vs[1];
           normal[2] = contact.normal.data.vs[2];

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -442,8 +442,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   bool always_allow_collision = false;
   if (cdata->req->acm)
   {
-    thread_local AllowedCollision::Type type;
-
+    AllowedCollision::Type type;
     bool found = cdata->req->acm->getAllowedCollision(cd1->getID(), cd2->getID(), type);
     if (found)
     {
@@ -499,8 +498,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   pc = cd1->getID() < cd2->getID() ? std::make_pair(cd1->getID(), cd2->getID()) :
                                      std::make_pair(cd2->getID(), cd1->getID());
 
-  thread_local DistanceMap::iterator it;
-  it = cdata->res->distances.find(pc);
+  DistanceMap::iterator it = cdata->res->distances.find(pc);
 
   // GLOBAL search: for efficiency, distance_threshold starts at the smallest distance between any pairs found so far
   if (cdata->req->type == DistanceRequestType::GLOBAL)
@@ -524,8 +522,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     }
   }
 
-  thread_local fcl::DistanceResultd fcl_result;
-  fcl_result.clear();
+  fcl::DistanceResultd fcl_result;
   fcl_result.min_distance = dist_threshold;
   // fcl::distance segfaults when given an octree with a null root pointer (using FCL 0.6.1)
   if ((o1->getObjectType() == fcl::OT_OCTREE &&
@@ -572,7 +569,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       dist_result.nearest_points[1].setZero();
       dist_result.normal.setZero();
 
-      thread_local fcl::CollisionRequestd coll_req;
+      fcl::CollisionRequestd coll_req;
       thread_local fcl::CollisionResultd coll_res;
       coll_res.clear();
       coll_req.enable_contact = true;
@@ -603,7 +600,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
         dist_result.nearest_points[1] = Eigen::Vector3d(contact.pos.data.vs);
 #endif
 
-        thread_local Eigen::Vector3d normal;
+        Eigen::Vector3d normal;
         if (cdata->req->enable_nearest_points)
         {
 #if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -501,9 +501,8 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   dist_threshold = cdata->req->distance_threshold;
 
   thread_local std::pair<std::string, std::string> pc = std::make_pair(cd1->getID(), cd2->getID());
-  pc = cd1->getID() < cd2->getID() ?
-        std::make_pair(cd1->getID(), cd2->getID()) :
-        std::make_pair(cd2->getID(), cd1->getID());
+  pc = cd1->getID() < cd2->getID() ? std::make_pair(cd1->getID(), cd2->getID()) :
+                                     std::make_pair(cd2->getID(), cd1->getID());
 
   thread_local DistanceMap::iterator it;
   it = cdata->res->distances.find(pc);

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -606,9 +606,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 #if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
           normal = contact.normal;
 #else
-          normal[0] = contact.normal.data.vs[0];
-          normal[1] = contact.normal.data.vs[1];
-          normal[2] = contact.normal.data.vs[2];
+          normal = Eigen::Map<const Eigen::Vector3d>(contact.normal.data.vs);
 #endif
 
           // Check order of o1/o2 again, we might need to flip the normal

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -528,6 +528,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   }
 
   thread_local fcl::DistanceResultd fcl_result;
+  fcl_result.clear();
   fcl_result.min_distance = dist_threshold;
   // fcl::distance segfaults when given an octree with a null root pointer (using FCL 0.6.1)
   if ((o1->getObjectType() == fcl::OT_OCTREE &&
@@ -546,6 +547,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   if (distance < dist_threshold)
   {
     thread_local DistanceResultsData dist_result;
+    dist_result.clear();
     dist_result.distance = fcl_result.min_distance;
 
     // Careful here: Get the collision geometry data again, since FCL might
@@ -577,6 +579,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
       thread_local fcl::CollisionRequestd coll_req;
       thread_local fcl::CollisionResultd coll_res;
+      coll_res.clear();
       coll_req.enable_contact = true;
       coll_req.num_max_contacts = 200;
       std::size_t contacts = fcl::collide(o1, o2, coll_req, coll_res);

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -539,6 +539,8 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   // one and add the new distance information.
   if (distance < dist_threshold)
   {
+    // thread_local storage makes this variable persistent. We do not clear it at every iteration because all members
+    // get overwritten.
     thread_local DistanceResultsData dist_result;
     dist_result.distance = fcl_result.min_distance;
 
@@ -571,7 +573,7 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
       fcl::CollisionRequestd coll_req;
       thread_local fcl::CollisionResultd coll_res;
-      coll_res.clear();
+      coll_res.clear();  // thread_local storage makes the variable persistent. Ensure that it is cleared!
       coll_req.enable_contact = true;
       coll_req.num_max_contacts = 200;
       std::size_t contacts = fcl::collide(o1, o2, coll_req, coll_res);

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -49,7 +49,6 @@
 
 #include <boost/thread/mutex.hpp>
 #include <memory>
-#include <thread>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -500,9 +500,10 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   thread_local double dist_threshold;
   dist_threshold = cdata->req->distance_threshold;
 
-  const std::pair<std::string, std::string>& pc = cd1->getID() < cd2->getID() ?
-                                                      std::make_pair(cd1->getID(), cd2->getID()) :
-                                                      std::make_pair(cd2->getID(), cd1->getID());
+  thread_local std::pair<std::string, std::string> pc = std::make_pair(cd1->getID(), cd2->getID());
+  pc = cd1->getID() < cd2->getID() ?
+        std::make_pair(cd1->getID(), cd2->getID()) :
+        std::make_pair(cd2->getID(), cd1->getID());
 
   thread_local DistanceMap::iterator it;
   it = cdata->res->distances.find(pc);


### PR DESCRIPTION
While reviewing #2682 I noticed there are some variables declared inside the FCL distanceCallback. That's pretty bad, performance-wise, for a function that should be fast.

This simply makes these variables `thread_local` so they don't have to be allocated with every callback.

I see a 52% reduction in distanceCallback duration. The spreadsheet is attached and you can see how it was tested in the commit history (std::chrono::high_resolution_clock). Mean duration drops from 8.75 microseconds to 4.23 microseconds. Worst-case duration drops from 43->21 us. I can give PickNik'rs guidance on how to reproduce the test setup.
[print_of_distance_callback.ods](https://github.com/ros-planning/moveit/files/6570886/print_of_distance_callback.ods)


I think there's lots of opportunity to do this type of improvement in other places within the collision-checking code.



