### PR TITLE
Remove false octomap from catkin_packages LIBRARIES entries

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -152,7 +152,6 @@ catkin_package(
     moveit_dynamics_solver
     moveit_utils
     moveit_test_utils
-    ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     eigen_stl_containers
     geometric_shapes


### PR DESCRIPTION
### Description

Octomap is a dependency of moveit_core, but in the catkin_package description it is listed under LIBRARIES, which suggests it is a library that originates from moveit_core.

This PR is opened in order to fix this false entry, pointed out by @v4hn on another PR https://github.com/ros-planning/moveit/pull/2671

      Conceptually this line is probably wrong, because LIBRARIES should only list "the exported libraries from the project".
      In theory the entry OCTOMAP in DEPENDS below should do the same the right way.

      The corresponding line in moveit_core that you refer to is also 9 years old apparently and I guess nobody ever looked into it. 

Tested on a clean noetic build.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
