### PR TITLE
CHOMP: Read parameters from proper namespace

### DIFF
--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -52,7 +52,8 @@ public:
   void clear() override;
   bool terminate() override;
 
-  CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model);
+  CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
+                       ros::NodeHandle& nh);
 
   ~CHOMPPlanningContext() override = default;
 

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -65,7 +65,10 @@ void CHOMPInterface::loadParams()
   nh_.param("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
 
   nh_.param("joint_update_limit", params_.joint_update_limit_, 0.1);
-  nh_.param("collision_clearence", params_.min_clearence_, 0.2);
+  // TODO: remove this warning after 06/2022
+  if (!nh_.hasParam("collision_clearance") && nh_.hasParam("collision_clearence"))
+    ROS_WARN("The param 'collision_clearence' has been renamed to 'collision_clearance', please update your config!");
+  nh_.param("collision_clearance", params_.min_clearance_, 0.2);
   nh_.param("collision_threshold", params_.collision_threshold_, 0.07);
   // nh_.param("random_jump_amount", params_.random_jump_amount_, 1.0);
   nh_.param("use_stochastic_descent", params_.use_stochastic_descent_, true);

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -41,10 +41,10 @@
 namespace chomp_interface
 {
 CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::string& group,
-                                           const moveit::core::RobotModelConstPtr& model)
+                                           const moveit::core::RobotModelConstPtr& model, ros::NodeHandle& nh)
   : planning_interface::PlanningContext(name, group), robot_model_(model)
 {
-  chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface());
+  chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface(nh));
 }
 
 bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -49,12 +49,16 @@ public:
   {
   }
 
-  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& /*ns*/) override
+  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
+    ros::NodeHandle nh("~");
+    if (!ns.empty())
+      nh = ros::NodeHandle(ns);
+
     for (const std::string& group : model->getJointModelGroupNames())
     {
       planning_contexts_[group] =
-          CHOMPPlanningContextPtr(new CHOMPPlanningContext("chomp_planning_context", group, model));
+          CHOMPPlanningContextPtr(new CHOMPPlanningContext("chomp_planning_context", group, model, nh));
     }
     return true;
   }

--- a/moveit_planners/chomp/chomp_interface/test/chomp_planning.yaml
+++ b/moveit_planners/chomp/chomp_interface/test/chomp_planning.yaml
@@ -19,7 +19,7 @@ pseudo_inverse_ridge_factor: 1e-4
 animate_endeffector: false
 animate_endeffector_segment: "link3"
 joint_update_limit: 0.1
-collision_clearence: 0.2
+collision_clearance: 0.2
 collision_threshold: 0.07
 random_jump_amount: 1.0
 use_stochastic_descent: true

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -81,23 +81,23 @@ public:
   }
 
 private:
-  inline double getPotential(double field_distance, double radius, double clearence)
+  inline double getPotential(double field_distance, double radius, double clearance)
   {
     double d = field_distance - radius;
 
-    if (d >= clearence)  // everything is fine
+    if (d >= clearance)  // everything is fine
     {
       return 0.0;
     }
     else if (d >= 0.0)  // transition phase, no collision yet
     {
-      const double diff = (d - clearence);
-      const double gradient_magnitude = diff / clearence;
+      const double diff = (d - clearance);
+      const double gradient_magnitude = diff / clearance;
       return 0.5 * gradient_magnitude * diff;  // 0.5 * (d - clearance)^2 / clearance
     }
     else  // d < 0.0: collision
     {
-      return -d + 0.5 * clearence;  // linearly increase, starting from 0.5 * clearance
+      return -d + 0.5 * clearance;  // linearly increase, starting from 0.5 * clearance
     }
   }
   template <typename Derived>

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -91,7 +91,7 @@ public:
   double pseudo_inverse_ridge_factor_;  /// set the ridge factor if pseudo inverse is enabled
 
   double joint_update_limit_;   /// set the update limit for the robot joints
-  double min_clearence_;        /// the minimum distance that needs to be maintained to avoid obstacles
+  double min_clearance_;        /// the minimum distance that needs to be maintained to avoid obstacles
   double collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
   bool filter_mode_;
   // double random_jump_amount_;

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -949,7 +949,7 @@ void ChompOptimizer::performForwardKinematics()
           collision_point_pos_eigen_[i][j][2] = info.sphere_locations[k].z();
 
           collision_point_potential_[i][j] =
-              getPotential(info.distances[k], info.sphere_radii[k], parameters_->min_clearence_);
+              getPotential(info.distances[k], info.sphere_radii[k], parameters_->min_clearance_);
           collision_point_potential_gradient_[i][j][0] = info.gradients[k].x();
           collision_point_potential_gradient_[i][j][1] = info.gradients[k].y();
           collision_point_potential_gradient_[i][j][2] = info.gradients[k].z();

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -60,7 +60,7 @@ ChompParameters::ChompParameters()
   pseudo_inverse_ridge_factor_ = 1e-4;
 
   joint_update_limit_ = 0.1;
-  min_clearence_ = 0.2;
+  min_clearance_ = 0.2;
   collision_threshold_ = 0.07;
   // random_jump_amount_ = 1.0;
   use_stochastic_descent_ = true;

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -134,10 +134,13 @@ public:
       params_.joint_update_limit_ = 0.1;
       ROS_INFO_STREAM("Param joint_update_limit was not set. Using default value: " << params_.joint_update_limit_);
     }
-    if (!nh.getParam("min_clearence", params_.min_clearence_))
+    // TODO: remove this warning after 06/2022
+    if (!nh.hasParam("min_clearance") && nh.hasParam("min_clearence"))
+      ROS_WARN("The param 'min_clearence' has been renamed to 'min_clearance', please update your config!");
+    if (!nh.getParam("min_clearance", params_.min_clearance_))
     {
-      params_.min_clearence_ = 0.2;
-      ROS_INFO_STREAM("Param min_clearence was not set. Using default value: " << params_.min_clearence_);
+      params_.min_clearance_ = 0.2;
+      ROS_INFO_STREAM("Param min_clearance was not set. Using default value: " << params_.min_clearance_);
     }
     if (!nh.getParam("collision_threshold", params_.collision_threshold_))
     {

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -300,7 +300,7 @@ bool MoveItConfigData::outputCHOMPPlanningYAML(const std::string& file_path)
   emitter << YAML::Key << "use_pseudo_inverse" << YAML::Value << "false";
   emitter << YAML::Key << "pseudo_inverse_ridge_factor" << YAML::Value << "1e-4";
   emitter << YAML::Key << "joint_update_limit" << YAML::Value << "0.1";
-  emitter << YAML::Key << "collision_clearence" << YAML::Value << "0.2";
+  emitter << YAML::Key << "collision_clearance" << YAML::Value << "0.2";
   emitter << YAML::Key << "collision_threshold" << YAML::Value << "0.07";
   emitter << YAML::Key << "use_stochastic_descent" << YAML::Value << "true";
   emitter << YAML::Key << "enable_failure_recovery" << YAML::Value << "true";

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
@@ -3,6 +3,7 @@
   <arg name="planning_plugin" value="chomp_interface/CHOMPPlanner" />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
+  <arg name="jiggle_fraction" value="0.05" />
   <!-- The request adapters (plugins) used when planning.
        ORDER MATTERS -->
   <arg name="planning_adapters"
@@ -17,6 +18,7 @@
   <param name="planning_plugin" value="$(arg planning_plugin)" />
   <param name="request_adapters" value="$(arg planning_adapters)" />
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
+  <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
   <!-- Add MoveGroup capabilities specific to this pipeline -->
   <!-- <param name="capabilities" value="" /> -->

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -89,7 +89,9 @@
 
     <param name="allow_trajectory_execution" value="$(arg allow_trajectory_execution)"/>
     <param name="sense_for_plan/max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
-    <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
+    <param name="planning_pipelines/ompl/jiggle_fraction" value="$(arg jiggle_fraction)" />
+    <param name="planning_pipelines/chomp/jiggle_fraction" value="$(arg jiggle_fraction)" />
+    <param name="planning_pipelines/pilz_industrial_motion_planner/jiggle_fraction" value="$(arg jiggle_fraction)" />
     <param name="default_planning_pipeline" value="$(arg pipeline)" />
     <param name="capabilities" value="$(arg capabilities)" />
     <param name="disable_capabilities" value="$(arg disable_capabilities)" />

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -17,7 +17,6 @@
   <arg name="fake_execution" default="false"/>
   <arg name="execution_type" default="interpolate"/> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
   <arg name="max_safe_path_cost" default="1"/>
-  <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
 
   <arg name="capabilities" default=""/>
@@ -89,9 +88,6 @@
 
     <param name="allow_trajectory_execution" value="$(arg allow_trajectory_execution)"/>
     <param name="sense_for_plan/max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
-    <param name="planning_pipelines/ompl/jiggle_fraction" value="$(arg jiggle_fraction)" />
-    <param name="planning_pipelines/chomp/jiggle_fraction" value="$(arg jiggle_fraction)" />
-    <param name="planning_pipelines/pilz_industrial_motion_planner/jiggle_fraction" value="$(arg jiggle_fraction)" />
     <param name="default_planning_pipeline" value="$(arg pipeline)" />
     <param name="capabilities" value="$(arg capabilities)" />
     <param name="disable_capabilities" value="$(arg disable_capabilities)" />

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -15,10 +15,12 @@
               />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
+  <arg name="jiggle_fraction" value="0.05" />
 
   <param name="planning_plugin" value="$(arg planning_plugin)" />
   <param name="request_adapters" value="$(arg planning_adapters)" />
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
+  <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
   <!-- Add MoveGroup capabilities specific to this pipeline -->
   <!-- <param name="capabilities" value="" /> -->

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
@@ -7,11 +7,8 @@
        ORDER MATTERS -->
   <arg name="planning_adapters" value="" />
 
-  <arg name="start_state_max_bounds_error" value="0.1" />
-
   <param name="planning_plugin" value="$(arg planning_plugin)" />
   <param name="request_adapters" value="$(arg planning_adapters)" />
-  <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
   <!-- MoveGroup capabilities to load, append sequence capability -->
   <param name="capabilities" value="pilz_industrial_motion_planner/MoveGroupSequenceAction


### PR DESCRIPTION
This PR contains the following changes (see separate commits):

* CHOMP: Read parameters from proper namespace
* CHOMP: Rename param 'clearence' to 'clearance'
* MSA template: Put param jiggle_fraction into proper namespace

Fixes #2702.