### PR TITLE
Fix predefined poses benchmark example

### DIFF
--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch
@@ -26,7 +26,7 @@
   </group>
 
   <!-- Launch benchmark node -->
-  <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" output="screen" required="true">
+  <node name="moveit_run_benchmark" pkg="moveit_ros_benchmarks" type="moveit_combine_predefined_poses_benchmark" output="screen" required="true">
     <rosparam command="load" file="$(arg bench_opts)"/>
   </node>
 </launch>

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.yaml
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.yaml
@@ -16,7 +16,7 @@ benchmark_config:
         group: panda_arm      # Required
         timeout: 10.0
         output_directory: /tmp/moveit_benchmarks/
-        predefined_poses_group: panda_arm_hand # Group where the predefined poses are specified
+        predefined_poses_group: panda_arm # Group where the predefined poses are specified
         predefined_poses: # List of named targets
             - ready
             - extended


### PR DESCRIPTION
This fixes the `CombinePredefinedPosesBenchmark` a custom benchmark example derived from the BenchmarkExecutor class.
- Change the benchmark node type to the custom benchmark node. 
- The predefined poses named _ready_ and _extended_ exists only in the panda_arm group.

Will have to investigate further this error message probably triggered [here](https://github.com/ros-planning/moveit/blob/master/moveit_ros/benchmarks/src/simple_benchmarks/CombinePredefinedPosesBenchmark.cpp#L103):
``` shell
[ERROR] [1623807614.550173309]: Found empty JointState message
```
The benchmark works regardless of the error.
