### PR TITLE
fixed padding collision attached objects

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_robot_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_robot_fcl.cpp
@@ -85,7 +85,8 @@ void CollisionRobotFCL::getAttachedBodyObjects(const robot_state::AttachedBody* 
   const std::vector<shapes::ShapeConstPtr>& shapes = ab->getShapes();
   for (std::size_t i = 0; i < shapes.size(); ++i)
   {
-    FCLGeometryConstPtr co = createCollisionGeometry(shapes[i], ab, i);
+    FCLGeometryConstPtr co = createCollisionGeometry(shapes[i], getLinkScale(ab->getAttachedLinkName()),
+                                                     getLinkPadding(ab->getAttachedLinkName()), ab, i);
     if (co)
       geoms.push_back(co);
   }


### PR DESCRIPTION
### Description

The CollisionRobotFCL class did not consider the scale and the padding when creating the collision geometry for the attached objects. This change would lead the padding and scale to be exactly the same as the ones of the link the objects are attached to.

Pull request made after reporting the bug in ros-planning/moveit#2719.