### PR TITLE
Refactor moveit_servo::LowPassFilter to be assignable

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/low_pass_filter.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/low_pass_filter.h
@@ -63,7 +63,7 @@ private:
   double previous_measurements_[FILTER_LENGTH];
   double previous_filtered_measurement_;
   // Scale and feedback term are calculated from supplied filter coefficient
-  const double scale_term_;
-  const double feedback_term_;
+  double scale_term_;
+  double feedback_term_;
 };
 }  // namespace moveit_servo


### PR DESCRIPTION
### Description
`moveit_servo::LowPassFilter` is not currently assignable. At times, this makes it difficult to use with a `std::vector` without pointer semantics. There isn't an inherit reason for the type to be non-assignable and the members are not exposed in the public interface https://abseil.io/tips/177

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
