### PR TITLE
Fix reversed check in switchControllers

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -355,7 +355,8 @@ public:
     }
     srv.request.strictness = srv.request.STRICT;
 
-    if (!srv.request.start_controllers.empty() || srv.request.stop_controllers.empty())
+    // If stop_controllers is not empty, start_controllers will also not be empty (so only check start_controllers)
+    if (!srv.request.start_controllers.empty())
     {  // something to switch?
       if (!ros::service::call(getAbsName("controller_manager/switch_controller"), srv))
       {


### PR DESCRIPTION
### Description

While parsing through this code I saw a reversed sign on this check. This could cause two edge cases

Case 1: empty start_controllers and non-empty stop_controllers
This should cause the SwitchController to be made, but does not. Right now it is impossible for TrajectoryExecutionManager to pass in this condition though (if stop_controllers is non-empty, then by definition start_controllers will also be non-empty).

Case 2: empty start_controllers and empty stop_controllers
This should not cause the SwitchController to be made, but does. Right now TrajectoryExecutionManager does not invoke switchControllers if both lists are empty though.

TLDR This won't change anything behavior wise but should still be fixed.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
