### PR TITLE
Avoid push_back within getAttachedBodyObjects

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -173,7 +173,9 @@ void CollisionEnvFCL::getAttachedBodyObjects(const moveit::core::AttachedBody* a
                                              std::vector<FCLGeometryConstPtr>& geoms) const
 {
   const std::vector<shapes::ShapeConstPtr>& shapes = ab->getShapes();
-  for (std::size_t i = 0; i < shapes.size(); ++i)
+  const size_t num_shapes = shapes.size();
+  geoms.reserve(num_shapes);
+  for (std::size_t i = 0; i < num_shapes; ++i)
   {
     FCLGeometryConstPtr co = createCollisionGeometry(shapes[i], ab, i);
     if (co)


### PR DESCRIPTION
This is a pretty small optimization but I don't like to see `push_back()` called within a function that should be performant. This should be faster if there are multiple attached collision bodies.