### PR TITLE
Fix trajectory panel

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -91,15 +91,14 @@ void TrajectoryPanel::onDisable()
 
 void TrajectoryPanel::update(int way_point_count)
 {
-  int max_way_point = std::max(0, way_point_count - 1);
+  last_way_point_ = std::max(0, way_point_count - 1);
 
   slider_->setEnabled(way_point_count != 0);
   button_->setEnabled(way_point_count != 0);
 
-  last_way_point_ = max_way_point;
   slider_->setSliderPosition(0);
-  slider_->setMaximum(max_way_point);
-  maximum_label_->setText(QString::number(max_way_point));
+  slider_->setMaximum(last_way_point_);
+  maximum_label_->setText(QString::number(last_way_point_));
   pauseButton(false);
 }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_panel.cpp
@@ -86,7 +86,6 @@ void TrajectoryPanel::onEnable()
 void TrajectoryPanel::onDisable()
 {
   hide();
-  paused_ = false;
   parentWidget()->hide();
 }
 
@@ -98,10 +97,10 @@ void TrajectoryPanel::update(int way_point_count)
   button_->setEnabled(way_point_count != 0);
 
   last_way_point_ = max_way_point;
-  paused_ = false;
   slider_->setSliderPosition(0);
   slider_->setMaximum(max_way_point);
   maximum_label_->setText(QString::number(max_way_point));
+  pauseButton(false);
 }
 
 void TrajectoryPanel::pauseButton(bool pause)


### PR DESCRIPTION
This fixes a display bug in the rviz `TrajectoryPanel`, @v4hn mentioned today.
The second commit is some related, but independent code cleanup.