### PR TITLE
support arbitrary realtime-factors in trajectory visualization

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -122,6 +122,11 @@ protected:
    * \brief ROS callback for an incoming path message
    */
   void incomingDisplayTrajectory(const moveit_msgs::DisplayTrajectory::ConstPtr& msg);
+  /**
+   * \brief get time to show each single robot state
+   * \return Positive values indicate a fixed time per state
+   *         Negative values indicate a realtime-factor
+   */
   float getStateDisplayTime();
   void clearTrajectoryTrail();
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -90,14 +90,17 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   robot_path_alpha_property_->setMin(0.0);
   robot_path_alpha_property_->setMax(1.0);
 
-  state_display_time_property_ = new rviz::EditableEnumProperty("State Display Time", "0.05 s",
-                                                                "The amount of wall-time to wait in between displaying "
-                                                                "states along a received trajectory path",
-                                                                widget, SLOT(changedStateDisplayTime()), this);
-  state_display_time_property_->addOptionStd("REALTIME");
-  state_display_time_property_->addOptionStd("0.05 s");
-  state_display_time_property_->addOptionStd("0.1 s");
-  state_display_time_property_->addOptionStd("0.5 s");
+  state_display_time_property_ =
+      new rviz::EditableEnumProperty("State Display Time", "3x",
+                                     "Replay speed of trajectory. Either as factor of its time"
+                                     "parameterization or as constant time (s) per waypoint.",
+                                     widget, SLOT(changedStateDisplayTime()), this);
+  state_display_time_property_->addOptionStd("3x");
+  state_display_time_property_->addOptionStd("1x");
+  state_display_time_property_->addOptionStd("0.5x");
+  state_display_time_property_->addOptionStd("0.05s");
+  state_display_time_property_->addOptionStd("0.1s");
+  state_display_time_property_->addOptionStd("0.5s");
 
   loop_display_property_ = new rviz::BoolProperty("Loop Animation", false,
                                                   "Indicates whether the last received path "
@@ -337,24 +340,49 @@ void TrajectoryVisualization::interruptCurrentDisplay()
 
 float TrajectoryVisualization::getStateDisplayTime()
 {
+  constexpr char DEFAULT_TIME_STRING[] = "3x";
+  constexpr float DEFAULT_TIME_VALUE = -3.0f;
+
   std::string tm = state_display_time_property_->getStdString();
-  if (tm == "REALTIME")
-    return -1.0;
+  boost::trim(tm);
+
+  float type;
+
+  if (tm.back() == 'x')
+  {
+    type = -1.0f;
+  }
+  else if (tm.back() == 's')
+  {
+    type = 1.0f;
+  }
   else
   {
-    boost::replace_all(tm, "s", "");
-    boost::trim(tm);
-    float t = 0.05f;
-    try
-    {
-      t = boost::lexical_cast<float>(tm);
-    }
-    catch (const boost::bad_lexical_cast& ex)
-    {
-      state_display_time_property_->setStdString("0.05 s");
-    }
-    return t;
+    state_display_time_property_->setStdString(DEFAULT_TIME_STRING);
+    return DEFAULT_TIME_VALUE;
   }
+
+  tm.resize(tm.size() - 1);
+  boost::trim_right(tm);
+
+  float value;
+  try
+  {
+    value = boost::lexical_cast<float>(tm);
+  }
+  catch (const boost::bad_lexical_cast& ex)
+  {
+    state_display_time_property_->setStdString(DEFAULT_TIME_STRING);
+    return DEFAULT_TIME_VALUE;
+  }
+
+  if (value <= 0)
+  {
+    state_display_time_property_->setStdString(DEFAULT_TIME_STRING);
+    return DEFAULT_TIME_VALUE;
+  }
+
+  return type * value;
 }
 
 void TrajectoryVisualization::dropTrajectory()
@@ -426,13 +454,16 @@ void TrajectoryVisualization::update(float wall_dt, float /*ros_dt*/)
       current_state_time_ = 0.0;
     }
     else if (tm < 0.0)
-    {  // using realtime: skip to next waypoint based on elapsed display time
-      while (current_state_ < waypoint_count && (tm = displaying_trajectory_message_->getWayPointDurationFromPrevious(
-                                                     current_state_ + 1)) < current_state_time_)
+    {
+      // using realtime factors: skip to next waypoint based on elapsed display time
+      const float rt_factor = -tm;  // negative tm is the intended realtime factor
+      while (current_state_ < waypoint_count &&
+             (tm = displaying_trajectory_message_->getWayPointDurationFromPrevious(current_state_ + 1) / rt_factor) <
+                 current_state_time_)
       {
         current_state_time_ -= tm;
-        if (tm < current_state_time_)  // if we are stuck in the while loop we should
-                                       // move the robot along the path to keep up
+        // if we are stuck in the while loop we should move the robot along the path to keep up
+        if (tm < current_state_time_)
           display_path_robot_->update(displaying_trajectory_message_->getWayPointPtr(current_state_));
         ++current_state_;
       }


### PR DESCRIPTION
The fact that trajectory visualization ignored the time parameterization by default
and that the only way to change this is the special value "REALTIME" always bothered me.

I changed the default to a realtime factor of 3x to get a nice preview of the trajectory
when using the "Plan&Execute" button.

https://user-images.githubusercontent.com/680358/123707186-9cdfa400-d869-11eb-9e94-95935f15d163.mp4
