### PR TITLE
Remove faulty gtest include

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -46,9 +46,6 @@
 #include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/servo_calcs.h>
 
-// testing
-#include <gtest/gtest.h>
-
 namespace moveit_servo
 {
 /**


### PR DESCRIPTION
See https://github.com/ros-planning/moveit2/pull/526 for MoveIt2 patch.

https://github.com/ros-planning/moveit/pull/2471 was not sufficiently reviewed.

@henningkayser