### PR TITLE
use $(dirname) in MoveIt Setup Assistant

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/default_warehouse_db.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/default_warehouse_db.launch
@@ -5,7 +5,7 @@
   <arg name="moveit_warehouse_database_path" default="$(find [GENERATED_PACKAGE_NAME])/default_warehouse_mongo_db" />
 
   <!-- Launch the warehouse with the configured database location -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -43,7 +43,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="execution_type" value="$(arg execution_type)"/>
@@ -54,13 +54,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch" if="$(arg use_rviz)">
+  <include file="$(dirname)/moveit_rviz.launch" if="$(arg use_rviz)">
     <arg name="rviz_config" value="$(find [GENERATED_PACKAGE_NAME])/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -28,7 +28,7 @@
   <arg name="urdf_path" default="[URDF_LOCATION]"/>
 
   <!-- launch the gazebo simulator and spawn the robot -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/gazebo.launch" >
+  <include file="$(dirname)/gazebo.launch" >
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
     <arg name="urdf_path" value="$(arg urdf_path)"/>
@@ -51,7 +51,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="false"/>
     <arg name="info" value="true"/>
@@ -60,13 +60,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch">
+  <include file="$(dirname)/moveit_rviz.launch">
     <arg name="rviz_config" value="$(find [GENERATED_PACKAGE_NAME])/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -18,6 +18,6 @@
   <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -x 0 -y 0 -z 0"
     respawn="false" output="screen" />
 
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/ros_controllers.launch"/>
+  <include file="$(dirname)/ros_controllers.launch"/>
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -4,7 +4,7 @@
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix"
-           value="gdb -x $(find [GENERATED_PACKAGE_NAME])/launch/gdb_settings.gdb --ex run --args" />
+           value="gdb -x $(dirname)/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
   <arg name="info" default="$(arg debug)" />
@@ -39,7 +39,7 @@
 
   <arg name="load_robot_description" default="true" />
   <!-- load URDF, SRDF and joint_limits configuration -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
   </include>
 
@@ -47,29 +47,29 @@
   <group ns="move_group/planning_pipelines">
 
     <!-- OMPL -->
-    <include ns="ompl" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
     <!-- CHOMP -->
-    <include ns="chomp" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
     <!-- Pilz Industrial Motion-->
-    <include ns="pilz_industrial_motion_planner" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+    <include ns="pilz_industrial_motion_planner" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 
     <!-- Support custom planning pipeline -->
     <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])"
-	     file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+	     file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>
   </group>
 
   <!-- Trajectory Execution Functionality -->
-  <include ns="move_group" file="$(find [GENERATED_PACKAGE_NAME])/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="[ROBOT_NAME]" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
@@ -77,7 +77,7 @@
   </include>
 
   <!-- Sensors Functionality -->
-  <include ns="move_group" file="$(find [GENERATED_PACKAGE_NAME])/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_sensor_manager" value="[ROBOT_NAME]" />
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_pipeline.launch.xml
@@ -5,6 +5,6 @@
 
   <arg name="pipeline" default="ompl" />
 
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg pipeline)_planning_pipeline.launch.xml" />
+  <include file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_ompl.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_ompl.launch
@@ -4,12 +4,12 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_ompl_benchmark_warehouse"/>
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/sensor_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/sensor_manager.launch.xml
@@ -12,6 +12,6 @@
 
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="[ROBOT_NAME]" />
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+  <include file="$(dirname)/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
@@ -17,7 +17,7 @@
 
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="[ROBOT_NAME]" />
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
+  <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
     <arg name="execution_type" value="$(arg execution_type)" />
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse.launch
@@ -4,7 +4,7 @@
   <arg name="moveit_warehouse_database_path" />
 
   <!-- Load warehouse parameters -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse_settings.launch.xml" />
+  <include file="$(dirname)/warehouse_settings.launch.xml" />
 
   <!-- Run the DB server -->
   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">


### PR DESCRIPTION
Available since lunar. This simplifies the descriptions in moveit_resources
quite a bit because their package name does not match the include path
and we have to adapt the names everywhere after edits.

Note that two candidates for this replacement still remain -
they define the file path to the rviz config in an arg value.
Due to [a bug](https://github.com/ros/ros_comm/issues/1487) these two can not be replaced at this moment.

@gavanderhoorn Could you please review this patch?