### PR TITLE
MSA: kill setup_assistant.launch after MSA finished

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/edit_configuration_package.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/edit_configuration_package.launch
@@ -10,6 +10,7 @@
   <node pkg="moveit_setup_assistant" type="moveit_setup_assistant" name="moveit_setup_assistant"
         args="--config_pkg=[GENERATED_PACKAGE_NAME]"
         launch-prefix="$(arg launch_prefix)"
+        required="true"
         output="screen" />
 
 </launch>


### PR DESCRIPTION
just a tiny annoyance nobody complained about before.