### PR TITLE
Add planning_pipeline_id to MotionSequence service

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -194,7 +194,18 @@ void MoveGroupSequenceAction::executeMoveCallbackPlanOnly(const moveit_msgs::Mov
   RobotTrajCont traj_vec;
   try
   {
-    traj_vec = command_list_manager_->solve(the_scene, context_->planning_pipeline_, goal->request);
+    // Select planning_pipeline to handle request
+    // All motions in the SequenceRequest need to use the same planning pipeline (but can use different planners)
+    const planning_pipeline::PlanningPipelinePtr planning_pipeline =
+        resolvePlanningPipeline(goal->request.items[0].req.pipeline_id);
+    if (!planning_pipeline)
+    {
+      ROS_ERROR_STREAM("Could not load planning pipeline " << goal->request.items[0].req.pipeline_id);
+      res.response.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+      return;
+    }
+
+    traj_vec = command_list_manager_->solve(the_scene, planning_pipeline, goal->request);
   }
   catch (const MoveItErrorCodeException& ex)
   {

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -63,6 +63,14 @@ void MoveGroupSequenceService::initialize()
 bool MoveGroupSequenceService::plan(moveit_msgs::GetMotionSequence::Request& req,
                                     moveit_msgs::GetMotionSequence::Response& res)
 {
+  // Handle empty requests
+  if (req.request.items.empty())
+  {
+    ROS_WARN("Received empty request. That's ok but maybe not what you intended.");
+    res.response.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+    return true;
+  }
+
   // TODO: Do we lock on the correct scene? Does the lock belong to the scene
   // used for planning?
   planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);


### PR DESCRIPTION
In #2657 I added code to select the planning pipeline and planner to the `getMotionSequence` action. This is required to use the action and service when both OMPL and the Pilz planning pipelines are loaded, because `getMotionSequence` needs to use Pilz, but selects the default pipeline instead (OMPL).

I recently noticed that it should also be added to the service, which this PR does. It works, so if you need this feature you can use it. But it breaks some tests, and they seem to be in functionality (`Sequence`) that I don't have the time to dig into right now. Maybe @ct2034 or @jschleicher want to have a look.