### PR TITLE
Cleanup CollisionDetectorAllocatorTemplate::getName()

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -72,8 +72,6 @@ template <class CollisionEnvType, class CollisionDetectorAllocatorType>
 class CollisionDetectorAllocatorTemplate : public CollisionDetectorAllocator
 {
 public:
-  virtual const std::string& getName() const = 0;
-
   CollisionEnvPtr allocateEnv(const WorldPtr& world, const moveit::core::RobotModelConstPtr& robot_model) const override
   {
     return CollisionEnvPtr(new CollisionEnvType(robot_model, world));

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
@@ -54,10 +54,13 @@ MOVEIT_CLASS_FORWARD(CollisionPlugin);  // Defines CollisionPluginPtr, ConstPtr,
  *     public collision_detection::CollisionDetectorAllocatorTemplate<MyCollisionEnv, MyCollisionDetectorAllocator>
  *   {
  *     public:
+ *       const std::string& getName() const override {
+ *         static const std::string NAME = "my_checker";
+ *         return NAME;
+ *       }
  *       static const std::string NAME_;
  *   };
  *
- *   const std::string MyCollisionDetectorAllocator::NAME_("my_checker");
  *   }
  *
  *   namespace collision_detection

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -10,10 +10,11 @@ if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 include(GenerateExportHeader)
-generate_export_header(${MOVEIT_LIB_NAME})
-target_include_directories(${MOVEIT_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+generate_export_header(${MOVEIT_LIB_NAME} EXPORT_FILE_NAME ${CATKIN_DEVEL_PREFIX}/include/moveit/${MOVEIT_LIB_NAME}_export.h)
+target_include_directories(${MOVEIT_LIB_NAME} PRIVATE $<BUILD_INTERFACE:${CATKIN_DEVEL_PREFIX}/include>)  # for this library
+list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include)  # for use by other libraries in moveit_core
 
-# This line is needed to ensure that messages are done being built before this is built
+# This line ensures that messages are built before the library is built
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
@@ -24,4 +25,5 @@ install(TARGETS ${MOVEIT_LIB_NAME}
         RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MOVEIT_LIB_NAME}_export.h DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit/kinematics_base/)
+install(FILES ${CATKIN_DEVEL_PREFIX}/include/moveit/${MOVEIT_LIB_NAME}_export.h
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit)

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -44,7 +44,7 @@
 #include <boost/function.hpp>
 #include <string>
 
-#include "moveit_kinematics_base_export.h"
+#include <moveit/moveit_kinematics_base_export.h>
 
 namespace moveit
 {

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -4,8 +4,9 @@ add_library(${MOVEIT_LIB_NAME} src/planning_scene.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 include(GenerateExportHeader)
-generate_export_header(${MOVEIT_LIB_NAME})
-target_include_directories(${MOVEIT_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+generate_export_header(${MOVEIT_LIB_NAME} EXPORT_FILE_NAME ${CATKIN_DEVEL_PREFIX}/include/moveit/${MOVEIT_LIB_NAME}_export.h)
+target_include_directories(${MOVEIT_LIB_NAME} PRIVATE $<BUILD_INTERFACE:${CATKIN_DEVEL_PREFIX}/include>)  # for this library
+list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include)  # for use by other libraries in moveit_core
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_model
@@ -25,7 +26,8 @@ install(TARGETS ${MOVEIT_LIB_NAME}
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MOVEIT_LIB_NAME}_export.h DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit/planning_scene/)
+install(FILES ${CATKIN_DEVEL_PREFIX}/include/moveit/${MOVEIT_LIB_NAME}_export.h
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/moveit)
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_planning_scene test/test_planning_scene.cpp)

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -57,7 +57,7 @@
 #include <memory>
 
 // Import/export for windows dll's and visibility for gcc shared libraries.
-#include "moveit_planning_scene_export.h"
+#include <moveit/moveit_planning_scene_export.h>
 
 /** \brief This namespace includes the central class for representing planning contexts */
 namespace planning_scene


### PR DESCRIPTION
This is a small cleanup for 4963f32849b4d20c423f6a29a4114f1d48526c0d of #2604.

The change from `NAME_` to `getName()` wasn't updated in a doc comment.
`getName()` doesn't need to be redeclared as abstract in `CollisionDetectorAllocatorTemplate`.
