### PR TITLE
Servo: minor fixups

### DIFF
--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -327,7 +327,7 @@ bool Servo::getCommandFrameTransform(Eigen::Isometry3d& transform)
 
 bool Servo::getCommandFrameTransform(geometry_msgs::TransformStamped& transform)
 {
-  return servo_calcs_->getEEFrameTransform(transform);
+  return servo_calcs_->getCommandFrameTransform(transform);
 }
 
 bool Servo::getEEFrameTransform(Eigen::Isometry3d& transform)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -359,7 +359,7 @@ void ServoCalcs::calculateSingleIteration()
   }
 
   // Print a warning to the user if both are stale
-  if (!twist_command_is_stale_ || !joint_command_is_stale_)
+  if (twist_command_is_stale_ && joint_command_is_stale_)
   {
     ROS_WARN_STREAM_THROTTLE_NAMED(10, LOGNAME,
                                    "Stale command. "


### PR DESCRIPTION
### Description

Some fix, that seemed wrong from the code context.
The fix are minor and not serious.
-fixed a wrapper calling wrong member, though normally returning same value
-suppressed a wrong ROS_WARN message

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
