### PR TITLE
controller manager: enclose controller name in quotes

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -199,13 +199,13 @@ void FollowJointTrajectoryControllerHandle::controllerDoneCallback(
 {
   // Output custom error message for FollowJointTrajectoryResult if necessary
   if (!result)
-    ROS_WARN_STREAM_NAMED(LOGNAME, "Controller " << name_ << " done, no result returned");
+    ROS_WARN_STREAM_NAMED(LOGNAME, "Controller '" << name_ << "' done, no result returned");
   else if (result->error_code == control_msgs::FollowJointTrajectoryResult::SUCCESSFUL)
-    ROS_INFO_STREAM_NAMED(LOGNAME, "Controller " << name_ << " successfully finished");
+    ROS_INFO_STREAM_NAMED(LOGNAME, "Controller '" << name_ << "' successfully finished");
   else
-    ROS_WARN_STREAM_NAMED(LOGNAME, "Controller " << name_ << " failed with error "
-                                                 << errorCodeToMessage(result->error_code) << ": "
-                                                 << result->error_string);
+    ROS_WARN_STREAM_NAMED(LOGNAME, "Controller '" << name_ << "' failed with error "
+                                                  << errorCodeToMessage(result->error_code) << ": "
+                                                  << result->error_string);
   finishControllerExecution(state);
 }
 


### PR DESCRIPTION
So empty controller names are easier to spot.

Some MoveIt configurations have the controller `name` set to `""`. This is valid (although annoying), but the formatting of the log lines makes it difficult to spot this.

Without the quotes:

```
Controller  failed with error INVALID_GOAL: ...
```

With the quotes:

```
Controller '' failed with error INVALID_GOAL: ...
```
