### PR TITLE
CI: Switch to Noetic builds by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - IMAGE: master-ci
+          - IMAGE: noetic-ci
             CCOV: true
-          - IMAGE: master-ci-shadow-fixed
+          - IMAGE: noetic-ci-shadow-fixed
             IKFAST_TEST: true
             CATKIN_LINT: true
             CLANG_TIDY: true
-          - IMAGE: melodic-ci
+          - IMAGE: master-ci # ROS Melodic with all dependencies required for master
             CATKIN_LINT: true
     env:
       CXXFLAGS: "-Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-deprecated-copy"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       BASEDIR: ${{ github.workspace }}/.work
       CLANG_TIDY_BASE_REF: "${{ github.base_ref || github.ref }}"
+      BUILDER: catkin_tools
 
     name: "${{ matrix.env.IMAGE }}${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && ' + clang-tidy' || '' }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
So far, we only used ROS Melodic builds for CI (based on the `master-ci` docker container).
This PR attempts to switch to `noetic-ci` by default and using only a single `master-ci` build for Melodic.