### PR TITLE
Fix Windows CI

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -181,6 +181,11 @@ catkin_package(
     ${BULLET_ENABLE}
     )
 
+if (WIN32)
+  # for msvc 2017 compatibility
+  add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
+endif()
+
 include_directories(SYSTEM ${catkin_INCLUDE_DIRS}
                            ${Boost_INCLUDE_DIRS}
                            ${EIGEN3_INCLUDE_DIRS}


### PR DESCRIPTION
Fixes error C2338: 
```
You've instantiated std::aligned_storage<Len, Align>
with an extended alignment (in other words, Align > alignof(max_align_t)).
Before VS 2017 15.8, the member type would non-conformingly have an
alignment of only alignof(max_align_t).
VS 2017 15.8 was fixed to handle this correctly, but the fix inherently
changes layout and breaks binary compatibility (*only* for uses of
aligned_storage with extended alignments). Please define either
1. _ENABLE_EXTENDED_ALIGNED_STORAGE to acknowledge that you understand
    this message and that you actually want a type with an extended alignment
2. _DISABLE_EXTENDED_ALIGNED_STORAGE to silence this message and
    get the old non-conformant behavior.
```