### PR TITLE
Set Goal tolerance per coordinate #1058

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -445,6 +445,14 @@ class MoveGroupCommander(object):
         """ When moving to an orientation goal or to a pose goal, the tolerance for the goal orientation is specified as the distance (roll, pitch, yaw) to the target origin of the end-effector """
         return self._g.get_goal_orientation_tolerance()
 
+    def get_goal_position_tolerance_xyz(self):
+        """ When moving to a position goal or to a pose goal, the tolerance for the goal position is specified as tolerances on each coordinate x, y, z relative the target origin of the end-effector """
+        return self._g.get_goal_position_tolerance()
+
+    def get_goal_orientation_tolerance_xyz(self):
+        """ When moving to an orientation goal or to a pose goal, the tolerance for the goal orientation is specified as the distance for each angle (roll, pitch, yaw) to the target origin of the end-effector """
+        return self._g.get_goal_orientation_tolerance()
+
     def set_goal_tolerance(self, value):
         """ Set the joint, position and orientation goal tolerances simultaneously """
         self._g.set_goal_tolerance(value)

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -272,17 +272,25 @@ public:
   /** \brief Get the number of seconds set by setPlanningTime() */
   double getPlanningTime() const;
 
-  /** \brief Get the tolerance that is used for reaching a joint goal. This is distance for each joint in configuration
-   * space */
+  /** \brief Get the tolerance that is used for reaching a joint goal. This is the distance for each joint in
+   * configuration space */
   double getGoalJointTolerance() const;
 
-  /** \brief Get the tolerance that is used for reaching a position goal. This is be the radius of a sphere where the
+  /** \brief Get the tolerance that is used for reaching a position goal. This is the radius of a sphere where the
    * end-effector must reach.*/
   double getGoalPositionTolerance() const;
 
   /** \brief Get the tolerance that is used for reaching an orientation goal. This is the tolerance for roll, pitch and
    * yaw, in radians. */
   double getGoalOrientationTolerance() const;
+
+  /** \brief Get the tolerance that is used for reaching a position goal. This is the tolerance for coordinates where
+   * the end-effector must reach.*/
+  std::vector<double> getGoalPositionToleranceXYZ() const;
+
+  /** \brief Get the tolerance that is used for reaching an orientation goal. This is one tolerance for each of the
+   * roll, pitch and yaw, in radians. */
+  std::vector<double> getGoalOrientationToleranceXYZ() const;
 
   /** \brief Set the tolerance that is used for reaching the goal. For
       joint state goals, this will be distance for each joint, in the
@@ -291,6 +299,10 @@ public:
       reach. This function simply triggers calls to setGoalPositionTolerance(),
       setGoalOrientationTolerance() and setGoalJointTolerance(). */
   void setGoalTolerance(double tolerance);
+
+  /** \brief Set the tolerance that is used for reaching the goal to default values. This function simply triggers calls
+     to setGoalPositionTolerance(), setGoalOrientationTolerance() and setGoalJointTolerance(). */
+  void setDefaultGoalTolerance();
 
   /** \brief Set the joint tolerance (for each joint) that is used for reaching the goal when moving to a joint value
    * target. */
@@ -301,6 +313,12 @@ public:
 
   /** \brief Set the orientation tolerance that is used for reaching the goal when moving to a pose. */
   void setGoalOrientationTolerance(double tolerance);
+
+  /** \brief Set the position tolerance (for each coordinate) that is used for reaching the goal when moving to a pose. */
+  void setGoalPositionToleranceXYZ(const std::vector<double>& tolerances);
+
+  /** \brief Set the orientation tolerance (for each coordinate) that is used for reaching the goal when moving to a pose. */
+  void setGoalOrientationToleranceXYZ(const std::vector<double>& tolerances);
 
   /** \brief Specify the workspace bounding box.
        The box is specified in the planning frame (i.e. relative to the robot root link start position).

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -740,12 +740,20 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("get_goal_position_tolerance", &MoveGroupInterfaceWrapper::getGoalPositionTolerance);
   move_group_interface_class.def("get_goal_orientation_tolerance",
                                  &MoveGroupInterfaceWrapper::getGoalOrientationTolerance);
+  move_group_interface_class.def("get_goal_position_tolerance_xyz",
+                                 &MoveGroupInterfaceWrapper::getGoalPositionToleranceXYZ);
+  move_group_interface_class.def("get_goal_orientation_tolerance_xyz",
+                                 &MoveGroupInterfaceWrapper::getGoalOrientationToleranceXYZ);
 
   move_group_interface_class.def("set_goal_joint_tolerance", &MoveGroupInterfaceWrapper::setGoalJointTolerance);
   move_group_interface_class.def("set_goal_position_tolerance", &MoveGroupInterfaceWrapper::setGoalPositionTolerance);
   move_group_interface_class.def("set_goal_orientation_tolerance",
                                  &MoveGroupInterfaceWrapper::setGoalOrientationTolerance);
   move_group_interface_class.def("set_goal_tolerance", &MoveGroupInterfaceWrapper::setGoalTolerance);
+  move_group_interface_class.def("set_goal_position_tolerance_xyz",
+                                 &MoveGroupInterfaceWrapper::setGoalPositionToleranceXYZ);
+  move_group_interface_class.def("set_goal_orientation_tolerance_xyz",
+                                 &MoveGroupInterfaceWrapper::setGoalOrientationToleranceXYZ);
 
   move_group_interface_class.def("set_start_state_to_current_state",
                                  &MoveGroupInterfaceWrapper::setStartStateToCurrentState);


### PR DESCRIPTION
### Description

- Solves https://github.com/ros-planning/moveit/issues/1058
- Allows to set a goal position tolerance for x, y, and z coordinates separately
- Allows to reset goal tolerances to default values

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
