### PR TITLE
Fix bullet plugin library path name

### DIFF
--- a/moveit_core/collision_detector_bullet_description.xml
+++ b/moveit_core/collision_detector_bullet_description.xml
@@ -1,4 +1,4 @@
-<library path="lib/libcollision_detector_bt_plugin">
+<library path="lib/libcollision_detector_bullet_plugin">
   <class name="Bullet" type="collision_detection::CollisionDetectorBtPluginLoader"
   base_class_type="collision_detection::CollisionPlugin">
     <description>


### PR DESCRIPTION
### Description
Fix wrong plugin library path for the Bullet collision detector.

```shell
Exception while loading Bullet: Could not find library corresponding to plugin Bullet. Make sure the plugin description XML file has the correct name of the library and that the library actually exists.

```