### PR TITLE
Don't discard object color and type when attached, so we can reuse them once detached

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1807,8 +1807,12 @@ bool PlanningScene::processCollisionObjectRemove(const moveit_msgs::CollisionObj
   else
   {
     world_->removeObject(object.id);
-    removeObjectColor(object.id);
-    removeObjectType(object.id);
+    if (!getCurrentState().hasAttachedBody(object.id))
+    {
+      // Don't discard object color and type when an attached object is just being detached
+      removeObjectColor(object.id);
+      removeObjectType(object.id);
+    }
   }
   return true;
 }


### PR DESCRIPTION
### Description

Tentative fix for #2777

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
