### PR TITLE
Trajectory Monitor: fix obvious bug

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -58,7 +58,7 @@ planning_scene_monitor::TrajectoryMonitor::~TrajectoryMonitor()
 
 void planning_scene_monitor::TrajectoryMonitor::setSamplingFrequency(double sampling_frequency)
 {
-  if (sampling_frequency != sampling_frequency_)
+  if (sampling_frequency == sampling_frequency_)
     return;  // silently return if nothing changes
 
   if (sampling_frequency <= std::numeric_limits<double>::epsilon())


### PR DESCRIPTION
Thank you to @griswaldbrooks for [finding this in a routine review](https://github.com/ros-planning/moveit2/pull/570#discussion_r677004874).

This is such a rare use interface that this bug almost surely was never noticed...