### PR TITLE
[fix] RobotState Constructor segfault

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -61,10 +61,16 @@ RobotState::RobotState(const RobotModelConstPtr& robot_model)
   , has_velocity_(false)
   , has_acceleration_(false)
   , has_effort_(false)
-  , dirty_link_transforms_(robot_model_->getRootJoint())
+  , dirty_link_transforms_(nullptr)
   , dirty_collision_body_transforms_(nullptr)
   , rng_(nullptr)
 {
+  if (robot_model == nullptr)
+  {
+    throw std::invalid_argument("RobotState cannot be constructed with nullptr RobotModelConstPtr");
+  }
+
+  dirty_link_transforms_ = robot_model_->getRootJoint();
   allocMemory();
   initTransforms();
 }


### PR DESCRIPTION
### Description

This is a backport of a bug I fixed in moveit2.

It came from this PR: https://github.com/ros-planning/moveit2/pull/562/files

I am backporting the bug fix separate from that full PR because I believe it should be trivial to merge whereas that whole PR might require more discussion before we backport that pattern from moveit2 to moveit.  That doesn't mean that we can't backport the bugs we fix while applying that pattern even if we don't want to backport the pattern yet.