### PR TITLE
Fix bug where setting planning scene publish frequency is ignored

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -49,6 +49,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
+#include <atomic>
 #include <memory>
 
 namespace planning_scene_monitor
@@ -494,7 +495,8 @@ protected:
   // variables for planning scene publishing
   ros::Publisher planning_scene_publisher_;
   std::unique_ptr<boost::thread> publish_planning_scene_;
-  double publish_planning_scene_frequency_;
+  std::atomic<double> publish_planning_scene_frequency_;
+  std::atomic<bool> publish_planning_scene_frequency_updated_;
   SceneUpdateType publish_update_types_;
   SceneUpdateType new_scene_update_;
   boost::condition_variable_any new_scene_update_condition_;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -52,7 +52,7 @@
 
 namespace
 {
-constexpr double DEFAULT_PLANNING_SCENE_PUBLISH_FREQUENCY = 2.0; // Hz
+constexpr double DEFAULT_PLANNING_SCENE_PUBLISH_FREQUENCY = 30.0; // Hz
 }  // namespace
 
 namespace planning_scene_monitor

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -50,6 +50,11 @@
 
 #include <memory>
 
+namespace
+{
+constexpr double DEFAULT_PLANNING_SCENE_PUBLISH_FREQUENCY = 2.0; // Hz
+}  // namespace
+
 namespace planning_scene_monitor
 {
 using namespace moveit_ros_planning;
@@ -137,7 +142,7 @@ PlanningSceneMonitor::PlanningSceneMonitor(const robot_model_loader::RobotModelL
 PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
                                            const robot_model_loader::RobotModelLoaderPtr& rm_loader,
                                            const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
-  : monitor_name_(name), nh_("~"), tf_buffer_(tf_buffer), rm_loader_(rm_loader)
+  : monitor_name_(name), nh_("~"), tf_buffer_(tf_buffer), rm_loader_(rm_loader), publish_planning_scene_frequency_(DEFAULT_PLANNING_SCENE_PUBLISH_FREQUENCY), publish_planning_scene_frequency_updated_(false)
 {
   root_nh_.setCallbackQueue(&queue_);
   nh_.setCallbackQueue(&queue_);
@@ -150,7 +155,7 @@ PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePt
                                            const robot_model_loader::RobotModelLoaderPtr& rm_loader,
                                            const ros::NodeHandle& nh, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                            const std::string& name)
-  : monitor_name_(name), nh_("~"), root_nh_(nh), tf_buffer_(tf_buffer), rm_loader_(rm_loader)
+  : monitor_name_(name), nh_("~"), root_nh_(nh), tf_buffer_(tf_buffer), rm_loader_(rm_loader), publish_planning_scene_frequency_(DEFAULT_PLANNING_SCENE_PUBLISH_FREQUENCY), publish_planning_scene_frequency_updated_(false)
 {
   // use same callback queue as root_nh_
   nh_.setCallbackQueue(root_nh_.getCallbackQueue());
@@ -234,7 +239,6 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     ROS_ERROR_NAMED(LOGNAME, "Robot model not loaded");
   }
 
-  publish_planning_scene_frequency_ = 2.0;
   new_scene_update_ = UPDATE_NONE;
 
   last_update_time_ = last_robot_motion_time_ = ros::Time::now();
@@ -348,12 +352,12 @@ void PlanningSceneMonitor::scenePublishingThread()
     ROS_DEBUG_NAMED(LOGNAME, "Published the full planning scene: '%s'", msg.name.c_str());
   }
 
+  ros::Rate rate(publish_planning_scene_frequency_);
   do
   {
     moveit_msgs::PlanningScene msg;
     bool publish_msg = false;
     bool is_full = false;
-    ros::Rate rate(publish_planning_scene_frequency_);
     {
       boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
       while (new_scene_update_ == UPDATE_NONE && publish_planning_scene_)
@@ -413,6 +417,11 @@ void PlanningSceneMonitor::scenePublishingThread()
       planning_scene_publisher_.publish(msg);
       if (is_full)
         ROS_DEBUG_NAMED(LOGNAME, "Published full planning scene: '%s'", msg.name.c_str());
+      if(publish_planning_scene_frequency_updated_) {
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Updating planning scene publish frequency to " << publish_planning_scene_frequency_);
+        rate = ros::Rate(publish_planning_scene_frequency_);
+        publish_planning_scene_frequency_updated_ = false;
+      }
       rate.sleep();
     }
   } while (publish_planning_scene_);
@@ -1313,8 +1322,10 @@ void PlanningSceneMonitor::clearUpdateCallbacks()
 void PlanningSceneMonitor::setPlanningScenePublishingFrequency(double hz)
 {
   publish_planning_scene_frequency_ = hz;
-  ROS_DEBUG_NAMED(LOGNAME, "Maximum frequency for publishing a planning scene is now %lf Hz",
-                  publish_planning_scene_frequency_);
+  publish_planning_scene_frequency_updated_ = true;
+
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Maximum frequency for publishing a planning scene is now "
+    << publish_planning_scene_frequency_ << " Hz");
 }
 
 void PlanningSceneMonitor::getUpdatedFrameTransforms(std::vector<geometry_msgs::TransformStamped>& transforms)


### PR DESCRIPTION
### Description

This fixes a bug where PlanningSceneMonitor::setPlanningScenePublishingFrequency does not update the rate used by the internal loop logic. This also increases the default frequency to 30 FPS, which I think is a better default value when you want to visualize movement of the robot with attached collision objects.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
