### PR TITLE
fix clang-tidy CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
       CLANG_TIDY_BASE_REF: "${{ github.base_ref || github.ref }}"
       BEFORE_CLANG_TIDY_CHECKS: (cd $TARGET_REPO_PATH; clang-tidy --list-checks)
       BUILDER: ${{ matrix.env.BUILDER || 'catkin_tools' }}
+      CC: ${{ matrix.env.CLANG_TIDY && 'clang' }}
+      CXX: ${{ matrix.env.CLANG_TIDY && 'clang++' }}
 
     name: "${{ matrix.env.IMAGE }}${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && ' + clang-tidy' || '' }}"
     runs-on: ubuntu-latest

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -5,6 +5,13 @@ add_library(${MOVEIT_LIB_NAME}
   src/collision_env_fcl.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # FIXME(v4hn): clang 10-12 produce broken code for the only std::map::insert call in the method
+  # however, the method calls in here are hotspots in the whole pipeline and disabling optimizations
+  # is no sufficient solution
+  set_source_files_properties(src/collision_common.cpp PROPERTIES COMPILE_FLAGS -O0)
+endif()
+
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})


### PR DESCRIPTION
https://github.com/ros-planning/moveit/pull/2790 and https://github.com/ros-planning/moveit/pull/2674 currently show that the clang-tidy job broke, likely due to 55886f770b0f9ebe1f2297b92869e8ca97cfc60a .

Recovering the clang-tidy job might fail for a variety of reasons, so I will mark this as WIP.
Anyone, feel free to fix and merge this if you have time.