### PR TITLE
Fixed a crash bug due to uninitialized class field being used.

### DIFF
--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -106,13 +106,13 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& urdf_string, const std::stri
   auto umodel = std::make_unique<urdf::Model>();
   if (umodel->initString(urdf_string))
   {
-    srdf_ = std::make_shared<srdf::Model>();
-    if (!srdf_->initString(*urdf_, srdf_string))
+    auto smodel = std::make_shared<srdf::Model>();
+    if (!smodel->initString(*umodel, srdf_string))
     {
       ROS_ERROR_NAMED("rdf_loader", "Unable to parse SRDF");
-      srdf_.reset();
     }
     urdf_ = std::move(umodel);
+    srdf_ = std::move(smodel);
   }
   else
   {


### PR DESCRIPTION
### Description

`RDFLoader` implementation was wrong: it used the method field *before* it was used, leading to a null-pointer segfault. THis commit fixes that.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
