### PR TITLE
Draft: Simultaneous execution of trajectories

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -132,7 +132,7 @@ public:
    * has the diffs specified by \e msg applied. */
   PlanningScenePtr diff(const moveit_msgs::PlanningScene& msg) const;
 
-  /** \brief Get the parent scene (whith respect to which the diffs are maintained). This may be empty */
+  /** \brief Get the parent scene (with respect to which the diffs are maintained). This may be empty */
   const PlanningSceneConstPtr& getParent() const
   {
     return parent_;

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -231,6 +231,7 @@ void RobotTrajectory::getRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajec
 
   std::vector<const moveit::core::JointModel*> onedof;
   std::vector<const moveit::core::JointModel*> mdof;
+  trajectory.group_name = group_ ? group_->getName() : "";
   trajectory.joint_trajectory.joint_names.clear();
   trajectory.multi_dof_joint_trajectory.joint_names.clear();
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/move_group_sequence_action.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/move_group_sequence_action.h
@@ -36,11 +36,12 @@
 
 #include <memory>
 
-#include <actionlib/server/simple_action_server.h>
+#include <actionlib/server/action_server.h>
 #include <moveit/move_group/move_group_capability.h>
 
 #include <moveit_msgs/MoveGroupSequenceAction.h>
 
+typedef actionlib::ActionServer<moveit_msgs::MoveGroupSequenceAction> MoveGroupSequenceActionServer;
 namespace pilz_industrial_motion_planner
 {
 class CommandListManager;
@@ -64,7 +65,7 @@ private:
   using PlannedTrajMsgs = moveit_msgs::MotionSequenceResponse::_planned_trajectories_type;
 
 private:
-  void executeSequenceCallback(const moveit_msgs::MoveGroupSequenceGoalConstPtr& goal);
+  void executeSequenceCallback(MoveGroupSequenceActionServer::GoalHandle goal_handle);
   void executeSequenceCallbackPlanAndExecute(const moveit_msgs::MoveGroupSequenceGoalConstPtr& goal,
                                              moveit_msgs::MoveGroupSequenceResult& action_res);
   void executeMoveCallbackPlanOnly(const moveit_msgs::MoveGroupSequenceGoalConstPtr& goal,
@@ -81,7 +82,7 @@ private:
                            PlannedTrajMsgs& plannedTrajsMsgs);
 
 private:
-  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::MoveGroupSequenceAction>> move_action_server_;
+  std::unique_ptr<actionlib::ActionServer<moveit_msgs::MoveGroupSequenceAction>> move_action_server_;
   moveit_msgs::MoveGroupSequenceFeedback move_feedback_;
 
   move_group::MoveGroupState move_state_{ move_group::IDLE };

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -247,7 +247,10 @@ bool MoveGroupSequenceAction::planUsingSequenceManager(const moveit_msgs::Motion
                                                        plan_execution::ExecutableMotionPlan& plan)
 {
   setMoveState(move_group::PLANNING);
-
+  // before we start planning, ensure that we have the latest robot state
+  // received...
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
+  context_->planning_scene_monitor_->updateFrameTransforms();
   planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);
   RobotTrajCont traj_vec;
   try

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -73,6 +73,9 @@ bool MoveGroupSequenceService::plan(moveit_msgs::GetMotionSequence::Request& req
 
   // TODO: Do we lock on the correct scene? Does the lock belong to the scene
   // used for planning?
+  // before we start planning, ensure that we have the latest robot state received...
+  context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
+  context_->planning_scene_monitor_->updateFrameTransforms();
   planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);
 
   ros::Time planning_start = ros::Time::now();

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -51,7 +51,7 @@ BaseFakeController::BaseFakeController(const std::string& name, const std::vecto
   ss << "Fake controller '" << name << "' with joints [ ";
   std::copy(joints.begin(), joints.end(), std::ostream_iterator<std::string>(ss, " "));
   ss << "]";
-  ROS_INFO_STREAM(ss.str());
+  ROS_INFO_STREAM_NAMED(name_, ss.str());
 }
 
 void BaseFakeController::getJoints(std::vector<std::string>& joints) const
@@ -61,7 +61,7 @@ void BaseFakeController::getJoints(std::vector<std::string>& joints) const
 
 moveit_controller_manager::ExecutionStatus BaseFakeController::getLastExecutionStatus()
 {
-  return moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+  return status_;
 }
 
 LastPointController::LastPointController(const std::string& name, const std::vector<std::string>& joints,
@@ -74,10 +74,11 @@ LastPointController::~LastPointController() = default;
 
 bool LastPointController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
-  ROS_INFO("Fake execution of trajectory");
+  ROS_INFO_NAMED(name_, "Fake execution of trajectory: Last point start");
   if (t.joint_trajectory.points.empty())
     return true;
 
+  status_ = moveit_controller_manager::ExecutionStatus::RUNNING;
   sensor_msgs::JointState js;
   const trajectory_msgs::JointTrajectoryPoint& last = t.joint_trajectory.points.back();
   js.header = t.joint_trajectory.header;
@@ -87,12 +88,15 @@ bool LastPointController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
   js.velocity = last.velocities;
   js.effort = last.effort;
   pub_.publish(js);
+  status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+  ROS_INFO_NAMED(name_, "Fake execution of trajectory: Last point done");
 
   return true;
 }
 
 bool LastPointController::cancelExecution()
 {
+  status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
   return true;
 }
 
@@ -123,7 +127,7 @@ bool ThreadedController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
   cancelTrajectory();  // cancel any previous fake motion
   cancel_ = false;
-  status_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
+  status_ = moveit_controller_manager::ExecutionStatus::RUNNING;
   thread_ = boost::thread([this, t] { execTrajectory(t); });
   return true;
 }
@@ -131,7 +135,7 @@ bool ThreadedController::sendTrajectory(const moveit_msgs::RobotTrajectory& t)
 bool ThreadedController::cancelExecution()
 {
   cancelTrajectory();
-  ROS_INFO("Fake trajectory execution cancelled");
+  ROS_INFO_NAMED(name_, "Fake trajectory execution cancelled");
   status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
   return true;
 }
@@ -158,7 +162,8 @@ ViaPointController::~ViaPointController() = default;
 
 void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
-  ROS_INFO("Fake execution of trajectory");
+  ROS_INFO_NAMED(name_, "Fake execution of trajectory: start");
+  status_ = moveit_controller_manager::ExecutionStatus::RUNNING;
   sensor_msgs::JointState js;
   js.header = t.joint_trajectory.header;
   js.name = t.joint_trajectory.joint_names;
@@ -177,13 +182,14 @@ void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
     ros::Duration wait_time = via->time_from_start - (ros::Time::now() - start_time);
     if (wait_time.toSec() > std::numeric_limits<float>::epsilon())
     {
-      ROS_DEBUG("Fake execution: waiting %0.1fs for next via point, %ld remaining", wait_time.toSec(), end - via);
+      ROS_DEBUG_NAMED(name_, "Fake execution: waiting %0.1fs for next via point, %ld remaining", wait_time.toSec(), end - via);
       wait_time.sleep();
     }
     js.header.stamp = ros::Time::now();
     pub_.publish(js);
   }
-  ROS_DEBUG("Fake execution of trajectory: done");
+  status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+  ROS_INFO_NAMED(name_, "Fake execution of trajectory: done");
 }
 
 InterpolatingController::InterpolatingController(const std::string& name, const std::vector<std::string>& joints,
@@ -217,7 +223,8 @@ void interpolate(sensor_msgs::JointState& js, const trajectory_msgs::JointTrajec
 
 void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory& t)
 {
-  ROS_INFO("Fake execution of trajectory");
+  ROS_INFO_NAMED(name_, "Fake execution of trajectory: start");
+  status_ = moveit_controller_manager::ExecutionStatus::RUNNING;
   if (t.joint_trajectory.points.empty())
     return;
 
@@ -244,7 +251,7 @@ void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory&
       break;
 
     double duration = (next->time_from_start - prev->time_from_start).toSec();
-    ROS_DEBUG("elapsed: %.3f via points %td,%td / %td  alpha: %.3f", elapsed.toSec(), prev - points.begin(),
+    ROS_DEBUG_NAMED(name_, "elapsed: %.3f via points %td,%td / %td  alpha: %.3f", elapsed.toSec(), prev - points.begin(),
               next - points.begin(), end - points.begin(),
               duration > std::numeric_limits<double>::epsilon() ? (elapsed - prev->time_from_start).toSec() / duration :
                                                                   1.0);
@@ -254,18 +261,21 @@ void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory&
     rate_.sleep();
   }
   if (cancelled())
+  {
+    status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
     return;
+  }
 
   ros::Duration elapsed = ros::Time::now() - start_time;
-  ROS_DEBUG("elapsed: %.3f via points %td,%td / %td  alpha: 1.0", elapsed.toSec(), prev - points.begin(),
+  ROS_DEBUG_NAMED(name_, "elapsed: %.3f via points %td,%td / %td  alpha: 1.0", elapsed.toSec(), prev - points.begin(),
             next - points.begin(), end - points.begin());
 
   // publish last point
   interpolate(js, *prev, *prev, prev->time_from_start);
   js.header.stamp = ros::Time::now();
   pub_.publish(js);
-
-  ROS_DEBUG("Fake execution of trajectory: done");
+  status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+  ROS_INFO_NAMED(name_, "Fake execution of trajectory: done");
 }
 
 }  // end namespace moveit_fake_controller_manager

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -46,6 +46,8 @@
 
 namespace moveit_fake_controller_manager
 {
+const std::string LOGNAME = "planning_scene";
+
 MOVEIT_CLASS_FORWARD(BaseFakeController);  // Defines BaseFakeControllerPtr, ConstPtr, WeakPtr... etc
 
 // common base class to all fake controllers in this package
@@ -61,7 +63,6 @@ protected:
   std::vector<std::string> joints_;
   const ros::Publisher& pub_;
   moveit_controller_manager::ExecutionStatus status_;
-  std::string name_ = "fake_controllers";
 };
 
 class LastPointController : public BaseFakeController

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -60,6 +60,8 @@ public:
 protected:
   std::vector<std::string> joints_;
   const ros::Publisher& pub_;
+  moveit_controller_manager::ExecutionStatus status_;
+  std::string name_ = "fake_controllers";
 };
 
 class LastPointController : public BaseFakeController
@@ -97,7 +99,6 @@ private:
 private:
   boost::thread thread_;
   bool cancel_;
-  moveit_controller_manager::ExecutionStatus status_;
 };
 
 class ViaPointController : public ThreadedController

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -61,6 +61,7 @@ private:
   void setExecuteTrajectoryState(MoveGroupState state);
 
   const std::string name_ = "trajectory_execution_action_capability";
+  boost::mutex goal_handles_mutex_;
 
   std::unique_ptr<ExecuteTrajectoryActionServer> execute_action_server_;
   std::vector<ExecuteTrajectoryActionServer::GoalHandle> goal_handles_;

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -48,6 +48,7 @@
 typedef actionlib::ActionServer<moveit_msgs::ExecuteTrajectoryAction> ExecuteTrajectoryActionServer;
 namespace move_group
 {
+const std::string LOGNAME = "trajectory_execution_action_capability";
 
 class MoveGroupExecuteTrajectoryAction : public MoveGroupCapability
 {
@@ -59,8 +60,9 @@ public:
 private:
   void executePathCallback(ExecuteTrajectoryActionServer::GoalHandle goal);
   void setExecuteTrajectoryState(MoveGroupState state);
+  // TODO(cambel): Update preempt logic with cancelling goals 
+  // void preemptExecuteTrajectoryCallback();
 
-  const std::string name_ = "trajectory_execution_action_capability";
   boost::mutex goal_handles_mutex_;
 
   std::unique_ptr<ExecuteTrajectoryActionServer> execute_action_server_;

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -41,12 +41,14 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
-#include <actionlib/server/simple_action_server.h>
+#include <actionlib/server/action_server.h>
 #include <moveit_msgs/ExecuteTrajectoryAction.h>
 #include <memory>
 
+typedef actionlib::ActionServer<moveit_msgs::ExecuteTrajectoryAction> ExecuteTrajectoryActionServer;
 namespace move_group
 {
+
 class MoveGroupExecuteTrajectoryAction : public MoveGroupCapability
 {
 public:
@@ -55,13 +57,13 @@ public:
   void initialize() override;
 
 private:
-  void executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal);
-  void executePath(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
-                   moveit_msgs::ExecuteTrajectoryResult& action_res);
-  void preemptExecuteTrajectoryCallback();
+  void executePathCallback(ExecuteTrajectoryActionServer::GoalHandle goal);
   void setExecuteTrajectoryState(MoveGroupState state);
 
-  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction> > execute_action_server_;
+  const std::string name_ = "trajectory_execution_action_capability";
+
+  std::unique_ptr<ExecuteTrajectoryActionServer> execute_action_server_;
+  std::vector<ExecuteTrajectoryActionServer::GoalHandle> goal_handles_;
 };
 
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_service_capability.cpp
@@ -82,7 +82,7 @@ bool MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::ExecuteKnown
   //    robot_trajectory::RobotTrajectory to_exec(planning_scene_monitor_->getRobotModel(), ;
 
   context_->trajectory_execution_manager_->clear();
-  if (context_->trajectory_execution_manager_->push(req.trajectory))
+  if (context_->trajectory_execution_manager_->pushToBlockingQueue(req.trajectory))
   {
     context_->trajectory_execution_manager_->execute();
     if (req.wait_for_execution)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -37,10 +37,11 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
-#include <actionlib/server/simple_action_server.h>
+#include <actionlib/server/action_server.h>
 #include <moveit_msgs/MoveGroupAction.h>
 #include <memory>
 
+typedef actionlib::ActionServer<moveit_msgs::MoveGroupAction> MoveGroupActionServer;
 namespace move_group
 {
 class MoveGroupMoveAction : public MoveGroupCapability
@@ -51,22 +52,22 @@ public:
   void initialize() override;
 
 private:
-  void executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal);
+  void executeMoveCallback(MoveGroupActionServer::GoalHandle goal_handle);
   void executeMoveCallbackPlanAndExecute(const moveit_msgs::MoveGroupGoalConstPtr& goal,
                                          moveit_msgs::MoveGroupResult& action_res);
   void executeMoveCallbackPlanOnly(const moveit_msgs::MoveGroupGoalConstPtr& goal,
                                    moveit_msgs::MoveGroupResult& action_res);
   void startMoveExecutionCallback();
   void startMoveLookCallback();
-  void preemptMoveCallback();
   void setMoveState(MoveGroupState state);
   bool planUsingPlanningPipeline(const planning_interface::MotionPlanRequest& req,
                                  plan_execution::ExecutableMotionPlan& plan);
 
-  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::MoveGroupAction> > move_action_server_;
+  std::unique_ptr<MoveGroupActionServer> move_action_server_;
   moveit_msgs::MoveGroupFeedback move_feedback_;
 
   MoveGroupState move_state_;
   bool preempt_requested_;
+  std::vector<MoveGroupActionServer::GoalHandle> goal_handles_;
 };
 }  // namespace move_group

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -82,7 +82,7 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
 
   // TODO(henningkayser): configure trajectory execution manager
   trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-      robot_model_, planning_scene_monitor_->getStateMonitor());
+      robot_model_, planning_scene_monitor_);
 
   ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -270,11 +270,12 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
   if (blocking)
   {
-    trajectory_execution_manager_->push(robot_trajectory_msg);
+    trajectory_execution_manager_->pushToBlockingQueue(robot_trajectory_msg);
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }
-  trajectory_execution_manager_->pushAndExecute(robot_trajectory_msg);
+  // TODO: Does this point to the same instance? Multiple TEMs may not be safe to execute. @henningkayser?
+  trajectory_execution_manager_->pushAndExecuteSimultaneous(robot_trajectory_msg);
   return true;
 }
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -79,7 +79,7 @@ plan_execution::PlanExecution::PlanExecution(
 {
   if (!trajectory_execution_manager_)
     trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_->getStateMonitor());
+        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_);
 
   default_max_replan_attempts_ = 5;
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -382,7 +382,7 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
     // convert to message, pass along
     moveit_msgs::RobotTrajectory msg;
     plan.plan_components_[i].trajectory_->getRobotTrajectoryMsg(msg);
-    if (!trajectory_execution_manager_->push(msg, plan.plan_components_[i].controller_names_))
+    if (!trajectory_execution_manager_->pushToBlockingQueue(msg, plan.plan_components_[i].controller_names_))
     {
       trajectory_execution_manager_->clear();
       ROS_ERROR_STREAM_NAMED("plan_execution", "Apparently trajectory initialization failed");

--- a/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
@@ -269,7 +269,7 @@ bool plan_execution::PlanWithSensing::lookAt(const std::set<collision_detection:
       if (sensor_manager_->pointSensorTo(name, point, sensor_trajectory))
       {
         if (!trajectory_processing::isTrajectoryEmpty(sensor_trajectory))
-          return trajectory_execution_manager_->push(sensor_trajectory) &&
+          return trajectory_execution_manager_->pushToBlockingQueue(sensor_trajectory) &&
                  trajectory_execution_manager_->executeAndWait();
         else
           return true;

--- a/moveit_ros/planning/trajectory_execution_manager/dox/trajectory_execution.dox
+++ b/moveit_ros/planning/trajectory_execution_manager/dox/trajectory_execution.dox
@@ -3,9 +3,11 @@
 @b MoveIt includes a library for managing controllers and the execution of trajectories. This code exists in the trajectory_execution_manager namespace.
 
 The trajectory_execution_manager::TrajectoryExecutionManager class allows two main operations:
- - trajectory_execution_manager::TrajectoryExecutionManager::push() adds trajectories specified as a moveit_msgs::RobotTrajectory message type to a queue of trajectories to be executed in sequence. Each trajectory can be specified for any set of joints in the robot. Because controllers may only be available for certain groups of joints, this function may decide to split one trajectory into multiple ones and pass them to corresponding controllers (this time in parallel, using the same time stamp for the trajectory points). This approach assumes that controllers respect the time stamps specified for the waypoints.
+ - trajectory_execution_manager::TrajectoryExecutionManager::pushToBlockingQueue() adds trajectories specified as a moveit_msgs::RobotTrajectory message type to a queue of trajectories to be executed in sequence. Each trajectory can be specified for any set of joints in the robot. Because controllers may only be available for certain groups of joints, this function may decide to split one trajectory into multiple ones and pass them to corresponding controllers (this time in parallel, using the same time stamp for the trajectory points). This approach assumes that controllers respect the time stamps specified for the waypoints.
  - trajectory_execution_manager::TrajectoryExecutionManager::execute() passes the appropriate trajectories to different controllers, monitors execution, optionally waits for completion of the execution and, very importantly, switches active controllers as needed (optionally) to be able to execute the specified trajectories.
 
 The functionality of the trajectory execution in MoveIt usually needs robot-specific interaction with controllers. For this reason, the concept of a controller manager specific to MoveIt (moveit_controller_manager::MoveItControllerManager) was defined. This is an abstract class that defines the functionality needed by trajectory_execution_manager::TrajectoryExecutionManager and needs to be implemented for each robot type. Often, the implementation of these plugins are quite similar and it is easy to modify existing code to achieve the desired functionality (see for example pr2_moveit_controller_manager::Pr2MoveItControllerManager).
 
 */
+
+// TODO (cambel, felixvd): Update this doc to explain the continuous queue

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -41,6 +41,7 @@
 #include <moveit/robot_model/link_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/attached_body.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit_msgs/CollisionObject.h>
@@ -91,11 +92,12 @@ public:
 
   /// Load the controller manager plugin, start listening for events on a topic.
   TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm);
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
+  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model, 
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
+                             bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)
   ~TrajectoryExecutionManager();
@@ -339,8 +341,8 @@ private:
   const std::string name_ = "trajectory_execution_manager";
 
   moveit::core::RobotModelConstPtr robot_model_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
-  planning_scene::PlanningScene planning_scene_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;
   ros::Subscriber event_topic_subscriber_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -139,25 +139,25 @@ public:
 
   /// Add a trajectory for future execution. Optionally specify a controller to use for the trajectory. If no controller
   /// is specified, a default is used.
-  bool push(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "");
+  bool pushToBlockingQueue(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "");
 
   /// Add a trajectory for future execution. Optionally specify a controller to use for the trajectory. If no controller
   /// is specified, a default is used.
-  bool push(const trajectory_msgs::JointTrajectory& trajectory, const std::string& controller = "");
+  bool pushToBlockingQueue(const trajectory_msgs::JointTrajectory& trajectory, const std::string& controller = "");
 
   /// Add a trajectory for future execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used.
-  bool push(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<std::string>& controllers);
+  bool pushToBlockingQueue(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<std::string>& controllers);
 
   /// Add a trajectory for future execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used.
-  bool push(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
+  bool pushToBlockingQueue(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
 
   /// Get the trajectories to be executed
   const std::vector<TrajectoryExecutionContext*>& getTrajectories() const;
@@ -209,15 +209,15 @@ public:
   bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
-  /// pushAndExecute(), it will immediately stop execution.
+  /// pushAndExecuteSimultaneous(), it will immediately stop execution.
   moveit_controller_manager::ExecutionStatus waitForExecution();
 
   /// Get the state that the robot is expected to be at, given current time, after execute() has been called. The return
   /// value is a pair of two index values:
-  /// first = the index of the trajectory to be executed (in the order push() was called), second = the index of the
+  /// first = the index of the trajectory to be executed (in the order pushToBlockingQueue() was called), second = the index of the
   /// point within that trajectory.
   /// Values of -1 are returned when there is no trajectory being executed, or if the trajectory was passed using
-  /// pushAndExecute().
+  /// pushAndExecuteSimultaneous().
   std::pair<int, int> getCurrentExpectedTrajectoryIndex() const;
 
   /// Return the controller status for the last attempted execution
@@ -349,14 +349,14 @@ private:
   bool manage_controllers_;
 
   // Thread used to execute trajectories using the execute() command. This is blocking and executes only one TrajectoryContext at a time.
-  std::unique_ptr<boost::thread> execution_thread_;
+  std::unique_ptr<boost::thread> blocking_execution_thread_;
 
   // Thread used to execute trajectories using pushAndExecuteSimultaneous(). This executes multiple TrajectoryContexts at the same time.
   std::unique_ptr<boost::thread> continuous_execution_thread_;
 
   boost::mutex execution_state_mutex_;
-  boost::mutex continuous_execution_mutex_;
-  boost::mutex execution_thread_mutex_;
+  boost::mutex continuous_execution_thread_mutex_;
+  boost::mutex blocking_execution_thread_mutex_;
 
   boost::condition_variable continuous_execution_condition_;
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -57,6 +57,8 @@
 
 namespace trajectory_execution_manager
 {
+const std::string LOGNAME = "trajectory_execution_manager";
+
 MOVEIT_CLASS_FORWARD(TrajectoryExecutionManager);  // Defines TrajectoryExecutionManagerPtr, ConstPtr, WeakPtr... etc
 
 // Two modes:
@@ -336,9 +338,6 @@ private:
   bool hasCommonHandles(TrajectoryExecutionContext& context1, TrajectoryExecutionContext& context2);
 
   bool checkCollisionsWithCurrentState(moveit_msgs::RobotTrajectory& trajectory);
-
-  // Name of this class for logging
-  const std::string name_ = "trajectory_execution_manager";
 
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -471,6 +471,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
         if (created_at + ros::Duration(expiration_time) < ros::Time::now())
         {
           ROS_WARN_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has expired (older than 1 minute). Assuming malfunction, removing from backlog.");
+          current_context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
           it = backlog.erase(it);
           continue;
         }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -499,6 +499,13 @@ void TrajectoryExecutionManager::continuousExecutionThread()
             ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has been executed correctly.");
             it = backlog.erase(it);
           }
+          else if (it == backlog.begin() && active_contexts_map.empty())
+          {
+            ROS_ERROR_STREAM_NAMED(name_, "Trajectory is in a deadlock, aborting");
+            // Since there is not active trajectory being executed but this Top priority backlog-trajectory is not executable, abort it.
+            current_context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+            it = backlog.erase(it);
+          }
           else
           {
             ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " is still not executable");

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -376,6 +376,38 @@ bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const moveit_msgs::R
 
 void TrajectoryExecutionManager::continuousExecutionThread()
 {
+
+  /*
+  TODO(cambel): Clean this method
+  - Remove the used_handles, used the active context map instead (maybe not if this is more efficient)
+  - Separate chunks of code into private methods
+  - Make logs DEBUG type
+  - format clang?
+  */
+  /*
+  TODO(cambel): Implement simple scheduling for trajectories
+  main loop:
+    0. Check if we have entries in the *backlog*
+      a. if so, 
+        I. check that the handles in the current item are not necessary in previous items of the backlog 
+          (avoid altering the sequential order in which requests arrived per handle), 
+          if there are not, go to step II., else check the next item in the backlog
+        II. check the first item is executable, step 2. to 6., if so remove backlog entry, else go to the next item in the backlog
+      b. go to step 2.
+      c. after checking the entire *backlog*, go to step 1.
+    1. Pop new request
+    --- new method start here ---
+    2. Check its handles (controllers) and see if they are available
+    3. Check that the necessary handles are not busy, otherwise push request into *backlog*
+    4. Check that the new trajectories are not in collision with the active collisions, otherwise push request into *backlog*
+    5. Check that the new trajectories start from the current pose of the robot, otherwise reject request
+    6. If everything is okay, execute trajectory, store request as used_handles, active_contexts_map
+    --- new method stop here ---
+  */
+  /*
+  TODO (cambel):
+  - Adapt the validation of the duration of a trajectory as done in ExecuteThread(), thus aborting trajectories with "Controller is taking longer than expected"
+  */
   std::set<moveit_controller_manager::MoveItControllerHandlePtr> used_handles;
   std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>> active_contexts_map;  // The list of trajectories currently being executed, and their controller handles
   std::deque<std::pair<TrajectoryExecutionContext*, ros::Time>> backlog;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -2114,7 +2114,9 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     // Check whether this trajectory part starts at current robot state
     if (!validate(context))
     {
-      return false;
+      ROS_ERROR_NAMED(name_, "Trajectory became invalid before execution, abort.");
+      context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+      return true;
     }
 
     // Send trajectory (part) to controller

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -2116,17 +2116,17 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     return false;
   }
 
+  // Check whether this trajectory starts at current robot state
+  if (!validate(context))
+  {
+    ROS_ERROR_NAMED(name_, "Trajectory became invalid before execution, abort.");
+    context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+    return true;
+  }
+
   // Push trajectory to all controllers simultaneously (each part goes to one controller)
   for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
   {
-    // Check whether this trajectory part starts at current robot state
-    if (!validate(context))
-    {
-      ROS_ERROR_NAMED(name_, "Trajectory became invalid before execution, abort.");
-      context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
-      return true;
-    }
-
     // Send trajectory (part) to controller
     bool ok = false;
     try

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1937,7 +1937,7 @@ bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_
       // TODO(cambel): We would like to activate verbose output, but is this leading to a crash?
       // std::string group_name = "";
       //  if(!planning_scene_->isPathValid(start_state_msg, new_trajectory, group_name, true))
-      if(!ps->isPathValid(start_state_msg, new_trajectory))
+      if(!ps->isPathValid(start_state_msg, new_trajectory, new_trajectory.group_name))
       {
         ROS_DEBUG_STREAM_NAMED(name_, "Done checkCollision between trajectories: Collision found!");
         return false;  // Return as soon as any point is invalid
@@ -2024,7 +2024,7 @@ bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(moveit_msgs::Ro
   {
     moveit_msgs::RobotState robot_state_msg;
     robotStateToRobotStateMsg(*current_state, robot_state_msg);
-    if(!ps->isPathValid(robot_state_msg, trajectory)) // TODO(cambel): Get the group name for improved performance (?)
+    if(!ps->isPathValid(robot_state_msg, trajectory, trajectory.group_name)) // TODO(cambel): Get the group name for improved performance (?)
     {
       ROS_DEBUG_NAMED(name_, "New trajectory collides with the current robot state. Abort!");
       last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -133,7 +133,7 @@ void TrajectoryExecutionManager::initialize()
   }
   catch (pluginlib::PluginlibException& ex)
   {
-    ROS_FATAL_STREAM_NAMED(name_, "Exception while creating controller manager plugin loader: " << ex.what());
+    ROS_FATAL_STREAM_NAMED(LOGNAME, "Exception while creating controller manager plugin loader: " << ex.what());
     return;
   }
 
@@ -146,15 +146,15 @@ void TrajectoryExecutionManager::initialize()
       if (classes.size() == 1)
       {
         controller = classes[0];
-        ROS_WARN_NAMED(name_,
+        ROS_WARN_NAMED(LOGNAME,
                        "Parameter '~moveit_controller_manager' is not specified but only one "
                        "matching plugin was found: '%s'. Using that one.",
                        controller.c_str());
       }
       else
-        ROS_FATAL_NAMED(name_, "Parameter '~moveit_controller_manager' not specified. This is needed to "
-                               "identify the plugin to use for interacting with controllers. No paths can "
-                               "be executed.");
+        ROS_FATAL_NAMED(LOGNAME, "Parameter '~moveit_controller_manager' not specified. This is needed to "
+                                 "identify the plugin to use for interacting with controllers. No paths can "
+                                 "be executed.");
     }
 
     if (!controller.empty())
@@ -164,7 +164,7 @@ void TrajectoryExecutionManager::initialize()
       }
       catch (pluginlib::PluginlibException& ex)
       {
-        ROS_FATAL_STREAM_NAMED(name_,
+        ROS_FATAL_STREAM_NAMED(LOGNAME,
                                "Exception while loading controller manager '" << controller << "': " << ex.what());
       }
   }
@@ -178,9 +178,9 @@ void TrajectoryExecutionManager::initialize()
   reconfigure_impl_ = new DynamicReconfigureImpl(this);
 
   if (manage_controllers_)
-    ROS_INFO_NAMED(name_, "Trajectory execution is managing controllers");
+    ROS_INFO_NAMED(LOGNAME, "Trajectory execution is managing controllers");
   else
-    ROS_INFO_NAMED(name_, "Trajectory execution is not managing controllers");
+    ROS_INFO_NAMED(LOGNAME, "Trajectory execution is not managing controllers");
 }
 
 void TrajectoryExecutionManager::enableExecutionDurationMonitoring(bool flag)
@@ -228,12 +228,12 @@ void TrajectoryExecutionManager::processEvent(const std::string& event)
   if (event == "stop")
     stopExecution(true);
   else
-    ROS_WARN_STREAM_NAMED(name_, "Unknown event type: '" << event << "'");
+    ROS_WARN_STREAM_NAMED(LOGNAME, "Unknown event type: '" << event << "'");
 }
 
 void TrajectoryExecutionManager::receiveEvent(const std_msgs::StringConstPtr& event)
 {
-  ROS_INFO_STREAM_NAMED(name_, "Received event '" << event->data << "'");
+  ROS_INFO_STREAM_NAMED(LOGNAME, "Received event '" << event->data << "'");
   processEvent(event->data);
 }
 
@@ -266,7 +266,7 @@ bool TrajectoryExecutionManager::pushToBlockingQueue(const moveit_msgs::RobotTra
 {
   if (!execution_complete_)
   {
-    ROS_ERROR_NAMED(name_, "Cannot push a new trajectory in blocking mode while another is being executed (use pushAndExecuteSimultaneous instead)");
+    ROS_ERROR_NAMED(LOGNAME, "Cannot push a new trajectory in blocking mode while another is being executed (use pushAndExecuteSimultaneous instead)");
     return false;
   }
 
@@ -282,7 +282,7 @@ bool TrajectoryExecutionManager::pushToBlockingQueue(const moveit_msgs::RobotTra
       ss << "]:" << std::endl;
       for (const moveit_msgs::RobotTrajectory& trajectory_part : context->trajectory_parts_)
         ss << trajectory_part << std::endl;
-      ROS_INFO_NAMED(name_, "%s", ss.str().c_str());
+      ROS_INFO_NAMED(LOGNAME, "%s", ss.str().c_str());
     }
     trajectories_.push_back(context);
     return true;
@@ -378,31 +378,23 @@ void TrajectoryExecutionManager::continuousExecutionThread()
 {
 
   /*
-  TODO(cambel): Clean this method
-  - Remove the used_handles, used the active context map instead (maybe not if this is more efficient)
-  - Separate chunks of code into private methods
-  - Make logs DEBUG type
-  - format clang?
-  */
-  /*
-  TODO(cambel): Implement simple scheduling for trajectories
+  Implemention of simple scheduling for simultaneous execution of multiple trajectories
   main loop:
-    0. Check if we have entries in the *backlog*
-      a. if so, 
+    1. Check if we have entries in the *backlog*
+      a. If so, 
         I. check that the handles in the current item are not necessary in previous items of the backlog 
-          (avoid altering the sequential order in which requests arrived per handle), 
-          if there are not, go to step II., else check the next item in the backlog
-        II. check the first item is executable, step 2. to 6., if so remove backlog entry, else go to the next item in the backlog
-      b. go to step 2.
-      c. after checking the entire *backlog*, go to step 1.
-    1. Pop new request
-    --- new method start here ---
-    2. Check its handles (controllers) and see if they are available
-    3. Check that the necessary handles are not busy, otherwise push request into *backlog*
-    4. Check that the new trajectories are not in collision with the active collisions, otherwise push request into *backlog*
-    5. Check that the new trajectories start from the current pose of the robot, otherwise reject request
-    6. If everything is okay, execute trajectory, store request as used_handles, active_contexts_map
-    --- new method stop here ---
+          (avoid altering the sequential order in which requests arrived per handle).
+         If there are not, go to step II., else check the next item in the backlog
+        II. check the first item is executable, step 3. to 7., if so remove backlog entry, else go to the next item in the backlog
+      c. after checking the entire *backlog*, go to step 2.
+    2. Pop new request
+    --- validateAndExecuteContext start here ---
+    3. Check its handles (controllers) and see if they are available
+    4. Check that the necessary handles are not busy, otherwise push request into *backlog*
+    5. Check that the new trajectories are not in collision with the active collisions, otherwise push request into *backlog*
+    6. Check that the new trajectories start from the current pose of the robot, otherwise abort request
+    7. If everything is okay, execute trajectory, store request as used_handles, active_contexts_map
+    --- validateAndExecuteContext stop here ---
   */
   /*
   TODO (cambel):
@@ -416,15 +408,15 @@ void TrajectoryExecutionManager::continuousExecutionThread()
   ros::Rate r(10);
   while (run_continuous_execution_thread_)
   {
-    ROS_DEBUG_NAMED(name_, "===========Loop top-most entry================");
+    ROS_DEBUG_NAMED(LOGNAME, "===========Loop top-most entry================");
     // This waits for the lock to be released
     if (!stop_continuous_execution_)
     {
       if (continuous_execution_queue_.empty() && !active_contexts_map.empty())  // While trajectories are still being executed, check their response.
                                     // Instead of doing this, we could add a callback in the controller_manager, but that seems like a bigger change.
       {
-        ROS_DEBUG_NAMED(name_, "Updating list in top-most loop");
-        ROS_DEBUG_STREAM_NAMED(name_, "active_contexts_map size: " << active_contexts_map.size());
+        ROS_DEBUG_NAMED(LOGNAME, "Updating list in top-most loop");
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "active_contexts_map size: " << active_contexts_map.size());
         updateActiveHandlesAndContexts(used_handles, active_contexts_map);
         r.sleep();  // Waiting like this instead of waitForExecution so the queue keeps being checked for new entries
       }
@@ -436,7 +428,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
     // If stop-flag is set, break out
     if (stop_continuous_execution_ || !run_continuous_execution_thread_)
     {
-      ROS_ERROR_STREAM_NAMED(name_, "Stop!. stop_continuous_execution: " << stop_continuous_execution_ << " run_continuous_execution_thread_: " << run_continuous_execution_thread_);
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Stop!. stop_continuous_execution: " << stop_continuous_execution_ << " run_continuous_execution_thread_: " << run_continuous_execution_thread_);
       // Cancel on going executions
       for (const moveit_controller_manager::MoveItControllerHandlePtr& used_handle : used_handles)
         if (used_handle->getLastExecutionStatus() == moveit_controller_manager::ExecutionStatus::RUNNING)
@@ -448,7 +440,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
       while (!continuous_execution_queue_.empty())
       {
         TrajectoryExecutionContext* context = continuous_execution_queue_.front();
-        ROS_DEBUG_STREAM_NAMED(name_, "Calling completed callback to abort");
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Calling completed callback to abort");
         context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
         continuous_execution_queue_.pop_front();
         delete context;
@@ -459,9 +451,9 @@ void TrajectoryExecutionManager::continuousExecutionThread()
 
     while (!continuous_execution_queue_.empty() || !backlog.empty())
     {
-      ROS_DEBUG_NAMED(name_, "===========Loop2 entry================");
+      ROS_DEBUG_NAMED(LOGNAME, "===========Loop2 entry================");
 
-      ROS_DEBUG_NAMED(name_, "Start checking backlog");
+      ROS_DEBUG_NAMED(LOGNAME, "Start checking backlog");
       // Check all backlog entries for trajectories that can now be executed 
       for (auto it = backlog.begin(); it != backlog.end(); )
       {
@@ -470,7 +462,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
         // Remove backlog items that have expired (to avoid deadlocks)
         if (created_at + ros::Duration(expiration_time) < ros::Time::now())
         {
-          ROS_WARN_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has expired (older than 1 minute). Assuming malfunction, removing from backlog.");
+          ROS_WARN_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has expired (older than 1 minute). Assuming malfunction, removing from backlog.");
           current_context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
           it = backlog.erase(it);
           continue;
@@ -478,37 +470,37 @@ void TrajectoryExecutionManager::continuousExecutionThread()
 
         // Validate that the handles used in this context are not already in earlier (= higher priority) backlogged trajectories
         bool controllers_not_used_earlier_in_backlog = true;
-        ROS_DEBUG_STREAM_NAMED(name_, "Backlog evaluation of item: " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog evaluation of item: " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
         for (auto it2 = backlog.begin(); it2 != it; ++it2)
         {
           TrajectoryExecutionContext* priority_context = it2->first; // Previous context in the backlog (earlier ones have priority)
-          ROS_DEBUG_STREAM_NAMED(name_, "Backlog comparing item with duration: " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
-          ROS_DEBUG_STREAM_NAMED(name_, "vs item with duration: " << priority_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+          ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog comparing item with duration: " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+          ROS_DEBUG_STREAM_NAMED(LOGNAME, "vs item with duration: " << priority_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
           if (hasCommonHandles(*current_context, *priority_context))
           {
             controllers_not_used_earlier_in_backlog = false;
-            ROS_DEBUG_NAMED(name_, "Backlog item has handles blocked by previous items");
+            ROS_DEBUG_NAMED(LOGNAME, "Backlog item has handles blocked by previous items");
             break;
           }
         }
         if(controllers_not_used_earlier_in_backlog)
         {
-          ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " will be checked and pushed to controller.");
+          ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " will be checked and pushed to controller.");
           if(validateAndExecuteContext(*current_context, used_handles, active_contexts_map))
           {
-            ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has been executed correctly.");
+            ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has been executed correctly.");
             it = backlog.erase(it);
           }
           else if (it == backlog.begin() && active_contexts_map.empty())
           {
-            ROS_ERROR_STREAM_NAMED(name_, "Trajectory is in a deadlock, aborting");
+            ROS_ERROR_STREAM_NAMED(LOGNAME, "Trajectory is in a deadlock, aborting");
             // Since there is not active trajectory being executed but this Top priority backlog-trajectory is not executable, abort it.
             current_context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
             it = backlog.erase(it);
           }
           else
           {
-            ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " is still not executable");
+            ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " is still not executable");
             it++;
           }
         }
@@ -516,7 +508,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
           it++;
       }
       r.sleep(); // Small delay to not process a pending trajectory over and over when it is temporarily blocked
-      ROS_DEBUG_STREAM_NAMED(name_, "Done checking backlog, size: " << backlog.size());
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "Done checking backlog, size: " << backlog.size());
 
       // Get next trajectory context from queue
       TrajectoryExecutionContext* context = nullptr;
@@ -530,18 +522,18 @@ void TrajectoryExecutionManager::continuousExecutionThread()
           continuous_execution_condition_.notify_all();
       }
 
-      ROS_DEBUG_NAMED(name_, "==========");
-      ROS_DEBUG_STREAM_NAMED(name_, "Popped element with duration " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start
+      ROS_DEBUG_NAMED(LOGNAME, "==========");
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "Popped element with duration " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start
                         << " from queue. Remaining length: " << continuous_execution_queue_.size());
 
 
       // First make sure desired controllers are active
       if (!areControllersActive(context->controllers_))
       {
-        ROS_ERROR_NAMED(name_, "Not all needed controllers are active. Cannot push and execute. You can try "
+        ROS_ERROR_NAMED(LOGNAME, "Not all needed controllers are active. Cannot push and execute. You can try "
                                 "calling ensureActiveControllers() before pushAndExecuteSimultaneous()");
         last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-        ROS_INFO_NAMED(name_, "Calling completed callback");
+        ROS_INFO_NAMED(LOGNAME, "Calling completed callback");
         context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
         delete context;
         continue;
@@ -552,8 +544,8 @@ void TrajectoryExecutionManager::continuousExecutionThread()
       for (auto backlog_context : backlog)
         if (hasCommonHandles(*backlog_context.first, *context))
         {
-          ROS_DEBUG_STREAM_NAMED(name_, "Request with duration " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
-          ROS_DEBUG_STREAM_NAMED(name_, "has handles blocked by backlog items. push_back to backlog");
+          ROS_DEBUG_STREAM_NAMED(LOGNAME, "Request with duration " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+          ROS_DEBUG_STREAM_NAMED(LOGNAME, "has handles blocked by backlog items. push_back to backlog");
           backlog.push_back(std::pair<TrajectoryExecutionContext*, ros::Time> (context, ros::Time::now()));
           controllers_not_used_in_backlog = false;
           break;
@@ -561,7 +553,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
 
       if(controllers_not_used_in_backlog && !validateAndExecuteContext(*context, used_handles, active_contexts_map))
       {
-        ROS_DEBUG_STREAM_NAMED(name_, "Request: " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " not executable, pushing it into backlog");
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Request: " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " not executable, pushing it into backlog");
         backlog.push_back(std::pair<TrajectoryExecutionContext*, ros::Time> (context, ros::Time::now()));
       }
     }
@@ -580,9 +572,9 @@ void TrajectoryExecutionManager::reloadControllerInformation()
       std::vector<std::string> joints;
       controller_manager_->getControllerJoints(name, joints);
       ControllerInformation ci;
-      ci.name_ = name;
+      ci.LOGNAME = name;
       ci.joints_.insert(joints.begin(), joints.end());
-      known_controllers_[ci.name_] = ci;
+      known_controllers_[ci.LOGNAME] = ci;
     }
 
     for (std::map<std::string, ControllerInformation>::iterator it = known_controllers_.begin();
@@ -609,7 +601,7 @@ void TrajectoryExecutionManager::updateControllerState(const std::string& contro
   if (it != known_controllers_.end())
     updateControllerState(it->second, age);
   else
-    ROS_ERROR_NAMED(name_, "Controller '%s' is not known.", controller.c_str());
+    ROS_ERROR_NAMED(LOGNAME, "Controller '%s' is not known.", controller.c_str());
 }
 
 void TrajectoryExecutionManager::updateControllerState(ControllerInformation& ci, const ros::Duration& age)
@@ -619,13 +611,13 @@ void TrajectoryExecutionManager::updateControllerState(ControllerInformation& ci
     if (controller_manager_)
     {
       if (verbose_)
-        ROS_INFO_NAMED(name_, "Updating information for controller '%s'.", ci.name_.c_str());
-      ci.state_ = controller_manager_->getControllerState(ci.name_);
+        ROS_INFO_NAMED(LOGNAME, "Updating information for controller '%s'.", ci.LOGNAME.c_str());
+      ci.state_ = controller_manager_->getControllerState(ci.LOGNAME);
       ci.last_update_ = ros::Time::now();
     }
   }
   else if (verbose_)
-    ROS_INFO_NAMED(name_, "Information for controller '%s' is assumed to be up to date.", ci.name_.c_str());
+    ROS_INFO_NAMED(LOGNAME, "Information for controller '%s' is assumed to be up to date.", ci.LOGNAME.c_str());
 }
 
 void TrajectoryExecutionManager::updateControllersState(const ros::Duration& age)
@@ -653,7 +645,7 @@ bool TrajectoryExecutionManager::checkControllerCombination(std::vector<std::str
       saj << actuated_joint << " ";
     for (const std::string& combined_joint : combined_joints)
       sac << combined_joint << " ";
-    ROS_INFO_NAMED(name_, "Checking if controllers [ %s] operating on joints [ %s] cover joints [ %s]",
+    ROS_INFO_NAMED(LOGNAME, "Checking if controllers [ %s] operating on joints [ %s] cover joints [ %s]",
                    ss.str().c_str(), sac.str().c_str(), saj.str().c_str());
   }
 
@@ -745,7 +737,7 @@ bool TrajectoryExecutionManager::findControllers(const std::set<std::string>& ac
       sac << available_controller << " ";
     for (const std::string& actuated_joint : actuated_joints)
       saj << actuated_joint << " ";
-    ROS_INFO_NAMED(name_, "Looking for %zu controllers among [ %s] that cover joints [ %s]. Found %zd options.",
+    ROS_INFO_NAMED(LOGNAME, "Looking for %zu controllers among [ %s] that cover joints [ %s]. Found %zd options.",
                    controller_count, sac.str().c_str(), saj.str().c_str(), selected_options.size());
   }
 
@@ -879,7 +871,7 @@ bool TrajectoryExecutionManager::distributeTrajectory(const moveit_msgs::RobotTr
     std::map<std::string, ControllerInformation>::iterator it = known_controllers_.find(controllers[i]);
     if (it == known_controllers_.end())
     {
-      ROS_ERROR_STREAM_NAMED(name_, "Controller " << controllers[i] << " not found.");
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Controller " << controllers[i] << " not found.");
       return false;
     }
     std::vector<std::string> intersect_mdof;
@@ -889,7 +881,7 @@ bool TrajectoryExecutionManager::distributeTrajectory(const moveit_msgs::RobotTr
     std::set_intersection(it->second.joints_.begin(), it->second.joints_.end(), actuated_joints_single.begin(),
                           actuated_joints_single.end(), std::back_inserter(intersect_single));
     if (intersect_mdof.empty() && intersect_single.empty())
-      ROS_WARN_STREAM_NAMED(name_, "No joints to be distributed for controller " << controllers[i]);
+      ROS_WARN_STREAM_NAMED(LOGNAME, "No joints to be distributed for controller " << controllers[i]);
     {
       if (!intersect_mdof.empty())
       {
@@ -993,12 +985,12 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
   if (allowed_start_tolerance_ == 0)  // skip validation on this magic number
     return true;
 
-  ROS_DEBUG_NAMED(name_, "Validating trajectory with allowed_start_tolerance %g", allowed_start_tolerance_);
+  ROS_DEBUG_NAMED(LOGNAME, "Validating trajectory with allowed_start_tolerance %g", allowed_start_tolerance_);
 
   moveit::core::RobotStatePtr current_state;
   if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
   {
-    ROS_WARN_NAMED(name_, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
+    ROS_WARN_NAMED(LOGNAME, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
     return false;
   }
 
@@ -1011,7 +1003,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
       const std::vector<std::string>& joint_names = trajectory.joint_trajectory.joint_names;
       if (positions.size() != joint_names.size())
       {
-        ROS_ERROR_NAMED(name_, "Wrong trajectory: #joints: %zu != #positions: %zu", joint_names.size(),
+        ROS_ERROR_NAMED(LOGNAME, "Wrong trajectory: #joints: %zu != #positions: %zu", joint_names.size(),
                         positions.size());
         return false;
       }
@@ -1021,7 +1013,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         const moveit::core::JointModel* jm = current_state->getJointModel(joint_names[i]);
         if (!jm)
         {
-          ROS_ERROR_STREAM_NAMED(name_, "Unknown joint in trajectory: " << joint_names[i]);
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unknown joint in trajectory: " << joint_names[i]);
           return false;
         }
 
@@ -1032,7 +1024,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         jm->enforcePositionBounds(&traj_position);
         if (jm->distance(&cur_position, &traj_position) > allowed_start_tolerance_)
         {
-          ROS_ERROR_NAMED(name_,
+          ROS_ERROR_NAMED(LOGNAME,
                           "\nInvalid Trajectory: start point deviates from current robot state more than %g"
                           "\njoint '%s': expected: %g, current: %g",
                           allowed_start_tolerance_, joint_names[i].c_str(), traj_position, cur_position);
@@ -1048,7 +1040,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
       const std::vector<std::string>& joint_names = trajectory.multi_dof_joint_trajectory.joint_names;
       if (transforms.size() != joint_names.size())
       {
-        ROS_ERROR_NAMED(name_, "Wrong trajectory: #joints: %zu != #transforms: %zu", joint_names.size(),
+        ROS_ERROR_NAMED(LOGNAME, "Wrong trajectory: #joints: %zu != #transforms: %zu", joint_names.size(),
                         transforms.size());
         return false;
       }
@@ -1058,7 +1050,7 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         const moveit::core::JointModel* jm = current_state->getJointModel(joint_names[i]);
         if (!jm)
         {
-          ROS_ERROR_STREAM_NAMED(name_, "Unknown joint in trajectory: " << joint_names[i]);
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unknown joint in trajectory: " << joint_names[i]);
           return false;
         }
 
@@ -1074,10 +1066,10 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
         rotation.fromRotationMatrix(cur_transform.linear().transpose() * start_transform.linear());
         if ((offset.array() > allowed_start_tolerance_).any() || rotation.angle() > allowed_start_tolerance_)
         {
-          ROS_ERROR_STREAM_NAMED(name_, "\nInvalid Trajectory: start point deviates from current robot state more than "
-                                            << allowed_start_tolerance_ << "\nmulti-dof joint '" << joint_names[i]
-                                            << "': pos delta: " << offset.transpose()
-                                            << " rot delta: " << rotation.angle());
+          ROS_ERROR_STREAM_NAMED(LOGNAME,
+                                 "\nInvalid Trajectory: start point deviates from current robot state more than "
+                                     << allowed_start_tolerance_ << "\nmulti-dof joint '" << joint_names[i]
+                                     << "': pos delta: " << offset.transpose() << " rot delta: " << rotation.angle());
           return false;
         }
       }
@@ -1111,7 +1103,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
 
   if (actuated_joints.empty())
   {
-    ROS_WARN_NAMED(name_, "The trajectory to execute specifies no joints");
+    ROS_WARN_NAMED(LOGNAME, "The trajectory to execute specifies no joints");
     return false;
   }
 
@@ -1159,7 +1151,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
       for (const std::string& controller : controllers)
         if (known_controllers_.find(controller) == known_controllers_.end())
         {
-          ROS_ERROR_NAMED(name_, "Controller '%s' is not known", controller.c_str());
+          ROS_ERROR_NAMED(LOGNAME, "Controller '%s' is not known", controller.c_str());
           return false;
         }
     if (selectControllers(actuated_joints, controllers, context.controllers_))
@@ -1171,14 +1163,14 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
   std::stringstream ss;
   for (const std::string& actuated_joint : actuated_joints)
     ss << actuated_joint << " ";
-  ROS_ERROR_NAMED(name_, "Unable to identify any set of controllers that can actuate the specified joints: [ %s]",
+  ROS_ERROR_NAMED(LOGNAME, "Unable to identify any set of controllers that can actuate the specified joints: [ %s]",
                   ss.str().c_str());
 
   std::stringstream ss2;
   std::map<std::string, ControllerInformation>::const_iterator mi;
   for (mi = known_controllers_.begin(); mi != known_controllers_.end(); mi++)
   {
-    ss2 << "controller '" << mi->second.name_ << "' controls joints:\n";
+    ss2 << "controller '" << mi->second.LOGNAME << "' controls joints:\n";
 
     std::set<std::string>::const_iterator ji;
     for (ji = mi->second.joints_.begin(); ji != mi->second.joints_.end(); ji++)
@@ -1186,7 +1178,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
       ss2 << "  " << *ji << std::endl;
     }
   }
-  ROS_ERROR_NAMED(name_, "Known controllers and their joints:\n%s", ss2.str().c_str());
+  ROS_ERROR_NAMED(LOGNAME, "Known controllers and their joints:\n%s", ss2.str().c_str());
   return false;
 }
 
@@ -1206,7 +1198,7 @@ void TrajectoryExecutionManager::stopExecutionInternal()
     }
     catch (std::exception& ex)
     {
-      ROS_ERROR_NAMED(name_, "Caught %s when canceling execution.", ex.what());
+      ROS_ERROR_NAMED(LOGNAME, "Caught %s when canceling execution.", ex.what());
     }
 }
 
@@ -1230,7 +1222,7 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
       // we set the status here; executePart() will not set status when execution_complete_ is true ahead of time
       last_execution_status_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
       execution_state_mutex_.unlock();
-      ROS_INFO_NAMED(name_, "Stopped trajectory execution.");
+      ROS_INFO_NAMED(LOGNAME, "Stopped trajectory execution.");
 
       // wait for the execution thread to finish
       boost::mutex::scoped_lock lock(blocking_execution_thread_mutex_);
@@ -1322,7 +1314,7 @@ void TrajectoryExecutionManager::clear()
     }
   }
   else
-    ROS_ERROR_NAMED(name_, "Cannot push a new trajectory while another is being executed");
+    ROS_ERROR_NAMED(LOGNAME, "Cannot push a new trajectory while another is being executed");
 }
 
 void TrajectoryExecutionManager::executeThread(const ExecutionCompleteCallback& callback,
@@ -1337,7 +1329,7 @@ void TrajectoryExecutionManager::executeThread(const ExecutionCompleteCallback& 
     return;
   }
 
-  ROS_DEBUG_NAMED(name_, "Starting trajectory execution ...");
+  ROS_DEBUG_NAMED(LOGNAME, "Starting trajectory execution ...");
   // assume everything will be OK
   last_execution_status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
 
@@ -1360,7 +1352,8 @@ void TrajectoryExecutionManager::executeThread(const ExecutionCompleteCallback& 
   if (last_execution_status_ == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
     waitForRobotToStop(*trajectories_[i - 1]);
 
-  ROS_INFO_NAMED(name_, "Completed trajectory execution with status %s ...", last_execution_status_.asString().c_str());
+  ROS_INFO_NAMED(LOGNAME, "Completed trajectory execution with status %s ...",
+                 last_execution_status_.asString().c_str());
 
   // notify whoever is waiting for the event of trajectory completion
   execution_state_mutex_.lock();
@@ -1407,14 +1400,14 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
           }
           catch (std::exception& ex)
           {
-            ROS_ERROR_NAMED(name_, "Caught %s when retrieving controller handle", ex.what());
+            ROS_ERROR_NAMED(LOGNAME, "Caught %s when retrieving controller handle", ex.what());
           }
           if (!h)
           {
             active_handles_.clear();
             current_context_ = -1;
             last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-            ROS_ERROR_NAMED(name_, "No controller handle for controller '%s'. Aborting.",
+            ROS_ERROR_NAMED(LOGNAME, "No controller handle for controller '%s'. Aborting.",
                             context.controllers_[i].c_str());
             return false;
           }
@@ -1430,7 +1423,7 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
           }
           catch (std::exception& ex)
           {
-            ROS_ERROR_NAMED(name_, "Caught %s when sending trajectory to controller", ex.what());
+            ROS_ERROR_NAMED(LOGNAME, "Caught %s when sending trajectory to controller", ex.what());
           }
           if (!ok)
           {
@@ -1441,12 +1434,12 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
               }
               catch (std::exception& ex)
               {
-                ROS_ERROR_NAMED(name_, "Caught %s when canceling execution", ex.what());
+                ROS_ERROR_NAMED(LOGNAME, "Caught %s when canceling execution", ex.what());
               }
-            ROS_ERROR_NAMED(name_, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
+            ROS_ERROR_NAMED(LOGNAME, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
                             context.trajectory_parts_.size(), active_handles_[i]->getName().c_str());
             if (i > 0)
-              ROS_ERROR_NAMED(name_, "Cancelling previously sent trajectory parts");
+              ROS_ERROR_NAMED(LOGNAME, "Cancelling previously sent trajectory parts");
             active_handles_.clear();
             current_context_ = -1;
             last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
@@ -1539,7 +1532,7 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
         if (!handle->waitForExecution(expected_trajectory_duration))
           if (!execution_complete_ && ros::Time::now() - current_time > expected_trajectory_duration)
           {
-            ROS_ERROR_NAMED(name_,
+            ROS_ERROR_NAMED(LOGNAME,
                             "Controller is taking too long to execute trajectory (the expected upper "
                             "bound for the trajectory execution was %lf seconds). Stopping trajectory.",
                             expected_trajectory_duration.toSec());
@@ -1564,8 +1557,8 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
       }
       else if (handle->getLastExecutionStatus() != moveit_controller_manager::ExecutionStatus::SUCCEEDED)
       {
-        ROS_WARN_STREAM_NAMED(name_, "Controller handle " << handle->getName() << " reports status "
-                                                          << handle->getLastExecutionStatus().asString());
+        ROS_WARN_STREAM_NAMED(LOGNAME, "Controller handle " << handle->getName() << " reports status "
+                                                            << handle->getLastExecutionStatus().asString());
         last_execution_status_ = handle->getLastExecutionStatus();
         result = false;
       }
@@ -1596,7 +1589,7 @@ bool TrajectoryExecutionManager::waitForRobotToStop(const TrajectoryExecutionCon
   // skip waiting for convergence?
   if (allowed_start_tolerance_ == 0 || !wait_for_trajectory_completion_)
   {
-    ROS_DEBUG_NAMED(name_, "Not waiting for trajectory completion");
+    ROS_DEBUG_NAMED(LOGNAME, "Not waiting for trajectory completion");
     return true;
   }
 
@@ -1613,7 +1606,7 @@ bool TrajectoryExecutionManager::waitForRobotToStop(const TrajectoryExecutionCon
   {
     if (!csm_->waitForCurrentState(ros::Time::now(), time_remaining) || !(cur_state = csm_->getCurrentState()))
     {
-      ROS_WARN_NAMED(name_, "Failed to receive current joint state");
+      ROS_WARN_NAMED(LOGNAME, "Failed to receive current joint state");
       return false;
     }
     cur_state->enforceBounds();
@@ -1728,12 +1721,12 @@ bool TrajectoryExecutionManager::ensureActiveControllers(const std::vector<std::
       std::map<std::string, ControllerInformation>::const_iterator it = known_controllers_.find(controller);
       if (it == known_controllers_.end())
       {
-        ROS_ERROR_STREAM_NAMED(name_, "Controller " << controller << " is not known");
+        ROS_ERROR_STREAM_NAMED(LOGNAME, "Controller " << controller << " is not known");
         return false;
       }
       if (!it->second.state_.active_)
       {
-        ROS_DEBUG_STREAM_NAMED(name_, "Need to activate " << controller);
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Need to activate " << controller);
         controllers_to_activate.push_back(controller);
         joints_to_be_activated.insert(it->second.joints_.begin(), it->second.joints_.end());
         for (const std::string& overlapping_controller : it->second.overlapping_controllers_)
@@ -1747,7 +1740,7 @@ bool TrajectoryExecutionManager::ensureActiveControllers(const std::vector<std::
         }
       }
       else
-        ROS_DEBUG_STREAM_NAMED(name_, "Controller " << controller << " is already active");
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Controller " << controller << " is already active");
     }
     std::set<std::string> diff;
     std::set_difference(joints_to_be_deactivated.begin(), joints_to_be_deactivated.end(),
@@ -1836,14 +1829,14 @@ void TrajectoryExecutionManager::loadControllerParams()
 void TrajectoryExecutionManager::updateActiveHandlesAndContexts(std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
                                                        std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map)
 {
-  ROS_DEBUG_STREAM_NAMED(name_, "Entered updateActiveHandlesAndContexts");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Entered updateActiveHandlesAndContexts");
   // Go through list of current trajectories, check the statuses of all handles
   // for (auto& context_controllers_pair : active_contexts_map)  // first: context. second: handles_ for that trajectory
   for (auto it = active_contexts_map.begin(); it != active_contexts_map.end(); )
   {
     auto& context = it->first;
     auto& handles_ = it->second;
-    ROS_DEBUG_STREAM_NAMED(name_, "Update context");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Update context");
 
     // TODO(felixvd): This doesn't cover all the cases, like TIMED_OUT, CONTROL_FAILED. Ugh.
     bool some_aborted = false;
@@ -1901,7 +1894,7 @@ void TrajectoryExecutionManager::updateActiveHandlesAndContexts(std::set<moveit_
   }
 
   // Remove controller handles from list if they are not executing a trajectory
-  ROS_DEBUG_STREAM_NAMED(name_, "Cleaning used_handles");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Cleaning used_handles");
   for (std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin(); uit != used_handles.end(); )
     if ((*uit)->getLastExecutionStatus() != moveit_controller_manager::ExecutionStatus::RUNNING)
     {
@@ -1910,18 +1903,14 @@ void TrajectoryExecutionManager::updateActiveHandlesAndContexts(std::set<moveit_
     }
     else
       ++uit;
-  ROS_DEBUG_STREAM_NAMED(name_, "Done updateActiveHandlesAndContexts");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Done updateActiveHandlesAndContexts");
 }
 
 // simultaneous execution
 bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory, const moveit_msgs::RobotTrajectory& active_trajectory)
 {
-  ROS_DEBUG_STREAM_NAMED(name_, "Start checkCollision between trajectories using PlanningScene.isPathValid()");
-  // Allow all collisions
-    // TODO: This has optimization potential (ACM is not used, all collisions are checked (instead of robot-robot only)
-    // collision_detection::AllowedCollisionMatrix& acm = scene.getAllowedCollisionMatrixNonConst();
-  ROS_DEBUG_STREAM_NAMED(name_, "getCurrentState");
-  // before we start planning, ensure that we have the latest robot state received...
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Start checkCollision between trajectories using PlanningScene.isPathValid()");
+  // before we start checking collisions, ensure that we have the latest robot state received...
   planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   planning_scene_monitor_->updateFrameTransforms();
 
@@ -1929,21 +1918,18 @@ bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_
   moveit::core::RobotState start_state = ps->getCurrentState();
   
   moveit_msgs::RobotState start_state_msg;
-  ROS_DEBUG_STREAM_NAMED(name_, "compute collision check");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Compute collision check");
   for(std::size_t i = 0; i < active_trajectory.joint_trajectory.points.size(); ++i)
     if (jointTrajPointToRobotState(active_trajectory.joint_trajectory, i, start_state))
     {
       robotStateToRobotStateMsg(start_state, start_state_msg);
-      // TODO(cambel): We would like to activate verbose output, but is this leading to a crash?
-      // std::string group_name = "";
-      //  if(!planning_scene_->isPathValid(start_state_msg, new_trajectory, group_name, true))
-      if(!ps->isPathValid(start_state_msg, new_trajectory, new_trajectory.group_name))
+      if(!ps->isPathValid(start_state_msg, new_trajectory, new_trajectory.group_name, true))
       {
-        ROS_DEBUG_STREAM_NAMED(name_, "Done checkCollision between trajectories: Collision found!");
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Done checkCollision between trajectories: Collision found!");
         return false;  // Return as soon as any point is invalid
       }
     }
-  ROS_DEBUG_STREAM_NAMED(name_, "Done checkCollision between trajectories: No collisions found");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Done checkCollision between trajectories: No collisions found");
   return true;
 }
 
@@ -1952,30 +1938,13 @@ bool TrajectoryExecutionManager::checkContextForCollisions(TrajectoryExecutionCo
 {
   // 2. Check that new trajectory does not collide with other active trajectories
 
-  /* Collision checking approaches:
-      1. swept volumes as collision objects : 
-        a. create one collision object of a whole trajectory 
-        b. create the collision objects for both trajectories
-        c. check if they collide
-      *Note* Collision objects could be huge, as we consider the whole arm and attach bodies
-      - Can be optimized by flattening or mergin overlapping meshes
-      - Can be optimized by keeping in memory the collision objects of an active trajectory, in case it is necessary latter.
-
-      2. swept volumes as gpu-voxel :
-        a. create a voxel from a trajectory
-        b. create the voxels for both trajectories
-        c. check if they collide
-      *Note* Needs a new dependency on GPU and gpu-voxels
-      
-      3. checking point by point :
-        a. create a new planning scene
-        b. update the planning scene with the first point of both trajectories
-        c. update the collision matrix to ignore everything except the two trajectories' links
-            The good thing here is that we can ignore half the robot links that are never going to be in collision
-        d. check if the two states collide, if so, return, no need to check anymore
+  /* Approach: checking point by point :
+        a. Get planning scene
+        b. Update the planning scene with the first point of both trajectories
+        c. Use robot's group name to check collisions of relevant links only 
+        d. Check if the two states collide, if so, return, no need to check anything else
       - Can be optimized by estimating the position of the robot in the active trajectory, then triming the active trajectory to check only the remaining states
-      - May be optimized by active trajectory backward, it is more likely that any collision would happen at the end of the trajectory than at the beginning.
-      - Anyway this approach is necessary to know if the current trajectory collides with the final state of the active trajectory
+      - May be optimized by active trajectory backward, it is more likely that any collision would happen at the end of the trajectory than at the beginning (given that the planning return a valid trajectory).
   */
 
   for (const auto& context_handles_pair : active_contexts_map)
@@ -1985,24 +1954,10 @@ bool TrajectoryExecutionManager::checkContextForCollisions(TrajectoryExecutionCo
 
     if (!checkCollisionBetweenTrajectories(context.trajectory_, currently_running_trajectory))
     {
-      // Do not wait just push to backlog
-      ROS_DEBUG_STREAM_NAMED(name_, "Collision found between trajectory with duration: " << context.trajectory_parts_[0].joint_trajectory.points.back().time_from_start 
+      // Push to backlog
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "Collision found between trajectory with duration: " << context.trajectory_parts_[0].joint_trajectory.points.back().time_from_start 
                                 <<  " and trajectory with duration: " << currently_running_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
       return false;
-
-      // ROS_INFO_NAMED(name_, "Waiting for active trajectory to finish");
-      // auto& active_handle = *context_handles_pair.second.begin();
-      // active_handle->waitForExecution();
-      // ROS_INFO_NAMED(name_, "Waited (after possible collision between moving trajectories)");
-      // moveit::core::RobotState robot_state = planning_scene_->getCurrentState();
-      // // TODO(cambel): Consider what the difference between this and just checking collisions with the current state is. 
-      // //               If there is none, move this to a separate "make sure trajectory does not cause collision" check (request from Michael).
-      // if (!checkCollisionsWithCurrentState(context.trajectory_))
-      // {
-      //   last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-      //   return false;
-      // }
-      // ROS_INFO_NAMED(name_, "New trajectory is not in collision");
     }
   }
   return true;
@@ -2013,20 +1968,17 @@ bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(moveit_msgs::Ro
   moveit::core::RobotStatePtr current_state;
   if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
   {
-    ROS_DEBUG_NAMED(name_, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
+    ROS_DEBUG_NAMED(LOGNAME, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
     return false;
   }
-
   planning_scene_monitor::LockedPlanningSceneRO ps(planning_scene_monitor_);
-  // TODO(cambel): Consider what the difference between this and just checking collisions with the current state is. 
-  //               If there is none, move this to a separate "make sure trajectory does not cause collision" check (request from Michael).
   if (jointTrajPointToRobotState(trajectory.joint_trajectory, trajectory.joint_trajectory.points.size()-1, *current_state))
   {
     moveit_msgs::RobotState robot_state_msg;
     robotStateToRobotStateMsg(*current_state, robot_state_msg);
-    if(!ps->isPathValid(robot_state_msg, trajectory, trajectory.group_name)) // TODO(cambel): Get the group name for improved performance (?)
+    if(!ps->isPathValid(robot_state_msg, trajectory, trajectory.group_name))
     {
-      ROS_DEBUG_NAMED(name_, "New trajectory collides with the current robot state. Abort!");
+      ROS_DEBUG_NAMED(LOGNAME, "New trajectory collides with the current robot state. Abort!");
       last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
       return false;
     }
@@ -2046,12 +1998,12 @@ void TrajectoryExecutionManager::getContextHandles(TrajectoryExecutionContext& c
     }
     catch (std::exception& ex)
     {
-      ROS_ERROR_NAMED(name_, "%s caught when retrieving controller handle", ex.what());
+      ROS_ERROR_NAMED(LOGNAME, "%s caught when retrieving controller handle", ex.what());
     }
     if (!h)
     {
       last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-      ROS_ERROR_NAMED(name_, "No controller handle for controller '%s'. Aborting.",
+      ROS_ERROR_NAMED(LOGNAME, "No controller handle for controller '%s'. Aborting.",
                       context.controllers_[i].c_str());
       handles.clear();
       break;
@@ -2064,7 +2016,7 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
                                                           std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
                                                           std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map)
 {
-  ROS_DEBUG_NAMED(name_, "Start validateAndExecuteContext");
+  ROS_DEBUG_NAMED(LOGNAME, "Start validateAndExecuteContext");
   updateActiveHandlesAndContexts(used_handles, active_contexts_map);
 
   // Get the controller handles needed to execute the new trajectory
@@ -2072,7 +2024,7 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
   getContextHandles(context, handles);
   if (handles.empty())
   {
-    ROS_ERROR_STREAM_NAMED(name_, "Trajectory context had no controller handles??");
+    ROS_ERROR_STREAM_NAMED(LOGNAME, "Trajectory context had no controller handles??");
     return false;
   }
 
@@ -2082,11 +2034,11 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     return false;
   }
   
-  ROS_DEBUG_NAMED(name_, "DEBUG: Printing necessary handles for new traj");
+  ROS_DEBUG_NAMED(LOGNAME, "DEBUG: Printing necessary handles for new traj");
   for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
   {
-    ROS_DEBUG_STREAM_NAMED(name_, "handle: " << (i+1) << " of " << context.trajectory_parts_.size() << " : " << handles[i]->getName());
-    ROS_DEBUG_STREAM_NAMED(name_, "Next-up trajectory has duration " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "handle: " << (i+1) << " of " << context.trajectory_parts_.size() << " : " << handles[i]->getName());
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Next-up trajectory has duration " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
   }
 
   // 1. Skip trajectory if it collides with other active trajectories
@@ -2103,7 +2055,7 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     while (uit != used_handles.end())
       if (handles[i]->getName() == (*uit)->getName())  // If controller is busy, return false so trajectory is pushed to backlog
       {
-        ROS_DEBUG_STREAM_NAMED(name_, "Handle " << handles[i]->getName() << " already in use: " << (*uit)->getLastExecutionStatus().asString());
+        ROS_DEBUG_STREAM_NAMED(LOGNAME, "Handle " << handles[i]->getName() << " already in use: " << (*uit)->getLastExecutionStatus().asString());
         return false;
       }
       else
@@ -2113,14 +2065,14 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
   // 3. Skip trajectory if it collides with current state
   if (!checkCollisionsWithCurrentState(context.trajectory_))
   {
-    ROS_DEBUG_STREAM_NAMED(name_, "Trajectory collides with current state. Cannot execute yet.");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Trajectory collides with current state. Cannot execute yet.");
     return false;
   }
 
   // Check whether this trajectory starts at current robot state
   if (!validate(context))
   {
-    ROS_ERROR_NAMED(name_, "Trajectory became invalid before execution, abort.");
+    ROS_ERROR_NAMED(LOGNAME, "Trajectory became invalid before execution, abort.");
     context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
     return true;
   }
@@ -2132,13 +2084,13 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     bool ok = false;
     try
     {
-      ROS_DEBUG_STREAM_NAMED(name_, "Sending trajectory to controller: " << handles[i]->getName());
-      ROS_DEBUG_STREAM_NAMED(name_, "duration: " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "Sending trajectory to controller: " << handles[i]->getName());
+      ROS_DEBUG_STREAM_NAMED(LOGNAME, "duration: " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
       ok = handles[i]->sendTrajectory(context.trajectory_parts_[i]);
     }
     catch (std::exception& ex)
     {
-      ROS_ERROR_NAMED(name_, "Caught %s when sending trajectory to controller", ex.what());
+      ROS_ERROR_NAMED(LOGNAME, "Caught %s when sending trajectory to controller", ex.what());
     }
     if (!ok)
     {
@@ -2149,12 +2101,12 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
         }
         catch (std::exception& ex)
         {
-          ROS_ERROR_NAMED(name_, "Caught %s when canceling execution", ex.what());
+          ROS_ERROR_NAMED(LOGNAME, "Caught %s when canceling execution", ex.what());
         }
-      ROS_ERROR_NAMED(name_, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
+      ROS_ERROR_NAMED(LOGNAME, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
                       context.trajectory_parts_.size(), handles[i]->getName().c_str());
       if (i > 0)
-        ROS_ERROR_NAMED(name_, "Cancelling previously sent trajectory parts");
+        ROS_ERROR_NAMED(LOGNAME, "Cancelling previously sent trajectory parts");
       return false;
     }
   }
@@ -2162,7 +2114,7 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
   // Remember which handles are now in use and which trajectories they execute
   if (!handles.empty())
   {
-    ROS_DEBUG_STREAM_NAMED(name_, "Populating the lists with " << handles.size() << " handles.");
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Populating the lists with " << handles.size() << " handles.");
     for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
     {
       used_handles.insert(handles[i]);
@@ -2179,10 +2131,10 @@ bool TrajectoryExecutionManager::hasCommonHandles(TrajectoryExecutionContext& co
   std::vector<moveit_controller_manager::MoveItControllerHandlePtr> ctx2_handles(context2.controllers_.size());
   getContextHandles(context1, ctx1_handles);
   getContextHandles(context2, ctx2_handles);
-  // TODO (cambel): surely there is a better way to compare these 2 vectors ;(
+  // TODO (cambel): surely there is a better way to compare these 2 vectors...
   for (auto ch : ctx2_handles)
     for (auto ph : ctx1_handles)
-      if (ch == ph)  // TODO (cambel): Confirm that this line works
+      if (ch == ph)
         return true;
   return false;
 }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -81,8 +81,8 @@ private:
 };
 
 TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                                                       const planning_scene_monitor::CurrentStateMonitorPtr& csm)
-  : robot_model_(robot_model), csm_(csm), planning_scene_(robot_model), node_handle_("~")
+                                                       const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+  : robot_model_(robot_model), csm_(planning_scene_monitor_->getStateMonitor()), planning_scene_monitor_(planning_scene_monitor), node_handle_("~")
 {
   if (!node_handle_.getParam("moveit_manage_controllers", manage_controllers_))
     manage_controllers_ = false;
@@ -91,9 +91,9 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::Robot
 }
 
 TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                                                       const planning_scene_monitor::CurrentStateMonitorPtr& csm,
+                                                       const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
                                                        bool manage_controllers)
-  : robot_model_(robot_model), csm_(csm), planning_scene_(robot_model), node_handle_("~"), manage_controllers_(manage_controllers)
+  : robot_model_(robot_model), csm_(planning_scene_monitor_->getStateMonitor()), planning_scene_monitor_(planning_scene_monitor), node_handle_("~"), manage_controllers_(manage_controllers)
 {
   initialize();
 }
@@ -1912,14 +1912,24 @@ bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_
   // Allow all collisions
     // TODO: This has optimization potential (ACM is not used, all collisions are checked (instead of robot-robot only)
     // collision_detection::AllowedCollisionMatrix& acm = scene.getAllowedCollisionMatrixNonConst();
-  moveit::core::RobotState start_state = planning_scene_.getCurrentState();
-  const std::string group = "";
+  ROS_DEBUG_STREAM_NAMED(name_, "getCurrentState");
+  // before we start planning, ensure that we have the latest robot state received...
+  planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
+  planning_scene_monitor_->updateFrameTransforms();
+
+  planning_scene_monitor::LockedPlanningSceneRO ps(planning_scene_monitor_);
+  moveit::core::RobotState start_state = ps->getCurrentState();
+  
   moveit_msgs::RobotState start_state_msg;
+  ROS_DEBUG_STREAM_NAMED(name_, "compute collision check");
   for(std::size_t i = 0; i < active_trajectory.joint_trajectory.points.size(); ++i)
     if (jointTrajPointToRobotState(active_trajectory.joint_trajectory, i, start_state))
     {
       robotStateToRobotStateMsg(start_state, start_state_msg);
-      if(!planning_scene_.isPathValid(start_state_msg, new_trajectory, group, true))
+      // TODO(cambel): We would like to activate verbose output, but is this leading to a crash?
+      // std::string group_name = "";
+      //  if(!planning_scene_->isPathValid(start_state_msg, new_trajectory, group_name, true))
+      if(!ps->isPathValid(start_state_msg, new_trajectory))
       {
         ROS_DEBUG_STREAM_NAMED(name_, "Done checkCollision between trajectories: Collision found!");
         return false;  // Return as soon as any point is invalid
@@ -1976,7 +1986,7 @@ bool TrajectoryExecutionManager::checkContextForCollisions(TrajectoryExecutionCo
       // auto& active_handle = *context_handles_pair.second.begin();
       // active_handle->waitForExecution();
       // ROS_INFO_NAMED(name_, "Waited (after possible collision between moving trajectories)");
-      // moveit::core::RobotState robot_state = planning_scene_.getCurrentState();
+      // moveit::core::RobotState robot_state = planning_scene_->getCurrentState();
       // // TODO(cambel): Consider what the difference between this and just checking collisions with the current state is. 
       // //               If there is none, move this to a separate "make sure trajectory does not cause collision" check (request from Michael).
       // if (!checkCollisionsWithCurrentState(context.trajectory_))
@@ -1999,14 +2009,14 @@ bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(moveit_msgs::Ro
     return false;
   }
 
-  ROS_DEBUG_NAMED(name_, "Checking if current state is in collision");
+  planning_scene_monitor::LockedPlanningSceneRO ps(planning_scene_monitor_);
   // TODO(cambel): Consider what the difference between this and just checking collisions with the current state is. 
   //               If there is none, move this to a separate "make sure trajectory does not cause collision" check (request from Michael).
   if (jointTrajPointToRobotState(trajectory.joint_trajectory, trajectory.joint_trajectory.points.size()-1, *current_state))
   {
     moveit_msgs::RobotState robot_state_msg;
     robotStateToRobotStateMsg(*current_state, robot_state_msg);
-    if(!planning_scene_.isPathValid(robot_state_msg, trajectory)) // TODO(cambel): Get the group name for improved performance (?)
+    if(!ps->isPathValid(robot_state_msg, trajectory)) // TODO(cambel): Get the group name for improved performance (?)
     {
       ROS_DEBUG_NAMED(name_, "New trajectory collides with the current robot state. Abort!");
       last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
@@ -2092,8 +2102,6 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
       else
         ++uit;
   }
-
-  updateActiveHandlesAndContexts(used_handles, active_contexts_map);
 
   // Skip trajectory if it collides with the current scene state
   if (!checkContextForCollisions(context, active_contexts_map)){

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -2089,13 +2089,12 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     ROS_DEBUG_STREAM_NAMED(name_, "Next-up trajectory has duration " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
   }
 
-  if (!checkCollisionsWithCurrentState(context.trajectory_))
-  {
-    ROS_DEBUG_STREAM_NAMED(name_, "Trajectory collides with current state. Cannot execute yet.");
+  // 1. Skip trajectory if it collides with other active trajectories
+  if (!checkContextForCollisions(context, active_contexts_map)){
     return false;
   }
-  
-  // 1. Check that controllers are not busy, wait for execution to finish if they are.
+
+  // 2. Check that controllers are not busy, wait for execution to finish if they are.
   for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
   {
     std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin();            
@@ -2111,8 +2110,10 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
         ++uit;
   }
 
-  // Skip trajectory if it collides with the current scene state
-  if (!checkContextForCollisions(context, active_contexts_map)){
+  // 3. Skip trajectory if it collides with current state
+  if (!checkCollisionsWithCurrentState(context.trajectory_))
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "Trajectory collides with current state. Cannot execute yet.");
     return false;
   }
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -40,6 +40,7 @@
 #include <geometric_shapes/check_isometry.h>
 #include <dynamic_reconfigure/server.h>
 #include <tf2_eigen/tf2_eigen.h>
+#include <moveit/robot_state/conversions.h>
 
 namespace trajectory_execution_manager
 {
@@ -81,7 +82,7 @@ private:
 
 TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
                                                        const planning_scene_monitor::CurrentStateMonitorPtr& csm)
-  : robot_model_(robot_model), csm_(csm), node_handle_("~")
+  : robot_model_(robot_model), csm_(csm), planning_scene_(robot_model), node_handle_("~")
 {
   if (!node_handle_.getParam("moveit_manage_controllers", manage_controllers_))
     manage_controllers_ = false;
@@ -92,7 +93,7 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::Robot
 TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
                                                        const planning_scene_monitor::CurrentStateMonitorPtr& csm,
                                                        bool manage_controllers)
-  : robot_model_(robot_model), csm_(csm), node_handle_("~"), manage_controllers_(manage_controllers)
+  : robot_model_(robot_model), csm_(csm), planning_scene_(robot_model), node_handle_("~"), manage_controllers_(manage_controllers)
 {
   initialize();
 }
@@ -295,42 +296,45 @@ bool TrajectoryExecutionManager::push(const moveit_msgs::RobotTrajectory& trajec
   return false;
 }
 
-bool TrajectoryExecutionManager::pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory,
-                                                const std::string& controller)
+
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
+                                                const std::string& controller, const ExecutionCompleteCallback& callback)
 {
   if (controller.empty())
-    return pushAndExecute(trajectory, std::vector<std::string>());
+    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(), callback);
   else
-    return pushAndExecute(trajectory, std::vector<std::string>(1, controller));
+    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(1, controller), callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory,
-                                                const std::string& controller)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
+                                                const std::string& controller, const ExecutionCompleteCallback& callback)
 {
   if (controller.empty())
-    return pushAndExecute(trajectory, std::vector<std::string>());
+    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(), callback);
   else
-    return pushAndExecute(trajectory, std::vector<std::string>(1, controller));
+    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(1, controller), callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecute(const sensor_msgs::JointState& state, const std::string& controller)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::string& controller, const ExecutionCompleteCallback& callback)
 {
   if (controller.empty())
-    return pushAndExecute(state, std::vector<std::string>());
+    return pushAndExecuteSimultaneous(state, std::vector<std::string>(), callback);
   else
-    return pushAndExecute(state, std::vector<std::string>(1, controller));
+    return pushAndExecuteSimultaneous(state, std::vector<std::string>(1, controller), callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory,
-                                                const std::vector<std::string>& controllers)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
+                                                const std::vector<std::string>& controllers,
+                                                const ExecutionCompleteCallback& callback)
 {
   moveit_msgs::RobotTrajectory traj;
   traj.joint_trajectory = trajectory;
-  return pushAndExecute(traj, controllers);
+  return pushAndExecuteSimultaneous(traj, controllers, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecute(const sensor_msgs::JointState& state,
-                                                const std::vector<std::string>& controllers)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const sensor_msgs::JointState& state,
+                                                const std::vector<std::string>& controllers,
+                                                const ExecutionCompleteCallback& callback)
 {
   moveit_msgs::RobotTrajectory traj;
   traj.joint_trajectory.header = state.header;
@@ -340,24 +344,21 @@ bool TrajectoryExecutionManager::pushAndExecute(const sensor_msgs::JointState& s
   traj.joint_trajectory.points[0].velocities = state.velocity;
   traj.joint_trajectory.points[0].effort = state.effort;
   traj.joint_trajectory.points[0].time_from_start = ros::Duration(0, 0);
-  return pushAndExecute(traj, controllers);
+  return pushAndExecuteSimultaneous(traj, controllers, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory,
-                                                const std::vector<std::string>& controllers)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
+                                                const std::vector<std::string>& controllers,
+                                                const ExecutionCompleteCallback& callback)
 {
-  if (!execution_complete_)
-  {
-    ROS_ERROR_NAMED(name_, "Cannot push & execute a new trajectory while another is being executed");
-    return false;
-  }
-
   TrajectoryExecutionContext* context = new TrajectoryExecutionContext();
   if (configure(*context, trajectory, controllers))
   {
+    context->execution_complete_callback = callback;
     {
       boost::mutex::scoped_lock slock(continuous_execution_mutex_);
       continuous_execution_queue_.push_back(context);
+      stop_continuous_execution_ = false;
       if (!continuous_execution_thread_)
         continuous_execution_thread_ = std::make_unique<boost::thread>([this] { continuousExecutionThread(); });
     }
@@ -376,24 +377,47 @@ bool TrajectoryExecutionManager::pushAndExecute(const moveit_msgs::RobotTrajecto
 void TrajectoryExecutionManager::continuousExecutionThread()
 {
   std::set<moveit_controller_manager::MoveItControllerHandlePtr> used_handles;
+  std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>> active_contexts_map;  // The list of trajectories currently being executed, and their controller handles
+  std::deque<std::pair<TrajectoryExecutionContext*, ros::Time>> backlog;
+  int expiration_time = 60; // seconds (after this time, the trajectory is discarded)  TODO (cambel): Make this less surprising
+
+  ros::Rate r(10);
   while (run_continuous_execution_thread_)
   {
+    ROS_DEBUG_NAMED(name_, "===========Loop top-most entry================");
+    // This waits for the lock to be released
     if (!stop_continuous_execution_)
     {
-      boost::unique_lock<boost::mutex> ulock(continuous_execution_mutex_);
-      while (continuous_execution_queue_.empty() && run_continuous_execution_thread_ && !stop_continuous_execution_)
+      if (continuous_execution_queue_.empty() && !active_contexts_map.empty())  // While trajectories are still being executed, check their response.
+                                    // Instead of doing this, we could add a callback in the controller_manager, but that seems like a bigger change.
+      {
+        ROS_DEBUG_NAMED(name_, "Updating list in top-most loop");
+        ROS_DEBUG_STREAM_NAMED(name_, "active_contexts_map size: " << active_contexts_map.size());
+        updateActiveHandlesAndContexts(used_handles, active_contexts_map);
+        r.sleep();  // Waiting like this instead of waitForExecution so the queue keeps being checked for new entries
+      }
+      boost::unique_lock<boost::mutex> ulock(continuous_execution_thread_mutex_);
+      while (continuous_execution_queue_.empty() && active_contexts_map.empty() && backlog.empty() && run_continuous_execution_thread_ && !stop_continuous_execution_)
         continuous_execution_condition_.wait(ulock);
     }
 
+    // If stop-flag is set, break out
     if (stop_continuous_execution_ || !run_continuous_execution_thread_)
     {
+      ROS_ERROR_STREAM_NAMED(name_, "Stop!. stop_continuous_execution: " << stop_continuous_execution_ << " run_continuous_execution_thread_: " << run_continuous_execution_thread_);
+      // Cancel on going executions
       for (const moveit_controller_manager::MoveItControllerHandlePtr& used_handle : used_handles)
         if (used_handle->getLastExecutionStatus() == moveit_controller_manager::ExecutionStatus::RUNNING)
           used_handle->cancelExecution();
+      // Clear map and used handles set
+      active_contexts_map.clear();
       used_handles.clear();
+      backlog.clear();
       while (!continuous_execution_queue_.empty())
       {
         TrajectoryExecutionContext* context = continuous_execution_queue_.front();
+        ROS_DEBUG_STREAM_NAMED(name_, "Calling completed callback to abort");
+        context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
         continuous_execution_queue_.pop_front();
         delete context;
       }
@@ -401,11 +425,63 @@ void TrajectoryExecutionManager::continuousExecutionThread()
       continue;
     }
 
-    while (!continuous_execution_queue_.empty())
+    while (!continuous_execution_queue_.empty() || !backlog.empty())
     {
+      ROS_DEBUG_NAMED(name_, "===========Loop2 entry================");
+
+      ROS_DEBUG_NAMED(name_, "Start checking backlog");
+      // Check all backlog entries for trajectories that can now be executed 
+      for (auto it = backlog.begin(); it != backlog.end(); )
+      {
+        TrajectoryExecutionContext* current_context = it->first;
+        ros::Time& created_at = it->second;
+        // Remove backlog items that have expired (to avoid deadlocks)
+        if (created_at + ros::Duration(expiration_time) < ros::Time::now())
+        {
+          ROS_WARN_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has expired (older than 1 minute). Assuming malfunction, removing from backlog.");
+          it = backlog.erase(it);
+          continue;
+        }
+
+        // Validate that the handles used in this context are not already in earlier (= higher priority) backlogged trajectories
+        bool controllers_not_used_earlier_in_backlog = true;
+        ROS_DEBUG_STREAM_NAMED(name_, "Backlog evaluation of item: " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+        for (auto it2 = backlog.begin(); it2 != it; ++it2)
+        {
+          TrajectoryExecutionContext* priority_context = it2->first; // Previous context in the backlog (earlier ones have priority)
+          ROS_DEBUG_STREAM_NAMED(name_, "Backlog comparing item with duration: " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+          ROS_DEBUG_STREAM_NAMED(name_, "vs item with duration: " << priority_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+          if (hasCommonHandles(*current_context, *priority_context))
+          {
+            controllers_not_used_earlier_in_backlog = false;
+            ROS_DEBUG_NAMED(name_, "Backlog item has handles blocked by previous items");
+            break;
+          }
+        }
+        if(controllers_not_used_earlier_in_backlog)
+        {
+          ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " will be checked and pushed to controller.");
+          if(validateAndExecuteContext(*current_context, used_handles, active_contexts_map))
+          {
+            ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has been executed correctly.");
+            it = backlog.erase(it);
+          }
+          else
+          {
+            ROS_DEBUG_STREAM_NAMED(name_, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " is still not executable");
+            it++;
+          }
+        }
+        else
+          it++;
+      }
+      r.sleep(); // Small delay to not process a pending trajectory over and over when it is temporarily blocked
+      ROS_DEBUG_STREAM_NAMED(name_, "Done checking backlog, size: " << backlog.size());
+
+      // Get next trajectory context from queue
       TrajectoryExecutionContext* context = nullptr;
       {
-        boost::mutex::scoped_lock slock(continuous_execution_mutex_);
+        boost::mutex::scoped_lock slock(continuous_execution_thread_mutex_);
         if (continuous_execution_queue_.empty())
           break;
         context = continuous_execution_queue_.front();
@@ -414,98 +490,39 @@ void TrajectoryExecutionManager::continuousExecutionThread()
           continuous_execution_condition_.notify_all();
       }
 
-      // remove handles we no longer need
-      std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin();
-      while (uit != used_handles.end())
-        if ((*uit)->getLastExecutionStatus() != moveit_controller_manager::ExecutionStatus::RUNNING)
-        {
-          std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator to_erase = uit;
-          ++uit;
-          used_handles.erase(to_erase);
-        }
-        else
-          ++uit;
+      ROS_DEBUG_NAMED(name_, "==========");
+      ROS_DEBUG_STREAM_NAMED(name_, "Popped element with duration " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start
+                        << " from queue. Remaining length: " << continuous_execution_queue_.size());
 
-      // now send stuff to controllers
 
-      // first make sure desired controllers are active
-      if (areControllersActive(context->controllers_))
+      // First make sure desired controllers are active
+      if (!areControllersActive(context->controllers_))
       {
-        // get the controller handles needed to execute the new trajectory
-        std::vector<moveit_controller_manager::MoveItControllerHandlePtr> handles(context->controllers_.size());
-        for (std::size_t i = 0; i < context->controllers_.size(); ++i)
-        {
-          moveit_controller_manager::MoveItControllerHandlePtr h;
-          try
-          {
-            h = controller_manager_->getControllerHandle(context->controllers_[i]);
-          }
-          catch (std::exception& ex)
-          {
-            ROS_ERROR_NAMED(name_, "%s caught when retrieving controller handle", ex.what());
-          }
-          if (!h)
-          {
-            last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-            ROS_ERROR_NAMED(name_, "No controller handle for controller '%s'. Aborting.",
-                            context->controllers_[i].c_str());
-            handles.clear();
-            break;
-          }
-          handles[i] = h;
-        }
+        ROS_ERROR_NAMED(name_, "Not all needed controllers are active. Cannot push and execute. You can try "
+                                "calling ensureActiveControllers() before pushAndExecuteSimultaneous()");
+        last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
+        ROS_INFO_NAMED(name_, "Calling completed callback");
+        context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+        delete context;
+        continue;
+      }
 
-        if (stop_continuous_execution_ || !run_continuous_execution_thread_)
+      // Check that this context's controller handles are not used in the backlog. Otherwise, add to backlog (because trajectories need to be executed in order)
+      bool controllers_not_used_in_backlog = true;
+      for (auto backlog_context : backlog)
+        if (hasCommonHandles(*backlog_context.first, *context))
         {
-          delete context;
+          ROS_DEBUG_STREAM_NAMED(name_, "Request with duration " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+          ROS_DEBUG_STREAM_NAMED(name_, "has handles blocked by backlog items. push_back to backlog");
+          backlog.push_back(std::pair<TrajectoryExecutionContext*, ros::Time> (context, ros::Time::now()));
+          controllers_not_used_in_backlog = false;
           break;
         }
 
-        // push all trajectories to all controllers simultaneously
-        if (!handles.empty())
-          for (std::size_t i = 0; i < context->trajectory_parts_.size(); ++i)
-          {
-            bool ok = false;
-            try
-            {
-              ok = handles[i]->sendTrajectory(context->trajectory_parts_[i]);
-            }
-            catch (std::exception& ex)
-            {
-              ROS_ERROR_NAMED(name_, "Caught %s when sending trajectory to controller", ex.what());
-            }
-            if (!ok)
-            {
-              for (std::size_t j = 0; j < i; ++j)
-                try
-                {
-                  handles[j]->cancelExecution();
-                }
-                catch (std::exception& ex)
-                {
-                  ROS_ERROR_NAMED(name_, "Caught %s when canceling execution", ex.what());
-                }
-              ROS_ERROR_NAMED(name_, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
-                              context->trajectory_parts_.size(), handles[i]->getName().c_str());
-              if (i > 0)
-                ROS_ERROR_NAMED(name_, "Cancelling previously sent trajectory parts");
-              last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-              handles.clear();
-              break;
-            }
-          }
-        delete context;
-
-        // remember which handles we used
-        for (const moveit_controller_manager::MoveItControllerHandlePtr& handle : handles)
-          used_handles.insert(handle);
-      }
-      else
+      if(controllers_not_used_in_backlog && !validateAndExecuteContext(*context, used_handles, active_contexts_map))
       {
-        ROS_ERROR_NAMED(name_, "Not all needed controllers are active. Cannot push and execute. You can try "
-                               "calling ensureActiveControllers() before pushAndExecute()");
-        last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-        delete context;
+        ROS_DEBUG_STREAM_NAMED(name_, "Request: " << context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " not executable, pushing it into backlog");
+        backlog.push_back(std::pair<TrajectoryExecutionContext*, ros::Time> (context, ros::Time::now()));
       }
     }
   }
@@ -1033,6 +1050,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
                                            const moveit_msgs::RobotTrajectory& trajectory,
                                            const std::vector<std::string>& controllers)
 {
+  context.trajectory_ = trajectory;
   if (trajectory.multi_dof_joint_trajectory.points.empty() && trajectory.joint_trajectory.points.empty())
   {
     // empty trajectories don't need to configure anything
@@ -1773,4 +1791,349 @@ void TrajectoryExecutionManager::loadControllerParams()
     }
   }
 }
+
+void TrajectoryExecutionManager::updateActiveHandlesAndContexts(std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
+                                                       std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map)
+{
+  ROS_DEBUG_STREAM_NAMED(name_, "Entered updateActiveHandlesAndContexts");
+  // Go through list of current trajectories, check the statuses of all handles
+  // for (auto& context_controllers_pair : active_contexts_map)  // first: context. second: handles_ for that trajectory
+  for (auto it = active_contexts_map.begin(); it != active_contexts_map.end(); )
+  {
+    auto& context = it->first;
+    auto& handles_ = it->second;
+    ROS_DEBUG_STREAM_NAMED(name_, "Update context");
+
+    // TODO(felixvd): This doesn't cover all the cases, like TIMED_OUT, CONTROL_FAILED. Ugh.
+    bool some_aborted = false;
+    bool all_aborted = true;
+    bool some_running = false;
+    bool all_running = true;
+    bool some_succeeded = false;
+    bool all_succeeded = true;
+    for (const moveit_controller_manager::MoveItControllerHandlePtr& handle : handles_)
+    {
+      auto last_status = handle->getLastExecutionStatus();
+      if (last_status == moveit_controller_manager::ExecutionStatus::ABORTED ||
+          last_status == moveit_controller_manager::ExecutionStatus::TIMED_OUT ||
+          last_status == moveit_controller_manager::ExecutionStatus::FAILED || 
+          last_status == moveit_controller_manager::ExecutionStatus::PREEMPTED)
+          // TODO: This converts everything to ABORTED.
+      {
+        some_aborted = true;
+        all_succeeded = false;
+        all_running = false;
+      }
+      else if (last_status == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
+      {
+        all_aborted = false;
+        some_succeeded = true;
+        all_running = false;
+      }
+      else if (last_status == moveit_controller_manager::ExecutionStatus::RUNNING)
+      {
+        all_aborted = false;
+        all_succeeded = false;
+        some_running = true;
+      }
+    }
+    
+    moveit_controller_manager::ExecutionStatus combined_status;
+    if (some_aborted || all_aborted)
+      combined_status = moveit_controller_manager::ExecutionStatus::ABORTED;
+    else if (some_running || all_running)
+      combined_status = moveit_controller_manager::ExecutionStatus::RUNNING;
+    else if (all_succeeded)
+      combined_status = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+    else
+      continue;
+    
+    if (combined_status == moveit_controller_manager::ExecutionStatus::SUCCEEDED ||
+        combined_status == moveit_controller_manager::ExecutionStatus::ABORTED)
+    {
+      context->execution_complete_callback(combined_status);
+      it = active_contexts_map.erase(it);
+      // TODO(cambel): remove used_handles here, lock handles until a context is fully completed
+    }else{
+      it++;
+    }
+  }
+
+  // Remove controller handles from list if they are not executing a trajectory
+  ROS_DEBUG_STREAM_NAMED(name_, "Cleaning used_handles");
+  for (std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin(); uit != used_handles.end(); )
+    if ((*uit)->getLastExecutionStatus() != moveit_controller_manager::ExecutionStatus::RUNNING)
+    {
+      std::map<moveit_controller_manager::MoveItControllerHandlePtr, moveit_msgs::RobotTrajectory>::iterator it;
+      uit = used_handles.erase(uit);
+    }
+    else
+      ++uit;
+  ROS_DEBUG_STREAM_NAMED(name_, "Done updateActiveHandlesAndContexts");
+}
+
+// simultaneous execution
+bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory, const moveit_msgs::RobotTrajectory& active_trajectory)
+{
+  ROS_DEBUG_STREAM_NAMED(name_, "Start checkCollision between trajectories using PlanningScene.isPathValid()");
+  // Allow all collisions
+    // TODO: This has optimization potential (ACM is not used, all collisions are checked (instead of robot-robot only)
+    // collision_detection::AllowedCollisionMatrix& acm = scene.getAllowedCollisionMatrixNonConst();
+  moveit::core::RobotState start_state = planning_scene_.getCurrentState();
+  const std::string group = "";
+  moveit_msgs::RobotState start_state_msg;
+  for(std::size_t i = 0; i < active_trajectory.joint_trajectory.points.size(); ++i)
+    if (jointTrajPointToRobotState(active_trajectory.joint_trajectory, i, start_state))
+    {
+      robotStateToRobotStateMsg(start_state, start_state_msg);
+      if(!planning_scene_.isPathValid(start_state_msg, new_trajectory, group, true))
+      {
+        ROS_DEBUG_STREAM_NAMED(name_, "Done checkCollision between trajectories: Collision found!");
+        return false;  // Return as soon as any point is invalid
+      }
+    }
+  ROS_DEBUG_STREAM_NAMED(name_, "Done checkCollision between trajectories: No collisions found");
+  return true;
+}
+
+bool TrajectoryExecutionManager::checkContextForCollisions(TrajectoryExecutionContext& context,
+                                                std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map)
+{
+  // 2. Check that new trajectory does not collide with other active trajectories
+
+  /* Collision checking approaches:
+      1. swept volumes as collision objects : 
+        a. create one collision object of a whole trajectory 
+        b. create the collision objects for both trajectories
+        c. check if they collide
+      *Note* Collision objects could be huge, as we consider the whole arm and attach bodies
+      - Can be optimized by flattening or mergin overlapping meshes
+      - Can be optimized by keeping in memory the collision objects of an active trajectory, in case it is necessary latter.
+
+      2. swept volumes as gpu-voxel :
+        a. create a voxel from a trajectory
+        b. create the voxels for both trajectories
+        c. check if they collide
+      *Note* Needs a new dependency on GPU and gpu-voxels
+      
+      3. checking point by point :
+        a. create a new planning scene
+        b. update the planning scene with the first point of both trajectories
+        c. update the collision matrix to ignore everything except the two trajectories' links
+            The good thing here is that we can ignore half the robot links that are never going to be in collision
+        d. check if the two states collide, if so, return, no need to check anymore
+      - Can be optimized by estimating the position of the robot in the active trajectory, then triming the active trajectory to check only the remaining states
+      - May be optimized by active trajectory backward, it is more likely that any collision would happen at the end of the trajectory than at the beginning.
+      - Anyway this approach is necessary to know if the current trajectory collides with the final state of the active trajectory
+  */
+
+  for (const auto& context_handles_pair : active_contexts_map)
+  {
+    auto& currently_running_context = context_handles_pair.first;
+    moveit_msgs::RobotTrajectory& currently_running_trajectory = currently_running_context->trajectory_;
+
+    if (!checkCollisionBetweenTrajectories(context.trajectory_, currently_running_trajectory))
+    {
+      // Do not wait just push to backlog
+      ROS_DEBUG_STREAM_NAMED(name_, "Collision found between trajectory with duration: " << context.trajectory_parts_[0].joint_trajectory.points.back().time_from_start 
+                                <<  " and trajectory with duration: " << currently_running_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start);
+      return false;
+
+      // ROS_INFO_NAMED(name_, "Waiting for active trajectory to finish");
+      // auto& active_handle = *context_handles_pair.second.begin();
+      // active_handle->waitForExecution();
+      // ROS_INFO_NAMED(name_, "Waited (after possible collision between moving trajectories)");
+      // moveit::core::RobotState robot_state = planning_scene_.getCurrentState();
+      // // TODO(cambel): Consider what the difference between this and just checking collisions with the current state is. 
+      // //               If there is none, move this to a separate "make sure trajectory does not cause collision" check (request from Michael).
+      // if (!checkCollisionsWithCurrentState(context.trajectory_))
+      // {
+      //   last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
+      //   return false;
+      // }
+      // ROS_INFO_NAMED(name_, "New trajectory is not in collision");
+    }
+  }
+  return true;
+}
+
+bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(moveit_msgs::RobotTrajectory& trajectory)
+{
+  moveit::core::RobotStatePtr current_state;
+  if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
+  {
+    ROS_DEBUG_NAMED(name_, "Failed to validate trajectory: couldn't receive full current joint state within 1s");
+    return false;
+  }
+
+  ROS_DEBUG_NAMED(name_, "Checking if current state is in collision");
+  // TODO(cambel): Consider what the difference between this and just checking collisions with the current state is. 
+  //               If there is none, move this to a separate "make sure trajectory does not cause collision" check (request from Michael).
+  if (jointTrajPointToRobotState(trajectory.joint_trajectory, trajectory.joint_trajectory.points.size()-1, *current_state))
+  {
+    moveit_msgs::RobotState robot_state_msg;
+    robotStateToRobotStateMsg(*current_state, robot_state_msg);
+    if(!planning_scene_.isPathValid(robot_state_msg, trajectory)) // TODO(cambel): Get the group name for improved performance (?)
+    {
+      ROS_DEBUG_NAMED(name_, "New trajectory collides with the current robot state. Abort!");
+      last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
+      return false;
+    }
+  }
+  
+  return true;
+}
+
+void TrajectoryExecutionManager::getContextHandles(TrajectoryExecutionContext& context, std::vector<moveit_controller_manager::MoveItControllerHandlePtr>& handles)
+{
+  for (std::size_t i = 0; i < context.controllers_.size(); ++i)
+  {
+    moveit_controller_manager::MoveItControllerHandlePtr h;
+    try
+    {
+      h = controller_manager_->getControllerHandle(context.controllers_[i]);
+    }
+    catch (std::exception& ex)
+    {
+      ROS_ERROR_NAMED(name_, "%s caught when retrieving controller handle", ex.what());
+    }
+    if (!h)
+    {
+      last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
+      ROS_ERROR_NAMED(name_, "No controller handle for controller '%s'. Aborting.",
+                      context.controllers_[i].c_str());
+      handles.clear();
+      break;
+    }
+    handles[i] = h;
+  }
+}
+
+bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionContext& context, 
+                                                          std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
+                                                          std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map)
+{
+  ROS_DEBUG_NAMED(name_, "Start validateAndExecuteContext");
+  updateActiveHandlesAndContexts(used_handles, active_contexts_map);
+
+  // Get the controller handles needed to execute the new trajectory
+  std::vector<moveit_controller_manager::MoveItControllerHandlePtr> handles(context.controllers_.size());
+  getContextHandles(context, handles);
+  if (handles.empty())
+  {
+    ROS_ERROR_STREAM_NAMED(name_, "Trajectory context had no controller handles??");
+    return false;
+  }
+
+  // Break out if flags set
+  if (stop_continuous_execution_ || !run_continuous_execution_thread_)
+  {
+    return false;
+  }
+  
+  ROS_DEBUG_NAMED(name_, "DEBUG: Printing necessary handles for new traj");
+  for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "handle: " << (i+1) << " of " << context.trajectory_parts_.size() << " : " << handles[i]->getName());
+    ROS_DEBUG_STREAM_NAMED(name_, "Next-up trajectory has duration " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
+  }
+
+  if (!checkCollisionsWithCurrentState(context.trajectory_))
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "Trajectory collides with current state. Cannot execute yet.");
+    return false;
+  }
+  
+  // 1. Check that controllers are not busy, wait for execution to finish if they are.
+  for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
+  {
+    std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin();            
+
+    // Check if required handle is already in use
+    while (uit != used_handles.end())
+      if (handles[i]->getName() == (*uit)->getName())  // If controller is busy, return false so trajectory is pushed to backlog
+      {
+        ROS_DEBUG_STREAM_NAMED(name_, "Handle " << handles[i]->getName() << " already in use: " << (*uit)->getLastExecutionStatus().asString());
+        return false;
+      }
+      else
+        ++uit;
+  }
+
+  updateActiveHandlesAndContexts(used_handles, active_contexts_map);
+
+  // Skip trajectory if it collides with the current scene state
+  if (!checkContextForCollisions(context, active_contexts_map)){
+    return false;
+  }
+
+  // Push trajectory to all controllers simultaneously (each part goes to one controller)
+  for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
+  {
+    // Check whether this trajectory part starts at current robot state
+    if (!validate(context))
+    {
+      return false;
+    }
+
+    // Send trajectory (part) to controller
+    bool ok = false;
+    try
+    {
+      ROS_DEBUG_STREAM_NAMED(name_, "Sending trajectory to controller: " << handles[i]->getName());
+      ROS_DEBUG_STREAM_NAMED(name_, "duration: " << context.trajectory_parts_[i].joint_trajectory.points.back().time_from_start);
+      ok = handles[i]->sendTrajectory(context.trajectory_parts_[i]);
+    }
+    catch (std::exception& ex)
+    {
+      ROS_ERROR_NAMED(name_, "Caught %s when sending trajectory to controller", ex.what());
+    }
+    if (!ok)
+    {
+      for (std::size_t j = 0; j < i; ++j)
+        try
+        {
+          handles[j]->cancelExecution();
+        }
+        catch (std::exception& ex)
+        {
+          ROS_ERROR_NAMED(name_, "Caught %s when canceling execution", ex.what());
+        }
+      ROS_ERROR_NAMED(name_, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
+                      context.trajectory_parts_.size(), handles[i]->getName().c_str());
+      if (i > 0)
+        ROS_ERROR_NAMED(name_, "Cancelling previously sent trajectory parts");
+      return false;
+    }
+  }
+
+  // Remember which handles are now in use and which trajectories they execute
+  if (!handles.empty())
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "Populating the lists with " << handles.size() << " handles.");
+    for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
+    {
+      used_handles.insert(handles[i]);
+    }
+    std::set<moveit_controller_manager::MoveItControllerHandlePtr> handle_set(handles.begin(), handles.end());  // TODO: If handles was a vector, this step could be skipped.
+    active_contexts_map.insert(std::pair<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>(&context, handle_set));
+  }
+  return true;
+}
+
+bool TrajectoryExecutionManager::hasCommonHandles(TrajectoryExecutionContext& context1, TrajectoryExecutionContext& context2)
+{
+  std::vector<moveit_controller_manager::MoveItControllerHandlePtr> ctx1_handles(context1.controllers_.size());
+  std::vector<moveit_controller_manager::MoveItControllerHandlePtr> ctx2_handles(context2.controllers_.size());
+  getContextHandles(context1, ctx1_handles);
+  getContextHandles(context2, ctx2_handles);
+  // TODO (cambel): surely there is a better way to compare these 2 vectors ;(
+  for (auto ch : ctx2_handles)
+    for (auto ph : ctx1_handles)
+      if (ch == ph)  // TODO (cambel): Confirm that this line works
+        return true;
+  return false;
+}
+
 }  // namespace trajectory_execution_manager
+

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
   traj1.joint_trajectory.joint_names.push_back("rj1");
   traj1.joint_trajectory.points.resize(1);
   traj1.joint_trajectory.points[0].positions.push_back(0.0);
-  if (!tem.push(traj1))
+  if (!tem.pushToBlockingQueue(traj1))
     ROS_ERROR("Fail!");
 
   moveit_msgs::RobotTrajectory traj2 = traj1;
@@ -91,11 +91,11 @@ int main(int argc, char** argv)
   traj2.multi_dof_joint_trajectory.points.resize(1);
   traj2.multi_dof_joint_trajectory.points[0].transforms.resize(1);
 
-  if (!tem.push(traj2))
+  if (!tem.pushToBlockingQueue(traj2))
     ROS_ERROR("Fail!");
 
   traj1.multi_dof_joint_trajectory = traj2.multi_dof_joint_trajectory;
-  if (!tem.push(traj1))
+  if (!tem.pushToBlockingQueue(traj1))
     ROS_ERROR("Fail!");
 
   if (!tem.executeAndWait())


### PR DESCRIPTION
@felixvd and I have been working on this PR

### Description

This draft PR proposes a method to allow the execution of multiple controllers in several independent trajectory plans at the same time.
So far, MoveIt only supports the execution of one trajectory at a time. If a second trajectory is sent for execution, the first trajectory is aborted and the second one is attempted instead. 

There are two main reasons for this limitation. First, all the action servers are of the type SimpleActionServer which can only serve one goal at a time and immediately reject any old goal as a new one is received. Second, the TrajectoryExecutionManager only supports the execution of one trajectory at a time by default, aborting any previous trajectory as a new one is pushed. 

The first issue is addressed by converting the SimpleActionServers into (General) ActionServers. This allows the server to handle multiple goals at the same time.
The second issue is addressed by implementing a **scheduling procedure** to execute trajectories simultaneously as long as the following conditions are met:

- The controllers needed for executing the trajectory are not being used.
- The trajectory is not in collision with any active trajectory.
- The trajectory is not in collision with the current state. This is assumed in the current trajectory execution scheme as it is expected that the planning covers this validation. For most cases, it works fine, but for simultaneous execution of trajectories, that assumption does not hold anymore, so an extra validation is needed.
- The start state of the trajectory matched that of the current state of the robot.

If the trajectory does not meet the conditions mentioned above, the trajectory is stored in a backlog and periodically checked. The trajectories in the backlog and newly received trajectories are evaluated and executed in a strict FIFO order.

Our use case: Simultaneous control of robots with different sets of instructions that do not have/need to be synchronized in any particular way. See this simple equip/unequip routine where both robots can follow their independent set of instructions without waiting for the other one.


https://user-images.githubusercontent.com/3798796/129310195-fa0787bf-6942-4447-a33c-ecbbbe054efd.mp4


There are some issues pending to be fixed:

- Re-enable feedback for the action servers.
- Simultaneous planning seems to crash MoveIt/move_group. It is a non-deterministic bug that we are still trying to understand. I am trying to debug [here](https://github.com/cambel/moveit/tree/tem-debug). The problem is not uncommon, it happens during the planning, as we do plan_only and then execute the plans. It even happens with only one robot planning at a time. The crash happens when sending a solution plan to the goal_handle (of the ActionServer), for whatever reason the executed trajectory of the action response (`MoveGroupResult`) is corrupted because something cannot be accessed `Cannot access memory at address`.
- Unless I am mistaken, the `execute_trajectory_service` also needs to be changed over to simultaneous execution
- There are no tests for the new behavior yet

Comments and contributions are highly appreciated!

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
