### PR TITLE
more fixes for the clang-tidy job

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -49,6 +49,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <memory>
+#include <type_traits>
 
 namespace collision_detection
 {
@@ -685,24 +686,6 @@ FCLShapeCache& GetShapeCache()
   return cache;
 }
 
-template <typename T1, typename T2>
-struct IfSameType
-{
-  enum
-  {
-    value = 0
-  };
-};
-
-template <typename T>
-struct IfSameType<T, T>
-{
-  enum
-  {
-    value = 1
-  };
-};
-
 /** \brief Templated helper function creating new collision geometry out of general object using an arbitrary bounding
  *  volume (BV).
  *
@@ -743,7 +726,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
   // attached objects could have previously been World::Object; we try to move them
   // from their old cache to the new one, if possible. the code is not pretty, but should help
   // when we attach/detach objects that are in the world
-  if (IfSameType<T, moveit::core::AttachedBody>::value == 1)
+  if (std::is_same<T, moveit::core::AttachedBody>::value)
   {
     // get the cache that corresponds to objects; maybe this attached object used to be a world object
     FCLShapeCache& othercache = GetShapeCache<BV, World::Object>();
@@ -776,7 +759,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       // world objects could have previously been attached objects; we try to move them
       // from their old cache to the new one, if possible. the code is not pretty, but should help
       // when we attach/detach objects that are in the world
-      if (IfSameType<T, World::Object>::value == 1)
+      if (std::is_same<T, World::Object>::value)
   {
     // get the cache that corresponds to objects; maybe this attached object used to be a world object
     FCLShapeCache& othercache = GetShapeCache<BV, moveit::core::AttachedBody>();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -476,7 +476,7 @@ void MotionPlanningFrame::copySelectedCollisionObject()
       continue;
 
     // find a name for the copy
-    name = "Copy of " + name;
+    name.insert(0, "Copy of ");
     if (ps->getWorld()->hasObject(name))
     {
       name += " ";


### PR DESCRIPTION
These two issues appeared in https://github.com/ros-planning/moveit/pull/2795 .
As clang-tidy only inspects files that changed, they did not show up before.

@tylerjw