### PR TITLE
Fix issue #2809 (broken test with clang)

### DIFF
--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -5,12 +5,6 @@ add_library(${MOVEIT_LIB_NAME}
   src/collision_env_fcl.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  # FIXME(v4hn): clang 10-12 produce broken code for the only std::map::insert call in the method
-  # however, the method calls in here are hotspots in the whole pipeline and disabling optimizations
-  # is no sufficient solution
-  set_source_files_properties(src/collision_common.cpp PROPERTIES COMPILE_FLAGS -O0)
-endif()
 
 
 target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -495,9 +495,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
   double dist_threshold = cdata->req->distance_threshold;
 
-  const std::pair<const std::string&, const std::string&> pc = cd1->getID() < cd2->getID() ?
-                                                                   std::make_pair(cd1->getID(), cd2->getID()) :
-                                                                   std::make_pair(cd2->getID(), cd1->getID());
+  const std::pair<const std::string, const std::string> pc = cd1->getID() < cd2->getID() ?
+                                                                 std::make_pair(cd1->getID(), cd2->getID()) :
+                                                                 std::make_pair(cd2->getID(), cd1->getID());
 
   DistanceMap::iterator it = cdata->res->distances.find(pc);
 

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -495,9 +495,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
   double dist_threshold = cdata->req->distance_threshold;
 
-  const std::pair<const std::string, const std::string> pc = cd1->getID() < cd2->getID() ?
-                                                                 std::make_pair(cd1->getID(), cd2->getID()) :
-                                                                 std::make_pair(cd2->getID(), cd1->getID());
+  const std::pair<const std::string, const std::string> pc12(cd1->getID(), cd2->getID());
+  const std::pair<const std::string, const std::string> pc21(cd2->getID(), cd1->getID());
+  const std::pair<const std::string, const std::string>& pc = cd1->getID() < cd2->getID() ? pc12 : pc21;
 
   DistanceMap::iterator it = cdata->res->distances.find(pc);
 

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -495,9 +495,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
   double dist_threshold = cdata->req->distance_threshold;
 
-  const std::pair<const std::string, const std::string> pc12(cd1->getID(), cd2->getID());
-  const std::pair<const std::string, const std::string> pc21(cd2->getID(), cd1->getID());
-  const std::pair<const std::string, const std::string>& pc = cd1->getID() < cd2->getID() ? pc12 : pc21;
+  const std::pair<const std::string&, const std::string&> pc =
+      cd1->getID() < cd2->getID() ? std::make_pair(std::cref(cd1->getID()), std::cref(cd2->getID())) :
+                                    std::make_pair(std::cref(cd2->getID()), std::cref(cd1->getID()));
 
   DistanceMap::iterator it = cdata->res->distances.find(pc);
 


### PR DESCRIPTION
The culprit of #2792 was essentially an optimization I proposed for #2698 to avoid copying strings to generate a map key.
Looks like this optimization leads to a stack-use-after-scope issue (found with asan), both in clang and gcc.
Reverting it, fixes the issue.

However, I'm not sure why this code doesn't work - the string references should exist:
```c++
#include <map>
#include <string>
#include <iostream>

int main(int argc, char const* argv[])
{
  using KeyT = std::pair<std::string, std::string>;
  std::map<KeyT, int> map;
  map.insert(std::make_pair(std::make_pair("foo", "bar"), 1));
  map.insert(std::make_pair(std::make_pair("bar", "foo"), 2));

  const std::string foo = "foo";
  const std::string bar = "bar";

  const std::pair<const std::string&, const std::string&> key =
      std::make_pair<const std::string&, const std::string&>(foo, bar);

  /*** at this point accessing elements of key results in stack-use-after-scope ***/
  std::cerr << key.first << ", " << key.second << std::endl;

  auto it = map.find(key);
  std::cerr << it->second << std::endl;
  return 0;
}
```