### PR TITLE
Remove python3-osrf-pycommon from Dockerfile

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -21,7 +21,7 @@ RUN \
         # Some basic requirements
         wget git sudo \
         # Preferred build tools
-        python3-catkin-tools python3-osrf-pycommon \
+        python3-catkin-tools \
         clang clang-format-10 clang-tidy clang-tools \
         ccache && \
     #


### PR DESCRIPTION
This was a workaround for https://github.com/catkin/catkin_tools/issues/594. It is no longer necessary since python3-catkin-tools 0.7 added the proper dependency.