### PR TITLE
Fix Bullet collision returning wrong contact type

### DIFF
--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
@@ -443,7 +443,7 @@ inline btScalar addDiscreteSingleResult(btManifoldPoint& cp, const btCollisionOb
   contact.nearest_points[1] = convertBtToEigen(cp.m_positionWorldOnB);
 
   contact.body_type_1 = cd0->getTypeID();
-  contact.body_type_2 = cd0->getTypeID();
+  contact.body_type_2 = cd1->getTypeID();
 
   if (!processResult(collisions, contact, pc, found))
   {
@@ -476,7 +476,7 @@ inline btScalar addCastSingleResult(btManifoldPoint& cp, const btCollisionObject
   contact.pos = convertBtToEigen(cp.m_positionWorldOnA);
 
   contact.body_type_1 = cd0->getTypeID();
-  contact.body_type_2 = cd0->getTypeID();
+  contact.body_type_2 = cd1->getTypeID();
 
   collision_detection::Contact* col = processResult(collisions, contact, pc, found);
 

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -311,6 +311,21 @@ TEST_F(BulletCollisionDetectionTester, ContinuousCollisionWorld)
   cenv_->checkRobotCollision(req, res, state1, state2, *acm_);
   ASSERT_TRUE(res.collision);
   ASSERT_EQ(res.contact_count, 4u);
+  // test contact types
+  for (auto& contact_pair : res.contacts)
+  {
+    for (collision_detection::Contact& contact : contact_pair.second)
+    {
+      collision_detection::BodyType contact_type1 = contact.body_name_1 == "box" ?
+                                                        collision_detection::BodyType::WORLD_OBJECT :
+                                                        collision_detection::BodyType::ROBOT_LINK;
+      collision_detection::BodyType contact_type2 = contact.body_name_2 == "box" ?
+                                                        collision_detection::BodyType::WORLD_OBJECT :
+                                                        collision_detection::BodyType::ROBOT_LINK;
+      ASSERT_EQ(contact.body_type_1, contact_type1);
+      ASSERT_EQ(contact.body_type_2, contact_type2);
+    }
+  }
   res.clear();
 }
 


### PR DESCRIPTION
### Description

When using Bullet collision, the collision response contact type is wrong. This is due to a typo in the bullet_utils.h which stores the first type into both contacts.

This PR fixes this issue and updates the continuous collision detection test to include a check for the contact type.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
