### PR TITLE
MotionPlanningFrame: Gracefully handle undefined parent widget

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -577,14 +577,16 @@ void MotionPlanningFrame::enable()
   ui_->object_status->setText("");
 
   // activate the frame
-  parentWidget()->show();
+  if (parentWidget())
+    parentWidget()->show();
 }
 
 void MotionPlanningFrame::disable()
 {
   move_group_.reset();
   scene_marker_.reset();
-  parentWidget()->hide();
+  if (parentWidget())
+    parentWidget()->hide();
 }
 
 void MotionPlanningFrame::tabChanged(int index)


### PR DESCRIPTION
If the MP plugin was created in a non-rviz context (e.g. directly via librviz),
there might be no window manager and thus no parent widget available for panels.

This fixes https://github.com/ros-visualization/rviz/issues/1653.