### PR TITLE
Makes rviz trajectory visualization topic relative

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,7 +26,7 @@ API changes in MoveIt releases
 - The joint states of `passive` joints must be published in ROS and the CurrentStateMonitor will now wait for them as well. Their semantics dictate that they cannot be actively controlled, but they must be known to use the full robot state in collision checks. (https://github.com/ros-planning/moveit/pull/2663)
 - Removed deprecated header `moveit/macros/deprecation.h`. Use `[[deprecated]]` instead.
 - All uses of `MOVEIT_CLASS_FORWARD` et. al. must now be followed by a semicolon for consistency (and to get -pedantic builds to pass for the codebase).
-- The default topic for the Rviz trajectory visualization tool now uses the relative instead of the absolute namespace (i.e. `move_group/display_planned_path` instead of `/move_group/display_planned_path`).
+- In case you start RViz in a namespace, the default topic for the trajectory visualization display now uses the relative instead of the absolute namespace (i.e. `<ns>/move_group/display_planned_path` instead of `/move_group/display_planned_path`).
 
 ## ROS Melodic
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,6 +26,7 @@ API changes in MoveIt releases
 - The joint states of `passive` joints must be published in ROS and the CurrentStateMonitor will now wait for them as well. Their semantics dictate that they cannot be actively controlled, but they must be known to use the full robot state in collision checks. (https://github.com/ros-planning/moveit/pull/2663)
 - Removed deprecated header `moveit/macros/deprecation.h`. Use `[[deprecated]]` instead.
 - All uses of `MOVEIT_CLASS_FORWARD` et. al. must now be followed by a semicolon for consistency (and to get -pedantic builds to pass for the codebase).
+- The Rviz trajectory visualization tool now looks for the trajectory topic to be on the relative ns instead of the absolute ns when it is first added to Rviz (i.e. `move_group/display_planned_path` vs. `/move_group/display_planned_path`).
 
 ## ROS Melodic
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,7 +26,7 @@ API changes in MoveIt releases
 - The joint states of `passive` joints must be published in ROS and the CurrentStateMonitor will now wait for them as well. Their semantics dictate that they cannot be actively controlled, but they must be known to use the full robot state in collision checks. (https://github.com/ros-planning/moveit/pull/2663)
 - Removed deprecated header `moveit/macros/deprecation.h`. Use `[[deprecated]]` instead.
 - All uses of `MOVEIT_CLASS_FORWARD` et. al. must now be followed by a semicolon for consistency (and to get -pedantic builds to pass for the codebase).
-- The Rviz trajectory visualization tool now looks for the trajectory topic to be on the relative ns instead of the absolute ns when it is first added to Rviz (i.e. `move_group/display_planned_path` vs. `/move_group/display_planned_path`).
+- The default topic for the Rviz trajectory visualization tool now uses the relative instead of the absolute namespace (i.e. `move_group/display_planned_path` instead of `/move_group/display_planned_path`).
 
 ## ROS Melodic
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -68,7 +68,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   , trajectory_slider_dock_panel_(nullptr)
 {
   trajectory_topic_property_ =
-      new rviz::RosTopicProperty("Trajectory Topic", "/move_group/display_planned_path",
+      new rviz::RosTopicProperty("Trajectory Topic", "move_group/display_planned_path",
                                  ros::message_traits::datatype<moveit_msgs::DisplayTrajectory>(),
                                  "The topic on which the moveit_msgs::DisplayTrajectory messages are received", widget,
                                  SLOT(changedTrajectoryTopic()), this);


### PR DESCRIPTION
This commit makes sure the RVIZ trajectory visualization plugin looks for the trajectory topic to be on the relative ns instead of the absolute ns when it is first added to Rviz (i.e. `move_group/display_planned_path` vs. `/move_group/display_planned_path`). This was done to make sure that it respects the namespaces that are set in launch files. This is useful when you are using MoveIt for multi robot control.

I did not find any images or text in the documentation that needs to be updates. Please let me know if I missed something.