### PR TITLE
Keep ob::PlannerTerminationCondition on heap

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -46,6 +46,14 @@
 #include <ompl/tools/multiplan/ParallelPlan.h>
 #include <ompl/base/StateStorage.h>
 
+namespace ompl
+{
+namespace base
+{
+class IterationTerminationCondition;
+}
+}  // namespace ompl
+
 namespace ompl_interface
 {
 namespace ob = ompl::base;
@@ -392,6 +400,8 @@ protected:
   std::vector<kinematic_constraints::KinematicConstraintSetPtr> goal_constraints_;
 
   const ob::PlannerTerminationCondition* ptc_;
+  std::vector<std::shared_ptr<ob::PlannerTerminationCondition>> ptcs_;
+  std::shared_ptr<ob::IterationTerminationCondition> it_ptc_;
   std::mutex ptc_lock_;
 
   /// the time spent computing the last plan

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -505,9 +505,13 @@ ompl_interface::ModelBasedPlanningContext::constructPlannerTerminationCondition(
   else if (termination_and_params[0] == "Iteration")
   {
     if (termination_and_params.size() > 1)
-      return ob::plannerOrTerminationCondition(
-          ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start)),
-          ob::IterationTerminationCondition(std::stoul(termination_and_params[1])));
+    {
+      ptcs_.clear();
+      ptcs_.push_back(std::make_shared<ob::PlannerTerminationCondition>(
+          ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start))));
+      it_ptc_ = std::make_shared<ob::IterationTerminationCondition>(std::stoul(termination_and_params[1]));
+      return ob::plannerOrTerminationCondition(*ptcs_[0], *it_ptc_);
+    }
     else
       ROS_ERROR_NAMED(LOGNAME, "Missing argument to Iteration termination condition");
   }
@@ -525,9 +529,12 @@ ompl_interface::ModelBasedPlanningContext::constructPlannerTerminationCondition(
       if (termination_and_params.size() > 2)
         epsilon = moveit::core::toDouble(termination_and_params[2]);
     }
-    return ob::plannerOrTerminationCondition(
-        ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start)),
-        ob::CostConvergenceTerminationCondition(ompl_simple_setup_->getProblemDefinition(), solutions_window, epsilon));
+    ptcs_.clear();
+    ptcs_.push_back(std::make_shared<ob::PlannerTerminationCondition>(
+        ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start))));
+    ptcs_.push_back(std::make_shared<ob::CostConvergenceTerminationCondition>(
+        ompl_simple_setup_->getProblemDefinition(), solutions_window, epsilon));
+    return ob::plannerOrTerminationCondition(*ptcs_[0], *ptcs_[1]);
   }
 #endif
   // Terminate as soon as an exact solution is found or a timeout occurs.
@@ -535,9 +542,12 @@ ompl_interface::ModelBasedPlanningContext::constructPlannerTerminationCondition(
   // the first feasible solution.
   else if (termination_and_params[0] == "ExactSolution")
   {
-    return ob::plannerOrTerminationCondition(
-        ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start)),
-        ob::exactSolnPlannerTerminationCondition(ompl_simple_setup_->getProblemDefinition()));
+    ptcs_.clear();
+    ptcs_.push_back(std::make_shared<ob::PlannerTerminationCondition>(
+        ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start))));
+    ptcs_.push_back(std::make_shared<ob::PlannerTerminationCondition>(
+        ob::exactSolnPlannerTerminationCondition(ompl_simple_setup_->getProblemDefinition())));
+    return ob::plannerOrTerminationCondition(*ptcs_[0], *ptcs_[1]);
   }
   else
     ROS_ERROR_NAMED(LOGNAME, "Unknown planner termination condition");


### PR DESCRIPTION
### Description
There is currently an invalid memory reference bug when constructing `ompl::base::plannerOrTerminationCondition` from `constructPlannerTerminationCondition`.

https://github.com/ompl/ompl/blob/9c3a20faaddfcd7f58fce235495f043ebee3e735/src/ompl/base/src/PlannerTerminationCondition.cpp#L197-L204

`ompl::base::plannerOrTerminationCondition` expects `ompl::base::PlannerTerminationCondition` alive in the memory while it is alive.
However, `constructPlannerTerminationCondition` allocates `ompl::base::PlannerTerminationCondition`s in the stack memory, then they are automatically destructed when returning `ompl::base::plannerOrTerminationCondition`.
This PR prevents this invalid memory reference bug by allocating  `ompl::base::PlannerTerminationCondition` on the heap memory for the lifetime of `ompl::base::plannerOrTerminationCondition`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
