### PR TITLE
supports for non-convex mesh in collision_detection_bullet

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -75,6 +75,20 @@ public:
 
   MOVEIT_STRUCT_FORWARD(Object);
 
+  /** \brief Specify whether detailed meshes or convex hulls (the default) will be used
+   * If doing continuous collision detection, only convex hull meshes should be used.
+   * However if the world objects are 'static', you can enable this.
+   */
+  void setUseDetailedMesh(const bool use_detailed_mesh)
+  {
+    use_detailed_mesh_ = use_detailed_mesh;
+  }
+
+  bool getUseDetailedMesh()
+  {
+    return use_detailed_mesh_;
+  }
+
   /** \brief A representation of an object */
   struct Object
   {
@@ -348,5 +362,8 @@ private:
 
   /// All registered observers of this world representation
   std::vector<Observer*> observers_;
+
+  /// If this optional parameter is true, detailed collision meshes are used
+  bool use_detailed_mesh_;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -41,11 +41,11 @@
 
 namespace collision_detection
 {
-World::World()
+World::World() : use_detailed_mesh_(false)
 {
 }
 
-World::World(const World& other)
+World::World(const World& other) : use_detailed_mesh_(false)
 {
   objects_ = other.objects_;
 }

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -254,7 +254,12 @@ void CollisionEnvBullet::addToManager(const World::Object* obj)
   for (const shapes::ShapeConstPtr& shape : obj->shapes_)
   {
     if (shape->type == shapes::MESH)
-      collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::CONVEX_HULL);
+    {
+      if (getWorld()->getUseDetailedMesh())
+        collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::USE_SHAPE_TYPE);
+      else
+        collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::CONVEX_HULL);
+    }
     else
       collision_object_types.push_back(collision_detection_bullet::CollisionObjectType::USE_SHAPE_TYPE);
   }

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -37,6 +37,28 @@
 static const std::string LOGNAME = "collision_detection";
 namespace collision_detection
 {
+
+void getUseDetailedMeshParam(ros::NodeHandle& nh, const planning_scene::PlanningScenePtr& scene)
+{
+  std::string param_name;
+  bool use_detailed_mesh;
+
+  if (nh.searchParam("use_detailed_mesh", param_name))
+  {
+    nh.getParam(param_name, use_detailed_mesh);
+  }
+  else if (nh.hasParam("/move_group/use_detailed_mesh"))
+  {
+    nh.getParam("/move_group/use_detailed_mesh", use_detailed_mesh);
+  }
+  else
+  {
+    use_detailed_mesh = false;
+  }
+
+  scene->getWorldNonConst()->setUseDetailedMesh(use_detailed_mesh);
+}
+
 void CollisionPluginLoader::setupScene(ros::NodeHandle& nh, const planning_scene::PlanningScenePtr& scene)
 {
   if (!scene)
@@ -68,6 +90,8 @@ void CollisionPluginLoader::setupScene(ros::NodeHandle& nh, const planning_scene
     // This is not a valid name for a collision detector plugin
     return;
   }
+
+  getUseDetailedMeshParam(nh, scene);
 
   activate(collision_detector_name, scene, true);
   ROS_INFO_STREAM("Using collision detector:" << scene->getActiveCollisionDetectorName().c_str());


### PR DESCRIPTION
## Description

### Features

- Add concave mesh mode to MoveIt bullet collision detector
  - only for WorldObject in PlanningScene.
- Add a Flag for world status(is static or not)



### Details

***Problem***

1. In collision_detection_bullet, all collisions of mesh-type are converted to convex-hull type.

     - When non-convex meshes are imported, collisions are detected in free space.

       - On the other hand, in FCL, primitive triangles are directly added to AABB tree for collision checking.
         https://github.com/ros-planning/moveit/blob/bef8f7cdde399287dc8b75b9a36b4da54704b69d/moveit_core/collision_detection_fcl/src/collision_common.cpp#L829-L847
       - these outcomes are not intuitive for beginners.
         (https://github.com/ros-planning/moveit/issues/742#issuecomment-358353284)

       

> *why we use convex-hull:*
>
> - using a convex shape is good enough for speed-up. 
> - for continuous collision detection, meshes have to be convex shape if they are dynamic.
>   (don't need to be a convex-shape for a static object)



**_Solution_**

1. Import original mesh shape(when the world objects are static)
   - Add **_a mode for importing primitive triangles from original meshes_** in collision_detection_bullet (like using FCL).
   - Add one more option for users:
     - (default) fast computation, but use convex-hull(casual mesh) for collision detection 
     - (option) slow computation, but use non-convex shape(sophisticated mesh) for collision detection
       - if world objects are "static" and the user wants to use non-convex mesh in the planning scene, the user can choose it.
   - how to make bullet recognize which object is needed to be imported as non-convex?
     1. **_chosen by world information_**
        - we can add some information to `World` class.
          - if `use_concave_mesh_` is true, we can import the original mesh(not converted to convex-hull)
     2. chosen by object information
        - we need to change urdf and its parser to contain this info (convex or not) 
          - https://discourse.ros.org/t/add-attribute-to-indicate-if-a-mesh-is-a-convex-hull/4479/5
          - https://gist.github.com/erwincoumans/6e98f5ef6186f883933a41e3e2c84104
          - https://ros-industrial-tesseract.readthedocs.io/en/latest/_source/tesseract_urdf_doc.html
        - this approach is the best, *but it seems difficult to be applied..* this is a long-term goal.
   - (with dynamic non-convex mesh, use convex decomposition; solution below.)



> *(another solution)*
>
> Use V-HACD and make a collision array for a link 
>
> - In [tesseract](https://github.com/ros-industrial-consortium/tesseract), vhacd module is embedded with bullet. but, in moveit, the module is not included so the processes are messy.
> - convex decomposition(such as vhacd) make the original shapes approximated. Thus, we couldn't use this when it is required to plan high-accuracy motion.

## Results
**BEFORE** applying this PR
<img src="https://user-images.githubusercontent.com/26274945/130755355-2f1a6134-4e7c-49b1-8bf4-69c667c17c89.gif" width="40%"/>


**AFTER** applying this PR
<img src="https://user-images.githubusercontent.com/26274945/130755372-a6ce9b83-25f9-409c-97af-b7b6b606ab22.gif" width="40%"/>

**TEST**
(scenario)
1. check collision on robot state1
2. check collision on robot state2
3. check conituous collision on state1 to state2
<img src="https://user-images.githubusercontent.com/26274945/130909943-9f000f55-093e-47a7-ac8b-0a0bb1df36ac.gif" width="40%"/>


## Checklist

- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
@rhaschke @v4hn  I think this feature needs to be included in bullet, pls review and feedback pls.