### PR TITLE
Adds missing deps to the package.xml template

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/package.xml.template
@@ -21,6 +21,7 @@
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>gazebo_ros_control</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
   <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
@@ -29,6 +30,7 @@
   <run_depend>rviz</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>xacro</run_depend>
+  <run_depend>joint_trajectory_controller</run_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
   [OTHER_DEPENDENCIES]


### PR DESCRIPTION
This commit adds the 'joint_trajectory_controller' and 'gazebo_ros_control' dependencies to the
`moveit_setup_assistant` package.xml template. These dependencies are needed for the gazebo simulation.