### PR TITLE
Added option to use padded robot for self-collision checking

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -1047,5 +1047,11 @@ private:
 
   // a map of object types
   std::unique_ptr<ObjectTypeMap> object_types_;
+
+  // used to specify if padded version of robot should also be used for self-collisions - disabled by default 
+  bool use_padding_self_collisions_;
+  static const std::string USE_PADDING_SELF_COLLISIONS_PARAM_NAME;
+
+  ros::NodeHandle nh_;
 };
 }  // namespace planning_scene

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -54,6 +54,7 @@ namespace planning_scene
 {
 const std::string PlanningScene::OCTOMAP_NS = "<octomap>";
 const std::string PlanningScene::DEFAULT_SCENE_NAME = "(noname)";
+const std::string PlanningScene::USE_PADDING_SELF_COLLISIONS_PARAM_NAME = "use_padding_self_collisions";
 
 const std::string LOGNAME = "planning_scene";
 
@@ -113,14 +114,14 @@ bool PlanningScene::isEmpty(const moveit_msgs::PlanningSceneWorld& msg)
 
 PlanningScene::PlanningScene(const moveit::core::RobotModelConstPtr& robot_model,
                              const collision_detection::WorldPtr& world)
-  : robot_model_(robot_model), world_(world), world_const_(world)
+  : robot_model_(robot_model), world_(world), world_const_(world), nh_("~")
 {
   initialize();
 }
 
 PlanningScene::PlanningScene(const urdf::ModelInterfaceSharedPtr& urdf_model,
                              const srdf::ModelConstSharedPtr& srdf_model, const collision_detection::WorldPtr& world)
-  : world_(world), world_const_(world)
+  : world_(world), world_const_(world), nh_("~")
 {
   if (!urdf_model)
     throw moveit::ConstructException("The URDF model cannot be NULL");
@@ -144,6 +145,15 @@ PlanningScene::~PlanningScene()
 void PlanningScene::initialize()
 {
   name_ = DEFAULT_SCENE_NAME;
+
+  if (!nh_.getParam(USE_PADDING_SELF_COLLISIONS_PARAM_NAME, use_padding_self_collisions_))
+  {
+    use_padding_self_collisions_ = false;
+    ROS_INFO_STREAM("Param '" << USE_PADDING_SELF_COLLISIONS_PARAM_NAME << "' was not set. Using default value: " << use_padding_self_collisions_);
+  }
+  else {
+    ROS_INFO_STREAM("Param '" << USE_PADDING_SELF_COLLISIONS_PARAM_NAME << "' was set to " << use_padding_self_collisions_);
+  }
 
   scene_transforms_ = std::make_shared<SceneTransforms>(this);
 
@@ -500,9 +510,16 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
   // check collision with the world using the padded version
   getCollisionEnv()->checkRobotCollision(req, res, robot_state, acm);
 
-  // do self-collision checking with the unpadded version of the robot
+  // do self-collision checking with the unpadded version of the robot - unless otherwise specified    
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
-    getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
+  {
+    if ( use_padding_self_collisions_ ) {
+      getCollisionEnv()->checkSelfCollision(req, res, robot_state, acm);
+    }
+    else {
+      getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
+    }
+  }
 }
 
 void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
@@ -522,10 +539,15 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
   // check collision with the world using the unpadded version
   getCollisionEnvUnpadded()->checkRobotCollision(req, res, robot_state, acm);
 
-  // do self-collision checking with the unpadded version of the robot
+  // do self-collision checking with the unpadded version of the robot - unless otherwise specified    
   if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
   {
-    getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
+    if ( use_padding_self_collisions_ ) {
+      getCollisionEnv()->checkSelfCollision(req, res, robot_state, acm);
+    }
+    else {
+      getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
+    }
   }
 }
 


### PR DESCRIPTION
### Description

There has been some discussion related to adding configurable padding options when doing self-collision checking #683. As of now, I believe configurable link padding values are only applied to collision checking of the robot with the environment / world, not for self-collision checks.

For my application, instead of providing separate configurable padding values each for self-collision checks and environment collision checks, I just implemented a parameter to enable/disable using the same configured padding values that are used environment collision checks for self-collision checks as well:

`/move_group/use_padding_self_collisions true/false`

```xml
<node name="move_group" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen">
    <param name="allow_trajectory_execution" value="true"/>
    <param name="max_safe_path_cost" value="1"/>
    <param name="jiggle_fraction" value="0.05" />
    <param name="start_state_max_dt" value="0.5" />
    <param name="max_sampling_attempts" value="100" />
    <param name="capabilities" value=""/>
    <param name="use_padding_self_collisions" value="true"/>
    <param name="disable_capabilities" value="move_group/ClearOctomapService"/>
</node>
```

May be useful for others as well. This functionality defaults to false/off if left unspecified and the current behavior is used where no padding values are used for self-collision checks. However if set to true and enabled, the padding values used for environment collision checks are also used for self-collision checks:

padding.yaml
```yaml
default_robot_padding: 0.05
default_robot_scale: 1.0
default_robot_link_padding: {   "base_link" : 0.05,
                                                   ......
                                              }
```

**Your environment**

- ROS Distro: Melodic
- OS Version: e.g. Ubuntu 18.04
- Source or Binary build? Source
- If source, which branch? Master
