### PR TITLE
Makes ompl template 'planning_adapters' argument optional

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -6,7 +6,7 @@
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
   <arg name="planning_adapters"
-       value="default_planner_request_adapters/AddTimeParameterization
+       default="default_planner_request_adapters/AddTimeParameterization
               default_planner_request_adapters/ResolveConstraintFrames
               default_planner_request_adapters/FixWorkspaceBounds
               default_planner_request_adapters/FixStartStateBounds


### PR DESCRIPTION
Simple pull request that makes sure that the `planning_adapters` argument in the [ompl_planning_pipeline.launch.xml](https://github.com/ros-planning/moveit/blob/master/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml) `moveit_setup_assistant` template launch file is optional. This change was already present in the [panda_moveit_config](https://github.com/ros-planning/panda_moveit_config/blob/melodic-devel/launch/ompl_planning_pipeline.launch.xml) repository.