### PR TITLE
Fixes setup_assistant custom planner ns problem

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -62,7 +62,7 @@
     </include>
 
     <!-- Support custom planning pipeline -->
-    <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])"
+    <include ns="$(arg pipeline)" if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])"
 	     file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>


### PR DESCRIPTION
### Description

While working on getting the Noetic branch of the panda_moveit_config ready (see https://github.com/rickstaa/panda_moveit_config/pull/26) I noticed that the namespace of custom planners is not set correctly. The current template causes the default chomp planner to be loaded and listed in the MotionPlanning plugin:

![image](https://user-images.githubusercontent.com/17570430/130854738-a66f123a-5a21-4ee0-898f-3b576229aded.png)
![image](https://user-images.githubusercontent.com/17570430/130854731-d3f7349a-ebb2-4a44-a955-74aeb73413ea.png)

While the stomp planner should be listed:

![image](https://user-images.githubusercontent.com/17570430/130854804-8a996b67-c1b0-49bf-8cb3-72ff0e577d34.png)
![image](https://user-images.githubusercontent.com/17570430/130854193-a9ce3223-6b13-44c2-9601-6aafc5d7a02f.png)

This bug might be new since the moveit_tutorial page shows [the right figure](https://ros-planning.github.io/moveit_tutorials/doc/stomp_planner/stomp_planner_tutorial.html).

## Steps to reproduce the issue

1. Clone my [panda_moveit_config branch](https://github.com/rickstaa/panda_moveit_config) inside a new catkin workspace.
2. Add [MoveIt](https://github.com/ros-planning/moveit) and [stomp_ros](https://github.com/ros-industrial/stomp_ros) to this same workspace.
2. Checkout the [rickstaa/panda_moveit_config/tree/adds_stomp_planner](https://github.com/rickstaa/panda_moveit_config/tree/adds_stomp_planner) branch.
3. Build the workspace
4. See the correct behaviour.
5. Checkout the [rickstaa/panda_moveit_config/tree/adds_stomp_planner_wrong](https://github.com/rickstaa/panda_moveit_config/tree/adds_stomp_planner) branch.
6. See the incorrect behaviour.