### PR TITLE
Adds 'kinematics.yaml' parameters to 'moveit_rviz.launch' template

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_rviz.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_rviz.launch
@@ -10,6 +10,7 @@
 
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
         args="$(arg command_args)" output="screen">
+    <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/kinematics.yaml"/>
   </node>
 
 </launch>


### PR DESCRIPTION
This commit gives users the ability to specify the kinematics parameters through the `kinematics.yaml` file. This change was already present in the [panda_moveit_config](https://github.com/ros-planning/panda_moveit_config/blob/e7e93fc30ec32e4b38fa0af4a8e69279c5a491f8/launch/moveit_rviz.launch#L13) repo, but I could not find it here.

Please let me know if the MoveIt package changed since ROS kinetic, and setting this parameter is no longer required. Or if there is another reason that these parameters for why these parameters are not set when using the  'moveit_setup_assistant' and a package name of `test_now`.

### Test

I tested this with the 'moveit_setup_assistant' and it does not break the config. The output is as follows:


```yaml
<launch>

  <arg name="debug" default="false" />
  <arg unless="$(arg debug)" name="launch_prefix" value="" />
  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />

  <arg name="rviz_config" default="" />
  <arg     if="$(eval rviz_config=='')" name="command_args" value="" />
  <arg unless="$(eval rviz_config=='')" name="command_args" value="-d $(arg rviz_config)" />

  <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
        args="$(arg command_args)" output="screen">
    <rosparam command="load" file="$(find tests_now)/config/kinematics.yaml"/>
  </node>

</launch>
```
The only warning that is thrown is:

```bash
No kinematics plugins defined. Fill and load kinematics.yaml!
```

But this warning is always present if you don't specify a kinematics plugin.
