### PR TITLE
Fixes Rviz Panel's box size Y and Z being inverted 

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -1026,7 +1026,7 @@ This is usually achieved by random seeding, which can flip the robot configurati
                </widget>
               </item>
               <item>
-               <widget class="QDoubleSpinBox" name="shape_size_z_spin_box">
+               <widget class="QDoubleSpinBox" name="shape_size_y_spin_box">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -1051,7 +1051,7 @@ This is usually achieved by random seeding, which can flip the robot configurati
                </widget>
               </item>
               <item>
-               <widget class="QDoubleSpinBox" name="shape_size_y_spin_box">
+               <widget class="QDoubleSpinBox" name="shape_size_z_spin_box">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                   <horstretch>0</horstretch>


### PR DESCRIPTION
### Description

Currently, when adding a box to the planning scene using the MoveIt RViz panel, the size of each axis is ordered **X, Z, Y**. This feels quite counter-intuitive, so I guess it might be a bug.

![image](https://user-images.githubusercontent.com/4281771/130994269-565c2f1e-60ac-49a3-8182-5fb5bb806f40.png)

![panel](https://user-images.githubusercontent.com/4281771/130997031-471463f9-9acc-4973-9fbe-913c68af17ea.png)

This PR swaps the Y and Z inputs order (making it X, Y, Z).

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
