### PR TITLE
Fixes *_planning_pipeline.launch template input args defaults

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
@@ -2,12 +2,12 @@
   <!-- CHOMP Plugin for MoveIt -->
   <arg name="planning_plugin" value="chomp_interface/CHOMPPlanner" />
 
-  <arg name="start_state_max_bounds_error" value="0.1" />
-  <arg name="jiggle_fraction" value="0.05" />
+  <arg name="start_state_max_bounds_error" default="0.1" />
+  <arg name="jiggle_fraction" default="0.05" />
   <!-- The request adapters (plugins) used when planning.
        ORDER MATTERS -->
   <arg name="planning_adapters"
-       value="default_planner_request_adapters/AddTimeParameterization
+       default="default_planner_request_adapters/AddTimeParameterization
               default_planner_request_adapters/ResolveConstraintFrames
               default_planner_request_adapters/FixWorkspaceBounds
               default_planner_request_adapters/FixStartStateBounds

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -6,7 +6,7 @@
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
   <arg name="planning_adapters"
-       value="default_planner_request_adapters/AddTimeParameterization
+       default="default_planner_request_adapters/AddTimeParameterization
               default_planner_request_adapters/ResolveConstraintFrames
               default_planner_request_adapters/FixWorkspaceBounds
               default_planner_request_adapters/FixStartStateBounds
@@ -14,8 +14,8 @@
               default_planner_request_adapters/FixStartStatePathConstraints"
               />
 
-  <arg name="start_state_max_bounds_error" value="0.1" />
-  <arg name="jiggle_fraction" value="0.05" />
+  <arg name="start_state_max_bounds_error" default="0.1" />
+  <arg name="jiggle_fraction" default="0.05" />
 
   <param name="planning_plugin" value="$(arg planning_plugin)" />
   <param name="request_adapters" value="$(arg planning_adapters)" />

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
@@ -5,7 +5,7 @@
 
   <!-- The request adapters (plugins) used when planning.
        ORDER MATTERS -->
-  <arg name="planning_adapters" value="" />
+  <arg name="planning_adapters" default="" />
 
   <param name="planning_plugin" value="$(arg planning_plugin)" />
   <param name="request_adapters" value="$(arg planning_adapters)" />

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
@@ -11,13 +11,13 @@
 
   <!-- The request adapters (plugins) used when planning with TrajOpt.
        ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+  <arg name="planning_adapters" default="default_planner_request_adapters/AddTimeParameterization
                                        default_planner_request_adapters/FixWorkspaceBounds
                                        default_planner_request_adapters/FixStartStateBounds
                                        default_planner_request_adapters/FixStartStateCollision
                                        default_planner_request_adapters/FixStartStatePathConstraints" />
 
-  <arg name="start_state_max_bounds_error" value="0.1" />
+  <arg name="start_state_max_bounds_error" default="0.1" />
 
   <param name="planning_plugin" value="$(arg planning_plugin)" />
   <param name="request_adapters" value="$(arg planning_adapters)" />


### PR DESCRIPTION
This commit makes sure that all input arguments of the *_planning_pipeline.launch templates do have a default value.

