### PR TITLE
Remove unnecessary subframes map copy

### DIFF
--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -347,10 +347,12 @@ void World::updateGlobalPosesInternal(ObjectPtr& obj, bool update_shape_poses, b
   // Update global subframe poses
   if (update_subframe_poses)
   {
-    obj->global_subframe_poses_ = obj->subframe_poses_;  // TODO (felixvd): Inefficient copy, but iterating through two
-                                                         // maps is complicated to write for this prototype
-    for (auto& pose_pair : obj->global_subframe_poses_)
-      pose_pair.second = obj->pose_ * pose_pair.second;
+    for (auto it_global_pose = obj->global_subframe_poses_.begin(), it_local_pose = obj->subframe_poses_.begin(),
+              end_poses = obj->global_subframe_poses_.end();
+         it_global_pose != end_poses; ++it_global_pose, ++it_local_pose)
+    {
+      it_global_pose->second = obj->pose_ * it_local_pose->second;
+    }
   }
 }
 

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -332,7 +332,7 @@ bool World::setSubframesOfObject(const std::string& object_id, const moveit::cor
     ASSERT_ISOMETRY(t.second)  // unsanitized input, could contain a non-isometry
   }
   obj_pair->second->subframe_poses_ = subframe_poses;
-
+  obj_pair->second->global_subframe_poses_ = subframe_poses;
   updateGlobalPosesInternal(obj_pair->second, false, true);
   return true;
 }


### PR DESCRIPTION
As noted in https://github.com/ros-planning/moveit/pull/2816, I left a quick-and-dirty solution in #2037 . This commit was supposed to fix that, but it has a bug.

It's probably simple, so I'm putting this up for someone to make me look stupid.