### PR TITLE
Fix pose-not-set-bug

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1718,9 +1718,8 @@ bool PlanningScene::shapesAndPosesFromCollisionObjectMessage(const moveit_msgs::
 
   bool switch_object_pose_and_shape_pose = false;
   if (num_shapes == 1)
-    if (object.pose.position.x == 0 && object.pose.position.y == 0 &&
-        object.pose.position.z == 0 && object.pose.orientation.x == 0 &&
-        object.pose.orientation.y == 0 && object.pose.orientation.z == 0 &&
+    if (object.pose.position.x == 0 && object.pose.position.y == 0 && object.pose.position.z == 0 &&
+        object.pose.orientation.x == 0 && object.pose.orientation.y == 0 && object.pose.orientation.z == 0 &&
         object.pose.orientation.w == 0)
     {
       switch_object_pose_and_shape_pose = true;  // If the object pose is not set but the shape pose is,

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1556,10 +1556,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::Attache
         const moveit::core::AttachedBody* ab = robot_state_->getAttachedBody(object.object.id);
 
         // Allow overriding the body's pose if provided, otherwise keep the old one
-        if (object.object.pose.position.x == 0 && object.object.pose.position.y == 0 &&
-            object.object.pose.position.z == 0 && object.object.pose.orientation.x == 0 &&
-            object.object.pose.orientation.y == 0 && object.object.pose.orientation.z == 0 &&
-            object.object.pose.orientation.w == 0)
+        if (moveit::core::isEmpty(object.object.pose))
           object_pose_in_link = ab->getPose();  // Keep old pose
 
         shapes.insert(shapes.end(), ab->getShapes().begin(), ab->getShapes().end());
@@ -1718,9 +1715,7 @@ bool PlanningScene::shapesAndPosesFromCollisionObjectMessage(const moveit_msgs::
 
   bool switch_object_pose_and_shape_pose = false;
   if (num_shapes == 1)
-    if (object.pose.position.x == 0 && object.pose.position.y == 0 && object.pose.position.z == 0 &&
-        object.pose.orientation.x == 0 && object.pose.orientation.y == 0 && object.pose.orientation.z == 0 &&
-        object.pose.orientation.w == 0)
+    if (moveit::core::isEmpty(object.pose))
     {
       switch_object_pose_and_shape_pose = true;  // If the object pose is not set but the shape pose is,
                                                  // use the shape's pose as the object pose.

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1718,9 +1718,14 @@ bool PlanningScene::shapesAndPosesFromCollisionObjectMessage(const moveit_msgs::
 
   bool switch_object_pose_and_shape_pose = false;
   if (num_shapes == 1)
-    if (object_pose.isApprox(Eigen::Isometry3d::Identity()))
+    if (object.pose.position.x == 0 && object.pose.position.y == 0 &&
+        object.pose.position.z == 0 && object.pose.orientation.x == 0 &&
+        object.pose.orientation.y == 0 && object.pose.orientation.z == 0 &&
+        object.pose.orientation.w == 0)
+    {
       switch_object_pose_and_shape_pose = true;  // If the object pose is not set but the shape pose is,
                                                  // use the shape's pose as the object pose.
+    }
 
   auto append = [&object_pose, &shapes, &shape_poses,
                  &switch_object_pose_and_shape_pose](shapes::Shape* s, const geometry_msgs::Pose& pose_msg) {

--- a/moveit_core/utils/include/moveit/utils/message_checks.h
+++ b/moveit_core/utils/include/moveit/utils/message_checks.h
@@ -45,6 +45,8 @@
 #include <moveit_msgs/PlanningSceneWorld.h>
 #include <moveit_msgs/RobotState.h>
 #include <moveit_msgs/Constraints.h>
+#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/Pose.h>
 
 namespace moveit
 {
@@ -61,5 +63,11 @@ bool isEmpty(const moveit_msgs::RobotState& msg);
 
 /** \brief Check if a message specifies constraints */
 bool isEmpty(const moveit_msgs::Constraints& msg);
+
+/** \brief Check if the message contains any non-zero entries */
+bool isEmpty(const geometry_msgs::Quaternion& msg);
+
+/** \brief Check if the message contains any non-zero entries */
+bool isEmpty(const geometry_msgs::Pose& msg);
 }  // namespace core
 }  // namespace moveit

--- a/moveit_core/utils/src/message_checks.cpp
+++ b/moveit_core/utils/src/message_checks.cpp
@@ -69,5 +69,15 @@ bool isEmpty(const moveit_msgs::Constraints& constr)
          constr.visibility_constraints.empty() && constr.joint_constraints.empty();
 }
 
+bool isEmpty(const geometry_msgs::Quaternion& msg)
+{
+  return msg.x == 0.0 && msg.y == 0.0 && msg.z == 0.0 && msg.w == 0.0;
+}
+
+bool isEmpty(const geometry_msgs::Pose& msg)
+{
+  return msg.position.x == 0.0 && msg.position.y == 0.0 && msg.position.z == 0.0 && isEmpty(msg.orientation);
+}
+
 }  // namespace core
 }  // namespace moveit


### PR DESCRIPTION
### Description

In #2816 , there was a fix for backwards compatibility for specifying a pose for a single collision shape. In that fix, I think there may be a bug. There is a check [here](https://github.com/ros-planning/moveit/blob/master/moveit_core/planning_scene/src/planning_scene.cpp#L1721) to determine if an object's pose has been set:
`if (object_pose.isApprox(Eigen::Isometry3d::Identity()))`

I think this check is problematic because if the pose is not set, all pose fields are zero. Checking if the pose is Identity assumes the unit quaternion which means that the "w" component is equal to 1. The way the code is currently, even if the object pose is set to identity, the shape pose will be used instead (which may not be aligned the same way as the object pose intended). This PR fixes this by explicitly checking that all fields of the object pose are zero.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
