### PR TITLE
update comments to current parameter name

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1308,36 +1308,36 @@ public:
       Values will be within default bounds. */
   void setToRandomPositions(const JointModelGroup* group, random_numbers::RandomNumberGenerator& rng);
 
-  /** \brief Set all joints in \e group to random values near the value in \near.
+  /** \brief Set all joints in \e group to random values near the value in \e seed.
    *  \e distance is the maximum amount each joint value will vary from the
-   *  corresponding value in \e near.  \distance represents meters for
+   *  corresponding value in \e seed.  \distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed, double distance);
 
-  /** \brief Set all joints in \e group to random values near the value in \near, using a specified random number generator.
+  /** \brief Set all joints in \e group to random values near the value in \e seed, using a specified random number generator.
    *  \e distance is the maximum amount each joint value will vary from the
-   *  corresponding value in \e near.  \distance represents meters for
+   *  corresponding value in \e seed.  \distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed, double distance,
                                   random_numbers::RandomNumberGenerator& rng);
 
-  /** \brief Set all joints in \e group to random values near the value in \near.
+  /** \brief Set all joints in \e group to random values near the value in \e seed.
    *  \e distances \b MUST have the same size as \c
    *  group.getActiveJointModels().  Each value in \e distances is the maximum
    *  amount the corresponding active joint in \e group will vary from the
-   *  corresponding value in \e near.  \distance represents meters for
+   *  corresponding value in \e seed.  \distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed,
                                   const std::vector<double>& distances);
 
-  /** \brief Set all joints in \e group to random values near the value in \near, using a specified random number generator.
+  /** \brief Set all joints in \e group to random values near the value in \e seed, using a specified random number generator.
    *  \e distances \b MUST have the same size as \c
    *  group.getActiveJointModels().  Each value in \e distances is the maximum
    *  amount the corresponding active joint in \e group will vary from the
-   *  corresponding value in \e near.  \distance represents meters for
+   *  corresponding value in \e seed.  \distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed,


### PR DESCRIPTION
I just saw these comments in #2799 and they should be updated.
We renamed the parameter earlier this year because MSVC apparently reserves "near" as a keyword.