### PR TITLE
use default copy constructor to clone attached object

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -177,9 +177,7 @@ void RobotState::copyFrom(const RobotState& other)
   // copy attached bodies
   clearAttachedBodies();
   for (const std::pair<const std::string, AttachedBody*>& it : other.attached_body_map_)
-    attachBody(it.second->getName(), it.second->getPose(), it.second->getShapes(), it.second->getShapePoses(),
-               it.second->getTouchLinks(), it.second->getAttachedLinkName(), it.second->getDetachPosture(),
-               it.second->getSubframes());
+    attachBody(new AttachedBody(*it.second));
 }
 
 bool RobotState::checkJointTransforms(const JointModel* joint) const


### PR DESCRIPTION
I stumbled upon this when helping @felixvd debug #2854  ... this PR would have prevented his long despair

C++ provides a default copy constructor if it reasonably can. `AttachedBody` is a simple data structure so indeed it can here. Using the copy constructor prevents forgetting to manually copy some member variables.