### PR TITLE
PS: do not list object as destroyed when they get attached

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1827,7 +1827,11 @@ bool PlanningScene::processCollisionObjectRemove(const moveit_msgs::CollisionObj
   else
   {
     if (!world_->removeObject(object.id))
+    {
+      ROS_WARN_STREAM_NAMED(LOGNAME,
+                            "Tried to remove world object '" << object.id << "', but it does not exist in this scene.");
       return false;
+    }
 
     removeObjectColor(object.id);
     removeObjectType(object.id);


### PR DESCRIPTION
The information in the diff is redundant because attaching an object implies its removal from the PlanningScene.
In the unlikely case you relied on the REMOVE entry in the diff message, use the newly attached collision object to indicate the same instead.

Since https://github.com/ros-planning/moveit/commit/fd88dd63469f2790b7d13864b425c813a2f95aa5 applying the message with both entries via `PlanningScene::usePlanningSceneMsg` fails, but messages generated by `PlanningScene::getPlanningSceneDiffMsg` should always be accepted there!

This currently breaks task execution through the MTC capability [here](https://github.com/ros-planning/moveit_task_constructor/blob/master/capabilities/src/execute_task_solution_capability.cpp#L179) whenever an object becomes attached (e.g., in the pick-place demo - aside from the missing frame issue).

Edit: also warn when anything tries to remove a world object that does not exist.