### PR TITLE
MPD: do not save/restore warehouse parameters

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -228,6 +228,16 @@ void MotionPlanningDisplay::onInitialize()
 
   rviz::WindowManagerInterface* window_context = context_->getWindowManager();
   frame_ = new MotionPlanningFrame(this, context_, window_context ? window_context->getParentWindow() : nullptr);
+
+  ros::NodeHandle move_group_nh(ros::names::append(getMoveGroupNS(), "move_group"));
+  std::string param_name;
+  std::string host_param;
+  int port;
+  if (move_group_nh.searchParam("warehouse_host", param_name) && move_group_nh.getParam(param_name, host_param))
+    frame_->ui_->database_host->setText(QString::fromStdString(host_param));
+  if (move_group_nh.searchParam("warehouse_port", param_name) && move_group_nh.getParam(param_name, port))
+    frame_->ui_->database_port->setValue(port);
+
   connect(frame_, SIGNAL(configChanged()), this->getModel(), SIGNAL(configChanged()));
   resetStatusTextColor();
   addStatusText("Initialized.");
@@ -1313,19 +1323,6 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
   PlanningSceneDisplay::load(config);
   if (frame_)
   {
-    QString host;
-    ros::NodeHandle nh;
-    std::string host_param;
-    if (config.mapGetString("MoveIt_Warehouse_Host", &host))
-      frame_->ui_->database_host->setText(host);
-    else if (nh.getParam("warehouse_host", host_param))
-    {
-      host = QString::fromStdString(host_param);
-      frame_->ui_->database_host->setText(host);
-    }
-    int port;
-    if (config.mapGetInt("MoveIt_Warehouse_Port", &port) || nh.getParam("warehouse_port", port))
-      frame_->ui_->database_port->setValue(port);
     float d;
     if (config.mapGetFloat("MoveIt_Planning_Time", &d))
       frame_->ui_->planning_time->setValue(d);
@@ -1373,8 +1370,7 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     }
     else
     {
-      std::string node_name = ros::names::append(getMoveGroupNS(), "move_group");
-      ros::NodeHandle nh(node_name);
+      ros::NodeHandle nh(ros::names::append(getMoveGroupNS(), "move_group"));
       double val;
       if (nh.getParam("default_workspace_bounds", val))
       {
@@ -1391,9 +1387,6 @@ void MotionPlanningDisplay::save(rviz::Config config) const
   PlanningSceneDisplay::save(config);
   if (frame_)
   {
-    config.mapSetValue("MoveIt_Warehouse_Host", frame_->ui_->database_host->text());
-    config.mapSetValue("MoveIt_Warehouse_Port", frame_->ui_->database_port->value());
-
     // "Options" Section
     config.mapSetValue("MoveIt_Planning_Time", frame_->ui_->planning_time->value());
     config.mapSetValue("MoveIt_Planning_Attempts", frame_->ui_->planning_attempts->value());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -147,7 +147,7 @@
           <item>
            <widget class="QLineEdit" name="database_host">
             <property name="text">
-             <string>127.0.0.1</string>
+             <string></string>
             </property>
            </widget>
           </item>
@@ -164,7 +164,7 @@
              <number>65535</number>
             </property>
             <property name="value">
-             <number>33829</number>
+             <number>0</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
If we reload these values from the config, setting the ROS parameters is much less useful. The correct db should be set in the parameters instead of the RViz config!
At least the *type* of warehouse_ros plugin (mongo or sqlite) cannot even be selected in the display, so you will probably need to meddle with the parameters anyway if you want to connect to a different db.

search for parameters warehouse_host/port because they are usually set at the top level, but you might want to set them differently for different move_groups.

I noticed the values in rviz are not updated when following [the new `warehouse_ros_sqlite` tutorial](https://github.com/ros-planning/moveit_tutorials/pull/658), but you would very much expect them to be!