### PR TITLE
Fix JointConstraintSampler

### DIFF
--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -67,7 +67,7 @@ public:
    *
    */
   JointConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
-    : ConstraintSampler(scene, group_name)
+    : ConstraintSampler(scene, group_name), random_number_generator_(new random_numbers::RandomNumberGenerator())
   {
   }
   /**
@@ -154,6 +154,11 @@ public:
     return SAMPLER_NAME;
   }
 
+  void setRandomSeed(const boost::uint32_t seed)
+  {
+    random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>(seed);
+  }
+
 protected:
   /// \brief An internal structure used for maintaining constraints on a particular joint
   struct JointInfo
@@ -191,7 +196,8 @@ protected:
 
   void clear() override;
 
-  random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random number generator used to sample */
+  std::unique_ptr<random_numbers::RandomNumberGenerator>
+      random_number_generator_;   /**< \brief Random number generator used to sample */
   std::vector<JointInfo> bounds_; /**< \brief The bounds for any joint with bounds that are more restrictive than the
                                      joint limits */
 
@@ -199,6 +205,8 @@ protected:
                                                              limits */
   std::vector<unsigned int> uindex_; /**< \brief The index of the unbounded joints in the joint state vector */
   std::vector<double> values_;       /**< \brief Values associated with this group to avoid continuously reallocating */
+  std::vector<const moveit::core::JointModel*>
+      continuous_jms_; /**< \brief The continuous revolute joints should enforce bounds after sampling */
 };
 
 /**

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -322,6 +322,16 @@ public:
     return joint_tolerance_below_;
   }
 
+  /**
+   * \brief Return whtehr it's joint type is continuous
+   *
+   * @return True if it is continuous, otherwise false
+   */
+  bool isJointContinous() const
+  {
+    return joint_is_continuous_;
+  }
+
 protected:
   const moveit::core::JointModel* joint_model_; /**< \brief The joint from the kinematic model for this constraint */
   bool joint_is_continuous_;                    /**< \brief Whether or not the joint is continuous */


### PR DESCRIPTION
### Description
 - For continous revolute joints, `constraint_samplers::JointConstraintSampler::JointInfo`'s bounds should not be limited by `moveit::core::VariableBounds`.
 - For example, if the desired position is `pi` and the tolerance bound is `[-0.3, 0.3]`, `JointConstraintSampler` should samples between `[pi - 0.3, pi]` or `[-pi, -pi + 0.3]`.
 - However, the current implementation samples only from `[pi - 0.3, pi]`.

Signed-off-by: Vinnam Kim <vinnam.kim@makinarocks.ai>

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
