### PR TITLE
Fixed Bullet collision checker not taking ACM defaults into account.

### DIFF
--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
@@ -65,7 +65,7 @@ inline bool acmCheck(const std::string& body_1, const std::string& body_2,
 
   if (acm != nullptr)
   {
-    if (acm->getEntry(body_1, body_2, allowed_type))
+    if (acm->getAllowedCollision(body_1, body_2, allowed_type))
     {
       if (allowed_type == collision_detection::AllowedCollision::Type::NEVER)
       {


### PR DESCRIPTION
### Description

The `acmCheck` method in `bullet_utils.h` directly looked up the relevant entry in the `AllowedCollisionMatrix`, ignoring any default values. This PR replaced the method call with `getAllowedCollision`, which appears to be the correct method (please review).

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
