### PR TITLE
PlanningSceneDisplay: always update the main scene node's pose

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -188,7 +188,7 @@ void PlanningSceneDisplay::onInitialize()
 {
   Display::onInitialize();
 
-  // the scene node that contains everything
+  // the scene node that contains everything and is located at the planning frame
   planning_scene_node_ = scene_node_->createChildSceneNode();
 
   if (robot_category_)
@@ -640,6 +640,8 @@ void PlanningSceneDisplay::update(float wall_dt, float ros_dt)
 
   executeMainLoopJobs();
 
+  calculateOffsetPosition();
+
   if (planning_scene_monitor_)
     updateInternal(wall_dt, ros_dt);
 }
@@ -652,7 +654,6 @@ void PlanningSceneDisplay::updateInternal(float wall_dt, float /*ros_dt*/)
        planning_scene_needs_render_))
   {
     renderPlanningScene();
-    calculateOffsetPosition();
     current_scene_time_ = 0.0f;
     robot_state_needs_render_ = false;
     planning_scene_needs_render_ = false;


### PR DESCRIPTION
This fixes https://github.com/ros-planning/moveit_task_constructor/issues/291.
We need to update the pose of the PlanningSceneDisplay's scene node in each update() cycle.
So far, it was only updated if the PlanningSceneMonitor received any update.

The following video illustrates the new (left) vs. the old=released behaviour (right):

https://user-images.githubusercontent.com/5376030/133408681-e76f08c1-79cc-49e1-beac-6e046b7f8bc0.mp4

Without this PR, the planning scene is only updated once when it gets initialized (or when joint updates are received, which is not the case here).