### PR TITLE
Temporarily pin orocos-kdl to fix cross-platform CI

### DIFF
--- a/.github/ci_cross_platform_env.yml
+++ b/.github/ci_cross_platform_env.yml
@@ -13,3 +13,4 @@ dependencies:
   - ros-distro-mutex 0.1 noetic
   - ros-noetic-catkin
   - ros-noetic-ros-environment
+  - orocos-kdl 1.5.0

--- a/.github/ci_cross_platform_env.yml
+++ b/.github/ci_cross_platform_env.yml
@@ -14,3 +14,4 @@ dependencies:
   - ros-noetic-catkin
   - ros-noetic-ros-environment
   - orocos-kdl 1.5.0
+  - python-orocos-kdl 1.5.0


### PR DESCRIPTION
### Description

Fix #2881 by pinning orocos-kdl to a working version.