### PR TITLE
[WIP] Issue 2889

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 API changes in MoveIt releases
 
 ## ROS Noetic
+- Renamed `addAttachedOjects` to `createAttachedCollisionObjects` in `CollisionEnvBullet` to reflect the non-mutating nature of the method.
 - `CollisionObject` messages are now defined with a `Pose`, and shapes and subframes are defined relative to the object's pose. This makes it easier to place objects with subframes and multiple shapes in the scene. This causes several changes:
     - `getFrameTransform()` now returns this pose instead of the first shape's pose.
     - The Rviz plugin's manipulation tab now uses the object's pose instead of the shape pose to evaluate if object's are in the region of interest.

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
@@ -96,7 +96,7 @@ protected:
   void updatedPaddingOrScaling(const std::vector<std::string>& links) override;
 
   /** \brief All of the attached objects in the robot state are wrapped into bullet collision objects */
-  void addAttachedOjects(const moveit::core::RobotState& state,
+  void createAttachedCollisionObjects(const moveit::core::RobotState& state,
                          std::vector<collision_detection_bullet::CollisionObjectWrapperPtr>& cows) const;
 
   /** \brief Bundles the different checkSelfCollision functions into a single function */

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_env_bullet.h
@@ -49,10 +49,10 @@ class CollisionEnvBullet : public CollisionEnv
 public:
   CollisionEnvBullet() = delete;
 
-  CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
+  CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0, max_rotation_per_step = M_PI/8.0);
 
   CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
-                     double scale = 1.0);
+                     double scale = 1.0, max_rotation_per_step = M_PI/8.0);
 
   CollisionEnvBullet(const CollisionEnvBullet& other, const WorldPtr& world);
 
@@ -144,5 +144,9 @@ private:
   void notifyObjectChange(const ObjectConstPtr& obj, World::Action action);
 
   World::ObserverHandle observer_handle_;
+
+  /** \brief For CCD queries, how much each link may rotate at most per step. **/
+  double max_rotation_per_step_;
+
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -185,7 +185,7 @@ void CollisionEnvBullet::checkRobotCollisionHelper(const CollisionRequest& req, 
   }
 
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
-  addAttachedOjects(state, attached_cows);
+  createAttachedCollisionObjects(state, attached_cows);
   updateTransformsFromState(state, manager_);
 
   for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -50,8 +50,8 @@ const double MAX_DISTANCE_MARGIN = 99;
 constexpr char LOGNAME[] = "collision_detection.bullet";
 }  // namespace
 
-CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding, double scale)
-  : CollisionEnv(model, padding, scale)
+CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, double padding, double scale, double max_rotation_per_step)
+: CollisionEnv(model, padding, scale), max_rotation_per_step_(max_rotation_per_step)
 {
   // request notifications about changes to new world
   observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, _1, _2));
@@ -63,8 +63,8 @@ CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& m
 }
 
 CollisionEnvBullet::CollisionEnvBullet(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world,
-                                       double padding, double scale)
-  : CollisionEnv(model, world, padding, scale)
+                                       double padding, double scale, double max_rotation_per_step)
+                                       : CollisionEnv(model, world, padding, scale), max_rotation_per_step_(max_rotation_per_step)
 {
   // request notifications about changes to new world
   observer_handle_ = getWorld()->addObserver(boost::bind(&CollisionEnvBullet::notifyObjectChange, this, _1, _2));
@@ -117,7 +117,7 @@ void CollisionEnvBullet::checkSelfCollisionHelper(const CollisionRequest& req, C
   std::lock_guard<std::mutex> guard(collision_env_mutex_);
 
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> cows;
-  addAttachedOjects(state, cows);
+  createAttachedCollisionObjects(state, cows);
 
   if (req.distance)
   {
@@ -211,26 +211,61 @@ void CollisionEnvBullet::checkRobotCollisionHelperCCD(const CollisionRequest& re
     // Ensure thread safety
   std::lock_guard<std::mutex> guard(collision_env_mutex_);
 
-  //
+  // Create collision objects for all attached objects
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
-  addAttachedOjects(state1, attached_cows);
+  createAttachedCollisionObjects(state1, attached_cows);
 
+  // Add those collision objects to the CCD collision manager.
   for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
   {
-    manager_CCD_->addCollisionObject(cow);
-    manager_CCD_->setCastCollisionObjectsTransform(
-        cow->getName(), state1.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0],
-        state2.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0]);
+      manager_CCD_->addCollisionObject(cow);
   }
 
-  for (const std::string& link : active_)
-  {
-    manager_CCD_->setCastCollisionObjectsTransform(link, state1.getCollisionBodyTransform(link, 0),
-                                                   state2.getCollisionBodyTransform(link, 0));
+  // Compute the number of sub-steps (segments in the motion).
+  size_t num_segments = std::min(std::ceil(state1.distanceRotation(state2)/max_rotation_per_step_),1);
+
+  // Compute the intermediate states through interpolation (number of segments - 1)
+  std::vector<moveit::core::RobotState> intermediate_states;
+  intermediate_states.reserve(num_segments-1);
+  for (size_t segment_idx = 1; segment_idx < num_segments; ++segment_idx) {
+      double t = (double) segment_idx / (double) num_segments;
+      moveit::core::RobotState st(state1);
+      state1.interpolate(state2, t, st);
+      intermediate_states.push_back(st);
   }
 
-  manager_CCD_->contactTest(res, req, acm, false);
+  // Go through the segments one-by-one.
+  for (size_t segment_idx = 0; segment_idx < num_segments; ++segment_idx) {
 
+      // Look up the start-and-end states of that segment.
+      const moveit::core::RobotState& st1 = segment_idx == 0 ? state1 : intermediate_states[segment_idx-1];
+      const moveit::core::RobotState& st2 = segment_idx == (num_segments-1) ? state2 : intermediate_states[segment_idx];
+
+      // Update the transforms, first for the attached objects...
+      for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
+      {
+          manager_CCD_->setCastCollisionObjectsTransform(
+                  cow->getName(),
+                  st1.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0],
+                  st2.getAttachedBody(cow->getName())->getGlobalCollisionBodyTransforms()[0]);
+      }
+
+      // ...and then the links themselves.
+      for (const std::string& link : active_)
+      {
+          manager_CCD_->setCastCollisionObjectsTransform(link,
+                                                         st1.getCollisionBodyTransform(link, 0),
+                                                         st2.getCollisionBodyTransform(link, 0));
+      }
+
+      // Perform the contact test
+      manager_CCD_->contactTest(res, req, acm, false);
+
+      // Stop the operation after the first collision.
+      if (res.collision) break;
+  }
+
+  // Remove the collision objects for the attached objects.
   for (const collision_detection_bullet::CollisionObjectWrapperPtr& cow : attached_cows)
   {
     manager_CCD_->removeCollisionObject(cow->getName());

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -208,8 +208,10 @@ void CollisionEnvBullet::checkRobotCollisionHelperCCD(const CollisionRequest& re
                                                       const moveit::core::RobotState& state2,
                                                       const AllowedCollisionMatrix* acm) const
 {
+    // Ensure thread safety
   std::lock_guard<std::mutex> guard(collision_env_mutex_);
 
+  //
   std::vector<collision_detection_bullet::CollisionObjectWrapperPtr> attached_cows;
   addAttachedOjects(state1, attached_cows);
 
@@ -324,7 +326,7 @@ void CollisionEnvBullet::notifyObjectChange(const ObjectConstPtr& obj, World::Ac
   }
 }
 
-void CollisionEnvBullet::addAttachedOjects(const moveit::core::RobotState& state,
+void CollisionEnvBullet::createAttachedCollisionObjects(const moveit::core::RobotState& state,
                                            std::vector<collision_detection_bullet::CollisionObjectWrapperPtr>& cows) const
 {
   std::vector<const moveit::core::AttachedBody*> attached_bodies;

--- a/moveit_core/robot_model/include/moveit/robot_model/fixed_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/fixed_joint_model.h
@@ -61,6 +61,7 @@ public:
   unsigned int getStateSpaceDimension() const override;
   double getMaximumExtent(const Bounds& other_bounds) const override;
   double distance(const double* values1, const double* values2) const override;
+  virtual double distanceRotation(const double* values1, const double* values2) const = 0;
 
   void computeTransform(const double* joint_values, Eigen::Isometry3d& transf) const override;
   void computeVariablePositions(const Eigen::Isometry3d& transf, double* joint_values) const override;

--- a/moveit_core/robot_model/include/moveit/robot_model/floating_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/floating_joint_model.h
@@ -80,7 +80,7 @@ public:
   bool normalizeRotation(double* values) const;
 
   /// Get the distance between the rotation components of two states
-  double distanceRotation(const double* values1, const double* values2) const;
+  double distanceRotation(const double* values1, const double* values2) const override;
 
   /// Get the distance between the translation components of two states
   double distanceTranslation(const double* values1, const double* values2) const;

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -348,6 +348,9 @@ public:
   /** \brief Compute the distance between two joint states of the same model (represented by the variable values) */
   virtual double distance(const double* value1, const double* value2) const = 0;
 
+  /** \brief Compute the total rotation angle in radians between two joint states (represented by the variable values) */
+  virtual double distanceRotation(const double* values1, const double* values2) const = 0;
+
   /** \brief Get the factor that should be applied to the value returned by distance() when that value is used in
    * compound distances */
   double getDistanceFactor() const

--- a/moveit_core/robot_model/include/moveit/robot_model/planar_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/planar_joint_model.h
@@ -61,6 +61,8 @@ public:
   unsigned int getStateSpaceDimension() const override;
   double getMaximumExtent(const Bounds& other_bounds) const override;
   double distance(const double* values1, const double* values2) const override;
+  double distanceRotation(const double* values1, const double* values2) const override;
+
 
   void computeTransform(const double* joint_values, Eigen::Isometry3d& transf) const override;
   void computeVariablePositions(const Eigen::Isometry3d& transf, double* joint_values) const override;

--- a/moveit_core/robot_model/include/moveit/robot_model/prismatic_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/prismatic_joint_model.h
@@ -63,6 +63,7 @@ public:
   unsigned int getStateSpaceDimension() const override;
   double getMaximumExtent(const Bounds& other_bounds) const override;
   double distance(const double* values1, const double* values2) const override;
+  double distanceRotation(const double* values1, const double* values2) const override;
 
   void computeTransform(const double* joint_values, Eigen::Isometry3d& transf) const override;
   void computeVariablePositions(const Eigen::Isometry3d& transf, double* joint_values) const override;

--- a/moveit_core/robot_model/include/moveit/robot_model/revolute_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/revolute_joint_model.h
@@ -63,6 +63,7 @@ public:
   unsigned int getStateSpaceDimension() const override;
   double getMaximumExtent(const Bounds& other_bounds) const override;
   double distance(const double* values1, const double* values2) const override;
+  double distanceRotation(const double* values1, const double* values2) const override;
 
   void computeTransform(const double* joint_values, Eigen::Isometry3d& transf) const override;
   void computeVariablePositions(const Eigen::Isometry3d& transf, double* joint_values) const override;

--- a/moveit_core/robot_model/src/fixed_joint_model.cpp
+++ b/moveit_core/robot_model/src/fixed_joint_model.cpp
@@ -80,6 +80,12 @@ double FixedJointModel::distance(const double* values1, const double* values2) c
   return 0.0;
 }
 
+double FixedJointModel::distanceRotation(const double* values1, const double* values2) const
+{
+    // A fixed joint never causes any rotation.
+    return 0.0;
+}
+
 double FixedJointModel::getMaximumExtent(const Bounds& other_bounds) const
 {
   return 0.0;

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -169,9 +169,16 @@ double PlanarJointModel::distance(const double* values1, const double* values2) 
   double dx = values1[0] - values2[0];
   double dy = values1[1] - values2[1];
 
-  double d = fabs(values1[2] - values2[2]);
-  d = (d > boost::math::constants::pi<double>()) ? 2.0 * boost::math::constants::pi<double>() - d : d;
-  return sqrt(dx * dx + dy * dy) + angular_distance_weight_ * d;
+  return sqrt(dx * dx + dy * dy) + angular_distance_weight_ * distanceRotation(values1, values2);
+}
+
+double PlanarJointModel::distanceRotation(const double* values1, const double* values2) const {
+    // Difference between the angular component of both sets of joint values.
+    double d = fabs(values1[2] - values2[2]);
+    // Wrap around to normalize within [-pi,pi] range
+    d = (d > boost::math::constants::pi<double>()) ? 2.0 * boost::math::constants::pi<double>() - d : d;
+
+    return d;
 }
 
 bool PlanarJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const

--- a/moveit_core/robot_model/src/prismatic_joint_model.cpp
+++ b/moveit_core/robot_model/src/prismatic_joint_model.cpp
@@ -111,6 +111,11 @@ double PrismaticJointModel::distance(const double* values1, const double* values
   return fabs(values1[0] - values2[0]);
 }
 
+double PrismaticJointModel::distanceRotation(const double* values1, const double* values2) const
+{
+    return 0.0; // Prismatic joints do not rotate
+}
+
 void PrismaticJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
 {
   state[0] = from[0] + (to[0] - from[0]) * t;

--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -158,6 +158,11 @@ double RevoluteJointModel::distance(const double* values1, const double* values2
     return fabs(values1[0] - values2[0]);
 }
 
+double RevoluteJointModel::distanceRotation(const double* values1, const double* values2) const
+{
+    return distance(values1,values2); // Revolute joints are simply a rotation.
+}
+
 bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   if (continuous_)

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1502,6 +1502,9 @@ public:
   /** \brief Return the sum of joint distances to "other" state. Only considers active joints. */
   double distance(const RobotState& other, const JointModelGroup* joint_group) const;
 
+  /** \brief Return an upper bound on the rotation angle (radians) of any one link of the robot between two states. */
+  double maximumRotation(const RobotState& other, const JointModelGroup* joint_group) const;
+
   /** \brief Return the sum of joint distances to "other" state. Only considers active joints. */
   double distance(const RobotState& other, const JointModel* joint) const
   {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -920,6 +920,17 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
   return d;
 }
 
+double RobotState::maximumRotation(const RobotState& other, const JointModelGroup* joint_group) const {
+    double d = 0.0;
+    const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
+    for (const JointModel* joint : jm)
+    {
+        const int idx = joint->getFirstVariableIndex();
+        d += joint->distanceRotation(position_ + idx, other.position_ + idx);
+    }
+    return d;
+}
+
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
   moveit::core::checkInterpolationParamBounds(LOGNAME, t);


### PR DESCRIPTION
### Description

See the discussion in Issue #2889.

TL;DR: Bullet-based CCD is currently implemented by taking the pairwise convex hulls of each collision ibject in the robot model in the "before" and "after" states, and performing a collision test against that.

If the robot's movement is a pure translation (and assuming all collision objects are convex), this corresponds perfectly with the swept volume of the robot during this movement. However, if the movement includes rotation, especially with large swinging motions, this is a severe under-approximation.

What this PR contributes is the addition of sub-steps in the collision detection method depending on the amount of rotation in the motion. This has the advantage of allowing for very few (if any) sub-steps for linear or near-linear motions, but still providing a far better approximation if there is rotation in the movement.

I specifically made the following changes:
- Added `JointModel::distanceRotation` as a virtual method to get an idea of the rotation induced by a state change on a per-joint basis. Name is borrowed from `FloatingJointModel` for consistency; change should be non-breaking for that class.
- Added `RobotState::maximumRotation` which combines the per-joint rotations to compute an upper bound on every link's rotation.
- Made necessary changes to `CollisionEnvBullet::checkRobotCollisionHelperCCD` and added a parameter `max_rotation_per_step_` that controls the number of sub-steps.

PR is currently WIP since I'd like some feedback on whether this method works as I'd expect, and on how to best test it.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
