### PR TITLE
Servo: sync position limit enforcement with MoveIt2

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -148,7 +148,7 @@ private:
   void enforceVelLimits(Eigen::ArrayXd& delta_theta);
 
   /** \brief Avoid overshooting joint limits */
-  bool enforcePositionLimits(sensor_msgs::msg::JointState& joint_state);
+  bool enforcePositionLimits(sensor_msgs::JointState& joint_state);
 
   /** \brief Possibly calculate a velocity scaling factor, due to proximity of
    * singularity and direction of motion

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -779,7 +779,7 @@ void ServoCalcs::enforceVelLimits(Eigen::ArrayXd& delta_theta)
   delta_theta = velocity_scaling_factor * velocity * parameters_.publish_period;
 }
 
-bool ServoCalcs::enforcePositionLimits(sensor_msgs::msg::JointState& joint_state)
+bool ServoCalcs::enforcePositionLimits(sensor_msgs::JointState& joint_state)
 {
   bool halting = false;
 
@@ -807,9 +807,9 @@ bool ServoCalcs::enforcePositionLimits(sensor_msgs::msg::JointState& joint_state
         auto joint_idx = std::distance(joint_state.name.begin(), joint_itr);
 
         if ((joint_state.velocity.at(joint_idx) < 0 &&
-             (joint_angle < (limits[0].min_position + parameters_->joint_limit_margin))) ||
+             (joint_angle < (limits[0].min_position + parameters_.joint_limit_margin))) ||
             (joint_state.velocity.at(joint_idx) > 0 &&
-             (joint_angle > (limits[0].max_position - parameters_->joint_limit_margin))))
+             (joint_angle > (limits[0].max_position - parameters_.joint_limit_margin))))
         {
           ROS_WARN_STREAM_THROTTLE_NAMED(ROS_LOG_THROTTLE_PERIOD, LOGNAME,
                                          ros::this_node::getName() << " " << joint->getName()


### PR DESCRIPTION
### Description
I was working on a project with @parunapu and we noticed an interesting behavior when using moveit_servo streaming velocity commands where joint limits would be exceeded. Upon further investigation I noticed in the [enforcePositionLimits()](https://github.com/ros-planning/moveit/blob/master/moveit_ros/moveit_servo/src/servo_calcs.cpp#L805) function that the current state velocities would be checked along with the joint position limits such that we only "halt if we are past a joint margin and joint velocity is moving even further past" (as described in a comment earlier in the function). The problem is that the check is for velocities greater or below zero which means that when the velocities become zero on that cycle, then on the next iteration, enforcePositionLImits() will return that everything is normal and a small delta velocity will actually end up being commanded. This will lead to a continuous jerky cycle of starts and stops violating the joint limit that we don't want. A simple fix would be to only check position limits with the margins but that would not take into account whether we are moving away or not from the limit. Hence, this fix simply uses the velocities already calculated in the `internal_joint_state_` variable to check if the command we want to send is going even further than the limit or not.

@AndyZe, let me know if this change makes sense.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
