### PR TITLE
Off-by-one error in servo_calcs.cpp Melodic branch

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -602,10 +602,11 @@ void ServoCalcs::insertRedundantPointsIntoTrajectory(trajectory_msgs::JointTraje
 {
   joint_trajectory.points.resize(count);
   auto point = joint_trajectory.points[0];
-  // Start from 2 because we already have the first point. End at count+1 so (total #) == count
-  for (int i = 2; i < count; ++i)
+  // Start from 2nd point because we already have the first point. 
+  // Timestamps should also be shifted up one period
+  for (int i = 1; i < count; ++i)
   {
-    point.time_from_start = ros::Duration(i * parameters_.publish_period);
+    point.time_from_start = ros::Duration( (i+1) * parameters_.publish_period);
     joint_trajectory.points[i] = point;
   }
 }


### PR DESCRIPTION
### Description
Servo server trajectory output incorrect.

- The 2nd point in the trajectory (instead of third) should be taken and the timestamp should also be shifted to the correct point.

- Minor fix that wasn't back-ported to the Melodic version

- Corresponding pull request: #2740 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
