### PR TITLE
broken melodic backport for default speed factors

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -124,10 +124,8 @@ public:
     goal_orientation_tolerance_ = 1e-3;  // ~0.1 deg
     allowed_planning_time_ = 5.0;
     num_planning_attempts_ = 1;
-    node_handle_.param<double>("robot_description_planning/default_velocity_scaling_factor",
-                               max_velocity_scaling_factor_, 0.1);
-    node_handle_.param<double>("robot_description_planning/default_acceleration_scaling_factor",
-                               max_acceleration_scaling_factor_, 0.1);
+    max_velocity_scaling_factor_ = 1.0;
+    max_acceleration_scaling_factor_ = 1.0;
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())


### PR DESCRIPTION
@tylerjw accidentally backported [a single change](https://github.com/ros-planning/moveit/pull/2630/commits/5b5d42e2f032b2c53a1d68886d95c6ab8841dc14) from the #1890 feature set to melodic [in May](https://github.com/ros-planning/moveit/pull/2630) and nobody noticed.

I vote to revert the commit in melodic even though we already released it there, accidentally breaking behavior on melodic once when the documentation says the change only exists in noetic.