### PR TITLE
CI: Generate API docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,45 @@
+name: API docs
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  docs:
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [noetic]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: addnab/docker-run-action@v3
+        name: Build API docs
+        with:
+          image: moveit/moveit:${{ matrix.ROS_DISTRO }}-source
+          options: -v /tmp/docs:/tmp/docs
+          shell: bash
+          run: |
+            # install required packages
+            apt-get -q update
+            PYTHON=python${{ matrix.ROS_DISTRO == 'noetic' && '3' || '' }}
+            apt-get -q install -y ros-${{ matrix.ROS_DISTRO }}-rosdoc-lite $PYTHON-sphinx-rtd-theme $PYTHON-pip
+            # We need a much more recent version of sphinx
+            $PYTHON -m pip install -U sphinx
+            # source workspace
+            source install/setup.bash
+            # iterate over all packages in topological order
+            while read -r -a line; do
+              set -- "${line[@]}"
+              pkg_name=$1
+              pkg_path=$2
+              rosdoc_lite -o /tmp/docs/$pkg_name src/moveit/$pkg_path
+            done <<< $(catkin_topological_order src/moveit)
+
+      - name: Deploy API docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
+          publish_dir: /tmp/docs
+          external_repository: ros-planning/moveit_tutorials
+          destination_dir: api


### PR DESCRIPTION
Initial attempt to deploy C++ and Python API docs ourselves (via GHA instead of ROS buildfarm). Fixes #2606.
For now, docs are deployed to [`https://ros-planning.github.io/moveit_tutorials/api/<package>/html`](https://ros-planning.github.io/moveit_tutorials/api/moveit_core/html).

TODOs:
- [ ] Decide about the deploy target location. Ideally, we would deploy to [`http://docs.ros.org/en/noetic/api/<package>/html`](http://docs.ros.org/en/noetic/api/moveit_core/html)
@tfoote, please think about that option.
- [ ] If we stick with `moveit.ros.org` or `moveit_tutorials`, we should create a landing page 
  at https://ros-planning.github.io/moveit_tutorials/api.
- [ ] Only trigger deploy process from `ros-planning` repo on a push