### PR TITLE
Normalize incoming transforms

### DIFF
--- a/moveit_core/transforms/src/transforms.cpp
+++ b/moveit_core/transforms/src/transforms.cpp
@@ -130,7 +130,8 @@ void Transforms::setTransform(const geometry_msgs::TransformStamped& transform)
 {
   if (sameFrame(transform.child_frame_id, target_frame_))
   {
-    // manually convert to ensure correct normalization (transforms from Gazebo have float accuracy only?)
+    // convert message manually to ensure correct normalization for double (error < 1e-12)
+    // tf2 only enforces float normalization (error < 1e-5)
     const auto& trans = transform.transform.translation;
     const auto& rot = transform.transform.rotation;
     Eigen::Translation3d translation(trans.x, trans.y, trans.z);


### PR DESCRIPTION
When running the MoveIt-Gazebo tutorial on a `Debug` build, I noticed that transforms (`panda_NE` -> `world`) published by Gazebo have imperfectly normalized quaternions (being off by 10^-5), which makes move_group crash with the following assertion:
```
The given transform is not an isometry! Its linear part involves non-unit scaling.
The scaling matrix diagonal differs from [1 1 1] by [-2.10082e-07 -1.11787e-05 -1.10814e-05] but the required precision is 1e-12.
```
Maybe, at some point, we should explicitly normalize transforms (received from external).