### PR TITLE
Updates 'moveit.rosinstall' panda_moveit_config branch

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -31,4 +31,4 @@
 - git:
     local-name: panda_moveit_config
     uri: https://github.com/ros-planning/panda_moveit_config.git
-    version: melodic-devel
+    version: noetic-devel


### PR DESCRIPTION
This pull request changes the [panda_moveit_config](https://github.com/ros-planning/panda_moveit_config/tree/noetic-devel) branch in the `moveit.rosinstall` file to `noetic-devel`. This needs to be done since the [noetic-devel](https://github.com/ros-planning/panda_moveit_config/tree/noetic-devel) branch has been released. 

Needed for the [getting started](https://ros-planning.github.io/moveit_tutorials/doc/getting_started/getting_started.html) moveit_tutorials.