### PR TITLE
moveit_controller_manager.launch: pass execution_type via pass_all_args

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
@@ -17,6 +17,8 @@
 
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="[ROBOT_NAME]" />
+  <!-- We use pass_all_args=true here to pass execution_type, which is required by fake controllers, but not by real-robot controllers.
+       As real-robot controller_manager.launch files shouldn't be required to define this argument, we use the trick of passing all args. -->
   <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" pass_all_args="true" />
 
 </launch>


### PR DESCRIPTION
While we need to pass `execution_type` to `fake_moveit_controller_manager.launch`, the `controller_manager.launch` files of real robots shouldn't be required to define this argument. However, if they don't, `roslaunch` fails with an `unused args` exception.
Passing the argument via `pass_all_args="true"` should solve that issue.
Fixes  #2786.