### PR TITLE
Fix win cross platform

### DIFF
--- a/.github/workflows/cross_platform_ci.yml
+++ b/.github/workflows/cross_platform_ci.yml
@@ -24,7 +24,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@v10
       with:
         environment-file: .github/ci_cross_platform_env.yml
-        micromamba-version: latest
+        micromamba-version: 0.17.0
 
     - name: Set up MoveIt Core Dependencies on Unix
       if: runner.os == 'Linux' || runner.os == 'macOS'


### PR DESCRIPTION
### Description

The problem with the micromamba action was that we referred to `main` which is the head branch of the github action. Better to use a known release. 

The "breaking" change in the github action was that we are now extracting the `micromamba` binary to another path that was apparently not on `PATH` and thus `which("micromamba.exe")` wasn't working as expected. 

This pins the github action version to `v10` (latest release) and also pins the `micromamba` release to the current latest `0.17.0` so that we have fewer surprises.

In the meantime I'll make sure that we re-add micromamba to the `PATH` in the github action :)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
