### PR TITLE
Reduced the minimum max velocity joint limit from 0.01 to 0.001 for totg

### DIFF
--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -932,17 +932,25 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     max_velocity[j] = 1.0;
     if (bounds.velocity_bounded_)
     {
+      if (bounds.max_velocity_ < std::numeric_limits<double>::epsilon())
+      {
+        ROS_ERROR_NAMED(LOGNAME, "Invalid max_velocity %f specified for '%s', must be greater than 0.0", bounds.max_velocity_ , vars[j].c_str());
+        return false;
+      }
       max_velocity[j] =
           std::min(std::fabs(bounds.max_velocity_), std::fabs(bounds.min_velocity_)) * velocity_scaling_factor;
-      max_velocity[j] = std::max(0.001, max_velocity[j]);
     }
 
     max_acceleration[j] = 1.0;
     if (bounds.acceleration_bounded_)
     {
+      if (bounds.max_acceleration_ < std::numeric_limits<double>::epsilon())
+      {
+        ROS_ERROR_NAMED(LOGNAME, "Invalid max_acceleration %f specified for '%s', must be greater than 0.0", bounds.max_acceleration_, vars[j].c_str());
+        return false;
+      }
       max_acceleration[j] = std::min(std::fabs(bounds.max_acceleration_), std::fabs(bounds.min_acceleration_)) *
                             acceleration_scaling_factor;
-      max_acceleration[j] = std::max(0.001, max_acceleration[j]);
     }
   }
 

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -934,7 +934,8 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     {
       if (bounds.max_velocity_ < std::numeric_limits<double>::epsilon())
       {
-        ROS_ERROR_NAMED(LOGNAME, "Invalid max_velocity %f specified for '%s', must be greater than 0.0", bounds.max_velocity_ , vars[j].c_str());
+        ROS_ERROR_NAMED(LOGNAME, "Invalid max_velocity %f specified for '%s', must be greater than 0.0",
+                        bounds.max_velocity_, vars[j].c_str());
         return false;
       }
       max_velocity[j] =
@@ -946,7 +947,8 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     {
       if (bounds.max_acceleration_ < std::numeric_limits<double>::epsilon())
       {
-        ROS_ERROR_NAMED(LOGNAME, "Invalid max_acceleration %f specified for '%s', must be greater than 0.0", bounds.max_acceleration_, vars[j].c_str());
+        ROS_ERROR_NAMED(LOGNAME, "Invalid max_acceleration %f specified for '%s', must be greater than 0.0",
+                        bounds.max_acceleration_, vars[j].c_str());
         return false;
       }
       max_acceleration[j] = std::min(std::fabs(bounds.max_acceleration_), std::fabs(bounds.min_acceleration_)) *

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -934,7 +934,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     {
       max_velocity[j] =
           std::min(std::fabs(bounds.max_velocity_), std::fabs(bounds.min_velocity_)) * velocity_scaling_factor;
-      max_velocity[j] = std::max(0.01, max_velocity[j]);
+      max_velocity[j] = std::max(0.001, max_velocity[j]);
     }
 
     max_acceleration[j] = 1.0;
@@ -942,7 +942,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     {
       max_acceleration[j] = std::min(std::fabs(bounds.max_acceleration_), std::fabs(bounds.min_acceleration_)) *
                             acceleration_scaling_factor;
-      max_acceleration[j] = std::max(0.01, max_acceleration[j]);
+      max_acceleration[j] = std::max(0.001, max_acceleration[j]);
     }
   }
 


### PR DESCRIPTION
### Description

Currently the minimum value you can specify for the the max velocity outputted for a joint during time optimal trajectory parameterization is 0.01 rad/s or m/s. For joints that are unable to move that fast and whose velocity limits are less than 0.01, the planned path outputted is unachievable with trajectory velocities being higher than the maximum velocity of the joint. 

Reduced the value to 0.001.
