### PR TITLE
Rework ACM defaults

### DIFF
--- a/.github/workflows/upstream.rosinstall
+++ b/.github/workflows/upstream.rosinstall
@@ -6,3 +6,7 @@
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
     version: noetic-devel
+- git:
+    local-name: srdfdom
+    uri: https://github.com/ubi-agni/srdfdom
+    version: noetic-devel

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -149,12 +149,14 @@ public:
   void setEntry(const std::string& name1, const std::string& name2, const DecideContactFn& fn);
 
   /** @brief Set the entries corresponding to a name.
-   *  With each of the the known names in the collision matrix, form a pair using the name
+   *  With each of the *known names* in the collision matrix, form a pair using the name
    *  specified as argument to this function and set the entry as indicated by \e allowed.
+   *  As the set of known names might change in future, consider using setDefaultEntry() instead!
    *  @param name the object name
    *  @param allowed If false, indicates that collisions between two elements must be checked for and no collisions
    *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between two elements are ok and an
    *  explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
+  void setEntry(const std::string& name, bool allowed);
 
   /** @brief Set multiple entries. Pairs of names are formed using \e name and \e other_names
    *  @param name name of first element

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -94,37 +94,36 @@ public:
   /** @brief Copy constructor */
   AllowedCollisionMatrix(const AllowedCollisionMatrix& acm) = default;
 
-  /** @brief Get the type of the allowed collision between two elements. Return true if the entry is included in the
-   * collision matrix.
-   * Return false if the entry is not found.
+  /** @brief Get the type of the allowed collision between two elements.
+   *  Return true if the entry is included in the collision matrix. Return false if the entry is not found.
    *  @param name1 name of first element
    *  @param name2 name of second element
    *  @param allowed_collision_type The allowed collision type will be filled here */
   bool getEntry(const std::string& name1, const std::string& name2,
                 AllowedCollision::Type& allowed_collision_type) const;
 
-  /** @brief Get the allowed collision predicate between two elements. Return true if a predicate for entry is included
-   * in the collision matrix
-   * (if the type is AllowedCollision::CONDITIONAL). Return false if the entry is not found.
+  /** @brief Get the allowed collision predicate between two elements.
+   *  Return true if a predicate for this entry is available in the collision matrix.
+   *  Return false if the entry is not found.
    *  @param name1 name of first element
    *  @param name2 name of second element
    *  @param fn A callback function that is used to decide if collisions are allowed between the two elements is filled
    * here */
   bool getEntry(const std::string& name1, const std::string& name2, DecideContactFn& fn) const;
 
-  /** @brief Check if the allowed collision matrix has an entry at all for an element. Returns true if the element is
-   * included.
+  /** @brief Check if the allowed collision matrix has an entry at all for an element.
+   *  Returns true if the element is included.
    *  @param name name of the element */
   bool hasEntry(const std::string& name) const;
 
-  /** @brief Check if the allowed collision matrix has an entry for a pair of elements. Returns true if the pair is
-   * included.
+  /** @brief Check if the allowed collision matrix has an entry for a pair of elements.
+   *  Returns true if the pair is included.
    *  @param name1 name of first element
    *  @param name2 name of second element*/
   bool hasEntry(const std::string& name1, const std::string& name2) const;
 
-  /** @brief Remove an entry corresponding to a pair of elements. Nothing happens if the pair does not exist in the
-   * collision matrix.
+  /** @brief Remove an entry corresponding to a pair of elements.
+   *  Nothing happens if the pair does not exist in the collision matrix.
    *  @param name1 name of first element
    *  @param name2 name of second element*/
   void removeEntry(const std::string& name1, const std::string& name2);
@@ -138,27 +137,24 @@ public:
    *  @param name2 name of second element
    *  @param allowed If false, indicates that collisions between two elements must be checked for and no collisions
    *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between two elements are ok and an
-   * explicit collision
-   *  computation is not necessary (AllowedCollision::ALWAYS).*/
+   *  explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
   void setEntry(const std::string& name1, const std::string& name2, bool allowed);
 
-  /** @brief Set an entry corresponding to a pair of elements. This sets the type of the entry to
-   * AllowedCollision::CONDITIONAL.
+  /** @brief Set an entry corresponding to a pair of elements.
+   *
+   *  This sets the type of the entry to AllowedCollision::CONDITIONAL.
    *  @param name1 name of first element
    *  @param name2 name of second element
-   *  @param fn A callback function that is used to decide if collisions are allowed between the two elements is
-   * expected here */
+   *  @param fn A callback function that is used to decide if collisions are allowed between the two elements */
   void setEntry(const std::string& name1, const std::string& name2, const DecideContactFn& fn);
 
-  /** @brief Set the entries corresponding to a name. With each of the the known names in the collision matrix, form a
-   * pair using the name
-   * specified as argument to this function and set the entry as indicated by \e allowed.
+  /** @brief Set the entries corresponding to a name.
+   *  With each of the the known names in the collision matrix, form a pair using the name
+   *  specified as argument to this function and set the entry as indicated by \e allowed.
    *  @param name the object name
    *  @param allowed If false, indicates that collisions between two elements must be checked for and no collisions
    *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between two elements are ok and an
-   * explicit collision
-   *  computation is not necessary (AllowedCollision::ALWAYS).*/
-  void setEntry(const std::string& name, bool allowed);
+   *  explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
 
   /** @brief Set multiple entries. Pairs of names are formed using \e name and \e other_names
    *  @param name name of first element
@@ -166,8 +162,7 @@ public:
    *  matrix entries will be set for all such pairs.
    *  @param allowed If false, indicates that collisions between two elements must be checked for and no collisions
    *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between two elements are ok and an
-   * explicit collision
-   *  computation is not necessary (AllowedCollision::ALWAYS).*/
+   *  explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
   void setEntry(const std::string& name, const std::vector<std::string>& other_names, bool allowed);
 
   /** @brief Set an entry corresponding to all possible pairs between two sets of elements
@@ -175,15 +170,13 @@ public:
    *  @param names2 Second set of names
    *  @param allowed If false, indicates that collisions between two elements must be checked for and no collisions
    *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between two elements are ok and an
-   * explicit collision
-   *  computation is not necessary (AllowedCollision::ALWAYS).*/
+   *  explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
   void setEntry(const std::vector<std::string>& names1, const std::vector<std::string>& names2, bool allowed);
 
   /** @brief Set an entry corresponding to all known pairs
    *  @param allowed If false, indicates that collisions between two elements must be checked for and no collisions
    *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between two elements are ok and an
-   * explicit collision
-   *  computation is not necessary (AllowedCollision::ALWAYS).*/
+   *  explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
   void setEntry(bool allowed);
 
   /** @brief Get all the names known to the collision matrix */

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -194,65 +194,42 @@ public:
     return entries_.size();
   }
 
-  /** @brief Set the default value for entries that include \e name. If such a default value is set, queries to
-   * getAllowedCollision() that include
-   *  \e name will return this value instead, @b even if a pair that includes \e name was previously specified with
-   * setEntry().
+  /** @brief Set the default value for entries that include \e name but are not set explicity with setEntry().
    *  @param name The name of the element for which to set the default value
    *  @param allowed If false, indicates that collisions between \e name and any other element must be checked for and
-   * no collisions
-   *  will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between \e name and any other
-   * element are ok and
-   *  an explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
+   *  no collisions will be ignored (AllowedCollision::NEVER). If true, indicates that collisions between \e name and
+   *  any other element are ok and an explicit collision computation is not necessary (AllowedCollision::ALWAYS).*/
   void setDefaultEntry(const std::string& name, bool allowed);
 
-  /** @brief Set the default value for entries that include \e name to be AllowedCollision::CONDITIONAL and specify the
-   * allowed contact predicate to be \e fn.
-   *  If this function is called, queries to getAllowedCollision() that include \e name will return this value instead,
-   * @b even if a pair that includes \e name
-   *  was previously specified with setEntry().
+  /** @brief Set the default value for entries that include \e name but are not set explicity with setEntry().
    *  @param name The name of the element for which to set the default value
    *  @param fn A callback function that is used to decide if collisions are allowed between \e name and some other
-   * element is expected here. */
+   *  element is expected here. */
   void setDefaultEntry(const std::string& name, const DecideContactFn& fn);
 
-  /** @brief Get the type of the allowed collision between to be considered by default for an element. Return true if a
-   * default value was
-   *  found for the specified element. Return false otherwise.
+  /** @brief Get the type of the allowed collision to be considered by default for an element.
+   *  Return true if a default value was found for the specified element. Return false otherwise.
    *  @param name name of the element
    *  @param allowed_collision The default allowed collision type will be filled here */
   bool getDefaultEntry(const std::string& name, AllowedCollision::Type& allowed_collision) const;
 
-  /** @brief Get the type of the allowed collision between to be considered by default for an element. Return true if a
-   * default value was
-   *  found for the specified element. Return false otherwise.
+  /** @brief Get the type of the allowed collision between to be considered by default for an element.
+   *  Return true if a default value was found for the specified element. Return false otherwise.
    *  @param name name of the element
-   *  @param fn A callback function that is used to decide if collisions are allowed between the two elements is filled
-   * here. */
+   *  @param fn Return the callback function that is used to decide if collisions are allowed between the two elements. */
   bool getDefaultEntry(const std::string& name, DecideContactFn& fn) const;
 
-  /** @brief Get the allowed collision predicate between two elements. Return true if a predicate for entry is included
-   * in the collision matrix
-   *  (if the type is AllowedCollision::CONDITIONAL) or if one was computed from defaults. Return false if the entry is
-   * not found.
-   *  Default values take precedence. If a default value is specified  for either \e name1 or \e name2, that value is
-   * returned instead (if both
-   *  elements have default values specified, both predicates must be satisfied). If no default values are specified,
-   * getEntry() is used to look
-   *  for the pair (\e name1, \e name2).
+  /** @brief Get the allowed collision predicate between two elements.
+   *  Return true if a predicate for entry is included in the collision matrix (if the type is AllowedCollision::CONDITIONAL)
+   *  or if one was computed from defaults. Return false if the entry is not found.
    *  @param name1 name of first element
    *  @param name2 name of second element
-   *  @param fn A callback function that is used to decide if collisions are allowed between the two elements is filled
-   * here */
+   *  @param fn Return the callback function that is used to decide if collisions are allowed between the two elements. */
   bool getAllowedCollision(const std::string& name1, const std::string& name2, DecideContactFn& fn) const;
 
-  /** @brief Get the type of the allowed collision between two elements. Return true if the entry is included in the
-   * collision matrix or if
-   *  specified defaults were found. Return false if the entry is not found. Default values take precedence. If a
-   * default value is specified
-   *  for either \e name1 or \e name2, that value is returned instead (if both elements have default values specified,
-   * AllowedCollision::NEVER takes
-   *  precedence). If no default values are specified, getEntry() is used to look for the pair (\e name1, \e name2).
+  /** @brief Get the type of the allowed collision between two elements.
+   *  Return true if the entry is included in the collision matrix or if specified defaults were found.
+   *  Return false if the entry is not found.
    *  @param name1 name of first element
    *  @param name2 name of second element
    *  @param allowed_collision The allowed collision type will be filled here */

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -242,6 +242,9 @@ public:
   void print(std::ostream& out) const;
 
 private:
+  bool getDefaultEntry(const std::string& name1, const std::string& name2,
+                       AllowedCollision::Type& allowed_collision) const;
+
   std::map<std::string, std::map<std::string, AllowedCollision::Type> > entries_;
   std::map<std::string, std::map<std::string, DecideContactFn> > allowed_contacts_;
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -88,6 +88,9 @@ public:
    *  will be ignored. */
   AllowedCollisionMatrix(const std::vector<std::string>& names, bool allowed = false);
 
+  /** @brief Construct from an SRDF representation */
+  AllowedCollisionMatrix(const srdf::Model& srdf);
+
   /** @brief Construct the structure from a message representation */
   AllowedCollisionMatrix(const moveit_msgs::AllowedCollisionMatrix& msg);
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -79,9 +79,6 @@ protected:
     robot_model_ok_ = static_cast<bool>(robot_model_);
 
     acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>();
-    // Use default collision operations in the SRDF to setup the acm
-    const std::vector<std::string>& collision_links = robot_model_->getLinkModelNamesWithCollisionGeometry();
-    acm_->setEntry(collision_links, collision_links, false);
 
     // load collision defaults
     for (const std::string& name : robot_model_->getSRDF()->getNoDefaultCollisionLinks())

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -78,14 +78,7 @@ protected:
     robot_model_ = moveit::core::loadTestingRobotModel("panda");
     robot_model_ok_ = static_cast<bool>(robot_model_);
 
-    acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>();
-
-    // load collision defaults
-    for (const std::string& name : robot_model_->getSRDF()->getNoDefaultCollisionLinks())
-      acm_->setDefaultEntry(name, collision_detection::AllowedCollision::NEVER);
-    // allow collisions for pairs that have been disabled
-    for (auto const& collision : robot_model_->getSRDF()->getCollisionPairs())
-      acm_->setEntry(collision.link1_, collision.link2_, collision.disabled_);
+    acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>(*robot_model_->getSRDF());
 
     cenv_ = value_->allocateEnv(robot_model_);
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -83,10 +83,12 @@ protected:
     const std::vector<std::string>& collision_links = robot_model_->getLinkModelNamesWithCollisionGeometry();
     acm_->setEntry(collision_links, collision_links, false);
 
+    // load collision defaults
+    for (const std::string& name : robot_model_->getSRDF()->getNoDefaultCollisionLinks())
+      acm_->setDefaultEntry(name, collision_detection::AllowedCollision::NEVER);
     // allow collisions for pairs that have been disabled
-    const std::vector<srdf::Model::DisabledCollision>& dc = robot_model_->getSRDF()->getDisabledCollisionPairs();
-    for (const srdf::Model::DisabledCollision& it : dc)
-      acm_->setEntry(it.link1_, it.link2_, true);
+    for (auto const& collision : robot_model_->getSRDF()->getCollisionPairs())
+      acm_->setEntry(collision.link1_, collision.link2_, collision.disabled_);
 
     cenv_ = value_->allocateEnv(robot_model_);
 

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -390,7 +390,7 @@ void AllowedCollisionMatrix::print(std::ostream& out) const
   // print indices along the top of the matrix
   for (std::size_t j = 0; j < number_digits; ++j)
   {
-    out << std::setw(spacing + number_digits + 4) << "";
+    out << std::setw(spacing + number_digits + 8) << "";
     for (std::size_t i = 0; i < names.size(); ++i)
     {
       std::stringstream ss;
@@ -400,17 +400,25 @@ void AllowedCollisionMatrix::print(std::ostream& out) const
     out << std::endl;
   }
 
+  const char* indicator = "01?";  // ALWAYS / NEVER / CONDITIONAL
   for (std::size_t i = 0; i < names.size(); ++i)
   {
     out << std::setw(spacing) << names[i];
     out << std::setw(number_digits + 1) << i;
     out << " | ";
+    // print default value
+    AllowedCollision::Type type;
+    if (getDefaultEntry(names[i], type))
+      out << indicator[type];
+    else
+      out << '-';
+    out << " | ";
+    // print pairs
     for (std::size_t j = 0; j < names.size(); ++j)
     {
-      AllowedCollision::Type type;
       bool found = getAllowedCollision(names[i], names[j], type);
       if (found)
-        out << std::setw(3) << (type == AllowedCollision::ALWAYS ? '1' : (type == AllowedCollision::NEVER ? '0' : '?'));
+        out << std::setw(3) << indicator[type];
       else
         out << std::setw(3) << '-';
     }

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -51,6 +51,19 @@ AllowedCollisionMatrix::AllowedCollisionMatrix(const std::vector<std::string>& n
       setEntry(names[i], names[j], allowed);
 }
 
+AllowedCollisionMatrix::AllowedCollisionMatrix(const srdf::Model& srdf)
+{
+  // load collision defaults
+  for (const std::string& name : srdf.getNoDefaultCollisionLinks())
+    setDefaultEntry(name, collision_detection::AllowedCollision::ALWAYS);
+  // re-enable specific collision pairs
+  for (auto const& collision : srdf.getEnabledCollisionPairs())
+    setEntry(collision.link1_, collision.link2_, false);
+  // *finally* disable selected collision pairs
+  for (auto const& collision : srdf.getDisabledCollisionPairs())
+    setEntry(collision.link1_, collision.link2_, true);
+}
+
 AllowedCollisionMatrix::AllowedCollisionMatrix(const moveit_msgs::AllowedCollisionMatrix& msg)
 {
   if (msg.entry_names.size() != msg.entry_values.size() ||

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -255,14 +255,12 @@ static bool andDecideContact(const DecideContactFn& f1, const DecideContactFn& f
 bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const std::string& name2,
                                                  DecideContactFn& fn) const
 {
-  DecideContactFn fn1, fn2;
-  bool found1 = getDefaultEntry(name1, fn1);
-  bool found2 = getDefaultEntry(name2, fn2);
-
-  if (!found1 && !found2)
-    return getEntry(name1, name2, fn);
-  else
+  bool found = getEntry(name1, name2, fn);
+  if (!found)
   {
+    DecideContactFn fn1, fn2;
+    bool found1 = getDefaultEntry(name1, fn1);
+    bool found2 = getDefaultEntry(name2, fn2);
     if (found1 && !found2)
       fn = fn1;
     else if (!found1 && found2)
@@ -271,21 +269,19 @@ bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const
       fn = std::bind(&andDecideContact, fn1, fn2, std::placeholders::_1);
     else
       return false;
-    return true;
   }
+  return true;
 }
 
 bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const std::string& name2,
                                                  AllowedCollision::Type& allowed_collision) const
 {
-  AllowedCollision::Type t1, t2;
-  bool found1 = getDefaultEntry(name1, t1);
-  bool found2 = getDefaultEntry(name2, t2);
-
-  if (!found1 && !found2)
-    return getEntry(name1, name2, allowed_collision);
-  else
+  bool found = getEntry(name1, name2, allowed_collision);
+  if (!found)
   {
+    AllowedCollision::Type t1, t2;
+    bool found1 = getDefaultEntry(name1, t1);
+    bool found2 = getDefaultEntry(name2, t2);
     if (found1 && !found2)
       allowed_collision = t1;
     else if (!found1 && found2)
@@ -301,8 +297,8 @@ bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const
     }
     else
       return false;
-    return true;
   }
+  return true;
 }
 
 void AllowedCollisionMatrix::clear()

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -282,7 +282,9 @@ bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const
     AllowedCollision::Type t1, t2;
     bool found1 = getDefaultEntry(name1, t1);
     bool found2 = getDefaultEntry(name2, t2);
-    if (found1 && !found2)
+    if (!found1 && !found2)
+      return false;
+    else if (found1 && !found2)
       allowed_collision = t1;
     else if (!found1 && found2)
       allowed_collision = t2;
@@ -295,8 +297,6 @@ bool AllowedCollisionMatrix::getAllowedCollision(const std::string& name1, const
       else  // ALWAYS is the only remaining case
         allowed_collision = AllowedCollision::ALWAYS;
     }
-    else
-      return false;
   }
   return true;
 }

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -81,10 +81,12 @@ protected:
     const std::vector<std::string>& collision_links = robot_model_->getLinkModelNamesWithCollisionGeometry();
     acm_->setEntry(collision_links, collision_links, false);
 
+    // load collision defaults
+    for (const std::string& name : robot_model_->getSRDF()->getNoDefaultCollisionLinks())
+      acm_->setDefaultEntry(name, collision_detection::AllowedCollision::NEVER);
     // allow collisions for pairs that have been disabled
-    const std::vector<srdf::Model::DisabledCollision>& dc = robot_model_->getSRDF()->getDisabledCollisionPairs();
-    for (const srdf::Model::DisabledCollision& it : dc)
-      acm_->setEntry(it.link1_, it.link2_, true);
+    for (auto const& collision : robot_model_->getSRDF()->getCollisionPairs())
+      acm_->setEntry(collision.link1_, collision.link2_, collision.disabled_);
 
     cenv_ = std::make_shared<collision_detection::CollisionEnvBullet>(robot_model_);
 

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -76,14 +76,7 @@ protected:
     robot_model_ = moveit::core::loadTestingRobotModel("panda");
     robot_model_ok_ = static_cast<bool>(robot_model_);
 
-    acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>();
-
-    // load collision defaults
-    for (const std::string& name : robot_model_->getSRDF()->getNoDefaultCollisionLinks())
-      acm_->setDefaultEntry(name, collision_detection::AllowedCollision::NEVER);
-    // allow collisions for pairs that have been disabled
-    for (auto const& collision : robot_model_->getSRDF()->getCollisionPairs())
-      acm_->setEntry(collision.link1_, collision.link2_, collision.disabled_);
+    acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>(*robot_model_->getSRDF());
 
     cenv_ = std::make_shared<collision_detection::CollisionEnvBullet>(robot_model_);
 

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -77,9 +77,6 @@ protected:
     robot_model_ok_ = static_cast<bool>(robot_model_);
 
     acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>();
-    // Use default collision operations in the SRDF to setup the acm
-    const std::vector<std::string>& collision_links = robot_model_->getLinkModelNamesWithCollisionGeometry();
-    acm_->setEntry(collision_links, collision_links, false);
 
     // load collision defaults
     for (const std::string& name : robot_model_->getSRDF()->getNoDefaultCollisionLinks())

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -151,16 +151,7 @@ void PlanningScene::initialize()
   robot_state_->setToDefaultValues();
   robot_state_->update();
 
-  acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>();
-
-  // load collision defaults
-  for (const std::string& name : getRobotModel()->getSRDF()->getNoDefaultCollisionLinks())
-    acm_->setDefaultEntry(name, collision_detection::AllowedCollision::ALWAYS);
-  // load collision pairs
-  for (auto const& collision : getRobotModel()->getSRDF()->getEnabledCollisionPairs())
-    acm_->setEntry(collision.link1_, collision.link2_, false);
-  for (auto const& collision : getRobotModel()->getSRDF()->getDisabledCollisionPairs())
-    acm_->setEntry(collision.link1_, collision.link2_, true);
+  acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>(*getRobotModel()->getSRDF());
 
   setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
 }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -152,9 +152,6 @@ void PlanningScene::initialize()
   robot_state_->update();
 
   acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>();
-  // Use default collision operations in the SRDF to setup the acm
-  const std::vector<std::string>& collision_links = robot_model_->getLinkModelNamesWithCollisionGeometry();
-  acm_->setEntry(collision_links, collision_links, false);
 
   // load collision defaults
   for (const std::string& name : getRobotModel()->getSRDF()->getNoDefaultCollisionLinks())

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -156,9 +156,11 @@ void PlanningScene::initialize()
   // load collision defaults
   for (const std::string& name : getRobotModel()->getSRDF()->getNoDefaultCollisionLinks())
     acm_->setDefaultEntry(name, collision_detection::AllowedCollision::ALWAYS);
-  // allow collisions for pairs that have been disabled
-  for (auto const& collision : getRobotModel()->getSRDF()->getCollisionPairs())
-    acm_->setEntry(collision.link1_, collision.link2_, collision.disabled_);
+  // load collision pairs
+  for (auto const& collision : getRobotModel()->getSRDF()->getEnabledCollisionPairs())
+    acm_->setEntry(collision.link1_, collision.link2_, false);
+  for (auto const& collision : getRobotModel()->getSRDF()->getDisabledCollisionPairs())
+    acm_->setEntry(collision.link1_, collision.link2_, true);
 
   setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
 }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -156,10 +156,12 @@ void PlanningScene::initialize()
   const std::vector<std::string>& collision_links = robot_model_->getLinkModelNamesWithCollisionGeometry();
   acm_->setEntry(collision_links, collision_links, false);
 
+  // load collision defaults
+  for (const std::string& name : getRobotModel()->getSRDF()->getNoDefaultCollisionLinks())
+    acm_->setDefaultEntry(name, collision_detection::AllowedCollision::ALWAYS);
   // allow collisions for pairs that have been disabled
-  const std::vector<srdf::Model::DisabledCollision>& dc = getRobotModel()->getSRDF()->getDisabledCollisionPairs();
-  for (const srdf::Model::DisabledCollision& it : dc)
-    acm_->setEntry(it.link1_, it.link2_, true);
+  for (auto const& collision : getRobotModel()->getSRDF()->getCollisionPairs())
+    acm_->setEntry(collision.link1_, collision.link2_, collision.disabled_);
 
   setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
 }

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -331,13 +331,6 @@ public:
   std::string getGazeboCompatibleURDF();
 
   /**
-   * \brief Set list of collision link pairs in SRDF; sorted; with optional filter
-   * \param link_pairs list of collision link pairs
-   * \param skip_mask mask of shifted moveit_setup_assistant::DisabledReason values that will be skipped
-   */
-  void setCollisionLinkPairs(const moveit_setup_assistant::LinkPairMap& link_pairs, size_t skip_mask = 0);
-
-  /**
    * \brief Decide the best two joints to be used for the projection evaluator
    * \param planning_group name of group to use
    * \return string - value to insert into yaml file

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -97,7 +97,11 @@ bool setup(moveit_setup_assistant::MoveItConfigData& config_data, bool keep_old,
   }
 
   if (!keep_old)
-    config_data.srdf_->collision_pairs_.clear();
+  {
+    config_data.srdf_->no_default_collision_links_.clear();
+    config_data.srdf_->enabled_collision_pairs_.clear();
+    config_data.srdf_->disabled_collision_pairs_.clear();
+  }
 
   return true;
 }

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -115,6 +115,52 @@ moveit_setup_assistant::LinkPairMap compute(moveit_setup_assistant::MoveItConfig
                                                           trials > 0, trials, min_collision_fraction, verbose);
 }
 
+// less operation for two CollisionPairs
+struct CollisionPairLess
+{
+  bool operator()(const srdf::Model::CollisionPair& left, const srdf::Model::CollisionPair& right) const
+  {
+    return left.link1_ < right.link1_ && left.link2_ < right.link2_;
+  }
+};
+
+// Update collision pairs
+void updateCollisionLinkPairs(std::vector<srdf::Model::CollisionPair>& target_pairs,
+                              const moveit_setup_assistant::LinkPairMap& source_pairs, size_t skip_mask)
+{
+  // remove duplicates
+  std::set<srdf::Model::CollisionPair, CollisionPairLess> filtered;
+  for (auto& p : target_pairs)
+  {
+    if (p.link1_ >= p.link2_)
+      std::swap(p.link1_, p.link2_);  // unify link1, link2 sorting
+    filtered.insert(p);
+  }
+
+  // copy the data in this class's LinkPairMap datastructure to srdf::Model::CollisionPair format
+  for (const auto& link_pair : source_pairs)
+  {
+    // Only copy those that are actually disabled
+    if (!link_pair.second.disable_check)
+      continue;
+
+    // Filter out pairs matching the skip_mask
+    if ((1 << link_pair.second.reason) & skip_mask)
+      continue;
+
+    srdf::Model::CollisionPair pair;
+    pair.link1_ = link_pair.first.first;
+    pair.link2_ = link_pair.first.second;
+    if (pair.link1_ >= pair.link2_)
+      std::swap(pair.link1_, pair.link2_);
+    pair.reason_ = moveit_setup_assistant::disabledReasonToString(link_pair.second.reason);
+
+    filtered.insert(pair);
+  }
+
+  target_pairs.assign(filtered.begin(), filtered.end());
+}
+
 int main(int argc, char* argv[])
 {
   std::string config_pkg_path;
@@ -205,7 +251,7 @@ int main(int argc, char* argv[])
   if (!include_always)
     skip_mask |= (1 << moveit_setup_assistant::ALWAYS);
 
-  config_data.setCollisionLinkPairs(link_pairs, skip_mask);
+  updateCollisionLinkPairs(config_data.srdf_->disabled_collision_pairs_, link_pairs, skip_mask);
 
   config_data.srdf_->writeSRDF(output_path.empty() ? config_data.srdf_path_ : output_path);
 

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -97,7 +97,7 @@ bool setup(moveit_setup_assistant::MoveItConfigData& config_data, bool keep_old,
   }
 
   if (!keep_old)
-    config_data.srdf_->disabled_collisions_.clear();
+    config_data.srdf_->collision_pairs_.clear();
 
   return true;
 }

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1204,59 +1204,6 @@ bool MoveItConfigData::outputJointLimitsYAML(const std::string& file_path)
 }
 
 // ******************************************************************************************
-// Set list of collision link pairs in SRDF; sorted; with optional filter
-// ******************************************************************************************
-
-class SortableCollisionPair
-{
-public:
-  SortableCollisionPair(const srdf::Model::CollisionPair& p)
-    : pair_(p), key_(p.link1_ < p.link2_ ? (p.link1_ + "|" + p.link2_) : (p.link2_ + "|" + p.link1_))
-  {
-  }
-  operator const srdf::Model::CollisionPair &() const
-  {
-    return pair_;
-  }
-  bool operator<(const SortableCollisionPair& other) const
-  {
-    return key_ < other.key_;
-  }
-
-private:
-  const srdf::Model::CollisionPair pair_;
-  const std::string key_;
-};
-
-void MoveItConfigData::setCollisionLinkPairs(const moveit_setup_assistant::LinkPairMap& link_pairs, size_t skip_mask)
-{
-  // Create temp disabled collision
-  srdf::Model::CollisionPair pair;
-
-  std::set<SortableCollisionPair> collision_pairs;
-  collision_pairs.insert(srdf_->collision_pairs_.begin(), srdf_->collision_pairs_.end());
-
-  // copy the data in this class's LinkPairMap datastructure to srdf::Model::CollisionPair format
-  for (const std::pair<const std::pair<std::string, std::string>, LinkPairData>& link_pair : link_pairs)
-  {
-    // Only copy those that are actually disabled
-    if (link_pair.second.disable_check)
-    {
-      if ((1 << link_pair.second.reason) & skip_mask)
-        continue;
-
-      pair.link1_ = link_pair.first.first;
-      pair.link2_ = link_pair.first.second;
-      pair.reason_ = moveit_setup_assistant::disabledReasonToString(link_pair.second.reason);
-
-      collision_pairs.insert(SortableCollisionPair(pair));
-    }
-  }
-
-  srdf_->collision_pairs_.assign(collision_pairs.begin(), collision_pairs.end());
-}
-
-// ******************************************************************************************
 // Decide the best two joints to be used for the projection evaluator
 // ******************************************************************************************
 std::string MoveItConfigData::decideProjectionJoints(const std::string& planning_group)

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -144,9 +144,9 @@ void MoveItConfigData::loadAllowedCollisionMatrix()
   allowed_collision_matrix_.clear();
 
   // Update the allowed collision matrix, in case there has been a change
-  for (const auto& disabled_collision : srdf_->disabled_collisions_)
+  for (const auto& collision : srdf_->collision_pairs_)
   {
-    allowed_collision_matrix_.setEntry(disabled_collision.link1_, disabled_collision.link2_, true);
+    allowed_collision_matrix_.setEntry(collision.link1_, collision.link2_, collision.disabled_);
   }
 }
 
@@ -1204,36 +1204,36 @@ bool MoveItConfigData::outputJointLimitsYAML(const std::string& file_path)
 // Set list of collision link pairs in SRDF; sorted; with optional filter
 // ******************************************************************************************
 
-class SortableDisabledCollision
+class SortableCollisionPair
 {
 public:
-  SortableDisabledCollision(const srdf::Model::DisabledCollision& dc)
-    : dc_(dc), key_(dc.link1_ < dc.link2_ ? (dc.link1_ + "|" + dc.link2_) : (dc.link2_ + "|" + dc.link1_))
+  SortableCollisionPair(const srdf::Model::CollisionPair& p)
+    : pair_(p), key_(p.link1_ < p.link2_ ? (p.link1_ + "|" + p.link2_) : (p.link2_ + "|" + p.link1_))
   {
   }
-  operator const srdf::Model::DisabledCollision &() const
+  operator const srdf::Model::CollisionPair &() const
   {
-    return dc_;
+    return pair_;
   }
-  bool operator<(const SortableDisabledCollision& other) const
+  bool operator<(const SortableCollisionPair& other) const
   {
     return key_ < other.key_;
   }
 
 private:
-  const srdf::Model::DisabledCollision dc_;
+  const srdf::Model::CollisionPair pair_;
   const std::string key_;
 };
 
 void MoveItConfigData::setCollisionLinkPairs(const moveit_setup_assistant::LinkPairMap& link_pairs, size_t skip_mask)
 {
   // Create temp disabled collision
-  srdf::Model::DisabledCollision dc;
+  srdf::Model::CollisionPair pair;
 
-  std::set<SortableDisabledCollision> disabled_collisions;
-  disabled_collisions.insert(srdf_->disabled_collisions_.begin(), srdf_->disabled_collisions_.end());
+  std::set<SortableCollisionPair> collision_pairs;
+  collision_pairs.insert(srdf_->collision_pairs_.begin(), srdf_->collision_pairs_.end());
 
-  // copy the data in this class's LinkPairMap datastructure to srdf::Model::DisabledCollision format
+  // copy the data in this class's LinkPairMap datastructure to srdf::Model::CollisionPair format
   for (const std::pair<const std::pair<std::string, std::string>, LinkPairData>& link_pair : link_pairs)
   {
     // Only copy those that are actually disabled
@@ -1242,15 +1242,15 @@ void MoveItConfigData::setCollisionLinkPairs(const moveit_setup_assistant::LinkP
       if ((1 << link_pair.second.reason) & skip_mask)
         continue;
 
-      dc.link1_ = link_pair.first.first;
-      dc.link2_ = link_pair.first.second;
-      dc.reason_ = moveit_setup_assistant::disabledReasonToString(link_pair.second.reason);
+      pair.link1_ = link_pair.first.first;
+      pair.link2_ = link_pair.first.second;
+      pair.reason_ = moveit_setup_assistant::disabledReasonToString(link_pair.second.reason);
 
-      disabled_collisions.insert(SortableDisabledCollision(dc));
+      collision_pairs.insert(SortableCollisionPair(pair));
     }
   }
 
-  srdf_->disabled_collisions_.assign(disabled_collisions.begin(), disabled_collisions.end());
+  srdf_->collision_pairs_.assign(collision_pairs.begin(), collision_pairs.end());
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -140,14 +140,17 @@ planning_scene::PlanningScenePtr MoveItConfigData::getPlanningScene()
 // ******************************************************************************************
 void MoveItConfigData::loadAllowedCollisionMatrix()
 {
-  // Clear the allowed collision matrix
   allowed_collision_matrix_.clear();
 
-  // Update the allowed collision matrix, in case there has been a change
-  for (const auto& collision : srdf_->collision_pairs_)
-  {
-    allowed_collision_matrix_.setEntry(collision.link1_, collision.link2_, collision.disabled_);
-  }
+  // load collision defaults
+  for (const std::string& name : srdf_->no_default_collision_links_)
+    allowed_collision_matrix_.setDefaultEntry(name, collision_detection::AllowedCollision::ALWAYS);
+  // re-enable specific collision pairs
+  for (auto const& collision : srdf_->enabled_collision_pairs_)
+    allowed_collision_matrix_.setEntry(collision.link1_, collision.link2_, false);
+  // *finally* disable selected collision pairs
+  for (auto const& collision : srdf_->disabled_collision_pairs_)
+    allowed_collision_matrix_.setEntry(collision.link1_, collision.link2_, true);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -641,7 +641,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   }
 
   // Check that at least 1 link pair is disabled from collision checking
-  if (config_data_->srdf_->collision_pairs_.empty())
+  if (config_data_->srdf_->disabled_collision_pairs_.empty())
   {
     dependencies << "No self-collisions have been disabled";
   }

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -641,7 +641,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   }
 
   // Check that at least 1 link pair is disabled from collision checking
-  if (config_data_->srdf_->disabled_collisions_.empty())
+  if (config_data_->srdf_->collision_pairs_.empty())
   {
     dependencies << "No self-collisions have been disabled";
   }

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -677,7 +677,7 @@ void DefaultCollisionsWidget::checkedFilterChanged()
 void DefaultCollisionsWidget::linkPairsToSRDF()
 {
   // reset the data in the SRDF Writer class
-  config_data_->srdf_->collision_pairs_.clear();
+  config_data_->srdf_->disabled_collision_pairs_.clear();
 
   // Create temp disabled collision
   srdf::Model::CollisionPair dc;
@@ -692,8 +692,7 @@ void DefaultCollisionsWidget::linkPairsToSRDF()
       dc.link1_ = pair_it->first.first;
       dc.link2_ = pair_it->first.second;
       dc.reason_ = moveit_setup_assistant::disabledReasonToString(pair_it->second.reason);
-      dc.disabled_ = pair_it->second.disable_check;
-      config_data_->srdf_->collision_pairs_.push_back(dc);
+      config_data_->srdf_->disabled_collision_pairs_.push_back(dc);
     }
   }
 
@@ -720,7 +719,7 @@ void DefaultCollisionsWidget::linkPairsFromSRDF()
   std::pair<std::string, std::string> link_pair;
 
   // Loop through all disabled collisions in SRDF and update the comprehensive list that has already been created
-  for (const auto& disabled_collision : config_data_->srdf_->collision_pairs_)
+  for (const auto& disabled_collision : config_data_->srdf_->disabled_collision_pairs_)
   {
     // Set the link names
     link_pair.first = disabled_collision.link1_;

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -677,12 +677,12 @@ void DefaultCollisionsWidget::checkedFilterChanged()
 void DefaultCollisionsWidget::linkPairsToSRDF()
 {
   // reset the data in the SRDF Writer class
-  config_data_->srdf_->disabled_collisions_.clear();
+  config_data_->srdf_->collision_pairs_.clear();
 
   // Create temp disabled collision
-  srdf::Model::DisabledCollision dc;
+  srdf::Model::CollisionPair dc;
 
-  // copy the data in this class's LinkPairMap datastructure to srdf::Model::DisabledCollision format
+  // copy the data in this class's LinkPairMap datastructure to srdf::Model::CollisionPair format
   for (moveit_setup_assistant::LinkPairMap::const_iterator pair_it = link_pairs_.begin(); pair_it != link_pairs_.end();
        ++pair_it)
   {
@@ -692,7 +692,8 @@ void DefaultCollisionsWidget::linkPairsToSRDF()
       dc.link1_ = pair_it->first.first;
       dc.link2_ = pair_it->first.second;
       dc.reason_ = moveit_setup_assistant::disabledReasonToString(pair_it->second.reason);
-      config_data_->srdf_->disabled_collisions_.push_back(dc);
+      dc.disabled_ = pair_it->second.disable_check;
+      config_data_->srdf_->collision_pairs_.push_back(dc);
     }
   }
 
@@ -719,7 +720,7 @@ void DefaultCollisionsWidget::linkPairsFromSRDF()
   std::pair<std::string, std::string> link_pair;
 
   // Loop through all disabled collisions in SRDF and update the comprehensive list that has already been created
-  for (const auto& disabled_collision : config_data_->srdf_->disabled_collisions_)
+  for (const auto& disabled_collision : config_data_->srdf_->collision_pairs_)
   {
     // Set the link names
     link_pair.first = disabled_collision.link1_;


### PR DESCRIPTION
This is a first implementation of #2936, considering ACM defaults as a fallback again (instead of an overrride).
This **depends on https://github.com/ros-planning/srdfdom/pull/97**, which implements corresponding SRDF extensions.

I encountered one difficulty implementing this, namely serializing and deserializing ACM messages: 
- Always the full matrix is serialized (there is no simple/compact alternative)
- The previous code didn't correctly serialize pair entries (only if a pair was specified, the value was serialized).
  Thus, when a default was specified, but no pairs, the wrong value was transmitted.
- Now, only if the pair deviates from the expected default, an explicit pair entry is created on the receiving side to keep the matrix as compact as possible.

An example application can be found in https://github.com/ros-planning/panda_moveit_config/pull/95.