### PR TITLE
Fix handling of sensors_3d.yaml

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -155,15 +155,15 @@ public:
   {
     comment_ = std::move(comment);
   };
-  std::string getName()
+  const std::string& getName() const
   {
     return name_;
   };
-  std::string getValue()
+  const std::string& getValue() const
   {
     return value_;
   };
-  std::string getComment()
+  const std::string& getComment() const
   {
     return comment_;
   };
@@ -437,14 +437,10 @@ public:
    */
   bool inputSetupAssistantYAML(const std::string& file_path);
 
-  /**
-   * Input sensors_3d file - contains 3d sensors config data
-   *
-   * @param default_file_path path to sensors_3d yaml file which contains default parameter values
-   * @param file_path path to sensors_3d yaml file in the config package
-   * @return true if the file was read correctly
-   */
-  bool input3DSensorsYAML(const std::string& default_file_path, const std::string& file_path = "");
+  /// Load perception sensor config (sensors_3d.yaml) into internal data structure
+  void input3DSensorsYAML(const std::string& file_path);
+  /// Load perception sensor config
+  static std::vector<std::map<std::string, GenericParameter>> load3DSensorsYAML(const std::string& file_path);
 
   /**
    * Helper Function for joining a file path and a file name, or two file paths, etc,
@@ -499,7 +495,10 @@ public:
   /**
    * \brief Used for adding a sensor plugin configuation parameter to the sensor plugin configuration parameter list
    */
-  std::vector<std::map<std::string, GenericParameter> > getSensorPluginConfig();
+  const std::vector<std::map<std::string, GenericParameter>>& getSensorPluginConfig() const
+  {
+    return sensors_plugin_config_parameter_list_;
+  }
 
   /**
    * \brief Helper function to get the default start pose for moveit_sim_hw_interface
@@ -526,7 +525,7 @@ private:
   // ******************************************************************************************
 
   /// Sensor plugin configuration parameter list, each sensor plugin type is a map
-  std::vector<std::map<std::string, GenericParameter> > sensors_plugin_config_parameter_list_;
+  std::vector<std::map<std::string, GenericParameter>> sensors_plugin_config_parameter_list_;
 
   /// Shared kinematic model
   moveit::core::RobotModelPtr robot_model_;

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -94,7 +94,6 @@ PerceptionWidget::PerceptionWidget(QWidget* parent, const MoveItConfigDataPtr& c
   // Point Cloud Topic
   point_cloud_topic_field_ = new QLineEdit(this);
   point_cloud_topic_field_->setMaximumWidth(400);
-  // point_cloud_topic_field_->setText(QString("/clud topic"));
   point_cloud_form_layout->addRow("Point Cloud Topic:", point_cloud_topic_field_);
 
   // Max Range
@@ -284,6 +283,35 @@ void PerceptionWidget::sensorPluginChanged(int index)
   }
 }
 
+uint PerceptionWidget::loadConfigIntoWidgets(std::map<std::string, GenericParameter> sensor_plugin_config)
+{
+  if (sensor_plugin_config["sensor_plugin"].getValue() == "occupancy_map_monitor/PointCloudOctomapUpdater")
+  {
+    point_cloud_topic_field_->setText(QString(sensor_plugin_config["point_cloud_topic"].getValue().c_str()));
+    max_range_field_->setText(QString(sensor_plugin_config["max_range"].getValue().c_str()));
+    point_subsample_field_->setText(QString(sensor_plugin_config["point_subsample"].getValue().c_str()));
+    padding_offset_field_->setText(QString(sensor_plugin_config["padding_offset"].getValue().c_str()));
+    padding_scale_field_->setText(QString(sensor_plugin_config["padding_scale"].getValue().c_str()));
+    max_update_rate_field_->setText(QString(sensor_plugin_config["max_update_rate"].getValue().c_str()));
+    filtered_cloud_topic_field_->setText(QString(sensor_plugin_config["filtered_cloud_topic"].getValue().c_str()));
+    return 1;
+  }
+  else if (sensor_plugin_config["sensor_plugin"].getValue() == "occupancy_map_monitor/DepthImageOctomapUpdater")
+  {
+    image_topic_field_->setText(QString(sensor_plugin_config["image_topic"].getValue().c_str()));
+    queue_size_field_->setText(QString(sensor_plugin_config["queue_size"].getValue().c_str()));
+    near_clipping_field_->setText(QString(sensor_plugin_config["near_clipping_plane_distance"].getValue().c_str()));
+    far_clipping_field_->setText(QString(sensor_plugin_config["far_clipping_plane_distance"].getValue().c_str()));
+    shadow_threshold_field_->setText(QString(sensor_plugin_config["shadow_threshold"].getValue().c_str()));
+    depth_padding_scale_field_->setText(QString(sensor_plugin_config["padding_scale"].getValue().c_str()));
+    depth_padding_offset_field_->setText(QString(sensor_plugin_config["padding_offset"].getValue().c_str()));
+    depth_filtered_cloud_topic_field_->setText(QString(sensor_plugin_config["filtered_cloud_topic"].getValue().c_str()));
+    depth_max_update_rate_field_->setText(QString(sensor_plugin_config["max_update_rate"].getValue().c_str()));
+    return 2;
+  }
+  return 0;
+}
+
 void PerceptionWidget::loadSensorPluginsComboBox()
 {
   // Only load this combo box once
@@ -292,53 +320,25 @@ void PerceptionWidget::loadSensorPluginsComboBox()
     return;
   has_loaded = true;
 
-  // Remove all old items
-  sensor_plugin_field_->clear();
-
   // Add None option, the default
   sensor_plugin_field_->addItem("None");
+  sensor_plugin_field_->setCurrentIndex(0);
 
   // Add the two avilable plugins to combo box
   sensor_plugin_field_->addItem("Point Cloud");
   sensor_plugin_field_->addItem("Depth Map");
 
-  // Load deafult config, or use the one in the config package if exists
-  std::vector<std::map<std::string, GenericParameter> > sensors_vec_map = config_data_->getSensorPluginConfig();
-  for (std::map<std::string, GenericParameter>& sensor_plugin_config : sensors_vec_map)
-  {
-    if (sensor_plugin_config["sensor_plugin"].getValue() ==
-        std::string("occupancy_map_monitor/PointCloudOctomapUpdater"))
-    {
-      sensor_plugin_field_->setCurrentIndex(1);
-      point_cloud_topic_field_->setText(QString(sensor_plugin_config["point_cloud_topic"].getValue().c_str()));
-      max_range_field_->setText(QString(sensor_plugin_config["max_range"].getValue().c_str()));
-      point_subsample_field_->setText(QString(sensor_plugin_config["point_subsample"].getValue().c_str()));
-      padding_offset_field_->setText(QString(sensor_plugin_config["padding_offset"].getValue().c_str()));
-      padding_scale_field_->setText(QString(sensor_plugin_config["padding_scale"].getValue().c_str()));
-      max_update_rate_field_->setText(QString(sensor_plugin_config["max_update_rate"].getValue().c_str()));
-      filtered_cloud_topic_field_->setText(QString(sensor_plugin_config["filtered_cloud_topic"].getValue().c_str()));
-    }
-    else if (sensor_plugin_config["sensor_plugin"].getValue() ==
-             std::string("occupancy_map_monitor/DepthImageOctomapUpdater"))
-    {
-      sensor_plugin_field_->setCurrentIndex(2);
-      image_topic_field_->setText(QString(sensor_plugin_config["image_topic"].getValue().c_str()));
-      queue_size_field_->setText(QString(sensor_plugin_config["queue_size"].getValue().c_str()));
-      near_clipping_field_->setText(QString(sensor_plugin_config["near_clipping_plane_distance"].getValue().c_str()));
-      far_clipping_field_->setText(QString(sensor_plugin_config["far_clipping_plane_distance"].getValue().c_str()));
-      shadow_threshold_field_->setText(QString(sensor_plugin_config["shadow_threshold"].getValue().c_str()));
-      depth_padding_scale_field_->setText(QString(sensor_plugin_config["padding_scale"].getValue().c_str()));
-      depth_padding_offset_field_->setText(QString(sensor_plugin_config["padding_offset"].getValue().c_str()));
-      depth_filtered_cloud_topic_field_->setText(
-          QString(sensor_plugin_config["filtered_cloud_topic"].getValue().c_str()));
-      depth_max_update_rate_field_->setText(QString(sensor_plugin_config["max_update_rate"].getValue().c_str()));
-    }
-  }
+  // Load values from default config
+  auto default_config = MoveItConfigData::load3DSensorsYAML(
+      config_data_->setup_assistant_path_ + "/templates/moveit_config_pkg_template/config/sensors_3d.yaml");
+  for (const auto& sensor_plugin_config : default_config)
+    loadConfigIntoWidgets(sensor_plugin_config);
 
-  // If no sensor config exists, default to None
-  if (sensors_vec_map.size() == 2)
+  // Load values from existing config
+  for (const auto& sensor_plugin_config : config_data_->getSensorPluginConfig())
   {
-    sensor_plugin_field_->setCurrentIndex(0);
+    uint idx = loadConfigIntoWidgets(sensor_plugin_config);
+    sensor_plugin_field_->setCurrentIndex(idx);
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/perception_widget.h
+++ b/moveit_setup_assistant/src/widgets/perception_widget.h
@@ -71,6 +71,7 @@ public:
 
   /// Populate the combo dropdown box with sensor plugins
   void loadSensorPluginsComboBox();
+  uint loadConfigIntoWidgets(std::map<std::string, GenericParameter> sensor_plugin_config);
 
   // ******************************************************************************************
   // Qt Components

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -738,18 +738,9 @@ bool StartScreenWidget::load3DSensorsFile()
   fs::path sensors_3d_yaml_path = config_data_->config_pkg_path_;
   sensors_3d_yaml_path /= "config/sensors_3d.yaml";
 
-  // Default parameters values are always loaded but overridden by values existing in sensors_3d
-  fs::path default_sensors_3d_yaml_path = "templates/moveit_config_pkg_template/config/sensors_3d.yaml";
-
-  if (!fs::is_regular_file(sensors_3d_yaml_path))
-  {
-    return config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().string());
-  }
-  else
-  {
-    return config_data_->input3DSensorsYAML(default_sensors_3d_yaml_path.make_preferred().string(),
-                                            sensors_3d_yaml_path.make_preferred().string());
-  }
+  if (fs::is_regular_file(sensors_3d_yaml_path))
+    config_data_->input3DSensorsYAML(sensors_3d_yaml_path.make_preferred().string());
+  return true;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/test/moveit_config_data_test.cpp
+++ b/moveit_setup_assistant/test/moveit_config_data_test.cpp
@@ -122,16 +122,15 @@ TEST_F(MoveItConfigData, ReadingSensorsConfig)
   // Read the file containing the default config parameters
   config_data->input3DSensorsYAML(
       (setup_assistant_path / "templates/moveit_config_pkg_template/config/sensors_3d.yaml").string());
+  auto configs = config_data->getSensorPluginConfig();
 
   // Default config for the two available sensor plugins
   // Make sure both are parsed correctly
-  ASSERT_EQ(config_data->getSensorPluginConfig().size(), 2u);
+  ASSERT_EQ(configs.size(), 2u);
 
-  EXPECT_EQ(config_data->getSensorPluginConfig()[0]["sensor_plugin"].getValue(),
-            std::string("occupancy_map_monitor/PointCloudOctomapUpdater"));
+  EXPECT_EQ(configs[0]["sensor_plugin"].getValue(), std::string("occupancy_map_monitor/PointCloudOctomapUpdater"));
 
-  EXPECT_EQ(config_data->getSensorPluginConfig()[1]["sensor_plugin"].getValue(),
-            std::string("occupancy_map_monitor/DepthImageOctomapUpdater"));
+  EXPECT_EQ(configs[1]["sensor_plugin"].getValue(), std::string("occupancy_map_monitor/DepthImageOctomapUpdater"));
 }
 
 // This tests writing of sensors_3d.yaml
@@ -147,33 +146,27 @@ TEST_F(MoveItConfigData, WritingSensorsConfig)
   // Temporary file used during the test and is deleted when the test is finished
   char test_file[] = "/tmp/msa_unittest_sensors.yaml";
 
-  // sensors yaml written correctly
+  // empty sensors.yaml written correctly
   EXPECT_EQ(config_data->output3DSensorPluginYAML(test_file), true);
 
   // Set default file
-  boost::filesystem::path setup_assistant_path(config_data->setup_assistant_path_);
   std::string default_file_path =
-      (setup_assistant_path / "templates/moveit_config_pkg_template/config/sensors_3d.yaml").string();
+      config_data->setup_assistant_path_ + "/templates/moveit_config_pkg_template/config/sensors_3d.yaml";
 
-  // Read from the written file
-  config_data = std::make_shared<moveit_setup_assistant::MoveItConfigData>();
-  EXPECT_EQ(config_data->input3DSensorsYAML(test_file), true);
-
-  // Should still have No Sensors
-  EXPECT_EQ(config_data->getSensorPluginConfig().size(), 0u);
+  // Read from the written (empty) file
+  auto config = moveit_setup_assistant::MoveItConfigData::load3DSensorsYAML(test_file);
+  // Should have No Sensors
+  EXPECT_EQ(config.size(), 0u);
 
   // Now load the default file and write it to a file
   config_data = std::make_shared<moveit_setup_assistant::MoveItConfigData>();
-  EXPECT_EQ(config_data->input3DSensorsYAML(default_file_path), true);
+  config_data->input3DSensorsYAML(default_file_path);
   EXPECT_EQ(config_data->getSensorPluginConfig().size(), 2u);
   EXPECT_EQ(config_data->output3DSensorPluginYAML(test_file), true);
 
   // Read from the written file
-  config_data = std::make_shared<moveit_setup_assistant::MoveItConfigData>();
-  EXPECT_EQ(config_data->input3DSensorsYAML(test_file), true);
-
-  // Should now have two sensors
-  EXPECT_EQ(config_data->getSensorPluginConfig().size(), 2u);
+  config = moveit_setup_assistant::MoveItConfigData::load3DSensorsYAML(test_file);
+  EXPECT_EQ(config.size(), 2u);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
The perception widget had several issues since its introduction in #969: 
- By reading both, the default and the existing package's `sensors_3d.yaml` into the config, the config file was growing by 2 configs each time.
- Not visiting the `Perception` tab, was writing the default config with 2 entries
- Selecting "None" was writing an invalid config:
  ```yaml
  sensors:
    - {}
    - {}
  ```