### PR TITLE
MoveitCpp - added ability to set path constraints for PlanningComponent.

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -175,6 +175,9 @@ public:
   /** \brief Set the goal constraints generated from a named target state */
   bool setGoal(const std::string& named_target);
 
+  /** \brief Set the path constraints used for planning */
+  bool setPathConstraints(const moveit_msgs::Constraints& path_constraints);
+
   /** \brief Run a plan from start or current state to fulfill the last goal constraints provided by setGoal() using
    * default parameters. */
   PlanSolution plan();
@@ -202,6 +205,7 @@ private:
   // The start state used in the planning motion request
   moveit::core::RobotStatePtr considered_start_state_;
   std::vector<moveit_msgs::Constraints> current_goal_constraints_;
+  moveit_msgs::Constraints current_path_constraints_;
   PlanRequestParameters plan_request_parameters_;
   moveit_msgs::WorkspaceParameters workspace_parameters_;
   bool workspace_parameters_set_ = false;

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -99,6 +99,12 @@ const std::string& PlanningComponent::getPlanningGroupName() const
   return group_name_;
 }
 
+bool PlanningComponent::setPathConstraints(const moveit_msgs::Constraints& path_constraints)
+{
+  current_path_constraints_ = path_constraints;
+  return true;
+}
+
 PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParameters& parameters)
 {
   last_plan_solution_ = std::make_shared<PlanSolution>();
@@ -146,6 +152,9 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
     return *last_plan_solution_;
   }
   req.goal_constraints = current_goal_constraints_;
+
+  // Set path constraints
+  req.path_constraints = current_path_constraints_;
 
   // Run planning attempt
   ::planning_interface::MotionPlanResponse res;


### PR DESCRIPTION
### Description

PR for issue [2958](https://github.com/ros-planning/moveit/issues/2958). Only minor difference from the corresponding moveit2 implementation is the change in the moveit_msg definitions.