### PR TITLE
Add MSA write gazebo urdf feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ qtcreator-*
 
 #gdb
 *.gdb
+compile_commands.json
 
 _build
 _autosummary

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -199,8 +199,9 @@ public:
     POSES = 1 << 6,
     END_EFFECTORS = 1 << 7,
     PASSIVE_JOINTS = 1 << 8,
-    AUTHOR_INFO = 1 << 9,
-    SENSORS_CONFIG = 1 << 10,
+    SIMULATION = 1 << 9,
+    AUTHOR_INFO = 1 << 10,
+    SENSORS_CONFIG = 1 << 11,
     SRDF = COLLISIONS | VIRTUAL_JOINTS | GROUPS | GROUP_CONTENTS | POSES | END_EFFECTORS | PASSIVE_JOINTS
   };
   unsigned long changes;  // bitfield of changes (composed of InformationFields)
@@ -222,6 +223,7 @@ public:
 
   /// Flag indicating whether the URDF was loaded from .xacro format
   bool urdf_from_xacro_;
+
   /// xacro arguments
   std::string xacro_args_;
 
@@ -230,6 +232,13 @@ public:
 
   /// URDF robot model string
   std::string urdf_string_;
+
+  /// Gazebo URDF robot model string
+  // NOTE: Created when the robot urdf is not compatible with Gazebo.
+  std::string gazebo_urdf_string_;
+
+  /// Whether a new Gazebo URDF is created
+  bool new_gazebo_urdf_;
 
   // ******************************************************************************************
   // SRDF Data
@@ -303,11 +312,17 @@ public:
   void loadAllowedCollisionMatrix();
 
   // ******************************************************************************************
+  // Public Functions that influence the configuration files widget
+  // ******************************************************************************************
+  bool gazeboURDFGenerated();
+
+  // ******************************************************************************************
   // Public Functions for outputting configuration and setting files
   // ******************************************************************************************
   std::vector<OMPLPlannerDescription> getOMPLPlanners() const;
   std::map<std::string, double> getInitialJoints() const;
   bool outputSetupAssistantFile(const std::string& file_path);
+  bool outputGazeboURDFFile(const std::string& file_path);
   bool outputOMPLPlanningYAML(const std::string& file_path);
   bool outputCHOMPPlanningYAML(const std::string& file_path);
   bool outputKinematicsYAML(const std::string& file_path);

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -201,6 +201,30 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
 }
 
 // ******************************************************************************************
+// Check if Gazebo URDF was generated
+// ******************************************************************************************
+bool MoveItConfigData::gazeboURDFGenerated()
+{
+  return new_gazebo_urdf_;
+}
+
+// ******************************************************************************************
+// Output Gazebo URDF file
+// ******************************************************************************************
+bool MoveItConfigData::outputGazeboURDFFile(const std::string& file_path)
+{
+  if (new_gazebo_urdf_)
+  {
+    TiXmlDocument urdf_document;
+
+    urdf_document.Parse((const char*)gazebo_urdf_string_.c_str(), nullptr, TIXML_ENCODING_UTF8);
+    urdf_document.SaveFile(file_path);
+  }
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
 // Output OMPL Planning config files
 // ******************************************************************************************
 bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -242,7 +242,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   // -------------------------------------------------------------------------------------------------------------------
   // CONIG FILES -------------------------------------------------------------------------------------------------------
   // -------------------------------------------------------------------------------------------------------------------
-  std::string config_path = "config";
+  config_path_ = "config";
 
   // config/ --------------------------------------------------------------------------------------
   file.file_name_ = "config/";
@@ -257,7 +257,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = config_data_->srdf_pkg_relative_path_.empty() ? config_data_->urdf_model_->getName() + ".srdf" :
                                                                     config_data_->srdf_pkg_relative_path_;
   file.rel_path_ = config_data_->srdf_pkg_relative_path_.empty() ?
-                       config_data_->appendPaths(config_path, file.file_name_) :
+                       config_data_->appendPaths(config_path_, file.file_name_) :
                        config_data_->srdf_pkg_relative_path_;
   file.description_ = "SRDF (<a href='http://www.ros.org/wiki/srdf'>Semantic Robot Description Format</a>) is a "
                       "representation of semantic information about robots. This format is intended to represent "
@@ -269,9 +269,23 @@ bool ConfigurationFilesWidget::loadGenFiles()
   // special step required so the generated .setup_assistant yaml has this value
   config_data_->srdf_pkg_relative_path_ = file.rel_path_;
 
+  // gazebo_<ROBOT>.urdf ---------------------------------------------------------------------------------------
+  file.file_name_ = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
+  file.description_ = "URDF (<a href='https://wiki.ros.org/urdf'>Unified Robot Description Format</a>) is an XML "
+                      "format for representing a robot model. This file is similar to the Robot model you loaded "
+                      "into the MSA but converted to the right format such that it is compatible with GAZEBO "
+                      "(checkout the <a href='http://gazebosim.org/tutorials/?tut=ros_urdf'>URDF gazebo</a> "
+                      "documentation for more information).";
+  file.hidden_func_ = !boost::bind(&MoveItConfigData::gazeboURDFGenerated, config_data_);
+  file.gen_func_ = boost::bind(&MoveItConfigData::outputGazeboURDFFile, config_data_, _1);
+  file.write_on_changes = MoveItConfigData::SIMULATION;
+  gen_files_.push_back(file);
+  file.hidden_func_.clear();
+
   // ompl_planning.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "ompl_planning.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Configures the OMPL (<a href='http://ompl.kavrakilab.org/'>Open Motion Planning Library</a>) "
                       "planning plugin. For every planning group defined in the SRDF, a number of planning "
                       "configurations are specified (under planner_configs). Additionally, default settings for the "
@@ -286,7 +300,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // chomp_planning.yaml  --------------------------------------------------------------------------------------
   file.file_name_ = "chomp_planning.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Specifies which chomp planning plugin parameters to be used for the CHOMP planner";
   file.gen_func_ = boost::bind(&MoveItConfigData::outputCHOMPPlanningYAML, config_data_, _1);
   file.write_on_changes = MoveItConfigData::GROUPS;  // need to double check if this is actually correct!
@@ -294,7 +308,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // kinematics.yaml  --------------------------------------------------------------------------------------
   file.file_name_ = "kinematics.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Specifies which kinematic solver plugin to use for each planning group in the SRDF, as well as "
                       "the kinematic solver search resolution.";
   file.gen_func_ = boost::bind(&MoveItConfigData::outputKinematicsYAML, config_data_, _1);
@@ -303,7 +317,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // joint_limits.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "joint_limits.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Contains additional information about joints that appear in your planning groups that is not "
                       "contained in the URDF, as well as allowing you to set maximum and minimum limits for velocity "
                       "and acceleration than those contained in your URDF. This information is used by our trajectory "
@@ -315,7 +329,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // cartesian_limits.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "cartesian_limits.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   template_path = config_data_->appendPaths(config_data_->template_package_path_, file.rel_path_);
   file.description_ = "Cartesian velocity for planning in the workspace."
                       "The velocity is used by pilz industrial motion planner as maximum velocity for cartesian "
@@ -326,7 +340,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // fake_controllers.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "fake_controllers.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Creates dummy configurations for controllers that correspond to defined groups. This is mostly "
                       "useful for testing.";
   file.gen_func_ = boost::bind(&MoveItConfigData::outputFakeControllersYAML, config_data_, _1);
@@ -335,7 +349,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // simple_moveit_controllers.yaml -------------------------------------------------------------------------------
   file.file_name_ = "simple_moveit_controllers.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Creates controller configuration for SimpleMoveItControllerManager";
   file.gen_func_ = boost::bind(&MoveItConfigData::outputSimpleControllersYAML, config_data_, _1);
   file.write_on_changes = MoveItConfigData::GROUPS;
@@ -343,7 +357,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // gazebo_controllers.yaml ------------------------------------------------------------------
   file.file_name_ = "gazebo_controllers.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   template_path = config_data_->appendPaths(config_data_->template_package_path_, file.rel_path_);
   file.description_ = "Configuration of Gazebo controllers";
   file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, _1);
@@ -351,7 +365,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // ros_controllers.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "ros_controllers.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Creates controller configurations for ros_control.";
   file.gen_func_ = boost::bind(&MoveItConfigData::outputROSControllersYAML, config_data_, _1);
   file.write_on_changes = MoveItConfigData::GROUPS;
@@ -359,7 +373,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
 
   // sensors_3d.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "sensors_3d.yaml";
-  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  file.rel_path_ = config_data_->appendPaths(config_path_, file.file_name_);
   file.description_ = "Creates configurations 3d sensors.";
   file.gen_func_ = boost::bind(&MoveItConfigData::output3DSensorPluginYAML, config_data_, _1);
   file.write_on_changes = MoveItConfigData::SENSORS_CONFIG;
@@ -569,6 +583,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.description_ = "Gazebo launch file which also launches ros_controllers and sends robot urdf to param server, "
                       "then using gazebo_ros pkg the robot is spawned to Gazebo";
   file.gen_func_ = boost::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, _1);
+  file.write_on_changes = MoveItConfigData::SIMULATION;
   gen_files_.push_back(file);
 
   // joystick_control.launch ------------------------------------------------------------------
@@ -906,6 +921,12 @@ bool ConfigurationFilesWidget::showGenFiles()
     // Link the gen_files_ index to this item
     item->setData(Qt::UserRole, QVariant(static_cast<qulonglong>(i)));
 
+    // Disable items that need to be disabled
+    if (file->hidden_func_ && file->hidden_func_())
+    {
+      item->setHidden(file->hidden_func_());
+    }
+
     // Add actions to list
     action_list_->addItem(item);
     action_desc_.append(QString(file->description_.c_str()));
@@ -1141,15 +1162,30 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     addTemplateString("[URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 
   // Pair 4
-  addTemplateString("[ROBOT_NAME]", config_data_->srdf_->robot_name_);
+  if (config_data_->new_gazebo_urdf_)
+  {
+    std::string file_name = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
+    std::string rel_path = config_data_->appendPaths(config_path_, file_name);
+    addTemplateString("[GAZEBO_URDF_LOAD_ATTRIBUTE]", "textfile=\"$(find " + new_package_name_ + ")/" + rel_path + "\"");
+  }
+  else if (config_data_->urdf_from_xacro_)
+  {
+    addTemplateString("[GAZEBO_URDF_LOAD_ATTRIBUTE]",
+                      "command=\"xacro " + config_data_->xacro_args_ + " '" + urdf_location + "'\"");
+  }
+  else
+    addTemplateString("[GAZEBO_URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 
   // Pair 5
-  addTemplateString("[ROBOT_ROOT_LINK]", config_data_->getRobotModel()->getRootLinkName());
+  addTemplateString("[ROBOT_NAME]", config_data_->srdf_->robot_name_);
 
   // Pair 6
-  addTemplateString("[PLANNING_FRAME]", config_data_->getRobotModel()->getModelFrame());
+  addTemplateString("[ROBOT_ROOT_LINK]", config_data_->getRobotModel()->getRootLinkName());
 
   // Pair 7
+  addTemplateString("[PLANNING_FRAME]", config_data_->getRobotModel()->getModelFrame());
+
+  // Pair 8
   std::stringstream vjb;
   for (std::size_t i = 0; i < config_data_->srdf_->virtual_joints_.size(); ++i)
   {
@@ -1159,7 +1195,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
   }
   addTemplateString("[VIRTUAL_JOINT_BROADCASTER]", vjb.str());
 
-  // Pair 8 - Add dependencies to package.xml if the robot.urdf file is relative to a ROS package
+  // Pair 9 - Add dependencies to package.xml if the robot.urdf file is relative to a ROS package
   if (config_data_->urdf_pkg_name_.empty())
   {
     addTemplateString("[OTHER_DEPENDENCIES", "");  // not relative to a ROS package
@@ -1171,7 +1207,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     addTemplateString("[OTHER_DEPENDENCIES]", deps.str());  // not relative to a ROS package
   }
 
-  // Pair 9 - List of ROS Controllers to load in ros_controllers.launch file
+  // Pair 10 - List of ROS Controllers to load in ros_controllers.launch file
   if (config_data_->getControllers().empty())
   {
     addTemplateString("[ROS_CONTROLLERS]", "");
@@ -1188,7 +1224,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     addTemplateString("[ROS_CONTROLLERS]", controllers.str());
   }
 
-  // Pair 10 - Add parameter files for the kinematics solvers that should be loaded
+  // Pair 11 - Add parameter files for the kinematics solvers that should be loaded
   // in addition to kinematics.yaml by planning_context.launch
   std::string kinematics_parameters_files_block;
   for (const auto& groups : config_data_->group_meta_data_)

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.h
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.h
@@ -62,9 +62,10 @@ struct GenerateFile
   std::string file_name_;
   std::string rel_path_;
   std::string description_;
-  unsigned long write_on_changes;  // bitfield indicating required rewrite
-  bool generate_;                  // "generate" checkbox ticked?
-  bool modified_;                  // file externally modified?
+  unsigned long write_on_changes;        // bitfield indicating required rewrite
+  bool generate_;                        // "generate" checkbox ticked?
+  bool modified_;                        // file externally modified?
+  boost::function<bool()> hidden_func_;  // function that hides a file checkbox
   boost::function<bool(std::string)> gen_func_;
 };
 
@@ -125,6 +126,9 @@ private:
   // ******************************************************************************************
   // Variables
   // ******************************************************************************************
+
+  /// Relative configuration path
+  std::string config_path_;
 
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;

--- a/moveit_setup_assistant/src/widgets/simulation_widget.h
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.h
@@ -38,6 +38,7 @@
 // Qt
 class QLabel;
 class QTextEdit;
+class QPushButton;
 
 // SA
 #ifndef Q_MOC_RUN
@@ -76,6 +77,12 @@ private Q_SLOTS:
   /// Generate URDF button clicked
   void generateURDFClick();
 
+  /// Overwrite original URDF button clicked
+  void overwriteURDFClick();
+
+  /// Display gazebo URDF on the GUI
+  void displayURDF();
+
 private:
   // ******************************************************************************************
   // Qt Components
@@ -83,6 +90,7 @@ private:
 
   QTextEdit* simulation_text_;
   QLabel* no_changes_label_;
+  QPushButton* btn_overwrite_;
   QLabel* copy_urdf_;
 
   /// Contains all the configuration data for the setup assistant

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -13,7 +13,7 @@
   </include>
 
   <!-- send robot urdf to param server -->
-  <param name="robot_description" [URDF_LOAD_ATTRIBUTE] />
+  <param name="robot_description" [GAZEBO_URDF_LOAD_ATTRIBUTE] />
 
   <!-- unpause only after loading robot model -->
   <arg name="unpause" value="$(eval '' if arg('paused') else '-unpause')" />


### PR DESCRIPTION
### Description

This pull request adds several improvements to the simulation tab of the MSA. The most significant change is that the Gazebo URDF shown in the simulation tab was not saved in the old version. As a result, when the provided URDF was incompatible with the Gazebo, the `gazebo.launch` file was not working. The new version now ensures that a gazebo URDF is saved as a MoveIT configuration file when the provided URDF is invalid. It further provides users with the option to overwrite the provided URDF and fixes a small bug:

- [fix(msa): fix redunant transmission tag create bug](https://github.com/ros-planning/moveit/pull/2960/commits/74f7bd3f4c7ad60af5f7ac8f62ee85743ff007ae)

I first tried 22284a59f6bc8c3d7a138681c261f04df009d286. However, in the end, I added 74f7bd3f4c7ad60af5f7ac8f62ee85743ff007ae since it does a better job at checking whether a urdf is Gazebo compatible. 

### Tests

#### New configuration no sim

![new_now_sim](https://user-images.githubusercontent.com/17570430/141830794-c26dd7ab-5771-45ae-a268-24567aa63132.gif)

The `gazebo_panda.urdf` is **NOT**  added.

#### New configuration + sim + compatible xacro

Here I use https://github.com/frankaemika/franka_ros/pull/199 for the xacro description. This model is Gazebo compatible. I however had to add an inertial tag to the [panda_link8_sc link](https://github.com/frankaemika/franka_ros/blob/63ecb779ae49d023b5ef93434a457bb599c553ed/franka_description/robots/arm.xacro#L271-L289) since my script has no knowledge of why this link has no inertia.

```diff
<link name="${prefix}link8_sc">
      <collision>
        <origin xyz="0.0424 0.0424 -0.0250" rpy="${pi} ${pi/2} ${pi/2}"/>
        <geometry>
          <cylinder radius="${0.03+safety_distance}"  length="0.01" />
        </geometry>
      </collision>
      <collision>
        <origin xyz="0.0424 0.0424 -0.02" rpy="0 0 0"/>
        <geometry>
          <sphere radius="${0.03+safety_distance}"  />
        </geometry>
      </collision>
      <collision>
        <origin xyz="0.0424 0.0424 -0.03" rpy="0 0 0"/>
        <geometry>
          <sphere radius="${0.03+safety_distance}"  />
        </geometry>
      </collision>
+      <inertial>
+        <mass value="0"/>
+       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
+     </inertial>
    </link>
```

![new_gazebo_compatibe_xacro](https://user-images.githubusercontent.com/17570430/141978928-ec604696-d742-4d2f-85e3-289417aeff39.gif)

The `gazebo_panda.urdf` is **NOT**  added.

#### New configuration + sim + xacro description

![new_gazebo_incompatible_xacro gif](https://user-images.githubusercontent.com/17570430/141831803-6c9b9aa1-ced4-4a81-ae60-21cc748ed587.gif)

The `gazebo_panda.urdf` is added.

#### New configuration + sim + xacro description + overwrite

![new_gazebo_incompatible_xacro_overwrite](https://user-images.githubusercontent.com/17570430/141832092-41f2c4c2-e5f3-4ec1-bfa0-31eaa2f2ca4f.gif)

The `gazebo_panda.urdf` is added.

#### New configuration + sim + compatible urdf

![new_gazebo_compatible_urdf](https://user-images.githubusercontent.com/17570430/141833756-06df46d4-02fd-4d7a-a4fa-52b9d8847b64.gif)

The `gazebo_panda.urdf` is **NOT**  added.

#### New configuration + sim + urdf description

![new_gazebo_incompatible_urdf](https://user-images.githubusercontent.com/17570430/141834932-a1db3d5b-c57d-4cfc-a0b3-6e3b9d9df14a.gif)

The `gazebo_panda.urdf` is added.

#### New configuration + sim + urdf description + overwrite

![new_gazebo_incompatible_urdf_overwrite](https://user-images.githubusercontent.com/17570430/141834231-4bb959aa-b190-4280-8f25-aa2fe24dc175.gif)

The `gazebo_panda.urdf` is **NOT**  added.

#### Existing configuration no sim

![existing_no_sim](https://user-images.githubusercontent.com/17570430/141835507-00dc5474-b5d5-4e56-b20b-6ead64f248cd.gif)

The `gazebo_panda.urdf` is **NOT**  added.

#### Existing configuration + sim + xacro description

![existing_no_sim_xacro](https://user-images.githubusercontent.com/17570430/141835601-ea51d09d-fe95-418d-a52f-68b6c4ff13bb.gif)

The `gazebo_panda.urdf` is added.

#### Existing configuration + sim + xacro description + overwrite

![existing_no_sim_xacro_overwrite](https://user-images.githubusercontent.com/17570430/141835680-41f2a063-7b21-4029-a020-cd3ece903a2f.gif)

The `gazebo_panda.urdf` is added.

#### Existing configuration + sim + compatible urdf description

![existing_sim_compatible_urdf](https://user-images.githubusercontent.com/17570430/141853703-034fa958-693f-426d-b386-1e2a16f98766.gif)

The `gazebo_panda.urdf` is **NOT** added.

#### Existing configuration + sim + urdf description

![existing_sim_incompatible_urdf](https://user-images.githubusercontent.com/17570430/141853830-1d4a7b9b-d9c1-4a48-9f52-9a15063f2d2b.gif)

The `gazebo_panda.urdf` is added.

#### Existing configuration + sim + urdf description + overwrite

![existing_sim_incompatible_urdf_overwrite](https://user-images.githubusercontent.com/17570430/141854023-7cef41fe-28a7-4e17-ba6a-6c6c7f1ddd46.gif)

The `gazebo_panda.urdf` is **NOT** added.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
    - [x] Simulation section of the moveit_tutorials have to be updated will be handled in https://github.com/ros-planning/moveit_tutorials/pull/678
- [x] Include a screenshot if changing a GUI


### Other downstream TODOS
- [ ] If this pull request is merged open a pull request at [franka_ros](https://github.com/frankaemika/franka_ros) to add a dummy `inertial` tag to the `panda_link8_sc` link. This way the Franka `urdf` is seen as Gazebo compatible.