### PR TITLE
TOTG: reject waypoints that have a duration of zero

### DIFF
--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -971,19 +971,21 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     {
       new_point[j] = waypoint->getVariablePosition(idx[j]);
       // If any joint angle is different and duration is nonzero, it's a unique waypoint
-      if ((p > 0) && (std::fabs(new_point[j] - points.back()[j]) > min_angle_change_) && (duration > 0))
+      if ((std::fabs(new_point[j] - points.back()[j]) > min_angle_change_) && (duration > 0))
       {
         diverse_point = true;
-      }
-      else
-      {
-        ROS_WARN_NAMED(LOGNAME, "TOTG skipped a waypoint because it is nearly identical to the previous waypoint, or "
-                                "has a duration of zero");
       }
     }
 
     if (diverse_point)
+    {
       points.push_back(new_point);
+    }
+    else
+    {
+      ROS_WARN_NAMED(LOGNAME, "TOTG skipped a waypoint because it is nearly identical to the previous waypoint, or "
+                              "has a duration of zero");
+    }
   }
 
   // Return trajectory with only the first waypoint if there are not multiple diverse points

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -963,14 +963,15 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   {
     moveit::core::RobotStatePtr waypoint = trajectory.getWayPointPtr(p);
     Eigen::VectorXd new_point(num_joints);
+    double duration = trajectory.getWayPointDurationFromPrevious(p);
     // The first point should always be kept
     bool diverse_point = (p == 0);
 
     for (size_t j = 0; j < num_joints; ++j)
     {
       new_point[j] = waypoint->getVariablePosition(idx[j]);
-      // If any joint angle is different, it's a unique waypoint
-      if (p > 0 && std::fabs(new_point[j] - points.back()[j]) > min_angle_change_)
+      // If any joint angle is different and duration is nonzero, it's a unique waypoint
+      if ((p > 0) && (std::fabs(new_point[j] - points.back()[j]) > min_angle_change_) && (duration > 0))
       {
         diverse_point = true;
       }

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -975,6 +975,11 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
       {
         diverse_point = true;
       }
+      else
+      {
+        ROS_WARN_NAMED(LOGNAME, "TOTG skipped a waypoint because it is nearly identical to the previous waypoint, or "
+                                "has a duration of zero");
+      }
     }
 
     if (diverse_point)


### PR DESCRIPTION
I haven't seen that this is an issue but might as well add a check for it.