### PR TITLE
fix(msa): fix modified files bug

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -182,7 +182,8 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
   emitter << YAML::Value << YAML::BeginMap;
   emitter << YAML::Key << "author_name" << YAML::Value << author_name_;
   emitter << YAML::Key << "author_email" << YAML::Value << author_email_;
-  emitter << YAML::Key << "generated_timestamp" << YAML::Value << std::time(nullptr);  // TODO: is this cross-platform?
+  auto cur_time = std::time(nullptr);
+  emitter << YAML::Key << "generated_timestamp" << YAML::Value << cur_time;  // TODO: is this cross-platform?
   emitter << YAML::EndMap;
 
   emitter << YAML::EndMap;
@@ -196,6 +197,10 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
 
   output_stream << emitter.c_str();
   output_stream.close();
+
+  /// Update the parsed setup_assistant timestamp
+  // NOTE: Needed for when people run the MSA generator multiple times in a row.
+  config_pkg_generated_timestamp_ = cur_time;
 
   return true;  // file created successfully
 }


### PR DESCRIPTION
This pull request fixes an MSA bug that caused files in a loaded MoveIt config to incorrectly be classified as externally modified. This happened when the `Generate Package` button is clicked multiple times and we go back to other tabs.
