### PR TITLE
Apply clang-tidy fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
         -Wno-unused-parameter
         ${{ matrix.env.CLANG_TIDY && '-Wno-error=c++17-compat -Wno-error=overloaded-virtual -Wno-error=unused-function' || '' }}
-      CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
+      CLANG_TIDY_ARGS: --fix --fix-errors
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall
       TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#melodic-devel

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -66,7 +66,7 @@ enum Type
       imply that the two bodies are in collision*/
   CONDITIONAL
 };
-}
+}  // namespace AllowedCollision
 
 /** \brief Signature of predicate that decides whether a contact is allowed or not (when AllowedCollision::Type is
  * CONDITIONAL) */

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -217,7 +217,7 @@ public:
   class ObserverHandle
   {
   public:
-    ObserverHandle() : observer_(NULL)
+    ObserverHandle() : observer_(nullptr)
     {
     }
 
@@ -246,7 +246,7 @@ public:
 
 private:
   /** notify all observers of a change */
-  void notify(const ObjectConstPtr&, Action);
+  void notify(const ObjectConstPtr& obj, Action action);
 
   /** send notification of change to all objects. */
   void notifyAll(Action action);

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world_diff.h
@@ -112,7 +112,7 @@ public:
 
 private:
   /** \brief Notification function */
-  void notify(const World::ObjectConstPtr&, World::Action);
+  void notify(const World::ObjectConstPtr& obj, World::Action action);
 
   /** keep changes in a map so they can be coalesced */
   std::map<std::string, World::Action> changes_;

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -139,12 +139,12 @@ struct CollisionGeometryData
 /** \brief Data structure which is passed to the collision callback function of the collision manager. */
 struct CollisionData
 {
-  CollisionData() : req_(NULL), active_components_only_(NULL), res_(NULL), acm_(NULL), done_(false)
+  CollisionData() : req_(nullptr), active_components_only_(nullptr), res_(nullptr), acm_(nullptr), done_(false)
   {
   }
 
   CollisionData(const CollisionRequest* req, CollisionResult* res, const AllowedCollisionMatrix* acm)
-    : req_(req), active_components_only_(NULL), res_(res), acm_(acm), done_(false)
+    : req_(req), active_components_only_(nullptr), res_(res), acm_(acm), done_(false)
   {
   }
 

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
@@ -13,7 +13,7 @@ namespace collision_detection
 class CollisionDetectorFCLPluginLoader : public CollisionPlugin
 {
 public:
-  virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const;
+  bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const override;
 };
 }  // namespace collision_detection
 #endif  // MOVEIT_COLLISION_DETECTION_FCL_COLLISION_DETECTOR_FCL_PLUGIN_LOADER_H_

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -417,20 +417,20 @@ public:
       dist = sqrt_table_[cell->distance_square_];
       pos = cell->closest_point_;
       const PropDistanceFieldVoxel* ncell = &voxel_grid_->getCell(pos.x(), pos.y(), pos.z());
-      return ncell == cell ? NULL : ncell;
+      return ncell == cell ? nullptr : ncell;
     }
     if (cell->negative_distance_square_ > 0)
     {
       dist = -sqrt_table_[cell->negative_distance_square_];
       pos = cell->closest_negative_point_;
       const PropDistanceFieldVoxel* ncell = &voxel_grid_->getCell(pos.x(), pos.y(), pos.z());
-      return ncell == cell ? NULL : ncell;
+      return ncell == cell ? nullptr : ncell;
     }
     dist = 0.0;
     pos.x() = x;
     pos.y() = y;
     pos.z() = z;
-    return NULL;
+    return nullptr;
   }
 
   /**

--- a/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
@@ -342,7 +342,7 @@ protected:
 template <typename T>
 VoxelGrid<T>::VoxelGrid(double size_x, double size_y, double size_z, double resolution, double origin_x,
                         double origin_y, double origin_z, T default_object)
-  : data_(NULL)
+  : data_(nullptr)
 {
   resize(size_x, size_y, size_z, resolution, origin_x, origin_y, origin_z, default_object);
 }
@@ -369,7 +369,7 @@ void VoxelGrid<T>::resize(double size_x, double size_y, double size_z, double re
                           double origin_y, double origin_z, T default_object)
 {
   delete[] data_;
-  data_ = NULL;
+  data_ = nullptr;
 
   size_[DIM_X] = size_x;
   size_[DIM_Y] = size_y;

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -145,7 +145,7 @@ public:
    *
    * @param [in] out The file descriptor for printing
    */
-  virtual void print(std::ostream& = std::cout) const
+  virtual void print(std::ostream& /*unused*/ = std::cout) const
   {
   }
 
@@ -209,7 +209,7 @@ public:
    * @param [in] model The kinematic model used for constraint evaluation
    */
   JointConstraint(const robot_model::RobotModelConstPtr& model)
-    : KinematicConstraint(model), joint_model_(NULL), joint_variable_index_(-1)
+    : KinematicConstraint(model), joint_model_(nullptr), joint_variable_index_(-1)
   {
     type_ = JOINT_CONSTRAINT;
   }
@@ -356,7 +356,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  OrientationConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  OrientationConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(nullptr)
   {
     type_ = ORIENTATION_CONSTRAINT;
   }
@@ -513,7 +513,7 @@ public:
    *
    * @param [in] model The kinematic model used for constraint evaluation
    */
-  PositionConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(NULL)
+  PositionConstraint(const robot_model::RobotModelConstPtr& model) : KinematicConstraint(model), link_model_(nullptr)
   {
     type_ = POSITION_CONSTRAINT;
   }

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -76,7 +76,7 @@ enum DiscretizationMethod
   SOME_RANDOM_SAMPLED /**< the discretization for some redundant joint will be randomly generated.
                            The unused redundant joints will be fixed at their current value. */
 };
-}
+}  // namespace DiscretizationMethods
 typedef DiscretizationMethods::DiscretizationMethod DiscretizationMethod;
 
 /*
@@ -98,7 +98,7 @@ enum KinematicError
   NO_SOLUTION                          /**< A valid joint solution that can reach this pose(s) could not be found */
 
 };
-}
+}  // namespace KinematicErrors
 typedef KinematicErrors::KinematicError KinematicError;
 
 /**
@@ -298,7 +298,7 @@ public:
                    double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
                    const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
                    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                   const moveit::core::RobotState* context_state = NULL) const
+                   const moveit::core::RobotState* context_state = nullptr) const
   {
     // For IK solvers that do not support multiple poses, fall back to single pose call
     if (ik_poses.size() == 1)
@@ -508,7 +508,7 @@ public:
    *          supported.
    * \return True if the group is supported, false if not.
    */
-  virtual bool supportsGroup(const moveit::core::JointModelGroup* jmg, std::string* error_text_out = NULL) const;
+  virtual bool supportsGroup(const moveit::core::JointModelGroup* jmg, std::string* error_text_out = nullptr) const;
 
   /**
    * @brief  Set the search discretization value for all the redundant joints

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -873,14 +873,14 @@ public:
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance and feasibility) */
   bool isPathValid(const moveit_msgs::RobotState& start_state, const moveit_msgs::RobotTrajectory& trajectory,
                    const std::string& group = "", bool verbose = false,
-                   std::vector<std::size_t>* invalid_index = NULL) const;
+                   std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance, feasibility and
    * constraint satisfaction). It is also checked that the goal constraints are satisfied by the last state on the
    * passed in trajectory. */
   bool isPathValid(const moveit_msgs::RobotState& start_state, const moveit_msgs::RobotTrajectory& trajectory,
                    const moveit_msgs::Constraints& path_constraints, const std::string& group = "",
-                   bool verbose = false, std::vector<std::size_t>* invalid_index = NULL) const;
+                   bool verbose = false, std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance, feasibility and
    * constraint satisfaction). It is also checked that the goal constraints are satisfied by the last state on the
@@ -888,7 +888,7 @@ public:
   bool isPathValid(const moveit_msgs::RobotState& start_state, const moveit_msgs::RobotTrajectory& trajectory,
                    const moveit_msgs::Constraints& path_constraints, const moveit_msgs::Constraints& goal_constraints,
                    const std::string& group = "", bool verbose = false,
-                   std::vector<std::size_t>* invalid_index = NULL) const;
+                   std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance, feasibility and
    * constraint satisfaction). It is also checked that the goal constraints are satisfied by the last state on the
@@ -896,7 +896,7 @@ public:
   bool isPathValid(const moveit_msgs::RobotState& start_state, const moveit_msgs::RobotTrajectory& trajectory,
                    const moveit_msgs::Constraints& path_constraints,
                    const std::vector<moveit_msgs::Constraints>& goal_constraints, const std::string& group = "",
-                   bool verbose = false, std::vector<std::size_t>* invalid_index = NULL) const;
+                   bool verbose = false, std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance, feasibility and
    * constraint satisfaction). It is also checked that the goal constraints are satisfied by the last state on the
@@ -904,7 +904,7 @@ public:
   bool isPathValid(const robot_trajectory::RobotTrajectory& trajectory,
                    const moveit_msgs::Constraints& path_constraints,
                    const std::vector<moveit_msgs::Constraints>& goal_constraints, const std::string& group = "",
-                   bool verbose = false, std::vector<std::size_t>* invalid_index = NULL) const;
+                   bool verbose = false, std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance, feasibility and
    * constraint satisfaction). It is also checked that the goal constraints are satisfied by the last state on the
@@ -912,17 +912,17 @@ public:
   bool isPathValid(const robot_trajectory::RobotTrajectory& trajectory,
                    const moveit_msgs::Constraints& path_constraints, const moveit_msgs::Constraints& goal_constraints,
                    const std::string& group = "", bool verbose = false,
-                   std::vector<std::size_t>* invalid_index = NULL) const;
+                   std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance, feasibility and
    * constraint satisfaction). */
   bool isPathValid(const robot_trajectory::RobotTrajectory& trajectory,
                    const moveit_msgs::Constraints& path_constraints, const std::string& group = "",
-                   bool verbose = false, std::vector<std::size_t>* invalid_index = NULL) const;
+                   bool verbose = false, std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Check if a given path is valid. Each state is checked for validity (collision avoidance and feasibility) */
   bool isPathValid(const robot_trajectory::RobotTrajectory& trajectory, const std::string& group = "",
-                   bool verbose = false, std::vector<std::size_t>* invalid_index = NULL) const;
+                   bool verbose = false, std::vector<std::size_t>* invalid_index = nullptr) const;
 
   /** \brief Get the top \e max_costs cost sources for a specified trajectory. The resulting costs are stored in \e
    * costs */

--- a/moveit_core/profiler/include/moveit/profiler/profiler.h
+++ b/moveit_core/profiler/include/moveit/profiler/profiler.h
@@ -136,19 +136,19 @@ public:
   }
 
   /** \brief Start counting time */
-  static void Start()
+  static void Start()  // NOLINT(readability-identifier-naming)
   {
     instance().start();
   }
 
   /** \brief Stop counting time */
-  static void Stop()
+  static void Stop()  // NOLINT(readability-identifier-naming)
   {
     instance().stop();
   }
 
   /** \brief Clear counted time and events */
-  static void Clear()
+  static void Clear()  // NOLINT(readability-identifier-naming)
   {
     instance().clear();
   }
@@ -163,7 +163,7 @@ public:
   void clear();
 
   /** \brief Count a specific event for a number of times */
-  static void Event(const std::string& name, const unsigned int times = 1)
+  static void Event(const std::string& name, const unsigned int times = 1)  // NOLINT(readability-identifier-naming)
   {
     instance().event(name, times);
   }
@@ -172,7 +172,7 @@ public:
   void event(const std::string& name, const unsigned int times = 1);
 
   /** \brief Maintain the average of a specific value */
-  static void Average(const std::string& name, const double value)
+  static void Average(const std::string& name, const double value)  // NOLINT(readability-identifier-naming)
   {
     instance().average(name, value);
   }
@@ -181,13 +181,13 @@ public:
   void average(const std::string& name, const double value);
 
   /** \brief Begin counting time for a specific chunk of code */
-  static void Begin(const std::string& name)
+  static void Begin(const std::string& name)  // NOLINT(readability-identifier-naming)
   {
     instance().begin(name);
   }
 
   /** \brief Stop counting time for a specific chunk of code */
-  static void End(const std::string& name)
+  static void End(const std::string& name)  // NOLINT(readability-identifier-naming)
   {
     instance().end(name);
   }
@@ -201,7 +201,7 @@ public:
   /** \brief Print the status of the profiled code chunks and
       events. Optionally, computation done by different threads
       can be printed separately. */
-  static void Status(std::ostream& out = std::cout, bool merge = true)
+  static void Status(std::ostream& out = std::cout, bool merge = true)  // NOLINT(readability-identifier-naming)
   {
     instance().status(out, merge);
   }
@@ -213,7 +213,7 @@ public:
 
   /** \brief Print the status of the profiled code chunks and
       events to the console (using msg::Console) */
-  static void Console(void)
+  static void Console()  // NOLINT(readability-identifier-naming)
   {
     instance().console();
   }
@@ -229,7 +229,7 @@ public:
   }
 
   /** \brief Check if the profiler is counting time or not */
-  static bool Running(void)
+  static bool Running()  // NOLINT(readability-identifier-naming)
   {
     return instance().running();
   }

--- a/moveit_core/profiler/include/moveit/profiler/profiler.h
+++ b/moveit_core/profiler/include/moveit/profiler/profiler.h
@@ -84,7 +84,7 @@ public:
       prof_.begin(name);
     }
 
-    ~ScopedBlock(void)
+    ~ScopedBlock()
     {
       prof_.end(name_);
     }
@@ -106,7 +106,7 @@ public:
         prof_.start();
     }
 
-    ~ScopedStart(void)
+    ~ScopedStart()
     {
       if (!wasRunning_)
         prof_.stop();
@@ -118,7 +118,7 @@ public:
   };
 
   /** \brief Return an instance of the class */
-  static Profiler& instance(void);
+  static Profiler& instance();
 
   /** \brief Constructor. It is allowed to separately instantiate this
       class (not only as a singleton) */
@@ -129,38 +129,38 @@ public:
   }
 
   /** \brief Destructor */
-  ~Profiler(void)
+  ~Profiler()
   {
     if (printOnDestroy_ && !data_.empty())
       status();
   }
 
   /** \brief Start counting time */
-  static void Start(void)
+  static void Start()
   {
     instance().start();
   }
 
   /** \brief Stop counting time */
-  static void Stop(void)
+  static void Stop()
   {
     instance().stop();
   }
 
   /** \brief Clear counted time and events */
-  static void Clear(void)
+  static void Clear()
   {
     instance().clear();
   }
 
   /** \brief Start counting time */
-  void start(void);
+  void start();
 
   /** \brief Stop counting time */
-  void stop(void);
+  void stop();
 
   /** \brief Clear counted time and events */
-  void clear(void);
+  void clear();
 
   /** \brief Count a specific event for a number of times */
   static void Event(const std::string& name, const unsigned int times = 1)
@@ -220,10 +220,10 @@ public:
 
   /** \brief Print the status of the profiled code chunks and
       events to the console (using msg::Console) */
-  void console(void);
+  void console();
 
   /** \brief Check if the profiler is counting time or not */
-  bool running(void) const
+  bool running() const
   {
     return running_;
   }
@@ -238,7 +238,7 @@ private:
   /** \brief Information about time spent in a section of the code */
   struct TimeInfo
   {
-    TimeInfo(void)
+    TimeInfo()
       : total(0, 0, 0, 0), shortest(boost::posix_time::pos_infin), longest(boost::posix_time::neg_infin), parts(0)
     {
     }
@@ -259,13 +259,13 @@ private:
     boost::posix_time::ptime start;
 
     /** \brief Begin counting time */
-    void set(void)
+    void set()
     {
       start = boost::posix_time::microsec_clock::universal_time();
     }
 
     /** \brief Add the counted time to the total time */
-    void update(void)
+    void update()
     {
       const boost::posix_time::time_duration& dt = boost::posix_time::microsec_clock::universal_time() - start;
       if (dt > longest)

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -100,7 +100,7 @@ public:
   /** \brief Return true if the model is empty (has no root link, no joints) */
   bool isEmpty() const
   {
-    return root_link_ == NULL;
+    return root_link_ == nullptr;
   }
 
   /** \brief Get the parsed URDF model */

--- a/moveit_core/robot_model/src/order_robot_model_items.inc
+++ b/moveit_core/robot_model/src/order_robot_model_items.inc
@@ -65,6 +65,6 @@ struct OrderGroupsByName
   }
 };
 
-}
-}
-}
+}  // namespace
+}  // namespace core
+}  // namespace moveit

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1905,7 +1905,7 @@ private:
   {
     dirty_joint_transforms_[joint->getJointIndex()] = 1;
     dirty_link_transforms_ =
-        dirty_link_transforms_ == NULL ? joint : robot_model_->getCommonRoot(dirty_link_transforms_, joint);
+        dirty_link_transforms_ == nullptr ? joint : robot_model_->getCommonRoot(dirty_link_transforms_, joint);
   }
 
   void markDirtyJointTransforms(const JointModelGroup* group)
@@ -1913,7 +1913,7 @@ private:
     const std::vector<const JointModel*>& jm = group->getActiveJointModels();
     for (std::size_t i = 0; i < jm.size(); ++i)
       dirty_joint_transforms_[jm[i]->getJointIndex()] = 1;
-    dirty_link_transforms_ = dirty_link_transforms_ == NULL ?
+    dirty_link_transforms_ = dirty_link_transforms_ == nullptr ?
                                  group->getCommonRoot() :
                                  robot_model_->getCommonRoot(dirty_link_transforms_, group->getCommonRoot());
   }

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -96,7 +96,7 @@ public:
   Trajectory(const Path& path, const Eigen::VectorXd& max_velocity, const Eigen::VectorXd& max_acceleration,
              double time_step = 0.001);
 
-  ~Trajectory(void);
+  ~Trajectory();
 
   /** @brief Call this method after constructing the object to make sure the
      trajectory generation succeeded without errors. If this method returns

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -286,8 +286,8 @@ private:
 
   template <class T = KinematicsPlugin>
   typename std::enable_if<!hasRobotModelAPI<T>::value, bool>::type
-  initializeImpl(const moveit::core::RobotModel&, const std::string&, const std::string&,
-                 const std::vector<std::string>&, double)
+  initializeImpl(const moveit::core::RobotModel& /*unused*/, const std::string& /*unused*/,
+                 const std::string& /*unused*/, const std::vector<std::string>& /*unused*/, double /*unused*/)
   {
     return false;  // API not supported
   }
@@ -306,7 +306,8 @@ private:
 
   template <class T = KinematicsPlugin>
   typename std::enable_if<!hasRobotDescAPI<T>::value, bool>::type
-  initializeImpl(const std::string&, const std::string&, const std::string&, const std::string&, double)
+  initializeImpl(const std::string& /*unused*/, const std::string& /*unused*/, const std::string& /*unused*/,
+                 const std::string& /*unused*/, double /*unused*/)
   {
     return false;  // API not supported
   }

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
@@ -84,11 +84,12 @@ public:
    *
    * where W_q and W_x are joint- and Cartesian weights respectively.
    * A smaller joint weight (< 1.0) will reduce the contribution of this joint to the solution. */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int CartToJnt(const JntArray& q_in, const Twist& v_in, JntArray& qdot_out, const Eigen::VectorXd& joint_weights,
                 const Eigen::Matrix<double, 6, 1>& cartesian_weights);
 
   /// not implemented.
-  int CartToJnt(const JntArray& q_init, const FrameVel& v_in, JntArrayVel& q_out) override
+  int CartToJnt(const JntArray& /*q_init*/, const FrameVel& /*v_in*/, JntArrayVel& /*q_out*/) override
   {
     return -1;
   }

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -53,7 +53,7 @@
 #include <kdl/chainfksolver.hpp>
 #include <kdl/chainiksolver.hpp>
 
-// MoveIt!
+// MoveIt
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/kdl_kinematics_plugin/joint_mimic.hpp>
 #include <moveit/robot_model/robot_model.h>
@@ -143,6 +143,7 @@ protected:
   typedef Eigen::Matrix<double, 6, 1> Twist;
 
   /// Solve position IK given initial joint values
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int CartToJnt(KDL::ChainIkSolverVelMimicSVD& ik_solver, const KDL::JntArray& q_init, const KDL::Frame& p_in,
                 KDL::JntArray& q_out, const unsigned int max_iter, const Eigen::VectorXd& joint_weights,
                 const Twist& cartesian_weights) const;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -240,26 +240,26 @@ bool KDLKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model
       }
     }
   }
-  for (std::size_t i = 0; i < mimic_joints_.size(); ++i)
+  for (JointMimic& mimic_joint : mimic_joints_)
   {
-    if (!mimic_joints_[i].active)
+    if (!mimic_joint.active)
     {
-      const robot_model::JointModel* joint_model =
-          joint_model_group_->getJointModel(mimic_joints_[i].joint_name)->getMimic();
-      for (std::size_t j = 0; j < mimic_joints_.size(); ++j)
+      const moveit::core::JointModel* joint_model =
+          joint_model_group_->getJointModel(mimic_joint.joint_name)->getMimic();
+      for (JointMimic& mimic_joint_recal : mimic_joints_)
       {
-        if (mimic_joints_[j].joint_name == joint_model->getName())
+        if (mimic_joint_recal.joint_name == joint_model->getName())
         {
-          mimic_joints_[i].map_index = mimic_joints_[j].map_index;
+          mimic_joint.map_index = mimic_joint_recal.map_index;
         }
       }
     }
   }
 
   // Setup the joint state groups that we need
-  state_.reset(new robot_state::RobotState(robot_model_));
+  state_ = std::make_shared<moveit::core::RobotState>(robot_model_);
 
-  fk_solver_.reset(new KDL::ChainFkSolverPos_recursive(kdl_chain_));
+  fk_solver_ = std::make_unique<KDL::ChainFkSolverPos_recursive>(kdl_chain_);
 
   initialized_ = true;
   ROS_DEBUG_NAMED("kdl", "KDL solver initialized");

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
@@ -54,13 +54,13 @@ public:
   virtual ~ChompCost();
 
   template <typename Derived>
-  void getDerivative(Eigen::MatrixXd::ColXpr joint_trajectory, Eigen::MatrixBase<Derived>& derivative) const;
+  void getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory, Eigen::MatrixBase<Derived>& derivative) const;
 
   const Eigen::MatrixXd& getQuadraticCostInverse() const;
 
   const Eigen::MatrixXd& getQuadraticCost() const;
 
-  double getCost(Eigen::MatrixXd::ColXpr joint_trajectory) const;
+  double getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const;
 
   double getMaxQuadCostInvValue() const;
 
@@ -76,7 +76,8 @@ private:
 };
 
 template <typename Derived>
-void ChompCost::getDerivative(Eigen::MatrixXd::ColXpr joint_trajectory, Eigen::MatrixBase<Derived>& derivative) const
+void ChompCost::getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory,
+                              Eigen::MatrixBase<Derived>& derivative) const
 {
   derivative = (quad_cost_full_ * (2.0 * joint_trajectory));
 }
@@ -91,7 +92,7 @@ inline const Eigen::MatrixXd& ChompCost::getQuadraticCost() const
   return quad_cost_;
 }
 
-inline double ChompCost::getCost(Eigen::MatrixXd::ColXpr joint_trajectory) const
+inline double ChompCost::getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const
 {
   return joint_trajectory.dot(quad_cost_full_ * joint_trajectory);
 }

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -50,7 +50,7 @@
 namespace pilz_industrial_motion_planner
 {
 /**
- * @brief Moveit Plugin for Planning with Standart Robot Commands
+ * @brief MoveIt Plugin for Planning with Standard Robot Commands
  * This planner is dedicated to return a instance of PlanningContext that
  * corresponds to the requested motion command
  * set as planner_id in the MotionPlanRequest).

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -60,7 +60,7 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   // collect most strict joint limits for each group in robot model
   for (const auto& jmg : robot_model->getJointModelGroups())
   {
-    auto active_joints = jmg->getActiveJointModelNames();
+    const auto& active_joints = jmg->getActiveJointModelNames();
 
     // no active joints
     if (active_joints.empty())

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -70,7 +70,7 @@ public:
 
   bool sendTrajectory(const moveit_msgs::RobotTrajectory& t) override;
   bool cancelExecution() override;
-  bool waitForExecution(const ros::Duration&) override;
+  bool waitForExecution(const ros::Duration& timeout) override;
 };
 
 class ThreadedController : public BaseFakeController
@@ -81,7 +81,7 @@ public:
 
   bool sendTrajectory(const moveit_msgs::RobotTrajectory& t) override;
   bool cancelExecution() override;
-  bool waitForExecution(const ros::Duration&) override;
+  bool waitForExecution(const ros::Duration& timeout) override;
   moveit_controller_manager::ExecutionStatus getLastExecutionStatus() override;
 
 protected:

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -154,7 +154,7 @@ public:
 
 protected:
   ros::NodeHandle nh_;
-  std::string getActionName(void) const
+  std::string getActionName() const
   {
     if (namespace_.empty())
       return name_;

--- a/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
+++ b/moveit_ros/manipulation/pick_place/include/moveit/pick_place/manipulation_plan.h
@@ -56,9 +56,9 @@ MOVEIT_STRUCT_FORWARD(ManipulationPlanSharedData);
 struct ManipulationPlanSharedData
 {
   ManipulationPlanSharedData()
-    : planning_group_(NULL)
-    , end_effector_group_(NULL)
-    , ik_link_(NULL)
+    : planning_group_(nullptr)
+    , end_effector_group_(nullptr)
+    , ik_link_(nullptr)
     , max_goal_sampling_attempts_(0)
     , minimize_object_distance_(false)
   {

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -97,7 +97,7 @@ public:
     return WriteLock(tree_mutex_);
   }
 
-  void triggerUpdateCallback(void)
+  void triggerUpdateCallback()
   {
     if (update_callback_)
       update_callback_();

--- a/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -95,7 +95,7 @@ protected:
   {
     SeeShape()
     {
-      body = NULL;
+      body = nullptr;
     }
 
     bodies::Body* body;

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -738,7 +738,7 @@ public:
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
                               moveit_msgs::RobotTrajectory& trajectory, bool avoid_collisions = true,
-                              moveit_msgs::MoveItErrorCodes* error_code = NULL);
+                              moveit_msgs::MoveItErrorCodes* error_code = nullptr);
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
@@ -755,7 +755,7 @@ public:
   double computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step, double jump_threshold,
                               moveit_msgs::RobotTrajectory& trajectory,
                               const moveit_msgs::Constraints& path_constraints, bool avoid_collisions = true,
-                              moveit_msgs::MoveItErrorCodes* error_code = NULL);
+                              moveit_msgs::MoveItErrorCodes* error_code = nullptr);
 
   /** \brief Stop any trajectory execution, if one is active */
   void stop();

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -217,7 +217,7 @@ public:
 
   /** \brief Clear any error settings.
    * This makes the markers appear as if the state is no longer invalid. */
-  void clearError(void);
+  void clearError();
 
 protected:
   bool transformFeedbackPose(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback,

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -79,7 +79,7 @@ public:
   RobotInteraction(const robot_model::RobotModelConstPtr& robot_model, const std::string& ns = "");
   virtual ~RobotInteraction();
 
-  const std::string& getServerTopic(void) const
+  const std::string& getServerTopic() const
   {
     return topic_;
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -103,7 +103,7 @@ class MotionPlanningFrame : public QWidget
 
 public:
   MotionPlanningFrame(const MotionPlanningFrame&) = delete;
-  MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::DisplayContext* context, QWidget* parent = 0);
+  MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::DisplayContext* context, QWidget* parent = nullptr);
   ~MotionPlanningFrame() override;
 
   void changePlanningGroup();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
@@ -124,7 +124,7 @@ class MotionPlanningFrameJointsWidget : public QWidget
 public:
   MotionPlanningFrameJointsWidget(const MotionPlanningFrameJointsWidget&) = delete;
   MotionPlanningFrameJointsWidget(MotionPlanningDisplay* display, QWidget* parent = nullptr);
-  ~MotionPlanningFrameJointsWidget();
+  ~MotionPlanningFrameJointsWidget() override;
 
   void changePlanningGroup(const std::string& group_name,
                            const robot_interaction::InteractionHandlerPtr& start_state_handler,
@@ -168,7 +168,7 @@ public:
     VariableBoundsRole
   };
 
-  ProgressBarDelegate(QWidget* parent = 0) : QStyledItemDelegate(parent)
+  ProgressBarDelegate(QWidget* parent = nullptr) : QStyledItemDelegate(parent)
   {
   }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
@@ -54,7 +54,7 @@ class MotionPlanningParamWidget : public rviz::PropertyTreeWidget
   Q_OBJECT
 public:
   MotionPlanningParamWidget(const MotionPlanningParamWidget&) = delete;
-  MotionPlanningParamWidget(QWidget* parent = 0);
+  MotionPlanningParamWidget(QWidget* parent = nullptr);
   ~MotionPlanningParamWidget() override;
 
   void setMoveGroup(const moveit::planning_interface::MoveGroupInterfacePtr& mg);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
@@ -54,7 +54,7 @@ class TrajectoryPanel : public rviz::Panel
   Q_OBJECT
 
 public:
-  TrajectoryPanel(QWidget* parent = 0);
+  TrajectoryPanel(QWidget* parent = nullptr);
 
   ~TrajectoryPanel() override;
 

--- a/moveit_ros/warehouse/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
+++ b/moveit_ros/warehouse/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
@@ -79,10 +79,10 @@ public:
   void removeTrajectoryConstraints(const std::string& name, const std::string& robot = "",
                                    const std::string& group = "");
 
-  void reset(void);
+  void reset();
 
 private:
-  void createCollections(void);
+  void createCollections();
 
   TrajectoryConstraintsCollection constraints_collection_;
 };

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -57,8 +57,8 @@ static const std::string ROBOT_DESCRIPTION = "robot_description";
 static const std::string MOVEIT_ROBOT_STATE = "moveit_robot_state";
 
 // Default kin solver values
-static const double DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION_ = 0.005;
-static const double DEFAULT_KIN_SOLVER_TIMEOUT_ = 0.005;
+static const double DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION_ = 0.005;  // NOLINT(readability-identifier-naming)
+static const double DEFAULT_KIN_SOLVER_TIMEOUT_ = 0.005;            // NOLINT(readability-identifier-naming)
 
 // ******************************************************************************************
 // Structs
@@ -513,7 +513,7 @@ public:
    * \param jm2 - a pointer to the second joint model to compare
    * \return bool of alphabetical sorting comparison
    */
-  struct joint_model_compare
+  struct joint_model_compare  // NOLINT(readability-identifier-naming)
   {
     bool operator()(const robot_model::JointModel* jm1, const robot_model::JointModel* jm2) const
     {

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -44,6 +44,8 @@
 #include <urdf/model.h>                                               // to share throughout app
 #include <srdfdom/srdf_writer.h>                                      // for writing srdf data
 
+#include <utility>
+
 namespace moveit_setup_assistant
 {
 // ******************************************************************************************
@@ -144,25 +146,25 @@ public:
 
   void setName(std::string name)
   {
-    name_ = name;
+    name_ = std::move(name);
   };
   void setValue(std::string value)
   {
-    value_ = value;
+    value_ = std::move(value);
   };
   void setComment(std::string comment)
   {
-    comment_ = comment;
+    comment_ = std::move(comment);
   };
-  std::string getName()
+  const std::string& getName() const
   {
     return name_;
   };
-  std::string getValue()
+  const std::string& getValue() const
   {
     return value_;
   };
-  std::string getComment()
+  const std::string& getComment() const
   {
     return comment_;
   };
@@ -176,7 +178,7 @@ private:
 MOVEIT_CLASS_FORWARD(MoveItConfigData);  // Defines MoveItConfigDataPtr, ConstPtr, WeakPtr... etc
 
 /** \brief This class is shared with all widgets and contains the common configuration data
-    needed for generating each robot's MoveIt! configuration package.
+    needed for generating each robot's MoveIt configuration package.
 
     All SRDF data is contained in a subclass of this class -
     srdf_writer.cpp. This class also contains the functions for writing
@@ -204,7 +206,7 @@ public:
   };
   unsigned long changes;  // bitfield of changes (composed of InformationFields)
 
-  // All of the data needed for creating a MoveIt! Configuration Files
+  // All of the data needed for creating a MoveIt Configuration Files
 
   // ******************************************************************************************
   // URDF Data
@@ -304,7 +306,7 @@ public:
   // ******************************************************************************************
   // Public Functions for outputting configuration and setting files
   // ******************************************************************************************
-  std::vector<OMPLPlannerDescription> getOMPLPlanners();
+  std::vector<OMPLPlannerDescription> getOMPLPlanners() const;
   bool outputSetupAssistantFile(const std::string& file_path);
   bool outputOMPLPlanningYAML(const std::string& file_path);
   bool outputCHOMPPlanningYAML(const std::string& file_path);

--- a/moveit_setup_assistant/src/tools/collision_linear_model.h
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.h
@@ -52,7 +52,7 @@ class CollisionLinearModel : public QAbstractProxyModel
   Q_OBJECT
 
 public:
-  CollisionLinearModel(CollisionMatrixModel* src, QObject* parent = NULL);
+  CollisionLinearModel(CollisionMatrixModel* src, QObject* parent = nullptr);
   ~CollisionLinearModel() override;
 
   // reimplement to return the model index in the proxy model that to the sourceIndex from the source model
@@ -82,7 +82,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
   Q_OBJECT
 
 public:
-  SortFilterProxyModel(QObject* parent = 0);
+  SortFilterProxyModel(QObject* parent = nullptr);
   QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
   void sort(int column, Qt::SortOrder order) override;
   void setShowAll(bool show_all);

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.h
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.h
@@ -50,7 +50,7 @@ class CollisionMatrixModel : public QAbstractTableModel
   Q_OBJECT
 public:
   CollisionMatrixModel(moveit_setup_assistant::LinkPairMap& pairs, const std::vector<std::string>& names,
-                       QObject* parent = NULL);
+                       QObject* parent = nullptr);
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
@@ -59,7 +59,7 @@ public:
 
   // for editing
   Qt::ItemFlags flags(const QModelIndex& index) const override;
-  bool setData(const QModelIndex&, const QVariant& value, int role) override;
+  bool setData(const QModelIndex& index, const QVariant& value, int role) override;
   void setEnabled(const QItemSelection& selection, bool value);
   void setEnabled(const QModelIndexList& indexes, bool value);
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -595,7 +595,7 @@ bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
   return true;  // file created successfully
 }
 
-std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
+std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners() const
 {
   std::vector<OMPLPlannerDescription> planner_des;
 

--- a/moveit_setup_assistant/src/tools/rotated_header_view.h
+++ b/moveit_setup_assistant/src/tools/rotated_header_view.h
@@ -44,7 +44,7 @@ namespace moveit_setup_assistant
 class RotatedHeaderView : public QHeaderView
 {
 public:
-  RotatedHeaderView(Qt::Orientation orientation, QWidget* parent = NULL);
+  RotatedHeaderView(Qt::Orientation orientation, QWidget* parent = nullptr);
   void paintSection(QPainter* painter, const QRect& rect, int logicalIndex) const override;
   QSize sectionSizeFromContents(int logicalIndex) const override;
   int sectionSizeHint(int logicalIndex) const;

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -241,7 +241,7 @@ class MonitorThread : public QThread
   Q_OBJECT
 
 public:
-  MonitorThread(const boost::function<void(unsigned int*)>& f, QProgressBar* progress_bar = NULL);
+  MonitorThread(const boost::function<void(unsigned int*)>& f, QProgressBar* progress_bar = nullptr);
   void run() override;
   void cancel()
   {

--- a/moveit_setup_assistant/src/widgets/double_list_widget.h
+++ b/moveit_setup_assistant/src/widgets/double_list_widget.h
@@ -71,7 +71,7 @@ public:
   /// Set the right box
   void setSelected(const std::vector<std::string>& items);
 
-  void clearContents(void);
+  void clearContents();
 
   /// Convenience function for reusing set table code
   void setTable(const std::vector<std::string>& items, QTableWidget* table);

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -266,7 +266,7 @@ void GroupEditWidget::setSelected(const std::string& group_name)
                          QString("Unable to find the kinematic solver '")
                              .append(kin_solver.c_str())
                              .append("'. Trying running rosmake for this package. Until fixed, this setting will be "
-                                     "lost the next time the MoveIt! configuration files are generated"));
+                                     "lost the next time the MoveIt configuration files are generated"));
     return;
   }
   else
@@ -321,7 +321,8 @@ void GroupEditWidget::loadKinematicPlannersComboBox()
   std::unique_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase>> loader;
   try
   {
-    loader.reset(new pluginlib::ClassLoader<kinematics::KinematicsBase>("moveit_core", "kinematics::KinematicsBase"));
+    loader = std::make_unique<pluginlib::ClassLoader<kinematics::KinematicsBase>>("moveit_core",
+                                                                                  "kinematics::KinematicsBase");
   }
   catch (pluginlib::PluginlibException& ex)
   {
@@ -339,22 +340,22 @@ void GroupEditWidget::loadKinematicPlannersComboBox()
   if (classes.empty())
   {
     QMessageBox::warning(this, "Missing Kinematic Solvers",
-                         "No MoveIt!-compatible kinematics solvers found. Try "
+                         "No MoveIt-compatible kinematics solvers found. Try "
                          "installing moveit_kinematics (sudo apt-get install "
                          "ros-${ROS_DISTRO}-moveit-kinematics)");
     return;
   }
 
   // Loop through all planners and add to combo box
-  for (std::vector<std::string>::const_iterator plugin_it = classes.begin(); plugin_it != classes.end(); ++plugin_it)
+  for (const std::string& kinematics_plugin_name : classes)
   {
-    kinematics_solver_field_->addItem(plugin_it->c_str());
+    kinematics_solver_field_->addItem(kinematics_plugin_name.c_str());
   }
 
   std::vector<OMPLPlannerDescription> planners = config_data_->getOMPLPlanners();
-  for (std::size_t i = 0; i < planners.size(); ++i)
+  for (OMPLPlannerDescription& planner : planners)
   {
-    std::string planner_name = planners[i].name_;
+    std::string planner_name = planner.name_;
     default_planner_field_->addItem(planner_name.c_str());
   }
 }

--- a/moveit_setup_assistant/src/widgets/navigation_widget.h
+++ b/moveit_setup_assistant/src/widgets/navigation_widget.h
@@ -54,7 +54,7 @@ class NavigationWidget : public QListView
 {
   Q_OBJECT
 public:
-  explicit NavigationWidget(QWidget* parent = 0);
+  explicit NavigationWidget(QWidget* parent = nullptr);
 
   void setNavs(const QList<QString>& navs);
   void setEnabled(const int& index, bool enabled);
@@ -75,7 +75,7 @@ class NavDelegate : public QStyledItemDelegate
 {
   Q_OBJECT
 public:
-  explicit NavDelegate(QObject* parent = 0);
+  explicit NavDelegate(QObject* parnullptrnt = nullptr);
 
   QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
   void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;


### PR DESCRIPTION
Apply most clang-tidy fixes. However, ignore `readability-identifier-naming` as this would modify API.