### PR TITLE
OMPL: Register and use termination condition for simplification as well

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -403,8 +403,12 @@ void ompl_interface::ModelBasedPlanningContext::setPlanningVolume(const moveit_m
 
 void ompl_interface::ModelBasedPlanningContext::simplifySolution(double timeout)
 {
-  ompl_simple_setup_->simplifySolution(timeout);
+  ompl::time::point start = ompl::time::now();
+  ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
+  registerTerminationCondition(ptc);
+  ompl_simple_setup_->simplifySolution(ptc);
   last_simplify_time_ = ompl_simple_setup_->getLastSimplificationTime();
+  unregisterTerminationCondition();
 }
 
 void ompl_interface::ModelBasedPlanningContext::interpolateSolution()


### PR DESCRIPTION
Currently a OMPL planner can only be canceled during the actual planning stage but will happily use up the timeout during simplification despite the request to cancel. This PR registers a termination condition for the simplification phase so this can be canceled as well.

This will still not cancel immediately as there is a default param `atLeastOnce` here https://github.com/ompl/ompl/blob/528f02cdc5ac785ba24e1dbdf1cf621a17020b7b/src/ompl/geometric/src/PathSimplifier.cpp#L677 that we cannot easily access and which ensures that the whole simplification process does at least one iteration of each simplification attempt.

Still this will hopefully save us some time as we need to wait for all planners to terminate before we can do some Octomap update. Can be 700ms or more currently and that unfortunately really shows

---

Another thing I was wondering about when coding this is what happens when a cancel request arrives in between planning and simplification or before the actual planning, does anyone remember why those termination conditions are scoped so narrowly and not set at the very beginning and destroyed only when returning the solution? 