### PR TITLE
feat(simple_controller_manager): add `max_effort` parameter to GripperCommand action

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -51,10 +51,11 @@ class GripperControllerHandle : public ActionBasedControllerHandle<control_msgs:
 {
 public:
   /* Topics will map to name/ns/goal, name/ns/result, etc */
-  GripperControllerHandle(const std::string& name, const std::string& ns)
+  GripperControllerHandle(const std::string& name, const std::string& ns, const double max_effort = 0.0)
     : ActionBasedControllerHandle<control_msgs::GripperCommandAction>(name, ns)
     , allow_failure_(false)
     , parallel_jaw_gripper_(false)
+    , max_effort_(max_effort)
   {
   }
 
@@ -110,7 +111,6 @@ public:
     // goal to be sent
     control_msgs::GripperCommandGoal goal;
     goal.command.position = 0.0;
-    goal.command.max_effort = 0.0;
 
     // send last point
     int tpoint = trajectory.joint_trajectory.points.size() - 1;
@@ -130,7 +130,13 @@ public:
       goal.command.position += trajectory.joint_trajectory.points[tpoint].positions[idx];
 
       if (trajectory.joint_trajectory.points[tpoint].effort.size() > idx)
+      {
         goal.command.max_effort = trajectory.joint_trajectory.points[tpoint].effort[idx];
+      }
+      else
+      {
+        goal.command.max_effort = max_effort_;
+      }
     }
 
     controller_action_client_->sendGoal(
@@ -201,6 +207,12 @@ private:
    * and the command will be the sum of the two joints.
    */
   bool parallel_jaw_gripper_;
+
+  /*
+   * The ``max_effort`` used in the GripperCommand message when no ``max_effort`` was
+   * specified in the requested trajectory. Defaults to ``0.0``.
+   */
+  double max_effort_;
 
   /*
    * A GripperCommand message has only a single float64 for the

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -94,7 +94,10 @@ public:
         ActionBasedControllerHandleBasePtr new_handle;
         if (type == "GripperCommand")
         {
-          new_handle = std::make_shared<GripperControllerHandle>(name, action_ns);
+          const double max_effort =
+              controller_list[i].hasMember("max_effort") ? double(controller_list[i]["max_effort"]) : 0.0;
+
+          new_handle = std::make_shared<GripperControllerHandle>(name, action_ns, max_effort);
           if (static_cast<GripperControllerHandle*>(new_handle.get())->isConnected())
           {
             if (controller_list[i].hasMember("parallel"))


### PR DESCRIPTION
This pull request adds the `max_effort` parameter to the GripperCommand declaration in the `controller_list` (see issue #2956). This value is only used when the effort is set in the requested gripper trajectory.

## How to test

1. Clone the [rickstaa/moveit#add_max_effort_param](https://github.com/rickstaa/moveit/tree/add_max_effort_param) branch into a catkin workspace.
2. Clone the [rickstaa/franka_ros#noetic-devel-panda_gazebo](https://github.com/rickstaa/franka_ros/tree/noetic-devel-panda_gazebo) branch into the catkin workspace.
3. Clone the [rickstaa/panda_moveit_config#noetic-devel-panda_gazebo](https://github.com/rickstaa/panda_moveit_config/tree/noetic-devel-panda_gazebo) branch into the catkin workspace
4. Install the ROS dependencies using `rosdep --from-path src --ignore-src -r -y`.
5. Build the catkin workspace `catkin build -DCMAKE_BUILD_TYPE=Release`. For this to work libfranka has to be installed see [the franka docs](https://frankaemika.github.io/docs/getting_started.html).
4. Launch the panda simulation using the `roslaunch franka_gazebo panda.launch` command.
5. Inspect the `/panda/franka_gripper/gripper_action/goal` topic while you control the hand using the RViz Motion planning plugin.
6. Use the following python script to control the hand.

```python
"""Small script for testing pull request #2984.
"""

import sys

import moveit_commander
import moveit_msgs.msg
import rospy
import numpy as np

# Enable if you want to add a custom effort to the trajectory
ADD_EFFORT = True

if __name__ == "__main__":

    # Initiate MoveIt commander and node
    moveit_commander.roscpp_initialize(sys.argv)
    rospy.init_node("move_group_python_interface_tutorial", anonymous=True)

    # Create commanders
    robot = moveit_commander.RobotCommander()
    scene = moveit_commander.PlanningSceneInterface()

    # Load arm and hand groups
    hand_move_group = moveit_commander.MoveGroupCommander("hand")

    display_trajectory_publisher = rospy.Publisher(
        "/hand_move_group/display_planned_path",
        moveit_msgs.msg.DisplayTrajectory,
        queue_size=20,
    )

    # We can get the name of the reference frame for this robot:
    planning_frame = hand_move_group.get_planning_frame()
    print("============ Planning frame: %s" % planning_frame)

    # We can get a list of all the groups in the robot:
    group_names = robot.get_group_names()
    print("============ Available Planning Groups:", robot.get_group_names())

    # Sometimes for debugging it is useful to print the entire state of the
    # robot:
    print("============ Printing robot state")
    print(robot.get_current_state())
    print("")

    # -- Plan hand goal --
    hand_move_group.set_joint_value_target([0.04, 0.04])
    (hand_plan_retval, plan, _, error_code) = hand_move_group.plan()

    # Add effort
    if ADD_EFFORT:
        for idx, _ in enumerate(plan.joint_trajectory.points):
            plan.joint_trajectory.points[idx].effort = list(np.random.rand(2))

    # Send command
    retval = hand_move_group.execute(plan, wait=True)

    # Calling ``stop()`` ensures that there is no residual movement
    hand_move_group.stop()
```
### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist

- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
    - @rhaschke I think we should update the yaml shown [here](https://ros-planning.github.io/moveit_tutorials/doc/controller_configuration/controller_configuration_tutorial.html?highlight=grippercommand#yaml-configuration) to make users aware of the options. 
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes.
    - @rhaschke Do you want me to add this to the MIGRATION.md note. I don't think it's a breaking change. 
