### PR TITLE
Hotfix: Add backwards compatibility for old scene serialization format

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1000,14 +1000,57 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in)
   return loadGeometryFromStream(in, Eigen::Isometry3d::Identity());  // Use no offset
 }
 
-bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Isometry3d& offset)
+bool PlanningScene::loadGeometryFromStream(std::istream& in_istream, const Eigen::Isometry3d& offset)
 {
-  if (!in.good() || in.eof())
+  if (!in_istream.good() || in_istream.eof())
   {
     ROS_ERROR_NAMED(LOGNAME, "Bad input stream when loading scene geometry");
     return false;
   }
+
+  // We need to get the full string of the stream for version detection,
+  // so create a stringstream for processing. We pass the entire istream
+  // into this stringstream
+  std::stringstream in;
+  in << in_istream.rdbuf();
+
+  // Read scene name
   std::getline(in, name_);
+
+  // Identify scene format version for backwards compatibility of parser
+  const std::string in_str = in.str();
+  std::vector<std::string> in_lines;
+  boost::split(in_lines, in_str, boost::is_any_of("\n"));
+  bool uses_new_scene_format = true;
+  for (std::size_t i = 0; i < in_lines.size() - 1; ++i)
+  {
+    // An asterisk at the start of the line signifies a new object.
+    // An object can consist of multiple shapes.
+    if (in_lines[i][0] == '*')
+    {
+      // Detect the version of the serialization format based on the
+      // line succeeding the object identifier.
+
+      // Trim leading and trailing spaces (in-place)
+      boost::algorithm::trim(in_lines[i + 1]);
+
+      // Reliable way of detecting the format version is to check
+      // whether there are spaces left _after_ trimming:
+      // If there are, they are delimiters of the translation of the pose.
+      bool has_spaces_as_delimiters_after_trimming = in_lines[i + 1].find(" ") != std::string::npos;
+      if (has_spaces_as_delimiters_after_trimming)
+      {
+        uses_new_scene_format = true;
+        break;
+      }
+      else
+      {
+        uses_new_scene_format = false;
+        break;
+      }
+    }
+  }
+
   Eigen::Isometry3d pose;  // Transient
   do
   {
@@ -1029,8 +1072,9 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Isomet
       }
       boost::algorithm::trim(object_id);
 
-      // Read in object pose
-      if (!readPoseFromText(in, pose))
+      // Read in object pose (added in the new scene format)
+      pose.setIdentity();
+      if (uses_new_scene_format && !readPoseFromText(in, pose))
       {
         ROS_ERROR_NAMED(LOGNAME, "Failed to read object pose from scene file");
         return false;
@@ -1075,22 +1119,25 @@ bool PlanningScene::loadGeometryFromStream(std::istream& in, const Eigen::Isomet
         }
       }
 
-      // Read in subframes
-      moveit::core::FixedTransformsMap subframes;
-      unsigned int subframe_count;
-      in >> subframe_count;
-      for (std::size_t i = 0; i < subframe_count && in.good() && !in.eof(); ++i)
+      // Read in subframes (added in the new scene format)
+      if (uses_new_scene_format)
       {
-        std::string subframe_name;
-        in >> subframe_name;
-        if (!readPoseFromText(in, pose))
+        moveit::core::FixedTransformsMap subframes;
+        unsigned int subframe_count;
+        in >> subframe_count;
+        for (std::size_t i = 0; i < subframe_count && in.good() && !in.eof(); ++i)
         {
-          ROS_ERROR_NAMED(LOGNAME, "Failed to read subframe pose from scene file");
-          return false;
+          std::string subframe_name;
+          in >> subframe_name;
+          if (!readPoseFromText(in, pose))
+          {
+            ROS_ERROR_NAMED(LOGNAME, "Failed to read subframe pose from scene file");
+            return false;
+          }
+          subframes[subframe_name] = pose;
         }
-        subframes[subframe_name] = pose;
+        world_->setSubframesOfObject(object_id, subframes);
       }
-      world_->setSubframesOfObject(object_id, subframes);
     }
     else if (marker == ".")
     {

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -164,7 +164,7 @@ TEST(PlanningScene, isStateValid)
   }
 }
 
-TEST(PlanningScene, loadGoodSceneGeometry)
+TEST(PlanningScene, loadGoodSceneGeometryNewFormat)
 {
   moveit::core::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("pr2");
   auto ps = std::make_shared<planning_scene::PlanningScene>(robot_model->getURDF(), robot_model->getSRDF());
@@ -196,6 +196,32 @@ TEST(PlanningScene, loadGoodSceneGeometry)
   EXPECT_EQ(ps->getName(), "foobar_scene");
   EXPECT_TRUE(ps->getWorld()->hasObject("foo"));
   EXPECT_TRUE(ps->getWorld()->hasObject("bar"));
+  EXPECT_FALSE(ps->getWorld()->hasObject("baz"));  // Sanity check.
+}
+
+TEST(PlanningScene, loadGoodSceneGeometryOldFormat)
+{
+  moveit::core::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("pr2");
+  auto ps = std::make_shared<planning_scene::PlanningScene>(robot_model->getURDF(), robot_model->getSRDF());
+
+  std::istringstream good_scene_geometry;
+  good_scene_geometry.str("foobar_scene\n"
+                          "* foo\n"
+                          "2\n"
+                          "box\n"
+                          ".77 0.39 0.05\n"
+                          "0 0 0.025\n"
+                          "0 0 0 1\n"
+                          "0.82 0.75 0.60 1\n"
+                          "box\n"
+                          ".77 0.39 0.05\n"
+                          "0 0 1.445\n"
+                          "0 0 0 1\n"
+                          "0.82 0.75 0.60 1\n"
+                          ".\n");
+  EXPECT_TRUE(ps->loadGeometryFromStream(good_scene_geometry));
+  EXPECT_EQ(ps->getName(), "foobar_scene");
+  EXPECT_TRUE(ps->getWorld()->hasObject("foo"));
   EXPECT_FALSE(ps->getWorld()->hasObject("baz"));  // Sanity check.
 }
 

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -234,34 +234,19 @@ TEST(PlanningScene, loadBadSceneGeometry)
   // This should fail since there is no planning scene name and no end of geometry marker.
   EXPECT_FALSE(ps->loadGeometryFromStream(empty_scene_geometry));
 
-  // Old Scene file format
-  std::istringstream malformed_scene_geometry_old_format;
-  malformed_scene_geometry_old_format.str("malformed_scene_geometry\n"
-                                          "* foo\n"
-                                          "1\n"
-                                          "box\n"
-                                          "2.58 1.36\n" /* Only two tokens; should be 3 */
-                                          "1.49257 1.00222 0.170051\n"
-                                          "0 0 4.16377e-05 1\n"
-                                          "0 0 1 0.3\n"
-                                          ".\n");
-  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry_old_format));
-
-  // New Scene file format
-  std::istringstream malformed_scene_geometry_new_format;
-  malformed_scene_geometry_new_format.str("malformed_scene_geometry\n"
-                                          "* foo\n"
-                                          "0 0 0\n"
-                                          "0 0 0 1\n"
-                                          "1\n"
-                                          "box\n"
-                                          "2.58 1.36\n" /* Only two tokens; should be 3 */
-                                          "1.49257 1.00222 0.170051\n"
-                                          "0 0 4.16377e-05 1\n"
-                                          "0 0 1 0.3\n"
-                                          "0\n" /* subframe count */
-                                          ".\n");
-  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry_new_format));
+  std::istringstream malformed_scene_geometry;
+  malformed_scene_geometry.str("malformed_scene_geometry\n"
+                               "* foo\n"
+                               "0 0 0\n"
+                               "0 0 0 1\n"
+                               "1\n"
+                               "box\n"
+                               "2.58 1.36\n" /* Only two tokens; should be 3 */
+                               "1.49257 1.00222 0.170051\n"
+                               "0 0 4.16377e-05 1\n"
+                               "0 0 1 0.3\n"
+                               ".\n");
+  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry));
 }
 
 class CollisionDetectorTests : public testing::TestWithParam<const char*>

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -234,17 +234,34 @@ TEST(PlanningScene, loadBadSceneGeometry)
   // This should fail since there is no planning scene name and no end of geometry marker.
   EXPECT_FALSE(ps->loadGeometryFromStream(empty_scene_geometry));
 
-  std::istringstream malformed_scene_geometry;
-  malformed_scene_geometry.str("malformed_scene_geometry\n"
-                               "* foo\n"
-                               "1\n"
-                               "box\n"
-                               "2.58 1.36\n" /* Only two tokens; should be 3 */
-                               "1.49257 1.00222 0.170051\n"
-                               "0 0 4.16377e-05 1\n"
-                               "0 0 1 0.3\n"
-                               ".\n");
-  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry));
+  // Old Scene file format
+  std::istringstream malformed_scene_geometry_old_format;
+  malformed_scene_geometry_old_format.str("malformed_scene_geometry\n"
+                                          "* foo\n"
+                                          "1\n"
+                                          "box\n"
+                                          "2.58 1.36\n" /* Only two tokens; should be 3 */
+                                          "1.49257 1.00222 0.170051\n"
+                                          "0 0 4.16377e-05 1\n"
+                                          "0 0 1 0.3\n"
+                                          ".\n");
+  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry_old_format));
+
+  // New Scene file format
+  std::istringstream malformed_scene_geometry_new_format;
+  malformed_scene_geometry_new_format.str("malformed_scene_geometry\n"
+                                          "* foo\n"
+                                          "0 0 0\n"
+                                          "0 0 0 1\n"
+                                          "1\n"
+                                          "box\n"
+                                          "2.58 1.36\n" /* Only two tokens; should be 3 */
+                                          "1.49257 1.00222 0.170051\n"
+                                          "0 0 4.16377e-05 1\n"
+                                          "0 0 1 0.3\n"
+                                          "0\n" /* subframe count */
+                                          ".\n");
+  EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry_new_format));
 }
 
 class CollisionDetectorTests : public testing::TestWithParam<const char*>


### PR DESCRIPTION
This PR adds backwards compatibility for the old scene serialization format to `PlanningScene` following #2037, cf. the regression report for Noetic in #2985. It first checks which version of the syntax is provided (by checking the line following the start of a new object - previously the number of shapes, now the translational component of the pose) and deactivates the subframe-poses if using the old format, as well as maintains compatibility by resetting the pose to identity.

@felixvd @rhaschke Can you please review this PR, backport it to noetic-devel, and release? :-)

I've added unittests for the old format as well. Detail on changes/logic in the individual commits. 

Resolves #2985 