### PR TITLE
quietly use backward_cpp/ros if available

### DIFF
--- a/moveit_core/cmake/moveit.cmake
+++ b/moveit_core/cmake/moveit.cmake
@@ -5,6 +5,8 @@ macro(moveit_build_options)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 
+  find_package(backward_ros QUIET)
+
   if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
     message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
     set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
This is plain convenient and you always need it when you did not explicitly add it.

Follow @tylerjw's initiative to add it to MoveIt2: https://github.com/ros-planning/moveit2/pull/794

The downside (at least on my system) is that the cmake config for the package is not implemented correctly and yields this warning for each find_package call:
```
CMake Warning (dev) at /usr/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:426 (message):
  The package name passed to `find_package_handle_standard_args` (Backward)
  does not match the name of the calling package (backward_ros).  This can
  lead to problems in calling code that expects `find_package` result
  variables (e.g., `_FOUND`) to follow a certain pattern.
```