### PR TITLE
Add object colors retrieval to planning scene interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ qtcreator-*
 # Vim
 *.swp
 
+# JetBrains IDEs (e.g. Pycharm or CLion)
+.idea/
+
 # Continous Integration
 .moveit_ci
 

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -42,6 +42,7 @@ from geometry_msgs.msg import Pose, Point
 from shape_msgs.msg import SolidPrimitive, Plane, Mesh, MeshTriangle
 from .exception import MoveItCommanderException
 from moveit_msgs.srv import ApplyPlanningScene, ApplyPlanningSceneRequest
+from std_msgs.msg import ColorRGBA
 
 try:
     from pyassimp import pyassimp
@@ -243,6 +244,18 @@ class PlanningSceneInterface(object):
             conversions.msg_from_string(msg, ser_aobjs[key])
             aobjs[key] = msg
         return aobjs
+
+    def get_object_colors(self):
+        """
+         Get all available object colors. Result key corresponds to the object id.
+        """
+        ser_colors = self._psi.get_object_colors()
+        colors = dict()
+        for key in ser_colors:
+            msg = ColorRGBA()
+            conversions.msg_from_string(msg, ser_colors[key])
+            colors[key] = msg
+        return colors
 
     def apply_planning_scene(self, planning_scene_message):
         """

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -247,7 +247,7 @@ class PlanningSceneInterface(object):
 
     def get_object_colors(self):
         """
-         Get all available object colors. Result key corresponds to the object id.
+        Get all available object color information. Result key corresponds to the object id.
         """
         ser_colors = self._psi.get_object_colors()
         colors = dict()

--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -98,6 +98,9 @@ public:
   std::map<std::string, moveit_msgs::AttachedCollisionObject>
   getAttachedObjects(const std::vector<std::string>& object_ids = std::vector<std::string>());
 
+  /** \brief Get all available object colors. Result key corresponds to the object id. */
+  std::map<std::string, std_msgs::ColorRGBA> getObjectColors();
+
   /** \brief Apply collision object to the planning scene of the move_group node synchronously.
       Other PlanningSceneMonitors will NOT receive the update unless they subscribe to move_group's monitored scene */
   bool applyCollisionObject(const moveit_msgs::CollisionObject& collision_object);

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -162,6 +162,25 @@ public:
     return result;
   }
 
+  std::map<std::string, std_msgs::ColorRGBA> getObjectColors()
+  {
+    moveit_msgs::GetPlanningScene::Request request;
+    moveit_msgs::GetPlanningScene::Response response;
+    std::map<std::string, std_msgs::ColorRGBA> result;
+    request.components.components = request.components.OBJECT_COLORS;
+    if (!planning_scene_service_.call(request, response))
+    {
+      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object colors");
+      return result;
+    }
+
+    for (const moveit_msgs::ObjectColor& object_color : response.scene.object_colors)
+    {
+      result[object_color.id] = object_color.color;
+    }
+    return result;
+  }
+
   std::map<std::string, moveit_msgs::CollisionObject> getObjects(const std::vector<std::string>& object_ids)
   {
     moveit_msgs::GetPlanningScene::Request request;
@@ -301,6 +320,11 @@ std::map<std::string, geometry_msgs::Pose>
 PlanningSceneInterface::getObjectPoses(const std::vector<std::string>& object_ids)
 {
   return impl_->getObjectPoses(object_ids);
+}
+
+std::map<std::string, std_msgs::ColorRGBA> PlanningSceneInterface::getObjectColors()
+{
+  return impl_->getObjectColors();
 }
 
 std::map<std::string, moveit_msgs::CollisionObject>

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -108,8 +108,7 @@ public:
   {
     std::map<std::string, std_msgs::ColorRGBA> colors = getObjectColors();
     std::map<std::string, py_bindings_tools::ByteString> ser_colors;
-    for (std::map<std::string, std_msgs::ColorRGBA>::const_iterator it = colors.begin();
-         it != colors.end(); ++it)
+    for (std::map<std::string, std_msgs::ColorRGBA>::const_iterator it = colors.begin(); it != colors.end(); ++it)
       ser_colors[it->first] = py_bindings_tools::serializeMsg(it->second);
 
     return py_bindings_tools::dictFromType(ser_colors);

--- a/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/wrap_python_planning_scene_interface.cpp
@@ -104,6 +104,17 @@ public:
     return py_bindings_tools::dictFromType(ser_aobjs);
   }
 
+  bp::dict getObjectColorsPython()
+  {
+    std::map<std::string, std_msgs::ColorRGBA> colors = getObjectColors();
+    std::map<std::string, py_bindings_tools::ByteString> ser_colors;
+    for (std::map<std::string, std_msgs::ColorRGBA>::const_iterator it = colors.begin();
+         it != colors.end(); ++it)
+      ser_colors[it->first] = py_bindings_tools::serializeMsg(it->second);
+
+    return py_bindings_tools::dictFromType(ser_colors);
+  }
+
   bool applyPlanningScenePython(const py_bindings_tools::ByteString& ps_str)
   {
     moveit_msgs::PlanningScene ps_msg;
@@ -123,6 +134,7 @@ static void wrap_planning_scene_interface()
   planning_scene_class.def("get_object_poses", &PlanningSceneInterfaceWrapper::getObjectPosesPython);
   planning_scene_class.def("get_objects", &PlanningSceneInterfaceWrapper::getObjectsPython);
   planning_scene_class.def("get_attached_objects", &PlanningSceneInterfaceWrapper::getAttachedObjectsPython);
+  planning_scene_class.def("get_object_colors", &PlanningSceneInterfaceWrapper::getObjectColorsPython);
   planning_scene_class.def("apply_planning_scene", &PlanningSceneInterfaceWrapper::applyPlanningScenePython);
 }
 }  // namespace planning_interface


### PR DESCRIPTION
- Retrieve object colors map from PlanningSceneInterface. Previously this was not possible, although color information itself is contained in the scene message. 
- Also adjust python bindings