### PR TITLE
pin previous tinyxml2 for static lib

### DIFF
--- a/.github/robostack_env.yaml
+++ b/.github/robostack_env.yaml
@@ -16,3 +16,5 @@ dependencies:
   - orocos-kdl 1.5.0
   - python-orocos-kdl 1.5.0
   - openssl 1.1.1*
+  # we need the static library of this build
+  - tinyxml2 9.0.0 *_1


### PR DESCRIPTION
@rhaschke let's see if this fixes the builds for now. 

We could also create a real "lock file" using a tool like [`conda-lock`](https://github.com/conda-incubator/conda-lock).