### PR TITLE
Restore compatibility for `RobotState::attachBody` API

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1699,6 +1699,27 @@ public:
     attachBody(id, pose, shapes, shape_poses, touch_links_set, link_name, detach_posture, subframe_poses);
   }
 
+  [[deprecated("No offset pose for the attached shapes can be specified with this overload; using a default offset of "
+               "identity")]] void
+  attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+             const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
+             const std::string& link_name,
+             const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory())
+  {
+    attachBody(id, Eigen::Isometry3d::Identity(), shapes, shape_poses, touch_links, link_name, detach_posture);
+  }
+
+  [[deprecated("No offset pose for the attached shapes can be specified with this overload; using a default offset of "
+               "identity")]] void
+  attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+             const EigenSTL::vector_Isometry3d& shape_poses, const std::vector<std::string>& touch_links,
+             const std::string& link_name,
+             const trajectory_msgs::JointTrajectory& detach_posture = trajectory_msgs::JointTrajectory())
+  {
+    std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
+    attachBody(id, Eigen::Isometry3d::Identity(), shapes, shape_poses, touch_links_set, link_name, detach_posture);
+  }
+
   /** \brief Get all bodies attached to the model corresponding to this state */
   void getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies) const;
 


### PR DESCRIPTION
### Description

The release of 1.1.6 breaks the `moveit::core::RobotState::attachBody` API between ROS Noetic and Melodic/Kinetic. I'm supporting builds of a project in Noetic and Melodic that use this function, and currently the Melodic build is failing due to this API change. This PR restores compatibility by adding deprecated function signatures for `attachBody` that match those in ROS Melodic/Kinetic.

Based on discussion in #2985 and #2986, it sounds like an updated version of MoveIt might be released soon to fix that breakage. If so, it would be great to wrap this change into that release as well.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
