### PR TITLE
pilz planner: report invalid joint

### DIFF
--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>chomp_motion_planner</exec_depend>
   <exec_depend>moveit_planners_chomp</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>pilz_industrial_motion_planner</exec_depend>
 
   <export>
     <metapackage/>

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -140,15 +140,6 @@ public:
    */
   bool verifyPositionLimit(const std::string& joint_name, const double& joint_position) const;
 
-  /**
-   * @brief verify position limits of multiple joints
-   * @param joint_names
-   * @param joint_positions
-   * @return
-   */
-  bool verifyPositionLimits(const std::vector<std::string>& joint_names,
-                            const std::vector<double>& joint_positions) const;
-
 private:
   /**
    * @brief update the most strict limit with given joint limit

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -223,7 +223,7 @@ private:
    *     - The start state velocity is below
    * TrajectoryGenerator::VELOCITY_TOLERANCE
    */
-  void checkStartState(const moveit_msgs::RobotState& start_state) const;
+  void checkStartState(const moveit_msgs::RobotState& start_state, const std::string& group) const;
 
   void checkGoalConstraints(const moveit_msgs::MotionPlanRequest::_goal_constraints_type& goal_constraints,
                             const std::vector<std::string>& expected_joint_names, const std::string& group_name) const;
@@ -235,6 +235,11 @@ private:
   void checkCartesianGoalConstraint(const moveit_msgs::Constraints& constraint, const std::string& group_name) const;
 
 private:
+  /**
+   * @return joint state message including only active joints in group
+   */
+  sensor_msgs::JointState filterGroupValues(const sensor_msgs::JointState& robot_state, const std::string& group) const;
+
   /**
    * @return True if scaling factor is valid, otherwise false.
    */

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
@@ -117,25 +117,6 @@ bool JointLimitsContainer::verifyPositionLimit(const std::string& joint_name, co
             (joint_position < getLimit(joint_name).min_position || joint_position > getLimit(joint_name).max_position)));
 }
 
-bool JointLimitsContainer::verifyPositionLimits(const std::vector<std::string>& joint_names,
-                                                const std::vector<double>& joint_positions) const
-{
-  if (joint_names.size() != joint_positions.size())
-  {
-    throw std::out_of_range("joint_names vector has a different size than joint_positions vector.");
-  }
-
-  for (std::size_t i = 0; i < joint_names.size(); ++i)
-  {
-    if (!verifyPositionLimit(joint_names.at(i), joint_positions.at(i)))
-    {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 void JointLimitsContainer::updateCommonLimit(const JointLimit& joint_limit, JointLimit& common_limit)
 {
   // check position limits

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_joint_limits_container.cpp
@@ -203,25 +203,6 @@ TEST_F(JointLimitsContainerTest, FirstPositionEmpty)
   EXPECT_EQ(-1, limits.min_position);
 }
 
-/**
- * @brief Check position limits
- */
-TEST_F(JointLimitsContainerTest, CheckVerifyPositionLimits)
-{
-  // positive check: inside limits
-  std::vector<std::string> joint_names{ "joint1", "joint2" };
-  std::vector<double> joint_positions{ 0.5, 0.5 };
-  EXPECT_TRUE(container_.verifyPositionLimits(joint_names, joint_positions));
-
-  // outside limit2
-  joint_positions[1] = 7;
-  EXPECT_FALSE(container_.verifyPositionLimits(joint_names, joint_positions));
-
-  // invalid size
-  std::vector<double> joint_positions1{ 0. };
-  EXPECT_THROW(container_.verifyPositionLimits(joint_names, joint_positions1), std::out_of_range);
-}
-
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Improve usability. I kept getting out of range errors in a start state and needed to implement this code to figure out which joints triggered the problem...