### PR TITLE
Do not assert on printTransform with non-isometry

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2194,11 +2194,20 @@ void RobotState::printStateInfo(std::ostream& out) const
 
 void RobotState::printTransform(const Eigen::Isometry3d& transform, std::ostream& out) const
 {
-  ASSERT_ISOMETRY(transform)  // unsanitized input, could contain a non-isometry
-  Eigen::Quaterniond q(transform.linear());
-  out << "T.xyz = [" << transform.translation().x() << ", " << transform.translation().y() << ", "
-      << transform.translation().z() << "], Q.xyzw = [" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w()
-      << "]" << std::endl;
+  if (checkIsometry(transform, CHECK_ISOMETRY_PRECISION, false))
+  {
+    Eigen::Quaterniond q(transform.linear());
+    out << "T.xyz = [" << transform.translation().x() << ", " << transform.translation().y() << ", "
+        << transform.translation().z() << "], Q.xyzw = [" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w()
+        << "]";
+  }
+  else
+  {
+    out << "[NON-ISOMETRY] "
+        << transform.matrix().format(
+               Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", "; ", "", "", "[", "]"));
+  }
+  out << std::endl;
 }
 
 void RobotState::printTransforms(std::ostream& out) const


### PR DESCRIPTION
Fix for #3002 because the author there decided to ignore the problem.

Instead of the assert print a tag and the matrix.
Building a Quaternion from non-isometries is undefined behavior in Eigen, thus the split.

The new output looks like this when isometries are broken:
```
Joint transforms:
  virtual_joint [dirty]: [NON-ISOMETRY] [6.92595e-310, 0, 0, 0; 6.92595e-310, 0, 7.41098e-323, 4.94066e-324; 8.98317e-317, 0, 0, 8.98318e-317; 0, 0, 0, 1]
  panda_joint1 [dirty]: [NON-ISOMETRY] [0, 0, 0, -nan; 0, 0, 0, 0; 0, 0, 0, 0; 0, 0, 0, 1]
  panda_joint2 [dirty]: [NON-ISOMETRY] [0, 1.63318e-319, 0, nan; 9.13379e-320, 0, 0, 0; 1.63318e-319, 0, 0, 0; 0, 0, 0, 1]
```
and usually like that (unchanged):
```
Joint transforms:
  virtual_joint: T.xyz = [0, 0, 0], Q.xyzw = [0, 0, 0, 1]
  panda_joint1: T.xyz = [0, 0, 0], Q.xyzw = [0, 0, 0, 1]
  panda_joint2: T.xyz = [0, 0, 0], Q.xyzw = [0, 0, 0, 1]
```