### PR TITLE
Fix MoveGroupInterface uninitialized RobotState

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1597,7 +1597,10 @@ void MoveGroupInterface::setStartState(const moveit_msgs::RobotState& start_stat
   if (start_state.is_diff)
     impl_->getCurrentState(rs);
   else
+  {
     rs = std::make_shared<moveit::core::RobotState>(getRobotModel());
+    rs->setToDefaultValues();  // initialize robot state values for conversion
+  }
   moveit::core::robotStateMsgToRobotState(start_state, *rs);
   setStartState(*rs);
 }


### PR DESCRIPTION
### Description

Setting the start state via the `MoveGroupInterface` with a RobotStateMsg that has missing joint state values will create a segfault when planning because the missing joint states are not [initialized](https://github.com/ros-planning/moveit/blob/master/moveit_core/robot_state/include/moveit/robot_state/robot_state.h#L92-L94). Using the classic panda `demo.launch` from moveit_resources. Maybe related to https://github.com/flexible-collision-library/fcl/issues/521.

Specifying only `panda_joint1` to `panda_joint7` and omitting `panda_finger_joint1/2` works using the PlanningPipeline. I guess it uses default values for the 2 missing joints in the MotionPlanRequest down the road (maybe in request adapters).

The obvious solution is to specify the missing joints. This PR makes the MoveGroupInterface behave like the PlanningPipeline by using the RobotState default values. The segfault for not specifying all the joints is somewhat hard to debug. If someone forgets to add a joint in the MotionPlanRequest it will have the default value (usually set to 0). From my perspective, it is easier to debug as you can see that the start state is not the one you requested.

**GDB backtrace**
```terminal
Thread 14 "move_group" received signal SIGSEGV, Segmentation fault.
0x00007ffff3f138c9 in fcl::detail::HierarchyTree<fcl::AABB<double> >::bottomup(__gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >, __gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >) () from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
(gdb) bt
#0  0x00007ffff3f138c9 in fcl::detail::HierarchyTree<fcl::AABB<double> >::bottomup(__gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >, __gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >) () from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
#1  0x00007ffff3f1701d in fcl::detail::HierarchyTree<fcl::AABB<double> >::topdown_0(__gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >, __gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >) () from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
#2  0x00007ffff3f16fee in fcl::detail::HierarchyTree<fcl::AABB<double> >::topdown_0(__gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >, __gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >) () from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
#3  0x00007ffff3f16fee in fcl::detail::HierarchyTree<fcl::AABB<double> >::topdown_0(__gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >, __gnu_cxx::__normal_iterator<fcl::detail::NodeBase<fcl::AABB<double> >**, std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> > >) () from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
#4  0x00007ffff3f17265 in fcl::detail::HierarchyTree<fcl::AABB<double> >::init_0(std::vector<fcl::detail::NodeBase<fcl::AABB<double> >*, std::allocator<fcl::detail::NodeBase<fcl::AABB<double> >*> >&) ()
   from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
#5  0x00007ffff3f18082 in fcl::DynamicAABBTreeCollisionManager<double>::registerObjects(std::vector<fcl::CollisionObject<double>*, std::allocator<fcl::CollisionObject<double>*> > const&) ()
   from /opt/ros/noetic/lib/x86_64-linux-gnu/libfcl.so.0.6
...
```
