### PR TITLE
Removed raw pointer creation using new from robot state test

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,7 @@ API changes in MoveIt releases
 - Removed deprecated header `moveit/macros/deprecation.h`. Use `[[deprecated]]` instead.
 - All uses of `MOVEIT_CLASS_FORWARD` et. al. must now be followed by a semicolon for consistency (and to get -pedantic builds to pass for the codebase).
 - In case you start RViz in a namespace, the default topic for the trajectory visualization display now uses the relative instead of the absolute namespace (i.e. `<ns>/move_group/display_planned_path` instead of `/move_group/display_planned_path`).
+- `RobotState::attachBody()` now takes a unique_ptr instead of an owning raw pointer.
 
 ## ROS Melodic
 

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -299,10 +299,9 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   poses.push_back(identity);
   std::set<std::string> touch_links;
   trajectory_msgs::JointTrajectory empty_state;
-  moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
 
-  robot_state.attachBody(attached_body);
+  robot_state.attachBody(std::make_unique<moveit::core::AttachedBody>(
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state));
 
   res = collision_detection::CollisionResult();
   cenv_->checkSelfCollision(req, res, robot_state, *acm_);
@@ -314,9 +313,8 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   touch_links.insert("r_gripper_palm_link");
   shapes[0] = std::make_shared<shapes::Box>(.1, .1, .1);
 
-  moveit::core::AttachedBody* attached_body_1 = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
-  robot_state.attachBody(attached_body_1);
+  robot_state.attachBody(std::make_unique<moveit::core::AttachedBody>(
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state));
 
   res = collision_detection::CollisionResult();
   cenv_->checkSelfCollision(req, res, robot_state, *acm_);

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1068,12 +1068,12 @@ public:
       @param timeout The timeout passed to the kinematics solver on each attempt
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-                 const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
+                 const std::vector<std::string>& tips, const std::vector<std::vector<double>>& consistency_limits,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-            const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
+            const std::vector<std::string>& tips, const std::vector<std::vector<double>>& consistency_limits,
             unsigned int /* attempts */, double timeout = 0.0,
             const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
             const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
@@ -1091,12 +1091,12 @@ public:
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIKSubgroups(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
                           const std::vector<std::string>& tips,
-                          const std::vector<std::vector<double> >& consistency_limits, double timeout = 0.0,
+                          const std::vector<std::vector<double>>& consistency_limits, double timeout = 0.0,
                           const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
   [[deprecated("The attempts argument is not supported anymore.")]] bool
   setFromIKSubgroups(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
-                     const std::vector<std::string>& tips, const std::vector<std::vector<double> >& consistency_limits,
+                     const std::vector<std::string>& tips, const std::vector<std::vector<double>>& consistency_limits,
                      unsigned int /* attempts */, double timeout = 0.0,
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
@@ -1628,6 +1628,18 @@ public:
    *  @{
    */
 
+  /** \brief Add an attached body to this state.
+   *
+   * This only adds the given body to this RobotState
+   * instance.  It does not change anything about other
+   * representations of the object elsewhere in the system.  So if the
+   * body represents an object in a collision_detection::World (like
+   * from a planning_scene::PlanningScene), you will likely need to remove the
+   * corresponding object from that world to avoid having collisions
+   * detected against it.
+   **/
+  void attachBody(std::unique_ptr<AttachedBody> attached_body);
+
   /** \brief Add an attached body to this state. Ownership of the
    * memory for the attached body is assumed by the state.
    *
@@ -1647,7 +1659,9 @@ public:
    * the body positions will get corrupted.  You need to make a fresh
    * copy of the AttachedBody object for each RobotState you attach it
    * to.*/
-  void attachBody(AttachedBody* attached_body);
+  [[deprecated("Deprecated use the overload requiring an unique_ptr instead")]] void
+  attachBody(AttachedBody* attached_body);
+  // TODO Remove this function
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
@@ -1951,7 +1965,7 @@ private:
   unsigned char* dirty_joint_transforms_;
 
   /** \brief All attached bodies that are part of this state, indexed by their name */
-  std::map<std::string, AttachedBody*> attached_body_map_;
+  std::map<std::string, std::unique_ptr<AttachedBody>> attached_body_map_;
 
   /** \brief This event is called when there is a change in the attached bodies for this state;
       The event specifies the body that changed and whether it was just attached or about to be detached. */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1659,9 +1659,7 @@ public:
    * the body positions will get corrupted.  You need to make a fresh
    * copy of the AttachedBody object for each RobotState you attach it
    * to.*/
-  [[deprecated("Deprecated use the overload requiring an unique_ptr instead")]] void
-  attachBody(AttachedBody* attached_body);
-  // TODO Remove this function
+  [[deprecated("Deprecated. Pass a unique_ptr instead")]] void attachBody(AttachedBody* attached_body);
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -176,8 +176,8 @@ void RobotState::copyFrom(const RobotState& other)
 
   // copy attached bodies
   clearAttachedBodies();
-  for (const std::pair<const std::string, AttachedBody*>& it : other.attached_body_map_)
-    attachBody(new AttachedBody(*it.second));
+  for (const auto& attachedBody : other.attached_body_map_)
+    attachBody(std::make_unique<AttachedBody>(*attachedBody.second));
 }
 
 bool RobotState::checkJointTransforms(const JointModel* joint) const
@@ -740,9 +740,9 @@ void RobotState::updateLinkTransformsInternal(const JointModel* start)
   }
 
   // update attached bodies tf; these are usually very few, so we update them all
-  for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
-       it != attached_body_map_.end(); ++it)
-    it->second->computeTransform(global_link_transforms_[it->second->getAttachedLink()->getLinkIndex()]);
+  for (const auto& attachedBody : attached_body_map_)
+    attachedBody.second->computeTransform(
+        global_link_transforms_[attachedBody.second->getAttachedLink()->getLinkIndex()]);
 }
 
 void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isometry3d& transform, bool backward)
@@ -792,9 +792,9 @@ void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isome
   }
 
   // update attached bodies tf; these are usually very few, so we update them all
-  for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
-       it != attached_body_map_.end(); ++it)
-    it->second->computeTransform(global_link_transforms_[it->second->getAttachedLink()->getLinkIndex()]);
+  for (const auto& attachedBody : attached_body_map_)
+    attachedBody.second->computeTransform(
+        global_link_transforms_[attachedBody.second->getAttachedLink()->getLinkIndex()]);
 }
 
 const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::string& frame) const
@@ -978,25 +978,30 @@ bool RobotState::hasAttachedBody(const std::string& id) const
 
 const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 {
-  std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(id);
+  const auto it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
   {
     ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' not found", id.c_str());
     return nullptr;
   }
   else
-    return it->second;
+    return it->second.get();
 }
 
-void RobotState::attachBody(AttachedBody* attached_body)
+void RobotState::attachBody(std::unique_ptr<AttachedBody> attached_body)
 {
   // If an attached body with the same id exists, remove it
   clearAttachedBody(attached_body->getName());
 
-  attached_body_map_[attached_body->getName()] = attached_body;
   attached_body->computeTransform(getGlobalLinkTransform(attached_body->getAttachedLink()));
   if (attached_body_update_callback_)
-    attached_body_update_callback_(attached_body, true);
+    attached_body_update_callback_(attached_body.get(), true);
+  attached_body_map_[attached_body->getName()] = std::move(attached_body);
+}
+
+void RobotState::attachBody(AttachedBody* attached_body)
+{
+  attachBody(std::unique_ptr<AttachedBody>(attached_body));
 }
 
 void RobotState::attachBody(const std::string& id, const Eigen::Isometry3d& pose,
@@ -1005,90 +1010,81 @@ void RobotState::attachBody(const std::string& id, const Eigen::Isometry3d& pose
                             const std::string& link, const trajectory_msgs::JointTrajectory& detach_posture,
                             const moveit::core::FixedTransformsMap& subframe_poses)
 {
-  const LinkModel* l = robot_model_->getLinkModel(link);
-  attachBody(new AttachedBody(l, id, pose, shapes, shape_poses, touch_links, detach_posture, subframe_poses));
+  attachBody(std::make_unique<AttachedBody>(robot_model_->getLinkModel(link), id, pose, shapes, shape_poses,
+                                            touch_links, detach_posture, subframe_poses));
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies) const
 {
   attached_bodies.clear();
   attached_bodies.reserve(attached_body_map_.size());
-  for (const std::pair<const std::string, AttachedBody*>& it : attached_body_map_)
-    attached_bodies.push_back(it.second);
+  for (const auto& it : attached_body_map_)
+    attached_bodies.push_back(it.second.get());
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies, const JointModelGroup* group) const
 {
   attached_bodies.clear();
-  for (const std::pair<const std::string, AttachedBody*>& it : attached_body_map_)
+  for (const auto& it : attached_body_map_)
     if (group->hasLinkModel(it.second->getAttachedLinkName()))
-      attached_bodies.push_back(it.second);
+      attached_bodies.push_back(it.second.get());
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies, const LinkModel* link_model) const
 {
   attached_bodies.clear();
-  for (const std::pair<const std::string, AttachedBody*>& it : attached_body_map_)
+  for (const auto& it : attached_body_map_)
     if (it.second->getAttachedLink() == link_model)
-      attached_bodies.push_back(it.second);
+      attached_bodies.push_back(it.second.get());
 }
 
 void RobotState::clearAttachedBodies()
 {
-  for (std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.begin();
-       it != attached_body_map_.end(); ++it)
+  for (const auto& it : attached_body_map_)
   {
     if (attached_body_update_callback_)
-      attached_body_update_callback_(it->second, false);
-    delete it->second;
+      attached_body_update_callback_(it.second.get(), false);
   }
   attached_body_map_.clear();
 }
 
 void RobotState::clearAttachedBodies(const LinkModel* link)
 {
-  std::map<std::string, AttachedBody*>::iterator it = attached_body_map_.begin();
-  while (it != attached_body_map_.end())
+  for (auto it = attached_body_map_.cbegin(); it != attached_body_map_.cend(); ++it)
   {
     if (it->second->getAttachedLink() != link)
     {
-      ++it;
       continue;
     }
     if (attached_body_update_callback_)
-      attached_body_update_callback_(it->second, false);
-    delete it->second;
-    std::map<std::string, AttachedBody*>::iterator del = it++;
+      attached_body_update_callback_(it->second.get(), false);
+    const auto del = it++;
     attached_body_map_.erase(del);
   }
 }
 
 void RobotState::clearAttachedBodies(const JointModelGroup* group)
 {
-  std::map<std::string, AttachedBody*>::iterator it = attached_body_map_.begin();
-  while (it != attached_body_map_.end())
+  for (auto it = attached_body_map_.cbegin(); it != attached_body_map_.cend(); ++it)
   {
     if (!group->hasLinkModel(it->second->getAttachedLinkName()))
     {
-      ++it;
       continue;
     }
     if (attached_body_update_callback_)
-      attached_body_update_callback_(it->second, false);
-    delete it->second;
-    std::map<std::string, AttachedBody*>::iterator del = it++;
+      attached_body_update_callback_(it->second.get(), false);
+    const auto del = it++;
     attached_body_map_.erase(del);
   }
 }
 
 bool RobotState::clearAttachedBody(const std::string& id)
 {
-  std::map<std::string, AttachedBody*>::iterator it = attached_body_map_.find(id);
+  const auto it = attached_body_map_.find(id);
   if (it != attached_body_map_.end())
   {
     if (attached_body_update_callback_)
-      attached_body_update_callback_(it->second, false);
-    delete it->second;
+      attached_body_update_callback_(it->second.get(), false);
     attached_body_map_.erase(it);
     return true;
   }
@@ -1137,7 +1133,7 @@ const Eigen::Isometry3d& RobotState::getFrameInfo(const std::string& frame_id, c
   robot_link = nullptr;
 
   // Check names of the attached bodies
-  std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(frame_id);
+  const auto jt = attached_body_map_.find(frame_id);
   if (jt != attached_body_map_.end())
   {
     const Eigen::Isometry3d& transform = jt->second->getGlobalPose();
@@ -1148,7 +1144,7 @@ const Eigen::Isometry3d& RobotState::getFrameInfo(const std::string& frame_id, c
   }
 
   // Check if an AttachedBody has a subframe with name frame_id
-  for (const std::pair<const std::string, AttachedBody*>& body : attached_body_map_)
+  for (const auto& body : attached_body_map_)
   {
     const Eigen::Isometry3d& transform = body.second->getGlobalSubframeTransform(frame_id, &frame_found);
     if (frame_found)
@@ -1172,12 +1168,12 @@ bool RobotState::knowsFrameTransform(const std::string& frame_id) const
     return true;
 
   // Check if an AttachedBody with name frame_id exists
-  std::map<std::string, AttachedBody*>::const_iterator it = attached_body_map_.find(frame_id);
+  const auto it = attached_body_map_.find(frame_id);
   if (it != attached_body_map_.end())
     return !it->second->getGlobalCollisionBodyTransforms().empty();
 
   // Check if an AttachedBody has a subframe with name frame_id
-  for (const std::pair<const std::string, AttachedBody*>& body : attached_body_map_)
+  for (const auto& body : attached_body_map_)
   {
     if (body.second->hasSubframeTransform(frame_id))
       return true;
@@ -1212,7 +1208,7 @@ void RobotState::getRobotMarkers(visualization_msgs::MarkerArray& arr, const std
     if (!link_model)
       continue;
     if (include_attached)
-      for (const std::pair<const std::string, AttachedBody*>& it : attached_body_map_)
+      for (const auto& it : attached_body_map_)
         if (it.second->getAttachedLink() == link_model)
         {
           for (std::size_t j = 0; j < it.second->getShapes().size(); ++j)
@@ -2055,7 +2051,7 @@ void RobotState::computeAABB(std::vector<double>& aabb) const
     transform.translate(link->getCenteredBoundingBoxOffset());
     bounding_box.extendWithTransformedBox(transform, extents);
   }
-  for (const std::pair<const std::string, AttachedBody*>& it : attached_body_map_)
+  for (const auto& it : attached_body_map_)
   {
     const EigenSTL::vector_Isometry3d& transforms = it.second->getGlobalCollisionBodyTransforms();
     const std::vector<shapes::ShapeConstPtr>& shapes = it.second->getShapes();

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -978,7 +978,7 @@ bool RobotState::hasAttachedBody(const std::string& id) const
 
 const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 {
-  const auto& it = attached_body_map_.find(id);
+  const auto it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
   {
     ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' not found", id.c_str());

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -176,8 +176,8 @@ void RobotState::copyFrom(const RobotState& other)
 
   // copy attached bodies
   clearAttachedBodies();
-  for (const auto& attachedBody : other.attached_body_map_)
-    attachBody(std::make_unique<AttachedBody>(*attachedBody.second));
+  for (const auto& attached_body : other.attached_body_map_)
+    attachBody(std::make_unique<AttachedBody>(*attached_body.second));
 }
 
 bool RobotState::checkJointTransforms(const JointModel* joint) const
@@ -740,9 +740,9 @@ void RobotState::updateLinkTransformsInternal(const JointModel* start)
   }
 
   // update attached bodies tf; these are usually very few, so we update them all
-  for (const auto& attachedBody : attached_body_map_)
-    attachedBody.second->computeTransform(
-        global_link_transforms_[attachedBody.second->getAttachedLink()->getLinkIndex()]);
+  for (const auto& attached_body : attached_body_map_)
+    attached_body.second->computeTransform(
+        global_link_transforms_[attached_body.second->getAttachedLink()->getLinkIndex()]);
 }
 
 void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isometry3d& transform, bool backward)
@@ -792,9 +792,9 @@ void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isome
   }
 
   // update attached bodies tf; these are usually very few, so we update them all
-  for (const auto& attachedBody : attached_body_map_)
-    attachedBody.second->computeTransform(
-        global_link_transforms_[attachedBody.second->getAttachedLink()->getLinkIndex()]);
+  for (const auto& attached_body : attached_body_map_)
+    attached_body.second->computeTransform(
+        global_link_transforms_[attached_body.second->getAttachedLink()->getLinkIndex()]);
 }
 
 const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::string& frame) const
@@ -978,7 +978,7 @@ bool RobotState::hasAttachedBody(const std::string& id) const
 
 const AttachedBody* RobotState::getAttachedBody(const std::string& id) const
 {
-  const auto it = attached_body_map_.find(id);
+  const auto& it = attached_body_map_.find(id);
   if (it == attached_body_map_.end())
   {
     ROS_ERROR_NAMED(LOGNAME, "Attached body '%s' not found", id.c_str());

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -690,7 +690,7 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b"), link_a);
 
   // attach "object" with "subframe" to link_b
-  state.attachBody(new moveit::core::AttachedBody(
+  state.attachBody(std::make_unique<moveit::core::AttachedBody>(
       link_b, "object", Eigen::Isometry3d::Identity(), std::vector<shapes::ShapeConstPtr>{},
       EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::JointTrajectory{},
       moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d::Identity() } }));

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -170,10 +170,8 @@ TEST(LoadingAndFK, SimpleRobot)
 
   state.setVariableAcceleration("base_joint/x", 0.0);
 
-  // making sure that values get copied
-  moveit::core::RobotState* new_state = new moveit::core::RobotState(state);
+  const auto new_state = std::make_unique<moveit::core::RobotState>(state);  // making sure that values get copied
   EXPECT_NEAR_TRACED(state.getGlobalLinkTransform("base_link").translation(), Eigen::Vector3d(10, 8, 0));
-  delete new_state;
 
   std::vector<double> jv(state.getVariableCount(), 0.0);
   jv[state.getRobotModel()->getVariableIndex("base_joint/x")] = 5.0;
@@ -364,7 +362,7 @@ protected:
         "</robot>";
 
     urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(MODEL2);
-    srdf::ModelSharedPtr srdf_model(new srdf::Model());
+    srdf::ModelSharedPtr srdf_model = std::make_shared<srdf::Model>();
     srdf_model->initString(*urdf_model, SMODEL2);
     robot_model_ = std::make_shared<moveit::core::RobotModel>(urdf_model, srdf_model);
   }

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -243,9 +243,9 @@ TEST_F(LoadPlanningModelsPr2, FullTest)
   std::set<std::string> touch_links;
 
   trajectory_msgs::JointTrajectory empty_state;
-  moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_model->getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
-  ks.attachBody(attached_body);
+
+  ks.attachBody(std::make_unique<moveit::core::AttachedBody>(robot_model->getLinkModel("r_gripper_palm_link"), "box",
+                                                             identity, shapes, poses, touch_links, empty_state));
 
   std::vector<const moveit::core::AttachedBody*> attached_bodies_1;
   ks.getAttachedBodies(attached_bodies_1);
@@ -286,14 +286,12 @@ TEST_F(LoadPlanningModelsPr2, ObjectPoseAndSubframes)
   subframes["frame1"] = Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1));
 
   trajectory_msgs::JointTrajectory empty_state;
-  moveit::core::AttachedBody* attached_body_a =
-      new moveit::core::AttachedBody(robot_model->getLinkModel("r_gripper_palm_link"), "boxA", pose_a, shapes, poses,
-                                     touch_links, empty_state, subframes);
-  moveit::core::AttachedBody* attached_body_b =
-      new moveit::core::AttachedBody(robot_model->getLinkModel("r_gripper_palm_link"), "boxB", pose_b, shapes, poses,
-                                     touch_links, empty_state, subframes);
-  ks.attachBody(attached_body_a);
-  ks.attachBody(attached_body_b);
+  ks.attachBody(std::make_unique<moveit::core::AttachedBody>(robot_model->getLinkModel("r_gripper_palm_link"), "boxA",
+                                                             pose_a, shapes, poses, touch_links, empty_state,
+                                                             subframes));
+  ks.attachBody(std::make_unique<moveit::core::AttachedBody>(robot_model->getLinkModel("r_gripper_palm_link"), "boxB",
+                                                             pose_b, shapes, poses, touch_links, empty_state,
+                                                             subframes));
 
   // Check position of shape in each body
   Eigen::Isometry3d p;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -860,12 +860,11 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
     if (ab)
     {
       known_collision_objects_[item->type()].first = item_text;
-      moveit::core::AttachedBody* new_ab =
-          new moveit::core::AttachedBody(ab->getAttachedLink(), known_collision_objects_[item->type()].first,
-                                         ab->getPose(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
-                                         ab->getDetachPosture(), ab->getSubframes());
+      auto new_ab = std::make_unique<moveit::core::AttachedBody>(
+          ab->getAttachedLink(), known_collision_objects_[item->type()].first, ab->getPose(), ab->getShapes(),
+          ab->getShapePoses(), ab->getTouchLinks(), ab->getDetachPosture(), ab->getSubframes());
       cs.clearAttachedBody(ab->getName());
-      cs.attachBody(new_ab);
+      cs.attachBody(std::move(new_ab));
     }
   }
   setLocalSceneEdited();


### PR DESCRIPTION
### Description

The method RobotState::attachBody(AttachBody*) expects an owning raw pointer. This can be seen from the comment above the method (see below).  This PR replaces that owning raw pointer with a `std::unique_ptr`. The old method is marked deprecated. This allows removing multiple `delete`'s in robot_state.cpp. Additionally two other `new` keywords were replaced in the __test__ code of robot_state.

~~~
  /** \brief Add an attached body to this state. Ownership of the
   * memory for the attached body is assumed by the state.
   *
   * This only adds the given body to this RobotState
   * instance.  It does not change anything about other
   * representations of the object elsewhere in the system.  So if the
   * body represents an object in a collision_detection::World (like
   * from a planning_scene::PlanningScene), you will likely need to remove the
   * corresponding object from that world to avoid having collisions
   * detected against it.
   *
   * \note This version of the function (taking an AttachedBody
   * pointer) does not copy the AttachedBody object, it just uses it
   * directly.  The AttachedBody object stores its position data
   * internally.  This means you should <b>never attach a single
   * AttachedBody instance to multiple RobotState instances</b>, or
   * the body positions will get corrupted.  You need to make a fresh
   * copy of the AttachedBody object for each RobotState you attach it
   * to.*/
~~~

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- ~~[ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)~~
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- ~~[] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)~~ refactoring, no behaviour changes
- ~~[ ] Include a screenshot if changing a GUI~~
- ~~[ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers~~

## Future steps
I would like to separate the AttachedBody management into a separate class. Then RobotState could call that class. This new class would be focussed around `the attached_body_map_` field, which should be moved to the new class. What do you think?