### PR TITLE
MSA cleanup

### DIFF
--- a/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/setup_assistant_widget.cpp
@@ -448,11 +448,9 @@ void SetupAssistantWidget::highlightGroup(const std::string& group_name)
       config_data_->getRobotModel()->getJointModelGroup(group_name);
   if (joint_model_group)
   {
-    const std::vector<const moveit::core::LinkModel*>& link_models = joint_model_group->getLinkModels();
     // Iterate through the links
-    for (std::vector<const moveit::core::LinkModel*>::const_iterator link_it = link_models.begin();
-         link_it < link_models.end(); ++link_it)
-      highlightLink((*link_it)->getName(), QColor(255, 0, 0));
+    for (const moveit::core::LinkModel* lm : joint_model_group->getLinkModels())
+      highlightLink(lm->getName(), QColor(255, 0, 0));
   }
 }
 
@@ -477,12 +475,12 @@ void SetupAssistantWidget::unhighlightAll()
   }
 
   // Iterate through the links
-  for (std::vector<std::string>::const_iterator link_it = links.begin(); link_it < links.end(); ++link_it)
+  for (const std::string& link : links)
   {
-    if ((*link_it).empty())
+    if (link.empty())
       continue;
 
-    robot_state_display_->unsetLinkColor(*link_it);
+    robot_state_display_->unsetLinkColor(link);
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -395,7 +395,7 @@ bool StartScreenWidget::loadExistingFiles()
   QApplication::processEvents();
 
   // Load the SRDF
-  if (!loadSRDFFile(config_data_->srdf_path_))
+  if (!loadSRDFFile(config_data_->srdf_path_, config_data_->xacro_args_))
     return false;  // error occured
 
   // Progress Indicator
@@ -546,9 +546,7 @@ bool StartScreenWidget::loadNewFiles()
 // ******************************************************************************************
 bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const std::string& xacro_args)
 {
-  const std::vector<std::string> vec_xacro_args = { xacro_args };
-
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(config_data_->urdf_string_, urdf_file_path, vec_xacro_args))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(config_data_->urdf_string_, urdf_file_path, { xacro_args }))
   {
     QMessageBox::warning(this, "Error Loading Files",
                          QString("URDF/COLLADA file not found: ").append(urdf_file_path.c_str()));
@@ -592,12 +590,10 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const st
 // ******************************************************************************************
 // Load SRDF File to Parameter Server
 // ******************************************************************************************
-bool StartScreenWidget::loadSRDFFile(const std::string& srdf_file_path)
+bool StartScreenWidget::loadSRDFFile(const std::string& srdf_file_path, const std::string& xacro_args)
 {
-  const std::vector<std::string> xacro_args;
-
   std::string srdf_string;
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, srdf_file_path, xacro_args))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, srdf_file_path, { xacro_args }))
   {
     QMessageBox::warning(this, "Error Loading Files", QString("SRDF file not found: ").append(srdf_file_path.c_str()));
     return false;

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -146,7 +146,7 @@ private:
   bool loadURDFFile(const std::string& urdf_file_path, const std::string& xacro_args);
 
   /// Load SRDF File
-  bool loadSRDFFile(const std::string& srdf_file_path);
+  bool loadSRDFFile(const std::string& srdf_file_path, const std::string& xacro_args);
 
   /// Put SRDF File on Parameter Server
   bool setSRDFFile(const std::string& srdf_string);


### PR DESCRIPTION
This PR factors out two simple commits from #2938:
- Pass xacro args to SRDF loading as well (fixes an issue reported by @rickstaa somewhere)
- Modernize some more loops (no idea why clang-tidy ignored them)