### PR TITLE
disable robot_interaction tests without NDEBUG

### DIFF
--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -551,62 +551,70 @@ TEST(LockedRobotState, set1)
   runThreads(1, 1, 0);
 }
 
-TEST(LockedRobotState, set2)
+// skip all more complex locking checks when optimizations are disabled
+// they can easily outrun 20 minutes with Debug builds
+#ifdef NDEBUG
+#define OPT_TEST(F, N) TEST(F, N)
+#else
+#define OPT_TEST(F, N) TEST(F, DISABLED_##N)
+#endif
+
+OPT_TEST(LockedRobotState, set2)
 {
   runThreads(1, 2, 0);
 }
 
-TEST(LockedRobotState, set3)
+OPT_TEST(LockedRobotState, set3)
 {
   runThreads(1, 3, 0);
 }
 
-TEST(LockedRobotState, mod1)
+OPT_TEST(LockedRobotState, mod1)
 {
   runThreads(1, 0, 1);
 }
 
-TEST(LockedRobotState, mod2)
+OPT_TEST(LockedRobotState, mod2)
 {
   runThreads(1, 0, 1);
 }
 
-TEST(LockedRobotState, mod3)
+OPT_TEST(LockedRobotState, mod3)
 {
   runThreads(1, 0, 1);
 }
 
-TEST(LockedRobotState, set1mod1)
+OPT_TEST(LockedRobotState, set1mod1)
 {
   runThreads(1, 1, 1);
 }
 
-TEST(LockedRobotState, set2mod1)
+OPT_TEST(LockedRobotState, set2mod1)
 {
   runThreads(1, 2, 1);
 }
 
-TEST(LockedRobotState, set1mod2)
+OPT_TEST(LockedRobotState, set1mod2)
 {
   runThreads(1, 1, 2);
 }
 
-TEST(LockedRobotState, set3mod1)
+OPT_TEST(LockedRobotState, set3mod1)
 {
   runThreads(1, 3, 1);
 }
 
-TEST(LockedRobotState, set1mod3)
+OPT_TEST(LockedRobotState, set1mod3)
 {
   runThreads(1, 1, 3);
 }
 
-TEST(LockedRobotState, set3mod3)
+OPT_TEST(LockedRobotState, set3mod3)
 {
   runThreads(1, 3, 3);
 }
 
-TEST(LockedRobotState, set3mod3c3)
+OPT_TEST(LockedRobotState, set3mod3c3)
 {
   runThreads(3, 3, 3);
 }


### PR DESCRIPTION
These tests are known to run for a very long time in debug builds.
So let's disable them in this case.
If you still insist to run them, you can do so via
`locked_robot_state_test --gtest_also_run_disabled_tests`

Inspired by #3012 .

This addresses the worst offender in #2107 .
The other long-running tests can probably be patched in similar ways if we deem it useful.

For documentation. This is an execution in debug mode of the first few tests on my local machine:
```
./devel/.private/moveit_ros_robot_interaction/lib/moveit_ros_robot_interaction/locked_robot_state_test
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from LockedRobotState
[ RUN      ] LockedRobotState.load
1640781730.871940801: ${node}.ros.moveit_core.robot_model: Loading robot model 'one_robot'...
[       OK ] LockedRobotState.load (8 ms)
[ RUN      ] LockedRobotState.URDF_sanity
[       OK ] LockedRobotState.URDF_sanity (0 ms)
[ RUN      ] LockedRobotState.robotStateChanged
[       OK ] LockedRobotState.robotStateChanged (0 ms)
[ RUN      ] LockedRobotState.set1
[       OK ] LockedRobotState.set1 (10366 ms)
[ RUN      ] LockedRobotState.set2
[       OK ] LockedRobotState.set2 (13375 ms)
[ RUN      ] LockedRobotState.set3
[       OK ] LockedRobotState.set3 (19507 ms)
[ RUN      ] LockedRobotState.mod1
[       OK ] LockedRobotState.mod1 (8487 ms)
[ RUN      ] LockedRobotState.mod2
[       OK ] LockedRobotState.mod2 (29348 ms)
[ RUN      ] LockedRobotState.mod3
[       OK ] LockedRobotState.mod3 (66884 ms)
[ RUN      ] LockedRobotState.set1mod1
[       OK ] LockedRobotState.set1mod1 (99204 ms)
[ RUN      ] LockedRobotState.set2mod1
[       OK ] LockedRobotState.set2mod1 (168234 ms)
[ RUN      ] LockedRobotState.set1mod2
[       OK ] LockedRobotState.set1mod2 (418637 ms)
[ RUN      ] LockedRobotState.set3mod1
[       OK ] LockedRobotState.set3mod1 (191074 ms)
[ RUN      ] LockedRobotState.set1mod3
[       OK ] LockedRobotState.set1mod3 (680054 ms)
```