### PR TITLE
Add missing noexcept declarations

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -151,8 +151,8 @@ public:
   MoveGroupInterface(const MoveGroupInterface&) = delete;
   MoveGroupInterface& operator=(const MoveGroupInterface&) = delete;
 
-  MoveGroupInterface(MoveGroupInterface&& other);
-  MoveGroupInterface& operator=(MoveGroupInterface&& other);
+  MoveGroupInterface(MoveGroupInterface&& other) noexcept;
+  MoveGroupInterface& operator=(MoveGroupInterface&& other) noexcept;
 
   /** \brief Get the name of the group this instance operates on */
   const std::string& getName() const;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1314,14 +1314,14 @@ moveit::planning_interface::MoveGroupInterface::~MoveGroupInterface()
   delete impl_;
 }
 
-moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(MoveGroupInterface&& other)
+moveit::planning_interface::MoveGroupInterface::MoveGroupInterface(MoveGroupInterface&& other) noexcept
   : remembered_joint_values_(std::move(other.remembered_joint_values_)), impl_(other.impl_)
 {
   other.impl_ = nullptr;
 }
 
 moveit::planning_interface::MoveGroupInterface&
-moveit::planning_interface::MoveGroupInterface::operator=(MoveGroupInterface&& other)
+moveit::planning_interface::MoveGroupInterface::operator=(MoveGroupInterface&& other) noexcept
 {
   if (this != &other)
   {

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -120,8 +120,8 @@ public:
   MoveItCpp(const MoveItCpp&) = delete;
   MoveItCpp& operator=(const MoveItCpp&) = delete;
 
-  MoveItCpp(MoveItCpp&& other);
-  MoveItCpp& operator=(MoveItCpp&& other);
+  MoveItCpp(MoveItCpp&& other) noexcept;
+  MoveItCpp& operator=(MoveItCpp&& other) noexcept;
 
   /** \brief Destructor */
   ~MoveItCpp();

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -111,7 +111,7 @@ public:
   PlanningComponent(const PlanningComponent&) = delete;
   PlanningComponent& operator=(const PlanningComponent&) = delete;
 
-  PlanningComponent(PlanningComponent&& other) noexcept;
+  PlanningComponent(PlanningComponent&& other) = delete;
   PlanningComponent& operator=(PlanningComponent&& other) noexcept;
 
   /** \brief Destructor */

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -111,8 +111,8 @@ public:
   PlanningComponent(const PlanningComponent&) = delete;
   PlanningComponent& operator=(const PlanningComponent&) = delete;
 
-  PlanningComponent(PlanningComponent&& other);
-  PlanningComponent& operator=(PlanningComponent&& other);
+  PlanningComponent(PlanningComponent&& other) noexcept;
+  PlanningComponent& operator=(PlanningComponent&& other) noexcept;
 
   /** \brief Destructor */
   ~PlanningComponent();

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -96,7 +96,7 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
   ROS_INFO_NAMED(LOGNAME, "MoveItCpp running");
 }
 
-MoveItCpp::MoveItCpp(MoveItCpp&& other)
+MoveItCpp::MoveItCpp(MoveItCpp&& other) noexcept
 {
   other.clearContents();
 }
@@ -107,7 +107,7 @@ MoveItCpp::~MoveItCpp()
   clearContents();
 }
 
-MoveItCpp& MoveItCpp::operator=(MoveItCpp&& other)
+MoveItCpp& MoveItCpp::operator=(MoveItCpp&& other) noexcept
 {
   if (this != &other)
   {

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -92,7 +92,7 @@ PlanningComponent::~PlanningComponent()
   clearContents();
 }
 
-PlanningComponent& PlanningComponent::operator=(PlanningComponent&& other)
+PlanningComponent& PlanningComponent::operator=(PlanningComponent&& other) noexcept
 {
   if (this != &other)
   {


### PR DESCRIPTION
as required by clang-tidy: https://github.com/ros-planning/moveit/runs/4660515498