### PR TITLE
Fix deprecation warning in moveit_cpp, add namespace to MoveItErrorCode

### DIFF
--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -111,7 +111,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   if (!joint_model_group_)
   {
     ROS_ERROR_NAMED(LOGNAME, "Failed to retrieve joint model group for name '%s'.", group_name_.c_str());
-    last_plan_solution_->error_code = MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME);
+    last_plan_solution_->error_code = moveit::core::MoveItErrorCode::INVALID_GROUP_NAME;
     return *last_plan_solution_;
   }
 
@@ -148,7 +148,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   if (current_goal_constraints_.empty())
   {
     ROS_ERROR_NAMED(LOGNAME, "No goal constraints set for planning request");
-    last_plan_solution_->error_code = MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
+    last_plan_solution_->error_code = moveit::core::MoveItErrorCode::INVALID_GOAL_CONSTRAINTS;
     return *last_plan_solution_;
   }
   req.goal_constraints = current_goal_constraints_;
@@ -161,7 +161,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   if (planning_pipeline_names_.find(parameters.planning_pipeline) == planning_pipeline_names_.end())
   {
     ROS_ERROR_NAMED(LOGNAME, "No planning pipeline available for name '%s'", parameters.planning_pipeline.c_str());
-    last_plan_solution_->error_code = MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
+    last_plan_solution_->error_code = moveit::core::MoveItErrorCode::FAILURE;
     return *last_plan_solution_;
   }
   const planning_pipeline::PlanningPipelinePtr pipeline =


### PR DESCRIPTION
### Description
The deprecation warning below shows up when building MoveIt from source.
This PR applies the suggestion given in the warning and removes the indirection through `moveit_msgs::MoveItErrorCodes`.
(Related to #3009)

```
Warnings   << moveit_ros_planning:make /home/jdm/ros/moveit_ws/logs/moveit_ros_planning/build.make.001.log                             
/home/jdm/ros/moveit_ws/src/moveit/moveit_ros/planning/moveit_cpp/src/planning_component.cpp:114:39: warning: 'MoveItErrorCode' is deprecated: Use moveit::core::MoveItErrorCode [-Wdeprecated-declarations]
    last_plan_solution_->error_code = MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME);
                                      ^
/home/jdm/ros/moveit_ws/src/moveit/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h:54:27: note: 'MoveItErrorCode' has been explicitly marked deprecated here
  using MoveItErrorCode [[deprecated("Use moveit::core::MoveItErrorCode")]] = moveit::core::MoveItErrorCode;
                          ^
/home/jdm/ros/moveit_ws/src/moveit/moveit_ros/planning/moveit_cpp/src/planning_component.cpp:151:39: warning: 'MoveItErrorCode' is deprecated: Use moveit::core::MoveItErrorCode [-Wdeprecated-declarations]
    last_plan_solution_->error_code = MoveItErrorCode(moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
                                      ^
/home/jdm/ros/moveit_ws/src/moveit/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h:54:27: note: 'MoveItErrorCode' has been explicitly marked deprecated here
  using MoveItErrorCode [[deprecated("Use moveit::core::MoveItErrorCode")]] = moveit::core::MoveItErrorCode;
                          ^
/home/jdm/ros/moveit_ws/src/moveit/moveit_ros/planning/moveit_cpp/src/planning_component.cpp:164:39: warning: 'MoveItErrorCode' is deprecated: Use moveit::core::MoveItErrorCode [-Wdeprecated-declarations]
    last_plan_solution_->error_code = MoveItErrorCode(moveit_msgs::MoveItErrorCodes::FAILURE);
                                      ^
/home/jdm/ros/moveit_ws/src/moveit/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h:54:27: note: 'MoveItErrorCode' has been explicitly marked deprecated here
  using MoveItErrorCode [[deprecated("Use moveit::core::MoveItErrorCode")]] = moveit::core::MoveItErrorCode;
                          ^
3 warnings generated.

```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
