### PR TITLE
Removed wrong transform in sphere decomposition

### DIFF
--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -52,7 +52,7 @@ collision_detection::determineCollisionSpheres(const bodies::Body* body, Eigen::
   body->computeBoundingCylinder(cyl);
   unsigned int num_points = ceil(cyl.length / (cyl.radius / 2.0));
   double spacing = cyl.length / ((num_points * 1.0) - 1.0);
-  relative_transform = body->getPose().inverse() * cyl.pose;
+  relative_transform = cyl.pose;
 
   for (unsigned int i = 1; i < num_points - 1; i++)
   {


### PR DESCRIPTION
### Description

For optimization-based trajectory planning, collision bodies can be sampled with spheres with `collision_detection::determineCollisionSpheres`. The current implementation introduces a wrong relative transform, leading to a wrong positioning of these spheres. The error is only noticeable, when collision bodies have an offset from the respective link pose.

Before the fix:
![moveit_sphere_decomposition_bugged](https://user-images.githubusercontent.com/7110154/148414609-ab932ce4-53f2-4d38-91d3-0f4713dde908.png)

With the fix:
![moveit_sphere_decomposition_fixed](https://user-images.githubusercontent.com/7110154/148414608-0b09572c-5fa2-463f-adeb-1d0a7ce15a98.png)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
