### PR TITLE
Make demo gazebo work

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -412,19 +412,6 @@ public:
                                   std::string& relative_filepath) const;
 
   /**
-   * Get the package name from package.xml.
-   *
-   * For cases where the name differs from the directory.
-   * (Example: panda_description in moveit_resources.)
-   *
-   * @param package_xml_path path to "package.xml"
-   * @param[out] package_name package name will be stored here.
-   * @return true when all went OK. false if parsing fails or tag not found.
-   */
-  bool extractPackageNameFromPackageXml(const std::string& package_xml_path,
-		  std::string& package_name) const;
-
-  /**
    * Resolve path to .setup_assistant file
    * @param path resolved path
    * @return true if the path could be resolved

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -412,6 +412,19 @@ public:
                                   std::string& relative_filepath) const;
 
   /**
+   * Get the package name from package.xml.
+   * 
+   * For cases where the name differs from the directory.
+   * (Example: panda_description in moveit_resources.)
+   *
+   * @param package_xml_path path to "package.xml"
+   * @param[out] package_name package name will be stored here.
+   * @return true when all went OK. false if parsing fails or tag not found.
+   */
+  bool extractPackageNameFromPackageXml(const std::string &package_xml_path,
+		  std::string &package_name) const;
+
+  /**
    * Resolve path to .setup_assistant file
    * @param path resolved path
    * @return true if the path could be resolved

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -314,8 +314,8 @@ public:
   bool outputJointLimitsYAML(const std::string& file_path);
   bool outputFakeControllersYAML(const std::string& file_path);
   bool outputSimpleControllersYAML(const std::string& file_path);
-  bool outputSimpleControllersYAMLBase(const std::string& file_path, const std::string &controller_ns);
-  bool outputGazeboControllersYAML(const std::string &file_path);
+  bool outputSimpleControllersYAMLBase(const std::string& file_path, const std::string& controller_ns);
+  bool outputGazeboControllersYAML(const std::string& file_path);
   bool outputROSControllersYAML(const std::string& file_path);
   bool output3DSensorPluginYAML(const std::string& file_path);
 
@@ -413,7 +413,7 @@ public:
 
   /**
    * Get the package name from package.xml.
-   * 
+   *
    * For cases where the name differs from the directory.
    * (Example: panda_description in moveit_resources.)
    *
@@ -421,8 +421,8 @@ public:
    * @param[out] package_name package name will be stored here.
    * @return true when all went OK. false if parsing fails or tag not found.
    */
-  bool extractPackageNameFromPackageXml(const std::string &package_xml_path,
-		  std::string &package_name) const;
+  bool extractPackageNameFromPackageXml(const std::string& package_xml_path,
+		  std::string& package_name) const;
 
   /**
    * Resolve path to .setup_assistant file

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -314,6 +314,8 @@ public:
   bool outputJointLimitsYAML(const std::string& file_path);
   bool outputFakeControllersYAML(const std::string& file_path);
   bool outputSimpleControllersYAML(const std::string& file_path);
+  bool outputSimpleControllersYAMLBase(const std::string& file_path, const std::string &controller_ns);
+  bool outputGazeboControllersYAML(const std::string &file_path);
   bool outputROSControllersYAML(const std::string& file_path);
   bool output3DSensorPluginYAML(const std::string& file_path);
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1752,9 +1752,9 @@ bool MoveItConfigData::extractPackageNameFromPath(const std::string& path, std::
     if (fs::is_regular_file(sub_path / "package.xml"))
     {
       ROS_DEBUG_STREAM("Found package.xml in " << sub_path.make_preferred().string());
+      package_found = true;
       relative_filepath = relative_path.string();
-      std::string package_xml_path = (sub_path / "package.xml").string();
-      package_found = extractPackageNameFromPackageXml(package_xml_path, package_name);
+      package_name = sub_path.leaf().string();
       break;
     }
     relative_path = sub_path.leaf() / relative_path;
@@ -1769,27 +1769,6 @@ bool MoveItConfigData::extractPackageNameFromPath(const std::string& path, std::
   }
 
   ROS_DEBUG_STREAM("Package name for file \"" << path << "\" is \"" << package_name << "\"");
-  return true;
-}
-
-bool MoveItConfigData::extractPackageNameFromPackageXml(const std::string& package_xml_path,
-		std::string& package_name) const
-{
-  TiXmlDocument package_xml_document;
-  if (! package_xml_document.LoadFile(package_xml_path.c_str(), TIXML_ENCODING_UTF8))
-  {
-    ROS_ERROR_STREAM_NAMED("moveit_config_data", "Failed to parse : '" << package_xml_path << "'");
-    return false;
-  }
-
-  const TiXmlElement *package_elem = package_xml_document.RootElement();
-  const TiXmlElement *name_elem = package_elem->FirstChildElement("name");
-  if (! name_elem)
-  {
-    ROS_ERROR_STREAM_NAMED("moveit_config_data", "'name' element not found : " << package_xml_path);
-    return false;
-  }
-  package_name = name_elem->GetText();
   return true;
 }
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -966,7 +966,7 @@ bool MoveItConfigData::outputGazeboControllersYAML(const std::string& file_path)
   return outputSimpleControllersYAMLBase(file_path, controller_ns);
 }
 
-bool MoveItConfigData::outputSimpleControllersYAMLBase(const std::string& file_path, const std::string &controller_ns)
+bool MoveItConfigData::outputSimpleControllersYAMLBase(const std::string& file_path, const std::string& controller_ns)
 {
   YAML::Emitter emitter;
   emitter << YAML::BeginMap;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1752,9 +1752,9 @@ bool MoveItConfigData::extractPackageNameFromPath(const std::string& path, std::
     if (fs::is_regular_file(sub_path / "package.xml"))
     {
       ROS_DEBUG_STREAM("Found package.xml in " << sub_path.make_preferred().string());
-      package_found = true;
       relative_filepath = relative_path.string();
-      package_name = sub_path.leaf().string();
+      std::string package_xml_path = (sub_path / "package.xml").string();
+      package_found = extractPackageNameFromPackageXml(package_xml_path, package_name);
       break;
     }
     relative_path = sub_path.leaf() / relative_path;
@@ -1770,6 +1770,27 @@ bool MoveItConfigData::extractPackageNameFromPath(const std::string& path, std::
 
   ROS_DEBUG_STREAM("Package name for file \"" << path << "\" is \"" << package_name << "\"");
   return true;
+}
+
+bool MoveItConfigData::extractPackageNameFromPackageXml(const std::string &package_xml_path,
+		std::string &package_name) const
+{
+	TiXmlDocument package_xml_document;
+	if (! package_xml_document.LoadFile(package_xml_path.c_str(), TIXML_ENCODING_UTF8))
+	{
+		ROS_ERROR_STREAM_NAMED("moveit_config_data", "Failed to parse : '" << package_xml_path << "'");
+		return false;
+	}
+
+	const TiXmlElement *package_elem = package_xml_document.RootElement();
+	const TiXmlElement *name_elem = package_elem->FirstChildElement("name");
+	if (! name_elem)
+	{
+		ROS_ERROR_STREAM_NAMED("moveit_config_data", "'name' element not found : " << package_xml_path);
+		return false;
+	}
+	package_name = name_elem->GetText();
+	return true;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -956,14 +956,14 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners() const
 // ******************************************************************************************
 bool MoveItConfigData::outputSimpleControllersYAML(const std::string& file_path)
 {
-	return outputSimpleControllersYAMLBase(file_path, "");
+  return outputSimpleControllersYAMLBase(file_path, "");
 }
 
-bool MoveItConfigData::outputGazeboControllersYAML(const std::string &file_path)
+bool MoveItConfigData::outputGazeboControllersYAML(const std::string& file_path)
 {
-    // The controllers exposed by Gazebo will be inside a namespace
-	std::string controller_ns = srdf_->robot_name_ + "/";
-	return outputSimpleControllersYAMLBase(file_path, controller_ns);
+  // The controllers exposed by Gazebo will be inside a namespace
+  std::string controller_ns = srdf_->robot_name_ + "/";
+  return outputSimpleControllersYAMLBase(file_path, controller_ns);
 }
 
 bool MoveItConfigData::outputSimpleControllersYAMLBase(const std::string& file_path, const std::string &controller_ns)
@@ -1772,25 +1772,25 @@ bool MoveItConfigData::extractPackageNameFromPath(const std::string& path, std::
   return true;
 }
 
-bool MoveItConfigData::extractPackageNameFromPackageXml(const std::string &package_xml_path,
-		std::string &package_name) const
+bool MoveItConfigData::extractPackageNameFromPackageXml(const std::string& package_xml_path,
+		std::string& package_name) const
 {
-	TiXmlDocument package_xml_document;
-	if (! package_xml_document.LoadFile(package_xml_path.c_str(), TIXML_ENCODING_UTF8))
-	{
-		ROS_ERROR_STREAM_NAMED("moveit_config_data", "Failed to parse : '" << package_xml_path << "'");
-		return false;
-	}
+  TiXmlDocument package_xml_document;
+  if (! package_xml_document.LoadFile(package_xml_path.c_str(), TIXML_ENCODING_UTF8))
+  {
+    ROS_ERROR_STREAM_NAMED("moveit_config_data", "Failed to parse : '" << package_xml_path << "'");
+    return false;
+  }
 
-	const TiXmlElement *package_elem = package_xml_document.RootElement();
-	const TiXmlElement *name_elem = package_elem->FirstChildElement("name");
-	if (! name_elem)
-	{
-		ROS_ERROR_STREAM_NAMED("moveit_config_data", "'name' element not found : " << package_xml_path);
-		return false;
-	}
-	package_name = name_elem->GetText();
-	return true;
+  const TiXmlElement *package_elem = package_xml_document.RootElement();
+  const TiXmlElement *name_elem = package_elem->FirstChildElement("name");
+  if (! name_elem)
+  {
+    ROS_ERROR_STREAM_NAMED("moveit_config_data", "'name' element not found : " << package_xml_path);
+    return false;
+  }
+  package_name = name_elem->GetText();
+  return true;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -357,6 +357,15 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   gen_files_.push_back(file);
 
+  // gazebo_controllers.yaml ------------------------------------------------------------------
+  file.file_name_ = "gazebo_moveit_controllers.yaml";
+  file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
+  template_path = config_data_->appendPaths(config_data_->template_package_path_, file.rel_path_);
+  file.description_ = "Creates MoveIt controller manager configuration for Gazebo controllers";
+  file.gen_func_ = std::bind(&MoveItConfigData::outputGazeboControllersYAML, config_data_, std::placeholders::_1);
+  file.write_on_changes = MoveItConfigData::GROUPS;
+  gen_files_.push_back(file);
+
   // ros_controllers.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "ros_controllers.yaml";
   file.rel_path_ = config_data_->appendPaths(config_path, file.file_name_);
@@ -564,7 +573,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = "simple_moveit_controller_manager.launch.xml";
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
-  file.description_ = "Loads the default controller plugin.";
+  file.description_ = "Loads the default MoveItControllerManager plugin.";
   file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);
@@ -572,7 +581,15 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.file_name_ = "ros_control_moveit_controller_manager.launch.xml";
   file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
   template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
-  file.description_ = "Loads the ros_control controller plugin.";
+  file.description_ = "Loads a MoveItControllerManager plugin (needs customization).";
+  file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
+  file.write_on_changes = 0;
+  gen_files_.push_back(file);
+
+  file.file_name_ = "gazebo_moveit_controller_manager.launch.xml";
+  file.rel_path_ = config_data_->appendPaths(launch_path, file.file_name_);
+  template_path = config_data_->appendPaths(template_launch_path, file.file_name_);
+  file.description_ = "Loads a MoveItControllerManager plugin to work with ROS controllers in Gazebo.";
   file.gen_func_ = std::bind(&ConfigurationFilesWidget::copyTemplate, this, template_path, std::placeholders::_1);
   file.write_on_changes = 0;
   gen_files_.push_back(file);

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -39,9 +39,10 @@
       <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
     </node>
 
-    <!-- Given the published joint states, publish tf for the robot links -->
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
   </group>
+
+  <!-- Given the published joint states, publish tf for the robot links -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(dirname)/move_group.launch">

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -12,10 +12,15 @@
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
   </include>
-
+  
+  <!-- read joint_states from gazebo and send them to tf -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <rosparam param="source_list">[ [ROBOT_NAME]/joint_states ]</rosparam>
+  </node>
+  
   <include file="$(dirname)/demo.launch" pass_all_args="true">
     <!-- robot description is loaded by gazebo.launch, to enable Gazebo features -->
     <arg name="load_robot_description" value="false" />
-    <arg name="moveit_controller_manager" value="ros_control" />
+    <arg name="moveit_controller_manager" value="gazebo" />
   </include>
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -12,12 +12,12 @@
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
   </include>
-  
+
   <!-- read joint_states from gazebo and send them to tf -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <rosparam param="source_list">[ [ROBOT_NAME]/joint_states ]</rosparam>
   </node>
-  
+
   <include file="$(dirname)/demo.launch" pass_all_args="true">
     <!-- robot description is loaded by gazebo.launch, to enable Gazebo features -->
     <arg name="load_robot_description" value="false" />

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -19,14 +19,16 @@
   <arg name="unpause" value="$(eval '' if arg('paused') else '-unpause')" />
   <!-- push robot_description to factory and spawn robot in gazebo at the origin, change x,y,z arguments to spawn in a different position -->
   <arg name="world_pose" value="-x 0 -y 0 -z 0" />
-  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot $(arg unpause) $(arg world_pose) $(arg initial_joint_positions)"
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model [ROBOT_NAME] $(arg unpause) $(arg world_pose) $(arg initial_joint_positions)"
     respawn="false" output="screen" />
 
-  <!-- Load joint controller parameters for Gazebo -->
-  <rosparam file="$(find [GENERATED_PACKAGE_NAME])/config/gazebo_controllers.yaml" />
+  <!-- Load joint state controller parameters for the controller manager in Gazebo to read.-->
+  <rosparam ns="[ROBOT_NAME]" file="$(find [GENERATED_PACKAGE_NAME])/config/gazebo_controllers.yaml" />
+  <!-- Load other parameters for other controllers inside Gazebo.-->
+  <rosparam ns="[ROBOT_NAME]" file="$(find [GENERATED_PACKAGE_NAME])/config/ros_controllers.yaml" />
+
   <!-- Spawn Gazebo ROS controllers -->
-  <node name="gazebo_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_state_controller" />
-  <!-- Load ROS controllers -->
-  <include file="$(dirname)/ros_controllers.launch"/>
+  <node ns="[ROBOT_NAME]" name="gazebo_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+   args="joint_state_controller [ROS_CONTROLLERS]" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo_moveit_controller_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo_moveit_controller_manager.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+  <!-- Select the MoveIt controller manager plugin that resides in MoveIt to connect
+       to the ROS controller manager in use. -->
+  <param name="moveit_controller_manager" value="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
+
+  <!-- Tell MoveIt where the ROS controllers are available -->
+  <rosparam file="$(find [GENERATED_PACKAGE_NAME])/config/gazebo_moveit_controllers.yaml" />
+</launch>


### PR DESCRIPTION
### Description

Hi. This is the first time submitting a PR for moveit. Please tell me if I am missing any procedures.

I modified SA so that demo_gazebo.launch will work out of the box for simple robots that do not require special treating at the Gazebo side (e.g. grippers with mimic joints need special treating).

The Gazebo side plugin to talk with ROS, "gazebo_ros_control" will be given a namespace instead of running in the root namespace.  The default for gazebo_ros_control is to use the URDF robot name as the namespace. I  followed this.  This will require some support in the config files, and maybe the current SA tried to avoid such support.  However, trying to make it run in "/" seems to me, make the config files harder to understand.

- 3 template files changed
- 1 template file added
- 1 generated config file added
- 2 source files and 1 header changed.

The changes are:
- The URDF generated in the simulation tab in SA will specify the above mentioned robot name namespace in robotNamespace tag (moveit_config_data.cpp 588). This will make the gazebo_ros_control plugin read ros params under that namespace, and expose actions, services, topics under that namespace too.
- When populating Gazebo with the robot model by the gazebo_ros/spawn_model node, the model name must be specified, but the current source gives a fixed "robot" here. It is changed to be the URDF robot name. (gazebo.launch 22)
- The controller manager inside gazebo_ros_control will look for controller manager parameters under the robot name namespace.  So the rosparam path must be changed accordingly. The namespace will be added by a "ns" parameter to rosparam when loading the controller definitions. Two sets of controllers need to be loaded this way- gazebo_controllers.yaml and ros_contollers.yaml. (gazebo.launch 25-28)
- The controller manager inside gazebo_ros_control must receive a spawn request to load those controllers. The controller_manager/spawner node must have the namespace specifed. (gazebo.launch 30-32)
- The MoveitConrollerManager plugin (not be confused with ContollerManager) that runs within MoveIt needs to know where the ROS controller actions are waiting to be called. The existing simple_moveit_controllers.yaml file has the same purpose but the action namespace must be changed to be prefixed by the gazebo_ros_control's namespace. So I chose to generate a new file gazebo_moveit_controllers.yaml based on the generator function for simple_moveit_controllers.yaml (moveit_config_data.cpp 957- 985)
- The JointState events that comes out of gazebo_ros_control will now be prefixed by the namespace. MoveIt will subscribe to /joint_states, so the events need to be mapped.  I chose to add a joint_state_publisher node for this purpose. (demo_gazebo.launch 16-19)
- For some reason, the current demo_gazebo.launch will not launch a robot_state_publisher. It is launched only when a fake MoveItControllerManager is selected.  I could not guess any motivation behind this design, AFAIK robot_state_publisher is always necessary.  So I took the node tag that launches robot_state_publisher outside of the conditional. (demo.launch 40-44)
- To configure MoveItControllerManager to work with Gazebo, a new file gazebo_moveit_controller_manager.launch.xml is added.  This is specified by an argument to demo.launch. (demo_gazebo.launch 24)

The fix has worked for a simple 6-DOF robot URDF that I have not published.

I tried to make it work with one of the tutorial example URDFs, but they are rather complicated. PANDA has a gripper with mimic joints.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
