### PR TITLE
Used API changes to make tests that uses RNG more con…

### DIFF
--- a/moveit_core/planning_scene/test/test_multi_threaded.cpp
+++ b/moveit_core/planning_scene/test/test_multi_threaded.cpp
@@ -40,7 +40,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <gtest/gtest.h>
 #include <thread>
-
+#include <random_numbers.h>
 #include <moveit/collision_detection/collision_common.h>
 #include <moveit/collision_detection/collision_plugin_cache.h>
 
@@ -118,9 +118,12 @@ TEST_P(CollisionDetectorTests, Threaded)
   for (unsigned int i = 0; i < THREADS; ++i)
   {
     moveit::core::RobotState* state = new moveit::core::RobotState(planning_scene_->getRobotModel());
+    const moveit::core::JointModelGroup* g_mim = model->getJointModelGroup("mim_joints");
     collision_detection::CollisionRequest req;
-    state->setToRandomPositions();
+    random_numbers::RandomNumberGenerator rng(void);
+    state.setToRandomPositions(g_min, rng);
     state->update();
+    
     states.push_back(moveit::core::RobotStatePtr(state));
     collisions.push_back(runCollisionDetection(0, 1, planning_scene_.get(), state));
   }

--- a/moveit_core/robot_state/test/robot_state_benchmark.cpp
+++ b/moveit_core/robot_state/test/robot_state_benchmark.cpp
@@ -39,7 +39,7 @@
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <gtest/gtest.h>
 #include <chrono>
-
+#include <random_numbers.h>
 // Helper class to measure time within a scoped block and output the result
 class ScopedTimer
 {
@@ -96,12 +96,15 @@ public:
 TEST_F(Timing, stateUpdate)
 {
   moveit::core::RobotModelPtr model = moveit::core::loadTestingRobotModel("pr2_description");
+  const moveit::core::JointModelGroup* g_mim = model->getJointModelGroup("mim_joints");
   ASSERT_TRUE(bool(model));
   moveit::core::RobotState state(model);
   ScopedTimer t("RobotState updates: ");
+
   for (unsigned i = 0; i < 1e5; ++i)
   {
-    state.setToRandomPositions();
+    random_numbers::RandomNumberGenerator rng(void);
+    state.setToRandomPositions(g_min, rng);
     state.update();
   }
 }

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <limits>
 #include <ctype.h>
+#include <random_numbers.h>
 
 namespace
 {
@@ -519,7 +520,9 @@ TEST_F(OneRobot, FK)
   state.copyJointGroupPositions(g_mim, gstate);
 
   // setToRandomPositions() uses a different mechanism to update mimic joints
-  state.setToRandomPositions(g_mim);
+  random_numbers::RandomNumberGenerator rng(void);
+  state.setToRandomPositions(g_mim, rng);
+
   double joint_f = state.getVariablePosition("joint_f");
   double mim_f = state.getVariablePosition("mim_f");
   EXPECT_NEAR(mim_f, 1.5 * joint_f + 0.1, 1e-8);


### PR DESCRIPTION
…sistent.

### Description
Addressed the issue created by [#2851 ]. Used the new API that was created to update the tests that used RNG.
Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
