### PR TITLE
Fix use of std::bind

### DIFF
--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -91,7 +91,7 @@ void mesh_filter::DepthSelfFiltering::onInit()
   model_label_ptr_ = std::make_shared<cv_bridge::CvImage>();
 
   mesh_filter_ = std::make_shared<MeshFilter<StereoCameraModel>>(
-      bind(&TransformProvider::getTransform, &transform_provider_, std::placeholders::_1, std::placeholders::_2),
+      std::bind(&TransformProvider::getTransform, &transform_provider_, std::placeholders::_1, std::placeholders::_2),
       mesh_filter::StereoCameraModel::REGISTERED_PSDK_PARAMS);
   mesh_filter_->parameters().setDepthRange(near_clipping_plane_distance_, far_clipping_plane_distance_);
   mesh_filter_->setShadowThreshold(shadow_threshold_);


### PR DESCRIPTION
### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

Fix compilation on osx:
```
FAILED: mesh_filter/CMakeFiles/moveit_depth_self_filter.dir/src/depth_self_filter_nodelet.cpp.o 
$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++ -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"moveit_ros_perception\" -Dmoveit_depth_self_filter_EXPORTS -I$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/lazy_free_space_updater/include -I$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/point_containment_filter/include -I$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/pointcloud_octomap_updater/include -I$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/semantic_world/include -I$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/mesh_filter/include -I$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/depth_image_octomap_updater/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/GLUT.framework/Headers -isystem $PREFIX/include -isystem $PREFIX/include/opencv4 -isystem $PREFIX/include/eigen3 -isystem $PREFIX/lib/urdfdom/cmake/../../../include -isystem $PREFIX/lib/urdfdom_headers/cmake/../../../include -isystem $PREFIX/include/bullet -isystem $PREFIX/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -isystem /usr/local/include -fdiagnostics-color=always -DBOOST_ERROR_CODE_HEADER_ONLY -O3 -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.15 -fPIC -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual -MD -MT mesh_filter/CMakeFiles/moveit_depth_self_filter.dir/src/depth_self_filter_nodelet.cpp.o -MF mesh_filter/CMakeFiles/moveit_depth_self_filter.dir/src/depth_self_filter_nodelet.cpp.o.d -o mesh_filter/CMakeFiles/moveit_depth_self_filter.dir/src/depth_self_filter_nodelet.cpp.o -c $SRC_DIR/ros-noetic-moveit-ros-perception/src/work/mesh_filter/src/depth_self_filter_nodelet.cpp
$SRC_DIR/ros-noetic-moveit-ros-perception/src/work/mesh_filter/src/depth_self_filter_nodelet.cpp:94:7: error: use of undeclared identifier 'bind'; did you mean 'boost::bind'?
      bind(&TransformProvider::getTransform, &transform_provider_, std::placeholders::_1, std::placeholders::_2),
      ^~~~
      boost::bind
```