### PR TITLE
Fix missing include

### DIFF
--- a/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
+++ b/moveit_ros/move_group/include/moveit/move_group/move_group_context.h
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <string>
 #include <moveit/macros/class_forward.h>
 
 namespace moveit_cpp


### PR DESCRIPTION
Compile fails on Windows:
C:\PROGRA~2\MICROS~1\2019\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\HostX64\x64\cl.exe  /nologo /TP -DBOOST_ALL_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_DATE_TIME_DYN_LINK -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DBOOST_THREAD_DYN_LINK -DNOMINMAX -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"moveit_ros_move_group\" -DWIN32_LEAN_AND_MEAN -D_USE_MATH_DEFINES -Dmoveit_move_group_capabilities_base_EXPORTS -I%SRC_DIR%\ros-noetic-moveit-ros-move-group\src\work\include -I%PREFIX%\Library\include -I%PREFIX%\Library\include\eigen3 -I%PREFIX%\Library\cmake\..\include -I%PREFIX%\Library\CMake\..\include -I%PREFIX%\Library\share\xmlrpcpp\cmake\..\..\..\include\xmlrpcpp /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MD /O2 /Ob2 /DNDEBUG   /D _VARIADIC_MAX=10 /Zc:__cplusplus /showIncludes /FoCMakeFiles\moveit_move_group_capabilities_base.dir\src\move_group_context.cpp.obj /FdCMakeFiles\moveit_move_group_capabilities_base.dir\ /FS -c %SRC_DIR%\ros-noetic-moveit-ros-move-group\src\work\src\move_group_context.cpp
%SRC_DIR%\ros-noetic-moveit-ros-move-group\src\work\include\moveit/move_group/move_group_context.h(73): error C2039: 'string': is not a member of 'std'

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
