### PR TITLE
Add option to use simulation time for rviz trajectory display

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -85,7 +85,7 @@ public:
 
   ~TrajectoryVisualization() override;
 
-  virtual void update(float wall_dt, float ros_dt);
+  virtual void update(float wall_dt, float sim_dt);
   virtual void reset();
 
   void onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context, const ros::NodeHandle& update_nh);
@@ -110,7 +110,7 @@ private Q_SLOTS:
   void changedDisplayPathCollisionEnabled();
   void changedRobotPathAlpha();
   void changedLoopDisplay();
-  void changedUseRosTime();
+  void changedUseSimTime();
   void changedShowTrail();
   void changedTrailStepSize();
   void changedTrajectoryTopic();
@@ -169,7 +169,7 @@ protected:
   rviz::RosTopicProperty* trajectory_topic_property_;
   rviz::FloatProperty* robot_path_alpha_property_;
   rviz::BoolProperty* loop_display_property_;
-  rviz::BoolProperty* use_ros_time_property_;
+  rviz::BoolProperty* use_sim_time_property_;
   rviz::BoolProperty* trail_display_property_;
   rviz::BoolProperty* interrupt_display_property_;
   rviz::ColorProperty* robot_color_property_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -110,6 +110,7 @@ private Q_SLOTS:
   void changedDisplayPathCollisionEnabled();
   void changedRobotPathAlpha();
   void changedLoopDisplay();
+  void changedUseRosTime();
   void changedShowTrail();
   void changedTrailStepSize();
   void changedTrajectoryTopic();
@@ -168,6 +169,7 @@ protected:
   rviz::RosTopicProperty* trajectory_topic_property_;
   rviz::FloatProperty* robot_path_alpha_property_;
   rviz::BoolProperty* loop_display_property_;
+  rviz::BoolProperty* use_ros_time_property_;
   rviz::BoolProperty* trail_display_property_;
   rviz::BoolProperty* interrupt_display_property_;
   rviz::ColorProperty* robot_color_property_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -110,7 +110,6 @@ private Q_SLOTS:
   void changedDisplayPathCollisionEnabled();
   void changedRobotPathAlpha();
   void changedLoopDisplay();
-  void changedUseSimTime();
   void changedShowTrail();
   void changedTrailStepSize();
   void changedTrajectoryTopic();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -103,7 +103,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   state_display_time_property_->addOptionStd("0.5s");
 
   use_sim_time_property_ = new rviz::BoolProperty("Use Sim Time", false,
-                                                  "Indicates wether simulation time or wall-time is "
+                                                  "Indicates whether simulation time or wall-time is "
                                                   "used for state display timing.",
                                                   widget, nullptr, this);
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -102,10 +102,10 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   state_display_time_property_->addOptionStd("0.1s");
   state_display_time_property_->addOptionStd("0.5s");
 
-  use_ros_time_property_ = new rviz::BoolProperty("Use Ros Time", false,
-                                                  "Indicates wether ros-time or wall-time is "
+  use_sim_time_property_ = new rviz::BoolProperty("Use Sim Time", false,
+                                                  "Indicates wether simulation time or wall-time is "
                                                   "used for state display timing.",
-                                                  widget, SLOT(changedUseRosTime()), this);
+                                                  widget, SLOT(changedUseSimTime()), this);
 
   loop_display_property_ = new rviz::BoolProperty("Loop Animation", false,
                                                   "Indicates whether the last received path "
@@ -224,7 +224,7 @@ void TrajectoryVisualization::changedLoopDisplay()
     trajectory_slider_panel_->pauseButton(false);
 }
 
-void TrajectoryVisualization::changedUseRosTime()
+void TrajectoryVisualization::changedUseSimTime()
 {
 }
 
@@ -399,7 +399,7 @@ void TrajectoryVisualization::dropTrajectory()
   drop_displaying_trajectory_ = true;
 }
 
-void TrajectoryVisualization::update(float wall_dt, float ros_dt)
+void TrajectoryVisualization::update(float wall_dt, float sim_dt)
 {
   if (drop_displaying_trajectory_)
   {
@@ -449,9 +449,9 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
   {
     int previous_state = current_state_;
     int waypoint_count = displaying_trajectory_message_->getWayPointCount();
-    if (use_ros_time_property_->getBool())
+    if (use_sim_time_property_->getBool())
     {
-      current_state_time_ += ros_dt;
+      current_state_time_ += sim_dt;
     }
     else
     {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -102,6 +102,11 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   state_display_time_property_->addOptionStd("0.1s");
   state_display_time_property_->addOptionStd("0.5s");
 
+  use_ros_time_property_ = new rviz::BoolProperty("Use Ros Time", false,
+                                                  "Indicates wether ros-time or wall-time is "
+                                                  "used for state display timing.",
+                                                  widget, SLOT(changedUseRosTime()), this);
+
   loop_display_property_ = new rviz::BoolProperty("Loop Animation", false,
                                                   "Indicates whether the last received path "
                                                   "is to be animated in a loop",
@@ -217,6 +222,10 @@ void TrajectoryVisualization::changedLoopDisplay()
   display_path_robot_->setVisible(display_->isEnabled() && displaying_trajectory_message_ && animating_path_);
   if (loop_display_property_->getBool() && trajectory_slider_panel_)
     trajectory_slider_panel_->pauseButton(false);
+}
+
+void TrajectoryVisualization::changedUseRosTime()
+{
 }
 
 void TrajectoryVisualization::changedShowTrail()
@@ -390,7 +399,7 @@ void TrajectoryVisualization::dropTrajectory()
   drop_displaying_trajectory_ = true;
 }
 
-void TrajectoryVisualization::update(float wall_dt, float /*ros_dt*/)
+void TrajectoryVisualization::update(float wall_dt, float ros_dt)
 {
   if (drop_displaying_trajectory_)
   {
@@ -440,7 +449,14 @@ void TrajectoryVisualization::update(float wall_dt, float /*ros_dt*/)
   {
     int previous_state = current_state_;
     int waypoint_count = displaying_trajectory_message_->getWayPointCount();
-    current_state_time_ += wall_dt;
+    if (use_ros_time_property_->getBool())
+    {
+      current_state_time_ += ros_dt;
+    }
+    else
+    {
+      current_state_time_ += wall_dt;
+    }
     float tm = getStateDisplayTime();
 
     if (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible() && trajectory_slider_panel_->isPaused())

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -105,7 +105,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property* widget, rviz::D
   use_sim_time_property_ = new rviz::BoolProperty("Use Sim Time", false,
                                                   "Indicates wether simulation time or wall-time is "
                                                   "used for state display timing.",
-                                                  widget, SLOT(changedUseSimTime()), this);
+                                                  widget, nullptr, this);
 
   loop_display_property_ = new rviz::BoolProperty("Loop Animation", false,
                                                   "Indicates whether the last received path "
@@ -222,10 +222,6 @@ void TrajectoryVisualization::changedLoopDisplay()
   display_path_robot_->setVisible(display_->isEnabled() && displaying_trajectory_message_ && animating_path_);
   if (loop_display_property_->getBool() && trajectory_slider_panel_)
     trajectory_slider_panel_->pauseButton(false);
-}
-
-void TrajectoryVisualization::changedUseSimTime()
-{
 }
 
 void TrajectoryVisualization::changedShowTrail()


### PR DESCRIPTION
### Description

The Rviz MoveIt Trajectory Display uses wall time by default for state display timing. This leads to unexpected results when working with simulation time (e.g. gazebo, bag files) with less than real time. The simulated robot speed does not match the trajectory speed visualization since they follow different clocks.

This PR adds  an additional option to use simulation time instead of wall time named "Use Sim Time" (see screenshot).

![image](https://user-images.githubusercontent.com/7110154/153177550-46a7625b-a176-475f-8b57-dc671e1e9424.png)

![image](https://user-images.githubusercontent.com/7110154/153177711-3fd7da5f-723f-4f10-bef0-f844fe279b5f.png)



### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
