### PR TITLE
Added special case for sphere bodies in sphere decomposition

### DIFF
--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -47,18 +47,25 @@ std::vector<collision_detection::CollisionSphere>
 collision_detection::determineCollisionSpheres(const bodies::Body* body, Eigen::Isometry3d& relative_transform)
 {
   std::vector<collision_detection::CollisionSphere> css;
-
-  bodies::BoundingCylinder cyl;
-  body->computeBoundingCylinder(cyl);
-  unsigned int num_points = ceil(cyl.length / (cyl.radius / 2.0));
-  double spacing = cyl.length / ((num_points * 1.0) - 1.0);
-  relative_transform = cyl.pose;
-
-  for (unsigned int i = 1; i < num_points - 1; i++)
+  if (body->getType() == shapes::ShapeType::SPHERE)
   {
-    collision_detection::CollisionSphere cs(
-        relative_transform * Eigen::Vector3d(0, 0, (-cyl.length / 2.0) + i * spacing), cyl.radius);
+    collision_detection::CollisionSphere cs(body->getPose().translation(), body->getDimensions()[0]);
     css.push_back(cs);
+  }
+  else
+  {
+    bodies::BoundingCylinder cyl;
+    body->computeBoundingCylinder(cyl);
+    unsigned int num_points = ceil(cyl.length / (cyl.radius / 2.0));
+    double spacing = cyl.length / ((num_points * 1.0) - 1.0);
+    relative_transform = cyl.pose;
+
+    for (unsigned int i = 1; i < num_points - 1; i++)
+    {
+      collision_detection::CollisionSphere cs(
+          relative_transform * Eigen::Vector3d(0, 0, (-cyl.length / 2.0) + i * spacing), cyl.radius);
+      css.push_back(cs);
+    }
   }
 
   return css;


### PR DESCRIPTION
### Description

For optimization-based trajectory planning, robot collision bodies are approximated with spheres. This is generally done by computing the bounding cylinder of every body and inserting spheres along the cylinder. This is done even in the case of a sphere collision body, even though the sphere decomposition of a sphere is trivial.

I fix this problem by adding a special case for sphere bodies in the sphere decomposition function.

Before:
![moveit_pr_sphere_decomposition_before](https://user-images.githubusercontent.com/7110154/153215075-264d5040-d562-4281-b93b-7c35ce00458f.png)

After:
![moveit_pr_sphere_decomposition_after](https://user-images.githubusercontent.com/7110154/153215114-836a32e0-576b-4673-82b9-c5e46160c745.png)


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
