### PR TITLE
do *not* automatically load robot description

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -37,7 +37,7 @@
                 " />
   -->
 
-  <arg name="load_robot_description" default="true" />
+  <arg name="load_robot_description" default="false" />
   <!-- load URDF, SRDF and joint_limits configuration -->
   <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />


### PR DESCRIPTION
... from move_group.launch .

This was a clear bug introduced in 261a0c4c9041d6fd2df6e7cd7d1160321c047c8b .
MoveIt should not overwrite a previously uploaded robot description.
It should only provide it optionally in demo mode.

I just found this issue mentioned in https://github.com/ros-industrial/universal_robot/pull/538#issuecomment-930073835 ,
but nobody reported or addressed it back here since then. I guess @gavanderhoorn had too many other things to do or didn't take it to be an upstream issue. :)