### PR TITLE
fix move_group_commander.go(tuple(...))

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -603,7 +603,7 @@ class MoveGroupCommander(object):
         elif joints is not None:
             try:
                 self.set_joint_value_target(self.get_remembered_joint_values()[joints])
-            except TypeError:
+            except (KeyError, TypeError):
                 self.set_joint_value_target(joints)
         if wait:
             return self._g.move()

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -43,12 +43,21 @@ import rostest
 import os
 
 from moveit_msgs.msg import RobotState
+from sensor_msgs.msg import JointState
 
 from moveit_commander import RobotCommander, PlanningSceneInterface
 
 
 class PythonMoveitCommanderTest(unittest.TestCase):
     PLANNING_GROUP = "manipulator"
+    JOINT_NAMES = [
+        "joint_1",
+        "joint_2",
+        "joint_3",
+        "joint_4",
+        "joint_5",
+        "joint_6",
+    ]
 
     @classmethod
     def setUpClass(self):
@@ -67,14 +76,7 @@ class PythonMoveitCommanderTest(unittest.TestCase):
     def test_enforce_bounds(self):
         in_msg = RobotState()
         in_msg.joint_state.header.frame_id = "base_link"
-        in_msg.joint_state.name = [
-            "joint_1",
-            "joint_2",
-            "joint_3",
-            "joint_4",
-            "joint_5",
-            "joint_6",
-        ]
+        in_msg.joint_state.name = self.JOINT_NAMES
         in_msg.joint_state.position = [0] * 6
         in_msg.joint_state.position[0] = 1000
 
@@ -87,14 +89,7 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         expected_state = RobotState()
         expected_state.joint_state.header.frame_id = "base_link"
         expected_state.multi_dof_joint_state.header.frame_id = "base_link"
-        expected_state.joint_state.name = [
-            "joint_1",
-            "joint_2",
-            "joint_3",
-            "joint_4",
-            "joint_5",
-            "joint_6",
-        ]
+        expected_state.joint_state.name = self.JOINT_NAMES
         expected_state.joint_state.position = [0] * 6
         self.assertEqual(self.group.get_current_state(), expected_state)
 
@@ -140,6 +135,25 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         success3, plan3, time3, err3 = self.plan(current)
         self.assertTrue(success3)
         self.assertTrue(self.group.execute(plan3))
+
+    def test_gogogo(self):
+        current_joints = np.asarray(self.group.get_current_joint_values())
+
+        self.group.set_joint_value_target(current_joints)
+        self.assertTrue(self.group.go(True))
+
+        self.assertTrue(self.group.go(current_joints))
+        self.assertTrue(self.group.go(list(current_joints)))
+        self.assertTrue(self.group.go(tuple(current_joints)))
+        self.assertTrue(
+            self.group.go(JointState(name=self.JOINT_NAMES, position=current_joints))
+        )
+
+        self.group.remember_joint_values("current")
+        self.assertTrue(self.group.go("current"))
+
+        current_pose = self.group.get_current_pose()
+        self.assertTrue(self.group.go(current_pose))
 
     def test_planning_scene_interface(self):
         planning_scene = PlanningSceneInterface()


### PR DESCRIPTION
Passing in a tuple of doubles triggers KeyError instead of TypeError.

This adds the appropriate test for the error and a integrates the fix from #3064 .

Fixes #3061 .