### PR TITLE
Fix collisions_updater set comparison

### DIFF
--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -120,7 +120,12 @@ struct CollisionPairLess
 {
   bool operator()(const srdf::Model::CollisionPair& left, const srdf::Model::CollisionPair& right) const
   {
-    return left.link1_ < right.link1_ && left.link2_ < right.link2_;
+    // bool result = left.link1_ < right.link1_ && left.link2_ < right.link2_;
+    auto left_pair = std::make_pair(left.link1_, left.link2_);
+    auto right_pair = std::make_pair(right.link1_, right.link2_);
+    bool result = left_pair < right_pair;
+    // ROS_INFO_STREAM("Comparing (" << left.link1_ << ", " << right.link1_ << ") to (" <<  left.link2_ << ", " << right.link2_ << "): result = " << result);
+    return result;
   }
 };
 

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -121,7 +121,7 @@ struct CollisionPairLess
   bool operator()(const srdf::Model::CollisionPair& left, const srdf::Model::CollisionPair& right) const
   {
     // use std::pair's operator<: (left.link1_, left.link2_) < (right.link1_, right.link2_)
-    return left.link1_ < right.link1_ || (!(left.link1_ < right.link1_) && left.link2_ < right.link2_);
+    return left.link1_ < right.link1_ || (!(right.link1_ < left.link1_) && left.link2_ < right.link2_);
   }
 };
 

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -120,7 +120,8 @@ struct CollisionPairLess
 {
   bool operator()(const srdf::Model::CollisionPair& left, const srdf::Model::CollisionPair& right) const
   {
-    return std::make_pair(left.link1_, left.link2_) < std::make_pair(right.link1_, right.link2_);
+    // use std::pair's operator<: (left.link1_, left.link2_) < (right.link1_, right.link2_)
+    return left.link1_ < right.link1_ || (!(left.link1_ < right.link1_) && left.link2_ < right.link2_);
   }
 };
 

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -120,12 +120,7 @@ struct CollisionPairLess
 {
   bool operator()(const srdf::Model::CollisionPair& left, const srdf::Model::CollisionPair& right) const
   {
-    // bool result = left.link1_ < right.link1_ && left.link2_ < right.link2_;
-    auto left_pair = std::make_pair(left.link1_, left.link2_);
-    auto right_pair = std::make_pair(right.link1_, right.link2_);
-    bool result = left_pair < right_pair;
-    // ROS_INFO_STREAM("Comparing (" << left.link1_ << ", " << right.link1_ << ") to (" <<  left.link2_ << ", " << right.link2_ << "): result = " << result);
-    return result;
+    return std::make_pair(left.link1_, left.link2_) < std::make_pair(right.link1_, right.link2_);
   }
 };
 


### PR DESCRIPTION
### Description

After debugging the issue in https://github.com/ros-planning/moveit/issues/3073 I found that the `CollisionPairLess` set comparison operator for `srdf::Model::CollisionPair`s somehow only checked uniqueness of `link1_` instead of both.

So, instead of making a set `{(a, b), (a, c), (a, d), (b, c), (b, d)}` it only allowed `{(a, b), (b, c)}`, which results in an incomplete allowed collision matrix. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] ~~Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)~~
- [x] ~~Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes~~
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] ~~Include a screenshot if changing a GUI~~
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
