### PR TITLE
use GLEW linking target

### DIFF
--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${MOVEIT_LIB_NAME}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} GLUT::GLUT ${GLEW_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} GLUT::GLUT GLEW::GLEW)
 
 add_library(moveit_depth_self_filter
   src/depth_self_filter_nodelet.cpp


### PR DESCRIPTION
long story short: it worked for Ubuntu's GLEW built before,
but not necessarily on other installs of GLEW.

It depends on the build system you use whether GLEW_LIBRARIES
is defined in the config or not, but the target should be there either way.