### PR TITLE
Filter more invalid values in moveit_benchmark_statistics.py

### DIFF
--- a/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
+++ b/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
@@ -112,6 +112,9 @@ def readRequiredMultilineValue(filevar):
 def readBenchmarkLog(dbname, filenames):
     """Parse benchmark log files and store the parsed data in a sqlite3 database."""
 
+    def isInvalidValue(value):
+        return len(value) == 0 or value in ["nan", "-nan", "inf", "-inf"]
+
     conn = sqlite3.connect(dbname)
     c = conn.cursor()
     c.execute("PRAGMA FOREIGN_KEYS = ON")
@@ -313,7 +316,7 @@ def readBenchmarkLog(dbname, filenames):
             runIds = []
             for j in range(numRuns):
                 runValues = [
-                    None if len(x) == 0 or x == "nan" or x == "inf" else x
+                    None if isInvalidValue(x) else x
                     for x in logfile.readline().split("; ")[:-1]
                 ]
                 values = tuple([experimentId, plannerId] + runValues)
@@ -362,7 +365,7 @@ def readBenchmarkLog(dbname, filenames):
                         values = tuple(
                             [runIds[j]]
                             + [
-                                None if len(x) == 0 or x == "nan" or x == "inf" else x
+                                None if isInvalidValue(x) else x
                                 for x in dataSample.split(",")[:-1]
                             ]
                         )


### PR DESCRIPTION
Count "-nan" and "-inf" as null value in the database.

### Description

In some configuration, the benchmarks can create "-nan" values in the log file. Those values where stored as string in the database, and caused issues when trying to plot them with `moveit_benchmark_statistics.py`.

This PR adds `-nan` and `-inf`, in addition with the already existing filter on `nan` and `inf`.

[Here is a .log file for testings](https://github.com/ros-planning/moveit/files/8206650/base_through_corridor_laloge-ThinkPad-P53_2022-03-08T09.35.44.083082.log.gz)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
