### PR TITLE
feat(simple_controller_manager): add `max_effort` parameter to GripperCommand action

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -52,10 +52,11 @@ class GripperControllerHandle : public ActionBasedControllerHandle<control_msgs:
 {
 public:
   /* Topics will map to name/ns/goal, name/ns/result, etc */
-  GripperControllerHandle(const std::string& name, const std::string& ns)
+  GripperControllerHandle(const std::string& name, const std::string& ns, const double max_effort = 0.0)
     : ActionBasedControllerHandle<control_msgs::GripperCommandAction>(name, ns)
     , allow_failure_(false)
     , parallel_jaw_gripper_(false)
+    , max_effort_(max_effort)
   {
   }
 
@@ -111,7 +112,7 @@ public:
     // goal to be sent
     control_msgs::GripperCommandGoal goal;
     goal.command.position = 0.0;
-    goal.command.max_effort = 0.0;
+
 
     // send last point
     int tpoint = trajectory.joint_trajectory.points.size() - 1;
@@ -133,7 +134,13 @@ public:
       goal.command.position += trajectory.joint_trajectory.points[tpoint].positions[idx];
 
       if (trajectory.joint_trajectory.points[tpoint].effort.size() > idx)
+      {
         goal.command.max_effort = trajectory.joint_trajectory.points[tpoint].effort[idx];
+      }
+      else
+      {
+        goal.command.max_effort = max_effort_;
+      }
     }
 
     controller_action_client_->sendGoal(goal,
@@ -203,6 +210,12 @@ private:
    * and the command will be the sum of the two joints.
    */
   bool parallel_jaw_gripper_;
+
+  /*
+   * The ``max_effort`` used in the GripperCommand message when no ``max_effort`` was
+   * specified in the requested trajectory. Defaults to ``0.0``.
+  */
+  double max_effort_;
 
   /*
    * A GripperCommand message has only a single float64 for the

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -94,7 +94,10 @@ public:
         ActionBasedControllerHandleBasePtr new_handle;
         if (type == "GripperCommand")
         {
-          new_handle.reset(new GripperControllerHandle(name, action_ns));
+          const double max_effort =
+              controller_list[i].hasMember("max_effort") ? double(controller_list[i]["max_effort"]) : 0.0;
+
+          new_handle.reset(new GripperControllerHandle(name, action_ns, max_effort));
           if (static_cast<GripperControllerHandle*>(new_handle.get())->isConnected())
           {
             if (controller_list[i].hasMember("parallel"))


### PR DESCRIPTION
## Description

This ports @rickstaa's [PR](https://github.com/ros-planning/moveit/pull/2984) back to `melodic-devel` as well.

This pull request adds the `max_effort` parameter to the GripperCommand declaration in the controller_list (see issue [#2956](https://github.com/ros-planning/moveit/issues/2956)). This value is only used when the effort is set in the requested gripper trajectory. 

## Testing

### Replicating the Issue

* Clone the [EZGripper](https://github.com/leander-dsouza/EZGripper) repository into your catkin workspace:
 
	  git clone --single-branch --branch=melodic-devel https://github.com/leander-dsouza/EZGripper

* Install all the required dependencies:

	  rosdep install --from-paths src --ignore-src -r -y

* Finally build the package and source your workspace:

	  catkin_make && source devel/setup.bash

* Run the MoveIt! simulation:

	  roslaunch ezgripper_dual_gen2_moveit_config demo_gazebo.launch 

* Use RViz to actuate the gripper into the "close" configuration (Saved Poses) and inspect the topic:

	  rostopic echo /ezgripper_dual_gen2/ezgripper_controller/gripper_cmd/goal

* Here you can see that the `max_effort` attribute is set to `0.0` despite of it being set to `1.0` in the [simple_moveit_controllers.yaml](https://github.com/leander-dsouza/EZGripper/blob/melodic-devel/ezgripper_dual_gen2_moveit_config/config/simple_moveit_controllers.yaml#L5) file.

### Solution

* Clone the pull request fork and build it to verify that the `max_effort` attribute is set to `1.0`:

	  git clone --single-branch --branch=melodic-devel https://github.com/leander-dsouza/moveit.git


### Checklist
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)

	* I think I can update the [Low Level Controllers documentation](https://docs.ros.org/en/melodic/api/moveit_tutorials/html/doc/controller_configuration/controller_configuration_tutorial.html?highlight=grippercommand#yaml-configuration) to include the `max_effort` attribute. 
