### PR TITLE
protect RobotState in RobotStateDisplay with mutex

### DIFF
--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -62,6 +62,7 @@ class LockedRobotState
 public:
   LockedRobotState(const moveit::core::RobotState& state);
   LockedRobotState(const moveit::core::RobotModelPtr& model);
+  LockedRobotState();
 
   virtual ~LockedRobotState();
 

--- a/moveit_ros/robot_interaction/src/locked_robot_state.cpp
+++ b/moveit_ros/robot_interaction/src/locked_robot_state.cpp
@@ -51,6 +51,10 @@ robot_interaction::LockedRobotState::LockedRobotState(const moveit::core::RobotM
   state_->update();
 }
 
+robot_interaction::LockedRobotState::LockedRobotState()
+{
+}
+
 robot_interaction::LockedRobotState::~LockedRobotState() = default;
 
 moveit::core::RobotStateConstPtr robot_interaction::LockedRobotState::getState() const
@@ -66,7 +70,7 @@ void robot_interaction::LockedRobotState::setState(const moveit::core::RobotStat
 
     // If someone else has a reference to the state, then make a new copy.
     // The old state is orphaned (does not change, but is now out of date).
-    if (state_.unique())
+    if (state_ && state_.unique())
       *state_ = state;
     else
       state_ = std::make_shared<moveit::core::RobotState>(state);
@@ -80,6 +84,9 @@ void robot_interaction::LockedRobotState::modifyState(const ModifyStateFunction&
 {
   {
     boost::mutex::scoped_lock lock(state_lock_);
+
+    if (!state_)
+      return;
 
     // If someone else has a reference to the state, then make a copy.
     // The old state is orphaned (does not change, but is now out of date).

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -57,6 +57,11 @@ class RosTopicProperty;
 class ColorProperty;
 }  // namespace rviz
 
+namespace robot_interaction
+{
+MOVEIT_CLASS_FORWARD(LockedRobotState);
+}
+
 namespace moveit_rviz_plugin
 {
 class RobotStateVisualization;
@@ -129,8 +134,7 @@ protected:
   RobotStateVisualizationPtr robot_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
   moveit::core::RobotModelConstPtr robot_model_;
-  moveit::core::RobotStatePtr robot_state_;
-  std::mutex robot_state_mutex_;
+  robot_interaction::LockedRobotStatePtr robot_state_;
   std::map<std::string, std_msgs::ColorRGBA> highlights_;
   bool update_state_;
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -43,6 +43,8 @@
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit_msgs/DisplayRobotState.h>
 #include <ros/ros.h>
+
+#include <mutex>
 #endif
 
 namespace rviz
@@ -128,6 +130,7 @@ protected:
   rdf_loader::RDFLoaderPtr rdf_loader_;
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr robot_state_;
+  std::mutex robot_state_mutex_;
   std::map<std::string, std_msgs::ColorRGBA> highlights_;
   bool update_state_;
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -43,8 +43,6 @@
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit_msgs/DisplayRobotState.h>
 #include <ros/ros.h>
-
-#include <mutex>
 #endif
 
 namespace rviz

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -294,8 +294,7 @@ void RobotStateDisplay::changedRobotStateTopic()
   robot_state_subscriber_.shutdown();
 
   // reset model to default state, we don't want to show previous messages
-  if (static_cast<bool>(robot_state_->getState()))
-    robot_state_->modifyState([](robot_state::RobotState* state) { state->setToDefaultValues(); });
+  robot_state_->modifyState([](robot_state::RobotState* state) { state->setToDefaultValues(); });
   update_state_ = true;
   robot_->setVisible(false);
   setStatus(rviz::StatusProperty::Warn, "RobotState", "No msg received");
@@ -323,8 +322,7 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::DisplayRobotSta
   }
   catch (const moveit::Exception& e)
   {
-    if (static_cast<bool>(robot_state_->getState()))
-      robot_state_->modifyState([](robot_state::RobotState* state) { state->setToDefaultValues(); });
+    robot_state_->modifyState([](robot_state::RobotState* state) { state->setToDefaultValues(); });
     setRobotHighlights(moveit_msgs::DisplayRobotState::_highlight_links_type());
     setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
     robot_->setVisible(false);


### PR DESCRIPTION
### Description

Currently the `RobotStateDisplay` is not thread-safe and a new incoming message updating the `robot_state_` while it's updated for rendering can cause a crash
