### PR TITLE
MSA: extended ACM editing

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -37,11 +37,10 @@
 #pragma once
 
 #include <moveit/macros/class_forward.h>
-#include <moveit/planning_scene/planning_scene.h>                     // for getting kinematic model
-#include <moveit/setup_assistant/tools/compute_default_collisions.h>  // for LinkPairMap
-#include <yaml-cpp/yaml.h>                                            // outputing yaml config files
-#include <urdf/model.h>                                               // to share throughout app
-#include <srdfdom/srdf_writer.h>                                      // for writing srdf data
+#include <moveit/planning_scene/planning_scene.h>  // for getting kinematic model
+#include <yaml-cpp/yaml.h>                         // outputing yaml config files
+#include <urdf/model.h>                            // to share throughout app
+#include <srdfdom/srdf_writer.h>                   // for writing srdf data
 
 #include <utility>
 
@@ -308,7 +307,7 @@ public:
   srdf::Model::Group* findGroupByName(const std::string& name);
 
   /// Load the allowed collision matrix from the SRDF's list of link pairs
-  void loadAllowedCollisionMatrix();
+  void loadAllowedCollisionMatrix(const srdf::SRDFWriter& srdf);
 
   // ******************************************************************************************
   // Public Functions for outputting configuration and setting files

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -35,6 +35,8 @@
 /* Author: Mathias Lüdtke */
 
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#include <moveit/setup_assistant/tools/compute_default_collisions.h>
+
 #include <moveit/rdf_loader/rdf_loader.h>
 
 #include <boost/program_options.hpp>

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -127,12 +127,6 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
   return QVariant();
 }
 
-DisabledReason CollisionLinearModel::reason(int row) const
-{
-  QModelIndex src_index = this->mapToSource(index(row, 0));
-  return qobject_cast<CollisionMatrixModel*>(sourceModel())->reason(src_index);
-}
-
 bool CollisionLinearModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
   QModelIndex src_index = this->mapToSource(index);
@@ -239,8 +233,7 @@ void SortFilterProxyModel::setShowAll(bool show_all)
 bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
 {
   CollisionLinearModel* m = qobject_cast<CollisionLinearModel*>(sourceModel());
-  if (!(show_all_ || m->reason(source_row) <= moveit_setup_assistant::ALWAYS ||
-        m->data(m->index(source_row, 2), Qt::CheckStateRole) == Qt::Checked))
+  if (!(show_all_ || m->data(m->index(source_row, 2), Qt::CheckStateRole) == Qt::Checked))
     return false;  // not accepted due to check state
 
   const QRegExp regexp = this->filterRegExp();

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -127,14 +127,15 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
 
 bool CollisionLinearModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
-  QModelIndex src_index = this->mapToSource(index);
-
   if (role == Qt::CheckStateRole)
   {
-    sourceModel()->setData(src_index, value, role);
-    int r = index.row();
-    Q_EMIT dataChanged(this->index(r, 2), this->index(r, 3));  // reason changed too
-    return true;
+    QModelIndex src_index = this->mapToSource(index);
+    if (sourceModel()->setData(src_index, value, role))
+    {
+      int r = index.row();
+      Q_EMIT dataChanged(this->index(r, 2), this->index(r, 3));  // reason changed too
+      return true;
+    }
   }
   return false;  // reject all other changes
 }

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -41,8 +41,6 @@
 #include <QPainter>
 #include <cmath>
 
-using namespace moveit_setup_assistant;
-
 CollisionLinearModel::CollisionLinearModel(CollisionMatrixModel* src, QObject* parent) : QAbstractProxyModel(parent)
 {
   setSourceModel(src);

--- a/moveit_setup_assistant/src/tools/collision_linear_model.h
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.h
@@ -40,10 +40,6 @@
 #include <QSortFilterProxyModel>
 #include <QVector>
 
-#ifndef Q_MOC_RUN
-#include <moveit/setup_assistant/tools/compute_default_collisions.h>
-#endif
-
 #include "collision_matrix_model.h"
 
 class CollisionLinearModel : public QAbstractProxyModel

--- a/moveit_setup_assistant/src/tools/collision_linear_model.h
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.h
@@ -66,7 +66,6 @@ public:
   QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
   QModelIndex parent(const QModelIndex& child) const override;
   QVariant data(const QModelIndex& index, int role) const override;
-  moveit_setup_assistant::DisabledReason reason(int row) const;
 
   bool setData(const QModelIndex& index, const QVariant& value, int role) override;
   void setEnabled(const QItemSelection& selection, bool value);

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
@@ -44,18 +44,6 @@
 #include <QApplication>
 #include <QItemSelection>
 
-using namespace moveit_setup_assistant;
-
-/// Boost mapping of reasons for disabling a link pair to strings
-static const boost::unordered_map<moveit_setup_assistant::DisabledReason, const char*> LONG_REASONS_TO_STRING =
-    boost::assign::map_list_of  // clang-format off
-    ( moveit_setup_assistant::NEVER, "Never in Collision" )
-    ( moveit_setup_assistant::DEFAULT, "Collision by Default" )
-    ( moveit_setup_assistant::ADJACENT, "Adjacent Links" )
-    ( moveit_setup_assistant::ALWAYS, "Always in Collision" )
-    ( moveit_setup_assistant::USER, "User Disabled" )
-    ( moveit_setup_assistant::NOT_DISABLED, "");  // clang-format on
-
 /// Boost mapping of reasons to a background color
 static const boost::unordered_map<moveit_setup_assistant::DisabledReason, QVariant> LONG_REASONS_TO_BRUSH =
     boost::assign::map_list_of  // clang-format off
@@ -66,9 +54,9 @@ static const boost::unordered_map<moveit_setup_assistant::DisabledReason, QVaria
     ( moveit_setup_assistant::USER, QBrush(QColor("yellow")) )
     ( moveit_setup_assistant::NOT_DISABLED, QBrush());  // clang-format on
 
-CollisionMatrixModel::CollisionMatrixModel(moveit_setup_assistant::LinkPairMap& pairs,
-                                           const std::vector<std::string>& names, QObject* parent)
-  : QAbstractTableModel(parent), pairs(pairs), std_names(names)
+CollisionMatrixModel::CollisionMatrixModel(const srdf::SRDFWriterPtr& srdf, const std::vector<std::string>& names,
+                                           QObject* parent)
+  : QAbstractTableModel(parent), srdf(srdf), std_names(names)
 {
   int idx = 0;
   for (std::vector<std::string>::const_iterator it = names.begin(), end = names.end(); it != end; ++it, ++idx)
@@ -76,20 +64,6 @@ CollisionMatrixModel::CollisionMatrixModel(moveit_setup_assistant::LinkPairMap& 
     visual_to_index << idx;
     q_names << QString::fromStdString(*it);
   }
-}
-
-// return item in pairs map given a normalized index, use item(normalized(index))
-moveit_setup_assistant::LinkPairMap::iterator CollisionMatrixModel::item(const QModelIndex& index)
-{
-  int r = visual_to_index[index.row()], c = visual_to_index[index.column()];
-  if (r == c)
-    return pairs.end();
-
-  // setLinkPair() actually inserts the pair (A,B) where A < B
-  if (std_names[r] >= std_names[c])
-    std::swap(r, c);
-
-  return pairs.find(std::make_pair(std_names[r], std_names[c]));
 }
 
 int CollisionMatrixModel::rowCount(const QModelIndex& /*parent*/) const
@@ -102,29 +76,74 @@ int CollisionMatrixModel::columnCount(const QModelIndex& /*parent*/) const
   return visual_to_index.size();
 }
 
+std::vector<srdf::Model::CollisionPair>::iterator
+CollisionMatrixModel::find(std::vector<srdf::Model::CollisionPair>& pairs, const std::string& link1,
+                           const std::string& link2) const
+{
+  const auto p = link1 < link2 ? std::make_pair(link1, link2) : std::make_pair(link2, link1);
+  for (auto it = pairs.begin(), end = pairs.end(); it != end; ++it)
+  {
+    if ((it->link1_ == p.first && it->link2_ == p.second) || (it->link2_ == p.first && it->link1_ == p.second))
+      return it;
+  }
+  return pairs.end();
+}
+
+bool CollisionMatrixModel::disabledByDefault(const std::string& link1, const std::string& link2) const
+{
+  for (const auto& name : srdf->no_default_collision_links_)
+    if (name == link1 || name == link2)
+      return true;
+  return false;
+}
+
 QVariant CollisionMatrixModel::data(const QModelIndex& index, int role) const
 {
-  if (index.isValid() && index.row() == index.column() && role == Qt::BackgroundRole)
-    return QApplication::palette().window();
+  static std::string enabled = "Explicitly enabled";
+  static std::string disabled = "Disabled by default";
+  static QBrush default_collision_brush(QColor("lightpink").darker(110));
 
-  moveit_setup_assistant::LinkPairMap::const_iterator item = this->item(index);
-  if (item == pairs.end())
-    return QVariant();
+  if (index.isValid() && index.row() == index.column())
+  {
+    switch (role)
+    {
+      case Qt::BackgroundRole:
+        return QApplication::palette().window();
+      default:
+        return QVariant();
+    }
+  }
+
+  const std::string* reason = nullptr;
+  int r = visual_to_index[index.row()], c = visual_to_index[index.column()];
+  auto it = find(srdf->disabled_collision_pairs_, std_names[r], std_names[c]);
+  if (it != srdf->disabled_collision_pairs_.end())
+    reason = &it->reason_;
+  else if (find(srdf->enabled_collision_pairs_, std_names[r], std_names[c]) != srdf->enabled_collision_pairs_.end())
+    reason = &enabled;
+  else if (disabledByDefault(std_names[r], std_names[c]))
+    reason = &disabled;
 
   switch (role)
   {
     case Qt::CheckStateRole:
-      return item->second.disable_check ? Qt::Checked : Qt::Unchecked;
+      return (!reason || reason == &enabled) ? Qt::Unchecked : Qt::Checked;
     case Qt::ToolTipRole:
-      return LONG_REASONS_TO_STRING.at(item->second.reason);
+      return reason ? QString::fromStdString(*reason) : QString();
     case Qt::BackgroundRole:
-      return LONG_REASONS_TO_BRUSH.at(item->second.reason);
+      if (!reason || reason == &enabled)
+        return QVariant();
+      else if (reason == &disabled)
+        return default_collision_brush;
+      else
+        return LONG_REASONS_TO_BRUSH.at(moveit_setup_assistant::disabledReasonFromString(*reason));
   }
   return QVariant();
 }
 
 bool CollisionMatrixModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
+#if 0
   if (role == Qt::CheckStateRole)
   {
     moveit_setup_assistant::LinkPairMap::iterator item = this->item(index);
@@ -150,6 +169,7 @@ bool CollisionMatrixModel::setData(const QModelIndex& index, const QVariant& val
     Q_EMIT dataChanged(mirror, mirror);
     return true;
   }
+#endif
   return false;  // reject all other changes
 }
 

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.cpp
@@ -123,14 +123,6 @@ QVariant CollisionMatrixModel::data(const QModelIndex& index, int role) const
   return QVariant();
 }
 
-moveit_setup_assistant::DisabledReason CollisionMatrixModel::reason(const QModelIndex& index) const
-{
-  moveit_setup_assistant::LinkPairMap::const_iterator item = this->item(index);
-  if (item == pairs.end())
-    return moveit_setup_assistant::NOT_DISABLED;
-  return item->second.reason;
-}
-
 bool CollisionMatrixModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
   if (role == Qt::CheckStateRole)

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.h
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <QAbstractTableModel>
+#include <srdfdom/srdf_writer.h>
 
 #ifndef Q_MOC_RUN
 #include <moveit/setup_assistant/tools/compute_default_collisions.h>
@@ -48,7 +49,7 @@ class CollisionMatrixModel : public QAbstractTableModel
 {
   Q_OBJECT
 public:
-  CollisionMatrixModel(moveit_setup_assistant::LinkPairMap& pairs, const std::vector<std::string>& names,
+  CollisionMatrixModel(const srdf::SRDFWriterPtr& srdf, const std::vector<std::string>& names,
                        QObject* parent = nullptr);
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -65,14 +66,12 @@ public Q_SLOTS:
   void setFilterRegExp(const QString& filter);
 
 private:
-  moveit_setup_assistant::LinkPairMap::iterator item(const QModelIndex& index);
-  moveit_setup_assistant::LinkPairMap::const_iterator item(const QModelIndex& index) const
-  {
-    return const_cast<CollisionMatrixModel*>(this)->item(index);
-  }
+  bool disabledByDefault(const std::string& link1, const std::string& link2) const;
+  std::vector<srdf::Model::CollisionPair>::iterator find(std::vector<srdf::Model::CollisionPair>& pairs,
+                                                         const std::string& link1, const std::string& link2) const;
 
 private:
-  moveit_setup_assistant::LinkPairMap& pairs;
+  srdf::SRDFWriterPtr srdf;
   const std::vector<std::string> std_names;  // names of links
   QList<QString> q_names;                    // names of links
   QList<int> visual_to_index;                // map from visual index to actual index

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.h
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.h
@@ -67,8 +67,6 @@ public Q_SLOTS:
 
 private:
   bool disabledByDefault(const std::string& link1, const std::string& link2) const;
-  std::vector<srdf::Model::CollisionPair>::iterator find(std::vector<srdf::Model::CollisionPair>& pairs,
-                                                         const std::string& link1, const std::string& link2) const;
 
 private:
   srdf::SRDFWriterPtr srdf;

--- a/moveit_setup_assistant/src/tools/collision_matrix_model.h
+++ b/moveit_setup_assistant/src/tools/collision_matrix_model.h
@@ -54,7 +54,6 @@ public:
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-  moveit_setup_assistant::DisabledReason reason(const QModelIndex& index) const;
 
   // for editing
   Qt::ItemFlags flags(const QModelIndex& index) const override;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1328,7 +1328,7 @@ bool MoveItConfigData::inputKinematicsYAML(const std::string& file_path)
     for (YAML::const_iterator group_it = doc.begin(); group_it != doc.end(); ++group_it)
     {
       const std::string& group_name = group_it->first.as<std::string>();
-      const YAML::Node& group = group_it->second;
+      const YAML::Node group = group_it->second;
 
       // Create new meta data
       GroupMetaData meta_data;
@@ -1339,7 +1339,7 @@ bool MoveItConfigData::inputKinematicsYAML(const std::string& file_path)
       parse(group, "kinematics_solver_timeout", meta_data.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT);
 
       // Assign meta data to vector
-      group_meta_data_[group_name] = meta_data;
+      group_meta_data_[group_name] = std::move(meta_data);
     }
   }
   catch (YAML::ParserException& e)  // Catch errors

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -139,18 +139,18 @@ planning_scene::PlanningScenePtr MoveItConfigData::getPlanningScene()
 // ******************************************************************************************
 // Load the allowed collision matrix from the SRDF's list of link pairs
 // ******************************************************************************************
-void MoveItConfigData::loadAllowedCollisionMatrix()
+void MoveItConfigData::loadAllowedCollisionMatrix(const srdf::SRDFWriter& srdf)
 {
   allowed_collision_matrix_.clear();
 
   // load collision defaults
-  for (const std::string& name : srdf_->no_default_collision_links_)
+  for (const std::string& name : srdf.no_default_collision_links_)
     allowed_collision_matrix_.setDefaultEntry(name, collision_detection::AllowedCollision::ALWAYS);
   // re-enable specific collision pairs
-  for (auto const& collision : srdf_->enabled_collision_pairs_)
+  for (auto const& collision : srdf.enabled_collision_pairs_)
     allowed_collision_matrix_.setEntry(collision.link1_, collision.link2_, false);
   // *finally* disable selected collision pairs
-  for (auto const& collision : srdf_->disabled_collision_pairs_)
+  for (auto const& collision : srdf.disabled_collision_pairs_)
     allowed_collision_matrix_.setEntry(collision.link1_, collision.link2_, true);
 }
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -338,6 +338,7 @@ void DefaultCollisionsWidget::loadCollisionTable()
   {
     CollisionLinearModel* linear_model = new CollisionLinearModel(matrix_model);
     SortFilterProxyModel* sorted_model = new SortFilterProxyModel();
+    sorted_model->setShowAll(collision_checkbox_->checkState() == Qt::Checked);
     model = sorted_model;
     sorted_model->setSourceModel(linear_model);
     // ensure deletion of underlying models with model

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -226,11 +226,11 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   radio_btn = new QRadioButton("linear view");
   bottom_layout->addWidget(radio_btn);
   view_mode_buttons_->addButton(radio_btn, LINEAR_MODE);
-  radio_btn->setChecked(true);
 
   radio_btn = new QRadioButton("matrix view");
   bottom_layout->addWidget(radio_btn);
   view_mode_buttons_->addButton(radio_btn, MATRIX_MODE);
+  radio_btn->setChecked(true);
   connect(view_mode_buttons_, SIGNAL(buttonClicked(int)), this, SLOT(loadCollisionTable()));
 
   // Revert Button

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -397,6 +397,7 @@ void DefaultCollisionsWidget::loadCollisionTable()
     collision_checkbox_->show();
     horizontal_header->setVisible(true);
     vertical_header->setVisible(true);
+    horizontal_header->setSectionResizeMode(QHeaderView::Stretch);
 
     vertical_header->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(vertical_header, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showHeaderContextMenu(QPoint)));

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -58,6 +58,7 @@ class QVBoxLayout;
 #include <boost/thread/thread.hpp>
 #include <boost/function/function_fwd.hpp>
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#include <moveit/setup_assistant/tools/compute_default_collisions.h>
 #endif
 
 #include "setup_screen_widget.h"  // a base class for screens in the setup assistant
@@ -90,16 +91,6 @@ public:
    */
   DefaultCollisionsWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
   ~DefaultCollisionsWidget() override;
-
-  /**
-   * \brief Output Link Pairs to SRDF Format
-   */
-  void linkPairsToSRDF();
-
-  /**
-   * \brief Load Link Pairs from SRDF Format
-   */
-  void linkPairsFromSRDF();
 
 private Q_SLOTS:
 
@@ -194,11 +185,10 @@ private:
   // ******************************************************************************************
   MonitorThread* worker_;
 
-  /// main storage of link pair data
-  moveit_setup_assistant::LinkPairMap link_pairs_;
-
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;
+  /// Working copy of SRDF config
+  srdf::SRDFWriterPtr wip_srdf_;
 
   // ******************************************************************************************
   // Private Functions

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -207,29 +207,23 @@ private:
    */
   void disableControls(bool disable);
 
-  /**
-   * \brief Allow toggling of all checkboxes in selection by filtering <space> keypresses
-   */
+  /** Allow toggling of all checkboxes in selection by filtering <space> keypresses */
   bool eventFilter(QObject* object, QEvent* event) override;
 
-  /**
-   * \brief Show header's sections in logicalIndexes and everything in between
-   */
+  /** Return list of selected sections */
+  QList<int> selectedSections(QHeaderView*& header) const;
+
+  /** Show header's sections in logicalIndexes and everything in between */
   void showSections(QHeaderView* header, const QList<int>& logicalIndexes);
-  /**
-   * \brief Enable/Disable selected sections by default
-   */
+
+  /** Enable/Disable selected sections by default */
   void setDefaults(bool enabled);
 
-  /**
-   * \brief Toggle enabled status of selection
-   */
+  /** Toggle enabled status of selection */
   void toggleSelection(QItemSelection selection);
 };
 
-/**
- * \brief QThread to monitor progress of a boost::thread
- */
+/** QThread to monitor progress of a boost::thread */
 class MonitorThread : public QThread
 {
   Q_OBJECT

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -217,6 +217,11 @@ private:
    */
   void showSections(QHeaderView* header, const QList<int>& logicalIndexes);
   /**
+   * \brief Enable/Disable selected sections by default
+   */
+  void setDefaults(bool enabled);
+
+  /**
    * \brief Toggle enabled status of selection
    */
   void toggleSelection(QItemSelection selection);

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -403,7 +403,7 @@ bool StartScreenWidget::loadExistingFiles()
   QApplication::processEvents();
 
   // Load the allowed collision matrix
-  config_data_->loadAllowedCollisionMatrix();
+  config_data_->loadAllowedCollisionMatrix(*config_data_->srdf_);
 
   // Load kinematics yaml file if available --------------------------------------------------
   fs::path kinematics_yaml_path = config_data_->config_pkg_path_;


### PR DESCRIPTION
As a follow-up to #2938, this PR aims to allow for editing the extended ACM in MSA, i.e. defining default-collision links, re-enabling and disabling collision pairs.
- [x] Display ACM considering default-collision links and re-enabled pairs
- [ ] ~~Choose a better data representation?~~
  For now, the CollisionMatrixModel directly operates on the `SRDFWriter`'s members. While that's the native data structure holding the relevant info, accessing any info requires several `string` compares. In the past, the `reason` strings were mapped onto enums internally and a map (`LinkPairMap`) was used instead of vectors.
However, I didn't notice a dramatic slowdown with a robot of ca. 20 links. So, maybe it's not worth the effort...
- [x] Reenable editing, particularly allow adding/removing defaullt-collision links.