### PR TITLE
Consider eef's parent group when creating eef markers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -30,6 +30,8 @@ API changes in MoveIt releases
 - In case you start RViz in a namespace, the default topic for the trajectory visualization display now uses the relative instead of the absolute namespace (i.e. `<ns>/move_group/display_planned_path` instead of `/move_group/display_planned_path`).
 - `RobotState::attachBody()` now takes a unique_ptr instead of an owning raw pointer.
 - Moved the class `MoveItErrorCode` from both `moveit_ros_planning` and `moveit_ros_planning_interface` to `moveit_core`. The class now is in namespace `moveit::core`, access via `moveit::planning_interface` or `moveit_cpp::PlanningComponent` is deprecated.
+- End-effector markers in rviz are shown only if the eef's parent group is active _and_ the parent link is part of that group. Before, these conditions were _OR_-connected.
+  You might need to define additional end-effectors.
 
 ## ROS Melodic
 

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -283,7 +283,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   auto add_active_end_effectors_for_single_group = [&](const moveit::core::JointModelGroup* single_group) {
     bool found_eef{ false };
     for (const srdf::Model::EndEffector& eef : eefs)
-      if ((single_group->hasLinkModel(eef.parent_link_) || single_group->getName() == eef.parent_group_) &&
+      if (single_group->hasLinkModel(eef.parent_link_) && single_group->getName() == eef.parent_group_ &&
           single_group->canSetStateFromIK(eef.parent_link_))
       {
         // We found an end-effector whose parent is the group.


### PR DESCRIPTION
In the `panda_moveit_config` we observed that two interactive markers are created although corresponding end-effectors are associated to different JMGs. The reason is that marker creation doesn't consider the parent group as a required, but only as an optional criterium. This PR makes the parent group a required criterium.

|Before | After|
|--------------|------------------|
| ![image](https://user-images.githubusercontent.com/5376030/158656158-9e51e7a6-3ac2-44ab-a373-b54e3f005e6c.png) | ![image](https://user-images.githubusercontent.com/5376030/158656114-96d9b9ab-e547-4bc1-9c12-edd346e1ae05.png) |

Of course, multiple markers are still possible, if corresponding end-effectors are defined employing the same group:
![image](https://user-images.githubusercontent.com/5376030/158655639-a8b129b7-1671-480f-94a3-9a62704c39e3.png)
