### PR TITLE
remove obsolete distutils.core

### DIFF
--- a/moveit_commander/setup.py
+++ b/moveit_commander/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()

--- a/moveit_ros/planning_interface/setup.py
+++ b/moveit_ros/planning_interface/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()

--- a/moveit_ros/visualization/setup.py
+++ b/moveit_ros/visualization/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()


### PR DESCRIPTION
Addresses this deprecation warning in python 3.10.

> DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives