### PR TITLE
always find end-effectors when parent_group is unset

### DIFF
--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -283,7 +283,9 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   auto add_active_end_effectors_for_single_group = [&](const moveit::core::JointModelGroup* single_group) {
     bool found_eef{ false };
     for (const srdf::Model::EndEffector& eef : eefs)
-      if (single_group->hasLinkModel(eef.parent_link_) && single_group->getName() == eef.parent_group_ &&
+    {
+      if (single_group->hasLinkModel(eef.parent_link_) &&
+          (eef.parent_group_.empty() || single_group->getName() == eef.parent_group_) &&
           single_group->canSetStateFromIK(eef.parent_link_))
       {
         // We found an end-effector whose parent is the group.
@@ -295,6 +297,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
         active_eef_.push_back(ee);
         found_eef = true;
       }
+    }
 
     // No end effectors found. Use last link in group as the "end effector".
     if (!found_eef && !single_group->getLinkModelNames().empty())


### PR DESCRIPTION
The parent_group attribute is explicitly optional in MSA,
so a lot of configurations out there (including my robot :))
do not have these attributes set at all.
In this case, these end-effectors should be picked up automatically
wherever they are useful.

Fixup for 9271e6a2edbeed291b7c713f55000bbc59d37b9e

@rhaschke you dropped a few too many interactive markers. :)