### PR TITLE
Constraint samplers with seed

### DIFF
--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -28,10 +28,11 @@ if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl REQUIRED)
   find_package(angles REQUIRED)
   find_package(tf2_kdl REQUIRED)
-
+  find_package(rostest REQUIRED)
   include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
 
-  catkin_add_gmock(test_constraint_samplers
+  add_rostest_gtest(test_constraint_samplers
+    test/constraint_samplers.test
     test/test_constraint_samplers.cpp
     test/pr2_arm_kinematics_plugin.cpp
     test/pr2_arm_ik.cpp

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CATKIN_ENABLE_TESTING)
 
   include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
 
-  catkin_add_gtest(test_constraint_samplers
+  catkin_add_gmock(test_constraint_samplers
     test/test_constraint_samplers.cpp
     test/pr2_arm_kinematics_plugin.cpp
     test/pr2_arm_ik.cpp
@@ -39,6 +39,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(test_constraint_samplers
     moveit_test_utils
+    gmock_main
     ${MOVEIT_LIB_NAME}
     ${catkin_LIBRARIES}
     ${angles_LIBRARIES}

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -72,7 +72,8 @@ public:
     int rng_seed;
     if (ros::param::get("~constraint_sampler_random_seed", rng_seed))
     {
-      ROS_WARN_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << std::to_string(rng_seed));
+      ROS_WARN_STREAM_NAMED("constraint_samplers",
+                            "Creating random number generator with seed " << std::to_string(rng_seed));
       random_number_generator_ =
           std::make_unique<random_numbers::RandomNumberGenerator>(static_cast<uint32_t>(rng_seed));
     }
@@ -320,7 +321,8 @@ public:
     int rng_seed;
     if (ros::param::get("~constraint_sampler_random_seed", rng_seed))
     {
-      ROS_WARN_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << std::to_string(rng_seed));
+      ROS_WARN_STREAM_NAMED("constraint_samplers",
+                            "Creating random number generator with seed " << std::to_string(rng_seed));
       random_number_generator_ =
           std::make_unique<random_numbers::RandomNumberGenerator>(static_cast<uint32_t>(rng_seed));
     }
@@ -537,11 +539,11 @@ protected:
   bool validate(moveit::core::RobotState& state) const;
 
   std::unique_ptr<random_numbers::RandomNumberGenerator>
-      random_number_generator_;   /**< \brief Random number generator used to sample */
-  IKSamplingPose sampling_pose_;                                  /**< \brief Holder for the pose used for sampling */
-  kinematics::KinematicsBaseConstPtr kb_;                         /**< \brief Holds the kinematics solver */
-  double ik_timeout_;                                             /**< \brief Holds the timeout associated with IK */
-  std::string ik_frame_;                                          /**< \brief Holds the base from of the IK solver */
+      random_number_generator_;           /**< \brief Random number generator used to sample */
+  IKSamplingPose sampling_pose_;          /**< \brief Holder for the pose used for sampling */
+  kinematics::KinematicsBaseConstPtr kb_; /**< \brief Holds the kinematics solver */
+  double ik_timeout_;                     /**< \brief Holds the timeout associated with IK */
+  std::string ik_frame_;                  /**< \brief Holds the base from of the IK solver */
   bool transform_ik_; /**< \brief True if the frame associated with the kinematic model is different than the base frame
                          of the IK solver */
   bool need_eef_to_ik_tip_transform_; /**< \brief True if the tip frame of the inverse kinematic is different than the

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -69,6 +69,17 @@ public:
   JointConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
   {
+    int rng_seed;
+    if (ros::param::get("~constraint_sampler_random_seed", rng_seed))
+    {
+      ROS_WARN_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << std::to_string(rng_seed));
+      random_number_generator_ =
+          std::make_unique<random_numbers::RandomNumberGenerator>(static_cast<uint32_t>(rng_seed));
+    }
+    else
+    {
+      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>();
+    }
   }
   /**
    * \brief Configures a joint constraint given a Constraints message.
@@ -191,7 +202,8 @@ protected:
 
   void clear() override;
 
-  random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random number generator used to sample */
+  std::unique_ptr<random_numbers::RandomNumberGenerator>
+      random_number_generator_;   /**< \brief Random number generator used to sample */
   std::vector<JointInfo> bounds_; /**< \brief The bounds for any joint with bounds that are more restrictive than the
                                      joint limits */
 
@@ -305,6 +317,17 @@ public:
   IKConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
   {
+    int rng_seed;
+    if (ros::param::get("~constraint_sampler_random_seed", rng_seed))
+    {
+      ROS_WARN_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << std::to_string(rng_seed));
+      random_number_generator_ =
+          std::make_unique<random_numbers::RandomNumberGenerator>(static_cast<uint32_t>(rng_seed));
+    }
+    else
+    {
+      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>();
+    }
   }
 
   /**
@@ -513,7 +536,8 @@ protected:
                     unsigned int max_attempts, bool project);
   bool validate(moveit::core::RobotState& state) const;
 
-  random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random generator used by the sampler */
+  std::unique_ptr<random_numbers::RandomNumberGenerator>
+      random_number_generator_;   /**< \brief Random number generator used to sample */
   IKSamplingPose sampling_pose_;                                  /**< \brief Holder for the pose used for sampling */
   kinematics::KinematicsBaseConstPtr kb_;                         /**< \brief Holds the kinematics solver */
   double ik_timeout_;                                             /**< \brief Holds the timeout associated with IK */

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -70,12 +70,10 @@ public:
     : ConstraintSampler(scene, group_name)
   {
     int rng_seed;
-    if (ros::param::get("~constraint_sampler_random_seed", rng_seed))
+    if (ros::param::get("~joint_constraint_sampler_random_seed", rng_seed))
     {
-      ROS_WARN_STREAM_NAMED("constraint_samplers",
-                            "Creating random number generator with seed " << std::to_string(rng_seed));
-      random_number_generator_ =
-          std::make_unique<random_numbers::RandomNumberGenerator>(static_cast<uint32_t>(rng_seed));
+      ROS_DEBUG_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << rng_seed);
+      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>(rng_seed);
     }
     else
     {
@@ -319,12 +317,10 @@ public:
     : ConstraintSampler(scene, group_name)
   {
     int rng_seed;
-    if (ros::param::get("~constraint_sampler_random_seed", rng_seed))
+    if (ros::param::get("~ik_constraint_sampler_random_seed", rng_seed))
     {
-      ROS_WARN_STREAM_NAMED("constraint_samplers",
-                            "Creating random number generator with seed " << std::to_string(rng_seed));
-      random_number_generator_ =
-          std::make_unique<random_numbers::RandomNumberGenerator>(static_cast<uint32_t>(rng_seed));
+      ROS_DEBUG_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << rng_seed);
+      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>(rng_seed);
     }
     else
     {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -42,6 +42,8 @@
 
 namespace constraint_samplers
 {
+random_numbers::RandomNumberGenerator createSeededRNG(const std::string& seed_param);
+
 MOVEIT_CLASS_FORWARD(JointConstraintSampler);  // Defines JointConstraintSamplerPtr, ConstPtr, WeakPtr... etc
 
 /**
@@ -68,18 +70,10 @@ public:
    */
   JointConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
+    , random_number_generator_(createSeededRNG("~joint_constraint_sampler_random_seed"))
   {
-    int rng_seed;
-    if (ros::param::get("~joint_constraint_sampler_random_seed", rng_seed))
-    {
-      ROS_DEBUG_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << rng_seed);
-      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>(rng_seed);
-    }
-    else
-    {
-      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>();
-    }
   }
+
   /**
    * \brief Configures a joint constraint given a Constraints message.
    *
@@ -201,8 +195,7 @@ protected:
 
   void clear() override;
 
-  std::unique_ptr<random_numbers::RandomNumberGenerator>
-      random_number_generator_;   /**< \brief Random number generator used to sample */
+  random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random number generator used to sample */
   std::vector<JointInfo> bounds_; /**< \brief The bounds for any joint with bounds that are more restrictive than the
                                      joint limits */
 
@@ -315,17 +308,8 @@ public:
    */
   IKConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
+    , random_number_generator_(createSeededRNG("~ik_constraint_sampler_random_seed"))
   {
-    int rng_seed;
-    if (ros::param::get("~ik_constraint_sampler_random_seed", rng_seed))
-    {
-      ROS_DEBUG_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << rng_seed);
-      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>(rng_seed);
-    }
-    else
-    {
-      random_number_generator_ = std::make_unique<random_numbers::RandomNumberGenerator>();
-    }
   }
 
   /**
@@ -534,12 +518,11 @@ protected:
                     unsigned int max_attempts, bool project);
   bool validate(moveit::core::RobotState& state) const;
 
-  std::unique_ptr<random_numbers::RandomNumberGenerator>
-      random_number_generator_;           /**< \brief Random number generator used to sample */
-  IKSamplingPose sampling_pose_;          /**< \brief Holder for the pose used for sampling */
-  kinematics::KinematicsBaseConstPtr kb_; /**< \brief Holds the kinematics solver */
-  double ik_timeout_;                     /**< \brief Holds the timeout associated with IK */
-  std::string ik_frame_;                  /**< \brief Holds the base from of the IK solver */
+  random_numbers::RandomNumberGenerator random_number_generator_; /**< \brief Random generator used by the sampler */
+  IKSamplingPose sampling_pose_;                                  /**< \brief Holder for the pose used for sampling */
+  kinematics::KinematicsBaseConstPtr kb_;                         /**< \brief Holds the kinematics solver */
+  double ik_timeout_;                                             /**< \brief Holds the timeout associated with IK */
+  std::string ik_frame_;                                          /**< \brief Holds the base from of the IK solver */
   bool transform_ik_; /**< \brief True if the frame associated with the kinematic model is different than the base frame
                          of the IK solver */
   bool need_eef_to_ik_tip_transform_; /**< \brief True if the tip frame of the inverse kinematic is different than the

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -162,14 +162,14 @@ bool JointConstraintSampler::sample(moveit::core::RobotState& state,
   for (std::size_t i = 0; i < unbounded_.size(); ++i)
   {
     v.resize(unbounded_[i]->getVariableCount());
-    unbounded_[i]->getVariableRandomPositions(random_number_generator_, &v[0]);
+    unbounded_[i]->getVariableRandomPositions(*random_number_generator_, &v[0]);
     for (std::size_t j = 0; j < v.size(); ++j)
       values_[uindex_[i] + j] = v[j];
   }
 
   // enforce the constraints for the constrained components (could be all of them)
   for (const JointInfo& bound : bounds_)
-    values_[bound.index_] = random_number_generator_.uniformReal(bound.min_bound_, bound.max_bound_);
+    values_[bound.index_] = random_number_generator_->uniformReal(bound.min_bound_, bound.max_bound_);
 
   state.setJointGroupPositions(jmg_, values_);
 
@@ -430,9 +430,9 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
     if (!b.empty())
     {
       bool found = false;
-      std::size_t k = random_number_generator_.uniformInteger(0, b.size() - 1);
+      std::size_t k = random_number_generator_->uniformInteger(0, b.size() - 1);
       for (std::size_t i = 0; i < b.size(); ++i)
-        if (b[(i + k) % b.size()]->samplePointInside(random_number_generator_, max_attempts, pos))
+        if (b[(i + k) % b.size()]->samplePointInside(*random_number_generator_, max_attempts, pos))
         {
           found = true;
           break;
@@ -467,13 +467,13 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
   {
     // sample a rotation matrix within the allowed bounds
     double angle_x =
-        2.0 * (random_number_generator_.uniform01() - 0.5) *
+        2.0 * (random_number_generator_->uniform01() - 0.5) *
         (sampling_pose_.orientation_constraint_->getXAxisTolerance() - std::numeric_limits<double>::epsilon());
     double angle_y =
-        2.0 * (random_number_generator_.uniform01() - 0.5) *
+        2.0 * (random_number_generator_->uniform01() - 0.5) *
         (sampling_pose_.orientation_constraint_->getYAxisTolerance() - std::numeric_limits<double>::epsilon());
     double angle_z =
-        2.0 * (random_number_generator_.uniform01() - 0.5) *
+        2.0 * (random_number_generator_->uniform01() - 0.5) *
         (sampling_pose_.orientation_constraint_->getZAxisTolerance() - std::numeric_limits<double>::epsilon());
 
     Eigen::Isometry3d diff;
@@ -518,7 +518,7 @@ bool IKConstraintSampler::samplePose(Eigen::Vector3d& pos, Eigen::Quaterniond& q
   {
     // sample a random orientation
     double q[4];
-    random_number_generator_.quaternion(q);
+    random_number_generator_->quaternion(q);
     quat = Eigen::Quaterniond(q[3], q[0], q[1], q[2]);  // quat is normalized by contract
   }
 
@@ -644,7 +644,7 @@ bool IKConstraintSampler::callIK(const geometry_msgs::Pose& ik_query,
     state.copyJointGroupPositions(jmg_, vals);
   else
     // sample a seed value
-    jmg_->getVariableRandomPositions(random_number_generator_, vals);
+    jmg_->getVariableRandomPositions(*random_number_generator_, vals);
 
   assert(vals.size() == ik_joint_bijection.size());
   for (std::size_t i = 0; i < ik_joint_bijection.size(); ++i)

--- a/moveit_core/constraint_samplers/test/constraint_samplers.test
+++ b/moveit_core/constraint_samplers/test/constraint_samplers.test
@@ -1,0 +1,4 @@
+<launch>
+  <test pkg="moveit_core" type="test_constraint_samplers" test-name="test_constraint_samplers"
+        time-limit="300" args=""/>
+</launch>

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1238,5 +1238,6 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "test_constraint_samplers");
+  ros::NodeHandle nh;
   return RUN_ALL_TESTS();
 }

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1126,7 +1126,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
 
 TEST_F(LoadPlanningModelsPr2, JointConstraintsSamplerSeeded)
 {
-  ros::param::set("~constraint_sampler_random_seed", 12345);
+  ros::param::set("~joint_constraint_sampler_random_seed", 12345);
   constraint_samplers::JointConstraintSampler seeded_sampler1(ps_, "right_arm");
   kinematic_constraints::JointConstraint jc(robot_model_);
   moveit_msgs::JointConstraint jcm;
@@ -1155,7 +1155,7 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsSamplerSeeded)
   using namespace testing;
   EXPECT_THAT(joint_positions_v, ContainerEq(joint_positions_v2));
 
-  ros::param::del("~constraint_sampler_random_seed");
+  ros::param::del("~joint_constraint_sampler_random_seed");
   constraint_samplers::JointConstraintSampler seeded_sampler3(ps_, "right_arm");
   EXPECT_TRUE(seeded_sampler3.configure(js));
   ks.setToDefaultValues();

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1238,6 +1238,5 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "test_constraint_samplers");
-  ros::Time::init();
   return RUN_ALL_TESTS();
 }

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -1205,7 +1205,7 @@ TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerSeeded)
   EXPECT_TRUE(seeded_sampler1.sample(ks, ks, 1));
   ks.update();
   bool found = false;
-  const Eigen::Isometry3d root_T_left_tool1 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  const Eigen::Isometry3d root_to_left_tool1 = ks.getFrameTransform("l_gripper_tool_frame", &found);
   EXPECT_TRUE(found);
 
   constraint_samplers::IKConstraintSampler seeded_sampler2(ps_, "left_arm");
@@ -1215,7 +1215,7 @@ TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerSeeded)
   EXPECT_TRUE(seeded_sampler2.sample(ks, ks, 1));
   ks.update();
   found = false;
-  const Eigen::Isometry3d root_T_left_tool2 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  const Eigen::Isometry3d root_to_left_tool2 = ks.getFrameTransform("l_gripper_tool_frame", &found);
   EXPECT_TRUE(found);
 
   ros::param::del("~ik_constraint_sampler_random_seed");
@@ -1226,12 +1226,12 @@ TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerSeeded)
   EXPECT_TRUE(seeded_sampler3.sample(ks, ks, 1));
   ks.update();
   found = false;
-  const Eigen::Isometry3d root_T_left_tool3 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  const Eigen::Isometry3d root_to_left_tool3 = ks.getFrameTransform("l_gripper_tool_frame", &found);
   EXPECT_TRUE(found);
 
-  EXPECT_TRUE((root_T_left_tool1 * root_T_left_tool2.inverse()).matrix().isIdentity(1e-7));
-  EXPECT_FALSE((root_T_left_tool1 * root_T_left_tool3.inverse()).matrix().isIdentity(1e-7));
-  EXPECT_FALSE((root_T_left_tool2 * root_T_left_tool3.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_TRUE((root_to_left_tool1 * root_to_left_tool2.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_FALSE((root_to_left_tool1 * root_to_left_tool3.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_FALSE((root_to_left_tool2 * root_to_left_tool3.inverse()).matrix().isIdentity(1e-7));
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -46,6 +46,7 @@
 #include <geometric_shapes/shape_operations.h>
 #include <visualization_msgs/MarkerArray.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
@@ -1123,9 +1124,120 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
                  (double)succ / (double)NT);
 }
 
+TEST_F(LoadPlanningModelsPr2, JointConstraintsSamplerSeeded)
+{
+  ros::param::set("~constraint_sampler_random_seed", 12345);
+  constraint_samplers::JointConstraintSampler seeded_sampler1(ps_, "right_arm");
+  kinematic_constraints::JointConstraint jc(robot_model_);
+  moveit_msgs::JointConstraint jcm;
+  jcm.position = 0.42;
+  jcm.tolerance_above = 0.01;
+  jcm.tolerance_below = 0.05;
+  jcm.weight = 1.0;
+  jcm.joint_name = "r_shoulder_pan_joint";
+  EXPECT_TRUE(jc.configure(jcm));
+  std::vector<kinematic_constraints::JointConstraint> js;
+  js.push_back(jc);
+  EXPECT_TRUE(seeded_sampler1.configure(js));
+
+  moveit::core::RobotState ks(robot_model_);
+  ks.setToDefaultValues();
+  EXPECT_TRUE(seeded_sampler1.sample(ks, ks, 1));
+  const double* joint_positions = ks.getVariablePositions();
+  const std::vector<double> joint_positions_v(joint_positions, joint_positions + ks.getVariableCount());
+
+  constraint_samplers::JointConstraintSampler seeded_sampler2(ps_, "right_arm");
+  EXPECT_TRUE(seeded_sampler2.configure(js));
+  ks.setToDefaultValues();
+  EXPECT_TRUE(seeded_sampler2.sample(ks, ks, 1));
+  const double* joint_positions2 = ks.getVariablePositions();
+  const std::vector<double> joint_positions_v2(joint_positions2, joint_positions2 + ks.getVariableCount());
+  using namespace testing;
+  EXPECT_THAT(joint_positions_v, ContainerEq(joint_positions_v2));
+
+  ros::param::del("~constraint_sampler_random_seed");
+  constraint_samplers::JointConstraintSampler seeded_sampler3(ps_, "right_arm");
+  EXPECT_TRUE(seeded_sampler3.configure(js));
+  ks.setToDefaultValues();
+  EXPECT_TRUE(seeded_sampler3.sample(ks, ks, 1));
+  const double* joint_positions3 = ks.getVariablePositions();
+  const std::vector<double> joint_positions_v3(joint_positions3, joint_positions3 + ks.getVariableCount());
+  EXPECT_THAT(joint_positions_v, Not(ContainerEq(joint_positions_v3)));
+  EXPECT_THAT(joint_positions_v2, Not(ContainerEq(joint_positions_v3)));
+}
+
+TEST_F(LoadPlanningModelsPr2, IKConstraintsSamplerSeeded)
+{
+  ros::param::set("~ik_constraint_sampler_random_seed", 12345);
+  kinematic_constraints::PositionConstraint pc(robot_model_);
+  moveit_msgs::PositionConstraint pcm;
+
+  pcm.link_name = "l_wrist_roll_link";
+  pcm.target_point_offset.x = 0;
+  pcm.target_point_offset.y = 0;
+  pcm.target_point_offset.z = 0;
+  pcm.constraint_region.primitives.resize(1);
+  pcm.constraint_region.primitives[0].type = shape_msgs::SolidPrimitive::SPHERE;
+  pcm.constraint_region.primitives[0].dimensions.resize(1);
+  pcm.constraint_region.primitives[0].dimensions[0] = 0.001;
+
+  pcm.constraint_region.primitive_poses.resize(1);
+  pcm.constraint_region.primitive_poses[0].position.x = 0.55;
+  pcm.constraint_region.primitive_poses[0].position.y = 0.2;
+  pcm.constraint_region.primitive_poses[0].position.z = 1.25;
+  pcm.constraint_region.primitive_poses[0].orientation.x = 0.0;
+  pcm.constraint_region.primitive_poses[0].orientation.y = 0.0;
+  pcm.constraint_region.primitive_poses[0].orientation.z = 0.0;
+  pcm.constraint_region.primitive_poses[0].orientation.w = 1.0;
+  pcm.weight = 1.0;
+
+  pcm.header.frame_id = robot_model_->getModelFrame();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
+  EXPECT_TRUE(pc.configure(pcm, tf));
+
+  constraint_samplers::IKConstraintSampler seeded_sampler1(ps_, "left_arm");
+  EXPECT_TRUE(seeded_sampler1.configure(constraint_samplers::IKSamplingPose(pc)));
+
+  moveit::core::RobotState ks(robot_model_);
+  ks.setToDefaultValues();
+  ks.update();
+
+  EXPECT_TRUE(seeded_sampler1.sample(ks, ks, 1));
+  ks.update();
+  bool found = false;
+  const Eigen::Isometry3d root_T_left_tool1 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  EXPECT_TRUE(found);
+
+  constraint_samplers::IKConstraintSampler seeded_sampler2(ps_, "left_arm");
+  EXPECT_TRUE(seeded_sampler2.configure(constraint_samplers::IKSamplingPose(pc)));
+  ks.setToDefaultValues();
+  ks.update();
+  EXPECT_TRUE(seeded_sampler2.sample(ks, ks, 1));
+  ks.update();
+  found = false;
+  const Eigen::Isometry3d root_T_left_tool2 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  EXPECT_TRUE(found);
+
+  ros::param::del("~ik_constraint_sampler_random_seed");
+  constraint_samplers::IKConstraintSampler seeded_sampler3(ps_, "left_arm");
+  EXPECT_TRUE(seeded_sampler3.configure(constraint_samplers::IKSamplingPose(pc)));
+  ks.setToDefaultValues();
+  ks.update();
+  EXPECT_TRUE(seeded_sampler3.sample(ks, ks, 1));
+  ks.update();
+  found = false;
+  const Eigen::Isometry3d root_T_left_tool3 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  EXPECT_TRUE(found);
+
+  EXPECT_TRUE((root_T_left_tool1 * root_T_left_tool2.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_FALSE((root_T_left_tool1 * root_T_left_tool3.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_FALSE((root_T_left_tool2 * root_T_left_tool3.inverse()).matrix().isIdentity(1e-7));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_constraint_samplers");
   ros::Time::init();
   return RUN_ALL_TESTS();
 }

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -64,6 +64,7 @@
   <test_depend condition="$ROS_DISTRO != noetic">orocos_kdl</test_depend>
   <test_depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</test_depend>
   <test_depend>rosunit</test_depend>
+  <test_depend>rostest</test_depend>
 
   <export>
     <moveit_core plugin="${prefix}/collision_detector_fcl_description.xml"/>


### PR DESCRIPTION
### Description

This PR adds the ability to specify a seed for constraint samplers through the parameter server, which would be useful in deterministic testing and benchmarking of these objects.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] No API changes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
