### PR TITLE
Add and fix dual arm test

### DIFF
--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -131,6 +131,7 @@ bool UnionConstraintSampler::sample(moveit::core::RobotState& state, const movei
 
   if (!samplers_.empty())
   {
+    state.updateLinkTransforms();
     if (!samplers_[0]->sample(state, reference_state, max_attempts))
       return false;
   }
@@ -141,7 +142,7 @@ bool UnionConstraintSampler::sample(moveit::core::RobotState& state, const movei
     // but requires a state with clean link transforms as input. This means that we need to clean the link
     // transforms between calls to ConstraintSampler::sample.
     state.updateLinkTransforms();
-    if (!samplers_[i]->sample(state, state, max_attempts))
+    if (!samplers_[i]->project(state, max_attempts))
       return false;
   }
   return true;

--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -128,24 +128,7 @@ bool UnionConstraintSampler::sample(moveit::core::RobotState& state, const movei
 {
   state = reference_state;
   state.setToRandomPositions(jmg_);
-
-  if (!samplers_.empty())
-  {
-    state.updateLinkTransforms();
-    if (!samplers_[0]->sample(state, reference_state, max_attempts))
-      return false;
-  }
-
-  for (std::size_t i = 1; i < samplers_.size(); ++i)
-  {
-    // ConstraintSampler::sample returns states with dirty link transforms (because it only writes values)
-    // but requires a state with clean link transforms as input. This means that we need to clean the link
-    // transforms between calls to ConstraintSampler::sample.
-    state.updateLinkTransforms();
-    if (!samplers_[i]->project(state, max_attempts))
-      return false;
-  }
-  return true;
+  return project(state, max_attempts);
 }
 
 bool UnionConstraintSampler::project(moveit::core::RobotState& state, unsigned int max_attempts)

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -16,6 +16,7 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest(python_move_group.test)
   add_rostest(python_move_group_ns.test)
   add_rostest(robot_state_update.test)
+  add_rostest(dual_arm_robot_state_update.test)
   add_rostest(cleanup.test)
 
   SET(HELPER_LIB moveit_planning_interface_test_serialize_msg_cpp_helper)

--- a/moveit_ros/planning_interface/test/dual_arm_robot_state_update.py
+++ b/moveit_ros/planning_interface/test/dual_arm_robot_state_update.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import unittest
+import rospy
+import rostest
+import os
+
+import moveit_commander
+
+from moveit_msgs.msg import MoveItErrorCodes, RobotTrajectory
+
+
+class RobotStateUpdateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.dual_arm_group = moveit_commander.MoveGroupCommander("dual_arm")
+        self.panda_1_group = moveit_commander.MoveGroupCommander("panda_1")
+        self.panda_2_group = moveit_commander.MoveGroupCommander("panda_2")
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def plan(self, target):
+        self.dual_arm_group.set_joint_value_target(target)
+        return self.dual_arm_group.plan()
+
+    def test(self):
+        panda_1_pose = self.panda_1_group.get_current_pose("panda_1_link8")
+        panda_1_pose.pose.position.z -= 0.05
+        panda_1_pose.pose.position.x += 0.05
+
+        panda_2_pose = self.panda_2_group.get_current_pose("panda_2_link8")
+        panda_2_pose.pose.position.z -= 0.05
+        panda_2_pose.pose.position.x -= 0.05
+        self.dual_arm_group.set_start_state_to_current_state()
+        self.dual_arm_group.set_pose_target(
+            panda_1_pose, end_effector_link="panda_1_link8"
+        )
+        self.dual_arm_group.set_pose_target(
+            panda_2_pose, end_effector_link="panda_2_link8"
+        )
+
+        result = self.dual_arm_group.plan()
+        if isinstance(result, RobotTrajectory):
+            self.assertTrue(result.joint_trajectory.joint_names)
+        else:
+            success, plan, planning_time, error = result
+            self.assertTrue(error.val == MoveItErrorCodes.SUCCESS)
+
+
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_robot_state_update"
+    rospy.init_node(NODENAME)
+    rostest.rosrun(PKGNAME, NODENAME, RobotStateUpdateTest)
+
+    # suppress cleanup segfault in ROS < Kinetic
+    os._exit(0)

--- a/moveit_ros/planning_interface/test/dual_arm_robot_state_update.test
+++ b/moveit_ros/planning_interface/test/dual_arm_robot_state_update.test
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find moveit_resources_dual_panda_moveit_config)/launch/test_environment.launch"/>
+  <test pkg="moveit_ros_planning_interface" type="dual_arm_robot_state_update.py" test-name="dual_arm_robot_state_update"
+        time-limit="300" args=""/>
+</launch>


### PR DESCRIPTION
### Description

I spent too many hours debugging this issue #3082 with not much progress.
My best guess as to the source of the issue is that the `Robot State` gets `dirty` (or just not updated as it used to), so the Sampler does not even bother trying to plan. I don't know why though.

Following @felixvd idea, I created a simple test case. I tested it on the `melodic-devel` branch and the master's branch commit [95ab9e](https://github.com/ros-planning/moveit/commit/95ab9eef58b552fe366f0513487a6f6db5a3e71e), and the test passes with no problem. Then in the `master/noetic-devel` branch, it fails. 

Now, I want to ask, is there an efficient way to use this test case to pinpoint the offending commit?

The test case depends on the [dual arm demo](https://github.com/cambel/dual_arm_demo) environment proposed by @bi3ri. By the way, I think this dual-arm demo is simple enough that it would be a good addition to `moveit_resources`

