### PR TITLE
Fix bug in applying planning scene diffs that have attached collision objects

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -652,8 +652,8 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
   else
   {
     scene_msg.robot_state = moveit_msgs::RobotState();
-    scene_msg.robot_state.is_diff = true;
   }
+  scene_msg.robot_state.is_diff = true;
 
   if (acm_)
     acm_->getMessage(scene_msg.allowed_collision_matrix);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -711,6 +711,19 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
     if (do_omap)
       getOctomapMsg(scene_msg.world.octomap);
   }
+
+  // This fixes an issue where detaching an object from the robot state diff is causing it to stay as attached collision
+  // object once applied back to the main scene, to get around this issue we make sure to delete it from robot state
+  for (const auto& collision_object : scene_msg.world.collision_objects)
+  {
+    if (parent_->getCurrentState().hasAttachedBody(collision_object.id))
+    {
+      moveit_msgs::AttachedCollisionObject aco;
+      aco.object.id = collision_object.id;
+      aco.object.operation = moveit_msgs::CollisionObject::REMOVE;
+      scene_msg.robot_state.attached_collision_objects.push_back(aco);
+    }
+  }
 }
 
 namespace

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -715,7 +715,7 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
   // Ensure any detached collision objects get detached from the parent planning scene, too
   for (const auto& collision_object : scene_msg.world.collision_objects)
   {
-    if (parent_->getCurrentState().hasAttachedBody(collision_object.id))
+    if (parent_ && parent_->getCurrentState().hasAttachedBody(collision_object.id))
     {
       moveit_msgs::AttachedCollisionObject aco;
       aco.object.id = collision_object.id;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -712,8 +712,7 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
       getOctomapMsg(scene_msg.world.octomap);
   }
 
-  // This fixes an issue where detaching an object from the robot state diff is causing it to stay as attached collision
-  // object once applied back to the main scene, to get around this issue we make sure to delete it from robot state
+  // Ensure any detached collision objects get detached from the parent planning scene, too
   for (const auto& collision_object : scene_msg.world.collision_objects)
   {
     if (parent_->getCurrentState().hasAttachedBody(collision_object.id))

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -450,7 +450,7 @@ TEST(PlanningScene, RobotStateDiffBug)
     EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
   }
 
-  // Test that trigger the bug related to removing an object from when having a robot state as diff
+  // Test that triggered a bug related to removing an object when having a robot state diff
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::REMOVE, true);
     ps->usePlanningSceneMsg(ps1);

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -438,7 +438,7 @@ TEST(PlanningScene, RobotStateDiffBug)
   // Attached collision objects case
   ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
 
-  // Test that trigger the bug related to having two diffs that adds two different objects
+  // Test that triggered a bug related to having two diffs that add two different objects
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::CollisionObject::ADD, true);
     const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::ADD, true);

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -345,6 +345,129 @@ TEST_P(CollisionDetectorTests, ClearDiff)
   parent.reset();
 }
 
+// Returns a planning scene diff message
+moveit_msgs::PlanningScene create_planning_scene_diff(planning_scene::PlanningScene& ps, const std::string& object_name,
+                                                      const int8_t operation, const bool attach_object = false,
+                                                      const bool create_object = true)
+{
+  // Helper function to create an object for RobotStateDiffBug
+  auto add_object = [](const std::string& object_name, const int8_t operation) {
+    moveit_msgs::CollisionObject co;
+    co.header.frame_id = "panda_link0";
+    co.id = object_name;
+    co.operation = operation;
+    co.primitives.push_back([] {
+      shape_msgs::SolidPrimitive primitive;
+      primitive.type = shape_msgs::SolidPrimitive::SPHERE;
+      primitive.dimensions.push_back(1.0);
+      return primitive;
+    }());
+    co.primitive_poses.push_back([] {
+      geometry_msgs::Pose pose;
+      pose.orientation.w = 1.0;
+      return pose;
+    }());
+    co.pose = co.primitive_poses[0];
+    return co;
+  };
+  // Helper function to create an attached object for RobotStateDiffBug
+  auto add_attached_object = [](const std::string& object_name, const int8_t operation) {
+    moveit_msgs::AttachedCollisionObject aco;
+    aco.object.operation = operation;
+    aco.object.id = object_name;
+    aco.link_name = "panda_link0";
+    return aco;
+  };
+
+  auto new_ps = ps.diff();
+  if (operation == moveit_msgs::CollisionObject::REMOVE ||
+      (operation == moveit_msgs::CollisionObject::ADD && create_object))
+    new_ps->processCollisionObjectMsg(add_object(object_name, operation));
+  if (attach_object)
+    new_ps->processAttachedCollisionObjectMsg(add_attached_object(object_name, operation));
+  moveit_msgs::PlanningScene scene_msg;
+  new_ps->getPlanningSceneDiffMsg(scene_msg);
+  return scene_msg;
+}
+
+// Returns collision objects names sorted alphabetically
+std::set<std::string> get_collision_objects_names(const planning_scene::PlanningScene& ps)
+{
+  std::vector<moveit_msgs::CollisionObject> collision_objects;
+  ps.getCollisionObjectMsgs(collision_objects);
+  std::set<std::string> collision_objects_names;
+  for (const auto& collision_object : collision_objects)
+    collision_objects_names.emplace(collision_object.id);
+  return collision_objects_names;
+}
+
+// Returns attached collision objects names sorted alphabetically
+std::set<std::string> get_attached_collision_objects_names(const planning_scene::PlanningScene& ps)
+{
+  std::vector<moveit_msgs::AttachedCollisionObject> collision_objects;
+  ps.getAttachedCollisionObjectMsgs(collision_objects);
+  std::set<std::string> collision_objects_names;
+  for (const auto& collision_object : collision_objects)
+    collision_objects_names.emplace(collision_object.object.id);
+  return collision_objects_names;
+}
+
+TEST(PlanningScene, RobotStateDiffBug)
+{
+  auto urdf_model = moveit::core::loadModelInterface("panda");
+  auto srdf_model = std::make_shared<srdf::Model>();
+  auto ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
+
+  // It works as expected for collision objects case
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::CollisionObject::ADD);
+    const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::ADD);
+
+    ps->usePlanningSceneMsg(ps2);
+    ps->usePlanningSceneMsg(ps1);
+    EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::REMOVE);
+
+    ps->usePlanningSceneMsg(ps1);
+    EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
+  }
+
+  // Attached collision objects case
+  ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
+
+  // Test that trigger the bug related to having two diffs that adds two different objects
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::CollisionObject::ADD, true);
+    const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::ADD, true);
+
+    ps->usePlanningSceneMsg(ps1);
+    ps->usePlanningSceneMsg(ps2);
+    EXPECT_TRUE(get_collision_objects_names(*ps).empty());
+    // Should print object1 and object2 -- it prints object2 only (or object1 depending on the order of operation)
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+
+  // Test that trigger the bug related to removing an object from when having a robot state as diff
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::REMOVE, true);
+    ps->usePlanningSceneMsg(ps1);
+
+    EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object2" }));
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
+  }
+
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::CollisionObject::ADD, true, false);
+    ps->usePlanningSceneMsg(ps1);
+
+    EXPECT_TRUE(get_collision_objects_names(*ps).empty());
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+}
+
 #ifndef INSTANTIATE_TEST_SUITE_P  // prior to gtest 1.10
 #define INSTANTIATE_TEST_SUITE_P(...) INSTANTIATE_TEST_CASE_P(__VA_ARGS__)
 #endif


### PR DESCRIPTION
### Description

This fixes a bug we had while executing an MTC task where having two different planning scenes diffs that add a collision object to the scene, the first commit is just a test that trigger the bug, the second commit sets `robot_state.is_diff` to true when calling `getPlanningSceneDiffMsg` which prevent [conversions.cpp#L369-L372](https://github.com/ros-planning/moveit/blob/master/moveit_core/robot_state/src/conversions.cpp#L369-L372) from deleting the aco from the robot state when applying the diffs, but now when calling [PlanningScene::setCurrentState](https://github.com/ros-planning/moveit/blob/master/moveit_core/planning_scene/src/planning_scene.cpp#L1146) while detaching an object that object is staying in the scene so the last commit fixes it by explicitly removing the aco in the case of scene diff

This work is sponsored by RE2 Robotics
