### PR TITLE
CI failure for master-ci due to broken vcs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall
-      TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#master
+      TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#heads/master
       DOWNSTREAM_WORKSPACE: .github/workflows/downstream.rosinstall
       # Fix for https://github.blog/2022-04-12-git-security-vulnerability-announced
       GIT_CEILING_DIRECTORIES: ${{ github.workspace }}/.work

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
       UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall
       TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#master
       DOWNSTREAM_WORKSPACE: .github/workflows/downstream.rosinstall
+      # Fix for https://github.blog/2022-04-12-git-security-vulnerability-announced
+      GIT_CEILING_DIRECTORIES: ${{ github.workspace }}/.work
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src

--- a/.github/workflows/downstream.rosinstall
+++ b/.github/workflows/downstream.rosinstall
@@ -1,16 +1,16 @@
 - git:
     local-name: rviz_visual_tools
     uri: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: master
+    version: heads/master
 - git:
     local-name: moveit_visual_tools
     uri: https://github.com/ros-planning/moveit_visual_tools.git
-    version: master
+    version: heads/master
 - git:
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
-    version: master
+    version: heads/master
 - git:
     local-name: panda_moveit_config
     uri: https://github.com/ros-planning/panda_moveit_config.git
-    version: melodic-devel
+    version: heads/melodic-devel

--- a/.github/workflows/upstream.rosinstall
+++ b/.github/workflows/upstream.rosinstall
@@ -1,12 +1,12 @@
 - git:
     local-name: moveit_msgs
     uri: https://github.com/ros-planning/moveit_msgs.git
-    version: master
+    version: heads/master
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
-    version: noetic-devel
+    version: heads/noetic-devel
 - git:
     local-name: srdfdom
     uri: https://github.com/ros-planning/srdfdom
-    version: noetic-devel
+    version: heads/noetic-devel


### PR DESCRIPTION
MoveIt GHA are broken for master-ci (running ROS Melodic), because `vcs` fails while importing the upstream workspace:
```
  === /home/runner/work/moveit/moveit/.work/upstream_ws/src/geometric_shapes (git) ===
  Could not determine ref type of version: 
  === /home/runner/work/moveit/moveit/.work/upstream_ws/src/moveit_msgs (git) ===
  Could not determine ref type of version: 
  === /home/runner/work/moveit/moveit/.work/upstream_ws/src/srdfdom (git) ===
  Could not determine ref type of version: 
```
The `--debug` output of `vcs` isn't very helpful either.
Performing exactly the same actions locally in the very same docker container (i.e. installing vcstool and importing), yields no problems! Any hints are very welcome, @dirk-thomas, @tylerjw.