### PR TITLE
Fix namespace of planning plugin for benchmarks examples

### DIFF
--- a/moveit_ros/benchmarks/examples/demo_panda.launch
+++ b/moveit_ros/benchmarks/examples/demo_panda.launch
@@ -8,7 +8,7 @@
   </include>
 
   <!-- Load all planning pipelines that will be benchmarked -->
-  <include ns="moveit_run_benchmark/ompl" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
+  <include ns="moveit_run_benchmark" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
     <arg name="pipeline" value="ompl" />
   </include>
 


### PR DESCRIPTION
Since #2888 / https://github.com/ros-planning/moveit_resources/pull/92 `planning_pipeline.launch.xml` loads into `pipeline` namespace by default, thus making an explicit specification of `ompl` redundant.

Fixes https://github.com/ros-planning/moveit/issues/3037.