### PR TITLE
Improve handling of empty octomap messages and "clear octomap" actions

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1288,8 +1288,9 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& sc
   for (const moveit_msgs::CollisionObject& collision_object : scene_msg.world.collision_objects)
     result &= processCollisionObjectMsg(collision_object);
 
-  // process octomap updates
-  processOctomapMsg(scene_msg.world.octomap);
+  // if an octomap was specified, replace the one we have with that one
+  if (!scene_msg.world.octomap.octomap.data.empty())
+    processOctomapMsg(scene_msg.world.octomap);
 
   return result;
 }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -842,6 +842,12 @@ bool PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const
     ROS_ERROR_NAMED(LOGNAME, "Unexpected number of shapes in octomap collision object. Not including '%s' object",
                     OCTOMAP_NS.c_str());
   }
+  else
+  {
+    // indicate empty octomap, which is different from a not set octomap field
+    octomap.octomap.id = "empty";
+    return true;
+  }
   return false;
 }
 
@@ -1289,7 +1295,7 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& sc
     result &= processCollisionObjectMsg(collision_object);
 
   // if an octomap was specified, replace the one we have with that one
-  if (!scene_msg.world.octomap.octomap.data.empty())
+  if (!scene_msg.world.octomap.octomap.id.empty())
     processOctomapMsg(scene_msg.world.octomap);
 
   return result;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -684,7 +684,12 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
     for (const std::pair<const std::string, collision_detection::World::Action>& it : *world_diff_)
     {
       if (it.first == OCTOMAP_NS)
-        do_omap = true;
+      {
+        if (it.second == collision_detection::World::DESTROY)
+          scene_msg.world.octomap.octomap.id = "cleared";  // indicate cleared octomap
+        else
+          do_omap = true;
+      }
       else if (it.second == collision_detection::World::DESTROY)
       {
         // if object became attached, it should not be recorded as removed here
@@ -841,12 +846,6 @@ bool PlanningScene::getOctomapMsg(octomap_msgs::OctomapWithPose& octomap) const
     }
     ROS_ERROR_NAMED(LOGNAME, "Unexpected number of shapes in octomap collision object. Not including '%s' object",
                     OCTOMAP_NS.c_str());
-  }
-  else
-  {
-    // indicate empty octomap, which is different from a not set octomap field
-    octomap.octomap.id = "empty";
-    return true;
   }
   return false;
 }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1288,9 +1288,8 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& sc
   for (const moveit_msgs::CollisionObject& collision_object : scene_msg.world.collision_objects)
     result &= processCollisionObjectMsg(collision_object);
 
-  // if an octomap was specified, replace the one we have with that one
-  if (!scene_msg.world.octomap.octomap.data.empty())
-    processOctomapMsg(scene_msg.world.octomap);
+  // process octomap updates
+  processOctomapMsg(scene_msg.world.octomap);
 
   return result;
 }


### PR DESCRIPTION
### Description

Currently, if a `PlanningScene` message is published on the `monitoried_planning_scene` topic with an empty `msg.world.octomap.octomap.data` field, the octomap is skipped altogether in if it is a `msg.is_diff` is True ([source](https://github.com/ros-planning/moveit/blob/master/moveit_core/planning_scene/src/planning_scene.cpp#L1292)). I think perhaps an empty `data` field is interpreted as the octomap field not being filled. But this makes it impossible to clear the octomap by sending an empty octomap message (for example via the "Clear octomap" button in the MotionPlanning panel in RViz).

This PR sets `octomap.id` to `"empty"` if the octomap is empty (this string can be anything except an empty string), and checks `octomap.id.empty()` instead of `octomap.data.empty()` to see if the octomap should be processed.

Fixes #3045.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
