### PR TITLE
CI: Restore original version names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall
-      TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#heads/master
+      TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#master
       DOWNSTREAM_WORKSPACE: .github/workflows/downstream.rosinstall
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src

--- a/.github/workflows/downstream.rosinstall
+++ b/.github/workflows/downstream.rosinstall
@@ -1,16 +1,16 @@
 - git:
     local-name: rviz_visual_tools
     uri: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: heads/master
+    version: master
 - git:
     local-name: moveit_visual_tools
     uri: https://github.com/ros-planning/moveit_visual_tools.git
-    version: heads/master
+    version: master
 - git:
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
-    version: heads/master
+    version: master
 - git:
     local-name: panda_moveit_config
     uri: https://github.com/ros-planning/panda_moveit_config.git
-    version: heads/melodic-devel
+    version: melodic-devel

--- a/.github/workflows/upstream.rosinstall
+++ b/.github/workflows/upstream.rosinstall
@@ -1,12 +1,12 @@
 - git:
     local-name: moveit_msgs
     uri: https://github.com/ros-planning/moveit_msgs.git
-    version: heads/master
+    version: master
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
-    version: heads/noetic-devel
+    version: noetic-devel
 - git:
     local-name: srdfdom
     uri: https://github.com/ros-planning/srdfdom
-    version: heads/noetic-devel
+    version: noetic-devel


### PR DESCRIPTION
Partially reverts #3126. It suffices to define git's `safe.directory`. See https://github.com/ros-planning/moveit/pull/3126#issuecomment-1126183675
