### PR TITLE
move_group can optionally monitor dynamics

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -303,6 +303,11 @@ int main(int argc, char** argv)
 
     move_group::MoveGroupExe mge(moveit_cpp, default_planning_pipeline, debug);
 
+    if (pnh.param<bool>("monitor_dynamics", false))
+    {
+      ROS_INFO_NAMED(LOGNAME, "MoveGroup monitors robot dynamics (higher load)");
+      planning_scene_monitor->getStateMonitor()->enableCopyDynamics(true);
+    }
     planning_scene_monitor->publishDebugInformation(debug);
 
     mge.status();

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -48,6 +48,8 @@
 static const std::string ROBOT_DESCRIPTION =
     "robot_description";  // name of the robot description (a param name, so it can be changed externally)
 
+constexpr char LOGNAME[] = "move_group";
+
 namespace move_group
 {
 // These capabilities are loaded unless listed in disable_capabilities
@@ -106,7 +108,7 @@ public:
       }
     }
     else
-      ROS_ERROR("No MoveGroup context created. Nothing will work.");
+      ROS_ERROR_NAMED(LOGNAME, "No MoveGroup context created. Nothing will work.");
   }
 
 private:
@@ -119,7 +121,8 @@ private:
     }
     catch (pluginlib::PluginlibException& ex)
     {
-      ROS_FATAL_STREAM("Exception while creating plugin loader for move_group capabilities: " << ex.what());
+      ROS_FATAL_STREAM_NAMED(LOGNAME,
+                             "Exception while creating plugin loader for move_group capabilities: " << ex.what());
       return;
     }
 
@@ -173,7 +176,8 @@ private:
       }
       catch (pluginlib::PluginlibException& ex)
       {
-        ROS_ERROR_STREAM("Exception while loading move_group capability '" << capability << "': " << ex.what());
+        ROS_ERROR_STREAM_NAMED(LOGNAME,
+                               "Exception while loading move_group capability '" << capability << "': " << ex.what());
       }
     }
 
@@ -185,7 +189,7 @@ private:
     for (const MoveGroupCapabilityPtr& cap : capabilities_)
       ss << "*     - " << cap->getName() << std::endl;
     ss << "********************************************************" << std::endl;
-    ROS_INFO_STREAM(ss.str());
+    ROS_INFO_STREAM_NAMED(LOGNAME, ss.str());
   }
 
   ros::NodeHandle node_handle_;
@@ -213,8 +217,8 @@ int main(int argc, char** argv)
   {
     if (planning_pipeline_configs.getType() != XmlRpc::XmlRpcValue::TypeStruct)
     {
-      ROS_ERROR_STREAM("Parameter '" << moveit_cpp_options.planning_pipeline_options.parent_namespace
-                                     << "' is expected to be a dictionary of pipeline configurations.");
+      ROS_ERROR_STREAM_NAMED(LOGNAME, "Parameter '" << moveit_cpp_options.planning_pipeline_options.parent_namespace
+                                                    << "' is expected to be a dictionary of pipeline configurations.");
     }
     else
     {
@@ -225,15 +229,15 @@ int main(int argc, char** argv)
                          [](std::pair<const std::string, XmlRpc::XmlRpcValue>& item) {
                            return item.first == "planning_plugin";
                          }) == config.second.end())
-          ROS_ERROR_STREAM("Planning pipeline parameter '~planning_pipelines/" << config.first
-                                                                               << "/planning_plugin' doesn't exist");
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Planning pipeline parameter '~planning_pipelines/"
+                                              << config.first << "/planning_plugin' doesn't exist");
         else
           moveit_cpp_options.planning_pipeline_options.pipeline_names.push_back(config.first);
       }
       if (planning_pipeline_configs.size() && moveit_cpp_options.planning_pipeline_options.pipeline_names.empty())
-        ROS_WARN_STREAM("No valid planning pipelines found in "
-                        << moveit_cpp_options.planning_pipeline_options.parent_namespace
-                        << ". Did you use a namespace, e.g. planning_pipelines/ompl/ ?");
+        ROS_WARN_STREAM_NAMED(LOGNAME, "No valid planning pipelines found in "
+                                           << moveit_cpp_options.planning_pipeline_options.parent_namespace
+                                           << ". Did you use a namespace, e.g. planning_pipelines/ompl/ ?");
     }
   }
 
@@ -245,16 +249,18 @@ int main(int argc, char** argv)
     // Ignore default_planning_pipeline if there is no matching entry in pipeline_names
     if (std::find(pipeline_names.begin(), pipeline_names.end(), default_planning_pipeline) == pipeline_names.end())
     {
-      ROS_WARN("MoveGroup launched with ~default_planning_pipeline '%s' not configured in ~planning_pipelines",
-               default_planning_pipeline.c_str());
+      ROS_WARN_NAMED(LOGNAME,
+                     "MoveGroup launched with ~default_planning_pipeline '%s' not configured in ~planning_pipelines",
+                     default_planning_pipeline.c_str());
       default_planning_pipeline = "";  // reset invalid pipeline id
     }
   }
   else if (pipeline_names.size() > 1)  // only warn if there are multiple pipelines to choose from
   {
     // Handle deprecated move_group.launch
-    ROS_WARN("MoveGroup launched without ~default_planning_pipeline specifying the namespace for the default "
-             "planning pipeline configuration");
+    ROS_WARN_NAMED(LOGNAME,
+                   "MoveGroup launched without ~default_planning_pipeline specifying the namespace for the default "
+                   "planning pipeline configuration");
   }
 
   // If there is no valid default pipeline, either pick the first available one, or fall back to old behavior
@@ -262,12 +268,12 @@ int main(int argc, char** argv)
   {
     if (!pipeline_names.empty())
     {
-      ROS_WARN("Using default pipeline '%s'", pipeline_names[0].c_str());
+      ROS_WARN_NAMED(LOGNAME, "Using default pipeline '%s'", pipeline_names[0].c_str());
       default_planning_pipeline = pipeline_names[0];
     }
     else
     {
-      ROS_WARN("Falling back to using the move_group node's namespace (deprecated Melodic behavior).");
+      ROS_WARN_NAMED(LOGNAME, "Falling back to using the move_group node's namespace (deprecated Melodic behavior).");
       moveit_cpp_options.planning_pipeline_options.pipeline_names = { default_planning_pipeline };
       moveit_cpp_options.planning_pipeline_options.parent_namespace = pnh.getNamespace();
     }
@@ -291,9 +297,9 @@ int main(int argc, char** argv)
         break;
       }
     if (debug)
-      ROS_INFO("MoveGroup debug mode is ON");
+      ROS_INFO_NAMED(LOGNAME, "MoveGroup debug mode is ON");
     else
-      ROS_INFO("MoveGroup debug mode is OFF");
+      ROS_INFO_NAMED(LOGNAME, "MoveGroup debug mode is OFF");
 
     move_group::MoveGroupExe mge(moveit_cpp, default_planning_pipeline, debug);
 
@@ -304,7 +310,7 @@ int main(int argc, char** argv)
     ros::waitForShutdown();
   }
   else
-    ROS_ERROR("Planning scene not configured");
+    ROS_ERROR_NAMED(LOGNAME, "Planning scene not configured");
 
   return 0;
 }

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -91,6 +91,10 @@
     <param name="capabilities" value="$(arg capabilities)" />
     <param name="disable_capabilities" value="$(arg disable_capabilities)" />
 
+    <!-- do not copy dynamics information from /joint_states to internal robot monitoring
+         default to false, because almost nothing in move_group relies on this information -->
+    <param name="monitor_dynamics" value="false" />
+
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
     <param name="planning_scene_monitor/publish_planning_scene" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_geometry_updates" value="$(arg publish_monitored_planning_scene)" />


### PR DESCRIPTION
I noticed this was disabled when using the `TrajectoryMonitor` feature of the `MoveGroup` action which returns the actually executed trajectory.
With the additional flag the recorded trajectory would not include velocities because they were not copied internally.