### PR TITLE
WIP: Simultaneous Trajectory Execution #3156

### DIFF
--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -231,6 +231,8 @@ void RobotTrajectory::getRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajec
 
   std::vector<const moveit::core::JointModel*> onedof;
   std::vector<const moveit::core::JointModel*> mdof;
+
+  trajectory.group_name = group_ ? group_->getName() : "";
   trajectory.joint_trajectory.joint_names.clear();
   trajectory.multi_dof_joint_trajectory.joint_names.clear();
 

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -82,7 +82,7 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
 
   // TODO(henningkayser): configure trajectory execution manager
   trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-      robot_model_, planning_scene_monitor_->getStateMonitor());
+      robot_model_, planning_scene_monitor_);
 
   ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -274,7 +274,7 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }
-  trajectory_execution_manager_->pushAndExecuteSimultaneous(robot_trajectory_msg);
+  trajectory_execution_manager_->pushAndExecuteSimultaneously(robot_trajectory_msg);
   return true;
 }
 

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -81,8 +81,8 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
   }
 
   // TODO(henningkayser): configure trajectory execution manager
-  trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-      robot_model_, planning_scene_monitor_);
+  trajectory_execution_manager_ =
+      std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(robot_model_, planning_scene_monitor_);
 
   ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }
@@ -274,7 +274,6 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }
-  // TODO: Does this point to the same instance? Multiple TEMs may not be safe to execute. @henningkayser?
   trajectory_execution_manager_->pushAndExecuteSimultaneous(robot_trajectory_msg);
   return true;
 }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -274,7 +274,8 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }
-  trajectory_execution_manager_->pushAndExecute(robot_trajectory_msg);
+  // TODO: Does this point to the same instance? Multiple TEMs may not be safe to execute. @henningkayser?
+  trajectory_execution_manager_->pushAndExecuteSimultaneous(robot_trajectory_msg);
   return true;
 }
 

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -38,6 +38,7 @@
   <build_depend>eigen</build_depend>
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
+  <test_depend>moveit_resources_dual_panda_moveit_config</test_depend>
   <test_depend>rostest</test_depend>
 
   <!-- we moved moveit_cpp from planning_interface in this version,

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -79,7 +79,7 @@ plan_execution::PlanExecution::PlanExecution(
 {
   if (!trajectory_execution_manager_)
     trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_->getStateMonitor());
+        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_);
 
   default_max_replan_attempts_ = 5;
 

--- a/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
+++ b/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
@@ -12,6 +12,14 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+    find_package(moveit_resources_dual_panda_moveit_config REQUIRED)
+    find_package(rostest REQUIRED)
+
+    add_rostest_gtest(test_simultaneous_execution_manager
+                      test/test_simultaneous_execution_manager.test
+                      test/test_simultaneous_execution_manager.cpp)
+    target_link_libraries(test_simultaneous_execution_manager moveit_cpp ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
+
 
 ## This needs further cleanup before it can run
 # add_library(test_controller_manager_plugin test/test_moveit_controller_manager_plugin.cpp)

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,6 +9,6 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
-gen.add("continuous_execution_thread_rate", int_t, 7, "Rate at which new/pending trajectories are processed on the continuous execution threat.", 10, 1, 1000)
+gen.add("continuous_execution_thread_rate", int_t, 7, "Rate at which new/pending trajectories are processed on the continuous execution thread.", 10, 1, 1000)
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,5 +9,6 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
+gen.add("continuous_execution_thread_rate", int_t, 7, "Rate at which new/pending trajectories are processed on the continuous execution threat.", 10, 1, 1000)
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -41,6 +41,7 @@
 #include <moveit/robot_model/link_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/attached_body.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit_msgs/CollisionObject.h>
@@ -91,11 +92,12 @@ public:
 
   /// Load the controller manager plugin, start listening for events on a topic.
   TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm);
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
+  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model, 
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
+                             bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)
   ~TrajectoryExecutionManager();
@@ -339,8 +341,8 @@ private:
   const std::string LOGNAME = "trajectory_execution_manager";
 
   moveit::core::RobotModelConstPtr robot_model_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
-  planning_scene::PlanningScene planning_scene_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;
   ros::Subscriber event_topic_subscriber_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -253,6 +253,9 @@ public:
   /// Enable or disable waiting for trajectory completion
   void setWaitForTrajectoryCompletion(bool flag);
 
+  /// Rate at which new/pending trajectories are processed on the continuous execution threat
+  void setcontinuousExecutionThreadRate(int rate);
+
 private:
   struct ControllerInformation
   {
@@ -374,6 +377,7 @@ private:
 
   bool stop_continuous_execution_;
   bool run_continuous_execution_thread_;
+  int continuous_execution_thread_rate_;
   std::vector<TrajectoryExecutionContext*> trajectories_;
   std::deque<TrajectoryExecutionContext*> continuous_execution_queue_;
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -168,7 +168,7 @@ public:
   bool push(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
 
   /// Get the trajectories to be executed
-  const std::vector<TrajectoryExecutionContext*>& getTrajectories() const;
+  const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& getTrajectories() const;
 
   /// Start the execution of pushed trajectories; this does not wait for completion, but calls a callback when done.
   void execute(const ExecutionCompleteCallback& callback = ExecutionCompleteCallback(), bool auto_clear = true);
@@ -346,8 +346,8 @@ private:
   // Removes controllers/handles and trajectory contexts that have finished or aborted execution
   void updateActiveHandlesAndContexts(
       std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
-      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>&
-          active_contexts_map);
+      std::map<std::shared_ptr<TrajectoryExecutionContext>,
+               std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
 
   bool checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory,
                                          const moveit_msgs::RobotTrajectory& active_trajectory);
@@ -355,13 +355,13 @@ private:
   // Check for collisions/controller issues, then send the trajectory for execution
   bool validateAndExecuteContext(
       TrajectoryExecutionContext& context, std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
-      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>&
-          active_contexts_map);
+      std::map<std::shared_ptr<TrajectoryExecutionContext>,
+               std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
 
   bool checkContextForCollisions(
       TrajectoryExecutionContext& context,
-      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>&
-          active_contexts_map);
+      std::map<std::shared_ptr<TrajectoryExecutionContext>,
+               std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
 
   void getContextHandles(TrajectoryExecutionContext& context,
                          std::vector<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
@@ -415,8 +415,8 @@ private:
   bool stop_continuous_execution_;
   bool run_continuous_execution_thread_;
   int continuous_execution_thread_rate_;
-  std::vector<TrajectoryExecutionContext*> trajectories_;
-  std::deque<TrajectoryExecutionContext*> continuous_execution_queue_;
+  std::vector<std::shared_ptr<TrajectoryExecutionContext>> trajectories_;
+  std::deque<std::shared_ptr<TrajectoryExecutionContext>> continuous_execution_queue_;
 
   std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager>> controller_manager_loader_;
   moveit_controller_manager::MoveItControllerManagerPtr controller_manager_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -186,26 +186,26 @@ public:
   /// controller is specified, a default is used. This call is non-blocking.
   /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
   /// Optionally specify callback that is called when the execution of the trajectory is completed.
-  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "",
-                                  const int& expiration_time = 60,
-                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneously(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "",
+                                    const int& expiration_time = 60,
+                                    const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
   /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
   /// Optionally specify callback that is called when the execution of the trajectory is completed.
-  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
-                                  const std::string& controller = "", const int& expiration_time = 60,
-                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneously(const trajectory_msgs::JointTrajectory& trajectory,
+                                    const std::string& controller = "", const int& expiration_time = 60,
+                                    const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a controller to use
   /// for the trajectory.
   /// If no controller is specified, a default is used. This call is non-blocking.
   /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
   /// Optionally specify callback that is called when the execution of the trajectory is completed.
-  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::string& controller = "",
-                                  const int& expiration_time = 60,
-                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneously(const sensor_msgs::JointState& state, const std::string& controller = "",
+                                    const int& expiration_time = 60,
+                                    const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
@@ -214,9 +214,9 @@ public:
   /// If no controller is specified, a default is used. This call is non-blocking.
   /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
   /// Optionally specify callback that is called when the execution of the trajectory is completed.
-  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
-                                  const std::vector<std::string>& controllers, const int& expiration_time = 60,
-                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneously(const trajectory_msgs::JointTrajectory& trajectory,
+                                    const std::vector<std::string>& controllers, const int& expiration_time = 60,
+                                    const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
@@ -225,9 +225,9 @@ public:
   /// If no controller is specified, a default is used. This call is non-blocking.
   /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
   /// Optionally specify callback that is called when the execution of the trajectory is completed.
-  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
-                                  const std::vector<std::string>& controllers, const int& expiration_time = 60,
-                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneously(const moveit_msgs::RobotTrajectory& trajectory,
+                                    const std::vector<std::string>& controllers, const int& expiration_time = 60,
+                                    const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a set of controllers
   /// to consider using for the trajectory.
@@ -236,19 +236,19 @@ public:
   /// is given to the already loaded ones. If no controller is specified, a default is used. This call is non-blocking.
   /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
   /// Optionally specify callback that is called when the execution of the trajectory is completed.
-  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers,
-                                  const int& expiration_time = 60,
-                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneously(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers,
+                                    const int& expiration_time = 60,
+                                    const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
-  /// pushAndExecuteSimultaneous(), it will immediately stop execution.
+  /// pushAndExecuteSimultaneously(), it will immediately stop execution.
   moveit_controller_manager::ExecutionStatus waitForExecution();
 
   /// Get the state that the robot is expected to be at, given current time, after execute() has been called. The return
   /// value is a pair of two index values:
   /// first = the index of the trajectory to be executed (in the order pushToBlockingQueue() was called), second = the
   /// index of the point within that trajectory. Values of -1 are returned when there is no trajectory being executed,
-  /// or if the trajectory was passed using pushAndExecuteSimultaneous().
+  /// or if the trajectory was passed using pushAndExecuteSimultaneously().
   std::pair<int, int> getCurrentExpectedTrajectoryIndex() const;
 
   /// Return the controller status for the last attempted execution
@@ -282,8 +282,8 @@ public:
   /// Enable or disable waiting for trajectory completion
   void setWaitForTrajectoryCompletion(bool flag);
 
-  /// Rate at which new/pending trajectories are processed on the continuous execution threat
-  void setcontinuousExecutionThreadRate(int rate);
+  /// Rate at which new/pending trajectories are processed on the continuous execution thread
+  void setContinuousExecutionThreadRate(int rate);
 
 private:
   struct ControllerInformation
@@ -393,7 +393,7 @@ private:
   // TrajectoryContext at a time.
   std::unique_ptr<boost::thread> blocking_execution_thread_;
 
-  // Thread used to execute trajectories using pushAndExecuteSimultaneous(). This executes multiple TrajectoryContexts at the same time.
+  // Thread used to execute trajectories using pushAndExecuteSimultaneously(). This executes multiple TrajectoryContexts at the same time.
   std::unique_ptr<boost::thread> continuous_execution_thread_;
 
   boost::mutex execution_state_mutex_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -351,14 +351,14 @@ private:
                                          const moveit_msgs::RobotTrajectory& active_trajectory);
 
   // Check for collisions/controller issues, then send the trajectory for execution
-  bool validateAndExecuteContext(TrajectoryExecutionContext& context,
+  bool validateAndExecuteContext(const TrajectoryExecutionContext& context,
                                  std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
                                  std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
 
-  bool checkContextForCollisions(TrajectoryExecutionContext& context,
-                                 std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
+  bool checkContextForCollisions(const TrajectoryExecutionContext& context,
+                                 const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
 
-  void getContextHandles(TrajectoryExecutionContext& context,
+  void getContextHandles(const TrajectoryExecutionContext& context,
                          std::set<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
 
   /**
@@ -367,9 +367,9 @@ private:
    * @param context2 The second trajectory context
    * @return true if there is any common controller handle, false otherwise
    */
-  bool hasCommonHandles(TrajectoryExecutionContext& context1, TrajectoryExecutionContext& context2);
+  bool hasCommonHandles(const TrajectoryExecutionContext& context1, const TrajectoryExecutionContext& context2);
 
-  bool checkCollisionsWithCurrentState(moveit_msgs::RobotTrajectory& trajectory);
+  bool checkCollisionsWithCurrentState(const moveit_msgs::RobotTrajectory& trajectory);
 
   // Name of this class for logging
   const std::string LOGNAME = "trajectory_execution_manager";

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -38,7 +38,12 @@
 
 #include <moveit/macros/class_forward.h>
 #include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_model/link_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_state/attached_body.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit_msgs/CollisionObject.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <sensor_msgs/JointState.h>
 #include <std_msgs/String.h>
@@ -78,6 +83,10 @@ public:
     // The trajectory to execute, split in different parts (by joints), each set of joints corresponding to one
     // controller
     std::vector<moveit_msgs::RobotTrajectory> trajectory_parts_;
+
+    moveit_msgs::RobotTrajectory trajectory_;
+
+    ExecutionCompleteCallback execution_complete_callback;
   };
 
   /// Load the controller manager plugin, start listening for events on a topic.
@@ -167,37 +176,37 @@ public:
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "");
+  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "", const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory, const std::string& controller = "");
+  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory, const std::string& controller = "", const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a controller to use
   /// for the trajectory.
   /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const sensor_msgs::JointState& state, const std::string& controller = "");
+  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::string& controller = "", const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<std::string>& controllers);
+  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
+  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a set of controllers
   /// to consider using for the trajectory.
   /// Multiple controllers can be used simultaneously to execute the different parts of the trajectory. If multiple
   /// controllers can be used, preference
   /// is given to the already loaded ones. If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers);
+  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
   /// pushAndExecute(), it will immediately stop execution.
@@ -300,8 +309,38 @@ private:
 
   void loadControllerParams();
 
+  // Removes controllers/handles and trajectory contexts that have finished or aborted execution
+  void updateActiveHandlesAndContexts(std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
+                                      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+
+  bool checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory, const moveit_msgs::RobotTrajectory& active_trajectory);
+
+  // Check for collisions/controller issues, then send the trajectory for execution
+  bool validateAndExecuteContext(TrajectoryExecutionContext& context, 
+                                std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
+                                std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+
+  bool checkContextForCollisions(TrajectoryExecutionContext& context,
+                                std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+
+  void getContextHandles(TrajectoryExecutionContext& context, std::vector<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
+
+  /**
+   * @brief Validate whether two trajectory context require a common controller handle
+   * @param context1 The first trajectory context
+   * @param context2 The second trajectory context
+   * @return true if there is any common controller handle, false otherwise
+  */
+  bool hasCommonHandles(TrajectoryExecutionContext& context1, TrajectoryExecutionContext& context2);
+
+  bool checkCollisionsWithCurrentState(moveit_msgs::RobotTrajectory& trajectory);
+
+  // Name of this class for logging
+  const std::string LOGNAME = "trajectory_execution_manager";
+
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
+  planning_scene::PlanningScene planning_scene_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;
   ros::Subscriber event_topic_subscriber_;
@@ -309,10 +348,10 @@ private:
   std::map<std::string, ControllerInformation> known_controllers_;
   bool manage_controllers_;
 
-  // thread used to execute trajectories using the execute() command
+  // Thread used to execute trajectories using the execute() command. This is blocking and executes only one TrajectoryContext at a time.
   std::unique_ptr<boost::thread> execution_thread_;
 
-  // thread used to execute trajectories using pushAndExecute()
+  // Thread used to execute trajectories using pushAndExecuteSimultaneous(). This executes multiple TrajectoryContexts at the same time.
   std::unique_ptr<boost::thread> continuous_execution_thread_;
 
   boost::mutex execution_state_mutex_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -344,27 +344,22 @@ private:
   void loadControllerParams();
 
   // Removes controllers/handles and trajectory contexts that have finished or aborted execution
-  void updateActiveHandlesAndContexts(
-      std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
-      std::map<std::shared_ptr<TrajectoryExecutionContext>,
-               std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+  void updateActiveHandlesAndContexts(std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
+                                      std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
 
   bool checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory,
                                          const moveit_msgs::RobotTrajectory& active_trajectory);
 
   // Check for collisions/controller issues, then send the trajectory for execution
-  bool validateAndExecuteContext(
-      TrajectoryExecutionContext& context, std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
-      std::map<std::shared_ptr<TrajectoryExecutionContext>,
-               std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+  bool validateAndExecuteContext(TrajectoryExecutionContext& context,
+                                 std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
+                                 std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
 
-  bool checkContextForCollisions(
-      TrajectoryExecutionContext& context,
-      std::map<std::shared_ptr<TrajectoryExecutionContext>,
-               std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+  bool checkContextForCollisions(TrajectoryExecutionContext& context,
+                                 std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
 
   void getContextHandles(TrajectoryExecutionContext& context,
-                         std::vector<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
+                         std::set<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
 
   /**
    * @brief Validate whether two trajectory context require a common controller handle

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -95,7 +95,7 @@ public:
                              const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   /// Load the controller manager plugin, start listening for events on a topic.
-  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model, 
+  TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
                              const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
                              bool manage_controllers);
 
@@ -178,37 +178,46 @@ public:
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "", const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "",
+                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory, const std::string& controller = "", const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
+                                  const std::string& controller = "",
+                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a controller to use
   /// for the trajectory.
   /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::string& controller = "", const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::string& controller = "",
+                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
+                                  const std::vector<std::string>& controllers,
+                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
   /// trajectory. Multiple controllers can be used simultaneously
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
+                                  const std::vector<std::string>& controllers,
+                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a set of controllers
   /// to consider using for the trajectory.
   /// Multiple controllers can be used simultaneously to execute the different parts of the trajectory. If multiple
   /// controllers can be used, preference
   /// is given to the already loaded ones. If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+  bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers,
+                                  const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
   /// pushAndExecuteSimultaneous(), it will immediately stop execution.
@@ -216,10 +225,9 @@ public:
 
   /// Get the state that the robot is expected to be at, given current time, after execute() has been called. The return
   /// value is a pair of two index values:
-  /// first = the index of the trajectory to be executed (in the order pushToBlockingQueue() was called), second = the index of the
-  /// point within that trajectory.
-  /// Values of -1 are returned when there is no trajectory being executed, or if the trajectory was passed using
-  /// pushAndExecuteSimultaneous().
+  /// first = the index of the trajectory to be executed (in the order pushToBlockingQueue() was called), second = the
+  /// index of the point within that trajectory. Values of -1 are returned when there is no trajectory being executed,
+  /// or if the trajectory was passed using pushAndExecuteSimultaneous().
   std::pair<int, int> getCurrentExpectedTrajectoryIndex() const;
 
   /// Return the controller status for the last attempted execution
@@ -296,7 +304,7 @@ private:
   void generateControllerCombination(std::size_t start_index, std::size_t controller_count,
                                      const std::vector<std::string>& available_controllers,
                                      std::vector<std::string>& selected_controllers,
-                                     std::vector<std::vector<std::string> >& selected_options,
+                                     std::vector<std::vector<std::string>>& selected_options,
                                      const std::set<std::string>& actuated_joints);
   bool selectControllers(const std::set<std::string>& actuated_joints,
                          const std::vector<std::string>& available_controllers,
@@ -315,27 +323,34 @@ private:
   void loadControllerParams();
 
   // Removes controllers/handles and trajectory contexts that have finished or aborted execution
-  void updateActiveHandlesAndContexts(std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
-                                      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+  void updateActiveHandlesAndContexts(
+      std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
+      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>&
+          active_contexts_map);
 
-  bool checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory, const moveit_msgs::RobotTrajectory& active_trajectory);
+  bool checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory,
+                                         const moveit_msgs::RobotTrajectory& active_trajectory);
 
   // Check for collisions/controller issues, then send the trajectory for execution
-  bool validateAndExecuteContext(TrajectoryExecutionContext& context, 
-                                std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles, 
-                                std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+  bool validateAndExecuteContext(
+      TrajectoryExecutionContext& context, std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
+      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>&
+          active_contexts_map);
 
-  bool checkContextForCollisions(TrajectoryExecutionContext& context,
-                                std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>& active_contexts_map);
+  bool checkContextForCollisions(
+      TrajectoryExecutionContext& context,
+      std::map<TrajectoryExecutionContext*, std::set<moveit_controller_manager::MoveItControllerHandlePtr>>&
+          active_contexts_map);
 
-  void getContextHandles(TrajectoryExecutionContext& context, std::vector<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
+  void getContextHandles(TrajectoryExecutionContext& context,
+                         std::vector<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
 
   /**
    * @brief Validate whether two trajectory context require a common controller handle
    * @param context1 The first trajectory context
    * @param context2 The second trajectory context
    * @return true if there is any common controller handle, false otherwise
-  */
+   */
   bool hasCommonHandles(TrajectoryExecutionContext& context1, TrajectoryExecutionContext& context2);
 
   bool checkCollisionsWithCurrentState(moveit_msgs::RobotTrajectory& trajectory);
@@ -353,7 +368,8 @@ private:
   std::map<std::string, ControllerInformation> known_controllers_;
   bool manage_controllers_;
 
-  // Thread used to execute trajectories using the execute() command. This is blocking and executes only one TrajectoryContext at a time.
+  // Thread used to execute trajectories using the execute() command. This is blocking and executes only one
+  // TrajectoryContext at a time.
   std::unique_ptr<boost::thread> blocking_execution_thread_;
 
   // Thread used to execute trajectories using pushAndExecuteSimultaneous(). This executes multiple TrajectoryContexts at the same time.
@@ -381,7 +397,7 @@ private:
   std::vector<TrajectoryExecutionContext*> trajectories_;
   std::deque<TrajectoryExecutionContext*> continuous_execution_queue_;
 
-  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager> > controller_manager_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager>> controller_manager_loader_;
   moveit_controller_manager::MoveItControllerManagerPtr controller_manager_;
 
   bool verbose_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -209,15 +209,15 @@ public:
   bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers, const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
-  /// pushAndExecute(), it will immediately stop execution.
+  /// pushAndExecuteSimultaneous(), it will immediately stop execution.
   moveit_controller_manager::ExecutionStatus waitForExecution();
 
   /// Get the state that the robot is expected to be at, given current time, after execute() has been called. The return
   /// value is a pair of two index values:
-  /// first = the index of the trajectory to be executed (in the order push() was called), second = the index of the
+  /// first = the index of the trajectory to be executed (in the order pushToBlockingQueue() was called), second = the index of the
   /// point within that trajectory.
   /// Values of -1 are returned when there is no trajectory being executed, or if the trajectory was passed using
-  /// pushAndExecute().
+  /// pushAndExecuteSimultaneous().
   std::pair<int, int> getCurrentExpectedTrajectoryIndex() const;
 
   /// Return the controller status for the last attempted execution
@@ -349,14 +349,14 @@ private:
   bool manage_controllers_;
 
   // Thread used to execute trajectories using the execute() command. This is blocking and executes only one TrajectoryContext at a time.
-  std::unique_ptr<boost::thread> execution_thread_;
+  std::unique_ptr<boost::thread> blocking_execution_thread_;
 
   // Thread used to execute trajectories using pushAndExecuteSimultaneous(). This executes multiple TrajectoryContexts at the same time.
   std::unique_ptr<boost::thread> continuous_execution_thread_;
 
   boost::mutex execution_state_mutex_;
-  boost::mutex continuous_execution_mutex_;
-  boost::mutex execution_thread_mutex_;
+  boost::mutex continuous_execution_thread_mutex_;
+  boost::mutex blocking_execution_thread_mutex_;
 
   boost::condition_variable continuous_execution_condition_;
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -85,9 +85,15 @@ public:
     // controller
     std::vector<moveit_msgs::RobotTrajectory> trajectory_parts_;
 
+    // The trajectory to execute, the whole trajectory, used for collision checking
     moveit_msgs::RobotTrajectory trajectory_;
 
+    // Callback to inform the outcome of trajectories sent for execution with the continuous execution thread
     ExecutionCompleteCallback execution_complete_callback;
+
+    // Time allowed for the processing of a new trajectory in the continuous execution thread (in seconds).
+    // Independent of the expected execution duration of the trajectory itself.
+    int expiration_time;
   };
 
   /// Load the controller manager plugin, start listening for events on a topic.
@@ -178,19 +184,27 @@ public:
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
+  /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
   bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "",
+                                  const int& expiration_time = 60,
                                   const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
   /// controller is specified, a default is used. This call is non-blocking.
+  /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
   bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
-                                  const std::string& controller = "",
+                                  const std::string& controller = "", const int& expiration_time = 60,
                                   const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a controller to use
   /// for the trajectory.
   /// If no controller is specified, a default is used. This call is non-blocking.
+  /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
   bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::string& controller = "",
+                                  const int& expiration_time = 60,
                                   const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
@@ -198,8 +212,10 @@ public:
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used. This call is non-blocking.
+  /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
   bool pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
-                                  const std::vector<std::string>& controllers,
+                                  const std::vector<std::string>& controllers, const int& expiration_time = 60,
                                   const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
@@ -207,8 +223,10 @@ public:
   /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
   /// already loaded ones.
   /// If no controller is specified, a default is used. This call is non-blocking.
+  /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
   bool pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
-                                  const std::vector<std::string>& controllers,
+                                  const std::vector<std::string>& controllers, const int& expiration_time = 60,
                                   const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a set of controllers
@@ -216,7 +234,10 @@ public:
   /// Multiple controllers can be used simultaneously to execute the different parts of the trajectory. If multiple
   /// controllers can be used, preference
   /// is given to the already loaded ones. If no controller is specified, a default is used. This call is non-blocking.
+  /// Optionally specify an expiration time for the trajectory, from reception to execution (default 60 secs).
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
   bool pushAndExecuteSimultaneous(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers,
+                                  const int& expiration_time = 60,
                                   const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
@@ -288,7 +309,7 @@ private:
   /// Validate first point of trajectory matches current robot state
   bool validate(const TrajectoryExecutionContext& context) const;
   bool configure(TrajectoryExecutionContext& context, const moveit_msgs::RobotTrajectory& trajectory,
-                 const std::vector<std::string>& controllers);
+                 const std::vector<std::string>& controllers, const int& expiration_time = 60);
 
   void updateControllersState(const ros::Duration& age);
   void updateControllerState(const std::string& controller, const ros::Duration& age);

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -112,7 +112,6 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(
 
 TrajectoryExecutionManager::~TrajectoryExecutionManager()
 {
-  run_continuous_execution_thread_ = false;
   stopExecution(true);
   delete reconfigure_impl_;
 }
@@ -1262,8 +1261,15 @@ void TrajectoryExecutionManager::stopExecutionInternal()
 
 void TrajectoryExecutionManager::stopExecution(bool auto_clear)
 {
+  // wait for the execution thread to finish
   stop_continuous_execution_ = true;
+  run_continuous_execution_thread_ = false;
   continuous_execution_condition_.notify_all();
+
+  if (continuous_execution_thread_)
+  {
+    continuous_execution_thread_->join();
+  }
 
   if (!execution_complete_)
   {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1957,6 +1957,9 @@ void TrajectoryExecutionManager::updateActiveHandlesAndContexts(
         context->execution_complete_callback(combined_status);
       it = active_contexts.erase(it);
 
+      // Remove controller handles from used_handles list
+      for (const auto& handle : context_handles)
+        used_handles.erase(handle);
     }
     else
     {
@@ -1964,17 +1967,6 @@ void TrajectoryExecutionManager::updateActiveHandlesAndContexts(
     }
   }
 
-  // Remove controller handles from list if they are not executing a trajectory
-  ROS_DEBUG_STREAM_NAMED(LOGNAME, "Cleaning used_handles");
-  for (std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin();
-       uit != used_handles.end();)
-    if ((*uit)->getLastExecutionStatus() != moveit_controller_manager::ExecutionStatus::RUNNING)
-    {
-      std::map<moveit_controller_manager::MoveItControllerHandlePtr, moveit_msgs::RobotTrajectory>::iterator it;
-      uit = used_handles.erase(uit);
-    }
-    else
-      ++uit;
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Done updateActiveHandlesAndContexts");
 }
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -77,7 +77,7 @@ private:
     owner_->setExecutionVelocityScaling(config.execution_velocity_scaling);
     owner_->setAllowedStartTolerance(config.allowed_start_tolerance);
     owner_->setWaitForTrajectoryCompletion(config.wait_for_trajectory_completion);
-    owner_->setcontinuousExecutionThreadRate(config.continuous_execution_thread_rate);
+    owner_->setContinuousExecutionThreadRate(config.continuous_execution_thread_rate);
   }
 
   TrajectoryExecutionManager* owner_;
@@ -225,7 +225,7 @@ void TrajectoryExecutionManager::setWaitForTrajectoryCompletion(bool flag)
   wait_for_trajectory_completion_ = flag;
 }
 
-void TrajectoryExecutionManager::setcontinuousExecutionThreadRate(int rate)
+void TrajectoryExecutionManager::setContinuousExecutionThreadRate(int rate)
 {
   continuous_execution_thread_rate_ = rate;
 }
@@ -284,7 +284,7 @@ bool TrajectoryExecutionManager::push(const moveit_msgs::RobotTrajectory& trajec
   if (!execution_complete_)
   {
     ROS_ERROR_NAMED(LOGNAME, "Cannot push a new trajectory in blocking mode while another is being executed (use "
-                             "pushAndExecuteSimultaneous instead)");
+                             "pushAndExecuteSimultaneously instead)");
     return false;
   }
 
@@ -314,50 +314,50 @@ bool TrajectoryExecutionManager::push(const moveit_msgs::RobotTrajectory& trajec
   return false;
 }
 
-bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
-                                                            const std::string& controller, const int& expiration_time,
-                                                            const ExecutionCompleteCallback& callback)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneously(const moveit_msgs::RobotTrajectory& trajectory,
+                                                              const std::string& controller, const int& expiration_time,
+                                                              const ExecutionCompleteCallback& callback)
 {
   if (controller.empty())
-    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(), expiration_time, callback);
+    return pushAndExecuteSimultaneously(trajectory, std::vector<std::string>(), expiration_time, callback);
   else
-    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(1, controller), expiration_time, callback);
+    return pushAndExecuteSimultaneously(trajectory, std::vector<std::string>(1, controller), expiration_time, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
-                                                            const std::string& controller, const int& expiration_time,
-                                                            const ExecutionCompleteCallback& callback)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneously(const trajectory_msgs::JointTrajectory& trajectory,
+                                                              const std::string& controller, const int& expiration_time,
+                                                              const ExecutionCompleteCallback& callback)
 {
   if (controller.empty())
-    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(), expiration_time, callback);
+    return pushAndExecuteSimultaneously(trajectory, std::vector<std::string>(), expiration_time, callback);
   else
-    return pushAndExecuteSimultaneous(trajectory, std::vector<std::string>(1, controller), expiration_time, callback);
+    return pushAndExecuteSimultaneously(trajectory, std::vector<std::string>(1, controller), expiration_time, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const sensor_msgs::JointState& state,
-                                                            const std::string& controller, const int& expiration_time,
-                                                            const ExecutionCompleteCallback& callback)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneously(const sensor_msgs::JointState& state,
+                                                              const std::string& controller, const int& expiration_time,
+                                                              const ExecutionCompleteCallback& callback)
 {
   if (controller.empty())
-    return pushAndExecuteSimultaneous(state, std::vector<std::string>(), expiration_time, callback);
+    return pushAndExecuteSimultaneously(state, std::vector<std::string>(), expiration_time, callback);
   else
-    return pushAndExecuteSimultaneous(state, std::vector<std::string>(1, controller), expiration_time, callback);
+    return pushAndExecuteSimultaneously(state, std::vector<std::string>(1, controller), expiration_time, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const trajectory_msgs::JointTrajectory& trajectory,
-                                                            const std::vector<std::string>& controllers,
-                                                            const int& expiration_time,
-                                                            const ExecutionCompleteCallback& callback)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneously(const trajectory_msgs::JointTrajectory& trajectory,
+                                                              const std::vector<std::string>& controllers,
+                                                              const int& expiration_time,
+                                                              const ExecutionCompleteCallback& callback)
 {
   moveit_msgs::RobotTrajectory traj;
   traj.joint_trajectory = trajectory;
-  return pushAndExecuteSimultaneous(traj, controllers, expiration_time, callback);
+  return pushAndExecuteSimultaneously(traj, controllers, expiration_time, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const sensor_msgs::JointState& state,
-                                                            const std::vector<std::string>& controllers,
-                                                            const int& expiration_time,
-                                                            const ExecutionCompleteCallback& callback)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneously(const sensor_msgs::JointState& state,
+                                                              const std::vector<std::string>& controllers,
+                                                              const int& expiration_time,
+                                                              const ExecutionCompleteCallback& callback)
 {
   moveit_msgs::RobotTrajectory traj;
   traj.joint_trajectory.header = state.header;
@@ -367,13 +367,13 @@ bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const sensor_msgs::J
   traj.joint_trajectory.points[0].velocities = state.velocity;
   traj.joint_trajectory.points[0].effort = state.effort;
   traj.joint_trajectory.points[0].time_from_start = ros::Duration(0, 0);
-  return pushAndExecuteSimultaneous(traj, controllers, expiration_time, callback);
+  return pushAndExecuteSimultaneously(traj, controllers, expiration_time, callback);
 }
 
-bool TrajectoryExecutionManager::pushAndExecuteSimultaneous(const moveit_msgs::RobotTrajectory& trajectory,
-                                                            const std::vector<std::string>& controllers,
-                                                            const int& expiration_time,
-                                                            const ExecutionCompleteCallback& callback)
+bool TrajectoryExecutionManager::pushAndExecuteSimultaneously(const moveit_msgs::RobotTrajectory& trajectory,
+                                                              const std::vector<std::string>& controllers,
+                                                              const int& expiration_time,
+                                                              const ExecutionCompleteCallback& callback)
 {
   std::shared_ptr<TrajectoryExecutionContext> context = std::make_shared<TrajectoryExecutionContext>();
   if (configure(*context, trajectory, controllers, expiration_time))
@@ -579,9 +579,9 @@ void TrajectoryExecutionManager::continuousExecutionThread()
       if (!areControllersActive(context->controllers_))
       {
         ROS_ERROR_NAMED(LOGNAME, "Not all needed controllers are active. Cannot push and execute. You can try "
-                                 "calling ensureActiveControllers() before pushAndExecuteSimultaneous()");
+                                 "calling ensureActiveControllers() before pushAndExecuteSimultaneously()");
         ROS_ERROR_NAMED(LOGNAME, "Not all needed controllers are active. Cannot push and execute. You can try "
-                                 "calling ensureActiveControllers() before pushAndExecuteSimultaneous()");
+                                 "calling ensureActiveControllers() before pushAndExecuteSimultaneously()");
         last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
         ROS_INFO_NAMED(LOGNAME, "Calling completed callback");
         if (!context->execution_complete_callback.empty())

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -502,6 +502,13 @@ void TrajectoryExecutionManager::continuousExecutionThread()
             ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has been executed correctly.");
             it = backlog.erase(it);
           }
+          else if (it == backlog.begin() && active_contexts_map.empty())
+          {
+            ROS_ERROR_STREAM_NAMED(name_, "Trajectory is in a deadlock, aborting");
+            // Since there is not active trajectory being executed but this Top priority backlog-trajectory is not executable, abort it.
+            current_context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+            it = backlog.erase(it);
+          }
           else
           {
             ROS_DEBUG_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " is still not executable");

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -474,6 +474,7 @@ void TrajectoryExecutionManager::continuousExecutionThread()
         if (created_at + ros::Duration(expiration_time) < ros::Time::now())
         {
           ROS_WARN_STREAM_NAMED(LOGNAME, "Backlog item with duration " << current_context->trajectory_parts_[0].joint_trajectory.points.back().time_from_start << " has expired (older than 1 minute). Assuming malfunction, removing from backlog.");
+          current_context->execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
           it = backlog.erase(it);
           continue;
         }
@@ -1916,7 +1917,7 @@ bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_
   // Allow all collisions
     // TODO: This has optimization potential (ACM is not used, all collisions are checked (instead of robot-robot only)
     // collision_detection::AllowedCollisionMatrix& acm = scene.getAllowedCollisionMatrixNonConst();
-  ROS_DEBUG_STREAM_NAMED(name_, "getCurrentState");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "getCurrentState");
   // before we start planning, ensure that we have the latest robot state received...
   planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   planning_scene_monitor_->updateFrameTransforms();
@@ -1925,7 +1926,7 @@ bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_
   moveit::core::RobotState start_state = ps->getCurrentState();
   
   moveit_msgs::RobotState start_state_msg;
-  ROS_DEBUG_STREAM_NAMED(name_, "compute collision check");
+  ROS_DEBUG_STREAM_NAMED(LOGNAME, "compute collision check");
   for(std::size_t i = 0; i < active_trajectory.joint_trajectory.points.size(); ++i)
     if (jointTrajPointToRobotState(active_trajectory.joint_trajectory, i, start_state))
     {
@@ -2118,7 +2119,7 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     // Check whether this trajectory part starts at current robot state
     if (!validate(context))
     {
-      ROS_ERROR_NAMED(name_, "Trajectory became invalid before execution, abort.");
+      ROS_ERROR_NAMED(LOGNAME, "Trajectory became invalid before execution, abort.");
       context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
       return true;
     }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -2120,17 +2120,17 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     return false;
   }
 
+  // Check whether this trajectory starts at current robot state
+  if (!validate(context))
+  {
+    ROS_ERROR_NAMED(LOGNAME, "Trajectory became invalid before execution, abort.");
+    context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+    return true;
+  }
+
   // Push trajectory to all controllers simultaneously (each part goes to one controller)
   for (std::size_t i = 0; i < context.trajectory_parts_.size(); ++i)
   {
-    // Check whether this trajectory part starts at current robot state
-    if (!validate(context))
-    {
-      ROS_ERROR_NAMED(LOGNAME, "Trajectory became invalid before execution, abort.");
-      context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
-      return true;
-    }
-
     // Send trajectory (part) to controller
     bool ok = false;
     try

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -2118,7 +2118,9 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(TrajectoryExecutionCo
     // Check whether this trajectory part starts at current robot state
     if (!validate(context))
     {
-      return false;
+      ROS_ERROR_NAMED(name_, "Trajectory became invalid before execution, abort.");
+      context.execution_complete_callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+      return true;
     }
 
     // Send trajectory (part) to controller

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -2007,7 +2007,8 @@ bool TrajectoryExecutionManager::checkCollisionBetweenTrajectories(const moveit_
 }
 
 bool TrajectoryExecutionManager::checkContextForCollisions(
-    TrajectoryExecutionContext& context, std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts)
+    const TrajectoryExecutionContext& context,
+    const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts)
 {
   // 2. Check that new trajectory does not collide with other active trajectories
 
@@ -2041,7 +2042,7 @@ bool TrajectoryExecutionManager::checkContextForCollisions(
   return true;
 }
 
-bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(moveit_msgs::RobotTrajectory& trajectory)
+bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(const moveit_msgs::RobotTrajectory& trajectory)
 {
   moveit::core::RobotStatePtr current_state;
   if (!csm_->waitForCurrentState(ros::Time::now()) || !(current_state = csm_->getCurrentState()))
@@ -2067,7 +2068,7 @@ bool TrajectoryExecutionManager::checkCollisionsWithCurrentState(moveit_msgs::Ro
 }
 
 void TrajectoryExecutionManager::getContextHandles(
-    TrajectoryExecutionContext& context, std::set<moveit_controller_manager::MoveItControllerHandlePtr>& handles)
+    const TrajectoryExecutionContext& context, std::set<moveit_controller_manager::MoveItControllerHandlePtr>& handles)
 {
   for (std::size_t i = 0; i < context.controllers_.size(); ++i)
   {
@@ -2092,7 +2093,8 @@ void TrajectoryExecutionManager::getContextHandles(
 }
 
 bool TrajectoryExecutionManager::validateAndExecuteContext(
-    TrajectoryExecutionContext& context, std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
+    const TrajectoryExecutionContext& context,
+    std::set<moveit_controller_manager::MoveItControllerHandlePtr>& used_handles,
     std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts)
 {
   ROS_DEBUG_NAMED(LOGNAME, "Start validateAndExecuteContext");
@@ -2210,8 +2212,8 @@ bool TrajectoryExecutionManager::validateAndExecuteContext(
   return true;
 }
 
-bool TrajectoryExecutionManager::hasCommonHandles(TrajectoryExecutionContext& context1,
-                                                  TrajectoryExecutionContext& context2)
+bool TrajectoryExecutionManager::hasCommonHandles(const TrajectoryExecutionContext& context1,
+                                                  const TrajectoryExecutionContext& context2)
 {
   std::set<moveit_controller_manager::MoveItControllerHandlePtr> ctx1_handles;
   std::set<moveit_controller_manager::MoveItControllerHandlePtr> ctx2_handles;

--- a/moveit_ros/planning/trajectory_execution_manager/test/config/joint_state_publisher.yaml
+++ b/moveit_ros/planning/trajectory_execution_manager/test/config/joint_state_publisher.yaml
@@ -1,0 +1,5 @@
+zeros:
+  panda_1_joint4: -1.5707
+  panda_1_joint6: 1.8
+  panda_2_joint4: -1.5707
+  panda_2_joint6: 1.8

--- a/moveit_ros/planning/trajectory_execution_manager/test/config/moveit_cpp.yaml
+++ b/moveit_ros/planning/trajectory_execution_manager/test/config/moveit_cpp.yaml
@@ -1,0 +1,18 @@
+planning_scene_monitor_options:
+  name: "planning_scene_monitor"
+  robot_description: "robot_description"
+  joint_state_topic: "/joint_states"
+  attached_collision_object_topic: "/planning_scene_monitor"
+  publish_planning_scene_topic: "/publish_planning_scene"
+  monitored_planning_scene_topic: "/monitored_planning_scene"
+  wait_for_initial_state_timeout: 10.0
+
+planning_pipelines:
+  pipeline_names:
+    - ompl
+
+plan_request_params:
+  planning_attempts: 1
+  planning_pipeline: ompl
+  max_velocity_scaling_factor: 1.0
+  max_acceleration_scaling_factor: 1.0

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.cpp
@@ -1,0 +1,229 @@
+/* Author: Cristian C. Beltran-Hernandez
+   Desc: Test the MoveItCpp and Planning Component interfaces
+*/
+
+// ROS
+#include <ros/ros.h>
+
+// Testing
+#include <gtest/gtest.h>
+
+// Main class
+#include <moveit/moveit_cpp/moveit_cpp.h>
+#include <moveit/moveit_cpp/planning_component.h>
+// Msgs
+#include <geometry_msgs/PointStamped.h>
+
+namespace moveit_cpp
+{
+class MoveItCppTest : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    nh_ = ros::NodeHandle("/test_moveit_cpp");
+
+    moveit_cpp_ptr = std::make_shared<MoveItCpp>(nh_);
+
+    robot_model_ptr = moveit_cpp_ptr->getRobotModel();
+
+    panda_1_planning_component_ptr = std::make_shared<PlanningComponent>(PANDA_1_PLANNING_GROUP, moveit_cpp_ptr);
+    panda_1_jmg_ptr = robot_model_ptr->getJointModelGroup(PANDA_1_PLANNING_GROUP);
+    panda_1_planning_component_ptr->setStartStateToCurrentState();
+
+    panda_2_planning_component_ptr = std::make_shared<PlanningComponent>(PANDA_2_PLANNING_GROUP, moveit_cpp_ptr);
+    panda_2_jmg_ptr = robot_model_ptr->getJointModelGroup(PANDA_2_PLANNING_GROUP);
+
+    panda_1_target_pose1.header.frame_id = "base";
+    panda_1_target_pose1.pose.position.x = 0.450;
+    panda_1_target_pose1.pose.position.y = -0.50;
+    panda_1_target_pose1.pose.position.z = 1.50;
+    panda_1_target_pose1.pose.orientation.x = 0.993436;
+    panda_1_target_pose1.pose.orientation.y = 3.5161e-05;
+    panda_1_target_pose1.pose.orientation.z = 0.114386;
+    panda_1_target_pose1.pose.orientation.w = 2.77577e-05;
+
+    panda_1_target_pose2.header.frame_id = "base";
+    panda_1_target_pose2.pose.position.x = 0.40;
+    panda_1_target_pose2.pose.position.y = -0.45;
+    panda_1_target_pose2.pose.position.z = 1.40;
+    panda_1_target_pose2.pose.orientation.x = 0.993436;
+    panda_1_target_pose2.pose.orientation.y = 3.5161e-05;
+    panda_1_target_pose2.pose.orientation.z = 0.114386;
+    panda_1_target_pose2.pose.orientation.w = 2.77577e-05;
+
+    panda_2_target_pose1.header.frame_id = "base";
+    panda_2_target_pose1.pose.position.x = 0.450;
+    panda_2_target_pose1.pose.position.y = 0.40;
+    panda_2_target_pose1.pose.position.z = 1.600;
+    panda_2_target_pose1.pose.orientation.x = 0.993434;
+    panda_2_target_pose1.pose.orientation.y = -7.54803e-06;
+    panda_2_target_pose1.pose.orientation.z = 0.114403;
+    panda_2_target_pose1.pose.orientation.w = 3.67256e-05;
+
+    panda_2_target_pose2.header.frame_id = "base";
+    panda_2_target_pose2.pose.position.x = 0.40;
+    panda_2_target_pose2.pose.position.y = 0.45;
+    panda_2_target_pose2.pose.position.z = 1.500;
+    panda_2_target_pose2.pose.orientation.x = 0.993434;
+    panda_2_target_pose2.pose.orientation.y = -7.54803e-06;
+    panda_2_target_pose2.pose.orientation.z = 0.114403;
+    panda_2_target_pose2.pose.orientation.w = 3.67256e-05;
+  }
+
+  void plan(const PlanningComponentPtr& planning_component, const geometry_msgs::PoseStamped& target_pose,
+            const std::string& end_effector_link)
+  {
+    planning_component->setStartStateToCurrentState();
+    planning_component->setGoal(target_pose, end_effector_link);
+    planning_component->plan();
+  }
+
+  void plan(const PlanningComponentPtr& planning_component, const geometry_msgs::PoseStamped& target_pose,
+            const std::string& end_effector_link, const moveit::core::RobotState& start_state)
+  {
+    planning_component->setStartState(start_state);
+    planning_component->setGoal(target_pose, end_effector_link);
+    planning_component->plan();
+  }
+
+  void plan(const PlanningComponentPtr& planning_component, const geometry_msgs::PoseStamped& target_pose,
+            const std::string& end_effector_link, const geometry_msgs::Pose& start_pose,
+            const moveit::core::JointModelGroup* jmg_ptr)
+  {
+    auto start_state = *(moveit_cpp_ptr->getCurrentState());
+    start_state.setFromIK(jmg_ptr, start_pose);
+    plan(planning_component, target_pose, end_effector_link, start_state);
+  }
+
+protected:
+  ros::NodeHandle nh_;
+  MoveItCppPtr moveit_cpp_ptr;
+  moveit::core::RobotModelConstPtr robot_model_ptr;
+
+  PlanningComponentPtr panda_1_planning_component_ptr;
+  const moveit::core::JointModelGroup* panda_1_jmg_ptr;
+  const std::string PANDA_1_PLANNING_GROUP = "panda_1";
+  geometry_msgs::PoseStamped panda_1_target_pose1;
+  geometry_msgs::PoseStamped panda_1_target_pose2;
+  geometry_msgs::Pose panda_1_start_pose;
+
+  PlanningComponentPtr panda_2_planning_component_ptr;
+  const moveit::core::JointModelGroup* panda_2_jmg_ptr;
+  const std::string PANDA_2_PLANNING_GROUP = "panda_2";
+  geometry_msgs::PoseStamped panda_2_target_pose1;
+  geometry_msgs::PoseStamped panda_2_target_pose2;
+  geometry_msgs::Pose panda_2_start_pose;
+};
+
+// Test the name of the planning group used by PlanningComponent for the Panda robot
+TEST_F(MoveItCppTest, ExecutionWithBlockingTest)
+{
+  plan(panda_1_planning_component_ptr, panda_1_target_pose1, "panda_1_link8");
+  plan(panda_2_planning_component_ptr, panda_2_target_pose1, "panda_2_link8");
+
+  auto panda_1_robot_trajectory = panda_1_planning_component_ptr->getLastPlanSolution()->trajectory;
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg;
+  panda_1_robot_trajectory->getRobotTrajectoryMsg(panda_1_robot_trajectory_msg);
+
+  auto panda_2_robot_trajectory = panda_2_planning_component_ptr->getLastPlanSolution()->trajectory;
+  moveit_msgs::RobotTrajectory panda_2_robot_trajectory_msg;
+  panda_2_robot_trajectory->getRobotTrajectoryMsg(panda_2_robot_trajectory_msg);
+
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_1_robot_trajectory_msg);
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->execute();
+
+  bool res = moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_2_robot_trajectory_msg);
+
+  // Expect FALSE as the second trajectory is rejected by the TEM
+  ASSERT_TRUE(!res);
+}
+
+TEST_F(MoveItCppTest, SimpleSimulatenousExecutionTest)
+{
+  plan(panda_1_planning_component_ptr, panda_1_target_pose1, "panda_1_link8");
+  plan(panda_2_planning_component_ptr, panda_2_target_pose1, "panda_2_link8");
+
+  auto panda_1_robot_trajectory = panda_1_planning_component_ptr->getLastPlanSolution()->trajectory;
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg;
+  panda_1_robot_trajectory->getRobotTrajectoryMsg(panda_1_robot_trajectory_msg);
+
+  auto panda_2_robot_trajectory = panda_2_planning_component_ptr->getLastPlanSolution()->trajectory;
+  moveit_msgs::RobotTrajectory panda_2_robot_trajectory_msg;
+  panda_2_robot_trajectory->getRobotTrajectoryMsg(panda_2_robot_trajectory_msg);
+
+  bool res1 =
+      moveit_cpp_ptr->getTrajectoryExecutionManager()->pushAndExecuteSimultaneously(panda_1_robot_trajectory_msg);
+  bool res2 =
+      moveit_cpp_ptr->getTrajectoryExecutionManager()->pushAndExecuteSimultaneously(panda_2_robot_trajectory_msg);
+
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->waitForExecution();
+  // Expect TRUE as both trajectories should be accepted
+  ASSERT_TRUE(res1 && res2);
+}
+
+TEST_F(MoveItCppTest, MultipleSimulatenousExecutionTest)
+{
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg;
+  moveit_msgs::RobotTrajectory panda_2_robot_trajectory_msg;
+  moveit_msgs::RobotTrajectory panda_3_robot_trajectory_msg;
+  moveit_msgs::RobotTrajectory panda_4_robot_trajectory_msg;
+
+  plan(panda_1_planning_component_ptr, panda_1_target_pose1, "panda_1_link8");
+  plan(panda_2_planning_component_ptr, panda_2_target_pose1, "panda_2_link8");
+
+  auto panda_1_robot_trajectory = panda_1_planning_component_ptr->getLastPlanSolution()->trajectory;
+  panda_1_robot_trajectory->getRobotTrajectoryMsg(panda_1_robot_trajectory_msg);
+
+  auto panda_2_robot_trajectory = panda_2_planning_component_ptr->getLastPlanSolution()->trajectory;
+  panda_2_robot_trajectory->getRobotTrajectoryMsg(panda_2_robot_trajectory_msg);
+
+  moveit::core::RobotState panda_1_start_state2 = *panda_1_robot_trajectory->getLastWayPointPtr();
+  moveit::core::RobotState panda_2_start_state2 = *panda_2_robot_trajectory->getLastWayPointPtr();
+  plan(panda_1_planning_component_ptr, panda_1_target_pose2, "panda_1_link8", panda_1_start_state2);
+  plan(panda_2_planning_component_ptr, panda_2_target_pose2, "panda_2_link8", panda_2_start_state2);
+
+  panda_1_robot_trajectory = panda_1_planning_component_ptr->getLastPlanSolution()->trajectory;
+  panda_1_robot_trajectory->getRobotTrajectoryMsg(panda_3_robot_trajectory_msg);
+
+  panda_2_robot_trajectory = panda_2_planning_component_ptr->getLastPlanSolution()->trajectory;
+  panda_2_robot_trajectory->getRobotTrajectoryMsg(panda_4_robot_trajectory_msg);
+
+  bool res1 =
+      moveit_cpp_ptr->getTrajectoryExecutionManager()->pushAndExecuteSimultaneously(panda_1_robot_trajectory_msg);
+  bool res2 =
+      moveit_cpp_ptr->getTrajectoryExecutionManager()->pushAndExecuteSimultaneously(panda_2_robot_trajectory_msg);
+  bool res3 =
+      moveit_cpp_ptr->getTrajectoryExecutionManager()->pushAndExecuteSimultaneously(panda_3_robot_trajectory_msg);
+  bool res4 =
+      moveit_cpp_ptr->getTrajectoryExecutionManager()->pushAndExecuteSimultaneously(panda_4_robot_trajectory_msg);
+
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->waitForExecution();
+  // Expect TRUE as both trajectories should be accepted
+  ASSERT_TRUE(res1 && res2 && res3 && res4);
+}
+
+// TODO:
+// - Multiple trajectories in series A-B-B-B-A-B (Check that order is being respected)
+// - Deadlock 1: A-B, B is in collision with A, after A is completed, B is still invalid
+// - Deadlock 2:
+
+}  // namespace moveit_cpp
+
+int main(int argc, char** argv)
+{
+  if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
+  {
+    ros::console::notifyLoggerLevelsChanged();
+  }
+
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_moveit_cpp");
+
+  ros::AsyncSpinner spinner(4);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
@@ -1,0 +1,38 @@
+<launch>
+    <!-- Specify the config files to use -->
+    <rosparam ns="test_moveit_cpp" command="load" file="$(find moveit_ros_planning)/trajectory_execution_manager/test/config/moveit_cpp.yaml" />
+    <rosparam ns="joint_state_publisher" command="load" file="$(find moveit_ros_planning)/trajectory_execution_manager/test/config/joint_state_publisher.yaml" />
+
+    <!-- Planning Pipeline -->
+    <include ns="/test_moveit_cpp/ompl" file="$(find moveit_resources_dual_panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml"/>
+
+    <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
+    <include ns="test_moveit_cpp" file="$(find moveit_resources_dual_panda_moveit_config)/launch/fake_moveit_controller_manager.launch.xml" />
+
+    <!-- Trajectory execution  -->
+    <!-- <include ns="test_moveit_cpp" file="$(find moveit_resources_dual_panda_moveit_config)/launch/trajectory_execution.launch.xml">
+      <arg name="moveit_controller_manager" value="fake"/>
+    </include> -->
+
+    <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+    <include file="$(find moveit_resources_dual_panda_moveit_config)/launch/planning_context.launch">
+      <arg name="load_robot_description" value="true"/>
+    </include>
+
+    <!-- If needed, broadcast static tf for robot root -->
+    <!-- <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" /> -->
+
+    <!-- Send fake joint values -->
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+      <rosparam param="source_list">["/test_moveit_cpp/fake_controller_joint_states"]</rosparam>
+    </node>
+
+    <!-- Start robot state publisher -->
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+    <test pkg="moveit_ros_planning"
+          type="test_simultaneous_execution_manager"
+          test-name="test_moveit_cpp"
+          time-limit="300" args=""/>
+
+</launch>


### PR DESCRIPTION
## Main PR for GSoC2022 project Simultaneous Trajectory Execution (STE) #3156.

This PR only includes the changes to the `TrajectoryExecutionManager` (TEM) and can just be tested via `MoveItCpp`.

Usage with MoveGroup will be addressed in a separate PR.

A test environment can be found [here](https://github.com/cambel/moveit_simultaneous_motions_demo).

The module TrajectoryExecutionManager now has two usages:

- [Standard] **Single Trajectory** (`push` method): The execution manager accepts only one trajectory at a time. In a similar fashion as the SimpleActionServers, if a new trajectory is received but an old one is still in execution, the old trajectory is aborted and then the new trajectory is executed.

- [New] **Multiple Trajectories** (`pushAndExecuteSimultaneous` method): The execution manager accepts all new trajectories and stores them in a queue (continuous_execution_queue). Trajectories are executed simultaneously, in the order of arrival, as long as they are valid:
    - The new trajectory is collision-free* with all active trajectories
    - The controllers for the joints being actuated in the trajectory are not already been used.

* All new trajectories are checked before execution within the TEM to guarantee that they are collision-free with any active trajectories or the current planning scene.

A scheduling manager is added to the TrajectoryExecutionManager for Multiple Trajectories that defines the priority for trajectory execution:

- In principle, trajectories are executed in order of arrival FIFO.
- Trajectories that are not immediately valid are stored in a backlog queue.
- Trajectories from the backlog takes priority over any new trajectory from the continuous_execution_queue
- Trajectories from the backlog can expire if they are not valid for execution after some period of time (this should be a dynamically configurable parameter)
- The scheduling manager checks trajectories from the backlog and the continuous_execution_queue at a fixed rate (this should be a dynamically configurable parameter)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
