### PR TITLE
[moveit_setup_assistant] Fixes build error: "cannot convert ‘const YAML::Node’ to ‘boo ’ in initialization"

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1256,7 +1256,7 @@ template <typename T>
 bool parse(const YAML::Node& node, const std::string& key, T& storage, const T& default_value = T())
 {
   const YAML::Node& n = node[key];
-  bool valid = n;
+  bool valid = n.as<bool>();
   storage = valid ? n.as<T>() : default_value;
   return valid;
 }


### PR DESCRIPTION
### Description
I was having a build error on my host os: Arch Linux x86_64 when trying to build the moveit setup assistant, and submitted to the below repo to fix an issue
https://github.com/ros-noetic-arch/ros-noetic-moveit-setup-assistant/issues/3  (build log is also present on this issue)
Originally, I made a patch to fix this build issue in trying to build this component as part of an AUR package, and I was requested to further submit a pull request here.

