### PR TITLE
Clean up TrajectoryExecutionManager API: remove unused code

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -33,6 +33,7 @@ API changes in MoveIt releases
 - End-effector markers in rviz are shown only if the eef's parent group is active _and_ the parent link is part of that group. Before, these conditions were _OR_-connected.
   You might need to define additional end-effectors.
 - Removed `ConstraintSampler::project()` as there was no real difference to `sample()`.
+- Removed `TrajectoryExecutionManager::pushAndExecute()` and the code associated to it. The code was unused and broken.
 
 ## ROS Melodic
 

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -268,13 +268,14 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   // Execute trajectory
   moveit_msgs::RobotTrajectory robot_trajectory_msg;
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
+  // TODO: cambel
+  // blocking is the only valid option right now. Add non-bloking use case
   if (blocking)
   {
     trajectory_execution_manager_->push(robot_trajectory_msg);
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }
-  trajectory_execution_manager_->pushAndExecute(robot_trajectory_msg);
   return true;
 }
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -165,40 +165,6 @@ public:
   /// waitForExecution()
   moveit_controller_manager::ExecutionStatus executeAndWait(bool auto_clear = true);
 
-  /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
-  /// controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory, const std::string& controller = "");
-
-  /// Add a trajectory for immediate execution. Optionally specify a controller to use for the trajectory. If no
-  /// controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory, const std::string& controller = "");
-
-  /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a controller to use
-  /// for the trajectory.
-  /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const sensor_msgs::JointState& state, const std::string& controller = "");
-
-  /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
-  /// trajectory. Multiple controllers can be used simultaneously
-  /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
-  /// already loaded ones.
-  /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory, const std::vector<std::string>& controllers);
-
-  /// Add a trajectory for immediate execution. Optionally specify a set of controllers to consider using for the
-  /// trajectory. Multiple controllers can be used simultaneously
-  /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
-  /// already loaded ones.
-  /// If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
-
-  /// Add a trajectory that consists of a single state for immediate execution. Optionally specify a set of controllers
-  /// to consider using for the trajectory.
-  /// Multiple controllers can be used simultaneously to execute the different parts of the trajectory. If multiple
-  /// controllers can be used, preference
-  /// is given to the already loaded ones. If no controller is specified, a default is used. This call is non-blocking.
-  bool pushAndExecute(const sensor_msgs::JointState& state, const std::vector<std::string>& controllers);
-
   /// Wait until the execution is complete. This only works for executions started by execute().  If you call this after
   /// pushAndExecute(), it will immediately stop execution.
   moveit_controller_manager::ExecutionStatus waitForExecution();
@@ -292,7 +258,6 @@ private:
                      bool auto_clear);
   bool executePart(std::size_t part_index);
   bool waitForRobotToStop(const TrajectoryExecutionContext& context, double wait_time = 1.0);
-  void continuousExecutionThread();
 
   void stopExecutionInternal();
 
@@ -312,14 +277,8 @@ private:
   // thread used to execute trajectories using the execute() command
   std::unique_ptr<boost::thread> execution_thread_;
 
-  // thread used to execute trajectories using pushAndExecute()
-  std::unique_ptr<boost::thread> continuous_execution_thread_;
-
   boost::mutex execution_state_mutex_;
-  boost::mutex continuous_execution_mutex_;
   boost::mutex execution_thread_mutex_;
-
-  boost::condition_variable continuous_execution_condition_;
 
   // this condition is used to notify the completion of execution for given trajectories
   boost::condition_variable execution_complete_condition_;
@@ -331,10 +290,7 @@ private:
   mutable boost::mutex time_index_mutex_;
   bool execution_complete_;
 
-  bool stop_continuous_execution_;
-  bool run_continuous_execution_thread_;
   std::vector<TrajectoryExecutionContext*> trajectories_;
-  std::deque<TrajectoryExecutionContext*> continuous_execution_queue_;
 
   std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager> > controller_manager_loader_;
   moveit_controller_manager::MoveItControllerManagerPtr controller_manager_;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -102,7 +102,6 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::Robot
 
 TrajectoryExecutionManager::~TrajectoryExecutionManager()
 {
-  run_continuous_execution_thread_ = false;
   stopExecution(true);
   delete reconfigure_impl_;
 }
@@ -112,10 +111,8 @@ void TrajectoryExecutionManager::initialize()
   reconfigure_impl_ = nullptr;
   verbose_ = false;
   execution_complete_ = true;
-  stop_continuous_execution_ = false;
   current_context_ = -1;
   last_execution_status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
-  run_continuous_execution_thread_ = true;
   execution_duration_monitoring_ = true;
   execution_velocity_scaling_ = 1.0;
   allowed_start_tolerance_ = 0.01;
@@ -296,222 +293,6 @@ bool TrajectoryExecutionManager::push(const moveit_msgs::RobotTrajectory& trajec
   }
 
   return false;
-}
-
-bool TrajectoryExecutionManager::pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory,
-                                                const std::string& controller)
-{
-  if (controller.empty())
-    return pushAndExecute(trajectory, std::vector<std::string>());
-  else
-    return pushAndExecute(trajectory, std::vector<std::string>(1, controller));
-}
-
-bool TrajectoryExecutionManager::pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory,
-                                                const std::string& controller)
-{
-  if (controller.empty())
-    return pushAndExecute(trajectory, std::vector<std::string>());
-  else
-    return pushAndExecute(trajectory, std::vector<std::string>(1, controller));
-}
-
-bool TrajectoryExecutionManager::pushAndExecute(const sensor_msgs::JointState& state, const std::string& controller)
-{
-  if (controller.empty())
-    return pushAndExecute(state, std::vector<std::string>());
-  else
-    return pushAndExecute(state, std::vector<std::string>(1, controller));
-}
-
-bool TrajectoryExecutionManager::pushAndExecute(const trajectory_msgs::JointTrajectory& trajectory,
-                                                const std::vector<std::string>& controllers)
-{
-  moveit_msgs::RobotTrajectory traj;
-  traj.joint_trajectory = trajectory;
-  return pushAndExecute(traj, controllers);
-}
-
-bool TrajectoryExecutionManager::pushAndExecute(const sensor_msgs::JointState& state,
-                                                const std::vector<std::string>& controllers)
-{
-  moveit_msgs::RobotTrajectory traj;
-  traj.joint_trajectory.header = state.header;
-  traj.joint_trajectory.joint_names = state.name;
-  traj.joint_trajectory.points.resize(1);
-  traj.joint_trajectory.points[0].positions = state.position;
-  traj.joint_trajectory.points[0].velocities = state.velocity;
-  traj.joint_trajectory.points[0].effort = state.effort;
-  traj.joint_trajectory.points[0].time_from_start = ros::Duration(0, 0);
-  return pushAndExecute(traj, controllers);
-}
-
-bool TrajectoryExecutionManager::pushAndExecute(const moveit_msgs::RobotTrajectory& trajectory,
-                                                const std::vector<std::string>& controllers)
-{
-  if (!execution_complete_)
-  {
-    ROS_ERROR_NAMED(LOGNAME, "Cannot push & execute a new trajectory while another is being executed");
-    return false;
-  }
-
-  TrajectoryExecutionContext* context = new TrajectoryExecutionContext();
-  if (configure(*context, trajectory, controllers))
-  {
-    {
-      boost::mutex::scoped_lock slock(continuous_execution_mutex_);
-      continuous_execution_queue_.push_back(context);
-      if (!continuous_execution_thread_)
-        continuous_execution_thread_ = std::make_unique<boost::thread>([this] { continuousExecutionThread(); });
-    }
-    last_execution_status_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
-    continuous_execution_condition_.notify_all();
-    return true;
-  }
-  else
-  {
-    delete context;
-    last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-    return false;
-  }
-}
-
-void TrajectoryExecutionManager::continuousExecutionThread()
-{
-  std::set<moveit_controller_manager::MoveItControllerHandlePtr> used_handles;
-  while (run_continuous_execution_thread_)
-  {
-    if (!stop_continuous_execution_)
-    {
-      boost::unique_lock<boost::mutex> ulock(continuous_execution_mutex_);
-      while (continuous_execution_queue_.empty() && run_continuous_execution_thread_ && !stop_continuous_execution_)
-        continuous_execution_condition_.wait(ulock);
-    }
-
-    if (stop_continuous_execution_ || !run_continuous_execution_thread_)
-    {
-      for (const moveit_controller_manager::MoveItControllerHandlePtr& used_handle : used_handles)
-        if (used_handle->getLastExecutionStatus() == moveit_controller_manager::ExecutionStatus::RUNNING)
-          used_handle->cancelExecution();
-      used_handles.clear();
-      while (!continuous_execution_queue_.empty())
-      {
-        TrajectoryExecutionContext* context = continuous_execution_queue_.front();
-        continuous_execution_queue_.pop_front();
-        delete context;
-      }
-      stop_continuous_execution_ = false;
-      continue;
-    }
-
-    while (!continuous_execution_queue_.empty())
-    {
-      TrajectoryExecutionContext* context = nullptr;
-      {
-        boost::mutex::scoped_lock slock(continuous_execution_mutex_);
-        if (continuous_execution_queue_.empty())
-          break;
-        context = continuous_execution_queue_.front();
-        continuous_execution_queue_.pop_front();
-        if (continuous_execution_queue_.empty())
-          continuous_execution_condition_.notify_all();
-      }
-
-      // remove handles we no longer need
-      std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator uit = used_handles.begin();
-      while (uit != used_handles.end())
-        if ((*uit)->getLastExecutionStatus() != moveit_controller_manager::ExecutionStatus::RUNNING)
-        {
-          std::set<moveit_controller_manager::MoveItControllerHandlePtr>::iterator to_erase = uit;
-          ++uit;
-          used_handles.erase(to_erase);
-        }
-        else
-          ++uit;
-
-      // now send stuff to controllers
-
-      // first make sure desired controllers are active
-      if (areControllersActive(context->controllers_))
-      {
-        // get the controller handles needed to execute the new trajectory
-        std::vector<moveit_controller_manager::MoveItControllerHandlePtr> handles(context->controllers_.size());
-        for (std::size_t i = 0; i < context->controllers_.size(); ++i)
-        {
-          moveit_controller_manager::MoveItControllerHandlePtr h;
-          try
-          {
-            h = controller_manager_->getControllerHandle(context->controllers_[i]);
-          }
-          catch (std::exception& ex)
-          {
-            ROS_ERROR_NAMED(LOGNAME, "%s caught when retrieving controller handle", ex.what());
-          }
-          if (!h)
-          {
-            last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-            ROS_ERROR_NAMED(LOGNAME, "No controller handle for controller '%s'. Aborting.",
-                            context->controllers_[i].c_str());
-            handles.clear();
-            break;
-          }
-          handles[i] = h;
-        }
-
-        if (stop_continuous_execution_ || !run_continuous_execution_thread_)
-        {
-          delete context;
-          break;
-        }
-
-        // push all trajectories to all controllers simultaneously
-        if (!handles.empty())
-          for (std::size_t i = 0; i < context->trajectory_parts_.size(); ++i)
-          {
-            bool ok = false;
-            try
-            {
-              ok = handles[i]->sendTrajectory(context->trajectory_parts_[i]);
-            }
-            catch (std::exception& ex)
-            {
-              ROS_ERROR_NAMED(LOGNAME, "Caught %s when sending trajectory to controller", ex.what());
-            }
-            if (!ok)
-            {
-              for (std::size_t j = 0; j < i; ++j)
-                try
-                {
-                  handles[j]->cancelExecution();
-                }
-                catch (std::exception& ex)
-                {
-                  ROS_ERROR_NAMED(LOGNAME, "Caught %s when canceling execution", ex.what());
-                }
-              ROS_ERROR_NAMED(LOGNAME, "Failed to send trajectory part %zu of %zu to controller %s", i + 1,
-                              context->trajectory_parts_.size(), handles[i]->getName().c_str());
-              if (i > 0)
-                ROS_ERROR_NAMED(LOGNAME, "Cancelling previously sent trajectory parts");
-              last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-              handles.clear();
-              break;
-            }
-          }
-        delete context;
-
-        // remember which handles we used
-        for (const moveit_controller_manager::MoveItControllerHandlePtr& handle : handles)
-          used_handles.insert(handle);
-      }
-      else
-      {
-        ROS_ERROR_NAMED(LOGNAME, "Not all needed controllers are active. Cannot push and execute. You can try "
-                                 "calling ensureActiveControllers() before pushAndExecute()");
-        last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
-        delete context;
-      }
-    }
-  }
 }
 
 void TrajectoryExecutionManager::reloadControllerInformation()
@@ -1157,9 +938,6 @@ void TrajectoryExecutionManager::stopExecutionInternal()
 
 void TrajectoryExecutionManager::stopExecution(bool auto_clear)
 {
-  stop_continuous_execution_ = true;
-  continuous_execution_condition_.notify_all();
-
   if (!execution_complete_)
   {
     execution_state_mutex_.lock();
@@ -1237,11 +1015,6 @@ moveit_controller_manager::ExecutionStatus TrajectoryExecutionManager::waitForEx
     while (!execution_complete_)
       execution_complete_condition_.wait(ulock);
   }
-  {
-    boost::unique_lock<boost::mutex> ulock(continuous_execution_mutex_);
-    while (!continuous_execution_queue_.empty())
-      continuous_execution_condition_.wait(ulock);
-  }
 
   // this will join the thread for executing sequences of trajectories
   stopExecution(false);
@@ -1256,14 +1029,6 @@ void TrajectoryExecutionManager::clear()
     for (TrajectoryExecutionContext* trajectory : trajectories_)
       delete trajectory;
     trajectories_.clear();
-    {
-      boost::mutex::scoped_lock slock(continuous_execution_mutex_);
-      while (!continuous_execution_queue_.empty())
-      {
-        delete continuous_execution_queue_.front();
-        continuous_execution_queue_.pop_front();
-      }
-    }
   }
   else
     ROS_ERROR_NAMED(LOGNAME, "Cannot push a new trajectory while another is being executed");


### PR DESCRIPTION
Part of #3156.

The idea is to first clean up the unused code of the API before adding new futures to handle the simultaneous execution of trajectories.