### PR TITLE
Test `moveit_commander.set_joint_value_target` with JointState argument

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -213,10 +213,6 @@ class MoveGroupCommander(object):
         if isinstance(arg1, JointState):
             if arg2 is not None or arg3 is not None:
                 raise MoveItCommanderException("Too many arguments specified")
-            if len(arg1.name) != len(arg1.position):
-                raise MoveItCommanderException(
-                    "Expected the same number of names and positions"
-                )
             if not self._g.set_joint_value_target_from_joint_state_message(
                 conversions.msg_to_string(arg1)
             ):

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -213,6 +213,10 @@ class MoveGroupCommander(object):
         if isinstance(arg1, JointState):
             if arg2 is not None or arg3 is not None:
                 raise MoveItCommanderException("Too many arguments specified")
+            if len(arg1.name) != len(arg1.position):
+                raise MoveItCommanderException(
+                    "Expected the same number of names and positions"
+                )
             if not self._g.set_joint_value_target_from_joint_state_message(
                 conversions.msg_to_string(arg1)
             ):

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -119,8 +119,12 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         self.check_target_setting([0.1] * n, js)
 
         # alternative formulation of the two above tests
-        self.check_target_setting([0.1] * n, JointState(self.JOINT_NAMES, [] * n, [] * n, [] * n))
-        self.check_target_setting([0.1] * n, JointState(self.JOINT_NAMES, [0.1] * n, [] * n, [] * n))
+        self.check_target_setting(
+            [0.1] * n, JointState(self.JOINT_NAMES, [] * n, [] * n, [] * n)
+        )
+        self.check_target_setting(
+            [0.1] * n, JointState(self.JOINT_NAMES, [0.1] * n, [] * n, [] * n)
+        )
 
     def plan(self, target):
         self.group.set_joint_value_target(target)

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -118,6 +118,10 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         js.position = [0.1] * n
         self.check_target_setting([0.1] * n, js)
 
+        # alternative formulation of the two above tests
+        self.check_target_setting([0.1] * n, JointState(self.JOINT_NAMES, [] * n, [] * n, [] * n))
+        self.check_target_setting([0.1] * n, JointState(self.JOINT_NAMES, [0.1] * n, [] * n, [] * n))
+
     def plan(self, target):
         self.group.set_joint_value_target(target)
         return self.group.plan()

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -117,15 +117,12 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         )
         self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
 
-        # check using JointState argument
+        js_target = JointState(name=self.JOINT_NAMES, position=[0.1] * n)
+        self.check_target_setting([0.1] * n, js_target)
         # name and position should have the same size, or raise exception
         with self.assertRaises(MoveItCommanderException):
-            self.group.set_joint_value_target(
-                JointState(name=self.JOINT_NAMES, position=[] * n)
-            )
-        self.check_target_setting(
-            [0.1] * n, JointState(name=self.JOINT_NAMES, position=[0.1] * n)
-        )
+            js_target.position = []
+            self.check_target_setting(None, js_target)
 
     def plan(self, target):
         self.group.set_joint_value_target(target)

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -112,6 +112,11 @@ class PythonMoveitCommanderTest(unittest.TestCase):
             [0.3] * n, {name: 0.3 for name in self.group.get_active_joints()}
         )
         self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
+        js = JointState()
+        js.name = self.JOINT_NAMES
+        self.check_target_setting([0.1] * n, js)
+        js.position = [0.1] * n
+        self.check_target_setting([0.1] * n, js)
 
     def plan(self, target):
         self.group.set_joint_value_target(target)

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -45,7 +45,11 @@ import os
 from moveit_msgs.msg import RobotState
 from sensor_msgs.msg import JointState
 
-from moveit_commander import RobotCommander, PlanningSceneInterface
+from moveit_commander import (
+    RobotCommander,
+    PlanningSceneInterface,
+    MoveItCommanderException,
+)
 
 
 class PythonMoveitCommanderTest(unittest.TestCase):
@@ -112,18 +116,15 @@ class PythonMoveitCommanderTest(unittest.TestCase):
             [0.3] * n, {name: 0.3 for name in self.group.get_active_joints()}
         )
         self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
-        js = JointState()
-        js.name = self.JOINT_NAMES
-        self.check_target_setting([0.1] * n, js)
-        js.position = [0.1] * n
-        self.check_target_setting([0.1] * n, js)
 
-        # alternative formulation of the two above tests
+        # check using JointState argument
+        # name and position should have the same size, or raise exception
+        with self.assertRaises(MoveItCommanderException):
+            self.group.set_joint_value_target(
+                JointState(name=self.JOINT_NAMES, position=[] * n)
+            )
         self.check_target_setting(
-            [0.1] * n, JointState(self.JOINT_NAMES, [] * n, [] * n, [] * n)
-        )
-        self.check_target_setting(
-            [0.1] * n, JointState(self.JOINT_NAMES, [0.1] * n, [] * n, [] * n)
+            [0.1] * n, JointState(name=self.JOINT_NAMES, position=[0.1] * n)
         )
 
     def plan(self, target):

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1712,6 +1712,11 @@ bool MoveGroupInterface::setJointValueTarget(const std::map<std::string, double>
 bool MoveGroupInterface::setJointValueTarget(const std::vector<std::string>& variable_names,
                                              const std::vector<double>& variable_values)
 {
+  if (variable_names.size() != variable_values.size())
+  {
+    ROS_ERROR_STREAM("sizes of name and position arrays do not match");
+    return false;
+  }
   const auto& allowed = impl_->getJointModelGroup()->getVariableNames();
   for (const auto& variable_name : variable_names)
   {


### PR DESCRIPTION
### Description

- Add tests of `moveit_commander.set_joint_value_target` with `JointState` argument
- Add test of `moveit_commander.set_joint_value_target` with incomplete `JointState` argument

Fixes #3186 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
