### PR TITLE
Improve Cartesian interpolation

### DIFF
--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -20,6 +20,8 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 # Unit tests
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+
   catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
   target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils)
 
@@ -27,7 +29,9 @@ if(CATKIN_ENABLE_TESTING)
   add_executable(robot_state_benchmark test/robot_state_benchmark.cpp)
   target_link_libraries(robot_state_benchmark ${MOVEIT_LIB_NAME} moveit_test_utils ${GTEST_LIBRARIES})
 
-  catkin_add_gtest(test_cartesian_interpolator test/test_cartesian_interpolator.cpp)
+  add_rostest_gtest(test_cartesian_interpolator
+    test/test_cartesian_interpolator.test
+    test/test_cartesian_interpolator.cpp)
   target_link_libraries(test_cartesian_interpolator ${MOVEIT_LIB_NAME} moveit_test_utils)
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -97,18 +97,16 @@ class CartesianInterpolator
   // TODO(mlautman): Eventually, this planner should be moved out of robot_state
 
 public:
-  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular group.
+  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path for a particular link.
 
-     The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
-     The Cartesian path to be followed is specified as a direction of motion (\e direction, unit vector) for the origin
-     of a robot link (\e link). The direction is assumed to be either in a global reference frame or in the local
-     reference frame of the link. In the latter case (\e global_reference_frame is false) the \e direction is rotated
-     accordingly. The link needs to move in a straight line, following the specified direction, for the desired \e
-     distance. The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     The Cartesian path to be followed is specified as a \e translation vector to be followed by the robot \e link.
+     This vector is assumed to be specified either in the global reference frame or in the local
+     reference frame of the link.
+     The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
      Cartesian space between consecutive points on the resulting path is specified in the \e MaxEEFStep struct which
      provides two fields: translation and rotation. If a \e validCallback is specified, this is passed to the internal
      call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to
-     the distance that was computed and for which corresponding states were added to the path.  At the end of the
+     the distance that was achieved and for which corresponding states were added to the path.  At the end of the
      function call, the state of the group corresponds to the last attempted Cartesian pose.
 
      During the computation of the trajectory, it is usually preferred if consecutive joint values do not 'jump' by a
@@ -130,17 +128,34 @@ public:
   static double
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
                        std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
+                       const Eigen::Vector3d& translation, bool global_reference_frame, const MaxEEFStep& max_step,
+                       const JumpThreshold& jump_threshold,
+                       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+
+  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular link.
+
+     In contrast to the previous function, the translation vector is specified as a (unit) direction vector and
+     a distance. */
+  static double
+  computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
+                       std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
                        const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                        const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                        const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions())
+  {
+    return computeCartesianPath(start_state, group, traj, link, distance * direction, global_reference_frame, max_step,
+                                jump_threshold, validCallback, options);
+  }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
      In contrast to the previous function, the Cartesian path is specified as a target frame to be reached (\e target)
      for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or
      in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is
-     rotated accordingly. All other comments from the previous function apply. */
+     rotated accordingly. This function returns the fraction (0..1) of path that was achieved.
+     All other comments from the previous function apply. */
   static double
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
                        std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
@@ -153,7 +168,7 @@ public:
 
      In contrast to the previous functions, the Cartesian path is specified as a set of \e waypoints to be sequentially
      reached for the origin of a robot link (\e link). The waypoints are transforms given either in a global reference
-     frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move
+     frame or in the local reference frame of the link at the immediately preceding waypoint. The link needs to move
      in a straight line between two consecutive waypoints. All other comments apply. */
   static double
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -149,34 +149,35 @@ public:
                                 jump_threshold, validCallback, options);
   }
 
-  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
+  /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular frame.
 
      In contrast to the previous function, the Cartesian path is specified as a target frame to be reached (\e target)
-     for the origin of a robot link (\e link). The target frame is assumed to be either in a global reference frame or
-     in the local reference frame of the link. In the latter case (\e global_reference_frame is false) the \e target is
-     rotated accordingly. This function returns the fraction (0..1) of path that was achieved.
-     All other comments from the previous function apply. */
+     for a virtual frame attached to the robot \e link with the given \e link_offset.
+     The target frame is assumed to be specified either w.r.t. to the global reference frame or the virtual link frame.
+     This function returns the fraction (0..1) of path that was achieved. All other comments from the previous function apply. */
   static double
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
                        std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
                        const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
                        const JumpThreshold& jump_threshold,
                        const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                       const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
      In contrast to the previous functions, the Cartesian path is specified as a set of \e waypoints to be sequentially
-     reached for the origin of a robot link (\e link). The waypoints are transforms given either in a global reference
-     frame or in the local reference frame of the link at the immediately preceding waypoint. The link needs to move
-     in a straight line between two consecutive waypoints. All other comments apply. */
+     reached by the virtual frame attached to the robot \e link. The waypoints are transforms given either w.r.t. the global
+     reference frame or the virtual frame at the immediately preceding waypoint. The virtual frame needs
+     to move in a straight line between two consecutive waypoints. All other comments apply. */
   static double
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
                        std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
                        const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame,
                        const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                        const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                       const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
 
   /** \brief Tests joint space jumps of a trajectory.
 

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -76,21 +76,24 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
                                                    const Eigen::Isometry3d& target, bool global_reference_frame,
                                                    const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                                                    const GroupStateValidityCallbackFn& validCallback,
-                                                   const kinematics::KinematicsQueryOptions& options)
+                                                   const kinematics::KinematicsQueryOptions& options,
+                                                   const Eigen::Isometry3d& link_offset)
 {
+  // check unsanitized inputs for non-isometry
+  ASSERT_ISOMETRY(target)
+  ASSERT_ISOMETRY(link_offset)
+
   const std::vector<const JointModel*>& cjnt = group->getContinuousJointModels();
   // make sure that continuous joints wrap
   for (const JointModel* joint : cjnt)
     start_state->enforceBounds(joint);
 
-  // this is the Cartesian pose we start from, and we move in the direction indicated
-  // getGlobalLinkTransform() returns a valid isometry by contract
-  Eigen::Isometry3d start_pose = start_state->getGlobalLinkTransform(link);  // valid isometry
-
-  ASSERT_ISOMETRY(target)  // unsanitized input, could contain a non-isometry
+  // Cartesian pose we start from
+  Eigen::Isometry3d start_pose = start_state->getGlobalLinkTransform(link) * link_offset;
+  Eigen::Isometry3d offset = link_offset.inverse();
 
   // the target can be in the local reference frame (in which case we rotate it)
-  Eigen::Isometry3d rotated_target = global_reference_frame ? target : start_pose * target;  // valid isometry
+  Eigen::Isometry3d rotated_target = global_reference_frame ? target : start_pose * target;
 
   Eigen::Quaterniond start_quaternion(start_pose.linear());
   Eigen::Quaterniond target_quaternion(rotated_target.linear());
@@ -156,7 +159,7 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
 
     // Explicitly use a single IK attempt only: We want a smooth trajectory.
     // Random seeding (of additional attempts) would probably create IK jumps.
-    if (start_state->setFromIK(group, pose, link->getName(), consistency_limits, 0.0, validCallback, options))
+    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options))
       traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
     else
       break;
@@ -169,13 +172,11 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
   return last_valid_percentage;
 }
 
-double CartesianInterpolator::computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
-                                                   std::vector<RobotStatePtr>& traj, const LinkModel* link,
-                                                   const EigenSTL::vector_Isometry3d& waypoints,
-                                                   bool global_reference_frame, const MaxEEFStep& max_step,
-                                                   const JumpThreshold& jump_threshold,
-                                                   const GroupStateValidityCallbackFn& validCallback,
-                                                   const kinematics::KinematicsQueryOptions& options)
+double CartesianInterpolator::computeCartesianPath(
+    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+    const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame, const MaxEEFStep& max_step,
+    const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
+    const kinematics::KinematicsQueryOptions& options, const Eigen::Isometry3d& link_offset)
 {
   double percentage_solved = 0.0;
   for (std::size_t i = 0; i < waypoints.size(); ++i)
@@ -185,7 +186,7 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
     std::vector<RobotStatePtr> waypoint_traj;
     double wp_percentage_solved =
         computeCartesianPath(start_state, group, waypoint_traj, link, waypoints[i], global_reference_frame, max_step,
-                             NO_JOINT_SPACE_JUMP_TEST, validCallback, options);
+                             NO_JOINT_SPACE_JUMP_TEST, validCallback, options, link_offset);
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
       percentage_solved = (double)(i + 1) / (double)waypoints.size();

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
+ *   * Neither the name of the PickNik nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
@@ -39,199 +39,20 @@
 #include <moveit/robot_state/cartesian_interpolator.h>
 #include <moveit/utils/robot_model_test_utils.h>
 
-#include <urdf_parser/urdf_parser.h>
 #include <gtest/gtest.h>
 
-#include <memory>
-#include <sstream>
-#include <algorithm>
-#include <ctype.h>
+using namespace moveit::core;
 
-class OneRobot : public testing::Test
+class SimpleRobot : public testing::Test
 {
 protected:
   void SetUp() override
   {
-    // TODO(mlautman): Use new testing framework for loading models
-    // https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html
-    static const std::string MODEL2 =
-        "<?xml version=\"1.0\" ?>"
-        "<robot name=\"one_robot\">"
-        "<link name=\"base_link\">"
-        "  <inertial>"
-        "    <mass value=\"2.81\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision name=\"my_collision\">"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "<joint name=\"panda_joint0\" type=\"continuous\">"
-        "   <axis xyz=\"0 0 1\"/>"
-        "   <parent link=\"base_link\"/>"
-        "   <child link=\"link_a\"/>"
-        "   <origin rpy=\" 0.0 0 0 \" xyz=\"0.0 0 0 \"/>"
-        "</joint>"
-        "<link name=\"link_a\">"
-        "  <inertial>"
-        "    <mass value=\"1.0\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "<joint name=\"joint_b\" type=\"fixed\">"
-        "  <parent link=\"link_a\"/>"
-        "  <child link=\"link_b\"/>"
-        "  <origin rpy=\" 0.0 -0.42 0 \" xyz=\"0.0 0.5 0 \"/>"
-        "</joint>"
-        "<link name=\"link_b\">"
-        "  <inertial>"
-        "    <mass value=\"1.0\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "  <joint name=\"panda_joint1\" type=\"prismatic\">"
-        "    <axis xyz=\"1 0 0\"/>"
-        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.09\" velocity=\"0.2\"/>"
-        "    <safety_controller k_position=\"20.0\" k_velocity=\"500.0\" soft_lower_limit=\"0.0\" "
-        "soft_upper_limit=\"0.089\"/>"
-        "    <parent link=\"link_b\"/>"
-        "    <child link=\"link_c\"/>"
-        "    <origin rpy=\" 0.0 0.42 0.0 \" xyz=\"0.0 -0.1 0 \"/>"
-        "  </joint>"
-        "<link name=\"link_c\">"
-        "  <inertial>"
-        "    <mass value=\"1.0\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "  <joint name=\"mim_f\" type=\"prismatic\">"
-        "    <axis xyz=\"1 0 0\"/>"
-        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
-        "    <parent link=\"link_c\"/>"
-        "    <child link=\"link_d\"/>"
-        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
-        "    <mimic joint=\"joint_f\" multiplier=\"1.5\" offset=\"0.1\"/>"
-        "  </joint>"
-        "  <joint name=\"joint_f\" type=\"prismatic\">"
-        "    <axis xyz=\"1 0 0\"/>"
-        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
-        "    <parent link=\"link_d\"/>"
-        "    <child link=\"link_e\"/>"
-        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
-        "  </joint>"
-        "<link name=\"link_d\">"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "<link name=\"link_e\">"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "</robot>";
-
-    static const std::string SMODEL2 =
-        "<?xml version=\"1.0\" ?>"
-        "<robot name=\"one_robot\">"
-        "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"planar\"/>"
-        "<group name=\"base_from_joints\">"
-        "<joint name=\"base_joint\"/>"
-        "<joint name=\"panda_joint0\"/>"
-        "<joint name=\"panda_joint1\"/>"
-        "</group>"
-        "<group name=\"mim_joints\">"
-        "<joint name=\"joint_f\"/>"
-        "<joint name=\"mim_f\"/>"
-        "</group>"
-        "<group name=\"base_with_subgroups\">"
-        "<group name=\"base_from_base_to_tip\"/>"
-        "<joint name=\"panda_joint1\"/>"
-        "</group>"
-        "<group name=\"base_from_base_to_tip\">"
-        "<chain base_link=\"base_link\" tip_link=\"link_b\"/>"
-        "<joint name=\"base_joint\"/>"
-        "</group>"
-        "<group name=\"arm\">"
-        "<chain base_link=\"base_link\" tip_link=\"link_e\"/>"
-        "<joint name=\"base_joint\"/>"
-        "</group>"
-        "<group name=\"base_with_bad_subgroups\">"
-        "<group name=\"error\"/>"
-        "</group>"
-        "</robot>";
-
-    urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(MODEL2);
-    srdf::ModelSharedPtr srdf_model(new srdf::Model());
-    srdf_model->initString(*urdf_model, SMODEL2);
-    robot_model_ = std::make_shared<moveit::core::RobotModel>(urdf_model, srdf_model);
+    RobotModelBuilder builder("simple", "a");
+    builder.addChain("a->b", "continuous");
+    builder.addChain("b->c", "prismatic");
+    builder.addGroupChain("a", "c", "group");
+    robot_model_ = builder.build();
   }
 
   void TearDown() override
@@ -239,53 +60,56 @@ protected:
   }
 
 protected:
-  moveit::core::RobotModelConstPtr robot_model_;
+  RobotModelConstPtr robot_model_;
+
+  static std::size_t generateTestTraj(std::vector<std::shared_ptr<RobotState>>& traj,
+                                      const RobotModelConstPtr& robot_model_);
 };
 
-std::size_t generateTestTraj(std::vector<std::shared_ptr<moveit::core::RobotState>>& traj,
-                             const moveit::core::RobotModelConstPtr& robot_model_)
+std::size_t SimpleRobot::generateTestTraj(std::vector<std::shared_ptr<RobotState>>& traj,
+                                          const RobotModelConstPtr& robot_model_)
 {
   traj.clear();
 
-  std::shared_ptr<moveit::core::RobotState> robot_state(new moveit::core::RobotState(robot_model_));
+  std::shared_ptr<RobotState> robot_state(new RobotState(robot_model_));
   robot_state->setToDefaultValues();
   double ja, jc;
 
   // 3 waypoints with default joints
   for (std::size_t traj_ix = 0; traj_ix < 3; ++traj_ix)
   {
-    traj.push_back(std::make_shared<moveit::core::RobotState>(*robot_state));
+    traj.push_back(std::make_shared<RobotState>(*robot_state));
   }
 
-  ja = robot_state->getVariablePosition("panda_joint0");
-  jc = robot_state->getVariablePosition("panda_joint1");
+  ja = robot_state->getVariablePosition("a-b-joint");  // revolute joint
+  jc = robot_state->getVariablePosition("b-c-joint");  // prismatic joint
 
   // 4th waypoint with a small jump of 0.01 in revolute joint and prismatic joint. This should not be considered a jump
   ja = ja - 0.01;
-  robot_state->setVariablePosition("panda_joint0", ja);
+  robot_state->setVariablePosition("a-b-joint", ja);
   jc = jc - 0.01;
-  robot_state->setVariablePosition("panda_joint1", jc);
-  traj.push_back(std::make_shared<moveit::core::RobotState>(*robot_state));
+  robot_state->setVariablePosition("b-c-joint", jc);
+  traj.push_back(std::make_shared<RobotState>(*robot_state));
 
   // 5th waypoint with a large jump of 1.01 in first revolute joint
   ja = ja + 1.01;
-  robot_state->setVariablePosition("panda_joint0", ja);
-  traj.push_back(std::make_shared<moveit::core::RobotState>(*robot_state));
+  robot_state->setVariablePosition("a-b-joint", ja);
+  traj.push_back(std::make_shared<RobotState>(*robot_state));
 
   // 6th waypoint with a large jump of 1.01 in first prismatic joint
   jc = jc + 1.01;
-  robot_state->setVariablePosition("panda_joint1", jc);
-  traj.push_back(std::make_shared<moveit::core::RobotState>(*robot_state));
+  robot_state->setVariablePosition("b-c-joint", jc);
+  traj.push_back(std::make_shared<RobotState>(*robot_state));
 
   // 7th waypoint with no jump
-  traj.push_back(std::make_shared<moveit::core::RobotState>(*robot_state));
+  traj.push_back(std::make_shared<RobotState>(*robot_state));
 
   return traj.size();
 }
 
-TEST_F(OneRobot, testGenerateTrajectory)
+TEST_F(SimpleRobot, testGenerateTrajectory)
 {
-  std::vector<std::shared_ptr<moveit::core::RobotState>> traj;
+  std::vector<std::shared_ptr<RobotState>> traj;
 
   // The full trajectory should be of length 7
   const std::size_t expected_full_traj_len = 7;
@@ -297,10 +121,10 @@ TEST_F(OneRobot, testGenerateTrajectory)
   EXPECT_EQ(full_traj_len, expected_full_traj_len);  // full traj should be 7 waypoints long
 }
 
-TEST_F(OneRobot, checkAbsoluteJointSpaceJump)
+TEST_F(SimpleRobot, checkAbsoluteJointSpaceJump)
 {
-  const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("arm");
-  std::vector<std::shared_ptr<moveit::core::RobotState>> traj;
+  const JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("group");
+  std::vector<std::shared_ptr<RobotState>> traj;
 
   // A revolute joint jumps 1.01 at the 5th waypoint and a prismatic joint jumps 1.01 at the 6th waypoint
   const std::size_t expected_revolute_jump_traj_len = 4;
@@ -315,43 +139,39 @@ TEST_F(OneRobot, checkAbsoluteJointSpaceJump)
   double fraction;
 
   // Direct call of absolute version
-  fraction = moveit::core::CartesianInterpolator::checkAbsoluteJointSpaceJump(joint_model_group, traj, 1.0, 1.0);
+  fraction = CartesianInterpolator::checkAbsoluteJointSpaceJump(joint_model_group, traj, 1.0, 1.0);
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut
   EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
 
   // Indirect call using checkJointSpaceJumps
   generateTestTraj(traj, robot_model_);
-  fraction = moveit::core::CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj,
-                                                                      moveit::core::JumpThreshold(1.0, 1.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(1.0, 1.0));
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut before the revolute jump
   EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
 
   // Test revolute joints
   generateTestTraj(traj, robot_model_);
-  fraction = moveit::core::CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj,
-                                                                      moveit::core::JumpThreshold(1.0, 0.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(1.0, 0.0));
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut before the revolute jump
   EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
 
   // Test prismatic joints
   generateTestTraj(traj, robot_model_);
-  fraction = moveit::core::CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj,
-                                                                      moveit::core::JumpThreshold(0.0, 1.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(0.0, 1.0));
   EXPECT_EQ(expected_prismatic_jump_traj_len, traj.size());  // traj should be cut before the prismatic jump
   EXPECT_NEAR(expected_prismatic_jump_fraction, fraction, 0.01);
 
   // Ignore all absolute jumps
   generateTestTraj(traj, robot_model_);
-  fraction = moveit::core::CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj,
-                                                                      moveit::core::JumpThreshold(0.0, 0.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(0.0, 0.0));
   EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
   EXPECT_NEAR(1.0, fraction, 0.01);
 }
 
-TEST_F(OneRobot, checkRelativeJointSpaceJump)
+TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
 {
-  const moveit::core::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("arm");
-  std::vector<std::shared_ptr<moveit::core::RobotState>> traj;
+  const JointModelGroup* joint_model_group = robot_model_->getJointModelGroup("group");
+  std::vector<std::shared_ptr<RobotState>> traj;
 
   // The first large jump of 1.01 occurs at the 5th waypoint so the test should trim the trajectory to length 4
   const std::size_t expected_relative_jump_traj_len = 4;
@@ -364,21 +184,19 @@ TEST_F(OneRobot, checkRelativeJointSpaceJump)
   double fraction;
 
   // Direct call of relative version: 1.01 > 2.97 * (0.01 * 2 + 1.01 * 2)/6.
-  fraction = moveit::core::CartesianInterpolator::checkRelativeJointSpaceJump(joint_model_group, traj, 2.97);
+  fraction = CartesianInterpolator::checkRelativeJointSpaceJump(joint_model_group, traj, 2.97);
   EXPECT_EQ(expected_relative_jump_traj_len, traj.size());  // traj should be cut before the first jump of 1.01
   EXPECT_NEAR(expected_relative_jump_fraction, fraction, 0.01);
 
   // Indirect call of relative version using checkJointSpaceJumps
   generateTestTraj(traj, robot_model_);
-  fraction = moveit::core::CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj,
-                                                                      moveit::core::JumpThreshold(2.97));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(2.97));
   EXPECT_EQ(expected_relative_jump_traj_len, traj.size());  // traj should be cut before the first jump of 1.01
   EXPECT_NEAR(expected_relative_jump_fraction, fraction, 0.01);
 
   // Trajectory should not be cut: 1.01 < 2.98 * (0.01 * 2 + 1.01 * 2)/6.
   generateTestTraj(traj, robot_model_);
-  fraction = moveit::core::CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj,
-                                                                      moveit::core::JumpThreshold(2.98));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(2.98));
   EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
   EXPECT_NEAR(1.0, fraction, 0.01);
 }

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.test
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.test
@@ -1,0 +1,3 @@
+<launch>
+	<test pkg="moveit_core" type="test_cartesian_interpolator" test-name="test_cartesian_interpolator" />
+</launch>

--- a/moveit_core/utils/include/moveit/utils/eigen_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/eigen_test_utils.h
@@ -1,0 +1,77 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Haschke */
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <Eigen/Geometry>
+
+/** Provide operator<< for Eigen::Transform */
+template <typename _Scalar, int _Dim, int _Mode, int _Options>
+std::ostream& operator<<(std::ostream& s, const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>& t)
+{
+  return s << "p=[" << t.translation().transpose() << "] q=[" << Eigen::Quaterniond(t.linear()).coeffs().transpose()
+           << "]";
+}
+
+/** Predicate to compare two Eigen entities */
+template <typename T1, typename T2>
+struct IsApprox
+{
+  double prec_;
+  IsApprox(double prec_) : prec_(prec_)
+  {
+  }
+
+  ::testing::AssertionResult operator()(const char* expr1, const char* expr2, T1 val1, T2 val2)
+  {
+    if (val1.isApprox(val2, prec_))
+      return ::testing::AssertionSuccess();
+
+    std::stringstream msg;
+    msg << "Expected equality of these values (up to precision " << prec_ << "):" << std::fixed
+        << std::setprecision(1 - std::log10(prec_))        // limit to precision
+        << "\n  " << expr1 << "\n    Which is: " << val1   // first
+        << "\n  " << expr2 << "\n    Which is: " << val2;  // second
+    return ::testing::AssertionFailure() << msg.str();
+  }
+};
+
+#define EXPECT_EIGEN_EQ(val1, val2)                                                                                    \
+  EXPECT_PRED_FORMAT2((IsApprox<decltype(val1), decltype(val2)>(                                                       \
+                          Eigen::NumTraits<typename std::decay<decltype(val1)>::type::Scalar>::dummy_precision())),    \
+                      val1, val2)
+#define EXPECT_EIGEN_NEAR(val1, val2, prec_)                                                                           \
+  EXPECT_PRED_FORMAT2((IsApprox<decltype(val1), decltype(val2)>(prec_)), val1, val2)

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -70,6 +70,16 @@ urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name);
  */
 srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name);
 
+/** \brief Load an IK solver plugin for the given joint model group
+ * \param[in] jmg joint model group to load the plugin for
+ * \param[in] base_link base link of chain
+ * \param[in] tip_link tip link of chain
+ * \param[in] plugin name of the plugin ("KDL", or full name)
+ * \param[in] timeout default solver timeout
+ */
+void loadIKPluginForGroup(JointModelGroup* jmg, const std::string& base_link, const std::string& tip_link,
+                          std::string plugin = "KDL", double timeout = 0.1);
+
 /** \brief Easily build different robot models for testing.
  *  Essentially a programmer-friendly light wrapper around URDF and SRDF.
  *  Best shown by an example:

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1564,9 +1564,8 @@ double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs:
                                                 double jump_threshold, moveit_msgs::RobotTrajectory& trajectory,
                                                 bool avoid_collisions, moveit_msgs::MoveItErrorCodes* error_code)
 {
-  moveit_msgs::Constraints path_constraints_tmp;
-  return computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints_tmp, avoid_collisions,
-                              error_code);
+  return computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, moveit_msgs::Constraints(),
+                              avoid_collisions, error_code);
 }
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::Pose>& waypoints, double eef_step,
@@ -1574,17 +1573,10 @@ double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs:
                                                 const moveit_msgs::Constraints& path_constraints, bool avoid_collisions,
                                                 moveit_msgs::MoveItErrorCodes* error_code)
 {
-  if (error_code)
-  {
-    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
-                                       avoid_collisions, *error_code);
-  }
-  else
-  {
-    moveit_msgs::MoveItErrorCodes error_code_tmp;
-    return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
-                                       avoid_collisions, error_code_tmp);
-  }
+  moveit_msgs::MoveItErrorCodes err_tmp;
+  moveit_msgs::MoveItErrorCodes& err = error_code ? *error_code : err_tmp;
+  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints,
+                                     avoid_collisions, err);
 }
 
 void MoveGroupInterface::stop()


### PR DESCRIPTION
So far, Cartesian interpolation only considered _link frames_ to move along a straight-line. This PR augments this to arbitrary frames by considering a configurable offset to the link frame. Thus, now the frame resulting from link * offset should move along a straight line towards the target. Obviously, this is only relevant for rotational motions - a fixed offset for linear motions doesn't change the resulting motion. For example, the new implementation [allows for circular motions around a non-link origin](https://github.com/ros-planning/moveit_task_constructor/pull/380).