### PR TITLE
Pass xacro_args to both, urdf and srdf loading

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -4,12 +4,12 @@
 FROM moveit/moveit:melodic-ci
 MAINTAINER Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
-# Switch to ros-shadow-fixed
-RUN echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list
+# Switch to ros-testing
+RUN echo "deb http://packages.ros.org/ros-testing/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros1-latest.list
 
-# Upgrade packages to ros-shadow-fixed and clean apt-cache within one RUN command
+# Upgrade packages to ros-testing and clean apt-cache within one RUN command
 RUN apt-get -qq update && \
-    apt-get -qq dist-upgrade && \
+    apt-get -qq -y dist-upgrade && \
     #
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -395,7 +395,7 @@ bool StartScreenWidget::loadExistingFiles()
   QApplication::processEvents();
 
   // Load the SRDF
-  if (!loadSRDFFile(config_data_->srdf_path_))
+  if (!loadSRDFFile(config_data_->srdf_path_, config_data_->xacro_args_))
     return false;  // error occured
 
   // Progress Indicator
@@ -546,9 +546,7 @@ bool StartScreenWidget::loadNewFiles()
 // ******************************************************************************************
 bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const std::string& xacro_args)
 {
-  const std::vector<std::string> vec_xacro_args = { xacro_args };
-
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(config_data_->urdf_string_, urdf_file_path, vec_xacro_args))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(config_data_->urdf_string_, urdf_file_path, { xacro_args }))
   {
     QMessageBox::warning(this, "Error Loading Files",
                          QString("URDF/COLLADA file not found: ").append(urdf_file_path.c_str()));
@@ -592,12 +590,10 @@ bool StartScreenWidget::loadURDFFile(const std::string& urdf_file_path, const st
 // ******************************************************************************************
 // Load SRDF File to Parameter Server
 // ******************************************************************************************
-bool StartScreenWidget::loadSRDFFile(const std::string& srdf_file_path)
+bool StartScreenWidget::loadSRDFFile(const std::string& srdf_file_path, const std::string& xacro_args)
 {
-  const std::vector<std::string> xacro_args;
-
   std::string srdf_string;
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, srdf_file_path, xacro_args))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, srdf_file_path, { xacro_args }))
   {
     QMessageBox::warning(this, "Error Loading Files", QString("SRDF file not found: ").append(srdf_file_path.c_str()));
     return false;

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -147,7 +147,7 @@ private:
   bool loadURDFFile(const std::string& urdf_file_path, const std::string& xacro_args);
 
   /// Load SRDF File
-  bool loadSRDFFile(const std::string& srdf_file_path);
+  bool loadSRDFFile(const std::string& srdf_file_path, const std::string& xacro_args);
 
   /// Put SRDF File on Parameter Server
   bool setSRDFFile(const std::string& srdf_string);


### PR DESCRIPTION
This is a (partial) backport of #3013 from noetic-devel. Running xacro for srdf loading in MSA is an important feature for `panda_moveit_config`.