### PR TITLE
Fix CI: Relax compiler warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
         -Wno-unused-parameter
-        ${{ matrix.env.CLANG_TIDY && '-Wno-error=c++17-compat -Wno-error=overloaded-virtual -Wno-error=unused-function' || '' }}
+        ${{ matrix.env.CLANG_TIDY && '-Wno-c++17-compat -Wno-overloaded-virtual -Wno-unused-function' || '-Wno-unused-but-set-parameter' }}
       CLANG_TIDY_ARGS: --fix --fix-errors
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: .github/workflows/upstream.rosinstall


### PR DESCRIPTION
Unfortunately, CI is broken again:
- [gcc complains about `unused-but-set-parameter` in OGRE code](https://github.com/ros-planning/moveit/runs/8141833958?check_suite_focus=true)
- [clang creates hundreds of warnings cluttering the view for relevant issues](https://github.com/ros-planning/moveit/runs/8141834092?check_suite_focus=true)
- [`eigenpy` triggers linker issues](https://github.com/ros/rosdistro/pull/34283#issuecomment-1234806721)

This PR addresses the first two items, suppressing some compiler warnings.