### PR TITLE
version.h: automatically bump patch number for devel builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The [MoveIt Motion Planning Framework for ROS](http://moveit.ros.org). For the R
 - We develop latest features on `master`.
 - The `*-devel` branches correspond to released and stable versions of MoveIt for specific distributions of ROS. `noetic-devel` is synced to `master` currently.
 - Bug fixes occasionally get backported to these released versions of MoveIt.
+- To facilitate compile-time switching, the patch version of `MOVEIT_VERSION` of a development branch will be incremented by 1 w.r.t. the package.xml's version number.
 
 ## MoveIt Status
 

--- a/moveit_core/version/CMakeLists.txt
+++ b/moveit_core/version/CMakeLists.txt
@@ -1,18 +1,11 @@
 # Generate and install version.h
 
-if(NOT "$ENV{USER}" STREQUAL "buildfarm") # Don't define version postfix on buildfarm
-	set(MOVEIT_VERSION_EXTRA "devel" CACHE STRING "version string postfix")
-endif()
-
-message(STATUS " *** Building MoveIt ${${PROJECT_NAME}_VERSION} ${MOVEIT_VERSION_EXTRA} ***")
-
 # https://stackoverflow.com/questions/13920072/how-to-always-run-command-when-building-regardless-of-any-dependency
 add_custom_command(
 	OUTPUT ${VERSION_FILE_PATH}/moveit/version.h always_rebuild
 	COMMAND ${CMAKE_COMMAND}
 	-DVERSION_FILE_PATH="${VERSION_FILE_PATH}"
 	-DMOVEIT_VERSION="${${PROJECT_NAME}_VERSION}"
-	-DMOVEIT_VERSION_EXTRA="${MOVEIT_VERSION_EXTRA}"
 	-P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/moveit_core/version/version.cmake
+++ b/moveit_core/version/version.cmake
@@ -1,3 +1,8 @@
+# Extract version number components
+string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" MOVEIT_VERSION_MAJOR "${MOVEIT_VERSION}")
+string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" MOVEIT_VERSION_MINOR "${MOVEIT_VERSION}")
+string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" MOVEIT_VERSION_PATCH "${MOVEIT_VERSION}")
+
 # Retrieve (active) branch name
 execute_process(
 	COMMAND git rev-parse --abbrev-ref HEAD
@@ -27,13 +32,26 @@ execute_process(
 	ERROR_QUIET
 )
 
-string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" MOVEIT_VERSION_MAJOR "${MOVEIT_VERSION}")
-string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" MOVEIT_VERSION_MINOR "${MOVEIT_VERSION}")
-string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" MOVEIT_VERSION_PATCH "${MOVEIT_VERSION}")
-set(MOVEIT_VERSION "${MOVEIT_VERSION_MAJOR}.${MOVEIT_VERSION_MINOR}.${MOVEIT_VERSION_PATCH}")
+# Retrieve all tags
+execute_process(
+	COMMAND git tag --points-at HEAD
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+	OUTPUT_VARIABLE GIT_TAGS
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	ERROR_QUIET
+)
 
-if(NOT "${MOVEIT_VERSION_EXTRA}" STREQUAL "")
-	string(APPEND MOVEIT_VERSION "-${MOVEIT_VERSION_EXTRA}")
+# split GIT_TAGS into list
+string(REPLACE "\n" ";" GIT_TAGS "${GIT_TAGS}")
+list(FIND GIT_TAGS "${MOVEIT_VERSION}" _index)
+
+if(_index LESS 0) # MOVEIT_VERSION is not a tag at HEAD
+	# increase patch number
+	math(EXPR MOVEIT_VERSION_PATCH "${MOVEIT_VERSION_PATCH}+1")
+	set(MOVEIT_VERSION_EXTRA "-devel")
 endif()
+
+set(MOVEIT_VERSION "${MOVEIT_VERSION_MAJOR}.${MOVEIT_VERSION_MINOR}.${MOVEIT_VERSION_PATCH}${MOVEIT_VERSION_EXTRA}")
+message(STATUS " *** Building MoveIt ${MOVEIT_VERSION} ***")
 
 configure_file("version.h.in" "${VERSION_FILE_PATH}/moveit/version.h")

--- a/moveit_core/version/version.cmake
+++ b/moveit_core/version/version.cmake
@@ -45,7 +45,7 @@ execute_process(
 string(REPLACE "\n" ";" GIT_TAGS "${GIT_TAGS}")
 list(FIND GIT_TAGS "${MOVEIT_VERSION}" _index)
 
-if(_index LESS 0) # MOVEIT_VERSION is not a tag at HEAD
+if(MOVEIT_GIT_COMMIT_HASH AND _index LESS 0) # MOVEIT_VERSION is not a tag at HEAD
 	# increase patch number
 	math(EXPR MOVEIT_VERSION_PATCH "${MOVEIT_VERSION_PATCH}+1")
 	set(MOVEIT_VERSION_EXTRA "-devel")


### PR DESCRIPTION
Follow up on #2793:
Automatically recognize a devel build by comparing package.xml's version with available git tags. If they don't match, assume a devel version, increase the patch number and append `-devel`, e.g. yielding 1.1.10-devel instead of 1.1.9.
Note that this adapted version number is only reported in `version.h` and thus via `moveit_version`.
Libraries still get the old version number listed in `package.xml`. This was a deliberative decision: During development, it is convenient to (re)build individual libs/packages only. These should still have the same library version number to be found by existing downstream packages.