### PR TITLE
wrote a free function that sets min, max, progress, and text visible …

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -43,6 +43,7 @@
 
 namespace moveit_rviz_plugin
 {
+  
 JMGItemModel::JMGItemModel(const moveit::core::RobotState& robot_state, const std::string& group_name, QObject* parent)
   : QAbstractTableModel(parent), robot_state_(robot_state), jmg_(nullptr)
 {
@@ -380,7 +381,13 @@ void MotionPlanningFrameJointsWidget::jogNullspace(double value)
   model->getRobotState().harmonizePositions(model->getJointModelGroup());
   triggerUpdate(model);
 }
-
+void SetQStyleOptionProgressBar(QStyleOptionProgressBa& opt, const float min, const float max, double value)
+  {
+    opt.minimum = 0;
+    opt.maximum = 1000;
+    opt.progress = 1000. * (value - min) / (max - min);
+    opt.textVisible = true;
+  }
 void ProgressBarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
   // copied from QStyledItemDelegate::paint
@@ -416,12 +423,9 @@ void ProgressBarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
 
       QStyleOptionProgressBar opt;
       opt.rect = option.rect;
-      opt.minimum = 0;
-      opt.maximum = 1000;
-      opt.progress = 1000. * (value - min) / (max - min);
       opt.text = style_option.text;
       opt.textAlignment = style_option.displayAlignment;
-      opt.textVisible = true;
+      SetQStyleOptionProgressBar(opt, min, max, value);
       style->drawControl(QStyle::CE_ProgressBar, &opt, painter);
       return;
     }
@@ -499,14 +503,12 @@ void ProgressBarEditor::paintEvent(QPaintEvent* /*event*/)
   QPainter painter(this);
 
   QStyleOptionProgressBar opt;
+  
   opt.rect = rect();
   opt.palette = this->palette();
-  opt.minimum = 0;
-  opt.maximum = 1000;
-  opt.progress = 1000. * (value_ - min_) / (max_ - min_);
   opt.text = QLocale().toString(value_, 'f', digits_);
   opt.textAlignment = Qt::AlignRight;
-  opt.textVisible = true;
+  SetQStyleOptionProgressBar(opt, min_, max_, value_);
   style()->drawControl(QStyle::CE_ProgressBar, &opt, &painter);
 }
 


### PR DESCRIPTION
…for progressbardelegate and progressbareditor.

### Description
Cleaned up code for setting the progress bar editor and progress bar delegate.
Please explain the changes you made, including a reference to the related issue if applicable
Made a free function that sets the min, max, visible, and text progress data values. Help clean up code.
### Checklist
- [x ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
