### PR TITLE
Drop shortcut avoiding planning when all constraints are already met

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -103,23 +103,6 @@ void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const moveit_msgs::M
   ROS_INFO_NAMED(getName(), "Combined planning and execution request received for MoveGroup action. "
                             "Forwarding to planning and execution pipeline.");
 
-  if (moveit::core::isEmpty(goal->planning_options.planning_scene_diff))
-  {
-    planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
-    const moveit::core::RobotState& current_state = lscene->getCurrentState();
-
-    // check to see if the desired constraints are already met
-    for (std::size_t i = 0; i < goal->request.goal_constraints.size(); ++i)
-      if (lscene->isStateConstrained(current_state,
-                                     kinematic_constraints::mergeConstraints(goal->request.goal_constraints[i],
-                                                                             goal->request.path_constraints)))
-      {
-        ROS_INFO_NAMED(getName(), "Goal constraints are already satisfied. No need to plan or execute any motions");
-        action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
-        return;
-      }
-  }
-
   plan_execution::PlanExecution::Options opt;
 
   const moveit_msgs::MotionPlanRequest& motion_plan_request =


### PR DESCRIPTION
When calling the PlanAndExcute action, there was a shortcut avoiding planning (and execution) at all when all goal constraints were already met. However, this check also succeeded when there was an error, e.g. resolving link names. As proper link resolution might require some planning request adapters to be executed, e.g. ResolveConstraintFrames, we should not skip planning.

Note, calling the PlanOnly action, didn't have this shortcut as well, resulting in inconsistent behavior.

I just decided to remove the shortcut check completely.

Fixes #3222