### PR TITLE
Trajopt fixes

### DIFF
--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_planning_context.h
@@ -13,7 +13,7 @@ class TrajOptPlanningContext : public planning_interface::PlanningContext
 {
 public:
   TrajOptPlanningContext(const std::string& name, const std::string& group,
-                         const moveit::core::RobotModelConstPtr& model);
+                         const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& nh);
   ~TrajOptPlanningContext() override
   {
   }

--- a/moveit_planners/trajopt/src/problem_description.cpp
+++ b/moveit_planners/trajopt/src/problem_description.cpp
@@ -555,7 +555,7 @@ void generateInitialTrajectory(const ProblemInfo& pci, const std::vector<double>
     current_pos(joint_index) = current_joint_values[joint_index];
   }
 
-  InitInfo init_info = pci.init_info;
+  const InitInfo& init_info = pci.init_info;
 
   // initialize based on type specified
   if (init_info.type == InitInfo::STATIONARY)

--- a/moveit_planners/trajopt/src/trajopt_interface.cpp
+++ b/moveit_planners/trajopt/src/trajopt_interface.cpp
@@ -166,7 +166,7 @@ bool TrajOptInterface::solve(const planning_scene::PlanningSceneConstPtr& planni
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
-  else if (!req.goal_constraints[0].orientation_constraints.empty() &&
+  else if (!req.goal_constraints[0].position_constraints.empty() &&
            req.goal_constraints[0].orientation_constraints.empty())
   {
     ROS_ERROR_STREAM_NAMED("trajopt_planner", "orientation constraint is not defined");

--- a/moveit_planners/trajopt/src/trajopt_interface.cpp
+++ b/moveit_planners/trajopt/src/trajopt_interface.cpp
@@ -53,6 +53,8 @@
 #include <Eigen/Geometry>
 #include <unordered_map>
 
+#include <trajopt_utils/eigen_conversions.hpp>
+
 #include "trajopt_interface/trajopt_interface.h"
 #include "trajopt_interface/problem_description.h"
 
@@ -188,6 +190,9 @@ bool TrajOptInterface::solve(const planning_scene::PlanningSceneConstPtr& planni
     }
     joint_pos_term->targets = joint_goal_constraints;
     problem_info.cnt_infos.push_back(joint_pos_term);
+
+    // needed to initialize trajectory
+    problem_info.init_info.data = util::toVectorXd(joint_goal_constraints);
   }
 
   ROS_INFO(" ======================================= Constraints from request start_state");

--- a/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
@@ -55,7 +55,7 @@ public:
 
   bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
-    ROS_INFO(" ======================================= initialize gets called");
+    ROS_INFO_STREAM(" ======================================= initialize gets called, ns: " << ns);
 
     if (!ns.empty())
       nh_ = ros::NodeHandle(ns);
@@ -66,7 +66,7 @@ public:
       ROS_INFO(" ======================================= group name: %s, robot model: %s", gpName.c_str(),
                model->getName().c_str());
       planning_contexts_[gpName] =
-          TrajOptPlanningContextPtr(new TrajOptPlanningContext("trajopt_planning_context", gpName, model));
+          TrajOptPlanningContextPtr(new TrajOptPlanningContext("trajopt_planning_context", gpName, model, nh_));
     }
 
     return true;

--- a/moveit_planners/trajopt/src/trajopt_planning_context.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planning_context.cpp
@@ -13,11 +13,11 @@
 namespace trajopt_interface
 {
 TrajOptPlanningContext::TrajOptPlanningContext(const std::string& context_name, const std::string& group_name,
-                                               const moveit::core::RobotModelConstPtr& model)
+                                               const moveit::core::RobotModelConstPtr& model, const ros::NodeHandle& nh)
   : planning_interface::PlanningContext(context_name, group_name), robot_model_(model)
 {
   ROS_INFO(" ======================================= TrajOptPlanningContext is constructed");
-  trajopt_interface_ = TrajOptInterfacePtr(new TrajOptInterface());
+  trajopt_interface_ = TrajOptInterfacePtr(new TrajOptInterface(nh));
 }
 
 bool TrajOptPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)


### PR DESCRIPTION
These are tiny fixes to the trajopt plugin that allow it to work in obstacle-free cases when direct joint interpolation is a valid solution.