### PR TITLE
Publish tf in gazebo

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -25,8 +25,6 @@
 
   <!-- If needed, broadcast static tf for robot root -->
 [VIRTUAL_JOINT_BROADCASTER]
-
-
   <group if="$(eval arg('moveit_controller_manager') == 'fake')">
     <!-- We do not have a real robot connected, so publish fake joint states via a joint_state_publisher
          MoveIt's fake controller's joint states are considered via the 'source_list' parameter -->

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -29,4 +29,7 @@
   <!-- Load ROS controllers -->
   <include file="$(dirname)/ros_controllers.launch"/>
 
+  <!-- Given the published joint states, publish tf for the robot links -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
 </launch>


### PR DESCRIPTION
### Description

Otherwise tf is missing in Gazebo by default.
Triple empty line fixed.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
