### PR TITLE
Pass world, spawn pose and other args to demo_gazebo.launch

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -1,21 +1,27 @@
+<?xml version="1.0"?>
 <launch>
 
-  <!-- specify the planning pipeline -->
-  <arg name="pipeline" default="ompl" />
-
   <!-- Gazebo specific options -->
-  <arg name="gazebo_gui" default="true"/>
+  <arg name="world_name" default="worlds/empty.world"/>
   <arg name="paused" default="false"/>
+  <arg name="gazebo_gui" default="true"/>
 
-  <!-- launch the gazebo simulator and spawn the robot -->
-  <include file="$(dirname)/gazebo.launch" >
+  <!-- Specify the planning pipeline -->
+  <arg name="pipeline" default="ompl"/>
+
+  <!-- Launch the Gazebo simulator and spawn the robot -->
+  <include file="$(dirname)/gazebo.launch" pass_all_args="true" >
+    <arg name="world_name" value="$(arg world_name)"/>
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
   </include>
 
+  <!-- Launch MoveIt -->
   <include file="$(dirname)/demo.launch" pass_all_args="true">
-    <!-- robot description is loaded by gazebo.launch, to enable Gazebo features -->
+    <arg name="pipeline" value="$(arg pipeline)"/>
+    <!-- robot_description is loaded by gazebo.launch, to enable Gazebo features -->
     <arg name="load_robot_description" value="false" />
     <arg name="moveit_controller_manager" value="ros_control" />
   </include>
+
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -1,31 +1,43 @@
 <?xml version="1.0"?>
 <launch>
+
+  <!-- Gazebo specific options -->
+  <arg name="world_name" default="worlds/empty.world"/>
   <arg name="paused" default="false"/>
   <arg name="gazebo_gui" default="true"/>
-  <arg name="initial_joint_positions" doc="Initial joint configuration of the robot"
-       default="[GAZEBO_INITIAL_JOINTS]"/>
 
-  <!-- startup simulated world -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch">
-    <arg name="world_name" default="worlds/empty.world"/>
+  <!-- Robot spawn pose -->
+  <arg name="x" default="0"/>
+  <arg name="y" default="0"/>
+  <arg name="z" default="0"/>
+  <arg name="R" default="0"/>
+  <arg name="P" default="0"/>
+  <arg name="Y" default="0"/>
+
+  <!-- Spawn options -->
+  <arg name="unpause" doc="Unpause only after loading robot model argument" value="$(eval '' if arg('paused') else '-unpause')"/>
+  <arg name="world_pose" doc="Robot spawn pose argument" default="-x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)"/>
+  <arg name="initial_joint_positions" doc="Initial joint configuration of the robot argument" default="[GAZEBO_INITIAL_JOINTS]"/>
+
+  <!-- Start Gazebo -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch" pass_all_args="true">
+    <arg name="world_name" value="$(arg world_name)"/>
     <arg name="paused" value="true"/>
     <arg name="gui" value="$(arg gazebo_gui)"/>
   </include>
 
-  <!-- send robot urdf to param server -->
+  <!-- Set robot urdf on the parameter server -->
   <param name="robot_description" [GAZEBO_URDF_LOAD_ATTRIBUTE] />
 
-  <!-- unpause only after loading robot model -->
-  <arg name="unpause" value="$(eval '' if arg('paused') else '-unpause')" />
-  <!-- push robot_description to factory and spawn robot in gazebo at the origin, change x,y,z arguments to spawn in a different position -->
-  <arg name="world_pose" value="-x 0 -y 0 -z 0" />
-  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot $(arg unpause) $(arg world_pose) $(arg initial_joint_positions)"
-    respawn="false" output="screen" />
+  <!-- Push robot_description to factory and spawn robot in Gazebo -->
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot $(arg unpause) $(arg world_pose) $(arg initial_joint_positions)" respawn="false" output="screen" />
 
   <!-- Load joint controller parameters for Gazebo -->
   <rosparam file="$(find [GENERATED_PACKAGE_NAME])/config/gazebo_controllers.yaml" />
+
   <!-- Spawn Gazebo ROS controllers -->
   <node name="gazebo_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_state_controller" />
+
   <!-- Load ROS controllers -->
   <include file="$(dirname)/ros_controllers.launch"/>
 


### PR DESCRIPTION
### Description

Change components of spawn pose individually.
pass_all_args to gazebo.launch and gazebo.launch to empty_world.launch for for using all options without having to change any files generated by moveit_setup_assistant. Comments and structure adjusted.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
