### PR TITLE
 Planning request adapters: short-circuit if failure, return code rather than bool

### DIFF
--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -39,6 +39,7 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/utils/moveit_error_code.h>
 #include <boost/function.hpp>
 
 /** \brief Generic interface to adapting motion planning requests */
@@ -49,9 +50,9 @@ MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);  // Defines PlanningRequestAdapter
 class PlanningRequestAdapter
 {
 public:
-  using PlannerFn =
-      boost::function<bool(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
-                           planning_interface::MotionPlanResponse&)>;
+  using PlannerFn = boost::function<moveit::core::MoveItErrorCode(const planning_scene::PlanningSceneConstPtr&,
+                                                                  const planning_interface::MotionPlanRequest&,
+                                                                  planning_interface::MotionPlanResponse&)>;
 
   PlanningRequestAdapter()
   {
@@ -71,25 +72,27 @@ public:
     return "";
   }
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req,
-                    planning_interface::MotionPlanResponse& res) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res) const;
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const;
 
   /** \brief Adapt the planning request if needed, call the planner
       function \e planner and update the planning response if
       needed. If the response is changed, the index values of the
       states added without planning are added to \e
       added_path_index */
-  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                            const planning_interface::MotionPlanRequest& req,
-                            planning_interface::MotionPlanResponse& res,
-                            std::vector<std::size_t>& added_path_index) const = 0;
+  virtual moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                                     const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                                     const planning_interface::MotionPlanRequest& req,
+                                                     planning_interface::MotionPlanResponse& res,
+                                                     std::vector<std::size_t>& added_path_index) const = 0;
 };
 
 /// Apply a sequence of adapters to a motion plan
@@ -105,15 +108,16 @@ public:
     adapters_.push_back(adapter);
   }
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req,
-                    planning_interface::MotionPlanResponse& res) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res) const;
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const;
 
 private:
   std::vector<PlanningRequestAdapterConstPtr> adapters_;

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -42,22 +42,30 @@ namespace planning_request_adapter
 {
 namespace
 {
-bool callPlannerInterfaceSolve(const planning_interface::PlannerManager& planner,
-                               const planning_scene::PlanningSceneConstPtr& planning_scene,
-                               const planning_interface::MotionPlanRequest& req,
-                               planning_interface::MotionPlanResponse& res)
+moveit::core::MoveItErrorCode callPlannerInterfaceSolve(const planning_interface::PlannerManager& planner,
+                                                        const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                                        const planning_interface::MotionPlanRequest& req,
+                                                        planning_interface::MotionPlanResponse& res)
 {
   planning_interface::PlanningContextPtr context = planner.getPlanningContext(planning_scene, req, res.error_code_);
   if (context)
-    return context->solve(res);
+  {
+    // TODO(andyz): consider returning a moveit::core::MoveItErrorCode from context->solve()
+    bool result = context->solve(res);
+    return result ? moveit::core::MoveItErrorCode::SUCCESS : moveit::core::MoveItErrorCode::FAILURE;
+  }
   else
-    return false;
+  {
+    return moveit::core::MoveItErrorCode::FAILURE;
+  }
 }
 
-bool callAdapter(const PlanningRequestAdapter& adapter, const PlanningRequestAdapter::PlannerFn& planner,
-                 const planning_scene::PlanningSceneConstPtr& planning_scene,
-                 const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                 std::vector<std::size_t>& added_path_index)
+moveit::core::MoveItErrorCode callAdapter(const PlanningRequestAdapter& adapter,
+                                          const PlanningRequestAdapter::PlannerFn& planner,
+                                          const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                          const planning_interface::MotionPlanRequest& req,
+                                          planning_interface::MotionPlanResponse& res,
+                                          std::vector<std::size_t>& added_path_index)
 {
   try
   {
@@ -75,11 +83,10 @@ bool callAdapter(const PlanningRequestAdapter& adapter, const PlanningRequestAda
 
 }  // namespace
 
-bool PlanningRequestAdapter::adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                                          const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                          const planning_interface::MotionPlanRequest& req,
-                                          planning_interface::MotionPlanResponse& res,
-                                          std::vector<std::size_t>& added_path_index) const
+moveit::core::MoveItErrorCode PlanningRequestAdapter::adaptAndPlan(
+    const planning_interface::PlannerManagerPtr& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
+    std::vector<std::size_t>& added_path_index) const
 {
   return adaptAndPlan(
       [&planner](const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
@@ -89,29 +96,26 @@ bool PlanningRequestAdapter::adaptAndPlan(const planning_interface::PlannerManag
       planning_scene, req, res, added_path_index);
 }
 
-bool PlanningRequestAdapter::adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                                          const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                          const planning_interface::MotionPlanRequest& req,
-                                          planning_interface::MotionPlanResponse& res) const
+moveit::core::MoveItErrorCode PlanningRequestAdapter::adaptAndPlan(
+    const planning_interface::PlannerManagerPtr& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res) const
 {
   std::vector<std::size_t> dummy;
   return adaptAndPlan(planner, planning_scene, req, res, dummy);
 }
 
-bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                                               const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                               const planning_interface::MotionPlanRequest& req,
-                                               planning_interface::MotionPlanResponse& res) const
+moveit::core::MoveItErrorCode PlanningRequestAdapterChain::adaptAndPlan(
+    const planning_interface::PlannerManagerPtr& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res) const
 {
   std::vector<std::size_t> dummy;
   return adaptAndPlan(planner, planning_scene, req, res, dummy);
 }
 
-bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                                               const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                               const planning_interface::MotionPlanRequest& req,
-                                               planning_interface::MotionPlanResponse& res,
-                                               std::vector<std::size_t>& added_path_index) const
+moveit::core::MoveItErrorCode PlanningRequestAdapterChain::adaptAndPlan(
+    const planning_interface::PlannerManagerPtr& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
+    std::vector<std::size_t>& added_path_index) const
 {
   // if there are no adapters, run the planner directly
   if (adapters_.empty())
@@ -138,15 +142,17 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
       fn = [&adapter = *adapters_[i], fn, &added_path_index = added_path_index_each[i]](
                const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
                planning_interface::MotionPlanResponse& res) {
+        // Abort pipeline and return in case of failure
         return callAdapter(adapter, fn, scene, req, res, added_path_index);
       };
     }
 
-    bool result = fn(planning_scene, req, res);
+    moveit::core::MoveItErrorCode moveit_code = fn(planning_scene, req, res);
     added_path_index.clear();
 
     // merge the index values from each adapter
     for (std::vector<std::size_t>& added_states_by_each_adapter : added_path_index_each)
+    {
       for (std::size_t& added_index : added_states_by_each_adapter)
       {
         for (std::size_t& index_in_path : added_path_index)
@@ -154,8 +160,9 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
             index_in_path++;
         added_path_index.push_back(added_index);
       }
+    }
     std::sort(added_path_index.begin(), added_path_index.end());
-    return result;
+    return moveit_code;
   }
 }
 

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -174,14 +174,18 @@ public:
     return "CHOMP Optimizer";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& ps,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& ps,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
     // variable which is then used by CHOMP for optimization of the computed trajectory
-    if (!planner(ps, req, res))
-      return false;
+    moveit::core::MoveItErrorCode moveit_code = planner(ps, req, res);
+    if (!bool(moveit_code))
+    {
+      return moveit_code;
+    }
 
     // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
@@ -202,10 +206,15 @@ public:
     {
       res.trajectory_ = res_detailed.trajectory_[0];
       res.planning_time_ += res_detailed.processing_time_[0];
+      moveit_code = moveit::core::MoveItErrorCode::FAILURE;
+    }
+    else
+    {
+      moveit_code = moveit::core::MoveItErrorCode::SUCCESS;
     }
     res.error_code_ = res_detailed.error_code_;
 
-    return planning_success;
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -235,7 +235,8 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
   {
     if (adapter_chain_)
     {
-      solved = adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index);
+      solved =
+          bool(adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index));
       if (!adapter_added_state_index.empty())
       {
         std::stringstream ss;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -58,23 +58,25 @@ public:
     return "Add Time Parameterization";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
       if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                          req.max_acceleration_scaling_factor))
       {
         ROS_ERROR("Time parametrization for the solution path failed.");
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -60,12 +60,14 @@ public:
     return "Add Time Optimal Parameterization";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
       TimeOptimalTrajectoryGeneration totg;
@@ -73,11 +75,11 @@ public:
                                   req.max_acceleration_scaling_factor))
       {
         ROS_ERROR("Time parametrization for the solution path failed.");
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return moveit_code;
   }
 };
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -57,23 +57,25 @@ public:
     return "Add Time Parameterization";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
       if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                          req.max_acceleration_scaling_factor))
       {
         ROS_ERROR("Time parametrization for the solution path failed.");
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -47,9 +47,11 @@ public:
     return "No Op";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     return planner(planning_scene, req, res);
   }

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -77,9 +77,11 @@ public:
     return "Fix Start State Bounds";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const override
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 
@@ -176,16 +178,18 @@ public:
       }
     }
 
-    bool solved;
+    moveit::core::MoveItErrorCode moveit_code;
     // if we made any changes, use them
     if (change_req)
     {
       planning_interface::MotionPlanRequest req2 = req;
       moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
-      solved = planner(planning_scene, req2, res);
+      moveit_code = planner(planning_scene, req2, res);
     }
     else
-      solved = planner(planning_scene, req, res);
+    {
+      moveit_code = planner(planning_scene, req, res);
+    }
 
     // re-add the prefix state, if it was constructed
     if (prefix_state && res.trajectory_ && !res.trajectory_->empty())
@@ -201,7 +205,7 @@ public:
       added_path_index.push_back(0);
     }
 
-    return solved;
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -92,9 +92,11 @@ public:
     return "Fix Start State In Collision";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const override
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 
@@ -152,8 +154,8 @@ public:
       {
         planning_interface::MotionPlanRequest req2 = req;
         moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
-        bool solved = planner(planning_scene, req2, res);
-        if (solved && !res.trajectory_->empty())
+        moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req2, res);
+        if (bool(moveit_code) && !res.trajectory_->empty())
         {
           // heuristically decide a duration offset for the trajectory (induced by the additional point added as a
           // prefix to the computed trajectory)
@@ -165,14 +167,15 @@ public:
             added_index++;
           added_path_index.push_back(0);
         }
-        return solved;
+        return moveit_code;
       }
       else
       {
         ROS_WARN("Unable to find a valid state nearby the start state (using jiggle fraction of %lf and %u sampling "
-                 "attempts). Passing the original planning request to the planner.",
+                 "attempts).",
                  jiggle_fraction_, sampling_attempts_);
-        return planner(planning_scene, req, res);
+        res.error_code_.val = moveit_msgs::MoveItErrorCodes::START_STATE_IN_COLLISION;
+        return moveit::core::MoveItErrorCode(moveit_msgs::MoveItErrorCodes::START_STATE_IN_COLLISION);
       }
     }
     else

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -59,9 +59,11 @@ public:
     return "Fix Start State Path Constraints";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const override
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 
@@ -86,20 +88,21 @@ public:
       // index information from that call
       std::vector<std::size_t> added_path_index_temp;
       added_path_index_temp.swap(added_path_index);
-      bool solved1 = planner(planning_scene, req2, res2);
+      moveit::core::MoveItErrorCode solved1 = planner(planning_scene, req2, res2);
       added_path_index_temp.swap(added_path_index);
 
-      if (solved1)
+      moveit::core::MoveItErrorCode solved2(moveit_msgs::MoveItErrorCodes::FAILURE);
+      if (bool(solved1))
       {
         planning_interface::MotionPlanRequest req3 = req;
-        ROS_INFO("Planned to path constraints. Resuming original planning request.");
+        ROS_INFO("The start state was modified to match path constraints. Now resuming the original planning request.");
 
         // extract the last state of the computed motion plan and set it as the new start state
         moveit::core::robotStateToRobotStateMsg(res2.trajectory_->getLastWayPoint(), req3.start_state);
-        bool solved2 = planner(planning_scene, req3, res);
+        solved2 = planner(planning_scene, req3, res);
         res.planning_time_ += res2.planning_time_;
 
-        if (solved2)
+        if (bool(solved2))
         {
           // since we add a prefix, we need to correct any existing index positions
           for (std::size_t& added_index : added_path_index)
@@ -112,24 +115,19 @@ public:
           // we need to append the solution paths.
           res2.trajectory_->append(*res.trajectory_, 0.0);
           res2.trajectory_->swap(*res.trajectory_);
-          return true;
+          return moveit_msgs::MoveItErrorCodes::SUCCESS;
         }
-        else
-          return false;
       }
-      else
+      if (!bool(solved1) || !bool(solved2))
       {
-        ROS_WARN("Unable to plan to path constraints. Running usual motion plan.");
-        bool result = planner(planning_scene, req, res);
-        res.planning_time_ += res2.planning_time_;
-        return result;
+        ROS_WARN("Unable to meet path constraints at the start.");
+        moveit::core::MoveItErrorCode moveit_code(moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS);
+        res.error_code_.val = moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS;
+        return moveit_code;
       }
     }
-    else
-    {
-      ROS_DEBUG("Path constraints are OK. Running usual motion plan.");
-      return planner(planning_scene, req, res);
-    }
+    ROS_DEBUG("Path constraints are OK. Continuing without `fix_start_state_path_constraints`.");
+    return planner(planning_scene, req, res);
   }
 };
 }  // namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -66,9 +66,11 @@ public:
     return "Fix Workspace Bounds";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
     const moveit_msgs::WorkspaceParameters& wparams = req.workspace_parameters;
@@ -83,8 +85,8 @@ public:
       default_wp.max_corner.x = default_wp.max_corner.y = default_wp.max_corner.z = workspace_extent_;
       return planner(planning_scene, req2, res);
     }
-    else
-      return planner(planning_scene, req, res);
+
+    return planner(planning_scene, req, res);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -57,15 +57,19 @@ public:
     return "Resolve constraint frames to robot links";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
     planning_interface::MotionPlanRequest modified = req;
     kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), modified.path_constraints);
     for (moveit_msgs::Constraints& constraint : modified.goal_constraints)
+    {
       kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), constraint);
+    }
     return planner(planning_scene, modified, res);
   }
 };


### PR DESCRIPTION
This is a backport of this MoveIt2 PR: https://github.com/ros-planning/moveit2/pull/1605
