### PR TITLE
Improve processing of multiple planning attempts

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -767,72 +767,47 @@ const moveit_msgs::MoveItErrorCodes ompl_interface::ModelBasedPlanningContext::s
 
   moveit_msgs::MoveItErrorCodes result;
   result.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+  ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
+  registerTerminationCondition(ptc);
   if (count <= 1 || multi_query_planning_enabled_)  // multi-query planners should always run in single instances
   {
     ROS_DEBUG_NAMED(LOGNAME, "%s: Solving the planning problem once...", name_.c_str());
-    ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
-    registerTerminationCondition(ptc);
     result.val = errorCode(ompl_simple_setup_->solve(ptc));
     last_plan_time_ = ompl_simple_setup_->getLastPlanComputationTime();
-    unregisterTerminationCondition();
   }
   else
   {
     ROS_DEBUG_NAMED(LOGNAME, "%s: Solving the planning problem %u times...", name_.c_str(), count);
     ompl_parallel_plan_.clearHybridizationPaths();
-    if (count <= max_planning_threads_)
-    {
+
+    auto plan_parallel = [this, &ptc](unsigned int num_planners) {
       ompl_parallel_plan_.clearPlanners();
       if (ompl_simple_setup_->getPlannerAllocator())
-        for (unsigned int i = 0; i < count; ++i)
+        for (unsigned int i = 0; i < num_planners; ++i)
           ompl_parallel_plan_.addPlannerAllocator(ompl_simple_setup_->getPlannerAllocator());
       else
-        for (unsigned int i = 0; i < count; ++i)
+        for (unsigned int i = 0; i < num_planners; ++i)
           ompl_parallel_plan_.addPlanner(ompl::tools::SelfConfig::getDefaultPlanner(ompl_simple_setup_->getGoal()));
 
-      ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
-      registerTerminationCondition(ptc);
-      result.val = errorCode(ompl_parallel_plan_.solve(ptc, 1, count, hybridize_));
-      last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);
-      unregisterTerminationCondition();
+      return errorCode(ompl_parallel_plan_.solve(ptc, 1, num_planners, hybridize_));
+    };
+
+    if (count <= max_planning_threads_)
+    {
+      result.val = plan_parallel(count);
     }
     else
     {
-      ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
-      registerTerminationCondition(ptc);
       int n = count / max_planning_threads_;
       bool res = true;
       for (int i = 0; i < n && !ptc(); ++i)
-      {
-        ompl_parallel_plan_.clearPlanners();
-        if (ompl_simple_setup_->getPlannerAllocator())
-          for (unsigned int i = 0; i < max_planning_threads_; ++i)
-            ompl_parallel_plan_.addPlannerAllocator(ompl_simple_setup_->getPlannerAllocator());
-        else
-          for (unsigned int i = 0; i < max_planning_threads_; ++i)
-            ompl_parallel_plan_.addPlanner(ompl::tools::SelfConfig::getDefaultPlanner(ompl_simple_setup_->getGoal()));
-        bool r = ompl_parallel_plan_.solve(ptc, 1, count, hybridize_) == ompl::base::PlannerStatus::EXACT_SOLUTION;
-        res = res && r;
-      }
-      n = count % max_planning_threads_;
-      if (n && !ptc())
-      {
-        ompl_parallel_plan_.clearPlanners();
-        if (ompl_simple_setup_->getPlannerAllocator())
-          for (int i = 0; i < n; ++i)
-            ompl_parallel_plan_.addPlannerAllocator(ompl_simple_setup_->getPlannerAllocator());
-        else
-          for (int i = 0; i < n; ++i)
-            ompl_parallel_plan_.addPlanner(ompl::tools::SelfConfig::getDefaultPlanner(ompl_simple_setup_->getGoal()));
-        bool r = ompl_parallel_plan_.solve(ptc, 1, count, hybridize_) == ompl::base::PlannerStatus::EXACT_SOLUTION;
-        res = res && r;
-      }
-      last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);
-      unregisterTerminationCondition();
+        res = res && plan_parallel(max_planning_threads_) == moveit_msgs::MoveItErrorCodes::SUCCESS;
+      res = res && plan_parallel(count % max_planning_threads_) == moveit_msgs::MoveItErrorCodes::SUCCESS;
       result.val = res ? moveit_msgs::MoveItErrorCodes::SUCCESS : moveit_msgs::MoveItErrorCodes::FAILURE;
     }
+    last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);
   }
-
+  unregisterTerminationCondition();
   postSolve();
   return result;
 }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -799,11 +799,10 @@ const moveit_msgs::MoveItErrorCodes ompl_interface::ModelBasedPlanningContext::s
     else
     {
       int n = count / max_planning_threads_;
-      bool res = true;
-      for (int i = 0; i < n && !ptc(); ++i)
-        res = res && plan_parallel(max_planning_threads_) == moveit_msgs::MoveItErrorCodes::SUCCESS;
-      res = res && plan_parallel(count % max_planning_threads_) == moveit_msgs::MoveItErrorCodes::SUCCESS;
-      result.val = res ? moveit_msgs::MoveItErrorCodes::SUCCESS : moveit_msgs::MoveItErrorCodes::FAILURE;
+      for (int i = 0; i < n && result.val != moveit_msgs::MoveItErrorCodes::SUCCESS && !ptc(); ++i)
+        result.val = plan_parallel(max_planning_threads_);
+      if (result.val != moveit_msgs::MoveItErrorCodes::SUCCESS && !ptc())
+        result.val = plan_parallel(count % max_planning_threads_);
     }
     last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);
   }


### PR DESCRIPTION
This is a follow-up to #3257, cleaning up the code of parallel planning. This PR factors out common code into a lambda function and fixes the evaluation of the planning result (keeping the first successful plan).