### PR TITLE
Short circuit planning adapters

### DIFF
--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -61,7 +61,9 @@ bool callAdapter(const PlanningRequestAdapter& adapter, const PlanningRequestAda
 {
   try
   {
-    return adapter.adaptAndPlan(planner, planning_scene, req, res, added_path_index);
+    bool result = adapter.adaptAndPlan(planner, planning_scene, req, res, added_path_index);
+    ROS_DEBUG_STREAM_NAMED("planning_request_adapter", adapter.getDescription() << ": " << res.error_code_.val);
+    return result;
   }
   catch (std::exception& ex)
   {

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Ioan Sucan */
 
+#include <moveit/utils/moveit_error_code.h>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <functional>
 #include <algorithm>
@@ -62,7 +63,8 @@ bool callAdapter(const PlanningRequestAdapter& adapter, const PlanningRequestAda
   try
   {
     bool result = adapter.adaptAndPlan(planner, planning_scene, req, res, added_path_index);
-    ROS_DEBUG_STREAM_NAMED("planning_request_adapter", adapter.getDescription() << ": " << res.error_code_.val);
+    ROS_DEBUG_STREAM_NAMED("planning_request_adapter", adapter.getDescription()
+                                                           << ": " << moveit::core::MoveItErrorCode(res.error_code_));
     return result;
   }
   catch (std::exception& ex)

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -2,8 +2,9 @@ set(MOVEIT_LIB_NAME moveit_utils)
 
 add_library(${MOVEIT_LIB_NAME}
   src/lexical_casts.cpp
-  src/xmlrpc_casts.cpp
   src/message_checks.cpp
+  src/moveit_error_code.cpp
+  src/xmlrpc_casts.cpp
 )
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/moveit_core/utils/include/moveit/utils/moveit_error_code.h
+++ b/moveit_core/utils/include/moveit/utils/moveit_error_code.h
@@ -46,11 +46,9 @@ namespace core
 class MoveItErrorCode : public moveit_msgs::MoveItErrorCodes
 {
 public:
-  MoveItErrorCode()
-  {
-    val = 0;
-  }
-  MoveItErrorCode(int code)
+  static const char* toString(const moveit_msgs::MoveItErrorCodes& error_code);
+
+  MoveItErrorCode(int code = 0)
   {
     val = code;
   }
@@ -62,6 +60,10 @@ public:
   {
     return val == moveit_msgs::MoveItErrorCodes::SUCCESS;
   }
+  explicit operator std::string() const
+  {
+    return toString(*this);
+  }
   bool operator==(const int c) const
   {
     return val == c;
@@ -71,6 +73,8 @@ public:
     return val != c;
   }
 };
+
+std::ostream& operator<<(std::ostream& out, const MoveItErrorCode& e);
 
 }  // namespace core
 }  // namespace moveit

--- a/moveit_core/utils/src/moveit_error_code.cpp
+++ b/moveit_core/utils/src/moveit_error_code.cpp
@@ -1,0 +1,108 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit/utils/moveit_error_code.h>
+
+namespace moveit
+{
+namespace core
+{
+const char* MoveItErrorCode::toString(const moveit_msgs::MoveItErrorCodes& error_code)
+{
+  switch (error_code.val)
+  {
+    case 0:
+      return "NOT INITIALIZED";
+    case moveit_msgs::MoveItErrorCodes::SUCCESS:
+      return "SUCCESS";
+    case moveit_msgs::MoveItErrorCodes::FAILURE:
+      return "FAILURE";
+    case moveit_msgs::MoveItErrorCodes::PLANNING_FAILED:
+      return "PLANNING_FAILED";
+    case moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN:
+      return "INVALID_MOTION_PLAN";
+    case moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE:
+      return "MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE";
+    case moveit_msgs::MoveItErrorCodes::CONTROL_FAILED:
+      return "CONTROL_FAILED";
+    case moveit_msgs::MoveItErrorCodes::UNABLE_TO_AQUIRE_SENSOR_DATA:
+      return "UNABLE_TO_AQUIRE_SENSOR_DATA";
+    case moveit_msgs::MoveItErrorCodes::TIMED_OUT:
+      return "TIMED_OUT";
+    case moveit_msgs::MoveItErrorCodes::PREEMPTED:
+      return "PREEMPTED";
+    case moveit_msgs::MoveItErrorCodes::START_STATE_IN_COLLISION:
+      return "START_STATE_IN_COLLISION";
+    case moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS:
+      return "START_STATE_VIOLATES_PATH_CONSTRAINTS";
+    case moveit_msgs::MoveItErrorCodes::GOAL_IN_COLLISION:
+      return "GOAL_IN_COLLISION";
+    case moveit_msgs::MoveItErrorCodes::GOAL_VIOLATES_PATH_CONSTRAINTS:
+      return "GOAL_VIOLATES_PATH_CONSTRAINTS";
+    case moveit_msgs::MoveItErrorCodes::GOAL_CONSTRAINTS_VIOLATED:
+      return "GOAL_CONSTRAINTS_VIOLATED";
+    case moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME:
+      return "INVALID_GROUP_NAME";
+    case moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS:
+      return "INVALID_GOAL_CONSTRAINTS";
+    case moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE:
+      return "INVALID_ROBOT_STATE";
+    case moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME:
+      return "INVALID_LINK_NAME";
+    case moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME:
+      return "INVALID_OBJECT_NAME";
+    case moveit_msgs::MoveItErrorCodes::FRAME_TRANSFORM_FAILURE:
+      return "FRAME_TRANSFORM_FAILURE";
+    case moveit_msgs::MoveItErrorCodes::COLLISION_CHECKING_UNAVAILABLE:
+      return "COLLISION_CHECKING_UNAVAILABLE";
+    case moveit_msgs::MoveItErrorCodes::ROBOT_STATE_STALE:
+      return "ROBOT_STATE_STALE";
+    case moveit_msgs::MoveItErrorCodes::SENSOR_INFO_STALE:
+      return "SENSOR_INFO_STALE";
+    case moveit_msgs::MoveItErrorCodes::COMMUNICATION_FAILURE:
+      return "COMMUNICATION_FAILURE";
+    case moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION:
+      return "NO_IK_SOLUTION";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+std::ostream& operator<<(std::ostream& out, const MoveItErrorCode& e)
+{
+  return out << MoveItErrorCode::toString(e);
+}
+
+}  // namespace core
+}  // namespace moveit

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -116,45 +116,45 @@ move_group::MoveGroupCapability::clearSceneRobotState(const moveit_msgs::Plannin
 std::string move_group::MoveGroupCapability::getActionResultString(const moveit_msgs::MoveItErrorCodes& error_code,
                                                                    bool planned_trajectory_empty, bool plan_only)
 {
-  if (error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+  switch (error_code.val)
   {
-    if (planned_trajectory_empty)
-      return "Requested path and goal constraints are already met.";
-    else
-    {
-      if (plan_only)
-        return "Motion plan was computed succesfully.";
+    case moveit_msgs::MoveItErrorCodes::SUCCESS:
+      if (planned_trajectory_empty)
+        return "Requested path and goal constraints are already met.";
       else
-        return "Solution was found and executed.";
-    }
+      {
+        if (plan_only)
+          return "Motion plan was computed succesfully.";
+        else
+          return "Solution was found and executed.";
+      }
+    case moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME:
+      return "Must specify group in motion plan request";
+    case moveit_msgs::MoveItErrorCodes::PLANNING_FAILED:
+    case moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN:
+      if (planned_trajectory_empty)
+        return "No motion plan found. No execution attempted.";
+      else
+        return "Motion plan was found but it seems to be invalid (possibly due to postprocessing). Not executing.";
+    case moveit_msgs::MoveItErrorCodes::UNABLE_TO_AQUIRE_SENSOR_DATA:
+      return "Motion plan was found but it seems to be too costly and looking around did not help.";
+    case moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE:
+      return "Solution found but the environment changed during execution and the path was aborted";
+    case moveit_msgs::MoveItErrorCodes::CONTROL_FAILED:
+      return "Solution found but controller failed during execution";
+    case moveit_msgs::MoveItErrorCodes::TIMED_OUT:
+      return "Timeout reached";
+    case moveit_msgs::MoveItErrorCodes::PREEMPTED:
+      return "Preempted";
+    case moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS:
+      return "Invalid goal constraints";
+    case moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME:
+      return "Invalid object name";
+    case moveit_msgs::MoveItErrorCodes::FAILURE:
+      return "Catastrophic failure";
+    default:
+      return "Unknown event";
   }
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME)
-    return "Must specify group in motion plan request";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::PLANNING_FAILED ||
-           error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN)
-  {
-    if (planned_trajectory_empty)
-      return "No motion plan found. No execution attempted.";
-    else
-      return "Motion plan was found but it seems to be invalid (possibly due to postprocessing). Not executing.";
-  }
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::UNABLE_TO_AQUIRE_SENSOR_DATA)
-    return "Motion plan was found but it seems to be too costly and looking around did not help.";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE)
-    return "Solution found but the environment changed during execution and the path was aborted";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::CONTROL_FAILED)
-    return "Solution found but controller failed during execution";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::TIMED_OUT)
-    return "Timeout reached";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::PREEMPTED)
-    return "Preempted";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS)
-    return "Invalid goal constraints";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME)
-    return "Invalid object name";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::FAILURE)
-    return "Catastrophic failure";
-  return "Unknown event";
 }
 
 std::string move_group::MoveGroupCapability::stateToStr(MoveGroupState state) const

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -37,6 +37,7 @@
 #include <moveit/moveit_cpp/moveit_cpp.h>
 #include <moveit/move_group/move_group_capability.h>
 #include <moveit/robot_state/conversions.h>
+#include <moveit/utils/moveit_error_code.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <sstream>
@@ -129,7 +130,7 @@ std::string move_group::MoveGroupCapability::getActionResultString(const moveit_
           return "Solution was found and executed.";
       }
     case moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME:
-      return "Must specify group in motion plan request";
+      return "Invalid group in motion plan request";
     case moveit_msgs::MoveItErrorCodes::PLANNING_FAILED:
     case moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN:
       if (planned_trajectory_empty)
@@ -140,20 +141,8 @@ std::string move_group::MoveGroupCapability::getActionResultString(const moveit_
       return "Motion plan was found but it seems to be too costly and looking around did not help.";
     case moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE:
       return "Solution found but the environment changed during execution and the path was aborted";
-    case moveit_msgs::MoveItErrorCodes::CONTROL_FAILED:
-      return "Solution found but controller failed during execution";
-    case moveit_msgs::MoveItErrorCodes::TIMED_OUT:
-      return "Timeout reached";
-    case moveit_msgs::MoveItErrorCodes::PREEMPTED:
-      return "Preempted";
-    case moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS:
-      return "Invalid goal constraints";
-    case moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME:
-      return "Invalid object name";
-    case moveit_msgs::MoveItErrorCodes::FAILURE:
-      return "Catastrophic failure";
     default:
-      return "Unknown event";
+      return moveit::core::MoveItErrorCode::toString(error_code);
   }
 }
 

--- a/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
+++ b/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_execution.h
@@ -139,8 +139,6 @@ public:
 
   void stop();
 
-  std::string getErrorCodeString(const moveit_msgs::MoveItErrorCodes& error_code);
-
 private:
   void planAndExecuteHelper(ExecutableMotionPlan& plan, const Options& opt);
   bool isRemainingPathValid(const ExecutableMotionPlan& plan, const std::pair<int, int>& path_segment);

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -39,6 +39,7 @@
 #include <moveit/trajectory_processing/trajectory_tools.h>
 #include <moveit/collision_detection/collision_tools.h>
 #include <moveit/utils/message_checks.h>
+#include <moveit/utils/moveit_error_code.h>
 #include <boost/algorithm/string/join.hpp>
 
 #include <dynamic_reconfigure/server.h>
@@ -102,35 +103,6 @@ plan_execution::PlanExecution::~PlanExecution()
 void plan_execution::PlanExecution::stop()
 {
   preempt_.request();
-}
-
-std::string plan_execution::PlanExecution::getErrorCodeString(const moveit_msgs::MoveItErrorCodes& error_code)
-{
-  if (error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
-    return "Success";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME)
-    return "Invalid group name";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::PLANNING_FAILED)
-    return "Planning failed.";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN)
-    return "Invalid motion plan";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::UNABLE_TO_AQUIRE_SENSOR_DATA)
-    return "Unable to aquire sensor data";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE)
-    return "Motion plan invalidated by environment change";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::CONTROL_FAILED)
-    return "Controller failed during execution";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::TIMED_OUT)
-    return "Timeout reached";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::PREEMPTED)
-    return "Preempted";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS)
-    return "Invalid goal constraints";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME)
-    return "Invalid object name";
-  else if (error_code.val == moveit_msgs::MoveItErrorCodes::FAILURE)
-    return "Catastrophic failure";
-  return "Unknown event";
 }
 
 void plan_execution::PlanExecution::planAndExecute(ExecutableMotionPlan& plan, const Options& opt)
@@ -267,7 +239,7 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
     ROS_DEBUG_NAMED("plan_execution", "PlanExecution finished successfully.");
   else
     ROS_DEBUG_NAMED("plan_execution", "PlanExecution terminating with error code %d - '%s'", plan.error_code_.val,
-                    getErrorCodeString(plan.error_code_).c_str());
+                    moveit::core::MoveItErrorCode::toString(plan.error_code_));
 }
 
 bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionPlan& plan,

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -169,10 +169,11 @@ public:
       }
       else
       {
-        ROS_WARN("Unable to find a valid state nearby the start state (using jiggle fraction of %lf and %u sampling "
-                 "attempts). Passing the original planning request to the planner.",
+        ROS_WARN("Unable to find a valid state nearby the start state "
+                 "(using jiggle fraction of %lf and %u sampling attempts).",
                  jiggle_fraction_, sampling_attempts_);
-        return planner(planning_scene, req, res);
+        res.error_code_.val = moveit_msgs::MoveItErrorCodes::START_STATE_IN_COLLISION;
+        return false;
       }
     }
     else

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -119,10 +119,10 @@ public:
       }
       else
       {
-        ROS_WARN("Unable to plan to path constraints. Running usual motion plan.");
-        bool result = planner(planning_scene, req, res);
-        res.planning_time_ += res2.planning_time_;
-        return result;
+        ROS_WARN("Unable to plan to path constraints.");
+        res.error_code_.val = moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS;
+        res.planning_time_ = res2.planning_time_;
+        return false;
       }
     }
     else


### PR DESCRIPTION
This is an alternative implementation of #3258, without the need to change the return types of all planning request adapters.
This yields the following output as originally intended:
```
[ INFO] ros.moveit_ros_planning: Start state appears to be in collision with respect to group panda_manipulator
[ WARN] ros.moveit_ros_planning: Unable to find a valid state nearby the start state (using jiggle fraction of 0.050000 and 100 sampling attempts).
[DEBUG] ros.moveit_core.planning_request_adapter: Fix Start State In Collision: -10
[DEBUG] ros.moveit_core.planning_request_adapter: Fix Start State Bounds: -10
[DEBUG] ros.moveit_core.planning_request_adapter: Fix Workspace Bounds: -10
[DEBUG] ros.moveit_core.planning_request_adapter: Resolve constraint frames to robot links: -10
[DEBUG] ros.moveit_core.planning_request_adapter: Add Time Parameterization: -10
[ WARN] ros.moveit_ros_planning_interface.move_group_interface: Fail: ABORTED: START_STATE_IN_COLLISION
```
