### PR TITLE
MotionPlanningDisplay: Fix RobotState inconsistency

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -64,23 +64,24 @@ class PlanningSceneInterface(object):
     See wrap_python_planning_scene_interface.cpp for the wrapped methods.
     """
 
-    def __init__(self, ns="", synchronous=False, service_timeout=5.0):
+    def __init__(self, ns="", synchronous=True, service_timeout=5.0):
         self._psi = _moveit_planning_scene_interface.PlanningSceneInterface(ns)
-
-        self._pub_co = rospy.Publisher(
-            ns_join(ns, "collision_object"), CollisionObject, queue_size=100
-        )
-        self._pub_aco = rospy.Publisher(
-            ns_join(ns, "attached_collision_object"),
-            AttachedCollisionObject,
-            queue_size=100,
-        )
         self.__synchronous = synchronous
+
         if self.__synchronous:
             self._apply_planning_scene_diff = rospy.ServiceProxy(
                 ns_join(ns, "apply_planning_scene"), ApplyPlanningScene
             )
             self._apply_planning_scene_diff.wait_for_service(service_timeout)
+        else:
+            self._pub_co = rospy.Publisher(
+                ns_join(ns, "collision_object"), CollisionObject, queue_size=100
+            )
+            self._pub_aco = rospy.Publisher(
+                ns_join(ns, "attached_collision_object"),
+                AttachedCollisionObject,
+                queue_size=100,
+            )
 
     def __submit(self, collision_object, attach=False):
         if self.__synchronous:

--- a/moveit_commander/test/python_moveit_commander_ros_namespace.py
+++ b/moveit_commander/test/python_moveit_commander_ros_namespace.py
@@ -47,7 +47,7 @@ from moveit_commander import PlanningSceneInterface
 
 class PythonMoveitCommanderRosNamespaceTest(unittest.TestCase):
     def test_namespace(self):
-        self.scene = PlanningSceneInterface()
+        self.scene = PlanningSceneInterface(synchronous=False)
         expected_resolved_co_name = "/test_ros_namespace/collision_object"
         expected_resolved_aco_name = "/test_ros_namespace/attached_collision_object"
         self.assertEqual(self.scene._pub_co.resolved_name, expected_resolved_co_name)

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1977,6 +1977,9 @@ private:
   random_numbers::RandomNumberGenerator* rng_;
 };
 
+/** Check that both RobotStates have the same set of attached objects */
+bool haveSameAttachedObjects(const RobotState& left, const RobotState& right, const std::string& logprefix = "");
+
 /** \brief Operator overload for printing variable bounds to a stream */
 std::ostream& operator<<(std::ostream& out, const RobotState& s);
 }  // namespace core

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2300,5 +2300,54 @@ std::ostream& operator<<(std::ostream& out, const RobotState& s)
   return out;
 }
 
+bool haveSameAttachedObjects(const RobotState& left, const RobotState& right, const std::string& prefix)
+{
+  std::vector<const moveit::core::AttachedBody*> left_attached;
+  std::vector<const moveit::core::AttachedBody*> right_attached;
+  left.getAttachedBodies(left_attached);
+  right.getAttachedBodies(right_attached);
+  if (left_attached.size() != right_attached.size())
+  {
+    ROS_DEBUG_STREAM(prefix << "different number of objects");
+    return false;
+  }
+
+  for (const moveit::core::AttachedBody* left_object : left_attached)
+  {
+    auto it = std::find_if(right_attached.cbegin(), right_attached.cend(),
+                           [left_object](const moveit::core::AttachedBody* object) {
+                             return object->getName() == left_object->getName();
+                           });
+    if (it == right_attached.cend())
+    {
+      ROS_DEBUG_STREAM(prefix << "object missing: " << left_object->getName());
+      return false;
+    }
+    const moveit::core::AttachedBody* right_object = *it;
+    if (left_object->getAttachedLink() != right_object->getAttachedLink())
+    {
+      ROS_DEBUG_STREAM(prefix << "different attach links: " << left_object->getName() << " attached to "
+                              << left_object->getAttachedLinkName() << " / " << right_object->getAttachedLinkName());
+      return false;  // links not matching
+    }
+    if (left_object->getShapes().size() != right_object->getShapes().size())
+    {
+      ROS_DEBUG_STREAM(prefix << "different object shapes: " << left_object->getName());
+      return false;  // shapes not matching
+    }
+
+    auto left_it = left_object->getShapePosesInLinkFrame().cbegin();
+    auto left_end = left_object->getShapePosesInLinkFrame().cend();
+    auto right_it = right_object->getShapePosesInLinkFrame().cbegin();
+    for (; left_it != left_end; ++left_it, ++right_it)
+      if (!(left_it->matrix() - right_it->matrix()).isZero(1e-4))
+      {
+        ROS_DEBUG_STREAM(prefix << "different pose of attached object shape: " << left_object->getName());
+        return false;  // transforms do not match
+      }
+  }
+  return true;
+}
+
 }  // end of namespace core
 }  // end of namespace moveit

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1235,15 +1235,17 @@ void MotionPlanningDisplay::updateStateExceptModified(moveit::core::RobotState& 
 void MotionPlanningDisplay::updateQueryStates(const moveit::core::RobotState& current_state)
 {
   std::string group = planning_group_property_->getStdString();
+  if (group.empty())
+    return;
 
-  if (query_start_state_ && query_start_state_property_->getBool() && !group.empty())
+  if (query_start_state_)
   {
     moveit::core::RobotState start = *getQueryStartState();
     updateStateExceptModified(start, current_state);
     setQueryStartState(start);
   }
 
-  if (query_goal_state_ && query_goal_state_property_->getBool() && !group.empty())
+  if (query_goal_state_)
   {
     moveit::core::RobotState goal = *getQueryGoalState();
     updateStateExceptModified(goal, current_state);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -181,7 +181,11 @@ void MotionPlanningFrame::computePlanButtonClicked()
 
   if (success)
   {
-    ui_->execute_button->setEnabled(true);
+    moveit::core::RobotState start_state(planning_display_->getRobotModel());
+    moveit::core::RobotState current_state(planning_display_->getPlanningSceneRO()->getCurrentState());
+    moveit::core::robotStateMsgToRobotState(current_plan_->start_state_, start_state, true);
+    if (moveit::core::haveSameAttachedObjects(start_state, current_state))
+      ui_->execute_button->setEnabled(true);
     ui_->result_label->setText(QString("Time: ").append(QString::number(current_plan_->planning_time_, 'f', 3)));
   }
   else


### PR DESCRIPTION
Fixes #3207, i.e.
1. attached objects missing in planning requests triggered from rviz, because automatic query state updates were only performed if the state was visible.
2. disabling execution if the attached bodies of the current RobotState and don't match those of the plan's start state.
Unfortunately, the trajectory execution [service](http://docs.ros.org/en/api/moveit_msgs/html/srv/ExecuteKnownTrajectory.html) and [action](http://docs.ros.org/en/api/moveit_msgs/html/action/ExecuteTrajectory.html) do not receive the plan's start state (but only the [`RobotTrajectory`](http://docs.ros.org/en/api/moveit_msgs/html/msg/RobotTrajectory.html)). Thus we cannot reject an invalid plan at that level (which would be the correct one in my opinion).
