### PR TITLE
MotionPlanningDisplay: Fix PlanningScene editing

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -253,7 +253,7 @@ private:
   void createSceneInteractiveMarker();
   void renameCollisionObject(QListWidgetItem* item);
   void attachDetachCollisionObject(QListWidgetItem* item);
-  void populateCollisionObjectsList();
+  void populateCollisionObjectsList(planning_scene_monitor::LockedPlanningSceneRO* pps = nullptr);
   void computeImportGeometryFromText(const std::string& path);
   void computeExportGeometryAsText(const std::string& path);
   visualization_msgs::InteractiveMarker

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -253,6 +253,7 @@ private:
   void createSceneInteractiveMarker();
   void renameCollisionObject(QListWidgetItem* item);
   void attachDetachCollisionObject(QListWidgetItem* item);
+  QListWidgetItem* addCollisionObjectToList(const std::string& name, int row, bool attached);
   void populateCollisionObjectsList(planning_scene_monitor::LockedPlanningSceneRO* pps = nullptr);
   void computeImportGeometryFromText(const std::string& path);
   void computeExportGeometryAsText(const std::string& path);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -320,9 +320,6 @@ private:
   void remoteUpdateCustomStartStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
   void remoteUpdateCustomGoalStateCallback(const moveit_msgs::RobotStateConstPtr& msg);
 
-  /* Selects or unselects a item in a list by the item name */
-  void setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list);
-
   ros::NodeHandle nh_;  // node handle with the namespace of the connected move_group node
   ros::Publisher planning_scene_publisher_;
   ros::Publisher planning_scene_world_publisher_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -500,6 +500,7 @@ void MotionPlanningFrame::addSceneObject()
   populateCollisionObjectsList();
 
   // Automatically select the inserted object so that its IM is displayed
+  ui_->collision_objects_list->clearSelection();
   setItemSelectionInList(shape_name, true, ui_->collision_objects_list);
 
   planning_display_->queueRenderSceneGeometry();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -487,10 +487,12 @@ void MotionPlanningFrame::addSceneObject()
 
     // Actually add object to the plugin's PlanningScene
     ps->getWorldNonConst()->addToObject(shape_name, shape, Eigen::Isometry3d::Identity());
-    populateCollisionObjectsList(&ps);
   }
   setLocalSceneEdited();
   planning_display_->queueRenderSceneGeometry();
+
+  // Finally add object name to GUI list
+  auto item = addCollisionObjectToList(shape_name, ui_->collision_objects_list->count(), false);
 
   // Automatically select the inserted object so that its IM is displayed
   ui_->collision_objects_list->clearSelection();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -232,13 +232,6 @@ void MotionPlanningFrame::approximateIKChanged(int state)
   planning_display_->useApproximateIK(state == Qt::Checked);
 }
 
-void MotionPlanningFrame::setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list)
-{
-  QList<QListWidgetItem*> found_items = list->findItems(QString(item_name.c_str()), Qt::MatchExactly);
-  for (QListWidgetItem* found_item : found_items)
-    found_item->setSelected(selection);
-}
-
 void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
 {
   // This is needed to prevent UI event (resuming the options) triggered
@@ -494,9 +487,10 @@ void MotionPlanningFrame::addSceneObject()
   // Finally add object name to GUI list
   auto item = addCollisionObjectToList(shape_name, ui_->collision_objects_list->count(), false);
 
-  // Automatically select the inserted object so that its IM is displayed
+  // Select it and make it current so that its IM is displayed
   ui_->collision_objects_list->clearSelection();
-  setItemSelectionInList(shape_name, true, ui_->collision_objects_list);
+  item->setSelected(true);
+  ui_->collision_objects_list->setCurrentItem(item);
 }
 
 shapes::ShapePtr MotionPlanningFrame::loadMeshResource(const std::string& url)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -492,12 +492,11 @@ void MotionPlanningFrame::addSceneObject()
 
   // Actually add object to the plugin's PlanningScene
   {
-    planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
+    auto ps = planning_display_->getPlanningSceneRW();
     ps->getWorldNonConst()->addToObject(shape_name, shape, Eigen::Isometry3d::Identity());
+    populateCollisionObjectsList(&ps);
   }
   setLocalSceneEdited();
-
-  populateCollisionObjectsList();
 
   // Automatically select the inserted object so that its IM is displayed
   ui_->collision_objects_list->clearSelection();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -497,12 +497,10 @@ void MotionPlanningFrame::addSceneObject()
   }
   setLocalSceneEdited();
 
-  planning_display_->addMainLoopJob([this] { populateCollisionObjectsList(); });
+  populateCollisionObjectsList();
 
   // Automatically select the inserted object so that its IM is displayed
-  planning_display_->addMainLoopJob([this, shape_name, list_widget = ui_->collision_objects_list] {
-    setItemSelectionInList(shape_name, true, list_widget);
-  });
+  setItemSelectionInList(shape_name, true, ui_->collision_objects_list);
 
   planning_display_->queueRenderSceneGeometry();
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -180,8 +180,7 @@ void JMGItemModel::updateRobotState(const moveit::core::RobotState& state)
 {
   if (robot_state_.getRobotModel() != state.getRobotModel())
     return;
-  robot_state_.setVariablePositions(state.getVariablePositions());
-
+  robot_state_ = state;
   dataChanged(index(0, 1), index(rowCount() - 1, 1));
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -219,11 +219,18 @@ void MotionPlanningFrame::removeSceneObject()
 
   if (planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW())
   {
+    bool removed_attached = false;
     for (QListWidgetItem* item : selection)
       if (item->checkState() == Qt::Unchecked)
         ps->getWorldNonConst()->removeObject(item->text().toStdString());
       else
+      {
         ps->getCurrentStateNonConst().clearAttachedBody(item->text().toStdString());
+        removed_attached = true;
+      }
+
+    if (removed_attached)
+      planning_display_->updateQueryStates(ps->getCurrentState());
   }
   scene_marker_.reset();
   setLocalSceneEdited();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -990,9 +990,11 @@ void MotionPlanningFrame::computeImportGeometryFromText(const std::string& path)
     }
   }
   if (!success)
-    QMessageBox::warning(nullptr, "Loading scene geometry",
-                         "Failed to load scene geometry.\n"
-                         "See console output for more details.");
+    planning_display_->addMainLoopJob([] {
+      QMessageBox::warning(nullptr, "Loading scene geometry",
+                           "Failed to load scene geometry.\n"
+                           "See console output for more details.");
+    });
 }
 
 void MotionPlanningFrame::importGeometryFromTextButtonClicked()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -176,7 +176,8 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
 
         ps->getWorldNonConst()->setSubframesOfObject(scaled_object_->id_, scaled_subframes);
         setLocalSceneEdited();
-        scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));
+        if (scene_marker_)
+          scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));
         planning_display_->queueRenderSceneGeometry();
       }
       else

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -278,7 +278,7 @@ static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
 
 void MotionPlanningFrame::currentCollisionObjectChanged()
 {
-  auto setValue = [](QDoubleSpinBox* w, float value) {
+  auto setValue = [](QDoubleSpinBox* w, float value) {  // NOLINT(readability-identifier-naming)
     QSignalBlocker block(w);
     w->setValue(value);
   };

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -142,10 +142,8 @@ void MotionPlanningFrame::clearScene()
   {
     ps->getWorldNonConst()->clearObjects();
     ps->getCurrentStateNonConst().clearAttachedBodies();
-    moveit_msgs::PlanningScene msg;
-    ps->getPlanningSceneMsg(msg);
-    planning_scene_publisher_.publish(msg);
-    setLocalSceneEdited(false);
+    setLocalSceneEdited(true);
+    planning_display_->updateQueryStates(ps->getCurrentState());
     populateCollisionObjectsList();  // update list + internal vars
     planning_display_->queueRenderSceneGeometry();
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -969,6 +969,9 @@ This is usually achieved by random seeding, which can flip the robot configurati
               <property name="editTriggers">
                <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
               </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::ExtendedSelection</enum>
+              </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
While working on #3263, I noticed several issues with planning scene editing, which I attempt to address here:
- [x] Allow extended selection mode in object list (only single selection was allowed before)
    Note: interactive marker handles are shown for the _current_ item only
- [x] "Clear Scene" button should clear rviz' local scene only instead of syncing automatically to the move_group's scene
- [x] Removing single objects from the scene isn't reflected in the query states
- [ ] Attached objects cannot be moved yet. I suggest to show their pose relative to the link their are attached to.
- [ ] It is not clear how incoming planning scene updates (from `move_group` node via topic `/move_group/monitored_planning_scene` and from current state monitor via `/joint_states`) should be handled. This is the current status:
  - [joint state updates are only considered, if the corresponding planning group was never selected before](https://github.com/ros-planning/moveit/blob/fe0c182a57b79f970eaca26c479e96d857242505/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp#L1216-L1234).
    This partially makes sense, because we don't want a goal query state be overridden by actual robot movements.
    However, [currently, updates are disabled as soon as the planning group was selected](https://github.com/ros-planning/moveit/blob/fe0c182a57b79f970eaca26c479e96d857242505/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp#L1033).
    I suggest to change this as follows:
    - Only add the current planning group to `modified_groups_` if the corresponding query state was _actually_ modified.
    - Remove the planning group from the list if `<current>` was selected (and query state thus reset)
    - Have separate `modified_groups_` variables for start and goal query state.
  - Updates to collision and attached objects are always considered. This might override changes made to rviz' scene locally.