### PR TITLE
Remove capability declarations from pipeline configs

### DIFF
--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/chomp_planning_pipeline.launch.xml
@@ -17,8 +17,5 @@
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
   <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-  <!-- Add MoveGroup capabilities specific to this pipeline -->
-  <!-- <param name="capabilities" value="" /> -->
-
   <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/chomp_planning.yaml" />
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/ompl_planning_pipeline.launch.xml
@@ -19,9 +19,6 @@
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
   <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-  <!-- Add MoveGroup capabilities specific to this pipeline -->
-  <!-- <param name="capabilities" value="" /> -->
-
   <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/ompl_planning.yaml"/>
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/stomp_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/stomp_planning_pipeline.launch.xml
@@ -19,8 +19,5 @@
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
   <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-  <!-- Add MoveGroup capabilities specific to this pipeline -->
-  <!-- <param name="capabilities" value="" /> -->
-
   <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/stomp_planning.yaml"/>
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
@@ -1,11 +1,5 @@
 <launch>
 
-  <!-- define capabilites that are loaded on start (space seperated) -->
-  <arg name="capabilities" default=""/>
-
-  <!-- inhibit capabilites (space seperated) -->
-  <arg name="disable_capabilities" default=""/>
-
   <!-- The request adapters (plugins) used when planning with TrajOpt. ORDER MATTERS! -->
   <arg name="planning_adapters"
        default="default_planner_request_adapters/LimitMaxCartesianLinkSpeed
@@ -22,8 +16,6 @@
   <param name="request_adapters" value="$(arg planning_adapters)" />
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
   <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
-  <param name="capabilities" value="$(arg capabilities)" />
-  <param name="disable_capabilities" value="$(arg disable_capabilities)" />
 
   <rosparam command="load" file="$(find [GENERATED_PACKAGE_NAME])/config/trajopt_planning.yaml"/>
 


### PR DESCRIPTION
Capabilities are _global_ to the `move_group` node and not specific to pipleline configs. As the latter ones load their parameters into a namespace, e.g. `/move_group/planning_pipelines/ompl/*`, loading a capability as suggested by the comments, doesn't have any effect.
