### PR TITLE
IK solver should return false if constraint is not satisfied

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1515,10 +1515,15 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
   for (std::size_t i = 0; i < bij.size(); ++i)
     solution[bij[i]] = ik_sol[i];
   if (constraint(state, group, &solution[0]))
+  {
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+    return true;
+  }
   else
+  {
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
-  return true;
+    return false;
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
This fixes a bug in `RobotState::setFromIK()` where the optional `GroupStateValidityCallbackFn()` fails. I think false should be returned.