### PR TITLE
Fix ik_callback_fn: propagate return value

### DIFF
--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -576,7 +576,7 @@ bool IKConstraintSampler::sampleHelper(moveit::core::RobotState& state, const mo
     adapted_ik_validity_callback = [this, state_ptr = &state](const geometry_msgs::Pose& /*unused*/,
                                                               const std::vector<double>& joints,
                                                               moveit_msgs::MoveItErrorCodes& error_code) {
-      return samplingIkCallbackFnAdapter(state_ptr, jmg_, group_state_validity_callback_, joints, error_code);
+      samplingIkCallbackFnAdapter(state_ptr, jmg_, group_state_validity_callback_, joints, error_code);
     };
 
   for (unsigned int a = 0; a < max_attempts; ++a)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1920,13 +1920,6 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
 
   // Convert Eigen poses to geometry_msg format
   std::vector<geometry_msgs::Pose> ik_queries(poses_in.size());
-  kinematics::KinematicsBase::IKCallbackFn ik_callback_fn;
-  if (constraint)
-    ik_callback_fn = [this, jmg, constraint](const geometry_msgs::Pose pose, const std::vector<double>& joints,
-                                             moveit_msgs::MoveItErrorCodes& error_code) {
-      ikCallbackFnAdapter(this, jmg, constraint, pose, joints, error_code);
-    };
-
   for (std::size_t i = 0; i < transformed_poses.size(); ++i)
   {
     Eigen::Quaterniond quat(transformed_poses[i].linear());

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1506,7 +1506,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
 
 namespace
 {
-bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
+void ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
                          const GroupStateValidityCallbackFn& constraint, const geometry_msgs::Pose& /*unused*/,
                          const std::vector<double>& ik_sol, moveit_msgs::MoveItErrorCodes& error_code)
 {
@@ -1518,7 +1518,6 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
     error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
   else
     error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
-  return true;
 }
 }  // namespace
 
@@ -1778,7 +1777,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   if (constraint)
     ik_callback_fn = [this, jmg, constraint](const geometry_msgs::Pose& pose, const std::vector<double>& joints,
                                              moveit_msgs::MoveItErrorCodes& error_code) {
-      return ikCallbackFnAdapter(this, jmg, constraint, pose, joints, error_code);
+      ikCallbackFnAdapter(this, jmg, constraint, pose, joints, error_code);
     };
 
   // Bijection

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1778,7 +1778,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   if (constraint)
     ik_callback_fn = [this, jmg, constraint](const geometry_msgs::Pose& pose, const std::vector<double>& joints,
                                              moveit_msgs::MoveItErrorCodes& error_code) {
-      ikCallbackFnAdapter(this, jmg, constraint, pose, joints, error_code);
+      return ikCallbackFnAdapter(this, jmg, constraint, pose, joints, error_code);
     };
 
   // Bijection


### PR DESCRIPTION
Reviewing #3276, I noticed that the return value of `ikCallbackFnAdapter()` wasn't propagated through the lambda.
This issue was introduced in #3106.

As the [return value of this `IKCallbackFn` is actually never used](https://github.com/ros-planning/moveit/pull/3276#pullrequestreview-1190740340), it would be even cleaner to drop the boolean result and just rely on the error_code. Having two failure notification mechanisms, obviously results in confusion. Any thoughts?