### PR TITLE
Load URDF file from config folder or regenerate by xacro

### DIFF
--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -884,6 +884,13 @@ void ConfigurationFilesWidget::changeCheckedState(QListWidgetItem* item)
 
   // Enable/disable file
   gen_files_[index].generate_ = generate;
+
+  // Update GAZEBO_URDF_LOAD_ATTRIBUTE to load URDF file from config folder or to regenerate by xacro
+  if (gen_files_[index].write_on_changes == MoveItConfigData::SIMULATION)
+  {
+    config_data_->save_gazebo_urdf_ = generate;
+    loadGenFiles();
+  }
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -886,7 +886,7 @@ void ConfigurationFilesWidget::changeCheckedState(QListWidgetItem* item)
   gen_files_[index].generate_ = generate;
 
   // Update GAZEBO_URDF_LOAD_ATTRIBUTE to load URDF file from config folder or to regenerate by xacro
-  if (gen_files_[index].write_on_changes == MoveItConfigData::SIMULATION)
+  if (gen_files_[index].write_on_changes & MoveItConfigData::SIMULATION)
   {
     config_data_->save_gazebo_urdf_ = generate;
     loadGenFiles();


### PR DESCRIPTION
Update GAZEBO_URDF_LOAD_ATTRIBUTE to load URDF file from config folder or to regenerate by xacro

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
