### PR TITLE
MSA: Cleanup SimulationWidget

### DIFF
--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -235,9 +235,6 @@ public:
   // NOTE: Created when the robot urdf is not compatible with Gazebo.
   std::string gazebo_urdf_string_;
 
-  /// Whether a new Gazebo URDF is created
-  bool save_gazebo_urdf_;
-
   // ******************************************************************************************
   // SRDF Data
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -210,16 +210,10 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
 }
 
 // ******************************************************************************************
-// Output Gazebo URDF file (or delete existing file if gazebo_urdf_string_ is empty)
+// Output Gazebo URDF file
 // ******************************************************************************************
 bool MoveItConfigData::outputGazeboURDFFile(const std::string& file_path)
 {
-  if (gazebo_urdf_string_.empty())
-  {
-    fs::remove(file_path.c_str());
-    return true;
-  }
-
   std::ofstream os(file_path.c_str(), std::ios_base::trunc);
   if (!os.good())
   {

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -210,10 +210,16 @@ bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
 }
 
 // ******************************************************************************************
-// Output Gazebo URDF file
+// Output Gazebo URDF file (or delete existing file if gazebo_urdf_string_ is empty)
 // ******************************************************************************************
 bool MoveItConfigData::outputGazeboURDFFile(const std::string& file_path)
 {
+  if (gazebo_urdf_string_.empty())
+  {
+    fs::remove(file_path.c_str());
+    return true;
+  }
+
   std::ofstream os(file_path.c_str(), std::ios_base::trunc);
   if (!os.good())
   {
@@ -221,7 +227,7 @@ bool MoveItConfigData::outputGazeboURDFFile(const std::string& file_path)
     return false;
   }
 
-  os << gazebo_urdf_string_.c_str() << std::endl;
+  os << gazebo_urdf_string_ << std::endl;
   os.close();
 
   return true;

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -276,16 +276,19 @@ bool ConfigurationFilesWidget::loadGenFiles()
   config_data_->srdf_pkg_relative_path_ = file.rel_path_;
 
   // gazebo_<ROBOT>.urdf ---------------------------------------------------------------------------------------
-  file.file_name_ = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
-  file.rel_path_ = config_data_->appendPaths(CONFIG_PATH, file.file_name_);
-  file.description_ =
-      "This <a href='https://wiki.ros.org/urdf'>URDF</a> file comprises your original robot description "
-      "augmented with tags required for use with Gazebo, i.e. defining inertia and transmission properties. "
-      "Checkout the <a href='http://gazebosim.org/tutorials/?tut=ros_urdf'>URDF Gazebo documentation</a> "
-      "for more infos.";
-  file.gen_func_ = [this](const std::string& output_path) { return config_data_->outputGazeboURDFFile(output_path); };
-  file.write_on_changes = MoveItConfigData::SIMULATION;
-  gen_files_.push_back(file);
+  if (!config_data_->gazebo_urdf_string_.empty())
+  {
+    file.file_name_ = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
+    file.rel_path_ = config_data_->appendPaths(CONFIG_PATH, file.file_name_);
+    file.description_ =
+        "This <a href='https://wiki.ros.org/urdf'>URDF</a> file comprises your original robot description "
+        "augmented with tags required for use with Gazebo, i.e. defining inertia and transmission properties. "
+        "Checkout the <a href='http://gazebosim.org/tutorials/?tut=ros_urdf'>URDF Gazebo documentation</a> "
+        "for more infos.";
+    file.gen_func_ = [this](const std::string& output_path) { return config_data_->outputGazeboURDFFile(output_path); };
+    file.write_on_changes = MoveItConfigData::SIMULATION;
+    gen_files_.push_back(file);
+  }
 
   // ompl_planning.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "ompl_planning.yaml";

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -276,19 +276,16 @@ bool ConfigurationFilesWidget::loadGenFiles()
   config_data_->srdf_pkg_relative_path_ = file.rel_path_;
 
   // gazebo_<ROBOT>.urdf ---------------------------------------------------------------------------------------
-  if (config_data_->save_gazebo_urdf_)
-  {
-    file.file_name_ = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
-    file.rel_path_ = config_data_->appendPaths(CONFIG_PATH, file.file_name_);
-    file.description_ =
-        "This <a href='https://wiki.ros.org/urdf'>URDF</a> file comprises your original robot description "
-        "augmented with tags required for use with Gazebo, i.e. defining inertia and transmission properties. "
-        "Checkout the <a href='http://gazebosim.org/tutorials/?tut=ros_urdf'>URDF Gazebo documentation</a> "
-        "for more infos.";
-    file.gen_func_ = [this](const std::string& output_path) { return config_data_->outputGazeboURDFFile(output_path); };
-    file.write_on_changes = MoveItConfigData::SIMULATION;
-    gen_files_.push_back(file);
-  }
+  file.file_name_ = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
+  file.rel_path_ = config_data_->appendPaths(CONFIG_PATH, file.file_name_);
+  file.description_ =
+      "This <a href='https://wiki.ros.org/urdf'>URDF</a> file comprises your original robot description "
+      "augmented with tags required for use with Gazebo, i.e. defining inertia and transmission properties. "
+      "Checkout the <a href='http://gazebosim.org/tutorials/?tut=ros_urdf'>URDF Gazebo documentation</a> "
+      "for more infos.";
+  file.gen_func_ = [this](const std::string& output_path) { return config_data_->outputGazeboURDFFile(output_path); };
+  file.write_on_changes = MoveItConfigData::SIMULATION;
+  gen_files_.push_back(file);
 
   // ompl_planning.yaml --------------------------------------------------------------------------------------
   file.file_name_ = "ompl_planning.yaml";
@@ -1257,7 +1254,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     addTemplateString("[URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 
   // Pair 4
-  if (config_data_->save_gazebo_urdf_)
+  if (config_data_->changes & MoveItConfigData::SIMULATION)
   {
     std::string file_name = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
     std::string rel_path = config_data_->appendPaths(CONFIG_PATH, file_name);

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1127,6 +1127,8 @@ bool ConfigurationFilesWidget::generatePackage()
     }
   }
 
+  loadTemplateStrings();
+
   // Begin to create files and folders ----------------------------------------------------------------------
   std::string absolute_path;
 
@@ -1143,9 +1145,6 @@ bool ConfigurationFilesWidget::generatePackage()
     // Create the absolute path
     absolute_path = config_data_->appendPaths(new_package_path, file->rel_path_);
     ROS_DEBUG_STREAM("Creating file " << absolute_path);
-
-    // Clear template strings in case export is run multiple times with changes in between
-    template_strings_.clear();
 
     // Run the generate function
     if (!file->gen_func_(absolute_path))
@@ -1237,6 +1236,9 @@ bool ConfigurationFilesWidget::noGroupsEmpty()
 // ******************************************************************************************
 void ConfigurationFilesWidget::loadTemplateStrings()
 {
+  // Clear strings (in case export is run multiple times)
+  template_strings_.clear();
+
   // Pair 1
   addTemplateString("[GENERATED_PACKAGE_NAME]", new_package_name_);
 
@@ -1355,12 +1357,6 @@ bool ConfigurationFilesWidget::addTemplateString(const std::string& key, const s
 // ******************************************************************************************
 bool ConfigurationFilesWidget::copyTemplate(const std::string& template_path, const std::string& output_path)
 {
-  // Check if template strings have been loaded yet
-  if (template_strings_.empty())
-  {
-    loadTemplateStrings();
-  }
-
   // Error check file
   if (!fs::is_regular_file(template_path))
   {

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1256,7 +1256,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
     addTemplateString("[URDF_LOAD_ATTRIBUTE]", "textfile=\"" + urdf_location + "\"");
 
   // Pair 4
-  if (config_data_->changes & MoveItConfigData::SIMULATION)
+  if (config_data_->changes & MoveItConfigData::SIMULATION && !config_data_->gazebo_urdf_string_.empty())
   {
     std::string file_name = "gazebo_" + config_data_->urdf_model_->getName() + ".urdf";
     std::string rel_path = config_data_->appendPaths(CONFIG_PATH, file_name);

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -678,7 +678,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   file.gen_func_ = [this, template_path](const std::string& output_path) {
     return copyTemplate(template_path, output_path);
   };
-  file.write_on_changes = MoveItConfigData::SIMULATION;
+  file.write_on_changes = 0;
   gen_files_.push_back(file);
 
   // joystick_control.launch ------------------------------------------------------------------

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -67,11 +67,18 @@ SimulationWidget::SimulationWidget(QWidget* parent, const MoveItConfigDataPtr& c
 
   // Top Header Area ------------------------------------------------
 
-  HeaderWidget* header = new HeaderWidget("Simulate With Gazebo",
-                                          "The following tool will auto-generate the URDF changes needed "
-                                          "for Gazebo compatibility with ROSControl and MoveIt. The "
-                                          "needed changes are shown in green.",
-                                          this);
+  HeaderWidget* header = new HeaderWidget(
+      "Gazebo Simulation",
+      QString("For use in the Gazebo physics simulation, the URDF needs to define inertial properties "
+              "for all links as well as control interfaces for all joints. "
+              "The required changes to your URDF are <b>highlighted below in "
+              "<font color=\"darkgreen\">green</font></b>.<br>"
+              "You can accept these suggestions and overwrite your existing URDF, or manually "
+              "adapt your URDF opening your preferred editor. "
+              "By default, a new file comprising those changes will be written to <tt>config/gazebo_%1.urdf</tt>")
+          .arg(config_data_->urdf_model_->getName().c_str())
+          .toStdString(),
+      this);
   layout->addWidget(header);
   layout->addSpacerItem(new QSpacerItem(1, 8, QSizePolicy::Fixed, QSizePolicy::Fixed));
 

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -171,7 +171,7 @@ bool SimulationWidget::focusLost()
   TiXmlDocument doc;
   auto urdf = simulation_text_->document()->toPlainText().toStdString();
   doc.Parse(urdf.c_str(), nullptr, TIXML_ENCODING_UTF8);
-  if (doc.Error())
+  if (!urdf.empty() && doc.Error())
   {
     QTextCursor cursor = simulation_text_->textCursor();
     cursor.movePosition(QTextCursor::Start);

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -150,7 +150,7 @@ void SimulationWidget::focusGiven()
   // GUI elements are visible only if there are URDF changes to display/edit
   simulation_text_->setVisible(have_changes);
   btn_overwrite_->setVisible(have_changes);
-  btn_open_->setVisible(have_changes && !qgetenv("EDITOR").isEmpty());
+  btn_open_->setVisible(have_changes);
   copy_urdf_->setVisible(have_changes);
   no_changes_label_->setVisible(!have_changes);
 
@@ -214,7 +214,12 @@ void SimulationWidget::overwriteURDF()
 
 void SimulationWidget::openURDF()
 {
-  QProcess::startDetached(qgetenv("EDITOR"), { config_data_->urdf_path_.c_str() });
+  QString editor = qgetenv("EDITOR");
+  if (editor.isEmpty())
+    editor = "xdg-open";
+  auto command = QString("%1 %2").arg(editor, config_data_->urdf_path_.c_str());
+  if (!QProcess::startDetached(command))
+    QMessageBox::warning(this, "URDF Editor", tr("Failed to open editor: <pre>%1</pre>").arg(editor));
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -139,7 +139,6 @@ void SimulationWidget::focusGiven()
 
   // Add generated Gazebo URDF to config file if not empty
   bool have_changes = !text.empty();
-  config_data_->save_gazebo_urdf_ = have_changes;
 
   // GUI elements are visible only if there are URDF changes to display/edit
   simulation_text_->setVisible(have_changes);
@@ -165,7 +164,7 @@ void SimulationWidget::focusGiven()
 
 bool SimulationWidget::focusLost()
 {
-  if (!config_data_->save_gazebo_urdf_)
+  if (!(config_data_->changes & MoveItConfigData::SIMULATION))
     return true;  // saving is disabled anyway
 
   // validate XML
@@ -203,7 +202,6 @@ void SimulationWidget::overwriteURDF()
                              "Original robot description URDF was successfully overwritten.");
 
   // Remove Gazebo URDF file from list of to-be-written config files
-  config_data_->save_gazebo_urdf_ = false;
   config_data_->changes &= ~MoveItConfigData::SIMULATION;
 }
 

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -210,13 +210,12 @@ void SimulationWidget::overwriteURDF()
 
   if (!config_data_->outputGazeboURDFFile(config_data_->urdf_path_))
     QMessageBox::warning(this, "Gazebo URDF", tr("Failed to save to ").append(config_data_->urdf_path_.c_str()));
-  else  // Display success message
-    QMessageBox::information(this, "Overwriting Successfull",
-                             "Original robot description URDF was successfully overwritten.");
-
-  // Remove Gazebo URDF file from list of to-be-written config files
-  setDirty(false);
-  config_data_->gazebo_urdf_string_.clear();
+  else
+  {
+    // Remove Gazebo URDF file from list of to-be-written config files
+    setDirty(false);
+    config_data_->gazebo_urdf_string_.clear();
+  }
 }
 
 void SimulationWidget::openURDF()

--- a/moveit_setup_assistant/src/widgets/simulation_widget.h
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.h
@@ -76,6 +76,8 @@ private Q_SLOTS:
   // Slot Event Functions
   // ******************************************************************************************
 
+  /// Mark document as changed
+  void setDirty(bool dirty = true);
   /// Overwrite original URDF with content of document
   void overwriteURDF();
   /// Open original URDF with system editor


### PR DESCRIPTION
`config_data_->save_gazebo_urdf_` is True if and only if `config_data_->changes` has the `MoveItConfigData::SIMULATION` bit set. Thus we can replace the former with the latter check.
Fixes #3280