### PR TITLE
Add joints_allowed_start_tolerance parameter (#3266)

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -205,6 +205,12 @@ public:
   /// Set joint-value tolerance for validating trajectory's start point against current robot state
   void setAllowedStartTolerance(double tolerance);
 
+  /// Set the start tolerance for a specific joint. Set to 0 to use the default value allowed_start_tolerance instead.
+  void setAllowedJointStartTolerance(std::string const& joint_name, double tolerance);
+
+  /// Set the start tolerance for a a set of  joint.
+  void setAllowedJointsStartTolerance(std::map<std::string, double> jointsStartTolerance);
+
   /// Enable or disable waiting for trajectory completion
   void setWaitForTrajectoryCompletion(bool flag);
 
@@ -265,6 +271,9 @@ private:
 
   void loadControllerParams();
 
+  double getJointAllowedStartTolerance(std::string const& jointName) const;
+  void updateJointsAllowedStartToleranceEmpty();
+
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   ros::NodeHandle node_handle_;
@@ -310,6 +319,9 @@ private:
   std::map<std::string, double> controller_allowed_goal_duration_margin_;
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
+  // joint tolerance per joint, overrides allowed_start_tolerance_.
+  std::map<std::string, double> joints_allowed_start_tolerance_;
+  bool joints_allowed_start_tolerance_empty_;  // True if joints_allowed_start_tolerance_ is empty or contains only 0
   double execution_velocity_scaling_;
   bool wait_for_trajectory_completion_;
 };

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -313,7 +313,7 @@ private:
   std::map<std::string, double> controller_allowed_goal_duration_margin_;
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
-  // joint tolerance per joint, overrides allowed_start_tolerance_.
+  // tolerance per joint, overrides global allowed_start_tolerance_.
   std::map<std::string, double> joints_allowed_start_tolerance_;
   double execution_velocity_scaling_;
   bool wait_for_trajectory_completion_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -205,12 +205,6 @@ public:
   /// Set joint-value tolerance for validating trajectory's start point against current robot state
   void setAllowedStartTolerance(double tolerance);
 
-  /// Set the start tolerance for a specific joint. Set to 0 to use the default value allowed_start_tolerance instead.
-  void setAllowedJointStartTolerance(std::string const& joint_name, double tolerance);
-
-  /// Set the start tolerance for a a set of  joint.
-  void setAllowedJointsStartTolerance(std::map<std::string, double> jointsStartTolerance);
-
   /// Enable or disable waiting for trajectory completion
   void setWaitForTrajectoryCompletion(bool flag);
 
@@ -272,12 +266,13 @@ private:
   void loadControllerParams();
 
   double getJointAllowedStartTolerance(std::string const& jointName) const;
-  void updateJointsAllowedStartToleranceEmpty();
+  void updateJointsAllowedStartTolerance();
 
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;
+  ros::NodeHandle trajectory_execution_node_handle_;
   ros::Subscriber event_topic_subscriber_;
 
   std::map<std::string, ControllerInformation> known_controllers_;
@@ -321,7 +316,6 @@ private:
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
   // joint tolerance per joint, overrides allowed_start_tolerance_.
   std::map<std::string, double> joints_allowed_start_tolerance_;
-  bool joints_allowed_start_tolerance_empty_;  // True if joints_allowed_start_tolerance_ is empty or contains only 0
   double execution_velocity_scaling_;
   bool wait_for_trajectory_completion_;
 };

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -272,7 +272,6 @@ private:
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;
-  ros::NodeHandle trajectory_execution_node_handle_;
   ros::Subscriber event_topic_subscriber_;
 
   std::map<std::string, ControllerInformation> known_controllers_;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1575,6 +1575,15 @@ void TrajectoryExecutionManager::updateJointsAllowedStartTolerance()
 {
   joints_allowed_start_tolerance_.clear();
   node_handle_.getParam("trajectory_execution/joints_allowed_start_tolerance", joints_allowed_start_tolerance_);
+
+  // remove negative values
+  for (auto it = joints_allowed_start_tolerance_.begin(); it != joints_allowed_start_tolerance_.end();)
+  {
+    if (it->second < 0)
+      it = joints_allowed_start_tolerance_.erase(it);
+    else
+      ++it;
+  }
 }
 
 }  // namespace trajectory_execution_manager

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -60,15 +60,19 @@ public:
     trajectory_execution_manager_ptr = moveit_cpp_ptr->getTrajectoryExecutionManagerNonConst();
 
     traj1.joint_trajectory.joint_names.push_back("panda_joint1");
-    traj1.joint_trajectory.points.resize(1);
+    traj1.joint_trajectory.points.resize(2);
     traj1.joint_trajectory.points[0].positions.push_back(0.0);
+    traj1.joint_trajectory.points[1].positions.push_back(0.5);
+    traj1.joint_trajectory.points[1].time_from_start.fromSec(0.5);
 
     traj2 = traj1;
     traj2.joint_trajectory.joint_names.push_back("panda_joint2");
     traj2.joint_trajectory.points[0].positions.push_back(1.0);
+    traj2.joint_trajectory.points[1].positions.push_back(1.5);
     traj2.multi_dof_joint_trajectory.joint_names.push_back("panda_joint3");
-    traj2.multi_dof_joint_trajectory.points.resize(1);
+    traj2.multi_dof_joint_trajectory.points.resize(2);
     traj2.multi_dof_joint_trajectory.points[0].transforms.resize(1);
+    traj2.multi_dof_joint_trajectory.points[1].transforms.resize(1);
   }
 
 protected:

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -108,6 +108,29 @@ TEST_F(MoveItCppTest, PushExecuteAndWaitTest)
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
 }
 
+TEST_F(MoveItCppTest, RejectTooFarFromStart)
+{
+  moveit_msgs::RobotTrajectory traj = traj1;
+  traj.joint_trajectory.points[0].positions[0] = 0.3;
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.01);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::ABORTED);
+}
+
+TEST_F(MoveItCppTest, AcceptAllowedJointStartTolerance)
+{
+  moveit_msgs::RobotTrajectory traj = traj1;
+  traj.joint_trajectory.points[0].positions[0] = 0.3;
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.01);
+  trajectory_execution_manager_ptr->setAllowedJointStartTolerance("panda_joint1", 0.5);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
+}
+
 }  // namespace moveit_cpp
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -152,7 +152,6 @@ TEST_F(MoveItCppTest, DoNotValidateJointStartToleranceZero)
   last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::ABORTED);
 
-  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.1);
   ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0);
   ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
   last_execution_status = trajectory_execution_manager_ptr->executeAndWait();

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -73,6 +73,8 @@ public:
     traj2.multi_dof_joint_trajectory.points.resize(2);
     traj2.multi_dof_joint_trajectory.points[0].transforms.resize(1);
     traj2.multi_dof_joint_trajectory.points[1].transforms.resize(1);
+
+    ros::param::del("~/trajectory_execution/joints_allowed_start_tolerance");
   }
 
 protected:
@@ -132,6 +134,28 @@ TEST_F(MoveItCppTest, AcceptAllowedJointStartTolerance)
   ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0.5);
   ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
   auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
+}
+
+TEST_F(MoveItCppTest, DoNotValidateJointStartToleranceZero)
+{
+  moveit_msgs::RobotTrajectory traj = traj1;
+  traj.joint_trajectory.points[0].positions[0] = 0.3;
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.1);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::ABORTED);
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.1);
+  ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
 }
 

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -125,7 +125,7 @@ TEST_F(MoveItCppTest, AcceptAllowedJointStartTolerance)
   traj.joint_trajectory.points[0].positions[0] = 0.3;
 
   trajectory_execution_manager_ptr->setAllowedStartTolerance(0.01);
-  trajectory_execution_manager_ptr->setAllowedJointStartTolerance("panda_joint1", 0.5);
+  ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0.5);
   ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
   auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);


### PR DESCRIPTION
Allow to specify a per joint allowed start tolerance for the TrajectoryExecutionManager.

### Description

Add the `/move_group/trajectory_execution/joints_allowed_start_tolerance`, a string/double map to specify an allowed start tolerance value for each joint. If the value is not set or set to 0 for a joint, it will fall back to the regular allowed_start_tolerance.

Closes #3266.

### Implementation details

Unlike allowed_start_tolerance, this doesn't uses the dynamic reconfigure server, because it is not possible to use maps with it.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
