### PR TITLE
Fix some consistency issues in PlanningScene handling

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -107,6 +107,11 @@ class PlanningSceneInterface(object):
         co = self.__make_cylinder(name, pose, height, radius)
         self.__submit(co, attach=False)
 
+    def add_cone(self, name, pose, height, radius):
+        """Add a cylinder to the planning scene"""
+        co = self.__make_cone(name, pose, height, radius)
+        self.__submit(co, attach=False)
+
     def add_mesh(self, name, pose, filename, size=(1, 1, 1)):
         """Add a mesh to the planning scene"""
         co = self.__make_mesh(name, pose, filename, size)
@@ -348,6 +353,19 @@ class PlanningSceneInterface(object):
         cylinder.type = SolidPrimitive.CYLINDER
         cylinder.dimensions = [height, radius]
         co.primitives = [cylinder]
+        return co
+
+    @staticmethod
+    def __make_cone(name, pose, height, radius):
+        co = CollisionObject()
+        co.operation = CollisionObject.ADD
+        co.id = name
+        co.header = pose.header
+        co.pose = pose.pose
+        cone = SolidPrimitive()
+        cone.type = SolidPrimitive.CONE
+        cone.dimensions = [height, radius]
+        co.primitives = [cone]
         return co
 
     @staticmethod

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -268,17 +268,23 @@ class PlanningSceneInterface(object):
         return co
 
     @staticmethod
-    def __make_box(name, pose, size):
+    def __make_primitive(name, pose, type, shape_args):
         co = CollisionObject()
         co.operation = CollisionObject.ADD
         co.id = name
         co.header = pose.header
         co.pose = pose.pose
-        box = SolidPrimitive()
-        box.type = SolidPrimitive.BOX
-        box.dimensions = list(size)
-        co.primitives = [box]
+        shape = SolidPrimitive()
+        shape.type = type
+        shape.dimensions = list(shape_args)
+        co.primitives = [shape]
         return co
+
+    @staticmethod
+    def __make_box(name, pose, size):
+        return PlanningSceneInterface.__make_primitive(
+            name, pose, SolidPrimitive.BOX, size
+        )
 
     @staticmethod
     def __make_mesh(name, pose, filename, scale=(1, 1, 1)):
@@ -331,42 +337,21 @@ class PlanningSceneInterface(object):
 
     @staticmethod
     def __make_sphere(name, pose, radius):
-        co = CollisionObject()
-        co.operation = CollisionObject.ADD
-        co.id = name
-        co.header = pose.header
-        co.pose = pose.pose
-        sphere = SolidPrimitive()
-        sphere.type = SolidPrimitive.SPHERE
-        sphere.dimensions = [radius]
-        co.primitives = [sphere]
-        return co
+        return PlanningSceneInterface.__make_primitive(
+            name, pose, SolidPrimitive.SPHERE, [radius]
+        )
 
     @staticmethod
     def __make_cylinder(name, pose, height, radius):
-        co = CollisionObject()
-        co.operation = CollisionObject.ADD
-        co.id = name
-        co.header = pose.header
-        co.pose = pose.pose
-        cylinder = SolidPrimitive()
-        cylinder.type = SolidPrimitive.CYLINDER
-        cylinder.dimensions = [height, radius]
-        co.primitives = [cylinder]
-        return co
+        return PlanningSceneInterface.__make_primitive(
+            name, pose, SolidPrimitive.CYLINDER, [height, radius]
+        )
 
     @staticmethod
     def __make_cone(name, pose, height, radius):
-        co = CollisionObject()
-        co.operation = CollisionObject.ADD
-        co.id = name
-        co.header = pose.header
-        co.pose = pose.pose
-        cone = SolidPrimitive()
-        cone.type = SolidPrimitive.CONE
-        cone.dimensions = [height, radius]
-        co.primitives = [cone]
-        return co
+        return PlanningSceneInterface.__make_primitive(
+            name, pose, SolidPrimitive.CONE, [height, radius]
+        )
 
     @staticmethod
     def __make_planning_scene_diff_req(collision_object, attach=False):

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -676,7 +676,84 @@ public:
 
   /**@}*/
 
-  /** \brief Save the geometry of the planning scene to a stream, as plain text */
+  /** \brief Save the geometry of the planning scene to a stream, as plain text
+
+   The .scene file format allows simple saving/loading of PlanningScene collisionn objects.
+   The file format is defined as follows:
+\verbatim
+  <FILE>:
+      <ID>  # scene id
+      <OBJECT_DESCRIPTION>*
+      . # single dot indicates end of file
+
+  <OBJECT_DESCRIPTION>:
+      * <ID>  # object id
+      <POSE>   # object pose
+      <NUMBER> # number of shapes in object
+      <SHAPE_DESCRIPTION>*
+      <NUMBER> # number of sub frames
+      <SUBFRAME_DESCRIPTION>*
+
+  <SHAPE_DESCRIPTION>:
+      <BOX> | <CONE> | <CYLINDER> | <SPHERE> | <PLANE> | <MESH>
+      <POSE>   # shape pose w.r.t. object's pose
+      <COLOR>  # common color for all shapes
+
+  <SUBFRAME_DESCRIPTION>:
+      <ID>  # sub frame id
+      <POSE>
+
+  <BOX>:
+      box
+      <FLOAT> <FLOAT> <FLOAT>  # box dimensions: x y z
+
+  <CONE>:
+      cone
+      <FLOAT> <FLOAT>  # radius height
+
+  <CYLINDER>:
+      cylinder
+      <FLOAT> <FLOAT>  # radius height
+
+  <SPHERE>:
+      sphere
+      <FLOAT>  # radius
+
+  <PLANE>:
+      plane
+      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # plane parameters: a b c d for a*x + b*y +c*z = d
+
+  <ID>: any text
+
+  <POSE>:
+      <FLOAT> <FLOAT> <FLOAT>  # position: x y z
+      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # quaternion: x y z w
+
+  <COLOR>:
+      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # R G B A
+\endverbatim
+
+   Here is an example:
+\verbatim
+My PlanningScene
+* object
+0 1.0 0
+0 0 0 1
+2
+box
+0.1 0.2 0.3
+0 1.0 0
+0 0 0 1
+1 0 0 0.5
+cylinder
+0.1 0.5
+0.5 0 0
+0 0 0 1
+0 0 1 0.5
+0
+.
+\endvarbatim
+  */
   void saveGeometryToStream(std::ostream& out) const;
 
   /** \brief Load the geometry of the planning scene from a stream */

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -69,6 +69,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   ui_->shapes_combo_box->addItem("Sphere", shapes::SPHERE);
   ui_->shapes_combo_box->addItem("Cylinder", shapes::CYLINDER);
   ui_->shapes_combo_box->addItem("Cone", shapes::CONE);
+  ui_->shapes_combo_box->addItem("Plane", shapes::PLANE);
   ui_->shapes_combo_box->addItem("Mesh from file", shapes::MESH);
   ui_->shapes_combo_box->addItem("Mesh from URL", shapes::MESH);
   setLocalSceneEdited(false);
@@ -446,6 +447,9 @@ void MotionPlanningFrame::addSceneObject()
       break;
     case shapes::CYLINDER:
       shape = std::make_shared<shapes::Cylinder>(0.5 * x_length, z_length);
+      break;
+    case shapes::PLANE:
+      shape = std::make_shared<shapes::Plane>(0., 0., 1., 0.);
       break;
     case shapes::MESH:
     {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -116,6 +116,21 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
       ogre_shape->setScale(Ogre::Vector3(d, z, d));
     }
     break;
+    case shapes::PLANE:
+    {
+      ogre_shape = new rviz::Shape(rviz::Shape::Cube, context_->getSceneManager(), node);
+      ogre_shape->setScale(Ogre::Vector3(10, 10, 0.001));  // model plane by thin box
+      alpha *= 0.5;                                        // and make it transparent
+      const auto* plane = static_cast<const shapes::Plane*>(s);
+      Eigen::Vector3d normal(plane->a, plane->b, plane->c);
+      double norm = normal.norm();
+      normal /= norm;
+      // adapt pose to match desired normal direction and position
+      Eigen::Quaterniond offset = Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d::UnitZ(), normal);
+      orientation = orientation * Ogre::Quaternion(offset.w(), offset.x(), offset.y(), offset.z());
+      position += plane->d / norm * Ogre::Vector3(normal.x(), normal.y(), normal.z());
+    }
+    break;
     case shapes::MESH:
     {
       const shapes::Mesh* mesh = static_cast<const shapes::Mesh*>(s);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -83,15 +83,6 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
   Eigen::Quaterniond q(p.linear());
   Ogre::Quaternion orientation(q.w(), q.x(), q.y(), q.z());
 
-  // we don't know how to render cones directly, but we can convert them to a mesh
-  if (s->type == shapes::CONE)
-  {
-    std::unique_ptr<shapes::Mesh> m(shapes::createMeshFromShape(static_cast<const shapes::Cone&>(*s)));
-    if (m)
-      renderShape(node, m.get(), p, octree_voxel_rendering, octree_color_mode, color, alpha);
-    return;
-  }
-
   switch (s->type)
   {
     case shapes::SPHERE:
@@ -115,6 +106,14 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
       double z = static_cast<const shapes::Cylinder*>(s)->length;
       ogre_shape->setScale(Ogre::Vector3(d, z, d));  // the shape has z as major axis, but the rendered cylinder has y
                                                      // as major axis (assuming z is upright);
+    }
+    break;
+    case shapes::CONE:
+    {
+      ogre_shape = new rviz::Shape(rviz::Shape::Cone, context_->getSceneManager(), node);
+      double d = 2.0 * static_cast<const shapes::Cone*>(s)->radius;
+      double z = static_cast<const shapes::Cone*>(s)->length;
+      ogre_shape->setScale(Ogre::Vector3(d, z, d));
     }
     break;
     case shapes::MESH:
@@ -174,7 +173,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
   {
     ogre_shape->setColor(color.r_, color.g_, color.b_, alpha);
 
-    if (s->type == shapes::CYLINDER)
+    if (s->type == shapes::CYLINDER || s->type == shapes::CONE)
     {
       // in geometric shapes, the z axis of the cylinder is its height;
       // for the rviz shape, the y axis is the height; we add a transform to fix this


### PR DESCRIPTION
This fixes some more issues pointed out in #3291 (see individual commit messages for details).

Example of cone visualization:
|old mesh | new cone|
|--- | ---|
|![image](https://user-images.githubusercontent.com/5376030/207883804-143da405-19aa-42ec-b830-2ce1233ff2e1.png) | ![image](https://user-images.githubusercontent.com/5376030/207883857-c40642db-6e2f-4722-955b-c36b3e35b7b5.png) |

Plane example:
![image](https://user-images.githubusercontent.com/5376030/207884489-4fbd7b53-b191-480e-a750-83800b09efe6.png)

Shapes created programmatically via python:
![image](https://user-images.githubusercontent.com/5376030/207892011-6a277f5e-647e-41c4-81b6-88d39334f499.png)
