### PR TITLE
Fix MoveGroupCommander.plan() and add corresponding unit tests

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -620,17 +620,12 @@ class MoveGroupCommander(object):
         """Return a tuple of the motion planning results such as
         (success flag : boolean, trajectory message : RobotTrajectory,
          planning time : float, error code : MoveitErrorCodes)"""
-        if type(joints) is JointState:
-            self.set_joint_value_target(joints)
-
+        if type(joints) is str:
+            self.set_joint_value_target(self.get_remembered_joint_values()[joints])
         elif type(joints) is Pose:
             self.set_pose_target(joints)
-
         elif joints is not None:
-            try:
-                self.set_joint_value_target(self.get_remembered_joint_values()[joints])
-            except MoveItCommanderException:
-                self.set_joint_value_target(joints)
+            self.set_joint_value_target(joints)
 
         (error_code_msg, trajectory_msg, planning_time) = self._g.plan()
 

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -128,6 +128,12 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         self.group.set_joint_value_target(target)
         return self.group.plan()
 
+    def test_plan(self):
+        state = JointState(name=self.JOINT_NAMES, position=[0, 0, 0, 0, 0, 0])
+        self.assertTrue(self.group.plan(state.position)[0])
+        self.assertTrue(self.group.plan("current")[0])
+        self.assertTrue(state, self.group.plan()[0])
+
     def test_validation(self):
         current = np.asarray(self.group.get_current_joint_values())
 


### PR DESCRIPTION
Fixes #2869
Just handle string and Pose arguments and rely on `MoveGroupCommander.set_joint_value_target()` to handle various joint-space arguments.