### PR TITLE
Fix the loading of Pilz parameters when there is a namespace

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/cartesian_limits_aggregator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/cartesian_limits_aggregator.cpp
@@ -54,28 +54,28 @@ pilz_industrial_motion_planner::CartesianLimitsAggregator::getAggregatedLimits(c
 
   // translational velocity
   double max_trans_vel;
-  if (nh.getParam(param_prefix + PARAM_MAX_TRANS_VEL, max_trans_vel))
+  if (ros::param::get(param_prefix + PARAM_MAX_TRANS_VEL, max_trans_vel))
   {
     cartesian_limit.setMaxTranslationalVelocity(max_trans_vel);
   }
 
   // translational acceleration
   double max_trans_acc;
-  if (nh.getParam(param_prefix + PARAM_MAX_TRANS_ACC, max_trans_acc))
+  if (ros::param::get(param_prefix + PARAM_MAX_TRANS_ACC, max_trans_acc))
   {
     cartesian_limit.setMaxTranslationalAcceleration(max_trans_acc);
   }
 
   // translational deceleration
   double max_trans_dec;
-  if (nh.getParam(param_prefix + PARAM_MAX_TRANS_DEC, max_trans_dec))
+  if (ros::param::get(param_prefix + PARAM_MAX_TRANS_DEC, max_trans_dec))
   {
     cartesian_limit.setMaxTranslationalDeceleration(max_trans_dec);
   }
 
   // rotational velocity
   double max_rot_vel;
-  if (nh.getParam(param_prefix + PARAM_MAX_ROT_VEL, max_rot_vel))
+  if (ros::param::get(param_prefix + PARAM_MAX_ROT_VEL, max_rot_vel))
   {
     cartesian_limit.setMaxRotationalVelocity(max_rot_vel);
   }

--- a/moveit_planners/pilz_industrial_motion_planner/src/cartesian_limits_aggregator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/cartesian_limits_aggregator.cpp
@@ -48,41 +48,42 @@ static const std::string PARAM_MAX_ROT_DEC = "max_rot_dec";
 pilz_industrial_motion_planner::CartesianLimit
 pilz_industrial_motion_planner::CartesianLimitsAggregator::getAggregatedLimits(const ros::NodeHandle& nh)
 {
-  std::string param_prefix = PARAM_CARTESIAN_LIMITS_NS + "/";
+  std::string param_prefix = "/" + PARAM_CARTESIAN_LIMITS_NS + "/";
 
   pilz_industrial_motion_planner::CartesianLimit cartesian_limit;
 
   // translational velocity
   double max_trans_vel;
-  if (ros::param::get(param_prefix + PARAM_MAX_TRANS_VEL, max_trans_vel))
+  if (nh.getParam(ros::this_node::getNamespace() + param_prefix + PARAM_MAX_TRANS_VEL, max_trans_vel))
   {
     cartesian_limit.setMaxTranslationalVelocity(max_trans_vel);
   }
 
   // translational acceleration
   double max_trans_acc;
-  if (ros::param::get(param_prefix + PARAM_MAX_TRANS_ACC, max_trans_acc))
+  if (ros::param::get(ros::this_node::getNamespace() + param_prefix + PARAM_MAX_TRANS_ACC, max_trans_acc))
   {
     cartesian_limit.setMaxTranslationalAcceleration(max_trans_acc);
   }
 
   // translational deceleration
   double max_trans_dec;
-  if (ros::param::get(param_prefix + PARAM_MAX_TRANS_DEC, max_trans_dec))
+  if (ros::param::get(ros::this_node::getNamespace() + param_prefix + PARAM_MAX_TRANS_DEC, max_trans_dec))
   {
     cartesian_limit.setMaxTranslationalDeceleration(max_trans_dec);
   }
 
   // rotational velocity
   double max_rot_vel;
-  if (ros::param::get(param_prefix + PARAM_MAX_ROT_VEL, max_rot_vel))
+  if (ros::param::get(ros::this_node::getNamespace() + param_prefix + PARAM_MAX_ROT_VEL, max_rot_vel))
   {
     cartesian_limit.setMaxRotationalVelocity(max_rot_vel);
   }
 
   // rotational acceleration + deceleration deprecated
   // LCOV_EXCL_START
-  if (nh.hasParam(param_prefix + PARAM_MAX_ROT_ACC) || nh.hasParam(param_prefix + PARAM_MAX_ROT_DEC))
+  if (nh.hasParam(ros::this_node::getNamespace() + param_prefix + PARAM_MAX_ROT_ACC) ||
+      nh.hasParam(param_prefix + PARAM_MAX_ROT_DEC))
   {
     ROS_WARN_STREAM("Ignoring cartesian limits parameters for rotational "
                     "acceleration / deceleration;"


### PR DESCRIPTION
### Description

I had some difficulty in loading parameters for dual arms, for example:

`/seg_0/cartesian_limits` vs `/cartesian_limits`. This seems to fix it.
