### PR TITLE
fix ruckig dependency with catkin

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -51,8 +51,14 @@ else()
 endif()
 
 find_package(octomap REQUIRED)
+
 find_package(ruckig REQUIRED)
+# work around catkin_package not fetching the interface includes from the target
+# to forward to downstream dependencies. The includes do not need to be added
+# in include_directories below because the target is correctly imported here.
+get_target_property(ruckig_INCLUDE_DIRS ruckig::ruckig INTERFACE_INCLUDE_DIRECTORIES)
 set(ruckig_LIBRARIES "ruckig::ruckig")
+
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 


### PR DESCRIPTION
catkin was not made for cmake target dependencies.

We do the same with fcl right above, but when porting/merging ruckig nobody cared...

FTR: ruckig does not have any `INTERFACE_LINK_LIBRARIES` and adding them for good measures in case it changes sets the variable to `ruckig_INTERFACE_LINK_LIBRARIES-NOT-FOUND` (breaking the build).

Fixes #3310 .