### PR TITLE
Fix doxygen

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_detector_allocator.h
@@ -59,7 +59,7 @@ public:
                                       const moveit::core::RobotModelConstPtr& robot_model) const = 0;
 
   /** create a new CollisionWorld by copying an existing CollisionWorld of the same type.s
-   * The world must be either the same world as used by \orig or a copy of that world which has not yet been modified.
+   * The world must be either the same world as used by \e orig or a copy of that world which has not yet been modified.
    */
   virtual CollisionEnvPtr allocateEnv(const CollisionEnvConstPtr& orig, const WorldPtr& world) const = 0;
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_env.h
@@ -56,14 +56,14 @@ public:
   /** @brief Constructor
    *  @param model A robot model to construct the collision robot from
    *  @param padding The padding to use for all objects/links on the robot
-   *  @scale scale A common scaling to use for all objects/links on the robot
+   *  @param scale A common scaling to use for all objects/links on the robot
    */
   CollisionEnv(const moveit::core::RobotModelConstPtr& model, double padding = 0.0, double scale = 1.0);
 
   /** @brief Constructor
    *  @param model A robot model to construct the collision robot from
    *  @param padding The padding to use for all objects/links on the robot
-   *  @scale scale A common scaling to use for all objects/links on the robot
+   *  @param scale A common scaling to use for all objects/links on the robot
    */
   CollisionEnv(const moveit::core::RobotModelConstPtr& model, const WorldPtr& world, double padding = 0.0,
                double scale = 1.0);
@@ -114,7 +114,7 @@ public:
    *  and the world are considered. Self collisions are not checked.
    *  @param req A CollisionRequest object that encapsulates the collision request
    *  @param res A CollisionResult object that encapsulates the collision result
-   *  @robot robot The collision model for the robot
+   *  @param robot The collision model for the robot
    *  @param state The kinematic state for which checks are being made
    */
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -124,7 +124,7 @@ public:
    *  Allowed collisions are ignored. Self collisions are not checked.
    *  @param req A CollisionRequest object that encapsulates the collision request
    *  @param res A CollisionResult object that encapsulates the collision result
-   *  @robot robot The collision model for the robot
+   *  @param robot The collision model for the robot
    *  @param state The kinematic state for which checks are being made
    *  @param acm The allowed collision matrix.*/
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
@@ -135,7 +135,6 @@ public:
    *  Allowed collisions are ignored. Self collisions are not checked.
    *  @param req A CollisionRequest object that encapsulates the collision request
    *  @param res A CollisionResult object that encapsulates the collision result
-   *  @robot robot The collision model for the robot
    *  @param state1 The kinematic state at the start of the segment for which checks are being made
    *  @param state2 The kinematic state at the end of the segment for which checks are being made
    *  @param acm The allowed collision matrix.*/
@@ -148,10 +147,9 @@ public:
    *  Allowed collisions are ignored. Self collisions are not checked.
    *  @param req A CollisionRequest object that encapsulates the collision request
    *  @param res A CollisionResult object that encapsulates the collision result
-   *  @robot robot The collision model for the robot
    *  @param state1 The kinematic state at the start of the segment for which checks are being made
    *  @param state2 The kinematic state at the end of the segment for which checks are being made
-   *  @param acm The allowed collision matrix.*/
+   */
   virtual void checkRobotCollision(const CollisionRequest& req, CollisionResult& res,
                                    const moveit::core::RobotState& state1,
                                    const moveit::core::RobotState& state2) const = 0;
@@ -175,7 +173,7 @@ public:
   }
 
   /** \brief The distance to self-collision given the robot is at state \e state, ignoring
-      the distances between links that are allowed to always collide (as specified by \e acm) */
+      the distances between links that are allowed to always collide (as specified by \param acm) */
   inline double distanceSelf(const moveit::core::RobotState& state, const AllowedCollisionMatrix& acm) const
   {
     DistanceRequest req;
@@ -190,13 +188,11 @@ public:
   /** \brief Compute the distance between a robot and the world
    *  @param req A DistanceRequest object that encapsulates the distance request
    *  @param res A DistanceResult object that encapsulates the distance result
-   *  @param robot The robot to check distance for
    *  @param state The state for the robot to check distances from */
   virtual void distanceRobot(const DistanceRequest& req, DistanceResult& res,
                              const moveit::core::RobotState& state) const = 0;
 
   /** \brief Compute the shortest distance between a robot and the world
-   *  @param robot The robot to check distance for
    *  @param state The state for the robot to check distances from
    *  @param verbose Output debug information about distance checks */
   inline double distanceRobot(const moveit::core::RobotState& state, bool verbose = false) const
@@ -212,7 +208,6 @@ public:
   }
 
   /** \brief Compute the shortest distance between a robot and the world
-   *  @param robot The robot to check distance for
    *  @param state The state for the robot to check distances from
    *  @param acm Using an allowed collision matrix has the effect of ignoring distances from links that are always
    * allowed to be in collision.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -73,10 +73,10 @@ using DecideContactFn = boost::function<bool(collision_detection::Contact&)>;
 
 MOVEIT_CLASS_FORWARD(AllowedCollisionMatrix);  // Defines AllowedCollisionMatrixPtr, ConstPtr, WeakPtr... etc
 
-/** @class AllowedCollisionMatrix
- *  @brief Definition of a structure for the allowed collision matrix. All elements in the collision world are referred
- * to by their names.
- *   This class represents which collisions are allowed to happen and which are not. */
+/** @brief Definition of a structure for the allowed collision matrix.
+ *
+ *  All elements in the collision world are referred to by their names.
+ *  This class represents which collisions are allowed to happen and which are not. */
 class AllowedCollisionMatrix
 {
 public:

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_octomap_filter.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_octomap_filter.h
@@ -49,13 +49,14 @@ namespace collision_detection
  *  Surfaces for Constraint-Based Haptic Rendering. ICRA, May 2012, St Paul, MN.
  *  http://adamleeper.com/research/papers/2012_ICRA_leeper-chan-salisbury.pdf
  *
- *  @param The octomap originally used for collision detection.
- *  @param The collision result (which will get its normals updated)
- *  @param The distance, as a multiple of the octomap cell size, from which to include neighboring cells.
- *  @param The minimum angle change required for a normal to be over-written
- *  @param Whether to request a depth estimate from the algorithm (experimental...)
- *  @param The iso-surface threshold value (0.5 is a reasonable default).
- *  @param The metaball radius, as a multiple of the octomap cell size (1.5 is a reasonable default)
+ *  @param object The octomap originally used for collision detection.
+ *  @param res    The collision result (which will get its normals updated)
+ *  @param cell_bbx_search_distance The distance, as a multiple of the octomap cell size,
+ *                                  from which to include neighboring cells.
+ *  @param allowed_angle_divergence The minimum angle change required for a normal to be over-written
+ *  @param estimate_depth           Whether to request a depth estimate from the algorithm (experimental...)
+ *  @param iso_value                The iso-surface threshold value (0.5 is a reasonable default).
+ *  @param metaball_radius_multiple The metaball radius, as a multiple of the octomap cell size (1.5 is a reasonable default)
  */
 int refineContactNormals(const World::ObjectConstPtr& object, CollisionResult& res,
                          double cell_bbx_search_distance = 1.0, double allowed_angle_divergence = 0.0,

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_bvh_manager.h
@@ -110,20 +110,8 @@ public:
 
   /**@brief Add a collision object to the checker
    *
-   * All objects are added should initially be added as static objects. Use the setContactRequest method of defining
-   * which collision objects are moving.
-   *
-   * @param name            The name of the object, must be unique.
-   * @param mask_id         User defined id which gets stored in the results structure.
-   * @param shapes          A vector of shapes that make up the collision object.
-   * @param shape_poses     A vector of poses for each shape, must be same length as shapes
-   * @param shape_types     A vector of shape types for encode the collision object. If the vector is of length 1 it is
-   * used for all shapes.
-   * @param collision_object_types A int identifying a conversion mode for the object. (ex. convert meshes to convex
-   * hulls)
-   * @param enabled         Indicate if the object is enabled for collision checking.
-   * @return true if successfully added, otherwise false. */
-  /**@brief Add a tesseract collision object to the manager
+   * All objects are added as static objects initially.
+   * Use the setContactRequest method for defining which collision objects are moving.
    * @param cow The tesseract bullet collision object */
   virtual void addCollisionObject(const CollisionObjectWrapperPtr& cow) = 0;
 

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -273,7 +273,7 @@ struct FCLManager
  *
  *   \param o1 First FCL collision object
  *   \param o2 Second FCL collision object
- *   \data General pointer to arbitrary data which is used during the callback
+ *   \param data General pointer to arbitrary data which is used during the callback
  *   \return True terminates the collision check, false continues it to the next pair of objects */
 bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data);
 
@@ -282,7 +282,7 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
  *
  *   \param o1 First FCL collision object
  *   \param o2 Second FCL collision object
- *   \data General pointer to arbitrary data which is used during the callback
+ *   \param data General pointer to arbitrary data which is used during the callback
  *   \return True terminates the distance check, false continues it to the next pair of objects */
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist);
 

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -111,9 +111,9 @@ protected:
   /** \brief Construct an FCL collision object from MoveIt's World::Object. */
   void constructFCLObjectWorld(const World::Object* obj, FCLObject& fcl_obj) const;
 
-  /** \brief Updates the specified object in \m fcl_objs_ and in the manager from new data available in the World.
+  /** \brief Updates the specified object in \c fcl_objs_ and in the manager from new data available in the World.
    *
-   *  If it does not exist in world, it is deleted. If it's not existing in \m fcl_objs_ yet, it's added there. */
+   *  If it does not exist in world, it is deleted. If it's not existing in \c fcl_objs_ yet, it's added there. */
   void updateFCLObject(const std::string& id);
 
   /** \brief Out of the current robot state and its attached bodies construct an FCLObject which can then be used to

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -404,7 +404,7 @@ struct FCLShapeCache
   /** \brief Map of weak pointers to the FCLGeometry. */
   ShapeMap map_;
 
-  /** \brief Counts cache usage and triggers clearing of cache when \m MAX_CLEAN_COUNT is exceeded. */
+  /** \brief Counts cache usage and triggers clearing of cache when \c MAX_CLEAN_COUNT is exceeded. */
   unsigned int clean_count_;
 };
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -124,15 +124,14 @@ public:
    *subgroup IKSolvers, the function will attempt to generate a sampler from the various subgroup solvers.
    *   - It will attempt to determine which constraints act on the IK link for the sub-group IK solvers, and attempts to
    *create ConstraintSampler functions by recursively calling \ref selectDefaultSampler for the sub-group.
-   *   - If any samplers are valid, it adds them to a vector of type \ref ConstraintSamplerPtr.
+   *   - If any samplers are valid, it adds them to a vector of type ConstraintSamplerPtr.
    *   - Once it has iterated through each sub-group, if any samplers are valid, they are returned in a
    *UnionConstraintSampler, along with a JointConstraintSampler if one exists.
    * @param scene The planning scene that will be used to create the ConstraintSampler
    * @param group_name The group name for which to create a sampler
    * @param constr The set of constraints for which to create a sampler
    *
-   * @return A valid \ref ConstraintSamplerPtr if one could be allocated, and otherwise an empty \ref
-   *ConstraintSamplerPtr
+   * @return A valid ConstraintSamplerPtr if one could be allocated, and otherwise an empty ConstraintSamplerPtr.
    */
   static ConstraintSamplerPtr selectDefaultSampler(const planning_scene::PlanningSceneConstPtr& scene,
                                                    const std::string& group_name,

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -131,7 +131,7 @@ public:
    * @param group_name The group name for which to create a sampler
    * @param constr The set of constraints for which to create a sampler
    *
-   * @return A valid ConstraintSamplerPtr if one could be allocated, and otherwise an empty ConstraintSamplerPtr.
+   * @return A valid ConstraintSamplerPtr if one could be allocated, otherwise an empty ConstraintSamplerPtr.
    */
   static ConstraintSamplerPtr selectDefaultSampler(const planning_scene::PlanningSceneConstPtr& scene,
                                                    const std::string& group_name,

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -112,24 +112,26 @@ public:
    * \brief No-op, as the union constraint sampler is for already
    * configured samplers
    *
-   * @param [in] constr Constraint message
+   * @param [in] constraint Constraint message
    *
    * @return Always true
    */
-  bool configure(const moveit_msgs::Constraints& /*constr*/) override
+  bool configure(const moveit_msgs::Constraints& constraint) override
   {
+    (void)constraint;
     return true;
   }
 
   /**
    * \brief No-op, as the union constraint sampler can act on anything
    *
-   * @param [in] constr Constraint message
+   * @param [in] constraint Constraint message
    *
    * @return Always true
    */
-  virtual bool canService(const moveit_msgs::Constraints& /*constr*/) const
+  virtual bool canService(const moveit_msgs::Constraints& constraint) const
   {
+    (void)constraint;
     return true;
   }
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -117,8 +117,7 @@ inline bool solveCosineEqn(const double& a, const double& b, const double& c, do
 class PR2ArmIK
 {
 public:
-  /** @class
-   *  @brief Inverse kinematics for the PR2 arm.
+  /** @brief Inverse kinematics for the PR2 arm.
    *  @author Sachin Chitta <sachinc@willowgarage.com>
    *
    */
@@ -127,35 +126,33 @@ public:
 
   /**
       @brief Initialize the solver by providing a urdf::Model and a root and tip name.
-      @param A urdf::Model representation of the PR2 robot model
-      @param The root joint name of the arm
-      @param The tip joint name of the arm
+      @param robot_model  A urdf::Model representation of the PR2 robot model
+      @param root_name    The root joint name of the arm
+      @param tip_name     The tip joint name of the arm
       @return true if initialization was successful, false otherwise.
   */
   bool init(const urdf::ModelInterface& robot_model, const std::string& root_name, const std::string& tip_name);
 
   /**
      @brief compute IK based on an initial guess for the shoulder pan angle.
-     @param Input pose for end-effector
-     @param Initial guess for shoulder pan angle
+     @param g_in                       Input pose for end-effector
+     @param shoulder_pan_initial_guess Initial guess for shoulder pan angle
   */
   void computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double& shoulder_pan_initial_guess,
                             std::vector<std::vector<double> >& solution) const;
 
   /**
      @brief compute IK based on an initial guess for the shoulder roll angle.
-     h       @param Input pose for end-effector
-     @param Initial guess for shoulder roll angle
+     @param g_in                        Input pose for end-effector
+     @param shoulder_roll_initial_guess Initial guess for shoulder roll angle
   */
   void computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double& shoulder_roll_initial_guess,
                              std::vector<std::vector<double> >& solution) const;
 
-  //  std::vector<std::vector<double> > solution_ik_;/// a vector of ik solutions
-
   /**
      @brief get chain information about the arm. This populates the IK query response, filling in joint level
      information including names and joint limits.
-     @param The response structure to be filled in.
+     @param info The response structure to be filled in.
   */
   void getSolverInfo(moveit_msgs::KinematicSolverInfo& info);
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -71,8 +71,7 @@ class PR2ArmIKSolver : public KDL::ChainIkSolverPos
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  /** @class
-   *  @brief ROS/KDL based interface for the inverse kinematics of the PR2 arm
+  /** @brief ROS/KDL based interface for the inverse kinematics of the PR2 arm
    *  @author Sachin Chitta <sachinc@willowgarage.com>
    *
    *  This class provides a KDL based interface to the inverse kinematics of the PR2 arm.
@@ -131,9 +130,7 @@ MOVEIT_CLASS_FORWARD(PR2ArmKinematicsPlugin);
 class PR2ArmKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
-  /** @class
-   *  @brief Plugin-able interface to the PR2 arm kinematics
-   */
+  /** @brief Plugin-able interface to the PR2 arm kinematics */
   PR2ArmKinematicsPlugin();
 
   /**
@@ -144,7 +141,6 @@ public:
 
   /**
    * @brief Given a desired pose of the end-effector, compute the joint angles to reach it
-   * @param ik_link_name - the name of the link for which IK is being computed
    * @param ik_pose the desired pose of the link
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @return True if a valid solution was found, false otherwise
@@ -177,7 +173,7 @@ public:
    */
   bool searchPositionIK(
       const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-      const std::vector<double>& consistency_limits, std::vector<double>& solution,
+      const std::vector<double>& consistency_limit, std::vector<double>& solution,
       moveit_msgs::MoveItErrorCodes& error_code,
       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
@@ -206,15 +202,12 @@ public:
    */
   bool searchPositionIK(
       const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-      const std::vector<double>& consistency_limits, std::vector<double>& solution,
+      const std::vector<double>& consistency_limit, std::vector<double>& solution,
       const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   /**
    * @brief Given a set of joint angles and a set of links, compute their pose
-   * @param request  - the request contains the joint angles, set of links for which poses are to be computed and a
-   * timeout
-   * @param response - the response contains stamped pose information for all the requested links
    * @return True if a valid solution was found, false otherwise
    */
   bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -144,8 +144,9 @@ public:
    *
    * @param [in] out The file descriptor for printing
    */
-  virtual void print(std::ostream& /*unused*/ = std::cout) const
+  virtual void print(std::ostream& out = std::cout) const
   {
+    (void)out;
   }
 
   /**

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -528,10 +528,8 @@ bool constructConstraints(XmlRpc::XmlRpcValue& params, moveit_msgs::Constraints&
   constraints.name = static_cast<std::string>(params["name"]);
   return collectConstraints(params["constraints"], constraints);
 }
-}  // namespace kinematic_constraints
 
-bool kinematic_constraints::resolveConstraintFrames(const moveit::core::RobotState& state,
-                                                    moveit_msgs::Constraints& constraints)
+bool resolveConstraintFrames(const moveit::core::RobotState& state, moveit_msgs::Constraints& constraints)
 {
   for (auto& c : constraints.position_constraints)
   {
@@ -577,3 +575,4 @@ bool kinematic_constraints::resolveConstraintFrames(const moveit::core::RobotSta
   }
   return true;
 }
+}  // namespace kinematic_constraints

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -140,7 +140,6 @@ struct KinematicsResult
 MOVEIT_CLASS_FORWARD(KinematicsBase);  // Defines KinematicsBasePtr, ConstPtr, WeakPtr... etc
 
 /**
- * @class KinematicsBase
  * @brief Provides an interface for kinematics solvers.
  */
 class KinematicsBase
@@ -607,10 +606,10 @@ protected:
    * for the private namespace and inside 'robot_description_kinematics'.
    * Parameters are searched in the following locations and order
    *
-   * ~/<group_name>/<param>
-   * ~/<param>
-   * robot_description_kinematics/<group_name>/<param>
-   * robot_description_kinematics/<param>
+   * - `~/<group_name>/<param>`
+   * - `~/<param>`
+   * - `robot_description_kinematics/<group_name>/<param>`
+   * - `robot_description_kinematics/<param>`
    *
    * This order maintains default behavior by keeping the private namespace
    * as the predominant configuration but also allows groupwise specifications.

--- a/moveit_core/macros/include/moveit/macros/declare_ptr.h
+++ b/moveit_core/macros/include/moveit/macros/declare_ptr.h
@@ -37,7 +37,7 @@
 #include <memory>
 
 /**
- * \def MOVEIT_DELCARE_PTR
+ * \def MOVEIT_DECLARE_PTR
  * Macro that given a Name and a Type declares the following types:
  * - ${Name}Ptr            = shared_ptr<${Type}>
  * - ${Name}ConstPtr       = shared_ptr<const ${Type}>
@@ -60,7 +60,7 @@
   typedef std::unique_ptr<const Type> Name##ConstUniquePtr
 
 /**
- * \def MOVEIT_DELCARE_PTR_MEMBER
+ * \def MOVEIT_DECLARE_PTR_MEMBER
  * The macro defines the same typedefs as MOVEIT_DECLARE_PTR, but shortens the new names to their suffix.
  *
  * This can be used to create `Classname::Ptr` style names, but in most situations in MoveIt's codebase,

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -59,7 +59,87 @@
 // Import/export for windows dll's and visibility for gcc shared libraries.
 #include <moveit/moveit_planning_scene_export.h>
 
-/** \brief This namespace includes the central class for representing planning contexts */
+/**
+\section scene-file-format Format of .scene files
+
+It is possible to read/write a PlanningScene's collision objects from a simple text file (`.scene`).
+The file format is defined as follows:
+\verbatim
+  <FILE>:
+      <ID>  # scene id
+      <OBJECT_DESCRIPTION>*
+      . # single dot indicates end of file
+
+  <OBJECT_DESCRIPTION>:
+      * <ID>  # object id
+      <POSE>   # object pose
+      <NUMBER> # number of shapes in object
+      <SHAPE_DESCRIPTION>*
+      <NUMBER> # number of sub frames
+      <SUBFRAME_DESCRIPTION>*
+
+  <SHAPE_DESCRIPTION>:
+      <BOX> | <CONE> | <CYLINDER> | <SPHERE> | <PLANE> | <MESH>
+      <POSE>   # shape pose w.r.t. object's pose
+      <COLOR>  # common color for all shapes
+
+  <SUBFRAME_DESCRIPTION>:
+      <ID>  # sub frame id
+      <POSE>
+
+  <BOX>:
+      box
+      <FLOAT> <FLOAT> <FLOAT>  # box dimensions: x y z
+
+  <CONE>:
+      cone
+      <FLOAT> <FLOAT>  # radius height
+
+  <CYLINDER>:
+      cylinder
+      <FLOAT> <FLOAT>  # radius height
+
+  <SPHERE>:
+      sphere
+      <FLOAT>  # radius
+
+  <PLANE>:
+      plane
+      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # plane parameters: a b c d for a*x + b*y +c*z = d
+
+  <ID>: any text
+
+  <POSE>:
+      <FLOAT> <FLOAT> <FLOAT>  # position: x y z
+      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # quaternion: x y z w
+
+  <COLOR>:
+      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # R G B A
+\endverbatim
+
+   Here is an example:
+\verbatim
+My PlanningScene
+* object
+0 1.0 0
+0 0 0 1
+2
+box
+0.1 0.2 0.3
+0 1.0 0
+0 0 0 1
+1 0 0 0.5
+cylinder
+0.1 0.5
+0.5 0 0
+0 0 0 1
+0 0 1 0.5
+0
+.
+\endverbatim
+*/
+
+/** \brief This namespace includes the central class for representing planning scenes */
 namespace planning_scene
 {
 MOVEIT_CLASS_FORWARD(PlanningScene);  // Defines PlanningScenePtr, ConstPtr, WeakPtr... etc
@@ -678,81 +758,7 @@ public:
 
   /** \brief Save the geometry of the planning scene to a stream, as plain text
 
-   The .scene file format allows simple saving/loading of PlanningScene collisionn objects.
-   The file format is defined as follows:
-\verbatim
-  <FILE>:
-      <ID>  # scene id
-      <OBJECT_DESCRIPTION>*
-      . # single dot indicates end of file
-
-  <OBJECT_DESCRIPTION>:
-      * <ID>  # object id
-      <POSE>   # object pose
-      <NUMBER> # number of shapes in object
-      <SHAPE_DESCRIPTION>*
-      <NUMBER> # number of sub frames
-      <SUBFRAME_DESCRIPTION>*
-
-  <SHAPE_DESCRIPTION>:
-      <BOX> | <CONE> | <CYLINDER> | <SPHERE> | <PLANE> | <MESH>
-      <POSE>   # shape pose w.r.t. object's pose
-      <COLOR>  # common color for all shapes
-
-  <SUBFRAME_DESCRIPTION>:
-      <ID>  # sub frame id
-      <POSE>
-
-  <BOX>:
-      box
-      <FLOAT> <FLOAT> <FLOAT>  # box dimensions: x y z
-
-  <CONE>:
-      cone
-      <FLOAT> <FLOAT>  # radius height
-
-  <CYLINDER>:
-      cylinder
-      <FLOAT> <FLOAT>  # radius height
-
-  <SPHERE>:
-      sphere
-      <FLOAT>  # radius
-
-  <PLANE>:
-      plane
-      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # plane parameters: a b c d for a*x + b*y +c*z = d
-
-  <ID>: any text
-
-  <POSE>:
-      <FLOAT> <FLOAT> <FLOAT>  # position: x y z
-      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # quaternion: x y z w
-
-  <COLOR>:
-      <FLOAT> <FLOAT> <FLOAT> <FLOAT>  # R G B A
-\endverbatim
-
-   Here is an example:
-\verbatim
-My PlanningScene
-* object
-0 1.0 0
-0 0 0 1
-2
-box
-0.1 0.2 0.3
-0 1.0 0
-0 0 0 1
-1 0 0 0.5
-cylinder
-0.1 0.5
-0.5 0 0
-0 0 0 1
-0 0 1 0.5
-0
-.
-\endvarbatim
+   The .scene file format allows simple saving/loading of PlanningScene collision objects (see \ref scene-file-format)
   */
   void saveGeometryToStream(std::ostream& out) const;
 

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -188,7 +188,7 @@ public:
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getGlobalSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
 
-  /** \brief Check whether a subframe of given @frame_name is present in this object.
+  /** \brief Check whether a subframe of given \param frame_name is present in this object.
    *
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1109,7 +1109,6 @@ public:
    * @param twist a Cartesian velocity on the 'tip' frame
    * @param tip the frame for which the twist is given
    * @param dt a time interval (seconds)
-   * @param st a secondary task computation function
    */
   bool setFromDiffIK(const JointModelGroup* group, const Eigen::VectorXd& twist, const std::string& tip, double dt,
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn());
@@ -1119,7 +1118,6 @@ public:
    * @param twist a Cartesian velocity on the 'tip' frame
    * @param tip the frame for which the twist is given
    * @param dt a time interval (seconds)
-   * @param st a secondary task computation function
    */
   bool setFromDiffIK(const JointModelGroup* group, const geometry_msgs::Twist& twist, const std::string& tip, double dt,
                      const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn());
@@ -1310,14 +1308,14 @@ public:
 
   /** \brief Set all joints in \e group to random values near the value in \e seed.
    *  \e distance is the maximum amount each joint value will vary from the
-   *  corresponding value in \e seed.  \distance represents meters for
+   *  corresponding value in \e seed.  \e distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed, double distance);
 
   /** \brief Set all joints in \e group to random values near the value in \e seed, using a specified random number generator.
    *  \e distance is the maximum amount each joint value will vary from the
-   *  corresponding value in \e seed.  \distance represents meters for
+   *  corresponding value in \e seed.  \e distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed, double distance,
@@ -1327,7 +1325,7 @@ public:
    *  \e distances \b MUST have the same size as \c
    *  group.getActiveJointModels().  Each value in \e distances is the maximum
    *  amount the corresponding active joint in \e group will vary from the
-   *  corresponding value in \e seed.  \distance represents meters for
+   *  corresponding value in \e seed.  \e distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed,
@@ -1337,7 +1335,7 @@ public:
    *  \e distances \b MUST have the same size as \c
    *  group.getActiveJointModels().  Each value in \e distances is the maximum
    *  amount the corresponding active joint in \e group will vary from the
-   *  corresponding value in \e seed.  \distance represents meters for
+   *  corresponding value in \e seed.  \e distance represents meters for
    *  prismatic/postitional joints and radians for revolute/orientation joints.
    *  Resulting values are clamped within default bounds. */
   void setToRandomPositionsNearBy(const JointModelGroup* group, const RobotState& seed,

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -137,7 +137,7 @@ public:
   }
 
   /** @brief  Returns the duration after start that a waypoint will be reached.
-   *  @param  The waypoint index.
+   *  @param index The waypoint index.
    *  @return The duration from start; returns overall duration if index is out of range.
    */
   double getWayPointDurationFromStart(std::size_t index) const;
@@ -278,18 +278,18 @@ public:
   RobotTrajectory& unwind(const moveit::core::RobotState& state);
 
   /** @brief Finds the waypoint indicies before and after a duration from start.
-   *  @param The duration from start.
-   *  @param The waypoint index before the supplied duration.
-   *  @param The waypoint index after (or equal to) the supplied duration.
-   *  @param The progress (0 to 1) between the two waypoints, based on time (not based on joint distances).
+   *  @param duration The duration from start.
+   *  @param before   The waypoint index before the supplied duration.
+   *  @param after    The waypoint index after (or equal to) the supplied duration.
+   *  @param blend    The progress (0 to 1) between the two waypoints, based on time (not based on joint distances).
    */
   void findWayPointIndicesForDurationAfterStart(const double& duration, int& before, int& after, double& blend) const;
 
   // TODO support visitor function for interpolation, or at least different types.
   /** @brief Gets a robot state corresponding to a supplied duration from start for the trajectory, using linear time
    * interpolation.
-   *  @param The duration from start.
-   *  @param The resulting robot state.
+   *  @param request_duration The duration from start.
+   *  @param output_state The resulting robot state.
    *  @return True if state is valid, false otherwise (trajectory is empty).
    */
   bool getStateAtDurationFromStart(const double request_duration, moveit::core::RobotStatePtr& output_state) const;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -90,8 +90,8 @@ private:
    * \brief Initialize Ruckig position/vel/accel. This initializes ruckig_input and ruckig_output to the same values
    * \param first_waypoint  The Ruckig input/output parameters are initialized to the values at this waypoint
    * \param joint_group     The MoveIt JointModelGroup of interest
-   * \param[out] rucking_input   Input parameters to Ruckig. Initialized here.
-   * \param[out] ruckig_output   Output from the Ruckig algorithm. Initialized here.
+   * \param[out] ruckig_input   Input parameters to Ruckig. Initialized here.
+   * \param[out] ruckig_output  Output from the Ruckig algorithm. Initialized here.
    */
   static void initializeRuckigState(const moveit::core::RobotState& first_waypoint,
                                     const moveit::core::JointModelGroup* joint_group,
@@ -108,6 +108,7 @@ private:
    * There is a trade-off between time-optimality of the output trajectory and runtime of the smoothing algorithm.
    * \param[in, out] trajectory      Trajectory to smooth.
    * \param[in, out] ruckig_input    Necessary input for Ruckig smoothing. Contains kinematic limits (vel, accel, jerk)
+   * \param[in]      batch_size      Minimum number of waypoints to include within a batch
    */
   static std::optional<robot_trajectory::RobotTrajectory>
   runRuckigInBatches(const size_t num_waypoints, const robot_trajectory::RobotTrajectory& trajectory,

--- a/moveit_core/transforms/include/moveit/transforms/transforms.h
+++ b/moveit_core/transforms/include/moveit/transforms/transforms.h
@@ -110,7 +110,7 @@ public:
 
   /**
    * @brief Set a transform in the transform tree (adding it if necessary)
-   * @param transform The input transforms (the frame_id must match the target frame)
+   * @param transforms The input transforms (the frame_id must match the target frame)
    */
   void setTransforms(const std::vector<geometry_msgs::TransformStamped>& transforms);
 
@@ -143,8 +143,8 @@ public:
   /**
    * @brief Transform a quaternion in from_frame to the target_frame
    * @param from_frame The frame in which the input quaternion is specified
-   * @param v_in The input quaternion (in from_frame). Make sure the quaternion is normalized.
-   * @param v_out The resultant (transformed) quaternion. It is guaranteed to be a valid and normalized quaternion.
+   * @param q_in The input quaternion (in from_frame). Make sure the quaternion is normalized.
+   * @param q_out The resultant (transformed) quaternion. It is guaranteed to be a valid and normalized quaternion.
    */
   void transformQuaternion(const std::string& from_frame, const Eigen::Quaterniond& q_in,
                            Eigen::Quaterniond& q_out) const

--- a/moveit_core/utils/include/moveit/utils/message_checks.h
+++ b/moveit_core/utils/include/moveit/utils/message_checks.h
@@ -36,10 +36,7 @@
 
 #pragma once
 
-/** \file empty_msgs.h
- *  \brief Checks for empty MoveIt-related messages
- *
- */
+/** \brief Checks for empty MoveIt-related messages */
 
 #include <moveit_msgs/PlanningScene.h>
 #include <moveit_msgs/PlanningSceneWorld.h>

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -124,16 +124,17 @@ public:
    *  \param[in] origin The origin pose of this collision mesh relative to the link origin
    */
   void addCollisionMesh(const std::string& link_name, const std::string& filename, geometry_msgs::Pose origin);
+
   /** \brief Adds a collision box to a specific link.
    *  \param[in] link_name The name of the link to which the box will be added. Must already be in the builder.
-   *  \param[in] size The dimensions of the box
+   *  \param[in] dims   The dimensions of the box
    *  \param[in] origin The origin pose of this collision box relative to the link origin
    */
   void addCollisionBox(const std::string& link_name, const std::vector<double>& dims, geometry_msgs::Pose origin);
 
   /** \brief Adds a visual box to a specific link.
    *  \param[in] link_name The name of the link to which the box will be added. Must already be in the builder.
-   *  \param[in] size The dimensions of the box
+   *  \param[in] size   The dimensions of the box
    *  \param[in] origin The origin pose of this visual box relative to the link origin
    */
   void addVisualBox(const std::string& link_name, const std::vector<double>& size, geometry_msgs::Pose origin);

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
@@ -56,8 +56,7 @@ public:
     unsigned int max_solutions_per_grid_location;
   };
 
-  /** @class
-   *  @brief An implementation of a cache for fast kinematics lookups. initialize needs to be called on this class
+  /** @brief An implementation of a cache for fast kinematics lookups. initialize needs to be called on this class
    * before it can be used.
    */
   KinematicsCache();

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/include/kinematics_cache_ros/kinematics_cache_ros.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/include/kinematics_cache_ros/kinematics_cache_ros.h
@@ -46,8 +46,7 @@ namespace kinematics_cache_ros
 class KinematicsCacheROS : public kinematics_cache::KinematicsCache
 {
 public:
-  /** @class
-   *  @brief An implementation of a cache for fast kinematics lookups
+  /** @brief An implementation of a cache for fast kinematics lookups
    *  This class inherits from KinematicsCache and provides an easy way of initializing the cache using ROS
    */
   KinematicsCacheROS(){};

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
@@ -56,8 +56,7 @@ public:
     unsigned int max_solutions_per_grid_location;
   };
 
-  /** @class
-   *  @brief An implementation of a cache for fast kinematics lookups. initialize needs to be called on this class
+  /** @brief An implementation of a cache for fast kinematics lookups. initialize needs to be called on this class
    * before it can be used.
    */
   KinematicsCache();

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_constraint_aware.h
@@ -63,9 +63,7 @@ class KinematicsConstraintAware;
 typedef std::shared_ptr<KinematicsConstraintAware> KinematicsConstraintAwarePtr;
 typedef std::shared_ptr<const KinematicsConstraintAware> KinematicsConstraintAwareConstPtr;
 
-/**
- * @class A kinematics solver that can be used with multiple arms
- */
+/** A kinematics solver that can be used with multiple arms */
 class KinematicsConstraintAware
 {
 public:

--- a/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_request_response.h
+++ b/moveit_experimental/kinematics_constraint_aware/include/moveit/kinematics_constraint_aware/kinematics_request_response.h
@@ -52,9 +52,7 @@
 
 namespace kinematics_constraint_aware
 {
-/**
- * @class A kinematics request
- */
+/** A kinematics request */
 class KinematicsRequest
 {
 public:
@@ -81,9 +79,7 @@ public:
   moveit::core::StateValidityCallbackFn constraint_callback_;
 };
 
-/**
- * @class A kinematics response
- */
+/** A kinematics response */
 class KinematicsResponse
 {
 public:

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -193,9 +193,7 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   }
 
 public:
-  /** @class
-   *  @brief Interface for an IKFast kinematics plugin
-   */
+  /** @brief Interface for an IKFast kinematics plugin */
   IKFastKinematicsPlugin() : num_joints_(GetNumJoints()), initialized_(false)
   {
     srand(time(nullptr));

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
@@ -47,8 +47,7 @@ namespace ompl_interface
 {
 class ModelBasedPlanningContext;
 
-/** @class ConstrainedGoalSampler
- *  An interface to the OMPL goal lazy sampler*/
+/** An interface to the OMPL goal lazy sampler */
 class ConstrainedGoalSampler : public ompl::base::GoalLazySamples
 {
 public:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_sampler.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_sampler.h
@@ -43,8 +43,7 @@ namespace ompl_interface
 {
 class ModelBasedPlanningContext;
 
-/** @class ConstrainedSampler
- *  This class defines a sampler that tries to find a sample that satisfies the constraints*/
+/** This class defines a sampler that tries to find a sample that satisfies the constraints */
 class ConstrainedSampler : public ompl::base::StateSampler
 {
 public:
@@ -54,10 +53,10 @@ public:
    */
   ConstrainedSampler(const ModelBasedPlanningContext* pc, constraint_samplers::ConstraintSamplerPtr cs);
 
-  /** @brief Sample a state (uniformly)*/
+  /** @brief Sample a state (uniformly) */
   void sampleUniform(ompl::base::State* state) override;
 
-  /** @brief Sample a state (uniformly) within a certain distance of another state*/
+  /** @brief Sample a state (uniformly) within a certain distance of another state */
   void sampleUniformNear(ompl::base::State* state, const ompl::base::State* near, const double distance) override;
 
   /** @brief Sample a state using the specified Gaussian*/

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/goal_union.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/goal_union.h
@@ -38,7 +38,7 @@
 
 namespace ompl_interface
 {
-/** @class GoalSampleableRegionMux*/
+/** GoalSampleableRegionMux */
 class GoalSampleableRegionMux : public ompl::base::GoalSampleableRegion
 {
 public:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/projection_evaluators.h
@@ -51,8 +51,7 @@ namespace ompl_interface
 {
 class ModelBasedPlanningContext;
 
-/** @class ProjectionEvaluatorLinkPose
-    @brief */
+/** ProjectionEvaluatorLinkPose */
 class ProjectionEvaluatorLinkPose : public ompl::base::ProjectionEvaluator
 {
 public:
@@ -68,8 +67,7 @@ private:
   TSStateStorage tss_;
 };
 
-/** @class ProjectionEvaluatorJointValue
-    @brief */
+/** ProjectionEvaluatorJointValue */
 class ProjectionEvaluatorJointValue : public ompl::base::ProjectionEvaluator
 {
 public:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
@@ -44,8 +44,7 @@ namespace ompl_interface
 {
 class ModelBasedPlanningContext;
 
-/** @class StateValidityChecker
-    @brief An interface for a OMPL state validity checker*/
+/** @brief An interface for a OMPL state validity checker */
 class StateValidityChecker : public ompl::base::StateValidityChecker
 {
 public:

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -49,8 +49,7 @@
 /** \brief The MoveIt interface to OMPL */
 namespace ompl_interface
 {
-/** @class OMPLInterface
- *  This class defines the interface to the motion planners in OMPL*/
+/** This class defines the interface to the motion planners in OMPL */
 class OMPLInterface
 {
 public:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_aggregator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_aggregator.h
@@ -120,11 +120,7 @@ protected:
   static void checkVelocityBoundsThrowing(const moveit::core::JointModel* joint_model, const JointLimit& joint_limit);
 };
 
-/**
- * @class AggregationException
- * @brief A base class for all aggregation exceptions inheriting from
- * std::runtime_exception
- */
+/** A base class for all aggregation exceptions inheriting from std::runtime_exception */
 class AggregationException : public std::runtime_error
 {
 public:
@@ -133,12 +129,7 @@ public:
   }
 };
 
-/**
- * @class AggregationJointMissingException
- * @brief Thrown the limits from the parameter server are weaker(forbidden) than
- * the ones defined in the urdf
- *
- */
+/** Thrown the limits from the parameter server are weaker(forbidden) than the ones defined in the urdf */
 class AggregationBoundsViolationException : public AggregationException
 {
 public:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_validator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_validator.h
@@ -105,7 +105,7 @@ public:
   }
 };
 
-/** Thrown the limits for a joint are defined in the urdf but not on the parameter server (loaded from yaml) */
+/** Thrown when the limits for a joint are defined in the urdf but not on the parameter server (loaded from yaml) */
 class ValidationJointMissingException : public ValidationException
 {
 public:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_validator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_validator.h
@@ -96,11 +96,7 @@ private:
   static bool decelerationEqual(const JointLimit& lhs, const JointLimit& rhs);
 };
 
-/**
- * @class ValidationException
- * @brief A base class for all validations exceptions inheriting from
- * std::runtime_exception
- */
+/** A base class for all validations exceptions inheriting from std::runtime_exception */
 class ValidationException : public std::runtime_error
 {
 public:
@@ -109,12 +105,7 @@ public:
   }
 };
 
-/**
- * @class ValidationJointMissingException
- * @brief Thrown the limits for a joint are defined in the urdf but not on the
- * parameter server (loaded from yaml)
- *
- */
+/** Thrown the limits for a joint are defined in the urdf but not on the parameter server (loaded from yaml) */
 class ValidationJointMissingException : public ValidationException
 {
 public:
@@ -123,11 +114,7 @@ public:
   }
 };
 
-/**
- * @class ValidationDifferentLimitsException
- * @brief Thrown when the limits differ
- *
- */
+/** Thrown when the limits differ */
 class ValidationDifferentLimitsException : public ValidationException
 {
 public:
@@ -136,12 +123,7 @@ public:
   }
 };
 
-/**
- * @class ValidationBoundsViolationException
- * @brief Thrown when the limits from the param server are weaker than the ones
- * obtained from the urdf
- *
- */
+/** Thrown when the limits from the param server are weaker than the ones obtained from the urdf */
 class ValidationBoundsViolationException : public ValidationException
 {
 public:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_exceptions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_exceptions.h
@@ -38,11 +38,7 @@
 
 namespace pilz_industrial_motion_planner
 {
-/**
- * @class PlanningException
- * @brief A base class for all pilz_industrial_motion_planner exceptions
- * inheriting from std::runtime_exception
- */
+/** A base class for all pilz_industrial_motion_planner exceptions inheriting from std::runtime_exception */
 class PlanningException : public std::runtime_error
 {
 public:
@@ -51,10 +47,7 @@ public:
   }
 };
 
-/**
- * @class PlanningContextFactoryRegistrationException
- * @brief An exception class thrown when the planner manager is unable to load a
- * factory
+/** An exception class thrown when the planner manager is unable to load a factory
  *
  * Loading a PlanningContextFactory can fail if a factory is loaded that
  * would provide a command which was already provided by another factory loaded

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -48,15 +48,14 @@ namespace planning_scene_monitor
 {
 using JointStateUpdateCallback = boost::function<void(const sensor_msgs::JointStateConstPtr&)>;
 
-/** @class CurrentStateMonitor
-    @brief Monitors the joint_states topic and tf to maintain the current state of the robot. */
+/** Monitors the joint_states topic and tf to maintain the current state of the robot. */
 class CurrentStateMonitor
 {
   using TFConnection = boost::signals2::connection;
 
 public:
   /**
-   * @brief Constructor.
+   * @brief Constructor
    * @param robot_model The current kinematic model to build on
    * @param tf_buffer A pointer to the tf2_ros Buffer to use
    */

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor.h
@@ -48,8 +48,7 @@ using TrajectoryStateAddedCallback = boost::function<void(const moveit::core::Ro
 
 MOVEIT_CLASS_FORWARD(TrajectoryMonitor);  // Defines TrajectoryMonitorPtr, ConstPtr, WeakPtr... etc
 
-/** @class TrajectoryMonitor
-    @brief Monitors the joint_states topic and tf to record the trajectory of the robot. */
+/** Monitors the joint_states topic and tf to record the trajectory of the robot. */
 class TrajectoryMonitor
 {
 public:

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -44,9 +44,7 @@ namespace rdf_loader
 {
 MOVEIT_CLASS_FORWARD(RDFLoader);  // Defines RDFLoaderPtr, ConstPtr, WeakPtr... etc
 
-/** @class RDFLoader
- *  @brief Default constructor
- *  @param robot_description The string name corresponding to the ROS param where the URDF is loaded*/
+/** Loader for .urdf and .srdf descriptions */
 class RDFLoader
 {
 public:

--- a/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/moveit_ros/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -45,7 +45,6 @@ namespace robot_model_loader
 {
 MOVEIT_CLASS_FORWARD(RobotModelLoader);  // Defines RobotModelLoaderPtr, ConstPtr, WeakPtr... etc
 
-/** @class RobotModelLoader */
 class RobotModelLoader
 {
 public:


### PR DESCRIPTION
moveit_tutorials is broken due to missing files, which should be generated by rosdoc/doxygen:
https://github.com/ros-planning/moveit_tutorials/actions/runs/3966977821/jobs/6798414067

Looking into the output of the corresponding [doc job](https://build.ros.org/job/Ndoc__moveit__ubuntu_focal_amd64/102/consoleFull), I found hundreds of doxygen warnings.
This PR addresses many of them (240 out of 340)! Then I gave up after 2 hours of fixing.
Anybody continuing is highly welcome!

The actual culprit was the `.scene` file format description, which I added recently in `planning_scene.h`: it was terminated with a misspelled `\endvarbatim` command.

To avoid such issues in the future, we should add a `rosdoc` job to CI and fail on corresponding warnings. Obviously, this would require fixing all existing warnings first...