### PR TITLE
Simplify servo config + Reusable launch scripts

### DIFF
--- a/moveit_ros/moveit_servo/launch/cpp_interface_example.launch
+++ b/moveit_ros/moveit_servo/launch/cpp_interface_example.launch
@@ -1,9 +1,0 @@
-<launch>
-  <!-- Launch an example that sends commands via C++ API. -->
-
-  <node name="servo_server" pkg="moveit_servo" type="cpp_interface_example" output="screen" >
-    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
-    <rosparam ns="optional_parameter_namespace" command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
-  </node>
-
-</launch>

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch
@@ -1,8 +1,7 @@
 <launch>
   <!-- Launch an example that sends commands via C++ API. -->
 
-  <node name="servo_server" pkg="moveit_servo" type="pose_tracking_example" output="screen" >
-    <!-- <param name="parameter_ns" type="string" value="servo_server" /> -->
+  <node name="servo_server" pkg="moveit_servo" type="pose_tracking_example" output="screen">
     <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
     <rosparam command="load" file="$(find moveit_servo)/config/pose_tracking_settings.yaml" />
   </node>

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch
@@ -1,8 +1,10 @@
 <launch>
   <!-- Launch an example that sends commands via C++ API. -->
 
+  <arg name="config" default="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
+
   <node name="servo_server" pkg="moveit_servo" type="pose_tracking_example" output="screen">
-    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
+    <rosparam command="load" file="$(arg config)" />
     <rosparam command="load" file="$(find moveit_servo)/config/pose_tracking_settings.yaml" />
   </node>
 

--- a/moveit_ros/moveit_servo/launch/spacenav_cpp.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_cpp.launch
@@ -8,12 +8,14 @@
        But, we do plan to accept teleop_tools config files (see spacenav_teleop_tools.launch)
   -->
 
+  <arg name="config" default="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
+
   <node name="spacenav_node" pkg="spacenav_node" type="spacenav_node" />
 
   <node name="spacenav_to_twist" pkg="moveit_servo" type="spacenav_to_twist" output="screen" />
 
   <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
-    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
+    <rosparam command="load" file="$(arg config)"/>
   </node>
 
 </launch>

--- a/moveit_ros/moveit_servo/launch/spacenav_cpp.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_cpp.launch
@@ -13,8 +13,7 @@
   <node name="spacenav_to_twist" pkg="moveit_servo" type="spacenav_to_twist" output="screen" />
 
   <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
-    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
-    <rosparam ns="optional_parameter_namespace" command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
+    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
   </node>
 
 </launch>

--- a/moveit_ros/moveit_servo/launch/spacenav_teleop_tools.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_teleop_tools.launch
@@ -10,8 +10,7 @@
 
   <!-- This node does the servoing calculations -->
   <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
-    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
-    <rosparam ns="optional_parameter_namespace" command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml" />
+    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
   </node>
 
   <!-- teleop_tools translates a joystick command into a twist message -->

--- a/moveit_ros/moveit_servo/launch/spacenav_teleop_tools.launch
+++ b/moveit_ros/moveit_servo/launch/spacenav_teleop_tools.launch
@@ -5,12 +5,14 @@
        We do plan to accept pull requests of config files for other controller types using this method.
   -->
 
+  <arg name="config" default="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
+
   <!-- This node publishes commands from the controller -->
   <node name="spacenav_node" pkg="spacenav_node" type="spacenav_node" />
 
   <!-- This node does the servoing calculations -->
   <node name="servo_server" pkg="moveit_servo" type="servo_server" output="screen" >
-    <rosparam command="load" file="$(find moveit_servo)/config/ur_simulated_config.yaml"/>
+    <rosparam command="load" file="$(arg config)"/>
   </node>
 
   <!-- teleop_tools translates a joystick command into a twist message -->

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -143,13 +143,7 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 
 void PoseTracking::readROSParams()
 {
-  // Optional parameter sub-namespace specified in the launch file. All other parameters will be read from this namespace.
-  std::string parameter_ns;
-  ros::param::get("~parameter_ns", parameter_ns);
-
-  // If parameters have been loaded into sub-namespace within the node namespace, append the parameter namespace
-  // to load the parameters correctly.
-  ros::NodeHandle nh = parameter_ns.empty() ? nh_ : ros::NodeHandle(nh_, parameter_ns);
+  ros::NodeHandle nh("~");
 
   // Wait for ROS parameters to load
   ros::Time begin = ros::Time::now();

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -86,13 +86,7 @@ bool Servo::readParameters()
 {
   std::size_t error = 0;
 
-  // Optional parameter sub-namespace specified in the launch file. All other parameters will be read from this namespace.
-  std::string parameter_ns;
-  ros::param::get("~parameter_ns", parameter_ns);
-
-  // If parameters have been loaded into sub-namespace within the node namespace, append the parameter namespace
-  // to load the parameters correctly.
-  ros::NodeHandle nh = parameter_ns.empty() ? nh_ : ros::NodeHandle(nh_, parameter_ns);
+  ros::NodeHandle nh("~");  // Load all parameters w.r.t. to node's private namespace
 
   error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_period", parameters_.publish_period);
   error += !rosparam_shortcuts::get(LOGNAME, nh, "collision_check_rate", parameters_.collision_check_rate);

--- a/moveit_ros/moveit_servo/test/basic_servo_tests.test
+++ b/moveit_ros/moveit_servo/test/basic_servo_tests.test
@@ -12,7 +12,6 @@
   </node>
 
   <test pkg="moveit_servo" type="basic_servo_tests" test-name="basic_servo_tests" time-limit="60" args="">
-    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
-    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings_low_latency.yaml" ns="optional_parameter_namespace"/>
+    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings_low_latency.yaml"/>
   </test>
 </launch>

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.test
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.test
@@ -7,7 +7,7 @@
 
   <!-- Initial joint positions -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <rosparam command="load" file="$(find moveit_servo)/test/config/initial_position.yaml" />
+    <rosparam command="load" file="$(find moveit_servo)/test/config/initial_position.yaml"/>
     <param name="publish_frequency" type="double" value="50.0"/>
   </node>
 
@@ -15,9 +15,7 @@
     <param name="publish_frequency" type="double" value="50.0"/>
   </node>
 
-  <test pkg="moveit_servo" type="pose_tracking_test" test-name="pose_tracking_test" time-limit="60
-    " args="">
-    <param name="parameter_ns" type="string" value="" />
+  <test pkg="moveit_servo" type="pose_tracking_test" test-name="pose_tracking_test" time-limit="60">
     <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings.yaml"/>
     <rosparam command="load" file="$(find moveit_servo)/config/pose_tracking_settings.yaml"/>
   </test>

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.test
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.test
@@ -12,7 +12,6 @@
   </node>
 
   <test pkg="moveit_servo" type="servo_cpp_interface_test" test-name="servo_cpp_interface_test" time-limit="60" args="">
-    <param name="parameter_ns" type="string" value="optional_parameter_namespace" />
-    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings.yaml" ns="optional_parameter_namespace"/>
+    <rosparam command="load" file="$(find moveit_servo)/test/config/servo_settings.yaml"/>
   </test>
 </launch>


### PR DESCRIPTION
When trying to generalize moveit_servo's launch scripts to handle user-specific config files, I noted a weird mechanism to load these parameters: 
First, a private parameter `~parameter_ns` was declared and its value was actually used as a namespace to load all parameters into. Instead of this error-prone and indirect scheme, I suggest loading these parameters directly into the private namespace of the node. I don't see a need to share these parameters across different server instances.

If one really wants to load those parameters somewhere else first, one can simply start the node with the corresponding namespace as its name.

The original purpose of this PR was to add an argument `config` to specify a .yaml file with the desired parameters (instead of locking it to `ur_simulated_config.yaml`). In this fashion, the launch scripts become reusable.