### PR TITLE
Tentative AITstar integration

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -66,6 +66,7 @@
 #include <ompl/geometric/planners/prm/LazyPRMstar.h>
 #include <ompl/geometric/planners/prm/SPARS.h>
 #include <ompl/geometric/planners/prm/SPARStwo.h>
+#include <ompl/geometric/planners/informedtrees/AITstar.h>
 
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h>
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
@@ -290,6 +291,7 @@ void ompl_interface::PlanningContextManager::registerDefaultPlanners()
   registerPlannerAllocatorHelper<og::SPARStwo>("geometric::SPARStwo");
   registerPlannerAllocatorHelper<og::STRIDE>("geometric::STRIDE");
   registerPlannerAllocatorHelper<og::TRRT>("geometric::TRRT");
+  registerPlannerAllocatorHelper<og::AITstar>("geometric::AITstar");
 }
 
 void ompl_interface::PlanningContextManager::registerDefaultStateSpaces()

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -863,6 +863,14 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners() const
   spar_stwo.addParameter("max_failures", "5000", "maximum consecutive failure limit. default: 5000");
   planner_des.push_back(spar_stwo);
 
+  OMPLPlannerDescription aitstar("AITstar", "geometric");
+  aitstar.addParameter("use_k_nearest", "0", "TODO");
+  aitstar.addParameter("rewire_factor", "1.0", "TODO");
+  aitstar.addParameter("samples_per_batch", "100", "TODO");
+  aitstar.addParameter("use_graph_pruning", "0", "TODO");
+  aitstar.addParameter("find_approximate_solutions", "1", "TODO");
+  planner_des.push_back(aitstar);
+
   return planner_des;
 }
 


### PR DESCRIPTION
### Description

Following Issue #3329, here is the minimal code to add AITstar from OMPL-1.6.0 or OMPL-1.5.0 to MoveIt

- `planning_context_manager.cpp` now includes the AITstar planner.
- The MoveIt assistant also adds a default AITstar configuration to `ompl_planning.yaml`