### PR TITLE
TrajectoryDisplay: hide links in trail

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -152,7 +152,7 @@ protected:
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr robot_state_;
 
-  // Pointers from parent display taht we save
+  // Pointers from parent display that we save
   rviz::Display* display_;  // the parent display that this class populates
   rviz::Property* widget_;
   Ogre::SceneNode* scene_node_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -252,6 +252,14 @@ void TrajectoryVisualization::changedShowTrail()
     if (enable_robot_color_property_->getBool())
       setRobotColor(&(r->getRobot()), robot_color_property_->getColor());
     r->setVisible(display_->isEnabled() && (!animating_path_ || waypoint_i <= current_state_));
+    auto& robotPathLinks = display_path_robot_->getRobot().getLinks();
+    for (const auto& robotLink : robotPathLinks)
+    {
+      r->getRobot()
+          .getLink(robotLink.first)
+          ->getLinkProperty()
+          ->setValue(robotLink.second->getLinkProperty()->getValue());
+    }
     trajectory_trail_[i] = std::move(r);
   }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -252,13 +252,14 @@ void TrajectoryVisualization::changedShowTrail()
     if (enable_robot_color_property_->getBool())
       setRobotColor(&(r->getRobot()), robot_color_property_->getColor());
     r->setVisible(display_->isEnabled() && (!animating_path_ || waypoint_i <= current_state_));
-    auto& robotPathLinks = display_path_robot_->getRobot().getLinks();
-    for (const auto& robotLink : robotPathLinks)
+    const auto& robot_path_links = display_path_robot_->getRobot().getLinks();
+    for (const auto& [link_name, robot_link] : robot_path_links)
     {
-      r->getRobot()
-          .getLink(robotLink.first)
-          ->getLinkProperty()
-          ->setValue(robotLink.second->getLinkProperty()->getValue());
+      rviz::RobotLink* l = r->getRobot().getLink(link_name);
+      rviz::Property* link_property = robot_link->getLinkProperty();
+      l->getLinkProperty()->setValue(link_property->getValue());
+      connect(link_property, &rviz::Property::changed, l,
+              [l, link_property]() { l->getLinkProperty()->setValue(link_property->getValue()); });
     }
     trajectory_trail_[i] = std::move(r);
   }


### PR DESCRIPTION
### Description

This allows to hide some parts of the robot in the trail mode by applying the general link visibility to the trail as well.

It is currently only applied on new incoming trajectories but adding some signal-slots for live update would be possible as well of course

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
