### PR TITLE
drop unnecessary cmake dependency on moveit_resources

### DIFF
--- a/moveit_ros/planning/moveit_cpp/CMakeLists.txt
+++ b/moveit_ros/planning/moveit_cpp/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(${MOVEIT_LIB_NAME}
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources_panda_moveit_config REQUIRED)
   find_package(rostest REQUIRED)
 
   add_rostest_gtest(moveit_cpp_test test/moveit_cpp_test.test test/moveit_cpp_test.cpp)

--- a/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
+++ b/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
@@ -12,7 +12,6 @@ install(TARGETS ${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-    find_package(moveit_resources_panda_moveit_config REQUIRED)
     find_package(rostest REQUIRED)
 
     add_rostest_gtest(test_execution_manager


### PR DESCRIPTION
It is only needed at *runtime* of the ros tests and there's no need to find_package.
catkin_lint is happy without these lines.
