### PR TITLE
Disentangle joint name methods and add group_state to commander

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -35,6 +35,7 @@ API changes in MoveIt releases
   You might need to define additional end-effectors.
 - Removed `ConstraintSampler::project()` as there was no real difference to `sample()`.
 - Removed `TrajectoryExecutionManager::pushAndExecute()` and the code associated to it. The code was unused and broken.
+- Renamed `MoveGroupInterface::getJointNames()` to `getVariableNames()`. If you used the method before, read up on `getJoints()`, `getVariableNames()` and `getActiveJoints()` to decide whether you used the correct method.
 
 ## ROS Melodic
 

--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -260,6 +260,9 @@ class MoveGroupCommandInterpreter(object):
         if cmd == "current":
             return self.command_current(g)
 
+        if cmd == "group_state":
+            return self.command_group_state(g)
+
         if cmd == "ground":
             pose = PoseStamped()
             pose.pose.position.x = 0
@@ -712,6 +715,19 @@ class MoveGroupCommandInterpreter(object):
             res.append(k + " = [" + " ".join([str(x) for x in known[k]]) + "]")
         return (MoveGroupInfoLevel.INFO, "\n".join(res))
 
+    def command_group_state(self, g):
+        res = (
+            '    <group_state name="custom_state" group="{}">\n'.format(g.get_name())
+            + "\n".join(
+                [
+                    '        <joint name="{}" value="{}"/>'.format(j, v)
+                    for j, v in zip(g._g.get_variables(), g.get_current_joint_values())
+                ]
+            )
+            + "\n    </group_state>"
+        )
+        return (MoveGroupInfoLevel.INFO, res)
+
     def command_current(self, g):
         res = (
             "joints = ["
@@ -779,6 +795,7 @@ class MoveGroupCommandInterpreter(object):
             "  constrain <name>    use the constraint <name> as a path constraint"
         )
         res.append("  current             show the current state of the active group")
+        res.append("  group_state         current state to copy&paste to srdf file")
         res.append(
             "  database            display the current database connection (if any)"
         )
@@ -861,6 +878,7 @@ class MoveGroupCommandInterpreter(object):
             "wait": [],
             "delete": known_vars,
             "database": [],
+            "group_state": [],
             "current": [],
             "use": groups,
             "load": [],

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -172,20 +172,35 @@ public:
   /** \brief Get the available planning group names */
   const std::vector<std::string>& getJointModelGroupNames() const;
 
-  /** \brief Get vector of names of joints available in move group */
-  const std::vector<std::string>& getJointNames() const;
-
   /** \brief Get vector of names of links available in move group */
   const std::vector<std::string>& getLinkNames() const;
 
   /** \brief Get the joint angles for targets specified by name */
   std::map<std::string, double> getNamedTargetValues(const std::string& name) const;
 
-  /** \brief Get only the active (actuated) joints this instance operates on */
-  const std::vector<std::string>& getActiveJoints() const;
+  /** \brief Get names of all the joints in this group
 
-  /** \brief Get all the joints this instance operates on (including fixed joints)*/
+      The list includes fixed joints, so not all joints in the list can move.
+      This complete list is mainly useful when considering relative transforms. */
   const std::vector<std::string>& getJoints() const;
+
+  /** \brief Get names of degrees of freedom in this group
+
+      This list does not include fixed joints, but does include mimic and passive joints.
+      Multi-DOF joints are represented as multiple separate entries.
+      It corresponds to the double vectors representing a robot state in the RobotState class.
+      The joints in this list define all information necessary to recreate a complete robot state
+      without additional knowledge. */
+  const std::vector<std::string>& getJointNames() const;
+
+  /** \brief Get names of joints with an active (actuated) DOF in this group
+
+      This list includes *only* joints that MoveIt can actuate through a controller.
+      Mimic joints are excluded, but can be recomputed with the robot model.
+      Passive joints explicitly excluded and cannot be recomputed from this set of joints.
+
+      This list is primarily useful to process trajectories meant for execution. */
+  const std::vector<std::string>& getActiveJoints() const;
 
   /** \brief Get the number of variables used to describe the state of this group. This is larger or equal to the number
    * of DOF. */

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -184,6 +184,11 @@ public:
       This complete list is mainly useful when considering relative transforms. */
   const std::vector<std::string>& getJoints() const;
 
+  [[deprecated("use getVariableNames")]] const std::vector<std::string>& getJointNames() const
+  {
+    return getVariableNames();
+  }
+
   /** \brief Get names of degrees of freedom in this group
 
       This list does not include fixed joints, but does include mimic and passive joints.
@@ -191,7 +196,7 @@ public:
       It corresponds to the double vectors representing a robot state in the RobotState class.
       The joints in this list define all information necessary to recreate a complete robot state
       without additional knowledge. */
-  const std::vector<std::string>& getJointNames() const;
+  const std::vector<std::string>& getVariableNames() const;
 
   /** \brief Get names of joints with an active (actuated) DOF in this group
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1643,7 +1643,7 @@ void MoveGroupInterface::setRandomTarget()
   impl_->setTargetType(JOINT);
 }
 
-const std::vector<std::string>& MoveGroupInterface::getJointNames() const
+const std::vector<std::string>& MoveGroupInterface::getVariableNames() const
 {
   return impl_->getJointModelGroup()->getVariableNames();
 }

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -167,7 +167,7 @@ public:
 
   bp::list getVariablesList() const
   {
-    return py_bindings_tools::listFromString(getJointNames());
+    return py_bindings_tools::listFromString(getVariableNames());
   }
 
   bp::list getCurrentJointValuesList()

--- a/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -165,6 +165,11 @@ public:
     return py_bindings_tools::listFromString(getJoints());
   }
 
+  bp::list getVariablesList() const
+  {
+    return py_bindings_tools::listFromString(getJointNames());
+  }
+
   bp::list getCurrentJointValuesList()
   {
     return py_bindings_tools::listFromDouble(getCurrentJointValues());
@@ -684,8 +689,9 @@ static void wrap_move_group_interface()
   move_group_interface_class.def("get_planning_frame", &MoveGroupInterfaceWrapper::getPlanningFrameCStr);
   move_group_interface_class.def("get_interface_description", &MoveGroupInterfaceWrapper::getInterfaceDescriptionPython);
 
-  move_group_interface_class.def("get_active_joints", &MoveGroupInterfaceWrapper::getActiveJointsList);
   move_group_interface_class.def("get_joints", &MoveGroupInterfaceWrapper::getJointsList);
+  move_group_interface_class.def("get_variables", &MoveGroupInterfaceWrapper::getVariablesList);
+  move_group_interface_class.def("get_active_joints", &MoveGroupInterfaceWrapper::getActiveJointsList);
   move_group_interface_class.def("get_variable_count", &MoveGroupInterfaceWrapper::getVariableCount);
   move_group_interface_class.def("allow_looking", &MoveGroupInterfaceWrapper::allowLooking);
   move_group_interface_class.def("allow_replanning", &MoveGroupInterfaceWrapper::allowReplanning);


### PR DESCRIPTION
- improve documentation of all MGI::get* functions for joint names
- expose get_variables in MGI python wrapper
- add "group_state" command to commander
- rename MGI::getJointNames() to getVariableNames()

The API-incompatible method rename can be dropped if requested, but it took me a while to figure out which method is correct when implementing `group_state`, so I believe refactoring makes a lot of sense.
